### PR TITLE
feat: Config to toggle cart subtotal and show tax instead of unit price

### DIFF
--- a/changelog/_unreleased/2025-03-27-added-new-configs-for-changing-cart-columns.md
+++ b/changelog/_unreleased/2025-03-27-added-new-configs-for-changing-cart-columns.md
@@ -10,12 +10,12 @@ ___
 # Storefront
 * Added check for new config `core.cart.showSubtotal` in `src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig`
 * Added new config to hide total field in
-  * ``src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig``
-  * ``src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig``
-  * ``src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig``
-  * ``src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig``
+  * `src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig`
+  * `src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig`
+  * `src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig`
+  * `src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig`
 * Added read new configs in
-  * ``src/Storefront/Resources/views/storefront/page/account/order/index.html.twig``
-  * ``src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig``
-  * ``src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig``
-  * ``src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig``
+  * `src/Storefront/Resources/views/storefront/page/account/order/index.html.twig`
+  * `src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig`
+  * `src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig`
+  * `src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig`

--- a/changelog/_unreleased/2025-03-27-added-new-configs-for-changing-cart-columns.md
+++ b/changelog/_unreleased/2025-03-27-added-new-configs-for-changing-cart-columns.md
@@ -1,0 +1,21 @@
+---
+title: Added new configs for changing cart columns
+issue: https://github.com/shopware/shopware/issues/7482
+author_github: @En0Ma1259
+---
+# Core
+* Added new `core.cart.showSubtotal` config to toggle cart subtotal column
+* Added new `core.cart.columnTaxInsteadUnitPrice` config to switch between "tax" and "unit price" cart column for oder confirmation page
+___
+# Storefront
+* Added check for new config `core.cart.showSubtotal` in `src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig`
+* Added new config to hide total field in
+  * ``src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig``
+  * ``src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig``
+  * ``src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig``
+  * ``src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig``
+* Added read new configs in
+  * ``src/Storefront/Resources/views/storefront/page/account/order/index.html.twig``
+  * ``src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig``
+  * ``src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig``
+  * ``src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig``

--- a/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
@@ -52,7 +52,7 @@ class CreateMigrationCommand extends Command
         $directory = (string) $input->getArgument('directory');
         $namespace = (string) $input->getArgument('namespace');
         $name = $input->getOption('name') ?? '';
-        $package = $input->getOption('package') ?? 'core';
+        $package = $input->getOption('package') ?? 'framework';
 
         if (!preg_match('/^[a-zA-Z0-9\_]*$/', (string) $name)) {
             throw MigrationException::invalidArgument('Migration name contains forbidden characters!');

--- a/src/Core/Migration/V6_7/Migration1743064966CartConfigSubtotalTaxColumn.php
+++ b/src/Core/Migration/V6_7/Migration1743064966CartConfigSubtotalTaxColumn.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1743064966CartConfigSubtotalTaxColumn extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1743064966;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->insertConfig($connection, 'core.cart.showSubtotal');
+        $this->insertConfig($connection, 'core.cart.columnTaxInsteadUnitPrice');
+    }
+
+    private function insertConfig(Connection $connection, string $key): void
+    {
+        $config = $connection->fetchAllAssociativeIndexed(
+            'SELECT `configuration_value` FROM `system_config` WHERE `configuration_key` = ? and `sales_channel_id` is null',
+            [$key]
+        );
+
+        if (!empty($config)) {
+            return;
+        }
+
+        $connection->insert('system_config', [
+            'id' => Uuid::randomBytes(),
+            'configuration_key' => $key,
+            'configuration_value' => json_encode(['_value' => true]),
+            'sales_channel_id' => null,
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+}

--- a/src/Core/System/Resources/config/cart.xml
+++ b/src/Core/System/Resources/config/cart.xml
@@ -36,6 +36,18 @@
             <label>Maximum addable products to cart per minute through API</label>
             <label lang="de-DE">Maximal hinzufügbare Produkte pro Minute in den Warenkorb durch die API</label>
         </input-field>
+
+        <input-field type="bool">
+            <name>showSubtotal</name>
+            <label>Show subtotal column</label>
+            <label lang="de-DE">Summenspalte anzeigen</label>
+        </input-field>
+
+        <input-field type="bool">
+            <name>columnTaxInsteadUnitPrice</name>
+            <label>Order confirm page: tax column instead of unit price</label>
+            <label lang="de-DE">Bestellbestätigung: Steuerspalte anstatt Stückpreis</label>
+        </input-field>
     </card>
 
     <card>

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
@@ -1,3 +1,8 @@
+$infoItemDetailMdSpace: 8;
+$infoItemInfoMdSpace: 5;
+$infoItemTotalPriceMdSpace: 2;
+$infoItemRemoveMdSpace: 1;
+
 .line-item {
     margin: 0;
     padding: 10px 0;
@@ -21,7 +26,7 @@
     @include make-col-ready();
     @include make-col(10);
     @include media-breakpoint-up(md) {
-        @include make-col(5);
+        @include make-col($infoItemInfoMdSpace);
     }
 }
 
@@ -33,7 +38,7 @@
         @include make-col(7);
     }
     @include media-breakpoint-up(md) {
-        @include make-col(8);
+        @include make-col($infoItemDetailMdSpace);
     }
 }
 
@@ -101,7 +106,7 @@
         @include make-col(4);
     }
     @include media-breakpoint-up(md) {
-        @include make-col(2);
+        @include make-col($infoItemTotalPriceMdSpace);
     }
 }
 
@@ -112,7 +117,7 @@
     @include make-col-ready();
     @include make-col(2);
     @include media-breakpoint-up(md) {
-        @include make-col(1);
+        @include make-col($infoItemRemoveMdSpace);
     }
 }
 
@@ -181,7 +186,42 @@
     // Info column needs to use more gird space when no remove button exists as last row.
     .line-item-info {
         @include media-breakpoint-up(md) {
-            @include make-col(6);
+            @include make-col($infoItemInfoMdSpace + $infoItemRemoveMdSpace);
+        }
+    }
+    .line-item-details {
+        @include media-breakpoint-up(md) {
+            @include make-col($infoItemDetailMdSpace + 1);
+        }
+    }
+}
+
+.no-summary {
+    // Info column needs to use more gird space when no subtotal column exists.
+    .line-item-info {
+        @include media-breakpoint-up(md) {
+            @include make-col($infoItemInfoMdSpace + $infoItemTotalPriceMdSpace);
+        }
+    }
+    .line-item-details {
+        @include media-breakpoint-up(md) {
+            @include make-col($infoItemDetailMdSpace + 1);
+        }
+    }
+}
+
+.no-summary.no-remove-button {
+    // Info column needs to use more gird space when no remove button and subtotal column exists.
+    .line-item-info {
+        @include media-breakpoint-up(md) {
+            @include make-col(
+                $infoItemInfoMdSpace + $infoItemRemoveMdSpace + $infoItemTotalPriceMdSpace
+            );
+        }
+    }
+    .line-item-details {
+        @include media-breakpoint-up(md) {
+            @include make-col($infoItemDetailMdSpace + 2);
         }
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/page/account/_order-detail.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/account/_order-detail.scss
@@ -220,6 +220,7 @@
         border-top: 0;
     }
 
+    .order-header-tax-price,
     .order-header-price,
     .order-item-price,
     .order-header-total,

--- a/src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig
@@ -3,10 +3,17 @@
         {% set showRemoveColumn = true %}
     {% endif %}
 
-    {% set infoColumnClass = 'col-6' %}
+    {% if showSubtotal is not defined %}
+        {% set showSubtotal = true %}
+    {% endif %}
 
+    {% set subtotalColumnSize = 2 %}
+    {% set infoColumnSize = 8 %}
+    {% if showSubtotal %}
+        {% set infoColumnSize = infoColumnSize - subtotalColumnSize %}
+    {% endif %}
     {% if showRemoveColumn %}
-        {% set infoColumnClass = 'col-5' %}
+        {% set infoColumnSize = infoColumnSize - 1 %}
     {% endif %}
 
     {% block component_checkout_cart_header_element %}
@@ -14,7 +21,7 @@
 
             <div class="row cart-header-row">
                 {% block component_checkout_cart_header_product_info %}
-                    <div class="{{ infoColumnClass }} cart-header-info">
+                    <div class="col-{{ infoColumnSize }} cart-header-info">
                         {{ 'checkout.cartHeaderInfo'|trans|sw_sanitize }}
                     </div>
                 {% endblock %}
@@ -26,15 +33,17 @@
                 {% endblock %}
 
                 {% if showTaxPrice %}
-                    <div class="col-2 cart-header-tax-price">
-                        {% if context.salesChannel.taxCalculationType == 'horizontal' %}
-                            {% if context.taxState == 'gross' %}
-                                {{ 'checkout.cartHeaderTaxIncludeVat'|trans|sw_sanitize }}
-                            {% else %}
-                                {{ 'checkout.cartHeaderTaxExcludeVat'|trans|sw_sanitize }}
+                    {% block component_checkout_cart_header_tax_price %}
+                        <div class="col-2 cart-header-tax-price">
+                            {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                {% if context.taxState == 'gross' %}
+                                    {{ 'checkout.cartHeaderTaxIncludeVat'|trans|sw_sanitize }}
+                                {% else %}
+                                    {{ 'checkout.cartHeaderTaxExcludeVat'|trans|sw_sanitize }}
+                                {% endif %}
                             {% endif %}
-                        {% endif %}
-                    </div>
+                        </div>
+                    {% endblock %}
                 {% else %}
                     {% block component_checkout_cart_header_unit_price %}
                         <div class="col-2 cart-header-unit-price">
@@ -44,9 +53,11 @@
                 {% endif %}
 
                 {% block component_checkout_cart_header_total_price %}
-                    <div class="col-2 cart-header-total-price">
-                        {{ 'checkout.cartHeaderTotalPrice'|trans|sw_sanitize }}
-                    </div>
+                    {% if showSubtotal %}
+                        <div class="col-{{ subtotalColumnSize }} cart-header-total-price">
+                            {{ 'checkout.cartHeaderTotalPrice'|trans|sw_sanitize }}
+                        </div>
+                    {% endif %}
                 {% endblock %}
             </div>
         </li>

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
@@ -10,6 +10,10 @@
     {% set showRemoveButton = true %}
 {% endif %}
 
+{% if showSubtotal is not defined %}
+    {% set showSubtotal = true %}
+{% endif %}
+
 {% set lineItemClasses = 'line-item line-item-' ~ lineItem.type ~ ' is-' ~ displayMode %}
 
 {% if displayMode === 'offcanvas' %}
@@ -18,6 +22,10 @@
 
 {% if not showRemoveButton %}
     {% set lineItemClasses = lineItemClasses ~ ' no-remove-button' %}
+{% endif %}
+
+{% if not showSubtotal %}
+    {% set lineItemClasses = lineItemClasses ~ ' no-summary' %}
 {% endif %}
 
 {% block component_line_item_type_container %}
@@ -83,13 +91,15 @@
                         {% endblock %}
                     {% endif %}
 
-                    {% block component_line_item_type_container_col_total_price %}
-                        <div class="line-item-total-price">
-                            {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                                currency: lineItem.order.currency.isoCode
-                            } %}
-                        </div>
-                    {% endblock %}
+                    {% if showSubtotal %}
+                        {% block component_line_item_type_container_col_total_price %}
+                            <div class="line-item-total-price">
+                                {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                                    currency: lineItem.order.currency.isoCode
+                                } %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
 
                     {% if showRemoveButton %}
                         {% block component_line_item_type_container_col_remove %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
@@ -9,6 +9,10 @@
     {% set showRemoveButton = true %}
 {% endif %}
 
+{% if showSubtotal is not defined %}
+    {% set showSubtotal = true %}
+{% endif %}
+
 {% set lineItemClasses = 'line-item line-item-' ~ lineItem.type ~ ' is-' ~ displayMode %}
 
 {% if displayMode === 'offcanvas' %}
@@ -17,6 +21,10 @@
 
 {% if not showRemoveButton %}
     {% set lineItemClasses = lineItemClasses ~ ' no-remove-button' %}
+{% endif %}
+
+{% if not showSubtotal %}
+    {% set lineItemClasses = lineItemClasses ~ ' no-summary' %}
 {% endif %}
 
 {% block component_line_item_type_discount %}
@@ -79,13 +87,15 @@
                         {% endblock %}
                     {% endif %}
 
-                    {% block component_line_item_type_discount_col_total_price %}
-                        <div class="line-item-total-price">
-                            {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                                currency: lineItem.order.currency.isoCode
-                            } %}
-                        </div>
-                    {% endblock %}
+                    {% if showSubtotal %}
+                        {% block component_line_item_type_discount_col_total_price %}
+                            <div class="line-item-total-price">
+                                {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                                    currency: lineItem.order.currency.isoCode
+                                } %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
 
                     {% if showRemoveButton %}
                         {% block component_line_item_type_discount_col_total_remove %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
@@ -13,6 +13,10 @@
     {% set showRemoveButton = true %}
 {% endif %}
 
+{% if showSubtotal is not defined %}
+    {% set showSubtotal = true %}
+{% endif %}
+
 {% set lineItemClasses = 'line-item line-item-' ~ lineItem.type ~ ' is-' ~ displayMode %}
 
 {% if displayMode === 'offcanvas' %}
@@ -21,6 +25,10 @@
 
 {% if not showRemoveButton %}
     {% set lineItemClasses = lineItemClasses ~ ' no-remove-button' %}
+{% endif %}
+
+{% if not showSubtotal %}
+    {% set lineItemClasses = lineItemClasses ~ ' no-summary' %}
 {% endif %}
 
 {% block component_line_item_type_generic %}
@@ -121,13 +129,15 @@
                         {% endblock %}
                     {% endif %}
 
-                    {% block component_line_item_type_generic_col_total_price %}
-                        <div class="line-item-total-price">
-                            {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                                currency: lineItem.order.currency.isoCode
-                            } %}
-                        </div>
-                    {% endblock %}
+                    {% if showSubtotal %}
+                        {% block component_line_item_type_generic_col_total_price %}
+                            <div class="line-item-total-price">
+                                {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                                    currency: lineItem.order.currency.isoCode
+                                } %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
 
                     {% if showRemoveButton %}
                         {% block component_line_item_type_generic_col_remove %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
@@ -9,6 +9,10 @@
     {% set showRemoveButton = true %}
 {% endif %}
 
+{% if showSubtotal is not defined %}
+    {% set showSubtotal = true %}
+{% endif %}
+
 {% set lineItemClasses = 'line-item line-item-' ~ lineItem.type ~ ' is-' ~ displayMode %}
 
 {% if displayMode === 'offcanvas' %}
@@ -17,6 +21,10 @@
 
 {% if not showRemoveButton %}
     {% set lineItemClasses = lineItemClasses ~ ' no-remove-button' %}
+{% endif %}
+
+{% if not showSubtotal %}
+    {% set lineItemClasses = lineItemClasses ~ ' no-summary' %}
 {% endif %}
 
 {% block component_line_item_type_product %}
@@ -126,13 +134,15 @@
                             {% endblock %}
                         {% endif %}
 
-                        {% block component_line_item_type_product_col_total_price %}
-                            <div class="line-item-total-price line-item-price">
-                                {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                                    currency: lineItem.order.currency.isoCode
-                                } %}
-                            </div>
-                        {% endblock %}
+                        {% if showSubtotal %}
+                            {% block component_line_item_type_product_col_total_price %}
+                                <div class="line-item-total-price line-item-price">
+                                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                                        currency: lineItem.order.currency.isoCode
+                                    } %}
+                                </div>
+                            {% endblock %}
+                        {% endif %}
 
                         {% if showRemoveButton %}
                             {% block component_line_item_type_product_col_remove %}

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-list.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-list.html.twig
@@ -5,7 +5,8 @@
                 {% block page_account_order_item_detail_line_item %}
                     {% sw_include '@Storefront/storefront/component/line-item/line-item.html.twig' with {
                         displayMode: 'order',
-                        showRemoveButton: false
+                        showRemoveButton: false,
+                        showSubtotal: showSubtotal
                     } %}
                 {% endblock %}
             {% endfor %}

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -1,8 +1,8 @@
 {% block page_account_order_item_detail_overview %}
-    {# @deprecated tag:v6.8.0 - Will listing to new "core.cart.columnTaxInsteadUnitPrice" config #}
-    {% set showTaxPrice = false %}
-    {% if feature('v6.8.0.0') %}
-        {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+    {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+    {# @deprecated tag:v6.8.0 - Will listening to core.cart.columnTaxInsteadUnitPrice instead #}
+    {% if not feature('v6.8.0.0') %}
+        {% set showTaxPrice = false %}
     {% endif %}
     {% set showSubtotal = config('core.cart.showSubtotal') %}
 

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -1,4 +1,11 @@
 {% block page_account_order_item_detail_overview %}
+    {# @deprecated tag:v6.8.0 - Will listing to new "core.cart.columnTaxInsteadUnitPrice" config #}
+    {% set showTaxPrice = false %}
+    {% if feature('v6.8.0.0') %}
+        {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+    {% endif %}
+    {% set showSubtotal = config('core.cart.showSubtotal') %}
+
     <div class="order-item-detail">
         <div class="collapse"
              id="order{{ order.orderNumber }}">
@@ -10,10 +17,16 @@
                 {% endblock %}
 
                 {% block page_account_order_item_detail_table_header %}
+                    {% set subtotalColumnSize = 2 %}
+                    {% set infoColumnSize = 8 %}
+                    {% if showSubtotal %}
+                        {% set infoColumnSize = infoColumnSize - subtotalColumnSize %}
+                    {% endif %}
+
                     <div class="order-detail-content-header" aria-hidden="true">
                         <div class="row">
                             {% block page_account_order_item_detail_table_header_name %}
-                                <div class="col-6 order-detail-content-header-cell order-header-name">
+                                <div class="col-{{ infoColumnSize }} order-detail-content-header-cell order-header-name">
                                     {{ 'account.orderItemColumnName'|trans|sw_sanitize }}
                                 </div>
                             {% endblock %}
@@ -24,16 +37,33 @@
                                 </div>
                             {% endblock %}
 
-                            {% block page_account_order_item_detail_table_header_price %}
-                                <div class="col-2 order-detail-content-header-cell order-header-price">
-                                    {{ 'account.orderItemColumnPrice'|trans|sw_sanitize }}
-                                </div>
-                            {% endblock %}
+                            {% if showTaxPrice %}
+                                {% block component_checkout_cart_header_tax_price %}
+                                    <div class="col-2 order-detail-content-header-cell order-header-tax-price">
+                                        {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                            {% if context.taxState == 'gross' %}
+                                                {{ 'checkout.cartHeaderTaxIncludeVat'|trans|sw_sanitize }}
+                                            {% else %}
+                                                {{ 'checkout.cartHeaderTaxExcludeVat'|trans|sw_sanitize }}
+                                            {% endif %}
+                                        {% endif %}
+                                    </div>
+                                {% endblock %}
+                            {% else %}
+                                {# @deprecated tag:v6.8.0 - Will only be rendered, if the "core.cart.columnTaxInsteadUnitPrice" config is false #}
+                                {% block page_account_order_item_detail_table_header_price %}
+                                    <div class="col-2 order-detail-content-header-cell order-header-price">
+                                        {{ 'account.orderItemColumnPrice'|trans|sw_sanitize }}
+                                    </div>
+                                {% endblock %}
+                            {% endif %}
 
                             {% block page_account_order_item_detail_table_header_total %}
-                                <div class="col-2 order-detail-content-header-cell order-header-total">
-                                    {{ 'account.orderItemColumnTotal'|trans|sw_sanitize }}
-                                </div>
+                                {% if showSubtotal %}
+                                    <div class="col-{{ subtotalColumnSize }} order-detail-content-header-cell order-header-total">
+                                        {{ 'account.orderItemColumnTotal'|trans|sw_sanitize }}
+                                    </div>
+                                {% endif %}
                             {% endblock %}
                         </div>
                     </div>
@@ -41,7 +71,10 @@
 
                 {% block page_account_order_item_detail_table_body %}
                     <div class="order-detail-content-body">
-                        {% sw_include '@Storefront/storefront/page/account/order-history/order-detail-list.html.twig' %}
+                        {% sw_include '@Storefront/storefront/page/account/order-history/order-detail-list.html.twig' with {
+                            showTaxPrice: showTaxPrice,
+                            showSubtotal: showSubtotal
+                        } %}
                     </div>
                 {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% set orderState = page.order.stateMachineState.technicalName %}
+{% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
 
 {% block page_checkout_confirm_header %}
     {% if page.errorCode == 'CHECKOUT__CUSTOMER_CANCELED_EXTERNAL_PAYMENT' %}
@@ -66,7 +67,7 @@
 
 {% block page_checkout_confirm_table_header %}
     {% sw_include '@Storefront/storefront/component/checkout/cart-header.html.twig' with {
-        showTaxPrice: true,
+        showTaxPrice: showTaxPrice,
         showRemoveColumn: false
     } %}
 {% endblock %}
@@ -76,7 +77,7 @@
         {% block page_checkout_confirm_table_item %}
             {% sw_include '@Storefront/storefront/component/line-item/line-item.html.twig' with {
                 redirectTo: 'frontend.checkout.confirm.page',
-                showTaxPrice: true,
+                showTaxPrice: showTaxPrice,
                 showRemoveButton: false
             } %}
         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
@@ -6,6 +6,7 @@
 
 {% set orderState = page.order.stateMachineState.technicalName %}
 {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+{% set showSubtotal = config('core.cart.showSubtotal') %}
 
 {% block page_checkout_confirm_header %}
     {% if page.errorCode == 'CHECKOUT__CUSTOMER_CANCELED_EXTERNAL_PAYMENT' %}
@@ -68,7 +69,8 @@
 {% block page_checkout_confirm_table_header %}
     {% sw_include '@Storefront/storefront/component/checkout/cart-header.html.twig' with {
         showTaxPrice: showTaxPrice,
-        showRemoveColumn: false
+        showRemoveColumn: false,
+        showSubtotal: showSubtotal
     } %}
 {% endblock %}
 
@@ -78,7 +80,8 @@
             {% sw_include '@Storefront/storefront/component/line-item/line-item.html.twig' with {
                 redirectTo: 'frontend.checkout.confirm.page',
                 showTaxPrice: showTaxPrice,
-                showRemoveButton: false
+                showRemoveButton: false,
+                showSubtotal: showSubtotal
             } %}
         {% endblock %}
     {% endfor %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -31,17 +31,23 @@
         {% endblock %}
 
         {% block page_checkout_cart_product_table %}
+            {% set showSubtotal = config('core.cart.showSubtotal') %}
+
             <div class="card checkout-product-table">
                 <ul class="card-body list-unstyled">
                     {% block page_checkout_cart_table_header %}
-                        {% sw_include '@Storefront/storefront/component/checkout/cart-header.html.twig' %}
+                        {% sw_include '@Storefront/storefront/component/checkout/cart-header.html.twig' with {
+                            showSubtotal: showSubtotal
+                        } %}
                     {% endblock %}
 
                     {% block page_checkout_cart_table_items %}
                         {% for lineItem in page.cart.lineItems %}
                             {% block page_checkout_cart_table_item %}
                                 {% block page_checkout_item %}
-                                    {% sw_include '@Storefront/storefront/component/line-item/line-item.html.twig' %}
+                                    {% sw_include '@Storefront/storefront/component/line-item/line-item.html.twig' with {
+                                        showSubtotal: showSubtotal
+                                    } %}
                                 {% endblock %}
                             {% endblock %}
                         {% endfor %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -31,10 +31,10 @@
         {% endblock %}
 
         {% block page_checkout_cart_product_table %}
-            {# @deprecated tag:v6.8.0 - Will listing to new core.cart.columnTaxInsteadUnitPrice config #}
-            {% set showTaxPrice = false %}
-            {% if feature('v6.8.0.0') %}
-                {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+            {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+            {# @deprecated tag:v6.8.0 - Will listening to core.cart.columnTaxInsteadUnitPrice instead #}
+            {% if not feature('v6.8.0.0') %}
+                {% set showTaxPrice = false %}
             {% endif %}
             {% set showSubtotal = config('core.cart.showSubtotal') %}
 

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -31,13 +31,19 @@
         {% endblock %}
 
         {% block page_checkout_cart_product_table %}
+            {# @deprecated tag:v6.8.0 - Will listing to new core.cart.columnTaxInsteadUnitPrice config #}
+            {% set showTaxPrice = false %}
+            {% if feature('v6.8.0.0') %}
+                {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+            {% endif %}
             {% set showSubtotal = config('core.cart.showSubtotal') %}
 
             <div class="card checkout-product-table">
                 <ul class="card-body list-unstyled">
                     {% block page_checkout_cart_table_header %}
                         {% sw_include '@Storefront/storefront/component/checkout/cart-header.html.twig' with {
-                            showSubtotal: showSubtotal
+                            showSubtotal: showSubtotal,
+                            showTaxPrice: showTaxPrice
                         } %}
                     {% endblock %}
 
@@ -46,7 +52,8 @@
                             {% block page_checkout_cart_table_item %}
                                 {% block page_checkout_item %}
                                     {% sw_include '@Storefront/storefront/component/line-item/line-item.html.twig' with {
-                                        showSubtotal: showSubtotal
+                                        showSubtotal: showSubtotal,
+                                        showTaxPrice: showTaxPrice
                                     } %}
                                 {% endblock %}
                             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -6,6 +6,9 @@
 
 {% block base_navigation %}{% endblock %}
 
+{% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+{% set showSubtotal = config('core.cart.showSubtotal') %}
+
 {% block page_checkout_main_content %}
     {% block page_checkout_confirm %}
         {% block page_checkout_confirm_header %}
@@ -139,7 +142,8 @@
                         <ul class="card-body list-unstyled">
                             {% block page_checkout_confirm_table_header %}
                                 {% sw_include '@Storefront/storefront/component/checkout/cart-header.html.twig' with {
-                                    showTaxPrice: true
+                                    showTaxPrice: showTaxPrice,
+                                    showSubtotal: showSubtotal
                                 } %}
                             {% endblock %}
 
@@ -148,7 +152,8 @@
                                     {% block page_checkout_confirm_table_item %}
                                         {% sw_include '@Storefront/storefront/component/line-item/line-item.html.twig' with {
                                             redirectTo: 'frontend.checkout.confirm.page',
-                                            showTaxPrice: true
+                                            showTaxPrice: showTaxPrice,
+                                            showSubtotal: showSubtotal
                                         } %}
                                     {% endblock %}
                                 {% endfor %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig
@@ -6,6 +6,9 @@
 
 {% block base_navigation %}{% endblock %}
 
+{% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
+{% set showSubtotal = config('core.cart.showSubtotal') %}
+
 {% block page_checkout_main_content %}
     {% block page_checkout_finish %}
         {% block page_checkout_finish_details %}
@@ -17,8 +20,9 @@
                 <ul class="card-body list-unstyled">
                     {% block page_checkout_finish_table_header %}
                         {% sw_include '@Storefront/storefront/component/checkout/cart-header.html.twig' with {
-                            showTaxPrice: true,
-                            showRemoveColumn: false
+                            showTaxPrice: showTaxPrice,
+                            showRemoveColumn: false,
+                            showSubtotal: showSubtotal
                         } %}
                     {% endblock %}
 
@@ -27,8 +31,9 @@
                             {% block page_checkout_finish_item %}
                                 {% sw_include '@Storefront/storefront/component/line-item/line-item.html.twig' with {
                                     redirectTo: 'frontend.checkout.confirm.page',
-                                    showTaxPrice: true,
-                                    showRemoveButton: false
+                                    showTaxPrice: showTaxPrice,
+                                    showRemoveButton: false,
+                                    showSubtotal: showSubtotal
                                 } %}
                             {% endblock %}
                         {% endfor %}

--- a/tests/migration/Core/V6_7/Migration1743064966CartConfigSubtotalTaxColumnTest.php
+++ b/tests/migration/Core/V6_7/Migration1743064966CartConfigSubtotalTaxColumnTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1743064966CartConfigSubtotalTaxColumn;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1743064966CartConfigSubtotalTaxColumn::class)]
+class Migration1743064966CartConfigSubtotalTaxColumnTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testSubtotalMigration(): void
+    {
+        $this->migrationTest('core.cart.showSubtotal');
+    }
+
+    public function testTaxInsteadUnitPriceMigration(): void
+    {
+        $this->migrationTest('core.cart.columnTaxInsteadUnitPrice');
+    }
+
+    private function migrationTest(string $key): void
+    {
+        $connection = self::getContainer()->get(Connection::class);
+
+        $connection->delete('system_config', ['configuration_key' => $key]);
+
+        $migration = new Migration1743064966CartConfigSubtotalTaxColumn();
+        $migration->update($connection);
+        $migration->update($connection);
+
+        $newConfiguration = $connection->fetchAllKeyValue(
+            'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
+            [$key]
+        );
+        $id = array_key_first($newConfiguration);
+
+        static::assertCount(1, $newConfiguration);
+        static::assertEquals('{"_value": true}', $newConfiguration[$id]);
+
+        $connection->update(
+            'system_config',
+            [
+                'configuration_value' => '{"_value": false}',
+            ],
+            ['id' => Uuid::fromHexToBytes((string) $id)]
+        );
+
+        $migration->update($connection);
+
+        $newConfiguration = $connection->fetchAllKeyValue(
+            'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
+            [$key]
+        );
+        $id = array_key_first($newConfiguration);
+
+        static::assertCount(1, $newConfiguration);
+        static::assertEquals('{"_value": false}', $newConfiguration[$id]);
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1743064966CartConfigSubtotalTaxColumnTest.php
+++ b/tests/migration/Core/V6_7/Migration1743064966CartConfigSubtotalTaxColumnTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -19,17 +20,8 @@ class Migration1743064966CartConfigSubtotalTaxColumnTest extends TestCase
 {
     use KernelTestBehaviour;
 
-    public function testSubtotalMigration(): void
-    {
-        $this->migrationTest('core.cart.showSubtotal');
-    }
-
-    public function testTaxInsteadUnitPriceMigration(): void
-    {
-        $this->migrationTest('core.cart.columnTaxInsteadUnitPrice');
-    }
-
-    private function migrationTest(string $key): void
+    #[DataProvider('migrationData')]
+    public function testMigration(string $key): void
     {
         $connection = self::getContainer()->get(Connection::class);
 
@@ -39,32 +31,48 @@ class Migration1743064966CartConfigSubtotalTaxColumnTest extends TestCase
         $migration->update($connection);
         $migration->update($connection);
 
-        $newConfiguration = $connection->fetchAllKeyValue(
-            'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
-            [$key]
-        );
+        $newConfiguration = $this->getConditionValues($key);
         $id = array_key_first($newConfiguration);
 
         static::assertCount(1, $newConfiguration);
-        static::assertEquals('{"_value": true}', $newConfiguration[$id]);
+        static::assertSame(['_value' => true], $newConfiguration[$id]);
 
         $connection->update(
             'system_config',
-            [
-                'configuration_value' => '{"_value": false}',
-            ],
+            ['configuration_value' => '{"_value": false}'],
             ['id' => Uuid::fromHexToBytes((string) $id)]
         );
 
         $migration->update($connection);
 
-        $newConfiguration = $connection->fetchAllKeyValue(
-            'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
-            [$key]
-        );
+        $newConfiguration = $this->getConditionValues($key);
         $id = array_key_first($newConfiguration);
 
         static::assertCount(1, $newConfiguration);
-        static::assertEquals('{"_value": false}', $newConfiguration[$id]);
+        static::assertSame(['_value' => false], $newConfiguration[$id]);
+    }
+
+    public static function migrationData(): \Generator
+    {
+        yield 'test with showSubtotal' => [
+            'key' => 'core.cart.showSubtotal',
+        ];
+        yield 'test with column TaxInsteadUnitPrice' => [
+            'key' => 'core.cart.columnTaxInsteadUnitPrice',
+        ];
+    }
+
+    /**
+     * @return array<string, array{'_value': bool}>
+     */
+    private function getConditionValues(string $key): array
+    {
+        return array_map(
+            static fn (string $json) => json_decode($json, true),
+            static::getContainer()->get(Connection::class)->fetchAllKeyValue(
+                'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = :key',
+                ['key' => $key],
+            )
+        );
     }
 }


### PR DESCRIPTION
closes: #7482

**User story**

As a U.S. merchant
I want to be able to change the columns shown for a line-item
so that the solely line-item quantity and unit price can be shown (no tax rates)

**Acceptance criteria**
- Add a toggle "show subtotal for each line item" to Settings > Cart settings to change the visibility of the subtotal column on the cart and confirm page
- Add a toggle "show unit price instead of taxes per line item" to Settings > Cart settings to change the visibility of the tax rate column on the confirm page