### PR TITLE
fix: Allow javascript plugins to be registered on document

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin-system/plugin.manager.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin-system/plugin.manager.js
@@ -66,7 +66,7 @@ class PluginManagerSingleton {
      *
      * @param {string} pluginName
      * @param {Plugin} pluginClass
-     * @param {string|NodeList|HTMLElement} selector
+     * @param {string|NodeList|HTMLElement|HTMLDocument} selector
      * @param {Object} options
      *
      * @returns {*}
@@ -190,7 +190,7 @@ class PluginManagerSingleton {
      * @returns {Map|null}
      */
     static getPluginInstancesFromElement(el) {
-        if (!(el instanceof HTMLElement)) {
+        if (!(el instanceof Node)) {
             throw new Error('Passed element is not an Html element!');
         }
 
@@ -279,7 +279,7 @@ class PluginManagerSingleton {
 
                 let selector = entry.selector;
 
-                if (selector instanceof HTMLElement) {
+                if (selector instanceof Node) {
                     queue.push({ pluginName: pluginName, pluginClassPromise: plugin.get('class') });
                     continue;
                 }
@@ -330,7 +330,7 @@ class PluginManagerSingleton {
         }
 
         let needsFetch = false;
-        if (selector instanceof HTMLElement) {
+        if (selector instanceof Node) {
             needsFetch = true;
         }
 
@@ -394,7 +394,7 @@ class PluginManagerSingleton {
      * @param {string} pluginName
      */
     _initializePlugin(pluginClass, selector, options, pluginName = false) {
-        if (selector instanceof HTMLElement) {
+        if (selector instanceof Node) {
             return PluginManagerSingleton._initializePluginOnElement(selector, pluginClass, options, pluginName);
         }
 

--- a/src/Storefront/Resources/app/storefront/test/plugin-system/plugin.manager.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin-system/plugin.manager.test.js
@@ -152,6 +152,32 @@ describe('Plugin manager', () => {
         PluginManager.deregister('FooPluginClassDataAttr', selector);
     });
 
+    it('should initialize plugin with node selector', async () => {
+
+        PluginManager.register('FooPluginClassOnDocument', FooPluginClass, document);
+
+        await PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPluginClassOnDocument').length).toBe(1);
+
+        expect(PluginManager.getPluginInstances('FooPluginClassOnDocument')[0]._initialized).toBe(true);
+
+        PluginManager.deregister('FooPluginClassOnDocument');
+    });
+
+    it('should initialize plugin with no selector (fallback to document)', async () => {
+
+        PluginManager.register('FooPluginClassWithoutSelector', FooPluginClass);
+
+        await PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPluginClassWithoutSelector').length).toBe(1);
+
+        expect(PluginManager.getPluginInstances('FooPluginClassWithoutSelector')[0]._initialized).toBe(true);
+
+        PluginManager.deregister('FooPluginClassWithoutSelector');
+    });
+
     it('should initialize plugin with async import', async () => {
         const asyncImport = new Promise((resolve) => {
             resolve({ default: AsyncPluginClass });


### PR DESCRIPTION
### 1. Why is this change necessary?

Due to the internal removal of the DomAccess helper the checks in the plugin manager were changed, which currently prevents plugins from being registered on the global `document`.

### 2. What does this change do, exactly?

Fixed the `instanceof` checks to also allow higher level nodes like `document` to be used as plugin targets.
