### PR TITLE
fix: nightly build migration tests

### DIFF
--- a/tests/migration/Core/V6_7/Migration1742897274RegistrationSalutationToggleConfigTest.php
+++ b/tests/migration/Core/V6_7/Migration1742897274RegistrationSalutationToggleConfigTest.php
@@ -29,14 +29,11 @@ class Migration1742897274RegistrationSalutationToggleConfigTest extends TestCase
         $migration->update($connection);
         $migration->update($connection);
 
-        $newConfiguration = $connection->fetchAllKeyValue(
-            'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
-            ['core.loginRegistration.showSalutation']
-        );
+        $newConfiguration = $this->getConditionValues();
         $id = array_key_first($newConfiguration);
 
         static::assertCount(1, $newConfiguration);
-        static::assertEquals('{"_value": true}', $newConfiguration[$id]);
+        static::assertSame(['_value' => true], $newConfiguration[$id]);
 
         $connection->update(
             'system_config',
@@ -48,13 +45,24 @@ class Migration1742897274RegistrationSalutationToggleConfigTest extends TestCase
 
         $migration->update($connection);
 
-        $newConfiguration = $connection->fetchAllKeyValue(
-            'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
-            ['core.loginRegistration.showSalutation']
-        );
+        $newConfiguration = $this->getConditionValues();
         $id = array_key_first($newConfiguration);
 
         static::assertCount(1, $newConfiguration);
-        static::assertEquals('{"_value": false}', $newConfiguration[$id]);
+        static::assertSame(['_value' => false], $newConfiguration[$id]);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function getConditionValues(): array
+    {
+        return array_map(
+            function (string $json) { return json_decode($json, true); },
+            static::getContainer()->get(Connection::class)->fetchAllKeyValue(
+                'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
+                ['core.loginRegistration.showSalutation'],
+            )
+        );
     }
 }


### PR DESCRIPTION
Since https://github.com/shopware/shopware/pull/7882 the nightly build is failing for mariadb migration steps

https://github.com/shopware/shopware/actions/runs/14096914501/job/39485902792
https://github.com/shopware/shopware/actions/runs/14096914501/job/39485903162

A Nightly build will be triggered manually to check, as migration job only runs over MySQL 8.0 prior merge (that's why it wasn't caught earlier) https://github.com/shopware/shopware/actions/runs/14108857932