### PR TITLE
chore: Added part about the not anymore needed `setTwig` method

### DIFF
--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -2547,6 +2547,11 @@ foreach($storefrontPluginConfig->getAssetPaths() as $relativePath) {
 }
 ```
 
+## Removal of `setTwig` method in `StorefrontController`
+The method `Shopware\Storefront\Controller\StorefrontController::setTwig` has been removed.
+Remove the `setTwig` call from the services config files.
+There is no further change required.
+
 ## Removal of deprecated product review loading logic in Storefront
 * The service `\Shopware\Storefront\Page\Product\Review\ProductReviewLoader` was removed. Use `\Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewLoader` instead.
 * The event `\Shopware\Storefront\Page\Product\Review\ProductReviewsLoadedEvent` was removed. Use `\Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent` instead.


### PR DESCRIPTION
### 1. Why is this change necessary?

Entry about that breaking change is missing

### 2. What does this change do, exactly?

Add the entry

### 3. Describe each step to reproduce the issue or behaviour.

Do not remove this in your plugin and wonder why it is not compatible with SW 6.7

### 4. Please link to the relevant issues (if any).

https://shopwarecommunity.slack.com/archives/C088R4V0R9P/p1743073109775419
