### PR TITLE
feat: save file hash if it is available

### DIFF
--- a/changelog/_unreleased/2025-03-28-save-file-hash-if-it-is-available.md
+++ b/changelog/_unreleased/2025-03-28-save-file-hash-if-it-is-available.md
@@ -5,4 +5,4 @@ author_email: sascha.heilmeier@netlogix.de
 author_github: @scarbous
 ---
 # Core
-* Added map `fileHash` independent of a  `MetadataLoaderInterface` is supported
+* Added save `fileHash` independent of used `MetadataLoader` in media metadata

--- a/changelog/_unreleased/2025-03-28-save-file-hash-if-it-is-available.md
+++ b/changelog/_unreleased/2025-03-28-save-file-hash-if-it-is-available.md
@@ -5,4 +5,4 @@ author_email: sascha.heilmeier@netlogix.de
 author_github: @scarbous
 ---
 # Core
-* Added save `fileHash` independent of used `MetadataLoader` in media metadata
+* Added saving of `fileHash` independently of the `MetadataLoader`, ensuring it is stored in media metadata, not just images.

--- a/changelog/_unreleased/2025-03-28-save-file-hash-if-it-is-available.md
+++ b/changelog/_unreleased/2025-03-28-save-file-hash-if-it-is-available.md
@@ -1,0 +1,8 @@
+---
+title: save fileHash if it is available
+author: Sascha Heilmeier
+author_email: sascha.heilmeier@netlogix.de
+author_github: @scarbous
+---
+# Core
+* Added map `fileHash` independent of a  `MetadataLoaderInterface` is supported

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -601,11 +601,6 @@ parameters:
 			path: src/Core/Content/Media/Message/DeleteFileMessage.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Metadata\\\\MetadataLoader\\:\\:loadFromFile\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/Media/Metadata/MetadataLoader.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\TypeDetector\\\\TypeDetector\\:\\:detect\\(\\) should return Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType but returns Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType\\|null\\.$#"
 			count: 1
 			path: src/Core/Content/Media/TypeDetector/TypeDetector.php

--- a/src/Core/Content/Media/Metadata/MetadataLoader.php
+++ b/src/Core/Content/Media/Metadata/MetadataLoader.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\Content\Media\Metadata;
 
@@ -13,9 +11,9 @@ use Shopware\Core\Framework\Log\Package;
 class MetadataLoader
 {
     /**
-     * @param MetadataLoaderInterface[] $metadataLoader
      * @internal
      *
+     * @param MetadataLoaderInterface[] $metadataLoader
      */
     public function __construct(private readonly iterable $metadataLoader)
     {

--- a/src/Core/Content/Media/Metadata/MetadataLoader.php
+++ b/src/Core/Content/Media/Metadata/MetadataLoader.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopware\Core\Content\Media\Metadata;
 
@@ -11,28 +13,31 @@ use Shopware\Core\Framework\Log\Package;
 class MetadataLoader
 {
     /**
+     * @param MetadataLoaderInterface[] $metadataLoader
      * @internal
      *
-     * @param MetadataLoaderInterface[] $metadataLoader
      */
     public function __construct(private readonly iterable $metadataLoader)
     {
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
     public function loadFromFile(MediaFile $mediaFile, MediaType $mediaType): ?array
     {
+        $metaData = [];
         foreach ($this->metadataLoader as $loader) {
             if ($loader->supports($mediaType)) {
                 $metaData = $loader->extractMetadata($mediaFile->getFileName());
-
-                if ($mediaFile->getHash()) {
-                    $metaData['hash'] = $mediaFile->getHash();
-                }
-
-                return $metaData;
+                break;
             }
         }
 
-        return null;
+        if ($mediaFile->getHash()) {
+            $metaData['hash'] = $mediaFile->getHash();
+        }
+
+        return $metaData ?: null;
     }
 }

--- a/tests/unit/Core/Content/Media/Metadata/MetadataLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Metadata/MetadataLoaderTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media\Metadata;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\File\MediaFile;
+use Shopware\Core\Content\Media\MediaType\AudioType;
+use Shopware\Core\Content\Media\MediaType\BinaryType;
+use Shopware\Core\Content\Media\MediaType\DocumentType;
+use Shopware\Core\Content\Media\MediaType\ImageType;
+use Shopware\Core\Content\Media\MediaType\MediaType;
+use Shopware\Core\Content\Media\MediaType\SpatialObjectType;
+use Shopware\Core\Content\Media\MediaType\VideoType;
+use Shopware\Core\Content\Media\Metadata\MetadataLoader;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(MetadataLoader::class)]
+class MetadataLoaderTest extends TestCase
+{
+    public static function fileTypeDataProvider(): iterable
+    {
+        yield 'ImageType' => [
+            new MediaFile(
+                'foo.bar',
+                'image/jpeg',
+                'jpg',
+                123,
+                'image_md5',
+            ),
+            new ImageType(),
+            [
+                'hash' => 'image_md5',
+            ],
+        ];
+
+        yield 'ImageType with metaData' => [
+            new MediaFile(
+                'foo.bar',
+                'image/jpeg',
+                'jpg',
+                123,
+                'image_md5',
+            ),
+            new ImageType(),
+            [
+                'type' => \IMAGETYPE_JPEG,
+                'width' => 1530,
+                'height' => 1021,
+                'hash' => 'image_md5',
+            ],
+            true,
+            [
+                'type' => \IMAGETYPE_JPEG,
+                'width' => 1530,
+                'height' => 1021,
+            ],
+        ];
+        yield 'AudioType' => [
+            new MediaFile(
+                'foo.bar',
+                'audio/mpeg',
+                'mp3',
+                123,
+                'audio_md5',
+            ),
+            new AudioType(),
+            [
+                'hash' => 'audio_md5',
+            ],
+        ];
+
+        yield 'VideoType' => [
+            new MediaFile(
+                'foo.bar',
+                'video/mp4',
+                'mp4',
+                123,
+                'video_md5',
+            ),
+            new VideoType(),
+            [
+                'hash' => 'video_md5',
+            ],
+        ];
+
+        yield 'SpatialObjectType' => [
+            new MediaFile(
+                'foo.bar',
+                'application/vnd.google-earth.kml+xml',
+                'kml',
+                123,
+                'spatial_md5',
+            ),
+            new SpatialObjectType(),
+            [
+                'hash' => 'spatial_md5',
+            ],
+        ];
+
+        yield 'DocumentType' => [
+            new MediaFile(
+                'foo.bar',
+                'application/pdf',
+                'pdf',
+                123,
+                'document_md5',
+            ),
+            new DocumentType(),
+            [
+                'hash' => 'document_md5',
+            ],
+        ];
+
+        yield 'BinaryType' => [
+            new MediaFile(
+                'foo.bar',
+                'application/octet-stream',
+                'bin',
+                123,
+                'binary_md5',
+            ),
+            new BinaryType(),
+            [
+                'hash' => 'binary_md5',
+            ],
+        ];
+
+        yield 'BinaryType - without hash' => [
+            new MediaFile(
+                'foo.bar',
+                'application/octet-stream',
+                'bin',
+                123
+            ),
+            new BinaryType(),
+            null,
+        ];
+    }
+
+    #[DataProvider('fileTypeDataProvider')]
+    public function testLoadFromFile(
+        MediaFile $file,
+        MediaType $type,
+        ?array $expected,
+        bool $supports = false,
+        ?array $extractMetadata = null,
+    ): void {
+        $loader = $this->createMock(MetadataLoader\MetadataLoaderInterface::class);
+        $loader->expects($this->once())
+            ->method('supports')
+            ->willReturn($supports);
+        if ($supports) {
+            $loader->expects($this->once())
+                ->method('extractMetadata')
+                ->with($file->getFileName())
+                ->willReturn($extractMetadata);
+        }
+
+        $metadataLoader = new MetadataLoader(new \ArrayIterator([$loader]));
+
+        $metadata = $metadataLoader->loadFromFile($file, $type);
+
+        static::assertEquals($expected, $metadata);
+    }
+}

--- a/tests/unit/Core/Content/Media/Metadata/MetadataLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Metadata/MetadataLoaderTest.php
@@ -25,7 +25,7 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(MetadataLoader::class)]
 class MetadataLoaderTest extends TestCase
 {
-    public static function fileTypeDataProvider(): iterable
+    public static function fileTypeDataProvider(): \Generator
     {
         yield 'ImageType' => [
             new MediaFile(
@@ -145,6 +145,10 @@ class MetadataLoaderTest extends TestCase
         ];
     }
 
+    /**
+     * @param array<string, string>|null $expected
+     * @param array<string, string>|null $extractMetadata
+     */
     #[DataProvider('fileTypeDataProvider')]
     public function testLoadFromFile(
         MediaFile $file,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
I want to check file changes using the hash value vie the API, but not all files have a hash value.

### 2. What does this change do, exactly?
The fileHash is generated for every file but gets only stored for images.
It saves the fileHash if it extists.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
Maybe the hash should mapped to fileHash from #6681

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
