### PR TITLE
fix: Changed `sw-checkbox-field` to `mt-checkbox` in the theme assignment modal

### DIFF
--- a/changelog/_unreleased/2025-03-28-replaced-sw-checkbox-field-component-by-mt-checkbox-in-theme-assignment.md
+++ b/changelog/_unreleased/2025-03-28-replaced-sw-checkbox-field-component-by-mt-checkbox-in-theme-assignment.md
@@ -1,0 +1,9 @@
+---
+title: Replaced `sw-checkbox-field` component by `mt-checkbox` in theme assignment
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the `sw-checkbox-field` component to the `mt-checkbox` component in the theme assignment in the administration and adjusted the corresponding styles
+* Changed the theme modal to preselect the currently active theme

--- a/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/view/sw-sales-channel-detail-theme/index.js
+++ b/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/view/sw-sales-channel-detail-theme/index.js
@@ -48,13 +48,7 @@ Component.register('sw-sales-channel-detail-theme', {
         'salesChannel.extensions.themes': {
             deep: true,
             handler() {
-                if (!this.salesChannel || !this.salesChannel.extensions || this.salesChannel.extensions.themes.length < 1) {
-                    return;
-                }
-
-                this.theme = this.salesChannel.extensions.themes[0];
-
-                this.getTheme(this.theme.id);
+                this.getTheme(this.salesChannel?.extensions?.themes[0]?.id);
             }
         }
     },
@@ -65,9 +59,7 @@ Component.register('sw-sales-channel-detail-theme', {
 
     methods: {
         createdComponent() {
-            if (!this.salesChannel ||
-                !this.salesChannel.extensions ||
-                this.salesChannel.extensions.themes.length < 1) {
+            if (!this.salesChannel?.extensions?.themes[0]) {
                 return;
             }
 

--- a/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/view/sw-sales-channel-detail-theme/sw-sales-channel-detail-theme.html.twig
+++ b/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/view/sw-sales-channel-detail-theme/sw-sales-channel-detail-theme.html.twig
@@ -17,6 +17,7 @@
                     {% block sw_sales_channel_detail_theme_modal %}
                         <sw-theme-modal
                             v-if="showThemeSelectionModal"
+                            :selected-theme-id="theme?.id"
                             @modal-theme-select="onChangeTheme"
                             @modal-close="closeThemeModal">
                         </sw-theme-modal>

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/index.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/index.js
@@ -17,6 +17,14 @@ Component.register('sw-theme-modal', {
         Mixin.getByName('listing')
     ],
 
+    props: {
+        selectedThemeId: {
+            type: String,
+            default: null,
+            required: false,
+        },
+    },
+
     data() {
         return {
             selected: null,
@@ -35,7 +43,15 @@ Component.register('sw-theme-modal', {
         }
     },
 
+    created() {
+        this.createdComponent();
+    },
+
     methods: {
+        createdComponent() {
+            this.selected = this.selectedThemeId;
+        },
+
         getList() {
             this.isLoading = true;
             const criteria = new Criteria(this.page, this.limit);

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/sw-theme-modal.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/sw-theme-modal.html.twig
@@ -34,7 +34,7 @@
                                 {% block sw_theme_modal_content_listing_item %}
 
                                     {% block sw_theme_modal_content_listing_item_checkbox %}
-                                        <sw-checkbox-field @update:value="onSelection(theme.id)" :value="theme.id === selected"></sw-checkbox-field>
+                                        <mt-checkbox @update:checked="onSelection(theme.id)" :checked="theme.id === selected" />
                                     {% endblock %}
 
                                     {% block sw_theme_modal_content_listing_item_inner %}

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/sw-theme-modal.scss
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/sw-theme-modal.scss
@@ -23,7 +23,7 @@
                 }
             }
 
-            .sw-field--checkbox {
+            .mt-field--checkbox {
                 margin: 0;
                 width: 16px;
                 position: absolute;


### PR DESCRIPTION
### 1. Why is this change necessary?
There are bugs which happen in the current `trunk` branch:
1. The checkbox is not properly styled: ![image](https://github.com/user-attachments/assets/cc6a1b46-89cc-4698-abf7-3022e520e2fc)
2. When no theme is selected initially there is a JS error, when selecting one: ![image](https://github.com/user-attachments/assets/336cbd54-6fe2-407e-8d33-ff86f3846f21)

Furthermore there is bad UX, as the currently selected theme is not preselected inside the theme selection modal.

### 2. What does this change do, exactly?
Replace the component and styles, fix the "accessor bug" (not sure why the watched property in general is needed) and preselect the theme in the theme modal.

The two first bugs were introduced with the 6.7 however that the theme is not preselected is also present in 6.6.x not sure if that should be backported?

### 3. Describe each step to reproduce the issue or behaviour.
Select a theme.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
