### PR TITLE
fix: increase criteria limit for property groups

### DIFF
--- a/changelog/_unreleased/2025-03-31-fix-issue-where-criteria-limit-of-500-prevents-loading-admin-modules.md
+++ b/changelog/_unreleased/2025-03-31-fix-issue-where-criteria-limit-of-500-prevents-loading-admin-modules.md
@@ -1,0 +1,5 @@
+---
+title: Fix the issue where a criteria limit of 500 prevents loading admin modules
+---
+# Administration
+* Changed methods `loadGroups` and `loadConfigSettingGroups` in `sw-product-detail-variants` component to load all groups instead of only 500


### PR DESCRIPTION
### Actual behaviour:

We noticed an error, when we want open the "Storefront presentation"-Modal on a variant-product: 
the modal opens with continious loading-icon, but never gets a content. 

After some checks, we noticed that the method that loads the property groups loads only the first 500 property group items because of the configured limit of 500 items per request. We already have more than 1,900 property groups, and so opening the Storefront presentation for many variant products is not possible anymore.

### Expected behaviour:

The administration-modal should open correctly and all groups schould be loaded with their property-options.

### How to reproduce:

Create more than 500 property-groups with related options

Create a variant-product with a configurator-option whose property group is not included into the first 500 property-groups loaded via the api-call

when you now try to open the "Storefront presentation"-Modal over the administration, the modal will be shown, but content ist not loaded and loading-icon will not disappear.
