### PR TITLE
fix: sw-number-field-deprecated showing NaN when allowEmpty is true and the input is cleared

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/index.js
@@ -142,7 +142,7 @@ Component.extend('sw-number-field-deprecated', 'sw-text-field-deprecated', {
         },
 
         stringRepresentation() {
-            if (this.currentValue === null) {
+            if (this.currentValue === null || Number.isNaN(this.currentValue)) {
                 return '';
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The `sw-number-field-deprecated` shows `NaN` when `allowEmpty` prop is true and the input is cleared


### 2. What does this change do, exactly?
check in the computed string value if the value is NaN.


### 3. Describe each step to reproduce the issue or behaviour.
1. add a `<sw-number-field-deprecated allowEmpty>` to `sw-dashboard-index.html.twig`
2. run the project and go to Dashboard
3.  Type a number in the input
4. blur the input
5. click again and clear the input. then `NaN` is showed in the input


### 4. Please link to the relevant issues (if any).
closes #6459
