### PR TITLE
fix: sw-colorpicker is not updating value

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker/sw-colorpicker.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker/sw-colorpicker.html.twig
@@ -2,7 +2,7 @@
 <mt-colorpicker
     v-bind="$attrs"
     :model-value="currentValue"
-    @change="currentValue = $event"
+    @update:modelValue="currentValue = $event"
 >
     <template
         v-for="(index, name) in getSlots()"


### PR DESCRIPTION
### 1. Why is this change necessary?
The `sw-colorpicker` component does not update the value


### 2. What does this change do, exactly?
The `sw-colorpicker` was listening the `@change` event to update the value. But the meteor component used inside, is emitting `@update:modelValue`

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to `Content` > `Themes` and edit a theme
2. change any color in the form and save
3. The color is reset to previous value before the fix


### 4. Please link to the relevant issues (if any).

- relates #7941
