### PR TITLE
fix: meta information in landing pages is not inherited

### DIFF
--- a/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
+++ b/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
@@ -1,0 +1,7 @@
+---
+title: Meta information in landing pages is not inherited
+issue: #3712
+---
+# Storefront
+
+* Changes `LandingPageLoader` to retrieve meta information (metaTitle, metaDescription & keywords) through translations, for proper language inheritance

--- a/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
+++ b/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
@@ -7,3 +7,4 @@ author_github: @Songworks
 ---
 # Storefront
 * Changed `LandingPageLoader` to retrieve meta information (metaTitle, metaDescription & keywords) through translations, for proper language inheritance
+* Deprecates `PageNotFoundException` in `LandingPageLoader` for v6.8.0, in favour of `LandingPageException::notFound`

--- a/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
+++ b/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
@@ -1,6 +1,9 @@
 ---
 title: Meta information in landing pages is not inherited
-issue: #3712
+issue: https://github.com/shopware/shopware/issues/3712
+author: Stefan Reichelt
+author_email: stefan@kreativsoehne.de
+author_github: @Songworks
 ---
 # Storefront
 * Changed `LandingPageLoader` to retrieve meta information (metaTitle, metaDescription & keywords) through translations, for proper language inheritance

--- a/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
+++ b/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
@@ -3,5 +3,4 @@ title: Meta information in landing pages is not inherited
 issue: #3712
 ---
 # Storefront
-
-* Changes `LandingPageLoader` to retrieve meta information (metaTitle, metaDescription & keywords) through translations, for proper language inheritance
+* Changed `LandingPageLoader` to retrieve meta information (metaTitle, metaDescription & keywords) through translations, for proper language inheritance

--- a/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
+++ b/changelog/_unreleased/2025-03-27-meta-information-in-landing-pages-is-not-inherited.md
@@ -7,4 +7,4 @@ author_github: @Songworks
 ---
 # Storefront
 * Changed `LandingPageLoader` to retrieve meta information (metaTitle, metaDescription & keywords) through translations, for proper language inheritance
-* Deprecates `PageNotFoundException` in `LandingPageLoader` for v6.8.0, in favour of `LandingPageException::notFound`
+* Deprecated `PageNotFoundException` in `LandingPageLoader` for v6.8.0, in favour of `LandingPageException::notFound`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2662,11 +2662,6 @@ parameters:
 
 		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
-			path: src/Storefront/Page/LandingPage/LandingPageLoader.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 2
 			path: src/Storefront/Page/Maintenance/MaintenancePageLoader.php
 

--- a/src/Storefront/Page/LandingPage/LandingPageLoader.php
+++ b/src/Storefront/Page/LandingPage/LandingPageLoader.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Storefront\Page\LandingPage;
 
-use Shopware\Core\Content\Cms\Exception\PageNotFoundException;
+use Shopware\Core\Content\LandingPage\LandingPageException;
 use Shopware\Core\Content\LandingPage\SalesChannel\AbstractLandingPageRoute;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
@@ -28,9 +28,6 @@ class LandingPageLoader
     ) {
     }
 
-    /**
-     * @throws PageNotFoundException
-     */
     public function load(Request $request, SalesChannelContext $context): LandingPage
     {
         $landingPageId = $request->attributes->get('landingPageId');
@@ -41,7 +38,7 @@ class LandingPageLoader
         $landingPage = $this->landingPageRoute->load($landingPageId, $request, $context)->getLandingPage();
 
         if ($landingPage->getCmsPage() === null) {
-            throw new PageNotFoundException($landingPageId);
+            throw LandingPageException::notFound($landingPageId);
         }
 
         $page = $this->genericPageLoader->load($request, $context);

--- a/src/Storefront/Page/LandingPage/LandingPageLoader.php
+++ b/src/Storefront/Page/LandingPage/LandingPageLoader.php
@@ -2,8 +2,10 @@
 
 namespace Shopware\Storefront\Page\LandingPage;
 
+use Shopware\Core\Content\Cms\Exception\PageNotFoundException;
 use Shopware\Core\Content\LandingPage\LandingPageException;
 use Shopware\Core\Content\LandingPage\SalesChannel\AbstractLandingPageRoute;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -38,6 +40,11 @@ class LandingPageLoader
         $landingPage = $this->landingPageRoute->load($landingPageId, $request, $context)->getLandingPage();
 
         if ($landingPage->getCmsPage() === null) {
+            // @deprecated tag:v6.8.0 - remove this if block
+            if (!Feature::isActive('v6.8.0.0')) {
+                throw new PageNotFoundException($landingPageId); // @phpstan-ignore shopware.domainException
+            }
+
             throw LandingPageException::notFound($landingPageId);
         }
 

--- a/src/Storefront/Page/LandingPage/LandingPageLoader.php
+++ b/src/Storefront/Page/LandingPage/LandingPageLoader.php
@@ -49,11 +49,14 @@ class LandingPageLoader
 
         $page->setLandingPage($landingPage);
 
+        $metaTitle = $landingPage->getTranslation('metaTitle') ?? $landingPage->getTranslation('name');
+        $metaDescription = $landingPage->getTranslation('metaDescription');
+        $metaKeywords = $landingPage->getTranslation('keywords');
+
         $metaInformation = new MetaInformation();
-        $metaTitle = $landingPage->getMetaTitle() ?? $landingPage->getName();
-        $metaInformation->setMetaTitle($metaTitle ?? '');
-        $metaInformation->setMetaDescription($landingPage->getMetaDescription() ?? '');
-        $metaInformation->setMetaKeywords($landingPage->getKeywords() ?? '');
+        $metaInformation->setMetaTitle((string) $metaTitle);
+        $metaInformation->setMetaDescription((string) $metaDescription);
+        $metaInformation->setMetaKeywords((string) $metaKeywords);
         $page->setMetaInformation($metaInformation);
 
         $this->eventDispatcher->dispatch(

--- a/tests/integration/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/integration/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -4,9 +4,11 @@ namespace Shopware\Tests\Integration\Storefront\Page\LandingPage;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsPageEntity;
+use Shopware\Core\Content\Cms\Exception\PageNotFoundException;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
 use Shopware\Core\Content\LandingPage\LandingPageException;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -81,11 +83,20 @@ class LandingPageLoaderTest extends TestCase
     public function testLoadWithoutCmsPage(): void
     {
         $this->ids = new IdsCollection();
+        $landingPageId = $this->ids->create('landing-page');
 
         $request = new Request([], [], [
-            'landingPageId' => $this->ids->create('landing-page'),
+            'landingPageId' => $landingPageId,
         ]);
-        $this->expectExceptionObject(LandingPageException::notFound($this->ids->get('landing-page')));
+
+        $expectedException = LandingPageException::notFound($landingPageId);
+
+        // @deprecated tag:v6.8.0 - remove this if block
+        if (!Feature::isActive('v6.8.0.0')) {
+            $expectedException = new PageNotFoundException($landingPageId);
+        }
+
+        $this->expectExceptionObject($expectedException);
 
         $context = $this->createSalesChannelContextWithNavigation();
         $this->ids->set('sales-channel', $context->getSalesChannelId());

--- a/tests/integration/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/integration/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -4,7 +4,6 @@ namespace Shopware\Tests\Integration\Storefront\Page\LandingPage;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsPageEntity;
-use Shopware\Core\Content\Cms\Exception\PageNotFoundException;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
 use Shopware\Core\Content\LandingPage\LandingPageException;
 use Shopware\Core\Framework\Context;
@@ -86,7 +85,7 @@ class LandingPageLoaderTest extends TestCase
         $request = new Request([], [], [
             'landingPageId' => $this->ids->create('landing-page'),
         ]);
-        $this->expectExceptionObject(new PageNotFoundException($this->ids->get('landing-page')));
+        $this->expectExceptionObject(LandingPageException::notFound($this->ids->get('landing-page')));
 
         $context = $this->createSalesChannelContextWithNavigation();
         $this->ids->set('sales-channel', $context->getSalesChannelId());

--- a/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -115,6 +115,7 @@ class LandingPageLoaderTest extends TestCase
         $page = $landingPageLoader->load($request, $salesChannelContext);
         $metaInformation = $page->getMetaInformation();
 
+        static::assertNotNull($metaInformation);
         static::assertEquals($metaInformation->getMetaTitle(), $expected['metaTitle']);
         static::assertEquals($metaInformation->getMetaDescription(), $expected['metaDescription']);
         static::assertEquals($metaInformation->getMetaKeywords(), $expected['metaKeywords']);
@@ -141,6 +142,7 @@ class LandingPageLoaderTest extends TestCase
         $page = $landingPageLoader->load($request, $salesChannelContext);
         $metaInformation = $page->getMetaInformation();
 
+        static::assertNotNull($metaInformation);
         static::assertEquals($metaInformation->getMetaTitle(), $expected['metaTitle']);
         static::assertEquals($metaInformation->getMetaDescription(), $expected['metaDescription']);
         static::assertEquals($metaInformation->getMetaKeywords(), $expected['metaKeywords']);
@@ -165,6 +167,9 @@ class LandingPageLoaderTest extends TestCase
         );
     }
 
+    /**
+     * @param array<string> $translated
+     */
     private function getLandingPageLoaderWithTranslated(string $landingPageId, array $translated, Request $request, SalesChannelContext $salesChannelContext): LandingPageLoader
     {
         $productId = Uuid::randomHex();

--- a/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -93,13 +93,9 @@ class LandingPageLoaderTest extends TestCase
 
     public function testItLoadsProperPageMetaInformation(): void
     {
-        $productId = Uuid::randomHex();
         $landingPageId = Uuid::randomHex();
         $request = new Request([], [], ['landingPageId' => $landingPageId]);
         $salesChannelContext = $this->getSalesChannelContext();
-
-        $product = $this->getProduct($productId);
-        $cmsPage = $this->getCmsPage($product);
 
         $translated = [
             'name' => 'TEST_NAME',
@@ -114,7 +110,7 @@ class LandingPageLoaderTest extends TestCase
             'metaKeywords' => $translated['keywords'],
         ];
 
-        $landingPageLoader = $this->getLandingPageLoaderWithTranslations($landingPageId, $cmsPage, $translated, $request, $salesChannelContext);
+        $landingPageLoader = $this->getLandingPageLoaderWithTranslated($landingPageId, $translated, $request, $salesChannelContext);
 
         $page = $landingPageLoader->load($request, $salesChannelContext);
         $metaInformation = $page->getMetaInformation();
@@ -126,13 +122,9 @@ class LandingPageLoaderTest extends TestCase
 
     public function testItLoadsProperPageMetaInformationWithNameOnly(): void
     {
-        $productId = Uuid::randomHex();
         $landingPageId = Uuid::randomHex();
         $request = new Request([], [], ['landingPageId' => $landingPageId]);
         $salesChannelContext = $this->getSalesChannelContext();
-
-        $product = $this->getProduct($productId);
-        $cmsPage = $this->getCmsPage($product);
 
         $translated = [
             'name' => 'TEST_NAME',
@@ -144,7 +136,7 @@ class LandingPageLoaderTest extends TestCase
             'metaKeywords' => '',
         ];
 
-        $landingPageLoader = $this->getLandingPageLoaderWithTranslations($landingPageId, $cmsPage, $translated, $request, $salesChannelContext);
+        $landingPageLoader = $this->getLandingPageLoaderWithTranslated($landingPageId, $translated, $request, $salesChannelContext);
 
         $page = $landingPageLoader->load($request, $salesChannelContext);
         $metaInformation = $page->getMetaInformation();
@@ -173,8 +165,12 @@ class LandingPageLoaderTest extends TestCase
         );
     }
 
-    private function getLandingPageLoaderWithTranslations(string $landingPageId, CmsPageEntity $cmsPage, array $translated, Request $request, SalesChannelContext $salesChannelContext): LandingPageLoader
+    private function getLandingPageLoaderWithTranslated(string $landingPageId, array $translated, Request $request, SalesChannelContext $salesChannelContext): LandingPageLoader
     {
+        $productId = Uuid::randomHex();
+        $product = $this->getProduct($productId);
+        $cmsPage = $this->getCmsPage($product);
+
         $landingPage = new LandingPageEntity();
         $landingPage->setId($landingPageId);
         $landingPage->setCmsPage($cmsPage);

--- a/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -11,11 +11,13 @@ use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionEntity;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
 use Shopware\Core\Content\Cms\CmsPageEntity;
+use Shopware\Core\Content\Cms\Exception\PageNotFoundException;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
 use Shopware\Core\Content\LandingPage\LandingPageException;
 use Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute;
 use Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRouteResponse;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -68,7 +70,14 @@ class LandingPageLoaderTest extends TestCase
         $request = new Request([], [], ['landingPageId' => $landingPageId]);
         $salesChannelContext = $this->getSalesChannelContext();
 
-        static::expectExceptionObject(LandingPageException::notFound($landingPageId));
+        $expectedException = LandingPageException::notFound($landingPageId);
+
+        // @deprecated tag:v6.8.0 - remove this if block
+        if (!Feature::isActive('v6.8.0.0')) {
+            $expectedException = new PageNotFoundException($landingPageId);
+        }
+
+        static::expectExceptionObject($expectedException);
         $landingPageLoader->load($request, $salesChannelContext);
     }
 

--- a/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -91,11 +91,95 @@ class LandingPageLoaderTest extends TestCase
         static::assertEquals($cmsPage, $cmsPageLoaded);
     }
 
+    public function testItLoadsProperPageMetaInformation(): void
+    {
+        $productId = Uuid::randomHex();
+        $landingPageId = Uuid::randomHex();
+        $request = new Request([], [], ['landingPageId' => $landingPageId]);
+        $salesChannelContext = $this->getSalesChannelContext();
+
+        $product = $this->getProduct($productId);
+        $cmsPage = $this->getCmsPage($product);
+
+        $translated = [
+            'name' => 'TEST_NAME',
+            'metaTitle' => 'TEST_META_TITLE',
+            'metaDescription' => 'TEST_META_DESCRIPTION',
+            'keywords' => 'TEST_KEYWORDS',
+        ];
+
+        $expected = [
+            'metaTitle' => $translated['metaTitle'],
+            'metaDescription' => $translated['metaDescription'],
+            'metaKeywords' => $translated['keywords'],
+        ];
+
+        $landingPageLoader = $this->getLandingPageLoaderWithTranslations($landingPageId, $cmsPage, $translated, $request, $salesChannelContext);
+
+        $page = $landingPageLoader->load($request, $salesChannelContext);
+        $metaInformation = $page->getMetaInformation();
+
+        static::assertEquals($metaInformation->getMetaTitle(), $expected['metaTitle']);
+        static::assertEquals($metaInformation->getMetaDescription(), $expected['metaDescription']);
+        static::assertEquals($metaInformation->getMetaKeywords(), $expected['metaKeywords']);
+    }
+
+    public function testItLoadsProperPageMetaInformationWithNameOnly(): void
+    {
+        $productId = Uuid::randomHex();
+        $landingPageId = Uuid::randomHex();
+        $request = new Request([], [], ['landingPageId' => $landingPageId]);
+        $salesChannelContext = $this->getSalesChannelContext();
+
+        $product = $this->getProduct($productId);
+        $cmsPage = $this->getCmsPage($product);
+
+        $translated = [
+            'name' => 'TEST_NAME',
+        ];
+
+        $expected = [
+            'metaTitle' => $translated['name'],
+            'metaDescription' => '',
+            'metaKeywords' => '',
+        ];
+
+        $landingPageLoader = $this->getLandingPageLoaderWithTranslations($landingPageId, $cmsPage, $translated, $request, $salesChannelContext);
+
+        $page = $landingPageLoader->load($request, $salesChannelContext);
+        $metaInformation = $page->getMetaInformation();
+
+        static::assertEquals($metaInformation->getMetaTitle(), $expected['metaTitle']);
+        static::assertEquals($metaInformation->getMetaDescription(), $expected['metaDescription']);
+        static::assertEquals($metaInformation->getMetaKeywords(), $expected['metaKeywords']);
+    }
+
     private function getLandingPageLoaderWithProduct(string $landingPageId, CmsPageEntity $cmsPage, Request $request, SalesChannelContext $salesChannelContext): LandingPageLoader
     {
         $landingPage = new LandingPageEntity();
         $landingPage->setId($landingPageId);
         $landingPage->setCmsPage($cmsPage);
+
+        $landingPageRouteMock = $this->createMock(LandingPageRoute::class);
+        $landingPageRouteMock
+            ->method('load')
+            ->with($landingPageId, $request, $salesChannelContext)
+            ->willReturn(new LandingPageRouteResponse($landingPage));
+
+        return new LandingPageLoader(
+            $this->createMock(GenericPageLoader::class),
+            $landingPageRouteMock,
+            $this->createMock(EventDispatcherInterface::class)
+        );
+    }
+
+    private function getLandingPageLoaderWithTranslations(string $landingPageId, CmsPageEntity $cmsPage, array $translated, Request $request, SalesChannelContext $salesChannelContext): LandingPageLoader
+    {
+        $landingPage = new LandingPageEntity();
+        $landingPage->setId($landingPageId);
+        $landingPage->setCmsPage($cmsPage);
+        $landingPage->setTranslated($translated);
+        $landingPage->setName('INCORRECT_NAME');
 
         $landingPageRouteMock = $this->createMock(LandingPageRoute::class);
         $landingPageRouteMock

--- a/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Page\GenericPageLoader;
 use Shopware\Storefront\Page\LandingPage\LandingPageLoader;
+use Shopware\Storefront\Page\MetaInformation;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -88,7 +89,7 @@ class LandingPageLoaderTest extends TestCase
         /** @phpstan-ignore-next-line */
         $cmsPageLoaded = $page->getLandingPage()->getCmsPage();
 
-        static::assertEquals($cmsPage, $cmsPageLoaded);
+        static::assertSame($cmsPage, $cmsPageLoaded);
     }
 
     public function testItLoadsProperPageMetaInformation(): void
@@ -115,10 +116,10 @@ class LandingPageLoaderTest extends TestCase
         $page = $landingPageLoader->load($request, $salesChannelContext);
         $metaInformation = $page->getMetaInformation();
 
-        static::assertNotNull($metaInformation);
-        static::assertEquals($metaInformation->getMetaTitle(), $expected['metaTitle']);
-        static::assertEquals($metaInformation->getMetaDescription(), $expected['metaDescription']);
-        static::assertEquals($metaInformation->getMetaKeywords(), $expected['metaKeywords']);
+        static::assertInstanceOf(MetaInformation::class, $metaInformation);
+        static::assertSame($metaInformation->getMetaTitle(), $expected['metaTitle']);
+        static::assertSame($metaInformation->getMetaDescription(), $expected['metaDescription']);
+        static::assertSame($metaInformation->getMetaKeywords(), $expected['metaKeywords']);
     }
 
     public function testItLoadsProperPageMetaInformationWithNameOnly(): void
@@ -142,10 +143,10 @@ class LandingPageLoaderTest extends TestCase
         $page = $landingPageLoader->load($request, $salesChannelContext);
         $metaInformation = $page->getMetaInformation();
 
-        static::assertNotNull($metaInformation);
-        static::assertEquals($metaInformation->getMetaTitle(), $expected['metaTitle']);
-        static::assertEquals($metaInformation->getMetaDescription(), $expected['metaDescription']);
-        static::assertEquals($metaInformation->getMetaKeywords(), $expected['metaKeywords']);
+        static::assertInstanceOf(MetaInformation::class, $metaInformation);
+        static::assertSame($metaInformation->getMetaTitle(), $expected['metaTitle']);
+        static::assertSame($metaInformation->getMetaDescription(), $expected['metaDescription']);
+        static::assertSame($metaInformation->getMetaKeywords(), $expected['metaKeywords']);
     }
 
     private function getLandingPageLoaderWithProduct(string $landingPageId, CmsPageEntity $cmsPage, Request $request, SalesChannelContext $salesChannelContext): LandingPageLoader

--- a/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -11,8 +11,8 @@ use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionEntity;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
 use Shopware\Core\Content\Cms\CmsPageEntity;
-use Shopware\Core\Content\Cms\Exception\PageNotFoundException;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\LandingPage\LandingPageException;
 use Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute;
 use Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRouteResponse;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
@@ -68,7 +68,7 @@ class LandingPageLoaderTest extends TestCase
         $request = new Request([], [], ['landingPageId' => $landingPageId]);
         $salesChannelContext = $this->getSalesChannelContext();
 
-        static::expectExceptionObject(new PageNotFoundException($landingPageId));
+        static::expectExceptionObject(LandingPageException::notFound($landingPageId));
         $landingPageLoader->load($request, $salesChannelContext);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

LandingPage MetaInformation content (title, description & keywords) is retrieved in current translation only and never inherits from parent/system translation.

### 2. What does this change do, exactly?

LandingPage MetaInformation content (title, description & keywords) is retrieved through the Entity translated, therefore retrieving the content from current translation or, if empty, from parent/system translation.

### 3. Describe each step to reproduce the issue or behaviour.

* Setup (Administration):
    * Create a CMS Page/Shopping Experience (necessary for Frontend access)
        * No content required
    * Create a Landingpage in system language
        * Fill out required fields
        * Assign CMS Page
        * Fill out fields Name (or "Meta title"), "Meta description" & "SEO Keywords"

* Without Fix:
    * Open LandingPage Frontend in system language
        * HTML head meta-properties for title, description & keywords should contain contents in system language
    * Open LandingPage Frontend in child language
        * HTML head meta-properties for title, description & keywords should appear empty

* With Fix:
    * Open LandingPage Frontend in system language
        * Should be unchanged
    * Open LandingPage Frontend in child language
        * HTML head meta-properties for title, description & keywords should contain contents in system language


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/3712

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

Cheers!