### PR TITLE
feat: regulation price is displayed regardless equals with tax price

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Price/ProductPriceCalculator.php
+++ b/src/Core/Content/Product/SalesChannel/Price/ProductPriceCalculator.php
@@ -231,7 +231,8 @@ class ProductPriceCalculator extends AbstractProductPriceCalculator
 
         $taxPrice = $this->getPriceForTaxState($price, $context);
         $value = $this->getPriceForTaxState($price->getRegulationPrice(), $context);
-        if ($taxPrice === 0.0 || $taxPrice === $value) {
+
+        if ($taxPrice === 0.0) {
             return null;
         }
 

--- a/tests/unit/Core/Content/Product/SalesChannel/Price/ProductPriceCalculatorTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Price/ProductPriceCalculatorTest.php
@@ -78,11 +78,13 @@ class ProductPriceCalculatorTest extends TestCase
 
         static::assertInstanceOf(CalculatedPrice::class, $price);
 
-        static::assertEquals($expected->price, $price->getTotalPrice());
+        static::assertSame($expected->price, $price->getTotalPrice());
 
-        static::assertEquals($expected->reference, $price->getReferencePrice()?->getPrice());
+        static::assertSame($expected->reference, $price->getReferencePrice()?->getPrice());
 
-        static::assertEquals($expected->listPrice, $price->getListPrice()?->getPrice());
+        static::assertSame($expected->listPrice, $price->getListPrice()?->getPrice());
+
+        static::assertSame($expected->regulation, $price->getRegulationPrice()?->getPrice());
     }
 
     #[DataProvider('taxStateWillBeUsedProvider')]
@@ -101,7 +103,7 @@ class ProductPriceCalculatorTest extends TestCase
 
         static::assertInstanceOf(CalculatedPrice::class, $price);
 
-        static::assertEquals($expected, $price->getTotalPrice());
+        static::assertSame($expected, $price->getTotalPrice());
     }
 
     public static function taxStateWillBeUsedProvider(): \Generator
@@ -219,14 +221,20 @@ class ProductPriceCalculatorTest extends TestCase
             new PriceAssertion(1.0, null, null, 2.0),
         ];
 
-        yield 'Regulation price will be skipped when equals' => [
+        yield 'Regulation price will be not skipped when equals' => [
             (new PartialEntity())->assign([
                 'taxId' => Uuid::randomHex(),
                 'price' => new PriceCollection([
-                    new Price(Defaults::CURRENCY, 2, 2, false, null, null, new Price(Defaults::CURRENCY, 2, 2, false)),
+                    new Price(
+                        currencyId: Defaults::CURRENCY,
+                        net: 2,
+                        gross: 2,
+                        linked: false,
+                        regulationPrice: new Price(Defaults::CURRENCY, 2, 2, false)
+                    ),
                 ]),
             ]),
-            new PriceAssertion(2.0),
+            new PriceAssertion(2.0, null, null, 2.0),
         ];
     }
 
@@ -254,14 +262,14 @@ class ProductPriceCalculatorTest extends TestCase
 
         static::assertInstanceOf(CalculatedPriceCollection::class, $prices);
 
-        static::assertEquals(\count($expected), $prices->count());
+        static::assertSame(\count($expected), $prices->count());
 
         foreach ($expected as $index => $value) {
             static::assertTrue($prices->has($index));
 
             $price = $prices->get($index);
 
-            static::assertEquals($value, $price->getTotalPrice());
+            static::assertSame($value, $price->getTotalPrice());
         }
     }
 
@@ -345,11 +353,11 @@ class ProductPriceCalculatorTest extends TestCase
 
         static::assertInstanceOf(CalculatedCheapestPrice::class, $price);
 
-        static::assertEquals($expected->price, $price->getTotalPrice());
+        static::assertSame($expected->price, $price->getTotalPrice());
 
-        static::assertEquals($expected->reference, $price->getReferencePrice()?->getPrice());
+        static::assertSame($expected->reference, $price->getReferencePrice()?->getPrice());
 
-        static::assertEquals($expected->listPrice, $price->getListPrice()?->getPrice());
+        static::assertSame($expected->listPrice, $price->getListPrice()?->getPrice());
     }
 
     public static function cheapestPriceWillBeCalculatedProvider(): \Generator

--- a/tests/unit/Core/Content/Product/SalesChannel/Price/ProductPriceCalculatorTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Price/ProductPriceCalculatorTest.php
@@ -262,7 +262,7 @@ class ProductPriceCalculatorTest extends TestCase
 
         static::assertInstanceOf(CalculatedPriceCollection::class, $prices);
 
-        static::assertSame(\count($expected), $prices->count());
+        static::assertCount(\count($expected), $prices);
 
         foreach ($expected as $index => $value) {
             static::assertTrue($prices->has($index));


### PR DESCRIPTION
### 1. Why is this change necessary?

legal compliance

### 2. What does this change do, exactly?

always display the lowest price in the last 30 days whenever a price reduction is indicated (e.g., via a strike-through price), regardless of whether the lowest price equals the current price.

#### Before: The regulation price is not shown when its value equals with the tax price 

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/807b2468-5c1b-41b2-84ec-c5689b9e360d" /> 
<img width="339" alt="image" src="https://github.com/user-attachments/assets/d2b6397f-a348-4e24-8339-67b91d9b76ae" />

#### After: The regulation price is shown even its value equals with the tax price 

<img width="345" alt="image" src="https://github.com/user-attachments/assets/66675afa-6e10-4262-983d-a1b7a825f920" />
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/bdf089c6-cb4b-495e-a83b-187c9b783e20" />