### PR TITLE
fix: company address appearing twice

### DIFF
--- a/src/Core/Framework/Resources/views/documents/includes/letter_header.html.twig
+++ b/src/Core/Framework/Resources/views/documents/includes/letter_header.html.twig
@@ -15,10 +15,6 @@ All blocks of this template are available in the template which renders this tem
     <div class="letter-header">
         <div class="recipient-address-container" tabindex="0">
             {% block document_recipient %}
-                {% set address %}
-                    <span class="company-address-small">{{ addressParts|join(' - ') }}</span><br><br>
-                {% endset %}
-
                 {% sw_include '@Framework/snippets/render.html.twig' with {
                     format: billingAddress.country.translated.addressFormat,
                     address: billingAddress

--- a/src/Core/Framework/Resources/views/documents/includes/letter_header.html.twig
+++ b/src/Core/Framework/Resources/views/documents/includes/letter_header.html.twig
@@ -19,10 +19,6 @@ All blocks of this template are available in the template which renders this tem
                     <span class="company-address-small">{{ addressParts|join(' - ') }}</span><br><br>
                 {% endset %}
 
-                {% if config.displayCompanyAddress and address is not empty %}
-                    {{ address }}
-                {% endif %}
-
                 {% sw_include '@Framework/snippets/render.html.twig' with {
                     format: billingAddress.country.translated.addressFormat,
                     address: billingAddress


### PR DESCRIPTION
### 1. Why is this change necessary?
The company address is shown twice on invoices and delivery notes. 

### 2. What does this change do, exactly?
Removes the part where it is rendered.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes #5079  - closes the issue #5079 when the PR is merged



### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
