### PR TITLE
fix: fix datepicker local and formatting issues

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@shopware-ag/meteor-admin-sdk": "5.7.7",
-        "@shopware-ag/meteor-component-library": "4.8.0",
+        "@shopware-ag/meteor-component-library": "^4.9.1",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",
         "@types/fs-extra": "^11.0.4",
@@ -4983,9 +4983,9 @@
       }
     },
     "node_modules/@shopware-ag/meteor-component-library": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.8.0.tgz",
-      "integrity": "sha512-fkxZogOYpV5dNJtfSCI0mynq3/poWGJFeNV3wFDnhpd8lnPApF0px8zYM3EKesXn0ja6gi1TZ1sDN8C+QbhjTQ==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.9.1.tgz",
+      "integrity": "sha512-EQyCI+2MCYcWACQVhrFGQhynW0nTbRLLdt5oou4H9wUNm1/NqbCfLj8YUW0V3dmNRKLF+OvOWH58zw1rixSuhQ==",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@floating-ui/dom": "^1.4.3",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@shopware-ag/meteor-admin-sdk": "5.7.7",
-    "@shopware-ag/meteor-component-library": "4.8.0",
+    "@shopware-ag/meteor-component-library": "^4.9.1",
     "@shopware-ag/meteor-icon-kit": "5.4.0",
     "@swc/core": "1.10.7",
     "@types/fs-extra": "^11.0.4",

--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.spec.js
@@ -699,7 +699,6 @@ describe('ASYNC app/adapter/view/vue.adapter.js', () => {
                 'mt-button',
                 'mt-checkbox',
                 'mt-colorpicker',
-                'mt-datepicker',
                 'mt-email-field',
                 'mt-number-field',
                 'mt-password-field',

--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
@@ -252,7 +252,6 @@ export default class VueAdapter extends ViewAdapter {
             'MtButton',
             'MtCheckbox',
             'MtColorpicker',
-            'MtDatepicker',
             'MtEmailField',
             'MtNumberField',
             'MtPasswordField',

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker/sw-colorpicker.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker/sw-colorpicker.html.twig
@@ -2,7 +2,7 @@
 <mt-colorpicker
     v-bind="$attrs"
     :model-value="currentValue"
-    @update:modelValue="currentValue = $event"
+    @update:model-value="currentValue = $event"
 >
     <template
         v-for="(index, name) in getSlots()"

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/index.ts
@@ -1,0 +1,130 @@
+import { MtDatepicker as MtDatepickerOriginal } from '@shopware-ag/meteor-component-library';
+import type { PropType } from 'vue';
+// eslint-disable-next-line max-len
+import type {DateTimeOptions} from "vue-i18n";
+import template from './mt-datepicker.html.twig';
+
+/**
+ * @sw-package framework
+ *
+ * @private
+ * @status ready
+ * @description Wrapper component for mt-datepicker. Replaces the
+ * datepicker with automatic language and formatting for the admin user.
+ */
+Shopware.Component.register('mt-datepicker', {
+    template,
+
+    components: {
+        'mt-datepicker-original': MtDatepickerOriginal,
+    },
+
+    props: {
+        /**
+         * Sets the locale for the date picker.
+         * This affects things like the language used for month names and weekdays.
+         */
+        locale: {
+            type: String as PropType<string>,
+            required: false,
+        },
+
+        /**
+         * The format of the date picker.
+         * You can use a string or a function to format the date.
+         */
+        format: {
+            type: Function,
+            required: false,
+            default: undefined,
+        },
+
+        /**
+         * Defines the time zone for the date picker.
+         * Useful for adjusting date and time according to a specific timezone.
+         */
+        timeZone: {
+            type: String as PropType<string>,
+            required: false,
+        },
+
+        /**
+         * Defines the type of the date picker.
+         * Options: "date" (for selecting a date), or "datetime" (for selecting both).
+         */
+        dateType: {
+            type: String as PropType<"date" | "datetime" | "time">,
+            required: false,
+            default: "datetime",
+        },
+
+        /**
+         * Determines if the timepicker is in 24 or 12 hour format
+         */
+        is24: {
+            type: Boolean as PropType<boolean>,
+            required: false,
+            default: true,
+        },
+    },
+
+    computed: {
+        userLocale(): string {
+            return Shopware.Store.get('session').adminLocaleLanguage || 'en';
+        },
+
+        userTimeZone() {
+            return Shopware?.Store?.get('session')?.currentUser?.timeZone ?? 'UTC';
+        },
+
+        formatterOptions(): DateTimeOptions {
+            const defaultFormat = {
+                hour12: !this.is24,
+                locale: this.userLocale,
+            };
+
+            let format: {
+                year?: 'numeric';
+                month?: '2-digit' | 'numeric';
+                day?: '2-digit' | 'numeric';
+                hour?: '2-digit' | 'numeric';
+                minute?: '2-digit' | 'numeric';
+            } = {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+            };
+
+            if (this.dateType === 'time') {
+                format = {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                };
+            }
+
+            if (this.dateType === 'date') {
+                format = {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                };
+            }
+
+            return {
+                ...defaultFormat,
+                ...format,
+            };
+        },
+    },
+
+    methods: {
+        customFormat(date: Date): string {
+            const currentLocale = Shopware.Store.get('session').currentLocale || 'en';
+            const formatter = new Intl.DateTimeFormat(currentLocale, this.formatterOptions);
+
+            return formatter.format(new Date(date));
+        },
+    },
+});

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/index.ts
@@ -64,22 +64,32 @@ Shopware.Component.register('mt-datepicker', {
         is24: {
             type: Boolean as PropType<boolean>,
             required: false,
-            default: true,
         },
     },
 
     computed: {
         userLocale(): string {
-            return Shopware.Store.get('session').adminLocaleLanguage || 'en';
+            return Shopware.Store.get('session').currentLocale || 'en-US';
         },
 
         userTimeZone() {
             return Shopware?.Store?.get('session')?.currentUser?.timeZone ?? 'UTC';
         },
 
+        is24HourFormat(): boolean {
+            if (this.is24) {
+                return this.is24 as boolean;
+            }
+
+            const locale = Shopware.Store.get('session').currentLocale!;
+            const formatter = new Intl.DateTimeFormat(locale, { hour: 'numeric' });
+            const intlOptions = formatter.resolvedOptions();
+            return !intlOptions.hour12;
+        },
+
         formatterOptions(): DateTimeOptions {
             const defaultFormat = {
-                hour12: !this.is24,
+                hour12: !this.is24HourFormat,
                 locale: this.userLocale,
             };
 
@@ -121,7 +131,7 @@ Shopware.Component.register('mt-datepicker', {
 
     methods: {
         customFormat(date: Date): string {
-            const currentLocale = Shopware.Store.get('session').currentLocale || 'en';
+            const currentLocale = Shopware.Store.get('session').currentLocale || 'en-US';
             const formatter = new Intl.DateTimeFormat(currentLocale, this.formatterOptions);
 
             return formatter.format(new Date(date));

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/mt-datepicker.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/mt-datepicker.html.twig
@@ -1,6 +1,6 @@
 <mt-datepicker-original
     v-bind="$attrs"
-    :is24="is24"
+    :is24="is24HourFormat"
     :date-type="dateType"
     :locale="locale || userLocale"
     :format="format || customFormat"

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/mt-datepicker.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/mt-datepicker.html.twig
@@ -1,0 +1,19 @@
+<mt-datepicker-original
+    v-bind="$attrs"
+    :is24="is24"
+    :date-type="dateType"
+    :locale="locale || userLocale"
+    :format="format || customFormat"
+    :time-zone="timeZone || userTimeZone"
+>
+    <!-- Dynamically pass all slots -->
+    <template
+        v-for="(_, name) in $slots"
+        #[name]="bindings"
+    >
+        <slot
+            :name="name"
+            v-bind="bindings"
+        ></slot>
+    </template>
+</mt-datepicker-original>

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/mt-datepicker.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/mt-datepicker.spec.js
@@ -1,0 +1,90 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+
+describe('src/app/component/meteor-wrapper/mt-datepicker', () => {
+    beforeAll(() => {
+        Shopware.Store.get('system').registerAdminLocale('de-DE');
+        Shopware.Store.get('system').registerAdminLocale('en-GB');
+    })
+
+    beforeEach(() => {
+        Shopware.Store.get('session').setCurrentUser({
+            firstName: 'John',
+            lastName: 'Doe',
+            timeZone: 'Europe/Berlin',
+        })
+
+        Shopware.Store.get('session').setAdminLocale('de-DE');
+    })
+
+    it('should be a Vue.js component', async () => {
+        const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }), {
+            props: {},
+            global: {},
+        });
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('should use the user timeZone', async () => {
+        const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }));
+
+        expect(wrapper.find('[data-test="time-zone-hint"]').text()).toBe('Europe/Berlin');
+    });
+
+    it('should use the user locale (de)', async () => {
+        const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }));
+
+        // Click on input to open datepicker
+        await wrapper.find('[data-test-id="dp-input"]').trigger('click');
+
+        // Expect german locale to be used
+        expect(document.body.textContent).toContain('MoDiMiDoFrSaSo');
+    });
+
+    it('should use the user locale (en)', async () => {
+        // Set the user locale to english
+        Shopware.Store.get('session').setAdminLocale('en-GB');
+
+        const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }));
+
+        // Click on input to open datepicker
+        await wrapper.find('[data-test-id="dp-input"]').trigger('click');
+
+        // Expect german locale to be used
+        expect(document.body.textContent).toContain('MoTuWeThFrSaSu');
+    });
+
+    it('should use custom format based on currentLocale (de)', async () => {
+        const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }), {
+            props: {
+                modelValue: '2023-10-01T00:00:00+02:00',
+            }
+        });
+
+        // Click on input to open datepicker
+        await wrapper.find('[data-test-id="dp-input"]').trigger('click');
+
+        // Expect german locale to be used
+        expect(wrapper.find('[data-test-id="dp-input"]').element.value).toBe('01.10.2023, 00:00');
+    })
+
+    it('should use custom format based on currentLocale (en)', async () => {
+        // Set the user locale to english
+        Shopware.Store.get('session').setAdminLocale('en-GB');
+
+        const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }), {
+            props: {
+                modelValue: '2023-10-01T00:00:00+02:00',
+            }
+        });
+
+        // Click on input to open datepicker
+        await wrapper.find('[data-test-id="dp-input"]').trigger('click');
+
+        // Expect german locale to be used
+        expect(wrapper.find('[data-test-id="dp-input"]').element.value).toBe('01/10/2023, 00:00');
+    });
+});

--- a/tests/acceptance/tests/Product/ProductBulkEdit.spec.ts
+++ b/tests/acceptance/tests/Product/ProductBulkEdit.spec.ts
@@ -48,7 +48,7 @@ test('As a merchant, I want to perform bulk edits on products information.', { t
             await ShopAdmin.expects(AdminProductDetail.priceGrossInput).toHaveValue(changes['grossPrice'].value);
             await ShopAdmin.expects(AdminProductDetail.activeForAllSalesChannelsToggle).not.toBeChecked();
             await ShopAdmin.expects(AdminProductDetail.manufacturerDropdownText).toHaveText(changes['manufacturer'].value);
-            await ShopAdmin.expects(AdminProductDetail.releaseDateInput).toHaveValue('2025/05/20, 00:00');
+            await ShopAdmin.expects(AdminProductDetail.releaseDateInput).toHaveValue('20/05/2025, 00:00');
             await ShopAdmin.expects(AdminProductDetail.stockInput).toHaveValue(changes['stock'].value);
             await ShopAdmin.expects(AdminProductDetail.restockTimeInput).toHaveValue('');
             await ShopAdmin.expects(AdminProductDetail.tagsInput).toContainText(originalTag.name);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
 Closes #7579

### 2. What does this change do, exactly?
Updates to the latest Meteor Component library. Creates a component wrapper which implements the global locale and formatting handling.

See the results:

de-DE with Berlin Timezone:
<img width="442" alt="Bildschirmfoto 2025-04-01 um 10 40 13" src="https://github.com/user-attachments/assets/f7e3bd31-cfe2-4dff-ac30-42ab5832b7c2" />


en-GB with London Timezone:
<img width="411" alt="Bildschirmfoto 2025-04-01 um 10 40 36" src="https://github.com/user-attachments/assets/eabdcfcd-04d5-4689-b1a3-b0ee4ad86e8f" />

en-US with UTC:
<img width="406" alt="Bildschirmfoto 2025-04-02 um 16 50 19" src="https://github.com/user-attachments/assets/2d5710f9-4f73-4572-933e-f193a75fddc7" />



### Required before it can continue:

https://github.com/shopware/meteor/pull/638 needs to be merged first