### PR TITLE
fix: settings mailer synchronous mail dispach not saved

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/index.js
@@ -148,6 +148,7 @@ export default {
                     ...defaultMailerSettings,
                     'core.mailerSettings.emailAgent': 'local',
                     'core.mailerSettings.disableDelivery': this.mailerSettings['core.mailerSettings.disableDelivery'],
+                    'core.mailerSettings.sendMailOptions': this.mailerSettings['core.mailerSettings.sendMailOptions'],
                 };
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
@@ -201,6 +201,7 @@ describe('src/module/sw-settings-mailer/page/sw-settings-mailer', () => {
             'core.mailerSettings.senderAddress': null,
             'core.mailerSettings.deliveryAddress': null,
             'core.mailerSettings.disableDelivery': true,
+            'core.mailerSettings.sendMailOptions': '-bs',
         });
     });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix the option Synchronous mail dispatch

### 2. What does this change do, exactly?
avoid removing the property on save

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Settings > mailer
2. Select `local email agent`
3. select Synchronous or Asynchronous option and press save


### 4. Please link to the relevant issues (if any).
closes #7886

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
