### PR TITLE
fix: redis services configuration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,6 +82,7 @@ jobs:
     env:
       APP_ENV: test
       DATABASE_URL: mysql://root@127.0.0.1:3306/root
+      REDIS_URL: redis://localhost:6379
       APP_URL: http://localhost:8000
       APP_SECRET: def00000bb5acb32b54ff8ee130270586eec0e878f7337dc7a837acc31d3ff00f93a56b595448b4b29664847dd51991b3314ff65aeeeb761a133b0ec0e070433bff08e48
       OPENSEARCH_URL: 127.0.0.1:9200
@@ -106,6 +107,10 @@ jobs:
         ports:
           - "3306:3306"
         options: --health-cmd="mysqladmin ping || mariadb-admin ping"
+      redis:
+        image: redis:alpine
+        ports:
+          - "6379:6379"
     steps:
       - name: Setup Shopware
         uses: shopware/setup-shopware@main

--- a/src/Core/Framework/Adapter/AdapterException.php
+++ b/src/Core/Framework/Adapter/AdapterException.php
@@ -36,6 +36,7 @@ class AdapterException extends HttpException
     final public const FILESYSTEM_FACTORY_NOT_FOUND = 'FRAMEWORK__FILESYSTEM_FACTORY_NOT_FOUND';
     final public const DUPLICATE_FILESYSTEM_FACTORY = 'FRAMEWORK__DUPLICATE_FILESYSTEM_FACTORY';
     final public const OPERATOR_NOT_SUPPORTED = 'FRAMEWORK__OPERATOR_NOT_SUPPORTED';
+    final public const MISSING_REQUIRED_PARAMETER = 'FRAMEWORK__MISSING_REQUIRED_PARAMETER';
 
     /**
      * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self
@@ -276,6 +277,15 @@ class AdapterException extends HttpException
             self::DUPLICATE_FILESYSTEM_FACTORY,
             'Filesystem factory for type "{{ type }}" already exists.',
             ['type' => $type]
+        );
+    }
+
+    public static function missingRequiredParameter(string $parameter): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::MISSING_REQUIRED_PARAMETER,
+            \sprintf('Parameter "%s" is required but not found in the container.', $parameter)
         );
     }
 }

--- a/src/Core/Framework/Adapter/AdapterException.php
+++ b/src/Core/Framework/Adapter/AdapterException.php
@@ -285,7 +285,8 @@ class AdapterException extends HttpException
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::MISSING_REQUIRED_PARAMETER,
-            \sprintf('Parameter "%s" is required but not found in the container.', $parameter)
+            'Parameter "{{ parameter }}" is required but not found in the container.',
+            ['parameter' => $parameter],
         );
     }
 }

--- a/src/Core/Framework/Adapter/Cache/CacheCompilerPass.php
+++ b/src/Core/Framework/Adapter/Cache/CacheCompilerPass.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Cache;
+
+use Shopware\Core\Framework\Adapter\AdapterException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+#[Package('framework')]
+class CacheCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $storage = $container->getParameter('shopware.cache.invalidation.delay_options.storage');
+
+        switch ($storage) {
+            case 'mysql':
+                $container->removeDefinition('shopware.cache.invalidator.storage.redis_adapter');
+                $container->removeDefinition('shopware.cache.invalidator.storage.redis');
+                break;
+            case 'redis':
+                if ($container->getParameter('shopware.cache.invalidation.delay_options.connection') === null) {
+                    throw AdapterException::missingRequiredParameter('shopware.cache.invalidation.delay_options.connection');
+                }
+
+                $container->removeDefinition('shopware.cache.invalidator.storage.mysql');
+                break;
+        }
+    }
+}

--- a/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
+++ b/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
@@ -39,7 +39,7 @@ class CacheWatchDelayedCommand extends Command
             return self::FAILURE;
         }
 
-        if ($this->container->has('shopware.cache.invalidator.storage.redis_adapter')) {
+        if (!$this->container->has('shopware.cache.invalidator.storage.redis_adapter')) {
             $output->writeln('Redis cache invalidation is not configured.');
 
             return self::FAILURE;
@@ -55,7 +55,6 @@ class CacheWatchDelayedCommand extends Command
         });
 
         /** @var RedisTypeHint $adapter */
-        /** @phpstan-ignore symfonyContainer.serviceNotFound */
         $adapter = $this->container->get('shopware.cache.invalidator.storage.redis_adapter');
 
         if (method_exists($adapter, 'sMembers') === false) {

--- a/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
+++ b/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
@@ -14,6 +14,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @phpstan-import-type RedisTypeHint from \Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory
+ */
 #[Package('framework')]
 #[AsCommand(name: 'cache:watch:delayed', description: 'Watches the delayed cache keys/tags')]
 class CacheWatchDelayedCommand extends Command
@@ -51,9 +54,15 @@ class CacheWatchDelayedCommand extends Command
             }
         });
 
-        /** @var \Redis $adapter */
+        /** @var RedisTypeHint $adapter */
         /** @phpstan-ignore symfonyContainer.serviceNotFound */
         $adapter = $this->container->get('shopware.cache.invalidator.storage.redis_adapter');
+
+        if (method_exists($adapter, 'sMembers') === false) {
+            $output->writeln('Redis adapter does not support sMembers method.');
+
+            return self::FAILURE;
+        }
 
         $before = $adapter
             ->sMembers('invalidation');

--- a/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
+++ b/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
@@ -36,6 +36,12 @@ class CacheWatchDelayedCommand extends Command
             return self::FAILURE;
         }
 
+        if ($this->container->has('shopware.cache.invalidator.storage.redis_adapter')) {
+            $output->writeln('Redis cache invalidation is not configured.');
+
+            return self::FAILURE;
+        }
+
         $this->dispatcher->addListener(ConsoleEvents::SIGNAL, function (ConsoleSignalEvent $event): void {
             $signal = $event->getHandlingSignal();
             $event->setExitCode(0);
@@ -45,8 +51,11 @@ class CacheWatchDelayedCommand extends Command
             }
         });
 
-        $before = $this->container
-            ->get('shopware.cache.invalidator.storage.redis_adapter')
+        /** @var \Redis $adapter */
+        /** @phpstan-ignore symfonyContainer.serviceNotFound */
+        $adapter = $this->container->get('shopware.cache.invalidator.storage.redis_adapter');
+
+        $before = $adapter
             ->sMembers('invalidation');
 
         $section = $output->section();
@@ -56,8 +65,7 @@ class CacheWatchDelayedCommand extends Command
 
         // @phpstan-ignore-next-line
         while (true) {
-            $current = $this->container
-                ->get('shopware.cache.invalidator.storage.redis_adapter')
+            $current = $adapter
                 ->sMembers('invalidation');
 
             if ($before !== $current) {

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -404,7 +404,7 @@ class Configuration implements ConfigurationInterface
                                     ->defaultValue('mysql')
                                 ->end()
                                 ->scalarNode('connection')
-                                    ->defaultValue('')
+                                    ->defaultValue(null)
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -404,7 +404,7 @@ class Configuration implements ConfigurationInterface
                                     ->defaultValue('mysql')
                                 ->end()
                                 ->scalarNode('connection')
-                                    ->defaultValue(null)
+                                    ->defaultValue('')
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -11,12 +11,12 @@
         </service>
 
         <service id="shopware.cache.invalidator.storage.redis_adapter" class="Redis" public="true">
+            <factory service="Shopware\Core\Framework\Adapter\Redis\RedisConnectionProvider" method="getConnection"/>
             <argument>%shopware.cache.invalidation.delay_options.connection%</argument>
         </service>
 
         <service id="shopware.cache.invalidator.storage.redis" class="Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\RedisInvalidatorStorage" lazy="true">
             <argument type="service" id="shopware.cache.invalidator.storage.redis_adapter"/>
-
             <tag name="shopware.cache.invalidator.storage" storage="redis"/>
         </service>
 

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework;
 
+use Shopware\Core\Framework\Adapter\Cache\CacheCompilerPass;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\ReverseProxyCompilerPass;
 use Shopware\Core\Framework\Adapter\Redis\RedisConnectionsCompilerPass;
@@ -115,6 +116,7 @@ class Framework extends Bundle
         $container->addCompilerPass(new RateLimiterCompilerPass());
         $container->addCompilerPass(new IncrementerGatewayCompilerPass());
         $container->addCompilerPass(new ReverseProxyCompilerPass());
+        $container->addCompilerPass(new CacheCompilerPass());
         $container->addCompilerPass(new RedisPrefixCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING, 0);
         $container->addCompilerPass(new AutoconfigureCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new HttpCacheConfigCompilerPass());

--- a/src/Core/System/DependencyInjection/number_range.xml
+++ b/src/Core/System/DependencyInjection/number_range.xml
@@ -61,6 +61,7 @@
         </service>
 
         <service id="shopware.number_range.redis" class="Redis">
+            <factory service="Shopware\Core\Framework\Adapter\Redis\RedisConnectionProvider" method="getConnection"/>
             <argument>%shopware.number_range.config.connection%</argument>
         </service>
 

--- a/tests/integration/Core/Framework/_snapshots/redis_test.yaml
+++ b/tests/integration/Core/Framework/_snapshots/redis_test.yaml
@@ -9,7 +9,6 @@ shopware:
     # delayed cache invalidation
     cache:
         invalidation:
-            delay: 1
             delay_options:
                 storage: 'redis'
                 # dsn: 'redis://localhost:6379/1'

--- a/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
+++ b/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
@@ -102,4 +102,12 @@ class AdapterExceptionTest extends TestCase
         static::assertSame('test', $exception->getMessage());
         static::assertEmpty($exception->getParameters());
     }
+
+    public function testMissingRequiredParameter(): void
+    {
+        static::expectException(AdapterException::class);
+        static::expectExceptionMessage('Parameter "shopware.cache.invalidation.delay_options.connection" is required but not found in the container.');
+
+        throw AdapterException::missingRequiredParameter('shopware.cache.invalidation.delay_options.connection');
+    }
 }

--- a/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
+++ b/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
@@ -105,9 +105,11 @@ class AdapterExceptionTest extends TestCase
 
     public function testMissingRequiredParameter(): void
     {
-        static::expectException(AdapterException::class);
-        static::expectExceptionMessage('Parameter "shopware.cache.invalidation.delay_options.connection" is required but not found in the container.');
+        $exception = AdapterException::missingRequiredParameter('test');
 
-        throw AdapterException::missingRequiredParameter('shopware.cache.invalidation.delay_options.connection');
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(AdapterException::MISSING_REQUIRED_PARAMETER, $exception->getErrorCode());
+        static::assertSame('Parameter "test" is required but not found in the container.', $exception->getMessage());
+        static::assertSame(['parameter' => 'test'], $exception->getParameters());
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheCompilerPassTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheCompilerPassTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Cache;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\AdapterException;
+use Shopware\Core\Framework\Adapter\Cache\CacheCompilerPass;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CacheCompilerPass::class)]
+class CacheCompilerPassTest extends TestCase
+{
+    private ContainerBuilder $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new ContainerBuilder();
+        $this->container->addDefinitions([
+            'shopware.cache.invalidator.storage.redis_adapter' => new Definition(),
+            'shopware.cache.invalidator.storage.redis' => new Definition(),
+            'shopware.cache.invalidator.storage.mysql' => new Definition(),
+        ]);
+        $this->container->setParameter('shopware.number_range.config.connection', null);
+    }
+
+    public function testProcessMySQL(): void
+    {
+        $container = $this->container;
+        $container->setParameter('shopware.cache.invalidation.delay_options.storage', 'mysql');
+
+        $compilerPass = new CacheCompilerPass();
+        $compilerPass->process($container);
+
+        static::assertFalse($container->hasDefinition('shopware.cache.invalidator.storage.redis'));
+        static::assertFalse($container->hasDefinition('shopware.cache.invalidator.storage.redis_adapter'));
+        static::assertTrue($container->hasDefinition('shopware.cache.invalidator.storage.mysql'));
+    }
+
+    public function testProcessRedis(): void
+    {
+        $container = $this->container;
+        $container->setParameter('shopware.cache.invalidation.delay_options.storage', 'redis');
+        $container->setParameter('shopware.cache.invalidation.delay_options.connection', 'connection_name');
+
+        $compilerPass = new CacheCompilerPass();
+        $compilerPass->process($container);
+
+        static::assertTrue($container->hasDefinition('shopware.cache.invalidator.storage.redis'));
+        static::assertTrue($container->hasDefinition('shopware.cache.invalidator.storage.redis_adapter'));
+        static::assertFalse($container->hasDefinition('shopware.cache.invalidator.storage.mysql'));
+    }
+
+    public function testProcessRedisNoConnectionConfigured(): void
+    {
+        $container = $this->container;
+        $container->setParameter('shopware.cache.invalidation.delay_options.storage', 'redis');
+        $container->setParameter('shopware.cache.invalidation.delay_options.connection', null); // default value
+
+        self::expectException(AdapterException::class);
+        $compilerPass = new CacheCompilerPass();
+        $compilerPass->process($container);
+    }
+}

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheCompilerPassTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheCompilerPassTest.php
@@ -63,7 +63,7 @@ class CacheCompilerPassTest extends TestCase
         $container->setParameter('shopware.cache.invalidation.delay_options.storage', 'redis');
         $container->setParameter('shopware.cache.invalidation.delay_options.connection', null); // default value
 
-        self::expectException(AdapterException::class);
+        self::expectExceptionObject(AdapterException::missingRequiredParameter('shopware.cache.invalidation.delay_options.connection'));
         $compilerPass = new CacheCompilerPass();
         $compilerPass->process($container);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

In current version few of Redis-dependent services in service container are misconfigured, which will cause exception when they are accessed.

### 2. What does this change do, exactly?

- Fixes configuration (using factory in container configuration)
- Fixed deprecated configuration parameter in the test.
- Added compiler pass to remove unused redis services for cache invalidation (similar to other redis usages)

### 3. Describe each step to reproduce the issue or behaviour.

See linked issue.

### 4. Please link to the relevant issues (if any).
- closes [8152](https://github.com/shopware/shopware/issues/8152)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
