### PR TITLE
feat: Add sidebar sdk handlers

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@shopware-ag/meteor-admin-sdk": "5.7.7",
+        "@shopware-ag/meteor-admin-sdk": "^5.9.0",
         "@shopware-ag/meteor-component-library": "^4.10.0",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",
@@ -2569,6 +2569,15 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -2606,6 +2615,17 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4760,239 +4780,40 @@
       }
     },
     "node_modules/@shopware-ag/meteor-admin-sdk": {
-      "version": "5.7.7",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-admin-sdk/-/meteor-admin-sdk-5.7.7.tgz",
-      "integrity": "sha512-9IAvRuvCOnG2GUr9wHNj8wt7BmnXJQEIjkDg/Z9iIUS5Nzd+1IKtqB1AuRWyE1nX0hb+SbEviqoWxTcHEZeaUw==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-admin-sdk/-/meteor-admin-sdk-5.9.0.tgz",
+      "integrity": "sha512-onMz+DH8AiVUVOhRj9eBx7LcZQWgXvKZ1MNtrRNgfqiBtvubbmtpMqOMJYdFLQtkDY5qah4u6IQ/PiXHimQnqA==",
       "license": "MIT",
       "dependencies": {
-        "@shopware-ag/meteor-component-library": "4.5.1",
+        "@shopware-ag/meteor-component-library": "4.10.1",
         "localforage": "^1.10.0",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@intlify/core-base": {
-      "version": "9.14.3",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.3.tgz",
-      "integrity": "sha512-nbJ7pKTlXFnaXPblyfiH6awAx1C0PWNNuqXAR74yRwgi5A/Re/8/5fErLY0pv4R8+EHj3ZaThMHdnuC/5OBa6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/message-compiler": "9.14.3",
-        "@intlify/shared": "9.14.3"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@intlify/message-compiler": {
-      "version": "9.14.3",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.3.tgz",
-      "integrity": "sha512-ANwC226BQdd+MpJ36rOYkChSESfPwu3Ss2Faw0RHTOknYLoHTX6V6e/JjIKVDMbzs0/H/df/rO6yU0SPiWHqNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/shared": "9.14.3",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@intlify/shared": {
-      "version": "9.14.3",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.3.tgz",
-      "integrity": "sha512-hJXz9LA5VG7qNE00t50bdzDv8Z4q9fpcL81wj4y4duKavrv0KM8YNLTwXNEFINHjTsfrG9TXvPuEjVaAvZ7yWg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@shopware-ag/meteor-component-library": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.5.1.tgz",
-      "integrity": "sha512-IjGJIdHVH+rmz+/GhFA8vxVyZG5CPfHx9g7wyWKF0eJZyebPsIBf6FtnaHAOh8hUMlEVImVhcdoAKzxDasxjbw==",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.4.9",
-        "@floating-ui/dom": "^1.4.3",
-        "@floating-ui/vue": "^1.1.6",
-        "@shopware-ag/meteor-icon-kit": "5.4.0",
-        "@shopware-ag/meteor-tokens": "1.0.0",
-        "@storybook/addon-a11y": "^8.4.5",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/vue": "^8.1.0",
-        "@tiptap/extension-bubble-menu": "^2.10.0",
-        "@tiptap/extension-bullet-list": "^2.10.0",
-        "@tiptap/extension-character-count": "^2.10.0",
-        "@tiptap/extension-color": "^2.9.1",
-        "@tiptap/extension-highlight": "^2.10.3",
-        "@tiptap/extension-link": "^2.10.0",
-        "@tiptap/extension-list-item": "^2.10.0",
-        "@tiptap/extension-ordered-list": "^2.10.0",
-        "@tiptap/extension-placeholder": "^2.10.4",
-        "@tiptap/extension-subscript": "^2.9.1",
-        "@tiptap/extension-superscript": "^2.9.1",
-        "@tiptap/extension-table": "^2.10.3",
-        "@tiptap/extension-table-cell": "^2.10.3",
-        "@tiptap/extension-table-header": "^2.10.3",
-        "@tiptap/extension-table-row": "^2.10.3",
-        "@tiptap/extension-text-align": "^2.9.1",
-        "@tiptap/extension-text-style": "^2.9.1",
-        "@tiptap/extension-underline": "^2.9.1",
-        "@tiptap/pm": "^2.9.1",
-        "@tiptap/starter-kit": "^2.9.1",
-        "@tiptap/vue-3": "^2.9.1",
-        "@vuepic/vue-datepicker": "^10.0.0",
-        "@vueuse/components": "^12.4.0",
-        "@vueuse/core": "^12.4.0",
-        "codemirror": "^6.0.1",
-        "date-fns": "4.1.0",
-        "date-fns-tz": "3.2.0",
-        "focus-trap": "^7.6.4",
-        "inter-ui": "^3.19.3",
-        "nanoid": "^5.0.7",
-        "vue-codemirror6": "^1.3.8",
-        "vue-i18n": "^9.9.1",
-        "vue-smooth-reflow": "^0.1.12"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@testing-library/jest-dom": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
         "lodash": "^4.17.21",
-        "redent": "^3.0.0"
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@types/web-bluetooth": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
-      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
-      "license": "MIT"
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@vueuse/core": {
-      "version": "12.8.2",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
-      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/web-bluetooth": "^0.0.21",
-        "@vueuse/metadata": "12.8.2",
-        "@vueuse/shared": "12.8.2",
-        "vue": "^3.5.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@vueuse/metadata": {
-      "version": "12.8.2",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
-      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@vueuse/shared": {
-      "version": "12.8.2",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
-      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
-      "license": "MIT",
-      "dependencies": {
-        "vue": "^3.5.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/date-fns-tz": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
-      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "date-fns": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "license": "MIT"
-    },
-    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/vue-i18n": {
-      "version": "9.14.3",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.3.tgz",
-      "integrity": "sha512-C+E0KE8ihKjdYCQx8oUkXX+8tBItrYNMnGJuzEPevBARQFUN2tKez6ZVOvBrWH0+KT5wEk3vOWjNk7ygb2u9ig==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/core-base": "9.14.3",
-        "@intlify/shared": "9.14.3",
-        "@vue/devtools-api": "^6.5.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/@shopware-ag/meteor-component-library": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.10.0.tgz",
-      "integrity": "sha512-wDw0ITpsLFVWOQMifp3FoHvEf6j4O26oxCkT7MqpfHEpRDcN/C/ks3OT37I2TkUtRywij3qCmx7lCtU13HSUdQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.10.1.tgz",
+      "integrity": "sha512-gHa3nsyl8ehqjiBXsQLuFYqH0a6hLk5WhLGtgPP94BeZv2yggDnvFFnpr8vZYKOR4uPeK+ErNJJpmTLKbJ8hrg==",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@floating-ui/dom": "^1.4.3",
         "@floating-ui/vue": "^1.1.6",
-        "@shopware-ag/meteor-icon-kit": "5.4.0",
-        "@shopware-ag/meteor-tokens": "1.0.0",
-        "@storybook/addon-a11y": "^8.4.5",
+        "@shopware-ag/meteor-icon-kit": "5.5.0",
+        "@shopware-ag/meteor-tokens": "1.1.0",
+        "@storybook/addon-a11y": "^8.6.12",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/vue": "^8.1.0",
         "@tiptap/extension-bubble-menu": "^2.10.0",
@@ -5073,6 +4894,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@shopware-ag/meteor-component-library/node_modules/@shopware-ag/meteor-icon-kit": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-icon-kit/-/meteor-icon-kit-5.5.0.tgz",
+      "integrity": "sha512-nVuiteldahhRUBCdFy80e7/nHzK7SVNXf530c0VfXeSNc/gB+b/voqZ/R0nAPu3nLncjTUm/0IXODKCcuWB2GA==",
+      "license": "MIT",
+      "dependencies": {
+        "@t3-oss/env-core": "^0.12.0",
+        "dotenv": "^16.4.1",
+        "js-md5": "^0.7.3",
+        "ora": "^8.2.0",
+        "winston": "^3.17.0",
+        "zod": "^3.24.2"
       }
     },
     "node_modules/@shopware-ag/meteor-component-library/node_modules/@testing-library/jest-dom": {
@@ -5197,9 +5032,9 @@
       }
     },
     "node_modules/@shopware-ag/meteor-tokens": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-tokens/-/meteor-tokens-1.0.0.tgz",
-      "integrity": "sha512-MdxJdmbHvrGdesuXuIfU2NujryaU+HByuf5FMIgK2xJ7dTWzQZWAj/+mR5Pt9+mOQTP9Gy/pBtoAzznT5/wrug==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-tokens/-/meteor-tokens-1.1.0.tgz",
+      "integrity": "sha512-GpOYyWSmNG2LkOMx17tgZXHpuWN+HIwSOgLkup0zC7kc+KlLmjLoMt6QeGYuJW7Ut1vrLggRIty6t3aDCYL0jw==",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.7",
@@ -5236,13 +5071,14 @@
       }
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-8.5.6.tgz",
-      "integrity": "sha512-LsJ93KTT9f3EW1XamH1U4zZaCbiP5wFWjQm3nw3meGZC1FE2X6vaaIEERVJwUtIPZtEU94Cu1WD15/FZqnpmAA==",
+      "version": "8.6.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-8.6.12.tgz",
+      "integrity": "sha512-H28zHiL8uuv29XsVNf9VjNWsCeht/l66GPYHT7aom1jh+f3fS9+sutrCGEBC/T7cnRpy8ZyuHCtihUqS+RI4pg==",
       "license": "MIT",
       "dependencies": {
-        "@storybook/addon-highlight": "8.5.6",
-        "@storybook/test": "8.5.6",
+        "@storybook/addon-highlight": "8.6.12",
+        "@storybook/global": "^5.0.0",
+        "@storybook/test": "8.6.12",
         "axe-core": "^4.2.0"
       },
       "funding": {
@@ -5250,13 +5086,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.6"
+        "storybook": "^8.6.12"
       }
     },
     "node_modules/@storybook/addon-highlight": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.5.6.tgz",
-      "integrity": "sha512-uuwBe+FwT9vKbEG9S/yqwZLD1GP3y5Mpu2gsiNcYcfhxHpwDQVbknOSeJJig/CGhuDMqy95GcgItIs/kPPFKqg==",
+      "version": "8.6.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.12.tgz",
+      "integrity": "sha512-9FITVxdoycZ+eXuAZL9ElWyML/0fPPn9UgnnAkrU7zkMi+Segq/Tx7y+WWanC5zfWZrXAuG6WTOYEXeWQdm//w==",
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0"
@@ -5266,20 +5102,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.6"
+        "storybook": "^8.6.12"
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.5.6.tgz",
-      "integrity": "sha512-ibgTGI3mcSsADABIQuhHWL8rxqF6CvooKIWpkZsB9kwNActS3OJzfCSAZDcgtvRkwaarPVjYX/sAOBzjqQNkXg==",
+      "version": "8.6.12",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.12.tgz",
+      "integrity": "sha512-t+ZuDzAlsXKa6tLxNZT81gEAt4GNwsKP/Id2wluhmUWD/lwYW0uum1JiPUuanw8xD6TdakCW/7ULZc7aQUBLCQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@storybook/csf": "0.1.12",
+        "@storybook/theming": "8.6.12",
         "better-opn": "^3.0.2",
         "browser-assert": "^1.2.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
         "esbuild-register": "^3.5.0",
         "jsdoc-type-pratt-parser": "^4.0.0",
         "process": "^0.11.10",
@@ -5315,9 +5151,9 @@
       }
     },
     "node_modules/@storybook/core/node_modules/recast": {
-      "version": "0.23.9",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.9.tgz",
-      "integrity": "sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==",
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5331,15 +5167,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@storybook/csf": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
-      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
@@ -5347,9 +5174,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/instrumenter": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.5.6.tgz",
-      "integrity": "sha512-uMOOiq/9dFoFhSl3IxuQ+yq4lClkcRtEuB6cPzD/rVCmlh+i//VkHTqFCNrDvpVA21Lsy9NLmnxLHJpBGN3Avg==",
+      "version": "8.6.12",
+      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.6.12.tgz",
+      "integrity": "sha512-VK5fYAF8jMwWP/u3YsmSwKGh+FeSY8WZn78flzRUwirp2Eg1WWjsqPRubAk7yTpcqcC/km9YMF3KbqfzRv2s/A==",
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
@@ -5360,18 +5187,17 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.6"
+        "storybook": "^8.6.12"
       }
     },
     "node_modules/@storybook/test": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.5.6.tgz",
-      "integrity": "sha512-U4HdyAcCwc/ictwq0HWKI6j2NAUggB9ENfyH3baEWaLEI+mp4pzQMuTnOIF9TvqU7K1D5UqOyfs/hlbFxUFysg==",
+      "version": "8.6.12",
+      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.6.12.tgz",
+      "integrity": "sha512-0BK1Eg+VD0lNMB1BtxqHE3tP9FdkUmohtvWG7cq6lWvMrbCmAmh3VWai3RMCCDOukPFpjabOr8BBRLVvhNpv2w==",
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf": "0.1.12",
         "@storybook/global": "^5.0.0",
-        "@storybook/instrumenter": "8.5.6",
+        "@storybook/instrumenter": "8.6.12",
         "@testing-library/dom": "10.4.0",
         "@testing-library/jest-dom": "6.5.0",
         "@testing-library/user-event": "14.5.2",
@@ -5383,7 +5209,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.6"
+        "storybook": "^8.6.12"
       }
     },
     "node_modules/@storybook/test/node_modules/@testing-library/jest-dom": {
@@ -5424,6 +5250,20 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "license": "MIT"
+    },
+    "node_modules/@storybook/theming": {
+      "version": "8.6.12",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.12.tgz",
+      "integrity": "sha512-6VjZg8HJ2Op7+KV7ihJpYrDnFtd9D1jrQnUS8LckcpuBXrIEbaut5+34ObY8ssQnSqkk2GwIZBBBQYQBCVvkOw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
     },
     "node_modules/@svgdotjs/svg.draggable.js": {
       "version": "3.0.6",
@@ -5692,6 +5532,28 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@t3-oss/env-core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-core/-/env-core-0.12.0.tgz",
+      "integrity": "sha512-lOPj8d9nJJTt81mMuN9GMk8x5veOt7q9m11OSnCBJhwp1QrL/qR+M8Y467ULBSm9SunosryWNbmQQbgoiMgcdw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.0.0",
+        "valibot": "^1.0.0-beta.7 || ^1.0.0",
+        "zod": "^3.24.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/dom": {
@@ -6780,6 +6642,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -7082,12 +6950,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.8.tgz",
-      "integrity": "sha512-n3LjS7fcW1BCoF+zWZxG7/5XvuYH+lsFg+BDwwAz0arIwHQJFUEsKBQ0BLU49fCxuM/2HSeBPHQD8WjgrxMfow==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
+      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.8",
+        "@vitest/spy": "3.1.2",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -7108,9 +6976,9 @@
       }
     },
     "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.8.tgz",
-      "integrity": "sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
+      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^3.0.2"
@@ -7141,12 +7009,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.8.tgz",
-      "integrity": "sha512-c7UUw6gEcOzI8fih+uaAXS5DwjlBaCJUo7KJ4VvJcjL95+DSR1kova2hFuRt3w41KZEFcOEiq098KkyrjXeM5w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
+      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.8",
+        "@vitest/utils": "3.1.2",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -7154,9 +7022,9 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.8.tgz",
-      "integrity": "sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
+      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -7166,12 +7034,12 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.8.tgz",
-      "integrity": "sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
+      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.8",
+        "@vitest/pretty-format": "3.1.2",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -7195,12 +7063,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.8.tgz",
-      "integrity": "sha512-x8IlMGSEMugakInj44nUrLSILh/zy1f2/BgH0UeHpNyOocG18M9CWVIFBaXPt8TrqVZWmcPjwfG/ht5tnpba8A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
+      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.8",
+        "@vitest/pretty-format": "3.1.2",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -7209,9 +7077,9 @@
       }
     },
     "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.8.tgz",
-      "integrity": "sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
+      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -8392,9 +8260,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
-      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
@@ -9737,6 +9605,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -9755,6 +9633,31 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -9767,6 +9670,16 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -11082,6 +10995,12 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -12841,6 +12760,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -13036,6 +12961,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/focus-trap": {
       "version": "7.6.4",
@@ -16884,6 +16815,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/launch-editor": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
@@ -17137,6 +17074,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/loupe": {
@@ -18841,6 +18795,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -21290,6 +21253,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -21666,6 +21638,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/sirv": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -22005,6 +21992,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -22083,9 +22079,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
-      "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
@@ -22114,13 +22110,13 @@
       }
     },
     "node_modules/storybook": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.5.6.tgz",
-      "integrity": "sha512-mrcYAA5CP6QBrq5O9grz2eqBoEfJNsK3b+Iz+PdGYqpr04oMC7rg1h80murV2pRwsbHxIWBFpLpXAVX8tMK01w==",
+      "version": "8.6.12",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.12.tgz",
+      "integrity": "sha512-Z/nWYEHBTLK1ZBtAWdhxC0l5zf7ioJ7G4+zYqtTdYeb67gTnxNj80gehf8o8QY9L2zA2+eyMRGLC2V5fI7Z3Tw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@storybook/core": "8.5.6"
+        "@storybook/core": "8.6.12"
       },
       "bin": {
         "getstorybook": "bin/index.cjs",
@@ -22839,6 +22835,12 @@
         "node": "*"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -22885,6 +22887,48 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
+      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tinypool": {
       "version": "1.0.2",
@@ -23083,6 +23127,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -23375,18 +23428,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -23969,9 +24010,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.8.tgz",
-      "integrity": "sha512-6PhR4H9VGlcwXZ+KWCdMqbtG649xCPZqfI9j2PsK1FcXgEzro5bGHcVKFCTqPLaNKZES8Evqv4LwvZARsq5qlg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
+      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -24089,30 +24130,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.8.tgz",
-      "integrity": "sha512-dfqAsNqRGUc8hB9OVR2P0w8PZPEckti2+5rdZip0WIz9WW0MnImJ8XiR61QhqLa92EQzKP2uPkzenKOAHyEIbA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
+      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.0.8",
-        "@vitest/mocker": "3.0.8",
-        "@vitest/pretty-format": "^3.0.8",
-        "@vitest/runner": "3.0.8",
-        "@vitest/snapshot": "3.0.8",
-        "@vitest/spy": "3.0.8",
-        "@vitest/utils": "3.0.8",
+        "@vitest/expect": "3.1.2",
+        "@vitest/mocker": "3.1.2",
+        "@vitest/pretty-format": "^3.1.2",
+        "@vitest/runner": "3.1.2",
+        "@vitest/snapshot": "3.1.2",
+        "@vitest/spy": "3.1.2",
+        "@vitest/utils": "3.1.2",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
-        "expect-type": "^1.1.0",
+        "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
-        "std-env": "^3.8.0",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.13",
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.0.8",
+        "vite-node": "3.1.2",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -24128,8 +24170,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.0.8",
-        "@vitest/ui": "3.0.8",
+        "@vitest/browser": "3.1.2",
+        "@vitest/ui": "3.1.2",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -24158,13 +24200,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.8.tgz",
-      "integrity": "sha512-Xu6TTIavTvSSS6LZaA3EebWFr6tsoXPetOWNMOlc7LO88QVVBwq2oQWBoDiLCN6YTvNYsGSjqOO8CAdjom5DCQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
+      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.8",
-        "@vitest/utils": "3.0.8",
+        "@vitest/spy": "3.1.2",
+        "@vitest/utils": "3.1.2",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -24173,9 +24215,9 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.8.tgz",
-      "integrity": "sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
+      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -24185,9 +24227,9 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.8.tgz",
-      "integrity": "sha512-MR+PzJa+22vFKYb934CejhR4BeRpMSoxkvNoDit68GQxRLSf11aT6CTj3XaqUU9rxgWJFnqicN/wxw6yBRkI1Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
+      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^3.0.2"
@@ -24197,12 +24239,12 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.8.tgz",
-      "integrity": "sha512-nkBC3aEhfX2PdtQI/QwAWp8qZWwzASsU4Npbcd5RdMPBSSLCpkZp52P3xku3s3uA0HIEhGvEcF8rNkBsz9dQ4Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
+      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.8",
+        "@vitest/pretty-format": "3.1.2",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -24211,9 +24253,9 @@
       }
     },
     "node_modules/vitest/node_modules/expect-type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
-      "integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -24773,6 +24815,42 @@
         "node": ">=4"
       }
     },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -25327,9 +25405,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -48,7 +48,7 @@
     "safari >= 7"
   ],
   "dependencies": {
-    "@shopware-ag/meteor-admin-sdk": "5.7.7",
+    "@shopware-ag/meteor-admin-sdk": "^5.9.0",
     "@shopware-ag/meteor-component-library": "^4.10.0",
     "@shopware-ag/meteor-icon-kit": "5.4.0",
     "@swc/core": "1.10.7",

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/sidebar/sw-help-sidebar/sw-help-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/sidebar/sw-help-sidebar/sw-help-sidebar.scss
@@ -13,7 +13,7 @@
     &__container {
         display: flex;
         flex-direction: column;
-        width: 400px;
+        width: 480px;
         max-width: 100%;
         height: 100%;
         margin-left: auto;
@@ -29,7 +29,7 @@
         @include flex-centering-vertical;
 
         justify-content: space-between;
-        height: 64px;
+        height: 81px;
         padding: 0 24px;
         border-bottom: 1px solid $color-gray-300;
     }

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/utils/sw-help-center/sw-help-center.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/utils/sw-help-center/sw-help-center.html.twig
@@ -2,6 +2,7 @@
 <div class="sw-help-center">
     <button
         class="sw-help-center__button"
+        :class="{ 'is--active': showHelpSidebar }"
         :aria-label="$tc('help-center.sidebar.ariaLabelButtonOpen')"
         @click="openHelpSidebar"
     >

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/utils/sw-help-center/sw-help-center.scss
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/utils/sw-help-center/sw-help-center.scss
@@ -5,7 +5,17 @@
     &__button {
         @include reset-button;
 
+        width: 40px;
+        height: 40px;
+        border-radius: var(--border-radius-button);
+        display: flex;
+        justify-content: center;
+        align-items: center;
         position: relative;
+
+        &.is--active {
+            background: var(--color-interaction-secondary-hover);
+        }
     }
 
     &__badge {

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-many-to-many-assignment-card/sw-many-to-many-assignment-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-many-to-many-assignment-card/sw-many-to-many-assignment-card.spec.js
@@ -42,7 +42,6 @@ async function createWrapper(customPropsData = {}) {
                 },
                 provide: {
                     repositoryFactory: {},
-
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
@@ -85,9 +85,13 @@ Shopware.Component.register('sw-extension-component-section', {
         },
 
         getActiveTab(componentSection: ComponentSectionEntry) {
-            return this.activeTabName
-                ? componentSection.props.tabs?.find((tab) => tab.name === this.activeTabName)
-                : componentSection.props.tabs?.[0];
+            if ('tabs' in componentSection.props) {
+                return this.activeTabName
+                    ? componentSection.props.tabs?.find((tab) => tab.name === this.activeTabName)
+                    : componentSection.props.tabs?.[0];
+            }
+
+            return null;
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
@@ -22,7 +22,7 @@
                 <sw-tabs-item
                     v-for="tab in componentSection.props.tabs"
                     :key="tab.name"
-                    :active-tab="getActiveTab(componentSection).name"
+                    :active-tab="getActiveTab(componentSection)?.name"
                     :name="tab.name"
                 >
                     {{ $tc(tab.label ?? '') }}
@@ -32,7 +32,7 @@
 
         <sw-iframe-renderer
             v-if="componentSection.props?.tabs && getActiveTab(componentSection)"
-            :key="getActiveTab(componentSection).name"
+            :key="getActiveTab(componentSection)?.name"
             :src="componentSection.src"
             :location-id="getActiveTab(componentSection)?.locationId"
         />

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.html.twig
@@ -28,5 +28,7 @@
         @modal-close="closeModal"
     />
     {% endblock %}
+
+    <sw-sidebar-renderer />
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.scss
@@ -1,6 +1,6 @@
 .sw-desktop {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto 1fr auto;
     position: relative;
     height: 100%;
     width: 100%;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.spec.js
@@ -128,6 +128,7 @@ async function createWrapper() {
                 'sw-admin-menu': true,
                 'router-view': true,
                 'sw-app-app-url-changed-modal': true,
+                'sw-sidebar-renderer': true,
                 'sw-error-boundary': true,
             },
             provide: {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-language-switch/sw-language-switch.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-language-switch/sw-language-switch.scss
@@ -8,4 +8,8 @@
     .sw-language-switch__select {
         margin-bottom: 0;
     }
+
+    .sw-block-field__block {
+        height: auto;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/index.js
@@ -162,6 +162,10 @@ Component.register('sw-page', {
                 'grid-row': rowNumber,
             };
         },
+
+        sidebars() {
+            return Shopware.Store.get('sidebar').sidebars;
+        },
     },
 
     created() {
@@ -232,6 +236,10 @@ Component.register('sw-page', {
             if (this.$route.meta.parentPath) {
                 this.parentRoute = this.$route.meta.parentPath;
             }
+        },
+
+        setActiveSidebar(locationId) {
+            Shopware.Store.get('sidebar').setActiveSidebar(locationId);
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.html.twig
@@ -28,10 +28,53 @@
         >
             <sw-app-topbar-button />
             {% block sw_page_notification_center %}
-            <sw-notification-center />
+            <div class="sw-page__sidebar-container">
+                <sw-notification-center />
+            </div>
             {% endblock %}
 
-            <sw-help-center-v2 />
+            <div class="sw-page__sidebar-container">
+                <sw-help-center-v2 />
+            </div>
+
+            <template v-if="sidebars && sidebars.length === 1">
+                <div class="sw-page__sidebar-container">
+                    <button
+                        v-tooltip="{ message: sidebars[0].title, placement: 'right' }"
+                        class="sw-page__sidebar-icon"
+                        :class="{ 'sw-page__sidebar-icon-active': sidebars[0].active }"
+                        :aria-label="$tc('sidebar.ariaLabelButtonOpen')"
+                        @click="setActiveSidebar(sidebars[0].locationId)"
+                    >
+                        <mt-icon
+                            :name="sidebars[0].icon"
+                            :size="20"
+                        />
+                    </button>
+                </div>
+            </template>
+
+            <template v-if="sidebars.length && sidebars.length > 1">
+                <div class="sw-page__sidebar-container">
+                    <sw-context-button>
+                        <template
+                            v-for="sidebar in sidebars"
+                            :key="sidebar.title"
+                        >
+                            <sw-context-menu-item
+                                @click="setActiveSidebar(sidebar.locationId)"
+                            >
+                                <mt-icon
+                                    :name="sidebar.icon"
+                                    :size="14"
+                                />
+
+                                {{ $t(sidebar.title) }}
+                            </sw-context-menu-item>
+                        </template>
+                    </sw-context-button>
+                </div>
+            </template>
         </div>
         {% endblock %}
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
@@ -51,7 +51,7 @@ $sw-page-search-bar-z-index: $z-index-sw-page-search-bar;
         align-content: flex-end;
         justify-content: flex-end;
         align-items: center;
-        gap: 16px;
+        gap: 4px;
     }
 
     .sw-page__smart-bar-divider {
@@ -184,5 +184,51 @@ $sw-page-search-bar-z-index: $z-index-sw-page-search-bar;
 
     .sw-page__side-content {
         border-right: 1px solid $sw-page-separator-color;
+    }
+
+    .sw-page__sidebar-container {
+        width: 40px;
+        height: 40px;
+        border-radius: var(--border-radius-button);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        &:hover {
+            background: var(--color-interaction-secondary-hover);
+        }
+
+        .sw-context-button__button {
+            width: 40px;
+            height: 40px;
+            border-radius: var(--border-radius-button);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
+            &:hover,
+            &is--active {
+                border: none;
+                background: var(--color-interaction-secondary-hover);
+            }
+        }
+    }
+
+    .sw-page__sidebar-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: var(--border-radius-button);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        transition: background-color 0.2s ease-in-out;
+
+        &:hover {
+            background: var(--color-interaction-secondary-hover);
+        }
+
+        &-active {
+            background: var(--color-interaction-secondary-hover);
+        }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.spec.js
@@ -15,6 +15,8 @@ async function createWrapper() {
                 'sw-app-actions': true,
                 'sw-help-center': true,
                 'sw-help-center-v2': true,
+                'sw-context-button': true,
+                'sw-context-menu-item': true,
                 'sw-app-topbar-button': true,
             },
             mocks: {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.spec.js
@@ -1,0 +1,94 @@
+import {mount} from "@vue/test-utils";
+import { ui } from '@shopware-ag/meteor-admin-sdk';
+import initializeSidebar from 'src/app/init/sidebar.init';
+
+describe('src/app/component/structure/sw-sidebar-renderer', () => {
+    async function createWrapper() {
+        return mount(await wrapTestComponent('sw-sidebar-renderer', {
+            sync: true,
+        }), {
+            global: {
+                stubs: {
+                    'sw-iframe-renderer': true,
+                },
+                provide: {},
+            },
+        });
+    }
+
+    beforeAll(() => {
+       // Start initalizer
+        initializeSidebar();
+    });
+
+    beforeEach(() => {
+        // Reset the sidebar store
+        Shopware.Store.get('sidebar').sidebars = [];
+
+        Shopware.Store.get('extensions').extensionsState = {};
+        Shopware.Store.get('extensions').addExtension({
+            name: 'jestapp',
+            baseUrl: '',
+            permissions: [],
+            version: '1.0.0',
+            type: 'app',
+            integrationId: '123',
+            active: true,
+        });
+    })
+
+    it('should be a Vue.js component', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('should render no sidebar when no sidebar is active', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.find('.sw-sidebar-renderer').exists()).toBe(false);
+    });
+
+    it('should render sidebar when a sidebar is active', async () => {
+        const wrapper = await createWrapper();
+
+        // Check that sidebar does not exist
+        expect(wrapper.find('.sw-sidebar-renderer').exists()).toBe(false);
+
+        // Create a sidebar
+        await ui.sidebar.add({
+            icon: 'regular-star',
+            title: 'Test sidebar',
+            locationId: 'test-sidebar',
+        });
+
+        // Make the sidebar active
+        Shopware.Store.get('sidebar').sidebars[0].active = true;
+
+        // Check that the sidebar is rendered
+        expect(wrapper.find('.sw-sidebar-renderer').exists()).toBe(true);
+    });
+
+    it('should close sidebar when close button is clicked', async () => {
+        const wrapper = await createWrapper();
+
+        // Create a sidebar
+        await ui.sidebar.add({
+            icon: 'regular-star',
+            title: 'Test sidebar',
+            locationId: 'test-sidebar',
+        });
+
+        // Make the sidebar active
+        Shopware.Store.get('sidebar').sidebars[0].active = true;
+
+        // Check that the sidebar is rendered
+        expect(wrapper.find('.sw-sidebar-renderer').exists()).toBe(true);
+
+        // Click the close button
+        await wrapper.find('.sw-sidebar-renderer__button-close').trigger('click');
+
+        // Check that the sidebar is closed
+        expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(false);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @sw-package framework
+ */
+
+import { computed } from 'vue';
+import template from './sw-sidebar-renderer.html.twig';
+import './sw-sidebar-renderer.scss';
+
+const { Component } = Shopware;
+
+/**
+ * @private
+ */
+Component.register('sw-sidebar-renderer', {
+    template,
+
+    setup() {
+        const activeSidebar = computed(() => {
+            return Shopware.Store.get('sidebar').getActiveSidebar;
+        });
+
+        const sidebars = computed(() => {
+            return Shopware.Store.get('sidebar').sidebars;
+        });
+
+        const closeSidebar = (locationId: string) => {
+            Shopware.Store.get('sidebar').closeSidebar(locationId);
+        };
+
+        return {
+            activeSidebar,
+            sidebars,
+            closeSidebar,
+        };
+    },
+});

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.html.twig
@@ -1,0 +1,35 @@
+<template
+    v-for="sidebar in sidebars"
+    :key="sidebar.locationId"
+>
+    <aside
+        class="sw-sidebar-renderer"
+        :class="{ 'is-active': activeSidebar && activeSidebar.locationId === sidebar.locationId }"
+        :style="{ display: (activeSidebar && activeSidebar.locationId === sidebar.locationId) ? 'flex' : 'none' }"
+    >
+        <header class="sw-sidebar-renderer__header">
+            <h3 class="sw-sidebar-renderer__title">
+                {{ $tc(sidebar.title) }}
+            </h3>
+
+            <button
+                class="sw-sidebar-renderer__button-close"
+                :aria-label="$tc('sidebar.ariaLabelButtonClose')"
+                @click="closeSidebar(sidebar.locationId)"
+            >
+                <mt-icon
+                    name="regular-times-xs"
+                    size="12px"
+                />
+            </button>
+        </header>
+
+        <section class="sw-sidebar-renderer__content">
+            <sw-iframe-renderer
+                :src="sidebar.baseUrl"
+                :location-id="sidebar.locationId"
+                :full-screen="false"
+            />
+        </section>
+    </aside>
+</template>

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.scss
@@ -1,0 +1,58 @@
+.sw-sidebar-renderer {
+    width: 480px;
+    flex-direction: column;
+    border-left: 1px solid var(--color-border-primary-default);
+    background: var(--color-elevation-surface-raised);
+
+    iframe {
+        width: 100%;
+        height: 100%;
+        border: none;
+    }
+
+    &__header {
+        display: flex;
+
+        // This value seems odd but is caused by the header of the page. 80px container plus 1px border seperator.
+        height: 81px;
+        padding: 0 24px;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+        flex-shrink: 0;
+        align-self: stretch;
+        border-bottom: 1px solid var(--color-border-primary-default);
+        background: var(--color-elevation-surface-raised);
+    }
+
+    .sw-iframe-renderer {
+        height: 100%;
+    }
+
+    &__content {
+        height: 100%;
+    }
+
+    &__button-close {
+        width: 40px;
+        height: 40px;
+        border-radius: var(--border-radius-button);
+        transition: background-color 0.2s ease-in-out;
+
+        &:hover {
+            background: var(--color-interaction-secondary-hover);
+        }
+
+        &-active {
+            background: var(--color-interaction-secondary-hover);
+        }
+    }
+
+    &__close-icon {
+        cursor: pointer;
+    }
+
+    &__title {
+        margin: 0;
+    }
+}

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/sw-notification-center.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/sw-notification-center.scss
@@ -1,10 +1,16 @@
 @import "~scss/variables";
 
 .sw-notification-center__context-button {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--border-radius-button);
+    display: flex;
+    justify-content: center;
+    align-items: center;
     cursor: pointer;
 
     &.is--active {
-        color: $color-shopware-brand-500;
+        background: var(--color-interaction-secondary-hover);
     }
 }
 

--- a/src/Administration/Resources/app/administration/src/app/init-pre/store.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-pre/store.init.ts
@@ -15,6 +15,7 @@ import 'src/app/store/settings-item.store';
 import 'src/app/store/shopware-apps.store';
 import 'src/app/store/system.store';
 import 'src/app/store/modals.store';
+import 'src/app/store/sidebar.store';
 import 'src/app/store/menu-item.store';
 import 'src/app/store/tabs.store';
 import 'src/app/store/usage-data.store';

--- a/src/Administration/Resources/app/administration/src/app/init/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/index.ts
@@ -25,6 +25,7 @@ import initTabs from 'src/app/init/tabs.init';
 import initCms from './cms.init';
 import initMenu from './menu-item.init';
 import initModals from './modals.init';
+import initializeSidebar from './sidebar.init';
 import initSettingItems from './settings-item.init';
 import initMainModules from './main-module.init';
 import initializeActionButtons from './action-button.init';
@@ -58,6 +59,7 @@ export default {
     menu: initMenu,
     settingItems: initSettingItems,
     modals: initModals,
+    sidebar: initializeSidebar,
     mainModules: initMainModules,
     actionButton: initializeActionButtons,
     actions: initializeActions,

--- a/src/Administration/Resources/app/administration/src/app/init/sidebar.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/sidebar.init.spec.js
@@ -1,0 +1,93 @@
+import { ui } from '@shopware-ag/meteor-admin-sdk';
+import initializeSidebar from './sidebar.init';
+
+describe('src/app/init/sidebar.init', () => {
+    beforeAll(() => {
+        // Execute the initializeSidebar function
+        initializeSidebar();
+    });
+
+    beforeEach(() => {
+        // Reset the sidebar store
+        Shopware.Store.get('sidebar').sidebars = [];
+
+        Shopware.Store.get('extensions').extensionsState = {};
+        Shopware.Store.get('extensions').addExtension({
+            name: 'jestapp',
+            baseUrl: '',
+            permissions: [],
+            version: '1.0.0',
+            type: 'app',
+            integrationId: '123',
+            active: true,
+        });
+    });
+
+    it('should handle uiSidebarAdd', async () => {
+        // Check that sidebar store is empty
+        expect(Shopware.Store.get('sidebar').sidebars).toEqual([]);
+
+        // Add a sidebar
+        await ui.sidebar.add({
+            icon: 'regular-star',
+            title: 'Test sidebar',
+            locationId: 'test-sidebar',
+        })
+
+        // Check that sidebar store has the added sidebar
+        expect(Shopware.Store.get('sidebar').sidebars).toHaveLength(1);
+        expect(Shopware.Store.get('sidebar').sidebars[0]).toEqual({
+            icon: 'regular-star',
+            title: 'Test sidebar',
+            locationId: 'test-sidebar',
+            active: false,
+            baseUrl: '',
+        });
+    });
+
+    it('should handle uiSidebarClose', async () => {
+        // Add a sidebar
+        await ui.sidebar.add({
+            icon: 'regular-star',
+            title: 'Test sidebar',
+            locationId: 'test-sidebar',
+        });
+
+        // Check that sidebar store has the added sidebar
+        expect(Shopware.Store.get('sidebar').sidebars).toHaveLength(1);
+
+        // Check that sidebar is not active
+        expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(false);
+
+        // Open the sidebar
+        Shopware.Store.get('sidebar').sidebars[0].active = true;
+
+        // Close the sidebar
+        await ui.sidebar.close({
+            locationId: 'test-sidebar',
+        });
+
+        // Check that sidebar is not active
+        expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(false);
+    });
+
+    it('should handle uiSidebarRemove', async () => {
+        // Add a sidebar
+        await ui.sidebar.add({
+            icon: 'regular-star',
+            title: 'Test sidebar',
+            locationId: 'test-sidebar',
+        });
+
+        // Check that sidebar store has the added sidebar
+        expect(Shopware.Store.get('sidebar').sidebars).toHaveLength(1);
+
+        // Remove the sidebar
+        await ui.sidebar.remove({
+            locationId: 'test-sidebar',
+        });
+
+        // Check that sidebar store is empty
+        expect(Shopware.Store.get('sidebar').sidebars).toEqual([]);
+    })
+});

--- a/src/Administration/Resources/app/administration/src/app/init/sidebar.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/sidebar.init.ts
@@ -1,0 +1,32 @@
+/**
+ * @sw-package framework
+ *
+ * @private
+ */
+export default function initializeSidebar(): void {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    Shopware.ExtensionAPI.handle('uiSidebarAdd', async (sidebarConfig, { _event_ }) => {
+        const extension = Object.values(Shopware.Store.get('extensions').extensionsState).find((ext) =>
+            ext.baseUrl.startsWith(_event_.origin),
+        );
+
+        if (!extension) {
+            throw new Error(`Extension with the origin "${_event_.origin}" not found.`);
+        }
+
+        // create sidebar store
+        Shopware.Store.get('sidebar').addSidebar({
+            baseUrl: extension.baseUrl,
+            active: false,
+            ...sidebarConfig,
+        });
+    });
+
+    Shopware.ExtensionAPI.handle('uiSidebarClose', ({ locationId }) => {
+        Shopware.Store.get('sidebar').closeSidebar(locationId);
+    });
+
+    Shopware.ExtensionAPI.handle('uiSidebarRemove', ({ locationId }) => {
+        Shopware.Store.get('sidebar').removeSidebar(locationId);
+    });
+}

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -1557,6 +1557,10 @@
   "sw-in-app-purchase-checkout": {
     "exsTitle": "Shopware Extension Store aktivieren"
   },
+  "sidebar": {
+    "ariaLabelButtonClose": "Seitenleiste schließen",
+    "ariaLabelButtonOpen": "Seitenleiste öffnen"
+  },
   "help-center": {
     "sidebar": {
       "title": "Hilfe",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -1557,6 +1557,10 @@
   "sw-in-app-purchase-checkout": {
     "exsTitle": "Activate the Shopware Extension Store"
   },
+  "sidebar": {
+    "ariaLabelButtonClose": "Close sidebar",
+    "ariaLabelButtonOpen": "Open sidebar"
+  },
   "help-center": {
     "sidebar": {
       "title": "Help",

--- a/src/Administration/Resources/app/administration/src/app/store/sidebar.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/sidebar.store.ts
@@ -1,0 +1,87 @@
+/**
+ * @sw-package framework
+ */
+
+import type { uiSidebarAdd } from '@shopware-ag/meteor-admin-sdk/es/ui/sidebar';
+import { reactive } from 'vue';
+
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export type SidebarItemEntry = Omit<uiSidebarAdd, 'responseType'> & {
+    baseUrl: string;
+    active: boolean;
+};
+
+const sidebarsStore = Shopware.Store.register({
+    id: 'sidebar',
+
+    state: () => ({
+        sidebars: [] as SidebarItemEntry[],
+    }),
+
+    getters: {
+        getActiveSidebar(): SidebarItemEntry | null {
+            return (
+                this.sidebars.find((sidebar) => {
+                    return sidebar.active;
+                }) || null
+            );
+        },
+    },
+
+    actions: {
+        // Extension API message methods
+        addSidebar({ locationId, title, icon, baseUrl }: SidebarItemEntry) {
+            const sidebar = reactive({
+                title,
+                icon,
+                locationId,
+                baseUrl,
+                active: false,
+            });
+
+            this.sidebars.push(sidebar);
+        },
+
+        closeSidebar(locationId: string): void {
+            const sidebar = this.sidebars.find((item) => {
+                return item.locationId === locationId;
+            });
+
+            if (!sidebar) {
+                return;
+            }
+            sidebar.active = false;
+        },
+
+        removeSidebar(locationId: string): void {
+            this.sidebars = this.sidebars.filter((sidebar) => {
+                return sidebar.locationId !== locationId;
+            });
+        },
+
+        // Store API
+        setActiveSidebar(locationId: string): void {
+            // reset all sidebars
+            this.sidebars.forEach((sidebar) => {
+                sidebar.active = false;
+            });
+
+            const sidebar = this.sidebars.find((item) => item.locationId === locationId);
+            if (!sidebar) {
+                return;
+            }
+
+            sidebar.active = true;
+        },
+    },
+});
+
+/**
+ * @private
+ */
+export type SidebarStore = ReturnType<typeof sidebarsStore>;
+
+/**
+ * @private
+ */
+export default sidebarsStore;

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -112,6 +112,7 @@ import type { SettingsItems } from './app/store/settings-item.store';
 import type { ShopwareApps } from './app/store/shopware-apps.store';
 import type { System } from './app/store/system.store';
 import type { ModalsStore } from './app/store/modals.store';
+import type { SidebarStore } from './app/store/sidebar.store';
 import type { MenuItemStore } from './app/store/menu-item.store';
 import type { NotificationStore } from './app/store/notification.store';
 import type { TabsStore } from './app/store/tabs.store';
@@ -385,6 +386,7 @@ declare global {
         shopwareApps: ShopwareApps;
         system: System;
         modals: ModalsStore;
+        sidebar: SidebarStore;
         menuItem: MenuItemStore;
         notification: NotificationStore;
         tabs: TabsStore;

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.spec.js
@@ -71,6 +71,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-customer', () => {
                     'sw-ignore-class': true,
                     'sw-entity-tag-select': true,
                     'sw-error-summary': true,
+                    'sw-context-menu-item': true,
                     'sw-bulk-edit-save-modal-error': await wrapTestComponent('sw-bulk-edit-save-modal-error', {
                         sync: true,
                     }),

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
@@ -69,6 +69,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-order', () => {
                     'sw-search-bar': true,
                     'sw-datepicker': true,
                     'sw-text-editor': true,
+                    'sw-context-menu-item': true,
                     'sw-language-switch': true,
                     'sw-notification-center': true,
                     'sw-help-center': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
@@ -84,6 +84,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
                     'sw-empty-state': await wrapTestComponent('sw-empty-state'),
                     'sw-button-process': await wrapTestComponent('sw-button-process'),
                     'sw-ignore-class': true,
+                    'sw-context-menu-item': true,
                     'sw-select-base': await wrapTestComponent('sw-select-base'),
                     'sw-single-select': await wrapTestComponent('sw-single-select'),
                     'sw-text-field': await wrapTestComponent('sw-text-field'),

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-link-settings/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-link-settings/index.js
@@ -125,9 +125,11 @@ export default {
 
         categoryLinkHelpText() {
             return this.$t('sw-category.base.link.categoryHelpText', {
-                types: this.allowedCategoryTypes.map((type) => {
-                    return this.$t(`sw-category.base.general.types.${type}`);
-                }).join(', '),
+                types: this.allowedCategoryTypes
+                    .map((type) => {
+                        return this.$t(`sw-category.base.general.types.${type}`);
+                    })
+                    .join(', '),
             });
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.spec.js
@@ -21,6 +21,8 @@ async function createWrapper(privileges = []) {
                 'router-link': true,
                 'sw-app-actions': true,
                 'sw-error-summary': true,
+                'sw-context-menu-item': true,
+                'sw-context-button': true,
             },
             mocks: {
                 $tc: jest.fn().mockImplementation((snippetPath, placeholders) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
@@ -25,6 +25,8 @@ async function createWrapper(back = null, push = jest.fn()) {
                 'sw-my-apps-error-page': true,
                 'sw-iframe-renderer': true,
                 'sw-language-switch': true,
+                'sw-context-menu-item': true,
+                'sw-context-button': true,
                 'router-link': {
                     props: {
                         to: {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-app-module-page/sw-extension-app-module-page.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-app-module-page/sw-extension-app-module-page.spec.js
@@ -24,6 +24,8 @@ async function createWrapper(props) {
                 'sw-loader': true,
                 'sw-app-topbar-button': true,
                 'sw-help-center-v2': true,
+                'sw-context-menu-item': true,
+                'sw-context-button': true,
                 'router-link': true,
             },
             mocks: {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.spec.js
@@ -75,6 +75,8 @@ describe('src/module/sw-order/page/sw-order-create', () => {
             'sw-help-center': true,
             'sw-search-bar': true,
             'sw-language-switch': true,
+            'sw-context-menu-item': true,
+            'sw-context-button': true,
             'sw-card-view': await wrapTestComponent('sw-card-view', {
                 sync: true,
             }),

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -121,7 +121,7 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
 
         Shopware.Store.get('swOrderDetail').order = {
             orderNumber: 1,
-            createdById: '2'
+            createdById: '2',
         };
         await nextTick();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-modal-preview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-modal-preview/index.js
@@ -291,10 +291,13 @@ export default {
 
             fields = shuffle(fields);
             const selectedFields = fields.slice(0, 2);
-            const directions = ['ASC', 'DESC'];
+            const directions = [
+                'ASC',
+                'DESC',
+            ];
             const randomDirection = directions[Math.floor(Math.random() * directions.length)];
 
-            selectedFields.forEach(field => {
+            selectedFields.forEach((field) => {
                 criteria.addSorting(Criteria.sort(field, randomDirection));
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-modal-preview/sw-product-stream-modal-preview.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-modal-preview/sw-product-stream-modal-preview.spec.js
@@ -363,8 +363,16 @@ describe('src/module/sw-product-stream/component/sw-product-stream-modal-preview
         const sortings = criteria.sortings;
         expect(sortings).toHaveLength(2);
 
-        const allowedFields = ['name', 'createdAt', 'cheapestPrice', 'releaseDate'];
-        const validDirections = ['ASC', 'DESC'];
+        const allowedFields = [
+            'name',
+            'createdAt',
+            'cheapestPrice',
+            'releaseDate',
+        ];
+        const validDirections = [
+            'ASC',
+            'DESC',
+        ];
 
         sortings.forEach((sorting) => {
             expect(allowedFields).toContain(sorting.field);
@@ -381,8 +389,16 @@ describe('src/module/sw-product-stream/component/sw-product-stream-modal-preview
         const sortings = criteria.sortings;
         expect(sortings).toHaveLength(2);
 
-        const allowedFields = ['name', 'createdAt', 'cheapestPrice', 'releaseDate'];
-        const validDirections = ['ASC', 'DESC'];
+        const allowedFields = [
+            'name',
+            'createdAt',
+            'cheapestPrice',
+            'releaseDate',
+        ];
+        const validDirections = [
+            'ASC',
+            'DESC',
+        ];
 
         sortings.forEach((sorting) => {
             expect(allowedFields).toContain(sorting.field);

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
@@ -272,7 +272,10 @@ export default {
 
             const results = await Promise.all(promises);
 
-            return [initialResult, ...results].flatMap((result) => result);
+            return [
+                initialResult,
+                ...results,
+            ].flatMap((result) => result);
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
@@ -249,9 +249,7 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
         });
         await flushPromises();
         const criteria = new Criteria(1, 500);
-        criteria
-            .addFields('name')
-            .addFilter(
+        criteria.addFields('name').addFilter(
             Criteria.equalsAny('id', [
                 'id-1',
                 'id-2',
@@ -279,32 +277,35 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
             .mockResolvedValueOnce({
                 total: 12,
                 length: 5,
-                map: (fn) => [
-                    { id: '1', name: 'group-1' },
-                    { id: '2', name: 'group-2' },
-                    { id: '3', name: 'group-3' },
-                    { id: '4', name: 'group-4' },
-                    { id: '5', name: 'group-5' },
-                ].map(fn),
+                map: (fn) =>
+                    [
+                        { id: '1', name: 'group-1' },
+                        { id: '2', name: 'group-2' },
+                        { id: '3', name: 'group-3' },
+                        { id: '4', name: 'group-4' },
+                        { id: '5', name: 'group-5' },
+                    ].map(fn),
             })
             .mockResolvedValueOnce({
                 total: 7,
                 length: 5,
-                map: (fn) => [
-                    { id: '6', name: 'group-6' },
-                    { id: '7', name: 'group-7' },
-                    { id: '8', name: 'group-8' },
-                    { id: '9', name: 'group-9' },
-                    { id: '10', name: 'group-10' },
-                ].map(fn),
+                map: (fn) =>
+                    [
+                        { id: '6', name: 'group-6' },
+                        { id: '7', name: 'group-7' },
+                        { id: '8', name: 'group-8' },
+                        { id: '9', name: 'group-9' },
+                        { id: '10', name: 'group-10' },
+                    ].map(fn),
             })
             .mockResolvedValueOnce({
                 total: 2,
                 length: 2,
-                map: (fn) => [
-                    { id: '11', name: 'group-11' },
-                    { id: '12', name: 'group-12' },
-                ].map(fn),
+                map: (fn) =>
+                    [
+                        { id: '11', name: 'group-11' },
+                        { id: '12', name: 'group-12' },
+                    ].map(fn),
             });
 
         wrapper.vm.loadConfigSettingGroups = jest.fn();
@@ -324,11 +325,12 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
         wrapper.vm.groupRepository.search = jest.fn().mockResolvedValueOnce({
             total: 3,
             length: 3,
-            map: (fn) => [
-                { id: '1', name: 'group-1' },
-                { id: '2', name: 'group-2' },
-                { id: '3', name: 'group-3' },
-            ].map(fn),
+            map: (fn) =>
+                [
+                    { id: '1', name: 'group-1' },
+                    { id: '2', name: 'group-2' },
+                    { id: '3', name: 'group-3' },
+                ].map(fn),
         });
 
         wrapper.vm.loadConfigSettingGroups = jest.fn();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.spec.js
@@ -58,7 +58,7 @@ const documentBaseConfigRepositoryMock = {
             return Promise.resolve({
                 id: id,
                 documentTypeId: 'documentTypeId',
-                config: { },
+                config: {},
             });
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.spec.js
@@ -42,7 +42,7 @@ async function createWrapper() {
                     'router-link': true,
                     'sw-app-actions': true,
                     'sw-sales-channel-switch': true,
-
+                    'sw-context-menu-item': true,
                     'sw-form-field-renderer': true,
                     'sw-inherit-wrapper': true,
                     'sw-ai-copilot-badge': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/page/sw-settings-seo/sw-settings-seo.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/page/sw-settings-seo/sw-settings-seo.spec.js
@@ -30,6 +30,7 @@ async function createWrapper() {
                     'sw-ignore-class': true,
                     'sw-loader': true,
                     'sw-app-actions': true,
+                    'sw-context-menu-item': true,
                     'sw-extension-component-section': true,
                     'sw-skeleton': true,
                     'sw-error-summary': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/sw-settings-snippet-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/sw-settings-snippet-detail.spec.js
@@ -170,6 +170,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-detail', () => {
                         'sw-app-topbar-button': true,
                         'sw-notification-center': true,
                         'sw-help-center-v2': true,
+                        'sw-context-menu-item': true,
                         'sw-context-button': true,
                         'sw-extension-component-section': true,
                         'sw-ai-copilot-badge': true,

--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -80,6 +80,7 @@ import '../../src/app/store/tabs.store';
 import '../../src/app/store/usage-data.store';
 import '../../src/app/store/session.store';
 import '../../src/app/store/sw-bulk-edit.store';
+import '../../src/app/store/sidebar.store';
 import '../../src/module/sw-category/page/sw-category-detail/store';
 import '../../src/module/sw-extension/store/extensions.store';
 import '../../src/module/sw-order/store/order-detail.store';


### PR DESCRIPTION
### 1. Why is this change necessary?
There should be the possibility to add sidebars via the sdk `sw.ui.sidebar.open` etc.

### 2. What does this change do, exactly?
Implement the handlers for the sdk sidebar [PR](https://github.com/shopware/meteor/pull/636)
