### PR TITLE
fix: fix email agent selection

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/index.js
@@ -14,6 +14,7 @@ const defaultMailerSettings = {
     'core.mailerSettings.senderAddress': null,
     'core.mailerSettings.deliveryAddress': null,
     'core.mailerSettings.disableDelivery': false,
+    'core.mailerSettings.sendMailOptions': null,
 };
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
@@ -120,11 +121,6 @@ export default {
         async saveMailerSettings() {
             this.isLoading = true;
 
-            // Inputs cannot return null
-            if (this.mailerSettings['core.mailerSettings.emailAgent'] === '') {
-                this.mailerSettings['core.mailerSettings.emailAgent'] = null;
-            }
-
             // Validate smtp configuration
             if (this.isSmtpMode) {
                 this.validateSmtpConfiguration();
@@ -148,6 +144,7 @@ export default {
                     ...defaultMailerSettings,
                     'core.mailerSettings.emailAgent': 'local',
                     'core.mailerSettings.disableDelivery': this.mailerSettings['core.mailerSettings.disableDelivery'],
+                    'core.mailerSettings.sendMailOptions': this.mailerSettings['core.mailerSettings.sendMailOptions'],
                 };
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
@@ -156,6 +156,7 @@ describe('src/module/sw-settings-mailer/page/sw-settings-mailer', () => {
                 'core.mailerSettings.encryption': 'ssl',
                 'core.mailerSettings.senderAddress': 'test@example.com',
                 'core.mailerSettings.deliveryAddress': 'info@test.de',
+                'core.mailerSettings.sendMailOptions': '-t -i',
             },
         });
 
@@ -173,6 +174,7 @@ describe('src/module/sw-settings-mailer/page/sw-settings-mailer', () => {
             'core.mailerSettings.senderAddress': null,
             'core.mailerSettings.deliveryAddress': null,
             'core.mailerSettings.disableDelivery': false,
+            'core.mailerSettings.sendMailOptions': '-t -i',
         });
     });
 
@@ -201,6 +203,7 @@ describe('src/module/sw-settings-mailer/page/sw-settings-mailer', () => {
             'core.mailerSettings.senderAddress': null,
             'core.mailerSettings.deliveryAddress': null,
             'core.mailerSettings.disableDelivery': true,
+            'core.mailerSettings.sendMailOptions': '-bs',
         });
     });
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Local mailer settings don't have any effect: https://github.com/shopware/shopware/issues/7891

### 2. What does this change do, exactly?

The resetting was done wrongly and is now fixed:


https://github.com/user-attachments/assets/8a273ac7-49b1-4df9-bdb5-a5e0a8c9b80c

Closes #7891
Closes #7886