### PR TITLE
fix: Improve search widget accessibility

### DIFF
--- a/changelog/_unreleased/2025-03-27-a11y-insufficient-accessibility-of-the-search-form-field-for-screen-readers.md
+++ b/changelog/_unreleased/2025-03-27-a11y-insufficient-accessibility-of-the-search-form-field-for-screen-readers.md
@@ -1,0 +1,10 @@
+---
+title: a11y insufficient accessibility of the search form field for screen readers
+issue: 7093
+author: Le Nguyen
+author_email: nguyenquocdaile@gmail.com
+author_github: @nguyenquocdaile
+---
+# Storefront
+* Added `role="combobox"`, `aria-autocomplete="list"`, ` aria-controls="search-suggest-listbox"`, `aria-expanded="false"` attributes to `layout_header_search_input` block in `Storefront/Resources/views/storefront/layout/header/search.html.twig`.
+* Added `role="listbox"` to `ul` tag element and `role="option"` to `li` tag element in `Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig`.

--- a/changelog/_unreleased/2025-04-02-search-widget-accessibility.md
+++ b/changelog/_unreleased/2025-04-02-search-widget-accessibility.md
@@ -1,0 +1,8 @@
+---
+title: Improve search widget accessibility
+issue: #7877
+---
+# Storefront
+* Deprecated `storefront/src/helper/arrow-navigation.helper.js` for v6.8.0 because it is obsolete.
+* Changed `storefront/src/plugin/header/search-widget.plugin.js` to add proper keyboard navigation via tab and arrow keys, using real focus states.
+* Added `aria-describedby` attribute to the search input field in `layout/header/search.html.twig` to read out search result changes for screen reader users.

--- a/src/Storefront/Resources/app/storefront/src/helper/arrow-navigation.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/arrow-navigation.helper.js
@@ -1,8 +1,8 @@
 
 const ARROW_NAVIGATION_ACTIVE_CLASS = 'is-active';
-
 const ARROW_NAVIGATION_ITERATOR_DEFAULT = -1;
 
+/** @deprecated tag:v6.8.0 - ArrowNavigationHelper will be removed without replacement. */
 export default class ArrowNavigationHelper {
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -4,7 +4,6 @@ import Debouncer from 'src/helper/debouncer.helper';
 import HttpClient from 'src/service/http-client.service';
 import ButtonLoadingIndicator from 'src/utility/loading-indicator/button-loading-indicator.util';
 import DeviceDetection from 'src/helper/device-detection.helper';
-import ArrowNavigationHelper from 'src/helper/arrow-navigation.helper';
 
 export default class SearchWidgetPlugin extends Plugin {
 
@@ -36,14 +35,6 @@ export default class SearchWidgetPlugin extends Plugin {
         /** @deprecated tag:v6.8.0 - HttpClient is deprecated. Use native fetch API instead. */
         this._client = new HttpClient();
 
-        // initialize the arrow navigation
-        this._navigationHelper = new ArrowNavigationHelper(
-            this._inputField,
-            this.options.searchWidgetResultSelector,
-            this.options.searchWidgetResultItemSelector,
-            true,
-        );
-
         this._registerEvents();
     }
 
@@ -62,6 +53,8 @@ export default class SearchWidgetPlugin extends Plugin {
             },
         );
 
+        this._inputField.addEventListener('keydown', this._handleKeyEvent.bind(this));
+
         this.el.addEventListener('submit', this._handleSearchEvent.bind(this));
 
         // add click event listener to body
@@ -73,11 +66,6 @@ export default class SearchWidgetPlugin extends Plugin {
 
         // add click event listener to close button
         this._closeButton.addEventListener('click', this._onCloseButtonClick.bind(this));
-
-        // add focus event listener to close button
-        this._closeButton.addEventListener('focus', () => {
-            document.querySelector(this.options.searchWidgetResultSelector).classList.add('d-none');
-        });
     }
 
     _handleSearchEvent(event) {
@@ -110,6 +98,108 @@ export default class SearchWidgetPlugin extends Plugin {
     }
 
     /**
+     * Handles the keydown event on the input field,
+     * to focus into the search suggestions list.
+     * 
+     * @param {Event} event
+     * @private
+     */
+    _handleKeyEvent(event) {
+        if (event.key !== 'ArrowDown' || 
+            this._inputField.value.trim() === '') {
+            return;
+        }
+
+        event.preventDefault();
+
+        const searchSuggest = document.querySelector(this.options.searchWidgetResultSelector);
+        if (!searchSuggest) {
+            return;
+        }
+
+        const searchSuggestItems = searchSuggest.querySelectorAll(this.options.searchWidgetResultItemSelector);
+        const firstItem = searchSuggestItems[0];
+
+        if (!firstItem) {
+            return;
+        }
+
+        const firstAnchor = firstItem.querySelector('a');
+        window.focusHandler.setFocus(firstAnchor, { focusVisible: true, preventScroll: true });
+    }
+
+    /**
+     * Handles the keydown event on the search suggestions list,
+     * to move the focus up or down the list.
+     * 
+     * @param {Event} event
+     * @private
+     */
+    _handleSearchItemKeyEvent(event) {
+        if (event.key !== 'ArrowDown' && 
+            event.key !== 'ArrowUp') {
+            return;
+        }
+ 
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+
+        if (event.key === 'ArrowDown') {
+            this._moveFocusDown(event.target);
+        }
+
+        if (event.key === 'ArrowUp') {
+            this._moveFocusUp(event.target);
+        }
+    }
+
+    /**
+     * Moves the focus up the search results list.
+     * 
+     * @param {EventTarget} eventTarget
+     * @private
+     */
+    _moveFocusUp(eventTarget) {
+        const listItem = eventTarget.closest(this.options.searchWidgetResultItemSelector);
+        if (!listItem) {
+            return;
+        }
+
+        const previousItem = listItem.previousElementSibling;
+
+        if (!previousItem) {
+            // Focus back on the input field.
+            window.focusHandler.setFocus(this._inputField, { focusVisible: true, preventScroll: true });
+        } else {
+            const previousAnchor = previousItem.querySelector('a');
+
+            window.focusHandler.setFocus(previousAnchor, { focusVisible: true, preventScroll: true });
+        }
+    }
+
+    /**
+     * Moves the focus down the search results list.
+     * 
+     * @param {EventTarget} eventTarget
+     * @private
+     */
+    _moveFocusDown(eventTarget) {
+        const listItem = eventTarget.closest(this.options.searchWidgetResultItemSelector);
+        if (!listItem) {
+            return;
+        }
+
+        const nextItem = listItem.nextElementSibling;
+
+        if (nextItem) {
+            const nextAnchor = nextItem.querySelector('a');
+
+            window.focusHandler.setFocus(nextAnchor, { focusVisible: true, preventScroll: true });
+        }
+    }
+
+    /**
      * Process the AJAX suggest and show results
      * @param {string} value
      * @private
@@ -135,7 +225,18 @@ export default class SearchWidgetPlugin extends Plugin {
                 indicator.remove();
 
                 // attach search results to the DOM
-                this.el.insertAdjacentHTML('beforeend', content);
+                const searchWidgetButtonField = this.el.querySelector(this.options.searchWidgetButtonFieldSelector);
+                searchWidgetButtonField.insertAdjacentHTML('afterend', content);
+
+                this._inputField.setAttribute('aria-expanded', 'true');
+
+                const searchSuggest = document.querySelector(this.options.searchWidgetResultSelector);
+                const searchSuggestItems = searchSuggest.querySelectorAll(this.options.searchWidgetResultItemSelector);
+
+                searchSuggestItems.forEach(item => {
+                    const anchor = item.querySelector('a');
+                    anchor.addEventListener('keydown', this._handleSearchItemKeyEvent.bind(this));
+                });
 
                 this.$emitter.publish('afterSuggest');
             });
@@ -146,12 +247,11 @@ export default class SearchWidgetPlugin extends Plugin {
      * @private
      */
     _clearSuggestResults() {
-        // reset arrow navigation helper to enable form submit on enter
-        this._navigationHelper.resetIterator();
-
         // remove all result popovers
         const results = document.querySelectorAll(this.options.searchWidgetResultSelector);
         results.forEach(result => result.remove());
+
+        this._inputField.setAttribute('aria-expanded', 'false');
 
         this.$emitter.publish('clearSuggestResults');
     }
@@ -185,6 +285,7 @@ export default class SearchWidgetPlugin extends Plugin {
     _onCloseButtonClick() {
         this._inputField.value = '';
         this._inputField.focus();
+        this._clearSuggestResults();
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -3,7 +3,6 @@ import Debouncer from 'src/helper/debouncer.helper';
 /** @deprecated tag:v6.8.0 - HttpClient is deprecated. Use native fetch API instead. */
 import HttpClient from 'src/service/http-client.service';
 import ButtonLoadingIndicator from 'src/utility/loading-indicator/button-loading-indicator.util';
-import DeviceDetection from 'src/helper/device-detection.helper';
 
 export default class SearchWidgetPlugin extends Plugin {
 
@@ -35,6 +34,8 @@ export default class SearchWidgetPlugin extends Plugin {
         /** @deprecated tag:v6.8.0 - HttpClient is deprecated. Use native fetch API instead. */
         this._client = new HttpClient();
 
+        this.searchSuggestLinks = [];
+
         this._registerEvents();
     }
 
@@ -58,8 +59,7 @@ export default class SearchWidgetPlugin extends Plugin {
         this.el.addEventListener('submit', this._handleSearchEvent.bind(this));
 
         // add click event listener to body
-        const event = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
-        document.body.addEventListener(event, this._onBodyClick.bind(this));
+        document.body.addEventListener('click', this._onBodyClick.bind(this));
 
         // add click event for mobile search
         this._registerInputFocus();
@@ -112,30 +112,22 @@ export default class SearchWidgetPlugin extends Plugin {
 
         event.preventDefault();
 
-        const searchSuggest = document.querySelector(this.options.searchWidgetResultSelector);
-        if (!searchSuggest) {
+        if (!this.searchSuggestLinks || !this.searchSuggestLinks.length) {
             return;
         }
 
-        const searchSuggestItems = searchSuggest.querySelectorAll(this.options.searchWidgetResultItemSelector);
-        const firstItem = searchSuggestItems[0];
-
-        if (!firstItem) {
-            return;
-        }
-
-        const firstAnchor = firstItem.querySelector('a');
-        window.focusHandler.setFocus(firstAnchor, { focusVisible: true, preventScroll: true });
+        window.focusHandler.setFocus(this.searchSuggestLinks[0], { focusVisible: true });
     }
 
     /**
      * Handles the keydown event on the search suggestions list,
      * to move the focus up or down the list.
      * 
+     * @param {number} index
      * @param {Event} event
      * @private
      */
-    _handleSearchItemKeyEvent(event) {
+    _handleSearchItemKeyEvent(index, event) {
         if (event.key !== 'ArrowDown' && 
             event.key !== 'ArrowUp') {
             return;
@@ -146,56 +138,40 @@ export default class SearchWidgetPlugin extends Plugin {
         event.stopImmediatePropagation();
 
         if (event.key === 'ArrowDown') {
-            this._moveFocusDown(event.target);
+            this._moveFocusDown(index);
         }
 
         if (event.key === 'ArrowUp') {
-            this._moveFocusUp(event.target);
+            this._moveFocusUp(index);
         }
     }
 
     /**
      * Moves the focus up the search results list.
      * 
-     * @param {EventTarget} eventTarget
+     * @param {number} currentIndex
      * @private
      */
-    _moveFocusUp(eventTarget) {
-        const listItem = eventTarget.closest(this.options.searchWidgetResultItemSelector);
-        if (!listItem) {
-            return;
-        }
-
-        const previousItem = listItem.previousElementSibling;
-
-        if (!previousItem) {
+    _moveFocusUp(currentIndex) {
+        if (currentIndex === 0) {
             // Focus back on the input field.
-            window.focusHandler.setFocus(this._inputField, { focusVisible: true, preventScroll: true });
+            window.focusHandler.setFocus(this._inputField, { focusVisible: true });
         } else {
-            const previousAnchor = previousItem.querySelector('a');
-
-            window.focusHandler.setFocus(previousAnchor, { focusVisible: true, preventScroll: true });
+            const previousItem = this.searchSuggestLinks[currentIndex - 1];
+            window.focusHandler.setFocus(previousItem, { focusVisible: true });
         }
     }
 
     /**
      * Moves the focus down the search results list.
      * 
-     * @param {EventTarget} eventTarget
+     * @param {number} currentIndex
      * @private
      */
-    _moveFocusDown(eventTarget) {
-        const listItem = eventTarget.closest(this.options.searchWidgetResultItemSelector);
-        if (!listItem) {
-            return;
-        }
-
-        const nextItem = listItem.nextElementSibling;
-
-        if (nextItem) {
-            const nextAnchor = nextItem.querySelector('a');
-
-            window.focusHandler.setFocus(nextAnchor, { focusVisible: true, preventScroll: true });
+    _moveFocusDown(currentIndex) {
+        if (currentIndex < this.searchSuggestLinks.length) {
+            const nextItem = this.searchSuggestLinks[currentIndex + 1];
+            window.focusHandler.setFocus(nextItem, { focusVisible: true });
         }
     }
 
@@ -231,14 +207,21 @@ export default class SearchWidgetPlugin extends Plugin {
                 this._inputField.setAttribute('aria-expanded', 'true');
 
                 const searchSuggest = document.querySelector(this.options.searchWidgetResultSelector);
-                const searchSuggestItems = searchSuggest.querySelectorAll(this.options.searchWidgetResultItemSelector);
 
-                searchSuggestItems.forEach(item => {
-                    const anchor = item.querySelector('a');
-                    anchor.addEventListener('keydown', this._handleSearchItemKeyEvent.bind(this));
+                this.searchSuggestLinks = Array.from(window.focusHandler.getFocusableElements(searchSuggest));
+
+                this.searchSuggestLinks.forEach((item, index) => {
+                    item.addEventListener('keydown', this._handleSearchItemKeyEvent.bind(this, index));
                 });
 
                 this.$emitter.publish('afterSuggest');
+            })
+            .catch(() => {
+                // remove indicator
+                indicator.remove();
+                
+                // clear any existing results
+                this._clearSuggestResults();
             });
     }
 
@@ -272,6 +255,7 @@ export default class SearchWidgetPlugin extends Plugin {
         if (e.target.closest(this.options.searchWidgetResultSelector)) {
             return;
         }
+
         // remove existing search results popover
         this._clearSuggestResults();
 
@@ -296,14 +280,10 @@ export default class SearchWidgetPlugin extends Plugin {
         this._toggleButton = document.querySelector(this.options.searchWidgetCollapseButtonSelector);
 
         if (!this._toggleButton) {
-            console.warn(`Called selector '${this.options.searchWidgetCollapseButtonSelector}' for the search toggle button not found. Autofocus has been disabled on mobile.`);
             return;
         }
 
-        const event = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
-        this._toggleButton.addEventListener(event, () => {
-            setTimeout(() => this._focusInput(), 0);
-        });
+        this._toggleButton.addEventListener('click', this._focusInput.bind(this));
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_search-suggest.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_search-suggest.scss
@@ -39,18 +39,19 @@ Contains styles for the search suggest popover in the shop header.
     &:last-child {
         border-bottom: 0;
     }
-
-    &.is-active {
-        .search-suggest-product-link {
-            color: $primary;
-        }
-    }
 }
 
 .search-suggest-product-link,
 .search-suggest-total-link {
     &:hover {
         text-decoration: none;
+    }
+
+    &:focus,
+    &:focus-visible {
+        color: $primary;
+        box-shadow: $focus-ring-box-shadow-inset;
+        outline: none;
     }
 }
 
@@ -73,6 +74,7 @@ Contains styles for the search suggest popover in the shop header.
 
 .search-suggest-product-price {
     text-align: right;
+    padding-right: 0.25rem;
 }
 
 .search-suggest-product-list-price,

--- a/src/Storefront/Resources/app/storefront/test/helper/arrow-navigation.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/arrow-navigation.helper.test.js
@@ -4,6 +4,7 @@ import template from './arrow-navigation.helper.template.html';
 const itemContainerSelector = 'ul.itemContainer';
 const itemSelector = 'li';
 
+/** @deprecated tag:v6.8.0 - ArrowNavigationHelper will be removed without replacement. */
 describe('arrow-navigation.helper', () => {
     beforeEach(() => {
         document.body.innerHTML = template;

--- a/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import SearchPlugin from 'src/plugin/header/search-widget.plugin';
+import FocusHandler from 'src/helper/focus-handler.helper';
 
 describe('SearchPlugin Tests', () => {
     let searchPlugin = undefined;
@@ -16,6 +17,8 @@ describe('SearchPlugin Tests', () => {
         `;
 
         formElement = document.getElementById('search-widget');
+
+        window.focusHandler = new FocusHandler();
 
         searchPlugin = new SearchPlugin(formElement);
     });
@@ -163,7 +166,110 @@ describe('SearchPlugin Tests', () => {
         expect(searchPlugin.$emitter.publish).toHaveBeenCalledWith('handleInputEvent', { "value": "abcd" });
     });
 
-    test('should add d-none class to search results on close button focus', () => {
+    test('_handleKeyEvent should focus first search result item when pressing ArrowDown', () => {
+        document.body.innerHTML = `
+            <form id="search-widget" data-search-widget="true">
+                <input type="search" name="search" autocapitalize="off" autocomplete="off">
+                <button type="submit" class="btn header-search-btn">Search</button>
+                <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
+                <div class="search-suggest js-search-result">
+                    <div class="js-result">
+                        <a href="#">First Result</a>
+                    </div>
+                </div>
+            </form>
+        `;
+
+        formElement = document.getElementById('search-widget');
+        searchPlugin = new SearchPlugin(formElement);
+
+        const eventMock = {
+            key: 'ArrowDown',
+            preventDefault: jest.fn()
+        };
+
+        searchPlugin._inputField.value = 'test';
+        searchPlugin._handleKeyEvent(eventMock);
+
+        expect(eventMock.preventDefault).toHaveBeenCalled();
+        expect(document.activeElement.textContent).toBe('First Result');
+    });
+
+    test('_handleKeyEvent should not focus when input is empty', () => {
+        const eventMock = {
+            key: 'ArrowDown',
+            preventDefault: jest.fn()
+        };
+
+        searchPlugin._inputField.value = '';
+        searchPlugin._handleKeyEvent(eventMock);
+
+        expect(eventMock.preventDefault).not.toHaveBeenCalled();
+    });
+
+    test('_handleSearchItemKeyEvent should move focus up and down', () => {
+        document.body.innerHTML = `
+            <form id="search-widget" data-search-widget="true">
+                <input type="search" name="search" autocapitalize="off" autocomplete="off">
+                <button type="submit" class="btn header-search-btn">Search</button>
+                <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
+                <div class="search-suggest js-search-result">
+                    <div class="js-result">
+                        <a href="#">First Result</a>
+                    </div>
+                    <div class="js-result">
+                        <a href="#">Second Result</a>
+                    </div>
+                    <div class="js-result">
+                        <a href="#">Third Result</a>
+                    </div>
+                </div>
+            </form>
+        `;
+
+        formElement = document.getElementById('search-widget');
+        searchPlugin = new SearchPlugin(formElement);
+
+        const secondResult = document.querySelectorAll('.js-result')[1].querySelector('a');
+        const eventMock = {
+            key: 'ArrowDown',
+            target: secondResult,
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+            stopImmediatePropagation: jest.fn()
+        };
+
+        // Test moving down
+        searchPlugin._handleSearchItemKeyEvent(eventMock);
+        expect(document.activeElement.textContent).toBe('Third Result');
+
+        // Test moving up
+        eventMock.key = 'ArrowUp';
+        searchPlugin._handleSearchItemKeyEvent(eventMock);
+        expect(document.activeElement.textContent).toBe('First Result');
+
+        // Test moving up from first item returns to input
+        eventMock.target = document.querySelector('.js-result').querySelector('a');
+        searchPlugin._handleSearchItemKeyEvent(eventMock);
+        expect(document.activeElement).toBe(searchPlugin._inputField);
+    });
+
+    test('_handleSearchItemKeyEvent should not handle non-arrow keys', () => {
+        const eventMock = {
+            key: 'Enter',
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+            stopImmediatePropagation: jest.fn()
+        };
+
+        searchPlugin._handleSearchItemKeyEvent(eventMock);
+
+        expect(eventMock.preventDefault).not.toHaveBeenCalled();
+        expect(eventMock.stopPropagation).not.toHaveBeenCalled();
+        expect(eventMock.stopImmediatePropagation).not.toHaveBeenCalled();
+    });
+
+    test('Click on close button should clear input and hide results', () => {
         document.body.innerHTML = `
             <form id="search-widget" data-search-widget="true">
                 <input type="search" name="search" autocapitalize="off" autocomplete="off">
@@ -176,12 +282,14 @@ describe('SearchPlugin Tests', () => {
         formElement = document.getElementById('search-widget');
         searchPlugin = new SearchPlugin(formElement);
 
-        const searchResult = document.querySelector('.js-search-result');
-        expect(searchResult.classList.contains('d-none')).toBe(false);
+        searchPlugin._inputField.value = 'test';
+        searchPlugin._clearSuggestResults = jest.fn();
 
-        searchPlugin._closeButton.focus();
+        const clickEvent = new Event('click');
+        searchPlugin._closeButton.dispatchEvent(clickEvent);
 
-        expect(searchResult.classList.contains('d-none')).toBe(true);
+        expect(searchPlugin._inputField.value).toBe('');
+        expect(searchPlugin._clearSuggestResults).toHaveBeenCalled();
     });
 });
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import SearchPlugin from 'src/plugin/header/search-widget.plugin';
 import FocusHandler from 'src/helper/focus-handler.helper';
+import DeviceDetection from 'src/helper/device-detection.helper';
 
 describe('SearchPlugin Tests', () => {
     let searchPlugin = undefined;
@@ -9,7 +10,7 @@ describe('SearchPlugin Tests', () => {
 
     beforeEach(() => {
         document.body.innerHTML = `
-            <form id="search-widget" data-search-widget="true">
+            <form id="search-widget" data-search-widget="true" data-url="/search" class="js-search-form">
                 <input type="search" name="search" autocapitalize="off" autocomplete="off">
                 <button type="submit" class="btn header-search-btn">Search</button>
                 <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
@@ -26,6 +27,7 @@ describe('SearchPlugin Tests', () => {
     afterEach(() => {
         searchPlugin = undefined;
         spyInitializePlugins.mockClear();
+        jest.clearAllMocks();
     });
 
     test('search plugin exists', () => {
@@ -33,9 +35,8 @@ describe('SearchPlugin Tests', () => {
     });
 
     test('_handleSearchEvent should preventDefault and stopPropagation', () => {
-        searchPlugin._inputField = {
-            value: 'ab'
-        }
+        searchPlugin._inputField.value = 'ab';
+
         const eventMock = {
             preventDefault: jest.fn(),
             stopPropagation: jest.fn()
@@ -49,17 +50,9 @@ describe('SearchPlugin Tests', () => {
         expect(eventMock.stopPropagation).toHaveBeenCalled();
     });
 
-    test('_registerInputFocus should warn if searchWidgetCollapseButton dosn\'t exist', () => {
-        console.warn = jest.fn();
-
-        searchPlugin._registerInputFocus()
-        expect(console.warn).toHaveBeenCalledWith(`Called selector '${searchPlugin.options.searchWidgetCollapseButtonSelector}' for the search toggle button not found. Autofocus has been disabled on mobile.`)
-    });
-
     test('_handleSearchEvent should not preventDefault and stopPropagation', () => {
-        searchPlugin._inputField = {
-            value: 'abcd'
-        }
+        searchPlugin._inputField.value = 'abcd';
+
         const eventMock = {
             preventDefault: jest.fn(),
             stopPropagation: jest.fn()
@@ -74,9 +67,8 @@ describe('SearchPlugin Tests', () => {
     });
 
     test('_handleSearchEvent should preventDefault and stopPropagation', () => {
-        searchPlugin._inputField = {
-            value: '         '
-        }
+        searchPlugin._inputField.value = '         ';
+
         const eventMock = {
             preventDefault: jest.fn(),
             stopPropagation: jest.fn()
@@ -91,9 +83,7 @@ describe('SearchPlugin Tests', () => {
     });
 
     test('_handleInputEvent should clearSuggestResult', () => {
-        searchPlugin._inputField = {
-            value: '         '
-        }
+        searchPlugin._inputField.value = '         ';
         searchPlugin._clearSuggestResults = jest.fn();
         searchPlugin._suggest = jest.fn();
         searchPlugin.$emitter.publish = jest.fn();
@@ -110,9 +100,7 @@ describe('SearchPlugin Tests', () => {
     });
 
     test('_handleInputEvent should not clearSuggestResult and publish handleInputEvent', () => {
-        searchPlugin._inputField = {
-            value: 'abcde'
-        }
+        searchPlugin._inputField.value = 'abcde';
         searchPlugin._clearSuggestResults = jest.fn();
         searchPlugin._suggest = jest.fn();
         searchPlugin.$emitter.publish = jest.fn();
@@ -129,9 +117,7 @@ describe('SearchPlugin Tests', () => {
     });
 
     test('_handleInputEvent should clearSuggestResult and not publish handleInputEvent because of trim', () => {
-        searchPlugin._inputField = {
-            value: 'ab  '
-        }
+        searchPlugin._inputField.value = 'ab  ';
         searchPlugin._clearSuggestResults = jest.fn();
         searchPlugin._suggest = jest.fn();
         searchPlugin.$emitter.publish = jest.fn();
@@ -148,9 +134,7 @@ describe('SearchPlugin Tests', () => {
     });
 
     test('_handleInputEvent should not clearSuggestResult and publish handleInputEvent and whitespaces being removed', () => {
-        searchPlugin._inputField = {
-            value: '  abcd   '
-        }
+        searchPlugin._inputField.value = '  abcd   ';
         searchPlugin._clearSuggestResults = jest.fn();
         searchPlugin._suggest = jest.fn();
         searchPlugin.$emitter.publish = jest.fn();
@@ -168,7 +152,7 @@ describe('SearchPlugin Tests', () => {
 
     test('_handleKeyEvent should focus first search result item when pressing ArrowDown', () => {
         document.body.innerHTML = `
-            <form id="search-widget" data-search-widget="true">
+            <form id="search-widget" data-search-widget="true" data-url="/search" class="js-search-form">
                 <input type="search" name="search" autocapitalize="off" autocomplete="off">
                 <button type="submit" class="btn header-search-btn">Search</button>
                 <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
@@ -180,8 +164,8 @@ describe('SearchPlugin Tests', () => {
             </form>
         `;
 
-        formElement = document.getElementById('search-widget');
-        searchPlugin = new SearchPlugin(formElement);
+        const formElement = document.getElementById('search-widget');
+        const searchPlugin = new SearchPlugin(formElement);
 
         const eventMock = {
             key: 'ArrowDown',
@@ -189,6 +173,8 @@ describe('SearchPlugin Tests', () => {
         };
 
         searchPlugin._inputField.value = 'test';
+        const searchSuggest = document.querySelector('.js-search-result');
+        searchPlugin.searchSuggestLinks = Array.from(window.focusHandler.getFocusableElements(searchSuggest));
         searchPlugin._handleKeyEvent(eventMock);
 
         expect(eventMock.preventDefault).toHaveBeenCalled();
@@ -209,7 +195,7 @@ describe('SearchPlugin Tests', () => {
 
     test('_handleSearchItemKeyEvent should move focus up and down', () => {
         document.body.innerHTML = `
-            <form id="search-widget" data-search-widget="true">
+            <form id="search-widget" data-search-widget="true" data-url="/search" class="js-search-form">
                 <input type="search" name="search" autocapitalize="off" autocomplete="off">
                 <button type="submit" class="btn header-search-btn">Search</button>
                 <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
@@ -227,10 +213,13 @@ describe('SearchPlugin Tests', () => {
             </form>
         `;
 
-        formElement = document.getElementById('search-widget');
-        searchPlugin = new SearchPlugin(formElement);
+        const formElement = document.getElementById('search-widget');
+        const searchPlugin = new SearchPlugin(formElement);
 
-        const secondResult = document.querySelectorAll('.js-result')[1].querySelector('a');
+        const searchSuggest = document.querySelector('.js-search-result');
+        searchPlugin.searchSuggestLinks = Array.from(window.focusHandler.getFocusableElements(searchSuggest));
+
+        const secondResult = searchPlugin.searchSuggestLinks[1];
         const eventMock = {
             key: 'ArrowDown',
             target: secondResult,
@@ -240,18 +229,27 @@ describe('SearchPlugin Tests', () => {
         };
 
         // Test moving down
-        searchPlugin._handleSearchItemKeyEvent(eventMock);
+        searchPlugin._handleSearchItemKeyEvent(1, eventMock);
         expect(document.activeElement.textContent).toBe('Third Result');
+        expect(eventMock.preventDefault).toHaveBeenCalled();
+        expect(eventMock.stopPropagation).toHaveBeenCalled();
+        expect(eventMock.stopImmediatePropagation).toHaveBeenCalled();
 
         // Test moving up
         eventMock.key = 'ArrowUp';
-        searchPlugin._handleSearchItemKeyEvent(eventMock);
-        expect(document.activeElement.textContent).toBe('First Result');
+        searchPlugin._handleSearchItemKeyEvent(2, eventMock);
+        expect(document.activeElement.textContent).toBe('Second Result');
+        expect(eventMock.preventDefault).toHaveBeenCalled();
+        expect(eventMock.stopPropagation).toHaveBeenCalled();
+        expect(eventMock.stopImmediatePropagation).toHaveBeenCalled();
 
         // Test moving up from first item returns to input
-        eventMock.target = document.querySelector('.js-result').querySelector('a');
-        searchPlugin._handleSearchItemKeyEvent(eventMock);
+        eventMock.target = searchPlugin.searchSuggestLinks[0];
+        searchPlugin._handleSearchItemKeyEvent(0, eventMock);
         expect(document.activeElement).toBe(searchPlugin._inputField);
+        expect(eventMock.preventDefault).toHaveBeenCalled();
+        expect(eventMock.stopPropagation).toHaveBeenCalled();
+        expect(eventMock.stopImmediatePropagation).toHaveBeenCalled();
     });
 
     test('_handleSearchItemKeyEvent should not handle non-arrow keys', () => {
@@ -262,7 +260,7 @@ describe('SearchPlugin Tests', () => {
             stopImmediatePropagation: jest.fn()
         };
 
-        searchPlugin._handleSearchItemKeyEvent(eventMock);
+        searchPlugin._handleSearchItemKeyEvent(0, eventMock);
 
         expect(eventMock.preventDefault).not.toHaveBeenCalled();
         expect(eventMock.stopPropagation).not.toHaveBeenCalled();
@@ -271,7 +269,7 @@ describe('SearchPlugin Tests', () => {
 
     test('Click on close button should clear input and hide results', () => {
         document.body.innerHTML = `
-            <form id="search-widget" data-search-widget="true">
+            <form id="search-widget" data-search-widget="true" class="js-search-form">
                 <input type="search" name="search" autocapitalize="off" autocomplete="off">
                 <button type="submit" class="btn header-search-btn">Search</button>
                 <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
@@ -279,8 +277,8 @@ describe('SearchPlugin Tests', () => {
             </form>
         `;
 
-        formElement = document.getElementById('search-widget');
-        searchPlugin = new SearchPlugin(formElement);
+        const formElement = document.getElementById('search-widget');
+        const searchPlugin = new SearchPlugin(formElement);
 
         searchPlugin._inputField.value = 'test';
         searchPlugin._clearSuggestResults = jest.fn();
@@ -291,6 +289,140 @@ describe('SearchPlugin Tests', () => {
         expect(searchPlugin._inputField.value).toBe('');
         expect(searchPlugin._clearSuggestResults).toHaveBeenCalled();
     });
+
+    test('_suggest should handle successful AJAX request', async () => {
+        const mockResponse = '<div class="js-search-result"><div class="js-result"><a href="#">Test Result</a></div></div>';
+        global.fetch = jest.fn().mockResolvedValue({
+            text: () => Promise.resolve(mockResponse)
+        });
+
+        searchPlugin._inputField.value = 'test';
+        searchPlugin.$emitter.publish = jest.fn();
+
+        await searchPlugin._suggest('test');
+
+        expect(searchPlugin.$emitter.publish).toHaveBeenCalledWith('beforeSearch');
+        expect(global.fetch).toHaveBeenCalledWith('/searchtest', {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        });
+
+        await new Promise(process.nextTick);
+        expect(searchPlugin.$emitter.publish).toHaveBeenCalledWith('afterSuggest');
+        expect(searchPlugin._inputField.getAttribute('aria-expanded')).toBe('true');
+        expect(searchPlugin.searchSuggestLinks.length).toBe(1);
+    });
+
+    test('_suggest should handle failed AJAX request', async () => {
+        global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+        searchPlugin._inputField.value = 'test';
+        searchPlugin.$emitter.publish = jest.fn();
+        searchPlugin._clearSuggestResults = jest.fn();
+
+        await searchPlugin._suggest('test');
+
+        expect(global.fetch).toHaveBeenCalled();
+        expect(searchPlugin.$emitter.publish).toHaveBeenCalledWith('beforeSearch');
+
+        await new Promise(process.nextTick);
+        expect(searchPlugin.$emitter.publish).not.toHaveBeenCalledWith('afterSuggest');
+        expect(searchPlugin._clearSuggestResults).toHaveBeenCalled();
+    });
+
+    test('_onBodyClick should clear results when clicking outside', () => {
+        document.body.innerHTML = `
+            <form id="search-widget" data-search-widget="true" data-url="/search" class="js-search-form">
+                <input type="search" name="search" autocapitalize="off" autocomplete="off">
+                <button type="submit" class="btn header-search-btn">Search</button>
+                <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
+                <div class="search-suggest js-search-result"></div>
+            </form>
+            <div id="outside">Outside content</div>
+        `;
+
+        const formElement = document.getElementById('search-widget');
+        const searchPlugin = new SearchPlugin(formElement);
+        searchPlugin._clearSuggestResults = jest.fn();
+
+        const clickEvent = new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            target: document.getElementById('outside')
+        });
+
+        document.body.dispatchEvent(clickEvent);
+
+        expect(searchPlugin._clearSuggestResults).toHaveBeenCalled();
+    });
+
+    test('_onBodyClick should not clear results when clicking inside search form', () => {
+        document.body.innerHTML = `
+            <form id="search-widget" data-search-widget="true" data-url="/search" class="js-search-form">
+                <input type="search" name="search" autocapitalize="off" autocomplete="off">
+                <button type="submit" class="btn header-search-btn">Search</button>
+                <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
+                <div class="search-suggest js-search-result"></div>
+            </form>
+        `;
+
+        const formElement = document.getElementById('search-widget');
+        const searchPlugin = new SearchPlugin(formElement);
+        searchPlugin._clearSuggestResults = jest.fn();
+
+        const clickEvent = new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+        });
+
+        searchPlugin._inputField.dispatchEvent(clickEvent);
+
+        expect(searchPlugin._clearSuggestResults).not.toHaveBeenCalled();
+    });
+
+    test('_onCloseButtonClick should clear input and results', () => {
+        document.body.innerHTML = `
+            <form id="search-widget" data-search-widget="true" data-url="/search" class="js-search-form">
+                <input type="search" name="search" autocapitalize="off" autocomplete="off">
+                <button type="submit" class="btn header-search-btn">Search</button>
+                <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
+                <div class="search-suggest js-search-result"></div>
+            </form>
+        `;
+
+        const formElement = document.getElementById('search-widget');
+        const searchPlugin = new SearchPlugin(formElement);
+
+        searchPlugin._inputField.value = 'test';
+        searchPlugin._clearSuggestResults = jest.fn();
+
+        const clickEvent = new Event('click');
+        searchPlugin._closeButton.dispatchEvent(clickEvent);
+
+        expect(searchPlugin._inputField.value).toBe('');
+        expect(searchPlugin._clearSuggestResults).toHaveBeenCalled();
+    });
+
+    test('_registerInputFocus should handle mobile focus', () => {
+        document.body.innerHTML = `
+            <form id="search-widget" data-search-widget="true" data-url="/search" class="js-search-form">
+                <input type="search" name="search" autocapitalize="off" autocomplete="off">
+                <button type="submit" class="btn header-search-btn">Search</button>
+                <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
+                <button type="button" class="js-search-toggle-btn">Toggle</button>
+            </form>
+        `;
+
+        const formElement = document.getElementById('search-widget');
+        const searchPlugin = new SearchPlugin(formElement);
+        searchPlugin._inputField.focus = jest.fn();
+
+        const toggleButton = document.querySelector('.js-search-toggle-btn');
+        const clickEvent = new Event('click', {
+            bubbles: true,
+            cancelable: true,
+        });
+        toggleButton.dispatchEvent(clickEvent);
+
+        expect(searchPlugin._inputField.focus).toHaveBeenCalled();
+    });
 });
-
-

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -1,13 +1,18 @@
 {# @var product \Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity #}
 
 {% block layout_search_suggest %}
-    <div class="search-suggest js-search-result" aria-label="{{ 'header.searchDropdownTitle'|trans|striptags }}">
+    <div class="search-suggest js-search-result">
         {% block layout_search_suggest_container %}
-            <ul class="search-suggest-container">
+
+            <ul class="search-suggest-container" 
+                id="search-suggest-listbox"
+                aria-label="{{ 'header.searchDropdownTitle'|trans|striptags }}"
+                role="listbox">
+
                 {% block layout_search_suggest_results %}
                     {% for product in page.searchResult %}
                         {% block layout_search_suggest_result_product %}
-                            <li class="search-suggest-product js-result">
+                            <li class="search-suggest-product js-result" role="option">
                                 {% block layout_search_suggest_result_link %}
                                     <a href="{{ seoUrl('frontend.detail.page', {productId: product.id}) }}"
                                        title="{{ product.translated.name }}"
@@ -94,13 +99,13 @@
                 {% block layout_search_suggest_result_total %}
                     {% if page.searchResult.total == 0 %}
                         {% block layout_search_suggest_no_result %}
-                            <li class="search-suggest-no-result">
+                            <li class="search-suggest-no-result" id="search-suggest-result-info" role="option">
                                 {{ 'header.searchNoResult'|trans|sw_sanitize }}
                             </li>
                         {% endblock %}
                     {% else %}
                         {% block layout_search_suggest_result_total_result %}
-                            <li class="js-result search-suggest-total">
+                            <li class="js-result search-suggest-total" role="option">
                                 <div class="row align-items-center g-0">
                                     {% block layout_search_suggest_result_total_link %}
                                         <div class="col">
@@ -115,7 +120,7 @@
                                     {% endblock %}
 
                                     {% block layout_search_suggest_result_total_count %}
-                                        <div class="col-auto search-suggest-total-count">
+                                        <div class="col-auto search-suggest-total-count" id="search-suggest-result-info">
                                             {{ 'header.searchResults'|trans({
                                                 '%count%': page.searchResult.total,
                                             })|sw_sanitize }}

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -8,7 +8,6 @@
                 id="search-suggest-listbox"
                 aria-label="{{ 'header.searchDropdownTitle'|trans|striptags }}"
                 role="listbox">
-
                 {% block layout_search_suggest_results %}
                     {% for product in page.searchResult %}
                         {% block layout_search_suggest_result_product %}

--- a/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
@@ -14,16 +14,21 @@
                     {% block layout_header_search_input_group %}
                         <div class="input-group">
                             {% block layout_header_search_input %}
-                                <input type="search"
-                                       id="header-main-search-input"
-                                       name="search"
-                                       class="form-control header-search-input"
-                                       autocomplete="off"
-                                       autocapitalize="off"
-                                       placeholder="{{ 'header.searchPlaceholder'|trans|striptags }}"
-                                       aria-label="{{ 'header.searchPlaceholder'|trans|striptags }}"
-                                       value="{{ page.searchTerm }}"
-                                >
+                                <input
+                                    type="search"
+                                    id="header-main-search-input"
+                                    name="search"
+                                    class="form-control header-search-input"
+                                    autocomplete="off"
+                                    autocapitalize="off"
+                                    placeholder="{{ 'header.searchPlaceholder'|trans|striptags }}"
+                                    aria-label="{{ 'header.searchPlaceholder'|trans|striptags }}"
+                                    role="combobox"
+                                    aria-autocomplete="list"
+                                    aria-controls="search-suggest-listbox"
+                                    aria-expanded="false"
+                                    aria-describedby="search-suggest-result-info"
+                                    value="{{ page.searchTerm }}">
                             {% endblock %}
 
                             {% block layout_header_search_button %}


### PR DESCRIPTION
Fixes #7877 
Fixes #7093
Fixes #8182
Fixes #8184

Includes: [7995](https://github.com/shopware/shopware/pull/7995)

### 1. Why is this change necessary?

The search widget is not very accessible. It misses proper keyboard navigation, focus states, and necessary information for screen reader users.

### 2. What does this change do, exactly?

* The keyboard navigation was improved to work with arrow keys and tab navigation and is based on proper focus states. You can now move directly into the search results via the keyboard.
* The search result dropdown is now better explained to screen reader users so that they understand that the search will open a list of search result suggestions.
* The search result is now read out to screen reader users.

![image](https://github.com/user-attachments/assets/810f4fb8-f033-4e1e-a8c3-f087b33ccf92)

