### PR TITLE
fix: order shipping cost input fix

### DIFF
--- a/changelog/_unreleased/2025-04-02-fix-admin-order-shipping-cost-input-behaviour.md
+++ b/changelog/_unreleased/2025-04-02-fix-admin-order-shipping-cost-input-behaviour.md
@@ -1,0 +1,17 @@
+---
+title: Fix admin order shipping cost input behaviour
+issue: https://github.com/shopware/shopware/issues/7958
+author_github: @En0Ma1259
+---
+___
+# Administration
+* Removed `fill-digits` option on `shippingCosts` field
+    * `src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig`
+    * `src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-details/sw-order-create-details.html.twig`
+* Added `step` option on `shippingCosts` field
+  * `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.html.twig`
+  * `src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig`
+  * `src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-details/sw-order-create-details.html.twig`
+  * `src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig`
+* Added `debounce` to `onShippingChargeEdited` method in `src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js`
+* Changed styles for `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-saveable-field/sw-order-saveable-field.html.twig`

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.html.twig
@@ -132,6 +132,7 @@
             v-model="shippingCost"
             class="sw-order-create-options__shipping-cost"
             :label="$tc('sw-order.initialModal.options.labelShippingCosts')"
+            :step="1"
             @update:model-value="onChangeShippingCost"
         >
             <template #suffix>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss
@@ -49,7 +49,6 @@ $sw-order-line-item-border: $color-gray-300;
 
     .sw-order-line-items-grid__item-payload-options {
         .sw-product-variant-info {
-            white-space: normal;
             text-overflow: unset;
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-saveable-field/sw-order-saveable-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-saveable-field/sw-order-saveable-field.html.twig
@@ -1,8 +1,9 @@
 {% block sw_order_saveable_field %}
 <sw-container
     v-if="isEditing"
-    columns="1fr 20px 25px"
+    columns="1fr 20px 20px"
     gap="0px 10px"
+    align="center"
     class="sw-order-saveable-field"
 >
     {% block sw_order_saveable_field_input %}
@@ -19,14 +20,13 @@
     {% block sw_order_saveable_field_cancel_button %}
     <mt-button
         size="x-small"
-        square
-        aria-label="global.default.cancel"
         variant="secondary"
+        aria-label="global.default.cancel"
+        square
         @click="onCancelButtonClicked"
     >
         <mt-icon
-            name="regular-times-xs"
-            size="16px"
+            name="regular-times-xxs"
         />
     </mt-button>
     {%  endblock %}
@@ -40,10 +40,9 @@
     >
         <mt-icon
             name="regular-checkmark-xxs"
-            size="16px"
         />
     </mt-button>
-    {%  endblock %}
+    {% endblock %}
     {% endblock %}
 </sw-container>
 <div

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-saveable-field/sw-order-saveable-field.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-saveable-field/sw-order-saveable-field.scss
@@ -1,9 +1,5 @@
 .sw-order-saveable-field {
-    .sw-container {
-        align-items: center;
-    }
-
-    .sw-field {
+    .mt-field {
         margin-bottom: 0;
 
         input {
@@ -11,7 +7,10 @@
         }
     }
 
-    .mt-icon {
-        padding: 4px;
+    // /meteor-component-library/src/components/form/mt-button/mt-button.vue
+    // Reset display to ".mt-button__content"'s value
+    // .mt-button--square -> display: inline
+    .mt-button--square .mt-button__content {
+        display: grid;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-saveable-field/sw-order-saveable-field.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-saveable-field/sw-order-saveable-field.scss
@@ -7,7 +7,6 @@
         }
     }
 
-    // /meteor-component-library/src/components/form/mt-button/mt-button.vue
     // Reset display to ".mt-button__content"'s value
     // .mt-button--square -> display: inline
     .mt-button--square .mt-button__content {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.scss
@@ -37,13 +37,23 @@
         dd {
             width: 160px;
             padding-right: 40px;
+        }
+    }
 
-            .sw-order-saveable-field {
-                transform: translateY(-50%);
-                position: relative;
-                left: 80px;
-                top: 50%;
+    .sw-order-detail__summary:has(.sw-order-saveable-field) {
+        dd {
+            width: 200px;
+
+            &:has(.sw-order-saveable-field) {
+                display: flex;
+                align-items: center;
+                padding-right: 0;
             }
+        }
+
+        .sw-order-saveable-field {
+            padding-left: 20px;
+            line-height: 1;
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-details/sw-order-create-details.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-details/sw-order-create-details.html.twig
@@ -93,7 +93,7 @@
                 v-model="shippingCosts"
                 :label="$tc('sw-order.createBase.labelShippingCosts')"
                 :min="0"
-                fill-digits
+                :step="1"
                 required
             >
                 <template #suffix>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
@@ -14,6 +14,10 @@ export default {
     template,
 
     inject: {
+        feature: {
+            from: 'feature',
+            default: null,
+        },
         swOrderDetailOnSaveAndReload: {
             from: 'swOrderDetailOnSaveAndReload',
             default: null,

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
@@ -5,7 +5,7 @@ import './sw-order-detail-details.scss';
  * @sw-package checkout
  */
 
-const { Component, Store } = Shopware;
+const { Component, Store, Utils } = Shopware;
 const { Criteria } = Shopware.Data;
 const { mapPropertyErrors } = Component.getComponentHelper();
 
@@ -134,6 +134,7 @@ export default {
             return this.order.price.taxStatus;
         },
 
+        // @deprecated tag:v6.8.0 - Will be removed, will not be used anymore.
         currency() {
             return this.order.currency;
         },
@@ -158,6 +159,7 @@ export default {
             return currentAddress?.customerAddressId || this.shippingAddress.id;
         },
 
+        // @deprecated tag:v6.8.0 - Will be removed, change shipping cost on order general view instead.
         shippingCosts: {
             get() {
                 return this.delivery?.shippingCosts.totalPrice || 0.0;
@@ -182,12 +184,13 @@ export default {
             });
         },
 
-        onShippingChargeEdited(amount) {
+        // @deprecated tag:v6.8.0 - Will be removed, change shipping cost on order general view instead.
+        onShippingChargeEdited: Utils.debounce(function onShippingChargeEdited(amount) {
             this.delivery.shippingCosts.unitPrice = amount;
             this.delivery.shippingCosts.totalPrice = amount;
 
             this.saveAndRecalculate();
-        },
+        }, 800),
 
         loadingChange(loading) {
             if (this.swOrderDetailOnLoadingChange) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
@@ -83,6 +83,7 @@
         {# file: src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig #}
         {% block sw_order_detail_details_shipping_costs %}
         <mt-number-field
+            v-if="!feature.isActive('v6.8.0.0')"
             v-model="shippingCosts"
             class="sw-order-detail-details__shipping-cost"
             :disabled="!acl.can('order.editor')"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
@@ -79,12 +79,14 @@
         />
         {% endblock %}
 
+        {# @deprecated tag:v6.8.0 - Will be removed, use shipping cost in general view instead. #}
+        {# file: src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig #}
         {% block sw_order_detail_details_shipping_costs %}
         <mt-number-field
             v-model="shippingCosts"
             class="sw-order-detail-details__shipping-cost"
             :disabled="!acl.can('order.editor')"
-            fill-digits
+            :step="1"
             :label="$tc('sw-order.detailDeliveries.labelShippingCosts')"
         >
             <template #suffix>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.spec.js
@@ -226,10 +226,13 @@ describe('src/module/sw-order/view/sw-order-detail-details', () => {
     });
 
     it('should able to edit shipping cost', async () => {
+        jest.useFakeTimers();
         global.activeAclRoles = ['order.editor'];
         wrapper = await createWrapper();
         const shippingCostField = wrapper.findComponent('.sw-order-detail-details__shipping-cost');
         await shippingCostField.setValue(20);
+
+        jest.advanceTimersByTime(1000);
 
         expect(wrapper.vm.delivery.shippingCosts.unitPrice).toBe(20);
         expect(wrapper.vm.delivery.shippingCosts.totalPrice).toBe(20);

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
@@ -71,6 +71,7 @@
                                     }"
                                     type="number"
                                     :editable="acl.can('order.editor')"
+                                    :step="1"
                                     :value="delivery.shippingCosts.totalPrice"
                                     @value-change="onShippingChargeEdited"
                                     @update:value="onShippingChargeUpdated"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
@@ -61,9 +61,15 @@
 
                         {% block sw_order_detail_general_line_items_summary_shipping_cost %}
                         <template v-if="delivery">
-                            <dt>{{ $tc('sw-order.detailBase.summaryLabelShippingCosts') }}</dt>
+                            <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
+                            <dt
+                                @click="$refs.editShippingCosts.onClick()"
+                            >
+                                {{ $tc('sw-order.detailBase.summaryLabelShippingCosts') }}
+                            </dt>
                             <dd>
                                 <sw-order-saveable-field
+                                    ref="editShippingCosts"
                                     v-tooltip="{
                                         showDelay: 300,
                                         message: shippingCostsDetail,


### PR DESCRIPTION
closes https://github.com/shopware/shopware/issues/7958

The shipping costs manual input on orders in the admin is completely weird. It seems to only work properly for prices with two decimals.

1. Order something.
2. Try to input >10€ in the order details tab shipping costs input field

It is jumping around and fixing inputs to <10€ only.

Also, clicking the increase/decrease spinners auto-recalculates the order and reloads the 


**What does this change do, exactly?**
1. Remove `fill-digit` attribute, so the keyboard problem is solved
2. Added a `debounce` on changing the shipping cost. So not every change will trigger a recalculation, but after 800ms
3. Steps are set to "1"
4. Deprecated shipping cost field on "order detail detail" page. Use shipping cost edit field on "order detail general" instead

----

closes https://github.com/shopware/shopware/issues/8062

**Layout**
1. The name of the product isn't centered in the table 
2. If you edit the shipping cost the input box is way too big and the button icons are off


**What does this change do, exactly?**
1. Fix new line for product names
2. Fix edit shipping cost layout