### PR TITLE
fix: price custom fields init empty validation

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/index.js
@@ -110,7 +110,17 @@ Component.register('sw-form-field-renderer', {
             currency: { id: Shopware.Context.app.systemCurrencyId, factor: 1 },
             currentComponentName: '',
             swFieldConfig: {},
-            currentValue: this.value,
+            currentValue:
+                this.type === 'price' && !this.value && !Array.isArray(this.value)
+                    ? [
+                          {
+                              currencyId: Shopware.Context.app.systemCurrencyId,
+                              gross: null,
+                              net: null,
+                              linked: true,
+                          },
+                      ]
+                    : this.value,
         };
     },
 
@@ -253,19 +263,22 @@ Component.register('sw-form-field-renderer', {
     },
 
     watch: {
-        currentValue(value) {
-            if (
-                Array.isArray(value) &&
-                Array.isArray(this.value) &&
-                value.length === this.value.length &&
-                value.every((val, index) => val === this.value[index])
-            ) {
-                return;
-            }
+        currentValue: {
+            handler(value) {
+                if (
+                    Array.isArray(value) &&
+                    Array.isArray(this.value) &&
+                    value.length === this.value.length &&
+                    value.every((val, index) => val === this.value[index])
+                ) {
+                    return;
+                }
 
-            if (value !== this.value) {
-                this.$emit('update:value', value);
-            }
+                if (value !== this.value) {
+                    this.$emit('update:value', value);
+                }
+            },
+            deep: true,
         },
         value() {
             this.currentValue = this.value;
@@ -279,17 +292,6 @@ Component.register('sw-form-field-renderer', {
     methods: {
         createdComponent() {
             this.fetchSystemCurrency();
-
-            if (this.type === 'price' && !Array.isArray(this.currentValue)) {
-                this.currentValue = [
-                    {
-                        currencyId: Shopware.Context.app.systemCurrencyId,
-                        gross: null,
-                        net: null,
-                        linked: true,
-                    },
-                ];
-            }
         },
 
         emitUpdate(data) {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/sw-form-field-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/sw-form-field-renderer.spec.js
@@ -93,4 +93,29 @@ describe('components/form/sw-form-field-renderer', () => {
 
         expect(wrapper.props().error).toBeInstanceOf(ShopwareError);
     });
+
+    it('should init the current value when type is price without emit the update event', async () => {
+        const wrapper = await createWrapper({
+            props: {
+                type: 'price',
+                config: {
+                    customFieldType: 'price',
+                },
+                value: undefined,
+            },
+        });
+
+        expect(wrapper.vm.currentValue).toStrictEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    currencyId: null,
+                    gross: null,
+                    net: null,
+                    linked: true,
+                }),
+            ]),
+        );
+
+        expect(wrapper.emitted('update:value')).toBeUndefined();
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
Empty price custom fields throws an validation error

### 2. What does this change do, exactly?
The issue was that the value was init with an object with null prices in the `sw-form-field-renderer`:

```js
{
    currencyId: Shopware.Context.app.systemCurrencyId,
    gross: null,
    net: null,
    linked: true,
}
```

The fix is init it but not emit the `udpate:value` event to the parent on the init.


### 3. Describe each step to reproduce the issue or behaviour.
1. create a price custom field for products
2. go to products and select specifications tab to render custom fields
3. press save and see the error notification


### 4. Please link to the relevant issues (if any).

closes #5742

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
