### PR TITLE
fix: small-buttons-icon-alignment

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -150,3 +150,7 @@ a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button) {
     background-color: $color-gray-100;
     border-bottom: 1px solid $color-gray-300;
 }
+
+.mt-button {
+    line-height: 1;
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
fixes #7541

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.
1. go to Settings  > Essential characteristics
2. add a new 
3. add values
4. see the arrow buttons with misaligned icons

### 4. Please link to the relevant issues (if any).
closes #7541
