### PR TITLE
fix: allow custom formatting in tooltips

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@shopware-ag/meteor-admin-sdk": "5.7.7",
-        "@shopware-ag/meteor-component-library": "^4.9.1",
+        "@shopware-ag/meteor-component-library": "^4.10.0",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",
         "@types/fs-extra": "^11.0.4",
@@ -4983,9 +4983,9 @@
       }
     },
     "node_modules/@shopware-ag/meteor-component-library": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.9.1.tgz",
-      "integrity": "sha512-EQyCI+2MCYcWACQVhrFGQhynW0nTbRLLdt5oou4H9wUNm1/NqbCfLj8YUW0V3dmNRKLF+OvOWH58zw1rixSuhQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.10.0.tgz",
+      "integrity": "sha512-wDw0ITpsLFVWOQMifp3FoHvEf6j4O26oxCkT7MqpfHEpRDcN/C/ks3OT37I2TkUtRywij3qCmx7lCtU13HSUdQ==",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@floating-ui/dom": "^1.4.3",
@@ -5022,6 +5022,7 @@
         "codemirror": "^6.0.1",
         "date-fns": "4.1.0",
         "date-fns-tz": "3.2.0",
+        "dompurify": "^3.2.4",
         "focus-trap": "^7.6.4",
         "inter-ui": "^3.19.3",
         "nanoid": "^5.0.7",
@@ -5155,6 +5156,15 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "license": "MIT"
+    },
+    "node_modules/@shopware-ag/meteor-component-library/node_modules/dompurify": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/@shopware-ag/meteor-component-library/node_modules/vue-i18n": {
       "version": "9.14.2",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@shopware-ag/meteor-admin-sdk": "5.7.7",
-    "@shopware-ag/meteor-component-library": "^4.9.1",
+    "@shopware-ag/meteor-component-library": "^4.10.0",
     "@shopware-ag/meteor-icon-kit": "5.4.0",
     "@swc/core": "1.10.7",
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
### 1. Why is this change necessary?

closes #8037

### 2. What does this change do, exactly?

Fix was done in the component library. This just updates to the latest version

<img width="1371" alt="Bildschirmfoto 2025-04-03 um 14 08 13" src="https://github.com/user-attachments/assets/64328937-67b8-44b1-ad47-85bb19e63934" />
<img width="946" alt="Bildschirmfoto 2025-04-03 um 14 08 36" src="https://github.com/user-attachments/assets/83b61301-3a78-48f2-a80f-a1ecd9e1b658" />
