### PR TITLE
fix: temporary technical name migration

### DIFF
--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -530,7 +530,8 @@ The default payment method "Direct debit" will no longer automatically change th
 The `technicalName` property will be required for payment and shipping methods in the API.
 The `technical_name` column will be made non-nullable for the `payment_method` and `shipping_method` tables in the database.
 
-Plugin developers will be required to supply a `technicalName` for their payment and shipping methods.
+Plugin developers will be required to supply a `technicalName` for their payment and shipping methods.  
+**If no technical name is specified before the migration is run, a temporary placeholder `temporary_<method-id>` will be used instead.**
 
 Merchants must review their custom created payment and shipping methods for the new `technicalName` property and update their methods through the administration accordingly.
 </details>

--- a/src/Core/Migration/V6_7/Migration1697112043TemporaryPaymentAndShippingTechnicalNames.php
+++ b/src/Core/Migration/V6_7/Migration1697112043TemporaryPaymentAndShippingTechnicalNames.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class Migration1697112043TemporaryPaymentAndShippingTechnicalNames extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1697112043;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addAppShippingMethodTechnicalNames($connection);
+        $this->addAppPaymentMethodTechnicalNames($connection);
+
+        $this->addTemporaryPaymentMethodTechnicalNames($connection);
+        $this->addTemporaryShippingMethodTechnicalNames($connection);
+    }
+
+    private function addTemporaryPaymentMethodTechnicalNames(Connection $connection): void
+    {
+        $connection->executeStatement('
+            UPDATE `payment_method`
+            SET `payment_method`.`technical_name` = CONCAT(\'temporary_\', LOWER(HEX(`payment_method`.`id`)))
+            WHERE `payment_method`.`technical_name` IS NULL;
+        ');
+    }
+
+    private function addTemporaryShippingMethodTechnicalNames(Connection $connection): void
+    {
+        $connection->executeStatement('
+            UPDATE `shipping_method`
+            SET `shipping_method`.`technical_name` = CONCAT(\'temporary_\', LOWER(HEX(`shipping_method`.`id`)))
+            WHERE `shipping_method`.`technical_name` IS NULL;
+        ');
+    }
+
+    private function addAppShippingMethodTechnicalNames(Connection $connection): void
+    {
+        $connection->executeStatement('
+            UPDATE IGNORE `shipping_method`
+            RIGHT JOIN `app_shipping_method` ON `app_shipping_method`.`shipping_method_id` = `shipping_method`.`id`
+            SET `shipping_method`.`technical_name` = CONCAT(\'shipping_\', `app_shipping_method`.`app_name`, \'_\', `app_shipping_method`.`identifier`)
+            WHERE `shipping_method`.`technical_name` IS NULL;
+        ');
+    }
+
+    private function addAppPaymentMethodTechnicalNames(Connection $connection): void
+    {
+        $connection->executeStatement('
+            UPDATE IGNORE `payment_method`
+            RIGHT JOIN `app_payment_method` ON `app_payment_method`.`payment_method_id` = `payment_method`.`id`
+            SET `payment_method`.`technical_name` = CONCAT(\'payment_\', LOWER(SUBSTRING_INDEX(`payment_method`.`handler_identifier`, \'\\\\\', -1)))
+            WHERE `payment_method`.`technical_name` IS NULL;
+        ');
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1697112043TemporaryPaymentAndShippingTechnicalNamesTest.php
+++ b/tests/migration/Core/V6_7/Migration1697112043TemporaryPaymentAndShippingTechnicalNamesTest.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1697112043TemporaryPaymentAndShippingTechnicalNames;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Migration1697112043TemporaryPaymentAndShippingTechnicalNames::class)]
+class Migration1697112043TemporaryPaymentAndShippingTechnicalNamesTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    private Migration1697112043TemporaryPaymentAndShippingTechnicalNames $migration;
+
+    private IdsCollection $ids;
+
+    protected function setUp(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->migration = new Migration1697112043TemporaryPaymentAndShippingTechnicalNames();
+        $this->ids = new IdsCollection();
+    }
+
+    #[After]
+    public function cleanUp(): void
+    {
+        $byteList = Uuid::fromHexToBytesList(\array_values($this->ids->all()));
+
+        foreach (['payment_method', 'shipping_method', 'app_shipping_method', 'app_payment_method'] as $table) {
+            $this->connection->executeStatement(
+                'DELETE FROM `' . $table . '` WHERE `id` in (:ids)',
+                ['ids' => $byteList],
+                ['ids' => ArrayParameterType::BINARY],
+            );
+        }
+    }
+
+    public function testMigrate(): void
+    {
+        $this->rollback();
+        $this->prepare();
+
+        $this->migration->update($this->connection);
+        $this->migration->update($this->connection);
+
+        $paymentMethods = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(HEX(id)) as id, technical_name FROM `payment_method` WHERE `id` IN (:ids)',
+            ['ids' => $this->ids->getByteList(['payment-method', 'payment-method--app'])],
+            ['ids' => ArrayParameterType::BINARY],
+        );
+
+        $shippingMethods = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(HEX(id)) as id, technical_name FROM `shipping_method` WHERE `id` IN (:ids)',
+            ['ids' => $this->ids->getByteList(['shipping-method', 'shipping-method--app'])],
+            ['ids' => ArrayParameterType::BINARY],
+        );
+
+        static::assertEquals([
+            [
+                'id' => $this->ids->get('payment-method'),
+                'technical_name' => 'temporary_' . $this->ids->get('payment-method'),
+            ],
+            [
+                'id' => $this->ids->get('payment-method--app'),
+                'technical_name' => 'payment_testapp_credit_card',
+            ],
+        ], $paymentMethods);
+
+        static::assertEquals([
+            [
+                'id' => $this->ids->get('shipping-method'),
+                'technical_name' => 'temporary_' . $this->ids->get('shipping-method'),
+            ],
+            [
+                'id' => $this->ids->get('shipping-method--app'),
+                'technical_name' => 'shipping_TestApp_express_transport',
+            ],
+        ], $shippingMethods);
+    }
+
+    private function rollback(): void
+    {
+        $this->connection->executeStatement('ALTER TABLE `payment_method` MODIFY COLUMN `technical_name` VARCHAR(255) NULL');
+        $this->connection->executeStatement('ALTER TABLE `shipping_method` MODIFY COLUMN `technical_name` VARCHAR(255) NULL');
+    }
+
+    /**
+     * Setup a payment and shipping method with and without an app
+     */
+    private function prepare(): void
+    {
+        $this->ids->set(
+            'delivery-time',
+            $this->connection->fetchOne('SELECT HEX(id) FROM `delivery_time` LIMIT 1'),
+        );
+
+        $this->connection->insert('payment_method', [
+            'id' => $this->ids->getBytes('payment-method'),
+            'handler_identifier' => 'Migration\Payment\Method',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $this->connection->insert('payment_method', [
+            'id' => $this->ids->getBytes('payment-method--app'),
+            'handler_identifier' => 'app\TestApp_credit_card',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $this->connection->insert('shipping_method', [
+            'id' => $this->ids->getBytes('shipping-method'),
+            'delivery_time_id' => $this->ids->getBytes('delivery-time'),
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $this->connection->insert('shipping_method', [
+            'id' => $this->ids->getBytes('shipping-method--app'),
+            'delivery_time_id' => $this->ids->getBytes('delivery-time'),
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $this->connection->insert('app_shipping_method', [
+            'id' => $this->ids->getBytes('app-shipping-method'),
+            'app_name' => 'TestApp',
+            'shipping_method_id' => $this->ids->getBytes('shipping-method--app'),
+            'identifier' => 'express_transport',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $this->connection->insert('app_payment_method', [
+            'id' => $this->ids->getBytes('app-payment-method'),
+            'app_name' => 'TestApp',
+            'payment_method_id' => $this->ids->getBytes('payment-method--app'),
+            'identifier' => 'credit_card',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
>When running the 6.7 migrations, if payment or shipping methods exist without technical names, the migration will fail. This is partly expected as we want to enforce the technical name. However, the solution is not easy as you need to understand the SQL error message and set the technical names for your and foreign shipping and payment methods, the latter is not intended.

### 2. What does this change do, exactly?
>The migrations should not fail. As most plugins will take care of this with the upcoming 6.7 compatibility, they may overlook that the requirement of the technical name was announced two majors ago and add one with their 6.7 compatible version. This will be too late, as Shopware migrations will have been done by then.
We should add a temporary name like temporary_<id-of-method> to have an easily identifiable name so that our migrations can succeed and plugins can add/replace the technical name.

### 3. Describe each step to reproduce the issue or behaviour.
>Run 6.7 migrations with shipping or payment methods without technical names

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
fixes #8238

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
