### PR TITLE
fix: sw-date-filter select timeframe placeholder translation

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.html.twig
@@ -15,7 +15,7 @@
         v-if="filter.showTimeframe"
         v-model:value="dateValue.timeframe"
         class="sw-date-filter__timeframe"
-        placeholder="Select timeframe"
+        :placeholder="$t('sw-date-filter.selectTimeframe.placeholder')"
         :options="timeframeOptions"
         @update:value="onTimeframeSelect"
     />

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -1496,6 +1496,11 @@
     "active": "Aktiv",
     "inactive": "Inaktiv"
   },
+  "sw-date-filter": {
+    "selectTimeframe": {
+      "placeholder": "Zeitraum auswählen"
+    }
+  },
   "sw-existence-filter": {
     "placeholder": "Alle",
     "noCriteria": "Kein {criteriaName}",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -1496,6 +1496,11 @@
     "active": "Active",
     "inactive": "Inactive"
   },
+  "sw-date-filter": {
+    "selectTimeframe": {
+      "placeholder": "Select timeframe"
+    }
+  },
   "sw-existence-filter": {
     "placeholder": "All",
     "noCriteria": "No {criteriaName}",


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes the issue  https://github.com/shopware/shopware/issues/7139

### 2. What does this change do, exactly?
Add a translation to snippets for the date filter select placeholder

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to orders listing
2. Open sidebar filters
3. Se the placeholder in the Order date filter


### 4. Please link to the relevant issues (if any).
closes #7139
