### PR TITLE
fix: CMS data sets

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-upload-v2/sw-media-upload-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-upload-v2/sw-media-upload-v2.spec.js
@@ -13,7 +13,6 @@ async function createWrapper(customOptions = {}) {
     };
 
     return mount(await wrapTestComponent('sw-media-upload-v2', { sync: true }), {
-        attachTo: document.body,
         props: {
             uploadTag: 'my-upload',
             addFilesOnMultiselect: true,
@@ -589,9 +588,8 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
         await flushPromises();
 
         // enable uploads via url
-        const contextMenuItem = document.body.querySelector('.sw-media-upload-v2__button-url-upload');
-        expect(contextMenuItem).toBeInstanceOf(HTMLElement);
-        contextMenuItem.click();
+        const contextMenuItem = wrapper.find('.sw-media-upload-v2__button-url-upload');
+        await contextMenuItem.trigger('click');
         await flushPromises();
 
         const urlInput = wrapper.find('#sw-field--url');

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/index.ts
@@ -1,7 +1,7 @@
 import { MtDatepicker as MtDatepickerOriginal } from '@shopware-ag/meteor-component-library';
 import type { PropType } from 'vue';
 // eslint-disable-next-line max-len
-import type {DateTimeOptions} from "vue-i18n";
+import type { DateTimeOptions } from 'vue-i18n';
 import template from './mt-datepicker.html.twig';
 
 /**
@@ -53,9 +53,9 @@ Shopware.Component.register('mt-datepicker', {
          * Options: "date" (for selecting a date), or "datetime" (for selecting both).
          */
         dateType: {
-            type: String as PropType<"date" | "datetime" | "time">,
+            type: String as PropType<'date' | 'datetime' | 'time'>,
             required: false,
-            default: "datetime",
+            default: 'datetime',
         },
 
         /**

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/mt-datepicker.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/mt-datepicker.spec.js
@@ -8,17 +8,17 @@ describe('src/app/component/meteor-wrapper/mt-datepicker', () => {
     beforeAll(() => {
         Shopware.Store.get('system').registerAdminLocale('de-DE');
         Shopware.Store.get('system').registerAdminLocale('en-GB');
-    })
+    });
 
     beforeEach(() => {
         Shopware.Store.get('session').setCurrentUser({
             firstName: 'John',
             lastName: 'Doe',
             timeZone: 'Europe/Berlin',
-        })
+        });
 
         Shopware.Store.get('session').setAdminLocale('de-DE');
-    })
+    });
 
     it('should be a Vue.js component', async () => {
         const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }), {
@@ -61,7 +61,7 @@ describe('src/app/component/meteor-wrapper/mt-datepicker', () => {
         const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }), {
             props: {
                 modelValue: '2023-10-01T00:00:00+02:00',
-            }
+            },
         });
 
         // Click on input to open datepicker
@@ -69,7 +69,7 @@ describe('src/app/component/meteor-wrapper/mt-datepicker', () => {
 
         // Expect german locale to be used
         expect(wrapper.find('[data-test-id="dp-input"]').element.value).toBe('01.10.2023, 00:00');
-    })
+    });
 
     it('should use custom format based on currentLocale (en)', async () => {
         // Set the user locale to english
@@ -78,7 +78,7 @@ describe('src/app/component/meteor-wrapper/mt-datepicker', () => {
         const wrapper = mount(await wrapTestComponent('mt-datepicker', { sync: true }), {
             props: {
                 modelValue: '2023-10-01T00:00:00+02:00',
-            }
+            },
         });
 
         // Click on input to open datepicker

--- a/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.ts
@@ -24,6 +24,7 @@ interface publishOptions {
     scope: scopeInterface;
     deprecated?: boolean;
     deprecationMessage?: string;
+    showDoubleRegistrationError?: boolean;
 }
 
 type dataset = {
@@ -189,7 +190,14 @@ function parsePath(path: string): ParsedPath | null {
 }
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
-export function publishData({ id, path, scope, deprecated, deprecationMessage }: publishOptions): () => void {
+export function publishData({
+    id,
+    path,
+    scope,
+    deprecated,
+    deprecationMessage,
+    showDoubleRegistrationError = true,
+}: publishOptions): () => void {
     if (unregisterPublishDataIds.includes(id)) {
         unregisterPublishDataIds = unregisterPublishDataIds.filter((value) => value !== id);
     }
@@ -197,7 +205,9 @@ export function publishData({ id, path, scope, deprecated, deprecationMessage }:
 
     // Dataset registered from different scope? Prevent update.
     if (registeredDataSet && registeredDataSet.scope !== scope?.$?.uid) {
-        console.error(`The dataset id "${id}" you tried to publish is already registered.`);
+        if (showDoubleRegistrationError) {
+            console.error(`The dataset id "${id}" you tried to publish is already registered.`);
+        }
 
         return () => {};
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/component/component.spec.js
@@ -63,6 +63,10 @@ describe('module/sw-cms/elements/location-renderer/component', () => {
             id: 'example_cms_element_type__config-element',
             path: 'element',
             scope: expect.anything(),
+            deprecated: true,
+            deprecationMessage:
+                // eslint-disable-next-line max-len
+                'The general cms element data set is deprecated. Please use a specific cms data set instead by provoding the element id.',
         });
 
         expect(Shopware.ExtensionAPI.publishData).toHaveBeenNthCalledWith(2, {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/component/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/component/index.ts
@@ -84,12 +84,17 @@ Component.register('sw-cms-el-location-renderer', {
                 this.unpublishDataWithElementId();
             }
 
-            // This is just for avoiding breaking changes for older implementations.
-            // The important part is the publisher with the element id.
+            /**
+             * @deprecated tag:v6.8.0 - Will be removed
+             */
             this.unpublishData = Shopware.ExtensionAPI.publishData({
                 id: this.publishingKey,
                 path: 'element',
                 scope: this,
+                deprecated: true,
+                deprecationMessage:
+                    // eslint-disable-next-line max-len
+                    'The general cms element data set is deprecated. Please use a specific cms data set instead by provoding the element id.',
             });
 
             this.unpublishDataWithElementId = Shopware.ExtensionAPI.publishData({

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/config/index.ts
@@ -55,10 +55,25 @@ Component.register('sw-cms-el-config-location-renderer', {
         createdComponent() {
             this.initElementConfig(this.elementData.name);
 
+            /**
+             * @deprecated tag:v6.8.0 - Will be removed
+             */
             Shopware.ExtensionAPI.publishData({
                 id: this.publishingKey,
                 path: 'element',
                 scope: this,
+                deprecated: true,
+                deprecationMessage:
+                    // eslint-disable-next-line max-len
+                    'The general cms element data set is deprecated. Please use a specific cms data set instead by provoding the element id.',
+                showDoubleRegistrationError: false,
+            });
+
+            Shopware.ExtensionAPI.publishData({
+                id: `${this.publishingKey}__${this.element.id}`,
+                path: 'element',
+                scope: this,
+                showDoubleRegistrationError: false,
             });
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
A support ticket made us aware that implementing CMS elements via the SDK has problems with the published Data sets.
The whole system needs a bigger refactoring but for now this fixes the issue.

### 2. What does this change do, exactly?
This change deprecates the old none element specific CMS data sets and makes sure that the config publishes the id specific one as well as the element.


### 3. Describe each step to reproduce the issue or behaviour.
https://developer.shopware.com/docs/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.html

