### PR TITLE
fix(offcanvas): OffCanvasSingleton does not remove hard-coded offcanvas from DOM

### DIFF
--- a/changelog/_unreleased/2025-04-04-offcanvassingleton-does-not-remove-hard-coded-offcanvas-from-dom.md
+++ b/changelog/_unreleased/2025-04-04-offcanvassingleton-does-not-remove-hard-coded-offcanvas-from-dom.md
@@ -1,0 +1,7 @@
+---
+title: OffCanvasSingleton does not remove hard-coded offcanvas from DOM
+issue: #4450
+---
+# Storefront
+* Added new class `js-offcanvas-singleton` to `OffCanvasSingleton` in order to identify Bootstrap OffCanvas created by `OffCanvasSingleton`.
+* Changed `OffCanvasSingleton::getOffCanvas` to query elements with selector `.js-offcanvas-singleton` instead of generic `.offcanvas`.

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js
@@ -1,6 +1,9 @@
 import NativeEventEmitter from 'src/helper/emitter.helper';
 
+// The bootstrap offcanvas class
 const OFF_CANVAS_CLASS = 'offcanvas';
+// Custom offcanvas class to identify offcanvas created by OffCanvasSingleton
+const OFF_CANVAS_JS_CLASS = 'js-offcanvas-singleton';
 const OFF_CANVAS_FULLWIDTH_CLASS = 'is-fullwidth';
 const OFF_CANVAS_CLOSE_TRIGGER_CLASS = 'js-offcanvas-close';
 const REMOVE_OFF_CANVAS_DELAY = 350;
@@ -69,7 +72,7 @@ class OffCanvasSingleton {
      * @private
      */
     getOffCanvas() {
-        return document.querySelectorAll(`.${OFF_CANVAS_CLASS}`);
+        return document.querySelectorAll(`.${OFF_CANVAS_JS_CLASS}`);
     }
 
     /**
@@ -211,7 +214,7 @@ class OffCanvasSingleton {
      */
     _createOffCanvas(position, fullwidth, cssClass, closable) {
         const offCanvas = document.createElement('div');
-        offCanvas.classList.add(OFF_CANVAS_CLASS);
+        offCanvas.classList.add(OFF_CANVAS_CLASS, OFF_CANVAS_JS_CLASS);
         offCanvas.classList.add(this._getPositionClass(position));
         offCanvas.setAttribute('tabindex', '-1');
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/offcanvas/offcanvas.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/offcanvas/offcanvas.plugin.test.js
@@ -273,4 +273,47 @@ describe('OffCanvas tests', () => {
             expect(document.querySelector('.offcanvas').classList.contains(position.expectedPositionClass)).toBe(true);
         });
     });
+
+    it('removes only offcanvas from the DOM created by OffCanvasSingleton and ignores other Bootstrap offcanvas', () => {
+        // Add a hard-coded Bootstrap offcanvas to the HTML which must not be removed by OffCanvasSingleton
+        document.body.innerHTML = `
+            <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasExample" aria-controls="offcanvasExample">
+                Open Bootstrap offcanvas
+            </button>
+            
+            <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvasExample" aria-labelledby="offcanvasExampleLabel">
+                <div class="offcanvas-header">
+                    <h5 class="offcanvas-title" id="offcanvasExampleLabel">Offcanvas</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </div>
+                <div class="offcanvas-body">
+                    Bootstrap offcanvas
+                </div>
+            </div>
+        `;
+
+        jest.useFakeTimers();
+
+        // Open the shopware OffCanvas via OffCanvasSingleton
+        OffCanvas.open('Interesting content');
+        jest.runAllTimers();
+
+        // Ensue shopware OffCanvas was opened
+        expect(OffCanvas.exists()).toBe(true);
+        expect(document.querySelector('.js-offcanvas-singleton').classList.contains('show')).toBe(true);
+
+        // Ensure hard-coded Bootstrap offcanvas is also present in the DOM. It must not be removed by "_removeExistingOffCanvas".
+        expect(document.getElementById('offcanvasExample')).toBeTruthy();
+
+        // Close the shopware OffCanvas
+        OffCanvas.close();
+        jest.runAllTimers();
+
+        // Ensure shopware OffCanvas is no longer existing in the DOM
+        expect(document.querySelector('.js-offcanvas-singleton')).toBeFalsy();
+        expect(OffCanvas.exists()).toBe(false);
+
+        // Ensure the hard-coded Bootstrap offcanvas is still in the DOM
+        expect(document.getElementById('offcanvasExample')).toBeTruthy();
+    });
 });


### PR DESCRIPTION
fixes #3303
fixes #4450

### 1. Why is this change necessary?

Manually added Bootstrap OffCanvas in the HTML are removed by the shopware JS OffCanvas `OffCanvasSingleton`

### 2. What does this change do, exactly?

Introduce a new class `js-offcanvas-singleton` that is used to identify the OffCanvas instead of the generic Bootstrap class `offcanvas`.

### 3. Describe each step to reproduce the issue or behaviour.

* Put a hard-coded OffCanvas into the template like described in the Bootstrap docs: https://getbootstrap.com/docs/5.3/components/offcanvas/#live-demo
* Initially, this OffCanvas works as expected.
* Open the OffCanvas cart
* When the OffCanvas cart is opened, the previously added Bootstrap OffCanvas is removed from the DOM.
* Try to open the hard-coded OffCanvas again. It does not work because it was removed from the DOM.

With this change, the hard-coded OffCanvas works alongside the shopware JS OffCanvas.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
