### PR TITLE
fix: navigating back from listing pages issues

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.ts
@@ -123,7 +123,7 @@ export default Shopware.Mixin.register(
         watch: {
             // Watch for changes in query parameters and update listing
             $route(newRoute, oldRoute) {
-                if (this.disableRouteParams || this.previousRouteName !== newRoute.name) {
+                if (this.disableRouteParams || oldRoute.name !== newRoute.name) {
                     return;
                 }
 

--- a/src/Administration/Resources/app/administration/src/app/service/filter.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/filter.service.js
@@ -40,10 +40,9 @@ export default class FilterService {
             const queryFilterValue = this._getQueryFilterValue(storeKey);
 
             if (queryFilterValue) {
-                this._filterEntity.value = JSON.parse(decodeURIComponent(queryFilterValue));
-                this._filterEntity.value = this._filterEntity.value || {};
+                this._filterEntity.value = JSON.parse(decodeURIComponent(queryFilterValue)) || {};
             } else {
-                this._pushFiltersToUrl();
+                this._pushFiltersToUrl(true);
             }
 
             return Promise.resolve(this._filterEntity.value);
@@ -111,7 +110,7 @@ export default class FilterService {
 
     _getUserConfigCriteria(storeKey) {
         const currentUser = Shopware.Store.get('session').currentUser;
-        const criteria = new Criteria(1, 25);
+        const criteria = new Criteria(1, 1);
 
         criteria.addFilter(Criteria.equals('key', storeKey));
         criteria.addFilter(Criteria.equals('userId', currentUser?.id));
@@ -119,7 +118,7 @@ export default class FilterService {
         return criteria;
     }
 
-    async _pushFiltersToUrl() {
+    async _pushFiltersToUrl(replaceRoute = false) {
         const urlFilterValue = types.isEmpty(this._filterEntity.value) ? null : this._filterEntity.value;
         const urlEncodedValue = encodeURIComponent(JSON.stringify(urlFilterValue));
 
@@ -143,8 +142,11 @@ export default class FilterService {
         }
 
         try {
-            await router.push(newRoute);
-            return Promise.resolve();
+            if (replaceRoute) {
+                return await router.replace(newRoute);
+            }
+
+            return await router.push(newRoute);
         } catch (error) {
             if (error?.name === 'NavigationDuplicated') {
                 return error;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.spec.js
@@ -104,6 +104,7 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-list', () => {
                 },
             },
             push: () => {},
+            replace: () => {},
         };
     });
 


### PR DESCRIPTION

### 1. Why is this change necessary?
Actual behaviour
When user navigates from dashboard to a listing page (like products), and click browser back button, it remains in the same page.

Expected behaviour
When user navigates from dashboard to a listing page (like products), and click browser back button, it must go back to previous page



### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.

1. Go to dashboard
2. Go to products
3. Click Browser back button
4. It is in the same page yet

### 4. Please link to the relevant issues (if any).
closes #8290

