### PR TITLE
fix: Show cross selling slider arrows

### DIFF
--- a/changelog/_unreleased/2025-04-04-show-navigation-arrows-of-product-cross-selling-sliders-again.md
+++ b/changelog/_unreleased/2025-04-04-show-navigation-arrows-of-product-cross-selling-sliders-again.md
@@ -1,0 +1,8 @@
+---
+title: Show navigation arrows of product cross selling sliders (again)
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed `@Storefront/storefront/element/cms-element-cross-selling.html.twig` template to show the slider navigation arrows for the cross selling sliders again

--- a/src/Storefront/Resources/views/storefront/element/cms-element-cross-selling.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-cross-selling.html.twig
@@ -71,12 +71,15 @@
                                                 navigation: {
                                                     value: true
                                                 },
+                                                navigationArrows: {
+                                                    value: 'outside'
+                                                },
                                                 displayMode: {
                                                     value: sliderConfig.displayMode.value
                                                 },
                                                 verticalAlign: {
                                                     value: center
-                                                }
+                                                },
                                             } %}
 
                                             {% block cms_element_cross_selling_tabs_content_container_slider %}


### PR DESCRIPTION
### 1. Why is this change necessary?
With the commit https://github.com/shopware/shopware/commit/425067f5ee0964f95c6e16ed1d813d5bd1af649e#diff-fc4bf1d3ab3a9109f33491709b07da8d6852accc3a0cdba67906063665f5ecf9 the product cross selling slider arrows have been removed, as the "default" config changed.

### 2. What does this change do, exactly?
Explicitly add the config.

### 3. Describe each step to reproduce the issue or behaviour.
Create a product cross selling slider.

### 4. Please link to the relevant issues (if any).
Closes https://github.com/shopware/shopware/issues/6970

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
