### PR TITLE
docs: add breaking change of `mt-tooltip` not supporting components in content to 6.7 UPGRADE

### DIFF
--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -2504,6 +2504,21 @@ After:
 ```html
 <mt-checkbox @update:checked="updateValue" />
 ```
+
+## Migration to "mt-tooltip"
+As part of the internal refactor of the Meteor component library, all tooltips are now rendered using the new `mt-tooltip` component.
+
+### `mt-tooltip` no longer supports Vue components inside the tooltip content. Previously, it was possible to render Vue components (such as `RouterLink`) inside the tooltip text. This is no longer supported. The tooltip content must now consist only of plain strings or standard HTML elements.
+
+Before:
+```html
+<mt-switch :help-text="`This is a help text. <RouterLink to="someUrl">Link</RouterLink>`" />
+```
+After:
+```html
+<mt-switch :help-text="`This is a help text. <a href="someUrl">Link</a>`" />
+```
+
 </details>
 
 ### Deprecated admin notification entity + related classes


### PR DESCRIPTION
### 1. Why is this change necessary?
The mt-tooltip no longer supports components in the content.

### 2. What does this change do, exactly?
Add that breaking change to The 6.7 UPGRADE guide 

### 4. Please link to the relevant issues (if any).
- closes #8299 