### PR TITLE
fix: set cms_section_version_id

### DIFF
--- a/tests/migration/Core/V6_7/Migration1733136208AddH1ToCmsCategoryListingTest.php
+++ b/tests/migration/Core/V6_7/Migration1733136208AddH1ToCmsCategoryListingTest.php
@@ -29,28 +29,34 @@ class Migration1733136208AddH1ToCmsCategoryListingTest extends TestCase
     {
         $this->rollback();
         $this->migrate();
-        $this->migrate();
 
-        $sectionId = $this->getSectionId('Default listing layout');
-        static::assertNotNull($sectionId);
+        $sectionData = $this->getSectionData('Default listing layout');
+        static::assertNotNull($sectionData);
+
+        $sectionId = $sectionData['id'];
+        $sectionVersionId = $sectionData['version_id'];
 
         $block = $this->getBlock($sectionId);
         static::assertNotNull($block);
         static::assertSame('Category name', $block['name']);
+        static::assertSame($sectionVersionId, $block['cms_section_version_id']);
     }
 
     public function testMigrationAddsH1ToDefaultListingSidebarLayout(): void
     {
         $this->rollback();
         $this->migrate();
-        $this->migrate();
 
-        $sectionId = $this->getSectionId('Default listing layout with sidebar');
-        static::assertNotNull($sectionId);
+        $sectionData = $this->getSectionData('Default listing layout with sidebar');
+        static::assertNotNull($sectionData);
+
+        $sectionId = $sectionData['id'];
+        $sectionVersionId = $sectionData['version_id'];
 
         $block = $this->getBlock($sectionId);
         static::assertNotNull($block);
         static::assertSame('Category name', $block['name']);
+        static::assertSame($sectionVersionId, $block['cms_section_version_id']);
     }
 
     private function migrate(): void
@@ -63,15 +69,20 @@ class Migration1733136208AddH1ToCmsCategoryListingTest extends TestCase
         $this->connection->executeStatement('DELETE FROM cms_block WHERE name = "Category name"');
     }
 
-    private function getSectionId(string $layoutName): ?string
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getSectionData(string $layoutName): ?array
     {
-        return $this->connection->fetchOne(
-            'SELECT cms_section.id
+        $result = $this->connection->fetchAssociative(
+            'SELECT cms_section.id, cms_section.version_id
              FROM cms_section
              INNER JOIN cms_page_translation ON cms_page_translation.cms_page_id = cms_section.cms_page_id
              WHERE cms_page_translation.name = :name',
             ['name' => $layoutName]
-        ) ?: null;
+        );
+
+        return $result ?: null;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Closes: #8273

### 2. What does this change do, exactly?
It re-uses the cms_section_version_id from the db.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
