### PR TITLE
fix: align help text style with meteor components

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/assets/scss/directives/tooltip.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/directives/tooltip.scss
@@ -1,9 +1,9 @@
 @import "~scss/variables";
 
 $sw-tooltip-z-index: $z-index-tooltip;
-$sw-tooltip-color-background: $color-menu-end;
-$sw-tooltip-color: $color-white;
-$sw-tooltip-border-radius: $border-radius-default;
+$sw-tooltip-color-background: var(--color-elevation-surface-floating);
+$sw-tooltip-color: var(--color-text-inverse-default);
+$sw-tooltip-border-radius: var(--border-radius-overlay);
 $sw-tooltip-color-light: $color-darkgray-200;
 $sw-tooltip-border-color-light: $color-gray-300;
 
@@ -15,8 +15,8 @@ $sw-tooltip-border-color-light: $color-gray-300;
         background-color: $sw-tooltip-color-background;
         border-radius: $sw-tooltip-border-radius;
         color: $sw-tooltip-color;
-        padding: 12px 16px;
-        font-size: $font-size-xs;
+        padding: var(--scale-size-12);
+        font-size: var(--font-size-2xs);
         word-wrap: break-word;
 
         &::before {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-help-text/sw-help-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-help-text/sw-help-text.html.twig
@@ -11,7 +11,7 @@
 >
     {% block sw_help_text_icon %}
     <mt-icon
-        name="regular-questionmark-s"
+        name="solid-question-circle-s"
     />
     {% endblock %}
 </span>

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-help-text/sw-help-text.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-help-text/sw-help-text.scss
@@ -3,21 +3,21 @@
 .sw-help-text {
     width: 16px;
     height: 16px;
-    background-color: $color-shopware-brand-500;
-    color: $color-white;
+    color: var(--color-icon-brand-default);
     border-radius: 50%;
     line-height: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     pointer-events: auto;
+    cursor: pointer;
+
+    &:hover {
+        color: var(--color-icon-brand-hover);
+    }
 
     .mt-icon {
         width: 16px;
         height: 16px;
-        padding-top: 4px;
-        padding-right: 5px;
-        padding-bottom: 3px;
-        padding-left: 5px;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
New meteor components has different tooltip styles comparing with old sw- components


### 2. What does this change do, exactly?
align the old help tooltip styles with the new mt-tooltip


### 3. Describe each step to reproduce the issue or behaviour.
Go to product detail and compare the different help tooltips


### 4. Please link to the relevant issues (if any).

- closes #8300

