### PR TITLE
fix: Admin assets symfony bundles

### DIFF
--- a/src/Administration/Framework/Twig/ViteFileAccessorDecorator.php
+++ b/src/Administration/Framework/Twig/ViteFileAccessorDecorator.php
@@ -121,6 +121,10 @@ class ViteFileAccessorDecorator extends FileAccessor
 
                 // Prepend the asset path to the every entry point
                 foreach ($entrypoint as $index => $entry) {
+                    // There is an edge case where symfony removes the "bundle" suffix from the bundle name
+                    // @see \Shopware\Core\Framework\Plugin\Util\AssetService::getTargetDirectory
+                    $entry = str_replace('bundle/administration', '/administration', $entry);
+
                     $content['entryPoints'][$technicalBundleName][$key][$index] = \sprintf('%s%s', $this->assetPath, $entry);
                 }
             }

--- a/tests/integration/Core/Framework/Api/Controller/Fixtures/InfoController/Resources/public/administration/.vite/entrypoints.json
+++ b/tests/integration/Core/Framework/Api/Controller/Fixtures/InfoController/Resources/public/administration/.vite/entrypoints.json
@@ -6,7 +6,7 @@
       ],
       "dynamic": [],
       "js": [
-        "/bundles/some-functionality-bundle/administration/js/some-functionality-bundle.js"
+        "/bundles/somefunctionalitybundle/administration/js/some-functionality-bundle.js"
       ],
       "legacy": false,
       "preload": []

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -420,7 +420,7 @@ class InfoControllerTest extends TestCase
         static::assertArrayHasKey('SomeFunctionalityBundle', $config['bundles']);
 
         static::assertStringEndsWith(
-            '/bundles/some-functionality-bundle/administration/js/some-functionality-bundle.js',
+            '/bundles/somefunctionality/administration/js/some-functionality-bundle.js',
             (string) $config['bundles']['SomeFunctionalityBundle']['js'][0]
         );
     }

--- a/tests/unit/Administration/Framework/Twig/Fixtures/Administration/Resources/public/administration/.vite/entrypoints.json
+++ b/tests/unit/Administration/Framework/Twig/Fixtures/Administration/Resources/public/administration/.vite/entrypoints.json
@@ -1,1 +1,12 @@
-{"entryPoints":{"administration":{"app":["app.js"]}}}
+{
+    "base": "/bundles/administration/",
+    "entryPoints": {
+        "administration": {
+            "js": [
+                "/bundles/administration/administration/assets/app.js"
+            ],
+            "legacy": false,
+            "preload": []
+        }
+    }
+}

--- a/tests/unit/Administration/Framework/Twig/Fixtures/TestBundle/Resources/public/administration/.vite/entrypoints.json
+++ b/tests/unit/Administration/Framework/Twig/Fixtures/TestBundle/Resources/public/administration/.vite/entrypoints.json
@@ -1,0 +1,14 @@
+{
+    "base": "/bundles/testbundle/administration/",
+    "entryPoints": {
+        "test-bundle": {
+            "css": [],
+            "dynamic": [],
+            "js": [
+                "/bundles/testbundle/administration/assets/app.js"
+            ],
+            "legacy": false,
+            "preload": []
+        }
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes https://github.com/shopware/shopware/issues/8271


### 2. What does this change do, exactly?
It removes the bundles suffix from bundle names in the ViteFileAccessorDecorator similar to the AssetService.


### 3. Describe each step to reproduce the issue or behaviour.
Create a plugin or bundle with a name like "MyTestBundle" that contains Admin code.

