### PR TITLE
chore: Move sw-admin-menu-user-actions to mt-link

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -58,7 +58,7 @@ a,
 }
 
 /* style inline external links */
-a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button) {
+a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button, .mt-link--external, .mt-link--internal) {
     display: inline-block;
     position: relative;
     color: $color-shopware-brand-500;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
@@ -160,8 +160,9 @@
 
                 {% block sw_admin_menu_user_actions_items_logout_user %}
                 <li class="sw-admin-menu__navigation-list-item">
-                    <a
-                        href="#"
+                    <mt-link
+                        as="a"
+                        to="#"
                         class="sw-admin-menu__navigation-link sw-admin-menu__logout-action"
                         @click.prevent="onLogoutUser"
                     >
@@ -171,7 +172,7 @@
                             size="16px"
                         />
                         {{ $tc('global.sw-admin-menu.linkLogout') }}
-                    </a>
+                    </mt-link>
                 </li>
                 {% endblock %}
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec.js
@@ -52,6 +52,7 @@ async function createWrapper(options = {}) {
                 'router-link': {
                     template: '<div class="router-link"><slot /></div>',
                 },
+                'mt-link': true,
                 'mt-icon': true,
             },
             provide: {

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/extension/sw-admin-menu/sw-admin-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/extension/sw-admin-menu/sw-admin-menu.html.twig
@@ -3,7 +3,7 @@
     v-if="acl.can('user.update_profile')"
     class="sw-admin-menu__navigation-list-item"
 >
-    <router-link
+    <mt-link
         class="sw-admin-menu__navigation-link sw-admin-menu__profile-item"
         :to="{ name: 'sw.profile.index', params: { currentUser } }"
     >
@@ -13,7 +13,7 @@
             size="16px"
         />
         {{ $tc('sw-profile.general.headlineProfile') }}
-    </router-link>
+    </mt-link>
 </li>
 
 {% parent %}


### PR DESCRIPTION
Changes in Rufus to an external link make this necessary to align things.