### PR TITLE
fix: shorten additional address line placeholder (#7475)

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
@@ -230,8 +230,8 @@
       "placeholderCity": "Gib eine Stadt ein ...",
       "placeholderCountry": "Wähle ein Land aus ...",
       "placeholderState": "Wähle ein (Bundes-)Land aus ...",
-      "placeholderAdditionalAddressLine1": "Gib eine erste zusätzliche Adresszeile ein ...",
-      "placeholderAdditionalAddressLine2": "Gib eine zweite zusätzliche Adresszeile ein ...",
+      "placeholderAdditionalAddressLine1": "Gib eine erste Adresszeile ein ...",
+      "placeholderAdditionalAddressLine2": "Gib eine zweite Adresszeile ein ...",
       "placeholderPhoneNumber": "Gib eine Telefonnummer an ...",
       "placeholderVatId": "Gib die USt-IdNr. ein ..."
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
@@ -230,8 +230,8 @@
       "placeholderCity": "Enter city...",
       "placeholderCountry": "Select country...",
       "placeholderState": "Select state...",
-      "placeholderAdditionalAddressLine1": "Enter a first additional address line...",
-      "placeholderAdditionalAddressLine2": "Enter a second additional address line...",
+      "placeholderAdditionalAddressLine1": "Enter a first address line...",
+      "placeholderAdditionalAddressLine2": "Enter a second address line...",
       "placeholderPhoneNumber": "Enter phone number...",
       "placeholderVatId": "Enter VAT Reg.No..."
     },


### PR DESCRIPTION
To stay in the style of the other placeholders, the only option is to remove the `additional' one. It is also clear that this is not a mandatory field, as it is marked without a *.