### PR TITLE
fix: display manual order badge

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
@@ -12,7 +12,7 @@
 
             {% block sw_order_detail_header_label_manual_order %}
             <sw-label
-                v-if="createdById"
+                v-if="order.createdById"
                 appearance="pill"
                 size="small"
                 class="sw-order-detail__manual-order-label"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -117,10 +117,11 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
 
     it('should contain manual label', async () => {
         wrapper = await createWrapper();
-        await wrapper.setData({ identifier: '1', createdById: '2' });
+        await wrapper.setData({ identifier: '1' });
 
         Shopware.Store.get('swOrderDetail').order = {
             orderNumber: 1,
+            createdById: '2'
         };
         await nextTick();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently the "Created by admin" badge is not displayed correctly in the order details, only in the order list:

![image](https://github.com/user-attachments/assets/f9c07a3d-241f-4975-b142-84e51f4daf17)

![image](https://github.com/user-attachments/assets/7a676b2d-3110-461c-911b-ee8ea1373ea6)

### 2. What does this change do, exactly?

It fixes the access to the `createdById` property of the order in the  `sw-order-detail.html.twig` template. Expected result:

![image](https://github.com/user-attachments/assets/51b69e4b-3e13-4230-a1dc-d93b397dd999)


### 3. Describe each step to reproduce the issue or behaviour.

1. Create an order in the administration
2. See the "Created by admin" badge in the order list
3. Open the order details
4. In the header the  "Created by admin" badge is missing

### 4. Please link to the relevant issues (if any).

-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes (only minimal change, no changelog needed)
- [x] I have written or adjusted the documentation according to my changes (no updates needed)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
