### PR TITLE
fix: sw-field heights

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,7 @@
         "phpstan/phpstan-deprecation-rules": "2.0.1",
         "phpstan/phpstan-phpunit": "2.0.4",
         "phpstan/phpstan-symfony": "2.0.2",
-        "phpunit/phpunit": "^11.5.11",
+        "phpunit/phpunit": "11.5.15",
         "predis/predis": "^2.2",
         "rector/type-perfect": "2.0.2",
         "shopware/dev-tools": "^1.3",

--- a/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-block-field/sw-block-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-block-field/sw-block-field.scss
@@ -7,6 +7,7 @@ $sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
         border: 1px solid $color-gray-300;
         border-radius: $border-radius-default;
         overflow: hidden;
+        height: 48px;
     }
 
     .sw-field--select__options .mt-icon {


### PR DESCRIPTION
### 1. Why is this change necessary?
The mt and sw fields have different heights.


### 2. What does this change do, exactly?
It aligns the height to 48px for all fields basing off the block field.

### 3. Describe each step to reproduce the issue or behaviour.
👀


### 4. Please link to the relevant issues (if any).
Fixes https://github.com/shopware/shopware/issues/8340
