### PR TITLE
fix: Add support for extended definition of attribute entity

### DIFF
--- a/changelog/_unreleased/2025-04-10-add-support-for-extended-definition-of-attribute-entity.md
+++ b/changelog/_unreleased/2025-04-10-add-support-for-extended-definition-of-attribute-entity.md
@@ -1,0 +1,12 @@
+---
+title: Add support for extended definition of attribute entity
+issue: #8393
+author: Thuy Le
+author_email: thuy.le@shopware.com
+author_github: @thuylt
+---
+# Core
+* Added `shopware.entity.definition` tag to `AttributeEntityDefinition`, `AttributeTranslationDefinition` and `AttributeMappingDefinition` in `Shopware\Core\Framework\DependencyInjection\CompilerPass\AttributeEntityCompilerPass`.
+* Changed `Shopware\Core\System\DependencyInjection\CompilerPass\SalesChannelEntityCompilerPass` to add metadata when creating an instance of `AttributeEntityDefinition` class.
+* Changed `Shopware\Core\Framework\DependencyInjection\CompilerPass\EntityCompilerPass` to skip adding a repository definition to compiled container for `AttributeEntityDefinition` class.
+* Changed the compiler pass priority for `AttributeEntityCompilerPass` from `beforeRemoving` to `beforeOptimization` in `Shopware\Core\Framework\Framework`.

--- a/src/Core/Framework/DependencyInjection/CompilerPass/AttributeEntityCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/AttributeEntityCompilerPass.php
@@ -62,6 +62,7 @@ class AttributeEntityCompilerPass implements CompilerPassInterface
         $definition = new Definition(AttributeEntityDefinition::class);
         $definition->addArgument($meta);
         $definition->setPublic(true);
+        $definition->addTag('shopware.entity.definition');
         $container->setDefinition($entity . '.definition', $definition);
 
         $registry = $container->getDefinition(DefinitionInstanceRegistry::class);
@@ -102,6 +103,7 @@ class AttributeEntityCompilerPass implements CompilerPassInterface
         $definition = new Definition(AttributeTranslationDefinition::class);
         $definition->addArgument($meta);
         $definition->setPublic(true);
+        $definition->addTag('shopware.entity.definition');
         $container->setDefinition($entity . '_translation.definition', $definition);
 
         $registry = $container->getDefinition(DefinitionInstanceRegistry::class);
@@ -136,6 +138,7 @@ class AttributeEntityCompilerPass implements CompilerPassInterface
         $definition = new Definition(AttributeMappingDefinition::class);
         $definition->addArgument($meta);
         $definition->setPublic(true);
+        $definition->addTag('shopware.entity.definition');
         $container->setDefinition($meta['entity_name'] . '.definition', $definition);
 
         $registry = $container->getDefinition(DefinitionInstanceRegistry::class);

--- a/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php
@@ -2,6 +2,9 @@
 
 namespace Shopware\Core\Framework\DependencyInjection\CompilerPass;
 
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeEntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeMappingDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -51,6 +54,11 @@ class EntityCompilerPass implements CompilerPassInterface
             if (!\is_subclass_of($class, EntityDefinition::class)) {
                 throw DependencyInjectionException::taggedServiceHasWrongType($serviceId, 'shopware.entity.definition', EntityDefinition::class);
             }
+
+            if (\in_array($class, [AttributeEntityDefinition::class, AttributeTranslationDefinition::class, AttributeMappingDefinition::class], true)) {
+                continue;
+            }
+
             $instance = new $class();
 
             $entityNameMap[$instance->getEntityName()] = $serviceId;

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -101,7 +101,7 @@ class Framework extends Bundle
         }
 
         // make sure to remove services behind a feature flag, before some other compiler passes may reference them, therefore the high priority
-        $container->addCompilerPass(new AttributeEntityCompilerPass(new AttributeEntityCompiler()), PassConfig::TYPE_BEFORE_REMOVING, 1000);
+        $container->addCompilerPass(new AttributeEntityCompilerPass(new AttributeEntityCompiler()), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new FeatureFlagCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new EntityCompilerPass());
         $container->addCompilerPass(new DisableTwigCacheWarmerCompilerPass());

--- a/src/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPass.php
+++ b/src/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPass.php
@@ -2,6 +2,9 @@
 
 namespace Shopware\Core\System\DependencyInjection\CompilerPass;
 
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeEntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeMappingDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\BulkEntityExtension;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityExtension;
@@ -62,7 +65,7 @@ class SalesChannelEntityCompilerPass implements CompilerPassInterface
                 $container->setAlias(self::PREFIX . $serviceId, new Alias($serviceId, true));
             }
 
-            // if both mask base with extended extended as base
+            // if both mask base with extended as base
             if (isset($definitions['extended'], $definitions['base'])) {
                 $container->setAlias(self::PREFIX . $definitions['base'], new Alias($definitions['extended'], true));
             }
@@ -148,8 +151,18 @@ class SalesChannelEntityCompilerPass implements CompilerPassInterface
 
             /** @var string $class */
             $class = $service->getClass();
+
+            if (\in_array($class, [AttributeEntityDefinition::class, AttributeTranslationDefinition::class, AttributeMappingDefinition::class], true)) {
+                if (empty($service->getArguments())) {
+                    continue;
+                }
+
+                $instance = new $class($service->getArguments()[0]);
+            } else {
+                $instance = new $class();
+            }
+
             /** @var EntityDefinition $instance */
-            $instance = new $class();
             $entityName = $instance->getEntityName();
             $result[$serviceId]['entityName'] = $entityName;
 

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/AttributeEntityCompilerPassTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/AttributeEntityCompilerPassTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\FieldType;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ManyToMany;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\OnDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Translations;
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeEntityCompiler;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity as EntityStruct;
+use Shopware\Core\Framework\DependencyInjection\CompilerPass\AttributeEntityCompilerPass;
+use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @internal
+ */
+#[CoversClass(AttributeEntityCompilerPass::class)]
+class AttributeEntityCompilerPassTest extends TestCase
+{
+    public function testAttributeEntityDefinitionHasTag(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition(DefinitionInstanceRegistry::class, new Definition(DefinitionInstanceRegistry::class));
+        $container->setDefinition(SalesChannelDefinitionInstanceRegistry::class, new Definition(SalesChannelDefinitionInstanceRegistry::class));
+
+        $attributeEntity = new Definition(TestAttributeEntity::class);
+        $attributeEntity->setPublic(true);
+        $attributeEntity->addTag('shopware.entity');
+        $container->setDefinition(TestAttributeEntity::class, $attributeEntity);
+
+        $compiler = new AttributeEntityCompiler();
+
+        $compilerPass = new AttributeEntityCompilerPass($compiler);
+        $compilerPass->process($container);
+
+        static::assertTrue($container->hasDefinition('test_attribute_entity.definition'));
+        static::assertTrue($container->getDefinition('test_attribute_entity.definition')->hasTag('shopware.entity.definition'));
+
+        static::assertTrue($container->hasDefinition('test_attribute_entity_translation.definition'));
+        static::assertTrue($container->getDefinition('test_attribute_entity_translation.definition')->hasTag('shopware.entity.definition'));
+
+        static::assertTrue($container->hasDefinition('customer_test_attribute_entity.definition'));
+        static::assertTrue($container->getDefinition('customer_test_attribute_entity.definition')->hasTag('shopware.entity.definition'));
+    }
+}
+
+/**
+ * @internal
+ */
+#[Entity('test_attribute_entity')]
+class TestAttributeEntity extends EntityStruct
+{
+    #[PrimaryKey]
+    #[Field(type: FieldType::UUID)]
+    public string $id;
+
+    #[Required]
+    #[Field(type: FieldType::STRING, translated: true)]
+    public string $name;
+
+    /**
+     * @var array<string, ArrayEntity>|null
+     */
+    #[Translations]
+    public ?array $translations = null;
+
+    /**
+     * @var array<string, CustomerEntity>|null
+     */
+    #[ManyToMany(entity: 'customer', onDelete: OnDelete::SET_NULL)]
+    public ?array $customers = null;
+}

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPassTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPassTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressDefinition;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeEntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DependencyInjection\CompilerPass\EntityCompilerPass;
@@ -75,5 +76,28 @@ class EntityCompilerPassTest extends TestCase
         $entityCompilerPass->process($container);
 
         static::assertTrue($container->hasAlias('Shopware\Core\Framework\DataAbstractionLayer\EntityRepository $productRepository'));
+    }
+
+    public function testEntityRepositoryAutowiringWithAttributeEntity(): void
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('test_attribute_entity.definition', AttributeEntityDefinition::class)
+            ->addTag('shopware.entity.definition')
+        ;
+        $container
+            ->register(DefinitionInstanceRegistry::class, DefinitionInstanceRegistry::class)
+            ->addArgument(new Reference('service_container'))
+            ->addArgument([
+                'test_attribute_entity' => 'test_attribute_entity.definition',
+            ])
+            ->addArgument([
+                'test_attribute_entity' => 'test_attribute_entity.repository',
+            ]);
+
+        $entityCompilerPass = new EntityCompilerPass();
+        $entityCompilerPass->process($container);
+
+        static::assertCount(0, $container->getAliases());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, extension classes that add extended fields to the attribute entity definition will throw the following error:

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/e241ff86-ecad-4303-8fb0-df65c1f553f9" />

The definitions generated from the attribute entity definition are not tagged with `shopware.entity.definition`, so they are not found by the `SalesChannelEntityCompilerPass` and the `EntityCompilerPass`.

### 2. What does this change do, exactly?
- add tag `shopware.entity.definition` for AttributeEntityDefinition, AttributeTranslationDefinition and AttributeMappingDefinition.
- change the order of execution of AttributeEntityCompilerPass in Framework.php from `beforeRemoving` to `beforeOptimization` to ensure that AttributeEntityCompilerPass is always executed before EntityCompilerPass and SalesChannelEntityCompilerPass

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
