### PR TITLE
fix: prevent empty pages in invoice document

### DIFF
--- a/changelog/_unreleased/2025-04-08-fix-invoice-empty-pages.md
+++ b/changelog/_unreleased/2025-04-08-fix-invoice-empty-pages.md
@@ -1,0 +1,8 @@
+---
+title: Fix invoice empty pages
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Changed styles in `src/Core/Framework/Resources/views/documents/style_base_portrait.css.twig` and `src/Core/Framework/Resources/views/documents/style_base_landscape.css.twig` to prevent empty pages in invoice document.

--- a/src/Core/Framework/Resources/views/documents/style_base_landscape.css.twig
+++ b/src/Core/Framework/Resources/views/documents/style_base_landscape.css.twig
@@ -217,9 +217,6 @@
 
         .payment-shipping-container, .shipping-address-container, .sum-container {
             page-break-inside: avoid;
-        }
-
-        .payment-shipping-container {
             clear: right;
         }
 

--- a/src/Core/Framework/Resources/views/documents/style_base_portrait.css.twig
+++ b/src/Core/Framework/Resources/views/documents/style_base_portrait.css.twig
@@ -224,9 +224,6 @@
 
         .payment-shipping-container, .shipping-address-container, .sum-container {
             page-break-inside: avoid;
-        }
-
-        .payment-shipping-container {
             clear: right;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Because there are multiple empty pages in invoice documents with a certain amount of line items - this issue was only partly fixed with 62b29c1
The delivery address is split across those empty pages, displayed inside the document footer.

### 2. What does this change do, exactly?
Prevent empty pages by using `clear: right;` on all elements with `page-break-inside: avoid;`.

### 3. Describe each step to reproduce the issue or behaviour.
The `config.displayDivergentDeliveryAddress` has to be active and there should be so many line items that the delivery address would be displayed right on the page-break.

### 4. Please link to the relevant issues (if any).
closes #7723

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
