### PR TITLE
fix: vite shared cache folder issues

### DIFF
--- a/src/Administration/Resources/.gitignore
+++ b/src/Administration/Resources/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log
 test/unit/coverage
 test/e2e/reports
 selenium-debug.log
+.tmp

--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -61,6 +61,8 @@ const getBaseConfig = (extension: ExtensionDefinition, isProd = false) => {
 
         customLogger: logger,
 
+        cacheDir: path.resolve(extension.path, '..', '.tmp/vite'),
+
         plugins: [
             TwigPlugin(),
             AssetPlugin(!isDev, path.resolve(extension.basePath, 'Resources/app/administration')),

--- a/src/Storefront/.gitignore
+++ b/src/Storefront/.gitignore
@@ -4,3 +4,4 @@ phpunit.xml
 Resources/app/storefront/build/artifacts
 Resources/app/storefront/vendor/*
 !Resources/app/storefront/vendor/Inter-3.5
+.tmp


### PR DESCRIPTION
### 1. Why is this change necessary?
The multiple plugin bundles were using the same cache folder, throwing errors when it tries to clear it but it is used and locked.


### 2. What does this change do, exactly?
configures different cache folder for each bundle