### PR TITLE
fix: changelog processor

### DIFF
--- a/src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
@@ -86,7 +86,8 @@ class ChangelogProcessor
     public function getFixCommits(string $fromRef): array
     {
         $cmd = \sprintf(
-            'git log --no-merges @ %s --pretty=format:%s -i -E --grep=%s',
+            'git -C %s log --no-merges @ %s --pretty=format:%s -i -E --grep=%s',
+            escapeshellarg($this->platformRoot ?? $this->projectDir),
             escapeshellarg('^' . $fromRef),
             escapeshellarg('%h'),
             escapeshellarg(ChangelogParser::FIXES_REGEX)
@@ -96,7 +97,7 @@ class ChangelogProcessor
 
         exec($cmd, $refs);
         foreach ($refs as $ref) {
-            $body = shell_exec('git log -n1 --pretty=format:%B ' . escapeshellarg($ref));
+            $body = shell_exec('git -C ' . escapeshellarg($this->platformRoot ?? $this->projectDir) . ' log -n1 --pretty=format:%B ' . escapeshellarg($ref));
 
             if ($body && preg_match_all('/' . ChangelogParser::FIXES_REGEX . '/i', $body, $matches)) {
                 $fix = [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In some scenarios we override the `platformRoot`, but the executed `git` commands doesn't respect it.

### 2. What does this change do, exactly?
With this change we use the `-C` parameter of `git` to execute the commands in the correct directory.

### 3. Describe each step to reproduce the issue or behaviour.
Use the `ChangelogReleaseCreator` and overwrite the platformRoot to generate a changelog where platform is not the root directory.

### 4. Please link to the relevant issues (if any).
Relates: https://github.com/shopware/saas/pull/47
