### PR TITLE
fix: return encoded iaps

### DIFF
--- a/src/Core/Framework/Store/InAppPurchase/Api/InAppPurchasesController.php
+++ b/src/Core/Framework/Store/InAppPurchase/Api/InAppPurchasesController.php
@@ -34,7 +34,7 @@ class InAppPurchasesController
     public function activeExtensionInAppPurchases(Context $context): JsonResponse
     {
         return new JsonResponse(
-            ['inAppPurchases' => $this->inAppPurchase->getByExtension($this->getAppName($context))]
+            ['inAppPurchases' => $this->inAppPurchase->getJWTByExtension($this->getAppName($context)) ?? []]
         );
     }
 

--- a/src/Core/Framework/Store/InAppPurchase/Api/InAppPurchasesController.php
+++ b/src/Core/Framework/Store/InAppPurchase/Api/InAppPurchasesController.php
@@ -34,7 +34,10 @@ class InAppPurchasesController
     public function activeExtensionInAppPurchases(Context $context): JsonResponse
     {
         return new JsonResponse(
-            ['inAppPurchases' => $this->inAppPurchase->getJWTByExtension($this->getAppName($context)) ?? []]
+            [
+                'inAppPurchases' => $this->inAppPurchase->getByExtension($this->getAppName($context)),
+                'encodedInAppPurchases' => $this->inAppPurchase->getJWTByExtension($this->getAppName($context)) ?? [],
+            ],
         );
     }
 

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Api/InAppPurchasesControllerTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Api/InAppPurchasesControllerTest.php
@@ -75,7 +75,7 @@ class InAppPurchasesControllerTest extends TestCase
         $content = $response->getContent();
         static::assertIsString($content);
         static::assertSame(
-            ['inAppPurchases' => ['purchase1', 'purchase2']],
+            ['inAppPurchases' => 'e7a7224d2f86ddc19057b9851032ceb0'],
             json_decode($content, true, 512, \JSON_THROW_ON_ERROR)
         );
 
@@ -87,7 +87,7 @@ class InAppPurchasesControllerTest extends TestCase
         $content = $response->getContent();
         static::assertIsString($content);
         static::assertSame(
-            ['inAppPurchases' => ['purchase1']],
+            ['inAppPurchases' => '63589da1885d77a78fec9363d16d72da'],
             json_decode($content, true, 512, \JSON_THROW_ON_ERROR)
         );
     }

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Api/InAppPurchasesControllerTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Api/InAppPurchasesControllerTest.php
@@ -60,7 +60,10 @@ class InAppPurchasesControllerTest extends TestCase
         $content = $response->getContent();
         static::assertIsString($content);
         static::assertSame(
-            ['inAppPurchases' => []],
+            [
+                'inAppPurchases' => [],
+                'encodedInAppPurchases' => [],
+            ],
             json_decode($content, true, 512, \JSON_THROW_ON_ERROR)
         );
     }
@@ -75,7 +78,10 @@ class InAppPurchasesControllerTest extends TestCase
         $content = $response->getContent();
         static::assertIsString($content);
         static::assertSame(
-            ['inAppPurchases' => 'e7a7224d2f86ddc19057b9851032ceb0'],
+            [
+                'inAppPurchases' => ['purchase1', 'purchase2'],
+                'encodedInAppPurchases' => 'e7a7224d2f86ddc19057b9851032ceb0',
+            ],
             json_decode($content, true, 512, \JSON_THROW_ON_ERROR)
         );
 
@@ -87,7 +93,10 @@ class InAppPurchasesControllerTest extends TestCase
         $content = $response->getContent();
         static::assertIsString($content);
         static::assertSame(
-            ['inAppPurchases' => '63589da1885d77a78fec9363d16d72da'],
+            [
+                'inAppPurchases' => ['purchase1'],
+                'encodedInAppPurchases' => '63589da1885d77a78fec9363d16d72da',
+            ],
             json_decode($content, true, 512, \JSON_THROW_ON_ERROR)
         );
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
IAP's are manipulatable because it's sent in plain text and not the jwt token

### 2. What does this change do, exactly?
Returns IAPs as a JWT

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
closes #8330 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
