### PR TITLE
feat: Trigger mail.sent.error in more cases

### DIFF
--- a/src/Core/Content/Mail/Service/MailSender.php
+++ b/src/Core/Content/Mail/Service/MailSender.php
@@ -10,7 +10,6 @@ use Shopware\Core\Framework\MessageQueue\Subscriber\MessageQueueSizeRestrictList
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Mime\Email;


### PR DESCRIPTION
Followup from: https://github.com/shopware/shopware/pull/6064 

I decided to keep the subscriber `FailedMessageSubscriber` because it handles logging for all the async ways of sending emails, so it is the most reliable. 

I previously suggested a catch in `SendMailHandler` but emails are not only sent via this handler, they are also sent directly via symfony's `MailerInterface` (`MailSender` line 80, because of https://github.com/shopware/shopware/pull/6355). But both should trigger a `FailedMessageEvent` and the subscriber can log the error.

So just an extra catch remains in this PR to log any errors when sending sync.