### PR TITLE
feat: Make search term in search route optional for search store-API

### DIFF
--- a/changelog/_unreleased/2025-04-15-make-search-parameter-optional-in-search-api.md
+++ b/changelog/_unreleased/2025-04-15-make-search-parameter-optional-in-search-api.md
@@ -1,0 +1,10 @@
+---
+title: Make search parameter optional in search api
+issue: 8293
+---
+# API
+* Changed `/store-api/search` to not require `search` parameter
+___
+# Storefront
+* Changed `\Shopware\Storefront\Page\Search\SearchPageLoader::load` to not throw exception when `search` parameter is not given
+* Changed the template `src/Storefront/Resources/views/storefront/page/search/index.html.twig` to hide the search result headline if empty search parameter is given

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -698,11 +698,6 @@ parameters:
 		-
 			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Product\\\\ProductException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
 			count: 1
-			path: src/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
-
-		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Product\\\\ProductException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
-			count: 1
 			path: src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
 
 		-

--- a/src/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
@@ -10,7 +10,6 @@ use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -36,17 +35,15 @@ class ProductSearchRoute extends AbstractProductSearchRoute
     #[Route(path: '/store-api/search', name: 'store-api.search', methods: ['POST'], defaults: ['_entity' => 'product'])]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): ProductSearchRouteResponse
     {
-        if (!$request->get('search')) {
-            throw RoutingException::missingRequestParameter('search');
-        }
-
         $criteria->addState(Criteria::STATE_ELASTICSEARCH_AWARE);
 
         $criteria->addFilter(
             new ProductAvailableFilter($context->getSalesChannelId(), ProductVisibilityDefinition::VISIBILITY_SEARCH)
         );
 
-        $this->searchBuilder->build($request, $criteria, $context);
+        if ($request->get('search')) {
+            $this->searchBuilder->build($request, $criteria, $context);
+        }
 
         $result = $this->productListingLoader->load($criteria, $context);
 

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/search.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/search.json
@@ -44,7 +44,6 @@
                             "schema": {
                                 "allOf": [
                                     {
-                                        "required": ["search"],
                                         "properties": {
                                             "search": {
                                                 "description": "Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag.",

--- a/src/Storefront/Page/Search/SearchPageLoader.php
+++ b/src/Storefront/Page/Search/SearchPageLoader.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\GenericPageLoaderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -34,14 +33,9 @@ class SearchPageLoader
     /**
      * @throws CategoryNotFoundException
      * @throws InconsistentCriteriaIdsException
-     * @throws RoutingException
      */
     public function load(Request $request, SalesChannelContext $salesChannelContext): SearchPage
     {
-        if (!$request->query->has('search')) {
-            throw RoutingException::missingRequestParameter('search');
-        }
-
         $page = $this->genericLoader->load($request, $salesChannelContext);
         $page = SearchPage::createFrom($page);
         $this->setMetaInformation($page);
@@ -56,7 +50,7 @@ class SearchPageLoader
         $page->setListing($result);
 
         $page->setSearchTerm(
-            (string) $request->query->get('search')
+            $request->query->getString('search')
         );
 
         $this->eventDispatcher->dispatch(

--- a/src/Storefront/Resources/views/storefront/page/search/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/search/index.html.twig
@@ -6,10 +6,12 @@
             {% block page_search_headline %}
                 <h1 class="search-headline text-center mb-4">
                     {% block page_search_headline_text %}
-                        {{ 'search.headline'|trans({
-                            '%count%': page.listing.total,
-                            '%searchTerm%': page.searchTerm,
-                        }) }}
+                        {% if page.searchTerm %}
+                            {{ 'search.headline'|trans({
+                                '%count%': page.listing.total,
+                                '%searchTerm%': page.searchTerm,
+                            }) }}
+                        {% endif %}
                     {% endblock %}
                 </h1>
             {% endblock %}

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
@@ -122,32 +122,30 @@ class ProductSearchRouteTest extends TestCase
         static::assertCount(0, $response['elements']);
     }
 
-    public function testMissingSearchTerm(): void
+    public function testMissingSearchTermWithFilter(): void
     {
         $browser = self::$browser;
         $browser->request(
             'POST',
             '/store-api/search',
             [
+                'manufacturer' => self::$ids->get('manufacturer'),
             ]
         );
 
         $response = \json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertIsArray($response);
-        static::assertArrayHasKey('errors', $response);
-        static::assertSame('FRAMEWORK__MISSING_REQUEST_PARAMETER', $response['errors'][0]['code']);
 
-        $browser->request(
-            'POST',
-            '/store-api/search-suggest',
-            [
-            ]
-        );
-
-        $response = \json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertIsArray($response);
-        static::assertArrayHasKey('errors', $response);
-        static::assertSame('FRAMEWORK__MISSING_REQUEST_PARAMETER', $response['errors'][0]['code']);
+        static::assertArrayHasKey('total', $response);
+        static::assertSame(1, $response['total']);
+
+        static::assertArrayHasKey('apiAlias', $response);
+        static::assertSame('product_listing', $response['apiAlias']);
+
+        static::assertArrayHasKey('elements', $response);
+        static::assertIsArray($response['elements']);
+        static::assertCount(1, $response['elements']);
+        static::assertSame(self::$ids->get('manufacturer'), $response['elements'][0]['manufacturerId']);
     }
 
     /**

--- a/tests/integration/Storefront/Page/SearchPageTest.php
+++ b/tests/integration/Storefront/Page/SearchPageTest.php
@@ -22,15 +22,6 @@ class SearchPageTest extends TestCase
 
     private const TEST_TERM = 'foo';
 
-    public function testItRequiresSearchParam(): void
-    {
-        $request = new Request();
-        $context = $this->createSalesChannelContextWithNavigation();
-
-        $this->expectParamMissingException('search');
-        $this->getPageLoader()->load($request, $context);
-    }
-
     public function testItDoesSearch(): void
     {
         $request = new Request(['search' => self::TEST_TERM]);

--- a/tests/unit/Core/Content/Product/SalesChannel/Search/ProductSearchRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Search/ProductSearchRouteTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Search;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader;
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
+use Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute;
+use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ProductSearchRoute::class)]
+class ProductSearchRouteTest extends TestCase
+{
+    /**
+     * @var ProductListingLoader&MockObject
+     */
+    private ProductListingLoader $listingLoader;
+
+    /**
+     * @var ProductSearchBuilderInterface&MockObject
+     */
+    private ProductSearchBuilderInterface $searchBuilder;
+
+    protected function setUp(): void
+    {
+        $this->searchBuilder = $this->createMock(ProductSearchBuilderInterface::class);
+        $this->listingLoader = $this->createMock(ProductListingLoader::class);
+    }
+
+    public function testGetDecoratedShouldThrowException(): void
+    {
+        static::expectException(DecorationPatternException::class);
+
+        $this->getProductSearchRoute()->getDecorated();
+    }
+
+    public function testLoadWithSearchTerm(): void
+    {
+        $request = new Request();
+        $request->query->set('search', 'test');
+
+        $criteria = new Criteria();
+
+        $this->searchBuilder->expects($this->once())
+            ->method('build')
+            ->with(
+                $request,
+                $criteria,
+                static::isInstanceOf(SalesChannelContext::class)
+            );
+
+        $this->listingLoader->expects($this->once())
+            ->method('load')
+            ->willReturn(new ProductListingResult(
+                ProductDefinition::ENTITY_NAME,
+                1,
+                new ProductCollection([]),
+                null,
+                $criteria,
+                Context::createDefaultContext()
+            ));
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn(Context::createDefaultContext());
+
+        $this->getProductSearchRoute()->load(
+            $request,
+            $salesChannelContext,
+            $criteria
+        );
+
+        static::assertTrue($criteria->hasState(Criteria::STATE_ELASTICSEARCH_AWARE));
+    }
+
+    public function testLoadWithoutSearchTerm(): void
+    {
+        $request = new Request();
+        $criteria = new Criteria();
+
+        $this->searchBuilder->expects($this->never())
+            ->method('build');
+
+        $this->listingLoader->expects($this->once())
+            ->method('load')
+            ->willReturn(new ProductListingResult(
+                ProductDefinition::ENTITY_NAME,
+                1,
+                new ProductCollection([]),
+                null,
+                $criteria,
+                Context::createDefaultContext()
+            ));
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn(Context::createDefaultContext());
+
+        $this->getProductSearchRoute()->load(
+            $request,
+            $salesChannelContext,
+            $criteria
+        );
+
+        static::assertTrue($criteria->hasState(Criteria::STATE_ELASTICSEARCH_AWARE));
+    }
+
+    private function getProductSearchRoute(): ProductSearchRoute
+    {
+        return new ProductSearchRoute(
+            $this->searchBuilder,
+            $this->listingLoader
+        );
+    }
+}

--- a/tests/unit/Storefront/Page/Search/SearchPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Search/SearchPageLoaderTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Page\Product;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\SalesChannel\Search\AbstractProductSearchRoute;
+use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Generator;
+use Shopware\Storefront\Page\GenericPageLoader;
+use Shopware\Storefront\Page\Search\SearchPageLoadedEvent;
+use Shopware\Storefront\Page\Search\SearchPageLoader;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(SearchPageLoader::class)]
+class SearchPageLoaderTest extends TestCase
+{
+    public function testItLoad(): void
+    {
+        $request = new Request(['search' => 'test']);
+        $salesChannelContext = $this->getSalesChannelContext();
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->willReturnCallback(function ($event) use ($salesChannelContext, $request) {
+                static::assertInstanceOf(SearchPageLoadedEvent::class, $event);
+                static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+                static::assertSame($request, $event->getRequest());
+
+                return $event;
+            });
+
+        $searchPageLoader = new SearchPageLoader(
+            $this->createMock(GenericPageLoader::class),
+            $this->createMock(AbstractProductSearchRoute::class),
+            $eventDispatcher,
+            $this->createMock(AbstractTranslator::class),
+        );
+
+        $page = $searchPageLoader->load($request, $salesChannelContext);
+
+        static::assertSame('test', $page->getSearchTerm());
+    }
+
+    public function testItLoadWithoutSearchTerm(): void
+    {
+        $request = new Request();
+        $salesChannelContext = $this->getSalesChannelContext();
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->willReturnCallback(function ($event) use ($salesChannelContext, $request) {
+                static::assertInstanceOf(SearchPageLoadedEvent::class, $event);
+                static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+                static::assertSame($request, $event->getRequest());
+
+                return $event;
+            });
+
+        $searchPageLoader = new SearchPageLoader(
+            $this->createMock(GenericPageLoader::class),
+            $this->createMock(AbstractProductSearchRoute::class),
+            $eventDispatcher,
+            $this->createMock(AbstractTranslator::class),
+        );
+
+        $page = $searchPageLoader->load($request, $salesChannelContext);
+
+        static::assertSame('', $page->getSearchTerm());
+    }
+
+    private function getSalesChannelContext(): SalesChannelContext
+    {
+        $salesChannelEntity = new SalesChannelEntity();
+        $salesChannelEntity->setId('salesChannelId');
+
+        return Generator::generateSalesChannelContext(
+            salesChannel: $salesChannelEntity,
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

On many occasions, when searching for products, we want to apply only the filters but not necessarily include the search term (see original issue #8293).
Furthermore, we can utilize search store-API to find products using Elasticsearch

### 2. What does this change do, exactly?

Make the 'search' parameter optional in ProductSearchRoute and SearchPageLoader


### 3. Describe each step to reproduce the issue or behavior.

See #8293

### 4. Please link to the relevant issues (if any).
- closes #8293  