### PR TITLE
fix: add option to skip first run wizard during system installation

### DIFF
--- a/src/Core/Maintenance/System/Command/SystemInstallCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemInstallCommand.php
@@ -47,6 +47,7 @@ class SystemInstallCommand extends Command
             ->addOption('shop-locale', null, InputOption::VALUE_REQUIRED, 'Default language locale of the shop')
             ->addOption('shop-currency', null, InputOption::VALUE_REQUIRED, 'Iso code for the default currency of the shop')
             ->addOption('skip-assets-install', null, InputOption::VALUE_NONE, 'Skips installing of assets')
+            ->addOption('skip-first-run-wizard', null, InputOption::VALUE_NONE, 'Skips the first run wizard')
         ;
     }
 
@@ -151,6 +152,14 @@ class SystemInstallCommand extends Command
         $commands[] = [
             'command' => 'cache:clear',
         ];
+
+        if ($input->getOption('skip-first-run-wizard')) {
+            $commands[] = [
+                'command' => 'system:config:set',
+                'key' => 'core.frw.completedAt',
+                'value' => (new \DateTime())->format('Y-m-d H:i:s'),
+            ];
+        }
 
         $result = $this->runCommands($commands, $output);
 

--- a/tests/unit/Core/Maintenance/System/Command/SystemInstallCommandTest.php
+++ b/tests/unit/Core/Maintenance/System/Command/SystemInstallCommandTest.php
@@ -135,6 +135,27 @@ class SystemInstallCommandTest extends TestCase
         static::assertSame(0, $result);
     }
 
+    public function testSkipFirstRunWizardOption(): void
+    {
+        $command = $this->prepareCommandInstance([
+            'database:migrate',
+            'database:migrate-destructive',
+            'system:configure-shop',
+            'dal:refresh:index',
+            'scheduled-task:register',
+            'plugin:refresh',
+            'theme:refresh',
+            'theme:compile',
+            'assets:install',
+            'system:config:set',
+            'cache:clear',
+        ]);
+
+        $result = $command->run(new ArrayInput(['--skip-first-run-wizard' => true]), new BufferedOutput());
+
+        static::assertSame(0, $result);
+    }
+
     /**
      * Test that sub commands of the system:install fire the correct lifecycle events, instead of testing
      * them all, we just test one: database:migrate. If it works for one it most likely works for all.


### PR DESCRIPTION
### 1. Why is this change necessary?

The First Run Wizard is annoying, added a flag to skip it

```
bin/console system:install --basic-setup --force --create-database --drop-database --skip-first-run-wizard
```


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
