### PR TITLE
fix: add spacing between remember me checkbox and button

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-login/page/index/sw-login.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/page/index/sw-login.scss
@@ -199,6 +199,10 @@ $sw-login-error-animation-duration: 0.15s;
         font-size: $font-size-xs;
     }
 
+    .sw-login__remember-me {
+        margin-bottom: var(--scale-size-24);
+    }
+
     .sw-login__back-arrow {
         cursor: pointer;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-login/sw-login-login.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-login/sw-login-login.html.twig
@@ -47,6 +47,7 @@
 
     <mt-checkbox
         v-model:checked="rememberMe"
+        class="sw-login__remember-me"
         :label="$tc('sw-login.index.labelKeepLoggedIn')"
     />
 


### PR DESCRIPTION
This pull request includes changes to the `sw-login` module to enhance the user interface by adding styling to the "Remember Me" checkbox.

Styling improvements:

* [`src/Administration/Resources/app/administration/src/module/sw-login/page/index/sw-login.scss`](diffhunk://#diff-09b0adf1e9069a5b7f8d843e22251203727707dac2438f361c97a3b1c3495d34R202-R205): Added a margin to the `sw-login__remember-me` class to improve spacing.
* [`src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-login/sw-login-login.html.twig`](diffhunk://#diff-0df699204b1c511f738d1082238cd0f1803b090894f83a9217ad15233c4b81ccR50): Applied the `sw-login__remember-me` class to the "Remember Me" checkbox for consistent styling.