### PR TITLE
fix: Only include subcategory navigation template if there are subcategories

### DIFF
--- a/changelog/_unreleased/2025-04-14-do-not-include-empty-subcategory-navigation-list.md
+++ b/changelog/_unreleased/2025-04-14-do-not-include-empty-subcategory-navigation-list.md
@@ -1,0 +1,9 @@
+---
+title: Do not include empty subcategory navigation lists
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed `@Storefront/storefront/layout/sidebar/category-navigation.html.twig` template to only include the subcategory navigation if there are any subcategories, avoiding empty lists displayed in the sidebar navigation
+* Changed `@Storefront/storefront/layout/navbar/categories.html.twig` template to only include the subcategory navigation if there are any subcategories, avoiding empty `div`s displayed in the category navigation

--- a/src/Storefront/Resources/views/storefront/layout/navbar/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/categories.html.twig
@@ -34,7 +34,7 @@
                     {% endblock %}
 
                     {% block layout_navbar_categories_recoursion %}
-                        {% if level < navigationMaxDepth %}
+                        {% if level < navigationMaxDepth and treeItem.children %}
                             {% sw_include '@Storefront/storefront/layout/navbar/categories.html.twig' with {
                                 navigationTree: treeItem.children,
                                 level: level + 1,

--- a/src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig
@@ -37,7 +37,7 @@
                             {% endif %}
 
                             {% block layout_navigation_categories_recoursion %}
-                                {% if level < navigationMaxDepth %}
+                                {% if level < navigationMaxDepth and item.children %}
                                     {% sw_include '@Storefront/storefront/layout/sidebar/category-navigation.html.twig' with {
                                         navigationTree: item.children,
                                         level: level + 1


### PR DESCRIPTION
### 1. Why is this change necessary?
![image](https://github.com/user-attachments/assets/642bbffe-a169-41cf-b221-1f24fd05f55e)
![image](https://github.com/user-attachments/assets/b742cc1a-4603-4a21-8cfa-c18ded9ca591)

### 2. What does this change do, exactly?
Only include the recursion templates, if there are subcategories. Note that in particular the sidebar navigation change is an accessibility related change, as `list` elements should have a child `listitem` element (at least according to Eye Able). So this probably should be backported to Shopware 6.6

### 3. Describe each step to reproduce the issue or behaviour.
Let Eye Able scan your shop.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
