### PR TITLE
fix: cant add sale channel in sale channel list page

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/index.js
@@ -109,7 +109,7 @@ export default {
 
     methods: {
         onAddSalesChannel() {
-            this.$root.$emit('on-add-sales-channel');
+            Shopware.Utils.EventBus.emit('sw-sales-channel-detail-base-sales-channel-change');
         },
 
         async getList() {


### PR DESCRIPTION
### Solution

Change the correct key and the way to emit an event. The correct key in

https://github.com/shopware/shopware/blob/trunk/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js#L153

https://github.com/user-attachments/assets/3b950bcf-31b8-4f5b-9baf-ccaf1bc4fb69




