### PR TITLE
feat: add http cache for some storefront routes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,16 @@
     "tests/integration/Storefront/Theme/ThemeTest.php": [
       "PHP2408"
     ]
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/*.code-search": true,
+    "var/**": true,
+    "public/theme/**": true,
+    "src/Storefront/Resources/app/storefront/dist/**": true,
+    "tests/acceptance/test-results/**": true,
+    "src/Administration/Resources/public/**": true,
+    "src/Administration/Resources/app/administration/.jestcache/**": true,
   }
 }

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -202,6 +202,10 @@ Use the `sw_macro_function` instead, which is available since v6.6.10.0.
 {% set mediaEntity = mediaRepository.getById(myMediaId) %}
 ```
 
+## CountryStateController supports only GET
+
+The `CountryStateController` route `/country/country-state-data` now supports only GET methods. This change improves compatibility with HTTP caching and aligns with the best practices for data retrieval routes.
+
 # Hosting & Configuration
 
 ## Removed Store-API Route caching configuration

--- a/changelog/2025-04-15-country-state-controller-get-support.md
+++ b/changelog/2025-04-15-country-state-controller-get-support.md
@@ -1,0 +1,5 @@
+---
+title: "CountryStateController: Support GET for /country/country-state-data and deprecate POST"
+---
+# Storefront
+* The `CountryStateController` route `/country/country-state-data` now supports both GET and POST methods. The POST method is deprecated and will be removed in v6.8.0. The controller now reads the `countryId` from the query string instead of the request body. This change improves compatibility with HTTP caching and aligns with best practices for data retrieval routes.

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -36,3 +36,8 @@ shopware:
         major: false
         toggleable: true
         description: "Experimental! Execute flows after the main unit of work has concluded"
+      - name: PERFORMANCE_TWEAKS
+        default: false
+        major: false
+        toggleable: true
+        description: "Experimental! Contains Performance Tweaks for future changes"

--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -17,12 +17,14 @@ use Shopware\Core\Checkout\Customer\SalesChannel\AbstractLogoutRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractResetPasswordRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractSendPasswordRecoveryMailRoute;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
@@ -61,6 +63,11 @@ class AuthController extends StorefrontController
     #[Route(path: '/account/login', name: 'frontend.account.login.page', defaults: ['_noStore' => true], methods: ['GET'])]
     public function loginPage(Request $request, RequestDataBag $data, SalesChannelContext $context): Response
     {
+        if (Feature::isActive('PERFORMANCE_TWEAKS') || Feature::isActive('v6.8.0.0')) {
+            $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
+            $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);
+        }
+
         /** @var string $redirect */
         $redirect = $request->get('redirectTo', 'frontend.account.home.page');
 
@@ -191,6 +198,11 @@ class AuthController extends StorefrontController
     #[Route(path: '/account/recover', name: 'frontend.account.recover.page', methods: ['GET'])]
     public function recoverAccountForm(Request $request, SalesChannelContext $context): Response
     {
+        if (Feature::isActive('PERFORMANCE_TWEAKS') || Feature::isActive('v6.8.0.0')) {
+            $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
+            $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);
+        }
+
         $page = $this->loginPageLoader->load($request, $context);
 
         return $this->renderStorefront('@Storefront/storefront/page/account/profile/recover-password.html.twig', [

--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -63,6 +63,7 @@ class AuthController extends StorefrontController
     #[Route(path: '/account/login', name: 'frontend.account.login.page', defaults: ['_noStore' => true], methods: ['GET'])]
     public function loginPage(Request $request, RequestDataBag $data, SalesChannelContext $context): Response
     {
+        // Add '_httpCache' => true, to defaults in Route and remove _noStore
         if (Feature::isActive('PERFORMANCE_TWEAKS') || Feature::isActive('v6.8.0.0')) {
             $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
             $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);
@@ -198,6 +199,7 @@ class AuthController extends StorefrontController
     #[Route(path: '/account/recover', name: 'frontend.account.recover.page', methods: ['GET'])]
     public function recoverAccountForm(Request $request, SalesChannelContext $context): Response
     {
+        // Add '_httpCache' => true, to defaults in Route
         if (Feature::isActive('PERFORMANCE_TWEAKS') || Feature::isActive('v6.8.0.0')) {
             $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
             $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);

--- a/src/Storefront/Controller/CountryStateController.php
+++ b/src/Storefront/Controller/CountryStateController.php
@@ -27,10 +27,13 @@ class CountryStateController extends StorefrontController
     {
     }
 
-    #[Route(path: 'country/country-state-data', name: 'frontend.country.country.data', defaults: ['XmlHttpRequest' => true, '_httpCache' => true], methods: ['POST'])]
+    /**
+     * @deprecated tag:v6.8.0 - reason:remove-route - Remove POST request and use GET instead only
+     */
+    #[Route(path: '/country/country-state-data', name: 'frontend.country.country.data', defaults: ['XmlHttpRequest' => true, '_httpCache' => true], methods: ['GET', 'POST'])]
     public function getCountryData(Request $request, SalesChannelContext $context): Response
     {
-        $countryId = (string) $request->request->get('countryId');
+        $countryId = (string) $request->get('countryId');
 
         if (!$countryId) {
             throw RoutingException::missingRequestParameter('countryId');

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -82,6 +82,7 @@ class RegisterController extends StorefrontController
             return $this->redirectToRoute('frontend.account.home.page');
         }
 
+        // Add '_httpCache' => true, to defaults in Route and remove _noStore
         if (Feature::isActive('PERFORMANCE_TWEAKS') || Feature::isActive('v6.8.0.0')) {
             $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
             $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);
@@ -114,6 +115,7 @@ class RegisterController extends StorefrontController
             return $this->redirectToRoute('frontend.account.home.page');
         }
 
+        // Add '_httpCache' => true, to defaults in Route and remove _noStore
         if (Feature::isActive('PERFORMANCE_TWEAKS') || Feature::isActive('v6.8.0.0')) {
             $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
             $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Customer\SalesChannel\AbstractRegisterRoute;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
@@ -19,6 +20,7 @@ use Shopware\Core\Framework\Validation\DataBag\QueryDataBag;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -80,6 +82,11 @@ class RegisterController extends StorefrontController
             return $this->redirectToRoute('frontend.account.home.page');
         }
 
+        if (Feature::isActive('PERFORMANCE_TWEAKS') || Feature::isActive('v6.8.0.0')) {
+            $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
+            $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);
+        }
+
         $redirect = $request->query->get('redirectTo', 'frontend.account.home.page');
         $errorRoute = $request->attributes->get('_route');
 
@@ -105,6 +112,11 @@ class RegisterController extends StorefrontController
 
         if ($context->getCustomer()) {
             return $this->redirectToRoute('frontend.account.home.page');
+        }
+
+        if (Feature::isActive('PERFORMANCE_TWEAKS') || Feature::isActive('v6.8.0.0')) {
+            $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
+            $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);
         }
 
         $redirect = $request->query->get('redirectTo', 'frontend.account.home.page');

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-country-state-select.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-country-state-select.plugin.js
@@ -98,11 +98,7 @@ export default class CountryStateSelectPlugin extends Plugin {
     }
 
     requestStateData(countryId, countryStateId = null, stateRequired = false) {
-        const payload = JSON.stringify({ countryId });
-
-        fetch(window.router['frontend.country.country-data'], {
-            method: 'POST',
-            body: payload,
+        fetch(`${window.router['frontend.country.country-data']}?countryId=${encodeURIComponent(countryId)}`, {
             headers: {
                 'X-Requested-With': 'XMLHttpRequest',
                 'Content-Type': 'application/json',


### PR DESCRIPTION
### 1. Why is this change necessary?

Performance


### 2. What does this change do, exactly?

Add HTTP Cache for the next major or Performance tweaks for

- `/account/login`
- `/account/register`
- `/account/recover`
- `/country/country-state-data`

so less requests land on PHP


### 3. Describe each step to reproduce the issue or behavior.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
