### PR TITLE
fix: sales-channel-list add channel button event and favorite switch styles

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/utils/eventBus.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/eventBus.utils.ts
@@ -12,6 +12,7 @@ interface Events extends Record<string | symbol, unknown> {
     'sw-language-switch-change-application-language': { languageId: string };
     'sw-sales-channel-detail-sales-channel-change': undefined;
     'sw-sales-channel-detail-base-sales-channel-change': undefined;
+    'sw-sales-channel-list-add-new-channel': undefined;
 }
 
 const emitter = mitt<Events>();

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
@@ -151,12 +151,14 @@ Component.register('sw-sales-channel-menu', {
             Shopware.Utils.EventBus.on('sw-sales-channel-detail-sales-channel-change', this.loadEntityData);
             Shopware.Utils.EventBus.on('sw-language-switch-change-application-language', this.loadEntityData);
             Shopware.Utils.EventBus.on('sw-sales-channel-detail-base-sales-channel-change', this.openSalesChannelModal);
+            Shopware.Utils.EventBus.on('sw-sales-channel-list-add-new-channel', this.openSalesChannelModal);
         },
 
         destroyedComponent() {
             Shopware.Utils.EventBus.off('sw-sales-channel-detail-sales-channel-change', this.loadEntityData);
             Shopware.Utils.EventBus.off('sw-language-switch-change-application-language', this.loadEntityData);
             Shopware.Utils.EventBus.off('sw-sales-channel-detail-base-sales-channel-change', this.openSalesChannelModal);
+            Shopware.Utils.EventBus.off('sw-sales-channel-list-add-new-channel', this.openSalesChannelModal);
         },
 
         getDomainLink(salesChannel) {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/sw-sales-channel-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/sw-sales-channel-menu.spec.js
@@ -491,4 +491,18 @@ describe('src/module/sw-sales-channel/component/structure/sw-sales-channel-menu'
 
         expect(wrapper.vm.salesChannelRepository.search).toHaveBeenCalledTimes(1);
     });
+
+    it.each([
+        'sw-sales-channel-detail-base-sales-channel-change',
+        'sw-sales-channel-list-add-new-channel',
+    ])('should show the sales channel modal when "%s" event is triggered', async (eventName) => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.find('sw-sales-channel-modal-stub').exists()).toBe(false);
+
+        Shopware.Utils.EventBus.emit(eventName);
+        await flushPromises();
+
+        expect(wrapper.find('sw-sales-channel-modal-stub').exists()).toBe(true);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/index.js
@@ -109,7 +109,7 @@ export default {
 
     methods: {
         onAddSalesChannel() {
-            Shopware.Utils.EventBus.emit('sw-sales-channel-detail-base-sales-channel-change');
+            Shopware.Utils.EventBus.emit('sw-sales-channel-list-add-new-channel');
         },
 
         async getList() {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/sw-sales-channel-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/sw-sales-channel-list.scss
@@ -5,11 +5,7 @@
         }
     }
 
-    .favorite-switch .sw-field--switch__input {
-        padding: 0;
-
-        .sw-field__switch-state {
-            position: relative;
-        }
+    .favorite-switch {
+        margin: 0;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, the "Add Sales Channel" button in the sales channel listing does not work, since it is dispatching an event for triggering the Sales Channel modal, which doesn't exist anymore. 


### 2. What does this change do, exactly?

- Introduce a new UI event to the `eventBus.utils` for triggering the `sw-sales-channel-menu` Sales Channel creation modal
- Fix some styles in the `sw-sales-channel-list` table

### 3. Describe each step to reproduce the issue or behaviour.
- Go to the Sales Channel listing and click on "Add Sales Channel"
- Without the fix, nothing will happen. With the fix, the modal will show up.

![image](https://github.com/user-attachments/assets/6f4d0d85-3c78-4deb-ac74-e3c477faa039)

### 4. Please link to the relevant issues (if any).
- closes #8475 
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
