### PR TITLE
ci: improve needs-triage label automation

### DIFF
--- a/.github/labeler-needs-triage.yml
+++ b/.github/labeler-needs-triage.yml
@@ -1,7 +1,0 @@
-version: 1
-appendOnly: true
-labels:
-- label: "needs-triage"
-  type: "pull_request"
-- label: "needs-triage"
-  type: "issue"

--- a/.github/workflows/01-needs-triage-labeler.yml
+++ b/.github/workflows/01-needs-triage-labeler.yml
@@ -1,17 +1,66 @@
-name: Add needs-triage label to new PullRequests and Issues
+name: Add or remove needs-triage label
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, labeled]
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 jobs:
-  label:
+  needs-triage:
     runs-on: ubuntu-24.04
     steps:
-      - uses: srvaroa/labeler@0a20eccb8c94a1ee0bed5f16859aece1c45c3e55 # 1.13.0
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
         with:
-          config_path: .github/labeler-needs-triage.yml
+          script: |
+            console.debug(context.payload);
+            const issue_number = context.payload.number;
+
+            // get labels via api
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+
+            if (labels.status !== 200) {
+              throw new Error(`Failed to fetch labels for issue #${issue_number}`);
+            }
+
+            console.debug(labels);
+
+            // Check if the issue has either a domain label or the needs-triage label
+            const hasDomainLabel = labels.data.some(label => label.name.startsWith('domain/') || label.name === 'needs-triage');
+            const hasNeedsTriageLabel = labels.data.some(label => label.name === 'needs-triage');
+            
+            // remove needs-triage label if it has a domain label
+            if (hasDomainLabel && hasNeedsTriageLabel) {
+              console.debug('remove needs-triage label');
+              const removeResponse = await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                name: "needs-triage",
+              });
+
+              if (removeResponse.status !== 200) {
+                throw new Error(`Failed to remove label needs-triage from issue #${issue_number}`);
+              }
+
+              return;
+            }
+
+            // if neither, add needs-triage label
+            if (!hasDomainLabel && !hasNeedsTriageLabel) {
+              console.debug('add needs-triage label');
+              const addResponse = await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                labels: ["needs-triage"],
+              });
+
+              if (addResponse.status !== 200) {
+                throw new Error(`Failed to add label needs-triage to issue #${issue_number}`);
+              }
+            }

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -2,205 +2,148 @@ name: Storefront checks and tests
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
   merge_group:
   workflow_dispatch:
   workflow_call:
 
 jobs:
-
-  needs-triage:
+  lint:
     runs-on: ubuntu-24.04
-    if: github.event
+    env:
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      COMPOSER_ROOT_VERSION: 6.7.9999999-dev
+
     steps:
-      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+      - name: Setup Shopware
+        uses: shopware/setup-shopware@main
         with:
-          script: |
-            console.log(context.payload);
+          mysql-version: skip
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
 
-            // get labels via api
-            const labels = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.number,
-            });
-            console.log(labels);
+      - name: Cache ESLint and Stylelint
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4
+        with:
+          path: |
+            src/Storefront/Resources/app/storefront/node_modules/.eslintcache
+            src/Storefront/Resources/app/storefront/node_modules/.stylelintcache
+          key: storefront-lint-${{ runner.os }}-6.6
 
-            // Check if the issue has either a domain label or the needs-triage label
-            const hasDomainLabel = labels.data.some(label => label.name.startsWith('domain/') || label.name === 'needs-triage');
-            const hasNeedsTriageLabel = labels.data.some(label => label.name === 'needs-triage');
-            
-            const issueNumber = context.payload.number;
-            // remove needs-triage label if it has a domain label
-            if (hasDomainLabel && hasNeedsTriageLabel) {
-              console.log('remove needs-triage label');
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
-                name: "needs-triage",
-              });
+      - name: Build Storefront
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
+        run: |
+          symfony console bundle:dump
+          symfony console feature:dump
+          npm --prefix src/Storefront/Resources/app/storefront ci
+          npm --prefix src/Storefront/Resources/app/storefront run production
 
-              return;
-            }
+      - name: Check Code
+        working-directory: src/Storefront/Resources/app/storefront
+        run: |
+          npm run lint:js
+          npm run lint:scss
 
-            // if neither, add needs-triage label
-            if (!hasDomainLabel && !hasNeedsTriageLabel) {
-              console.log('add needs-triage label');
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number,
-                labels: ["needs-triage"],
-              });
-            }
-          
-            if (response.status !== 200) {
-              throw new Error(`Failed to add label ${teamLabel} to issue #${issueNumber}`);
-            }
+  twig-lint-storefront:
+    name: Twig Lint (Storefront)
+    runs-on: ubuntu-latest
 
-  # lint:
-  #   runs-on: ubuntu-24.04
-  #   env:
-  #     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
-  #     COMPOSER_ROOT_VERSION: 6.7.9999999-dev
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
 
-  #   steps:
-  #     - name: Setup Shopware
-  #       uses: shopware/setup-shopware@main
-  #       with:
-  #         mysql-version: skip
-  #         shopware-version: ${{ github.ref }}
-  #         shopware-repository: ${{ github.repository }}
+      - name: Install ludtwig
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download --repo MalteJanz/ludtwig  --pattern '*unknown-linux-gnu.tar.gz' && tar xf *.tar.gz
+          mv ./ludtwig /usr/local/bin
 
-  #     - name: Cache ESLint and Stylelint
-  #       uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4
-  #       with:
-  #         path: |
-  #           src/Storefront/Resources/app/storefront/node_modules/.eslintcache
-  #           src/Storefront/Resources/app/storefront/node_modules/.stylelintcache
-  #         key: storefront-lint-${{ runner.os }}-6.6
+      - name: Run ludtwig linter
+        id: ludtwigStep
+        run: |
+          cd ./src/Storefront/Resources/views
+          ludtwig .
 
-  #     - name: Build Storefront
-  #       env:
-  #         PROJECT_ROOT: ${{ github.workspace }}
-  #       run: |
-  #         symfony console bundle:dump
-  #         symfony console feature:dump
-  #         npm --prefix src/Storefront/Resources/app/storefront ci
-  #         npm --prefix src/Storefront/Resources/app/storefront run production
+      - name: Instructions if ludtwig fails
+        if: ${{ failure() && steps.ludtwigStep.outcome == 'failure'}}
+        run: |
+          ludtwig --version
+          echo "If you want to run this locally install https://github.com/MalteJanz/ludtwig in the version above"
+          echo "And then composer run ludtwig:storefront or ludtwig:storefront:fix"
+          echo "Alternatively you also can run these in the DevEnv shell"
+          exit $status  # Fail the job if ludtwig . failed
 
-  #     - name: Check Code
-  #       working-directory: src/Storefront/Resources/app/storefront
-  #       run: |
-  #         npm run lint:js
-  #         npm run lint:scss
+  jest:
+    name: "Jest Storefront"
+    runs-on: ubuntu-24.04
+    env:
+      APP_ENV: prod
+      APP_URL: http://localhost:8000
+      APP_SECRET: def00000bb5acb32b54ff8ee130270586eec0e878f7337dc7a837acc31d3ff00f93a56b595448b4b29664847dd51991b3314ff65aeeeb761a133b0ec0e070433bff08e48
+      OPENSEARCH_URL: elasticsearch:9200
+      ADMIN_OPENSEARCH_URL: elasticsearch:9200
+      BLUE_GREEN_DEPLOYMENT: 1
+      COMPOSER_ROOT_VERSION: 6.7.9999999-dev
 
-  # twig-lint-storefront:
-  #   name: Twig Lint (Storefront)
-  #   runs-on: ubuntu-latest
+    steps:
+      - name: Setup Shopware
+        uses: shopware/setup-shopware@main
+        with:
+          mysql-version: skip
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+      - name: Run Jest Storefront
+        working-directory: src/Storefront/Resources/app/storefront
+        run: |
+          npm ci
+          npm run unit -- --silent
 
-  #     - name: Install ludtwig
-  #       env:
-  #         GH_TOKEN: ${{ github.token }}
-  #       run: |
-  #         gh release download --repo MalteJanz/ludtwig  --pattern '*unknown-linux-gnu.tar.gz' && tar xf *.tar.gz
-  #         mv ./ludtwig /usr/local/bin
+      - name: Upload coverage
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # 5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: build/artifacts/jest/cobertura-coverage.xml
+          flags: jest-storefront
 
-  #     - name: Run ludtwig linter
-  #       id: ludtwigStep
-  #       run: |
-  #         cd ./src/Storefront/Resources/views
-  #         ludtwig .
+  license-check:
+    runs-on: ubuntu-24.04
+    name: "License check"
+    env:
+      WHITELISTED_JS_PACKAGES: "abab@2.0.1;administration;taffydb@2.6.2"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4
+        with:
+          node-version: 20
+      - name: install packages
+        working-directory: src/Storefront/Resources/app/storefront
+        run: |
+          npm ci
+      - name: Check license
+        working-directory: src/Storefront/Resources/app/storefront
+        run: |
+          npx license-checker-rseidelsohn \
+            --onlyAllow "$(tr \\n \; < ${{ github.workspace }}/.allowed-licenses)" \
+            --excludePackages "${WHITELISTED_JS_PACKAGES}" \
+            --excludePrivatePackages
 
-  #     - name: Instructions if ludtwig fails
-  #       if: ${{ failure() && steps.ludtwigStep.outcome == 'failure'}}
-  #       run: |
-  #         ludtwig --version
-  #         echo "If you want to run this locally install https://github.com/MalteJanz/ludtwig in the version above"
-  #         echo "And then composer run ludtwig:storefront or ludtwig:storefront:fix"
-  #         echo "Alternatively you also can run these in the DevEnv shell"
-  #         exit $status  # Fail the job if ludtwig . failed
+  storefront-check:
+      if: always()
+      needs:
+      - lint
+      - jest
+      - license-check
+      - twig-lint-storefront
 
-  # jest:
-  #   name: "Jest Storefront"
-  #   runs-on: ubuntu-24.04
-  #   env:
-  #     APP_ENV: prod
-  #     APP_URL: http://localhost:8000
-  #     APP_SECRET: def00000bb5acb32b54ff8ee130270586eec0e878f7337dc7a837acc31d3ff00f93a56b595448b4b29664847dd51991b3314ff65aeeeb761a133b0ec0e070433bff08e48
-  #     OPENSEARCH_URL: elasticsearch:9200
-  #     ADMIN_OPENSEARCH_URL: elasticsearch:9200
-  #     BLUE_GREEN_DEPLOYMENT: 1
-  #     COMPOSER_ROOT_VERSION: 6.7.9999999-dev
-
-  #   steps:
-  #     - name: Setup Shopware
-  #       uses: shopware/setup-shopware@main
-  #       with:
-  #         mysql-version: skip
-  #         shopware-version: ${{ github.ref }}
-  #         shopware-repository: ${{ github.repository }}
-
-  #     - name: Run Jest Storefront
-  #       working-directory: src/Storefront/Resources/app/storefront
-  #       run: |
-  #         npm ci
-  #         npm run unit -- --silent
-
-  #     - name: Upload coverage
-  #       uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # 5
-  #       env:
-  #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  #       with:
-  #         files: build/artifacts/jest/cobertura-coverage.xml
-  #         flags: jest-storefront
-
-  # license-check:
-  #   runs-on: ubuntu-24.04
-  #   name: "License check"
-  #   env:
-  #     WHITELISTED_JS_PACKAGES: "abab@2.0.1;administration;taffydb@2.6.2"
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
-  #     - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4
-  #       with:
-  #         node-version: 20
-  #     - name: install packages
-  #       working-directory: src/Storefront/Resources/app/storefront
-  #       run: |
-  #         npm ci
-  #     - name: Check license
-  #       working-directory: src/Storefront/Resources/app/storefront
-  #       run: |
-  #         npx license-checker-rseidelsohn \
-  #           --onlyAllow "$(tr \\n \; < ${{ github.workspace }}/.allowed-licenses)" \
-  #           --excludePackages "${WHITELISTED_JS_PACKAGES}" \
-  #           --excludePrivatePackages
-
-  # storefront-check:
-  #     if: always()
-  #     needs:
-  #     - lint
-  #     - jest
-  #     - license-check
-  #     - twig-lint-storefront
-
-  #     runs-on: Ubuntu-latest
-  #     steps:
-  #     - name: Decide whether the needed jobs succeeded or failed
-  #       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
-  #       with:
-  #         # allowed-failures: docs, linters
-  #         # allowed-skips: non-voting-flaky-job
-  #         jobs: ${{ toJSON(needs) }}
+      runs-on: Ubuntu-latest
+      steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          # allowed-failures: docs, linters
+          # allowed-skips: non-voting-flaky-job
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -16,7 +16,6 @@ jobs:
 
   needs-triage:
     runs-on: ubuntu-24.04
-    if: github.event.action == 'opened' || github.event.action == 'labeled' || github.event.action == 'labeled'
     steps:
       - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
         with:

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -22,9 +22,18 @@ jobs:
         with:
           script: |
             console.log(context.payload);
+
+            // get labels via api
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.number,
+            });
+            console.log(labels);
+
             // Check if the issue has either a domain label or the needs-triage label
-            const hasDomainLabel = context.payload.issue.labels.some(label => label.name.startsWith('domain/') || label.name === 'needs-triage');
-            const hasNeedsTriageLabel = context.payload.issue.labels.some(label => label.name === 'needs-triage');
+            const hasDomainLabel = labels.data.some(label => label.name.startsWith('domain/') || label.name === 'needs-triage');
+            const hasNeedsTriageLabel = labels.data.some(label => label.name === 'needs-triage');
             
             const issueNumber = context.payload.number;
             // remove needs-triage label if it has a domain label

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - labeled
+      - unlabeled
   merge_group:
   workflow_dispatch:
   workflow_call:
@@ -15,14 +16,12 @@ jobs:
 
   needs-triage:
     runs-on: ubuntu-24.04
-    if: github.event.action == 'opened' || github.event.action == 'labeled'
+    if: github.event.action == 'opened' || github.event.action == 'labeled' || github.event.action == 'labeled'
     steps:
       - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
         with:
           script: |
             console.log(context.payload);
-
-            return;
             // Check if the issue has either a domain label or the needs-triage label
             const hasDomainLabel = context.payload.issue.labels.some(label => label.name.startsWith('domain/') || label.name === 'needs-triage');
             const hasNeedsTriageLabel = context.payload.issue.labels.some(label => label.name === 'needs-triage');
@@ -30,6 +29,7 @@ jobs:
             const issueNumber = context.payload.number;
             // remove needs-triage label if it has a domain label
             if (hasDomainLabel && hasNeedsTriageLabel) {
+              console.log('remove needs-triage label');
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -42,6 +42,7 @@ jobs:
 
             // if neither, add needs-triage label
             if (!hasDomainLabel && !hasNeedsTriageLabel) {
+              console.log('add needs-triage label');
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -2,6 +2,11 @@ name: Storefront checks and tests
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
   workflow_dispatch:
   workflow_call:
@@ -22,7 +27,7 @@ jobs:
             const hasDomainLabel = context.payload.issue.labels.some(label => label.name.startsWith('domain/') || label.name === 'needs-triage');
             const hasNeedsTriageLabel = context.payload.issue.labels.some(label => label.name === 'needs-triage');
             
-            const issueNumber = context.payload.issue?.number || context.payload.pull_request?.number;
+            const issueNumber = context.payload.number;
             // remove needs-triage label if it has a domain label
             if (hasDomainLabel && hasNeedsTriageLabel) {
               await github.rest.issues.removeLabel({

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -16,6 +16,7 @@ jobs:
 
   needs-triage:
     runs-on: ubuntu-24.04
+    if: github.event
     steps:
       - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
         with:

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -7,144 +7,185 @@ on:
   workflow_call:
 
 jobs:
-  lint:
+
+  needs-triage:
     runs-on: ubuntu-24.04
-    env:
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
-      COMPOSER_ROOT_VERSION: 6.7.9999999-dev
-
+    if: github.event.action == 'opened' || github.event.action == 'labeled'
     steps:
-      - name: Setup Shopware
-        uses: shopware/setup-shopware@main
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
         with:
-          mysql-version: skip
-          shopware-version: ${{ github.ref }}
-          shopware-repository: ${{ github.repository }}
+          script: |
+            console.log(context.payload);
 
-      - name: Cache ESLint and Stylelint
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4
-        with:
-          path: |
-            src/Storefront/Resources/app/storefront/node_modules/.eslintcache
-            src/Storefront/Resources/app/storefront/node_modules/.stylelintcache
-          key: storefront-lint-${{ runner.os }}-6.6
+            return;
+            // Check if the issue has either a domain label or the needs-triage label
+            const hasDomainLabel = context.payload.issue.labels.some(label => label.name.startsWith('domain/') || label.name === 'needs-triage');
+            const hasNeedsTriageLabel = context.payload.issue.labels.some(label => label.name === 'needs-triage');
+            
+            const issueNumber = context.payload.issue?.number || context.payload.pull_request?.number;
+            // remove needs-triage label if it has a domain label
+            if (hasDomainLabel && hasNeedsTriageLabel) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                name: "needs-triage",
+              });
 
-      - name: Build Storefront
-        env:
-          PROJECT_ROOT: ${{ github.workspace }}
-        run: |
-          symfony console bundle:dump
-          symfony console feature:dump
-          npm --prefix src/Storefront/Resources/app/storefront ci
-          npm --prefix src/Storefront/Resources/app/storefront run production
+              return;
+            }
 
-      - name: Check Code
-        working-directory: src/Storefront/Resources/app/storefront
-        run: |
-          npm run lint:js
-          npm run lint:scss
+            // if neither, add needs-triage label
+            if (!hasDomainLabel && !hasNeedsTriageLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                labels: ["needs-triage"],
+              });
+            }
+          
+            if (response.status !== 200) {
+              throw new Error(`Failed to add label ${teamLabel} to issue #${issueNumber}`);
+            }
 
-  twig-lint-storefront:
-    name: Twig Lint (Storefront)
-    runs-on: ubuntu-latest
+  # lint:
+  #   runs-on: ubuntu-24.04
+  #   env:
+  #     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+  #     COMPOSER_ROOT_VERSION: 6.7.9999999-dev
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+  #   steps:
+  #     - name: Setup Shopware
+  #       uses: shopware/setup-shopware@main
+  #       with:
+  #         mysql-version: skip
+  #         shopware-version: ${{ github.ref }}
+  #         shopware-repository: ${{ github.repository }}
 
-      - name: Install ludtwig
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download --repo MalteJanz/ludtwig  --pattern '*unknown-linux-gnu.tar.gz' && tar xf *.tar.gz
-          mv ./ludtwig /usr/local/bin
+  #     - name: Cache ESLint and Stylelint
+  #       uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4
+  #       with:
+  #         path: |
+  #           src/Storefront/Resources/app/storefront/node_modules/.eslintcache
+  #           src/Storefront/Resources/app/storefront/node_modules/.stylelintcache
+  #         key: storefront-lint-${{ runner.os }}-6.6
 
-      - name: Run ludtwig linter
-        id: ludtwigStep
-        run: |
-          cd ./src/Storefront/Resources/views
-          ludtwig .
+  #     - name: Build Storefront
+  #       env:
+  #         PROJECT_ROOT: ${{ github.workspace }}
+  #       run: |
+  #         symfony console bundle:dump
+  #         symfony console feature:dump
+  #         npm --prefix src/Storefront/Resources/app/storefront ci
+  #         npm --prefix src/Storefront/Resources/app/storefront run production
 
-      - name: Instructions if ludtwig fails
-        if: ${{ failure() && steps.ludtwigStep.outcome == 'failure'}}
-        run: |
-          ludtwig --version
-          echo "If you want to run this locally install https://github.com/MalteJanz/ludtwig in the version above"
-          echo "And then composer run ludtwig:storefront or ludtwig:storefront:fix"
-          echo "Alternatively you also can run these in the DevEnv shell"
-          exit $status  # Fail the job if ludtwig . failed
+  #     - name: Check Code
+  #       working-directory: src/Storefront/Resources/app/storefront
+  #       run: |
+  #         npm run lint:js
+  #         npm run lint:scss
 
+  # twig-lint-storefront:
+  #   name: Twig Lint (Storefront)
+  #   runs-on: ubuntu-latest
 
-  jest:
-    name: "Jest Storefront"
-    runs-on: ubuntu-24.04
-    env:
-      APP_ENV: prod
-      APP_URL: http://localhost:8000
-      APP_SECRET: def00000bb5acb32b54ff8ee130270586eec0e878f7337dc7a837acc31d3ff00f93a56b595448b4b29664847dd51991b3314ff65aeeeb761a133b0ec0e070433bff08e48
-      OPENSEARCH_URL: elasticsearch:9200
-      ADMIN_OPENSEARCH_URL: elasticsearch:9200
-      BLUE_GREEN_DEPLOYMENT: 1
-      COMPOSER_ROOT_VERSION: 6.7.9999999-dev
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
 
-    steps:
-      - name: Setup Shopware
-        uses: shopware/setup-shopware@main
-        with:
-          mysql-version: skip
-          shopware-version: ${{ github.ref }}
-          shopware-repository: ${{ github.repository }}
+  #     - name: Install ludtwig
+  #       env:
+  #         GH_TOKEN: ${{ github.token }}
+  #       run: |
+  #         gh release download --repo MalteJanz/ludtwig  --pattern '*unknown-linux-gnu.tar.gz' && tar xf *.tar.gz
+  #         mv ./ludtwig /usr/local/bin
 
-      - name: Run Jest Storefront
-        working-directory: src/Storefront/Resources/app/storefront
-        run: |
-          npm ci
-          npm run unit -- --silent
+  #     - name: Run ludtwig linter
+  #       id: ludtwigStep
+  #       run: |
+  #         cd ./src/Storefront/Resources/views
+  #         ludtwig .
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # 5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: build/artifacts/jest/cobertura-coverage.xml
-          flags: jest-storefront
+  #     - name: Instructions if ludtwig fails
+  #       if: ${{ failure() && steps.ludtwigStep.outcome == 'failure'}}
+  #       run: |
+  #         ludtwig --version
+  #         echo "If you want to run this locally install https://github.com/MalteJanz/ludtwig in the version above"
+  #         echo "And then composer run ludtwig:storefront or ludtwig:storefront:fix"
+  #         echo "Alternatively you also can run these in the DevEnv shell"
+  #         exit $status  # Fail the job if ludtwig . failed
 
-  license-check:
-    runs-on: ubuntu-24.04
-    name: "License check"
-    env:
-      WHITELISTED_JS_PACKAGES: "abab@2.0.1;administration;taffydb@2.6.2"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4
-        with:
-          node-version: 20
-      - name: install packages
-        working-directory: src/Storefront/Resources/app/storefront
-        run: |
-          npm ci
-      - name: Check license
-        working-directory: src/Storefront/Resources/app/storefront
-        run: |
-          npx license-checker-rseidelsohn \
-            --onlyAllow "$(tr \\n \; < ${{ github.workspace }}/.allowed-licenses)" \
-            --excludePackages "${WHITELISTED_JS_PACKAGES}" \
-            --excludePrivatePackages
+  # jest:
+  #   name: "Jest Storefront"
+  #   runs-on: ubuntu-24.04
+  #   env:
+  #     APP_ENV: prod
+  #     APP_URL: http://localhost:8000
+  #     APP_SECRET: def00000bb5acb32b54ff8ee130270586eec0e878f7337dc7a837acc31d3ff00f93a56b595448b4b29664847dd51991b3314ff65aeeeb761a133b0ec0e070433bff08e48
+  #     OPENSEARCH_URL: elasticsearch:9200
+  #     ADMIN_OPENSEARCH_URL: elasticsearch:9200
+  #     BLUE_GREEN_DEPLOYMENT: 1
+  #     COMPOSER_ROOT_VERSION: 6.7.9999999-dev
 
-  storefront-check:
-      if: always()
-      needs:
-      - lint
-      - jest
-      - license-check
-      - twig-lint-storefront
+  #   steps:
+  #     - name: Setup Shopware
+  #       uses: shopware/setup-shopware@main
+  #       with:
+  #         mysql-version: skip
+  #         shopware-version: ${{ github.ref }}
+  #         shopware-repository: ${{ github.repository }}
 
-      runs-on: Ubuntu-latest
-      steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
-        with:
-          # allowed-failures: docs, linters
-          # allowed-skips: non-voting-flaky-job
-          jobs: ${{ toJSON(needs) }}
+  #     - name: Run Jest Storefront
+  #       working-directory: src/Storefront/Resources/app/storefront
+  #       run: |
+  #         npm ci
+  #         npm run unit -- --silent
+
+  #     - name: Upload coverage
+  #       uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # 5
+  #       env:
+  #         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  #       with:
+  #         files: build/artifacts/jest/cobertura-coverage.xml
+  #         flags: jest-storefront
+
+  # license-check:
+  #   runs-on: ubuntu-24.04
+  #   name: "License check"
+  #   env:
+  #     WHITELISTED_JS_PACKAGES: "abab@2.0.1;administration;taffydb@2.6.2"
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+  #     - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4
+  #       with:
+  #         node-version: 20
+  #     - name: install packages
+  #       working-directory: src/Storefront/Resources/app/storefront
+  #       run: |
+  #         npm ci
+  #     - name: Check license
+  #       working-directory: src/Storefront/Resources/app/storefront
+  #       run: |
+  #         npx license-checker-rseidelsohn \
+  #           --onlyAllow "$(tr \\n \; < ${{ github.workspace }}/.allowed-licenses)" \
+  #           --excludePackages "${WHITELISTED_JS_PACKAGES}" \
+  #           --excludePrivatePackages
+
+  # storefront-check:
+  #     if: always()
+  #     needs:
+  #     - lint
+  #     - jest
+  #     - license-check
+  #     - twig-lint-storefront
+
+  #     runs-on: Ubuntu-latest
+  #     steps:
+  #     - name: Decide whether the needed jobs succeeded or failed
+  #       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+  #       with:
+  #         # allowed-failures: docs, linters
+  #         # allowed-skips: non-voting-flaky-job
+  #         jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
- add `needs-triage` if no domain label is set
- remove `needs-triage` label if `domain/*` label is set

Currently, we set `needs-triage` on all new issues and PRs.