### PR TITLE
fix: FilterTagIdsServiceTest, the state was never applied

### DIFF
--- a/tests/integration/Core/System/Tag/Service/FilterTagIdsServiceTest.php
+++ b/tests/integration/Core/System/Tag/Service/FilterTagIdsServiceTest.php
@@ -236,8 +236,9 @@ class FilterTagIdsServiceTest extends TestCase
             ],
         ];
 
-        Context::createDefaultContext()->addState(EntityIndexerRegistry::DISABLE_INDEXING);
-        static::getContainer()->get('tag.repository')->create($tags, Context::createDefaultContext());
+        $context = Context::createDefaultContext();
+        $context->addState(EntityIndexerRegistry::DISABLE_INDEXING);
+        static::getContainer()->get('tag.repository')->create($tags, $context);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
see https://github.com/shopware/shopware/issues/8517

### 2. What does this change do, exactly?

Fix the integration test by applying the state change before passing the context to the repository 