### PR TITLE
chore: deprecate unused admin component

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/index.js
@@ -3,6 +3,8 @@ import template from './sw-order-state-history-card-entry.html.twig';
 
 /**
  * @sw-package checkout
+ *
+ * @deprecated tag:v6.8.0 - will be removed, no usages found
  */
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card/index.js
@@ -2,6 +2,8 @@ import template from './sw-order-state-history-card.html.twig';
 
 /**
  * @sw-package checkout
+ *
+ * @deprecated tag:v6.8.0 - will be removed, no usages found
  */
 
 const { Mixin } = Shopware;


### PR DESCRIPTION
These components are completely unused and left over from Order UX v1