### PR TITLE
fix: Fix loading of inherited ManyToMany associations when filtered

### DIFF
--- a/changelog/_unreleased/2025-04-17-fix-dal-inherited-to-many.md
+++ b/changelog/_unreleased/2025-04-17-fix-dal-inherited-to-many.md
@@ -1,0 +1,7 @@
+---
+title: Fix DAL inherited to-many field reads with limits
+issue: 5328
+---
+# Core
+* Changed `\Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityReader::loadManyToManyWithCriteria` to filter by the fetched mapping ids for inherited association, instead of the primary key directly.
+


### PR DESCRIPTION
Fixes https://github.com/shopware/shopware/issues/5328

## Analysis

When a ManyToMany association was filtered we to a different search (https://github.com/shopware/shopware/blob/b0c433ad0eccc51a76b195c865de1557fdf82457/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php#L340) -> that's why the behaviour is different depending whether there is a limit or not

in the loadToManyWithCriteria we only load the associations that have a FK to the PK of the root entity (\Shopware\Core\Framework\DataAbstractionLayer\Dbal\query) -> that is why this worked when you include the parent ID in the criteria as well -> the hydration worked all the time

## Solution

To fetch the data we reuse the fetching of the mapping information, which gives us all the referenced IDs and already takes inheritance into account