### PR TITLE
chore(ci): exclude .git/config from context artifact

### DIFF
--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -50,6 +50,7 @@ jobs:
           include-hidden-files: true
           path: |
             .
+            !.git/config
             .github/
             !var/cache
             !tests/

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    if: github.repository == 'shopware/shopware'
+    # if: github.repository == 'shopware/shopware'
     env:
       SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION: "1"
       DATABASE_URL: mysql://root:root@127.0.0.1:3306/root

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    # if: github.repository == 'shopware/shopware'
+    if: github.repository == 'shopware/shopware'
     env:
       SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION: "1"
       DATABASE_URL: mysql://root:root@127.0.0.1:3306/root


### PR DESCRIPTION
This excludes the `.git/config` file from the build context, as it can contain short-lived access tokens we don't want to leak.