### PR TITLE
fix: inheritance switch with meteor components

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -154,3 +154,7 @@ a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button, .mt-lin
 .mt-button {
     line-height: 1;
 }
+
+.mt-inheritance-switch {
+    margin-right: 8px;
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig
@@ -152,12 +152,15 @@
                 <template #content="props">
 
                     <mt-switch
-                        :map-inheritance="props"
+                        :is-inheritance-field="props.isInheritField"
+                        :is-inherited="props.isInherited"
                         :help-text="buildAugmentedRealityTooltip('sw-media.sidebar.actions.arHelpText')"
                         :label="$tc('sw-media.sidebar.actions.ar')"
                         :disabled="props.isInherited || !editable"
                         :model-value="props.currentValue"
                         class="sw-media-sidebar__quickactions-switch ar-ready-toggle"
+                        @inheritance-restore="props.restoreInheritance"
+                        @inheritance-remove="props.removeInheritance"
                         @update:model-value="props.updateCurrentValue"
                     />
                 </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
@@ -9,14 +9,17 @@
         <template #content="props">
 
             <mt-text-field
-                :map-inheritance="props"
                 :model-value="props.currentValue"
+                :is-inheritance-field="props.isInheritField"
+                :is-inherited="props.isInherited"
                 :disabled="props.isInherited || !allowEdit"
                 :label="$tc('sw-product.basicForm.labelTitle')"
                 :required="isTitleRequired"
                 name="sw-field--product-name"
                 :error="productNameError"
                 :placeholder="placeholder(product, 'name', $tc('sw-product.basicForm.placeholderName'))"
+                @inheritance-restore="props.restoreInheritance"
+                @inheritance-remove="props.removeInheritance"
                 @update:model-value="props.updateCurrentValue"
             />
 
@@ -105,12 +108,15 @@
 
                 <mt-switch
                     :error="productMarkAsTopsellerError"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :help-text="highlightHelpText"
                     :label="$tc('sw-product.settingsForm.labelMarkAsTopseller')"
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
@@ -56,11 +56,14 @@
                 <mt-switch
                     class="sw-field--product-active no-margin"
                     :error="productActiveError"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :label="$tc('sw-product.settingsForm.labelActive')"
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
             </template>
         </sw-inherit-wrapper>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-downloadable-form/sw-product-deliverability-downloadable-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-downloadable-form/sw-product-deliverability-downloadable-form.html.twig
@@ -13,12 +13,15 @@
                 class="product-deliverability-downloadable-form__manage-stock-switch"
                 name="sw-field--product-is-closeout"
                 :error="productIsCloseoutError"
-                :map-inheritance="props"
+                :is-inheritance-field="props.isInheritField"
+                :is-inherited="props.isInherited"
                 :label="$tc('sw-product.detailBase.manageStockLabel')"
                 :help-text="$tc('sw-product.detailBase.manageStockTooltip')"
                 :disabled="props.isInherited || disabled"
                 :model-value="props.currentValue"
                 @update:model-value="props.updateCurrentValue"
+                @inheritance-restore="props.restoreInheritance"
+                @inheritance-remove="props.removeInheritance"
             />
 
         </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-form/sw-product-deliverability-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-form/sw-product-deliverability-form.html.twig
@@ -37,12 +37,15 @@
                 <mt-switch
                     name="sw-field--product-is-closeout"
                     :error="productIsCloseoutError"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :label="$tc('sw-product.settingsForm.labelIsCloseout')"
                     :help-text="$tc('sw-product.settingsForm.isCloseoutHelpText')"
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>
@@ -92,7 +95,8 @@
 
                 <mt-number-field
                     name="sw-field--product-restock-time"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     number-type="int"
                     allow-empty
                     :min="0"
@@ -102,6 +106,8 @@
                     :model-value="props.currentValue"
                     :error="productRestockTimeError"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>
@@ -119,12 +125,15 @@
             <template #content="props">
 
                 <mt-switch
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :error="productShippingFreeError"
                     :label="$tc('sw-product.settingsForm.labelShippingFree')"
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>
@@ -147,7 +156,8 @@
             <template #content="props">
 
                 <mt-number-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     number-type="int"
                     :min="1"
                     :error="productMinPurchaseError"
@@ -156,6 +166,8 @@
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>
@@ -173,7 +185,8 @@
             <template #content="props">
 
                 <mt-number-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     number-type="int"
                     :min="1"
                     :error="productPurchaseStepsError"
@@ -182,6 +195,8 @@
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
             </template>
         </sw-inherit-wrapper>
@@ -198,7 +213,8 @@
             <template #content="props">
 
                 <mt-number-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     number-type="int"
                     :allow-empty="true"
                     :min="0"
@@ -208,6 +224,8 @@
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
             </template>
         </sw-inherit-wrapper>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/sw-product-packaging-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/sw-product-packaging-form.html.twig
@@ -13,7 +13,8 @@
             <template #content="props">
 
                 <mt-number-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :label="$tc('sw-product.settingsForm.labelWidth')"
                     :placeholder="$tc('sw-product.settingsForm.placeholderWidth')"
                     allow-empty
@@ -22,6 +23,8 @@
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 >
                     <template #suffix>
                         <span>mm</span>
@@ -41,7 +44,8 @@
             <template #content="props">
 
                 <mt-number-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :label="$tc('sw-product.settingsForm.labelHeight')"
                     :placeholder="$tc('sw-product.settingsForm.placeholderHeight')"
                     allow-empty
@@ -50,6 +54,8 @@
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 >
                     <template #suffix>
                         <span>mm</span>
@@ -69,7 +75,8 @@
             <template #content="props">
 
                 <mt-number-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :label="$tc('sw-product.settingsForm.labelLength')"
                     :placeholder="$tc('sw-product.settingsForm.placeholderLength')"
                     allow-empty
@@ -78,6 +85,8 @@
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 >
                     <template #suffix>
                         <span>mm</span>
@@ -101,7 +110,8 @@
             <template #content="props">
 
                 <mt-number-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :label="$tc('sw-product.settingsForm.labelWeight')"
                     :placeholder="$tc('sw-product.settingsForm.placeholderWeight')"
                     allow-empty
@@ -111,6 +121,8 @@
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 >
                     <template #suffix>
                         <span>kg</span>
@@ -132,7 +144,8 @@
 
                 <mt-number-field
                     class="sw-product-packaging-form__purchase-unit-field"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     number-type="float"
                     allow-empty
                     :min="0"
@@ -144,6 +157,8 @@
                     :help-text="$tc('sw-product.packagingForm.purchaseUnitHelpText')"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>
@@ -191,7 +206,8 @@
 
                 <mt-text-field
                     class="sw-product-packaging-form__pack-unit-field"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :error="productPackUnitError"
                     :label="$tc('sw-product.priceForm.labelPackUnit')"
                     :placeholder="$tc('sw-product.priceForm.placeholderPackUnit')"
@@ -199,6 +215,8 @@
                     :help-text="$tc('sw-product.packagingForm.packUnitHelpText')"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>
@@ -216,7 +234,8 @@
 
                 <mt-text-field
                     class="sw-product-packaging-form__pack-unit-plural-field"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :error="productPackUnitPluralError"
                     :label="$tc('sw-product.priceForm.labelPackUnitPlural')"
                     :placeholder="$tc('sw-product.priceForm.placeholderPackUnitPlural')"
@@ -224,6 +243,8 @@
                     :help-text="$tc('sw-product.packagingForm.packUnitPluralHelpText')"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>
@@ -241,7 +262,8 @@
 
                 <mt-number-field
                     class="sw-product-packaging-form__reference-unit-field"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     number-type="float"
                     allow-empty
                     :min="0"
@@ -253,6 +275,8 @@
                     :model-value="props.currentValue"
                     :help-text="$tc('sw-product.packagingForm.referenceUnitHelpText')"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.html.twig
@@ -10,15 +10,14 @@
             v-model:value="product.releaseDate"
             :has-parent="!!parentProduct.id"
             :inherited-value="parentProduct.releaseDate"
+            :label="$tc('sw-product.settingsForm.labelReleaseDate')"
         >
             <template #content="props">
 
                 <mt-datepicker
-                    :map-inheritance="props"
                     date-type="datetime"
                     :disabled="props.isInherited || !allowEdit"
                     :error="productReleaseDateError"
-                    :label="$tc('sw-product.settingsForm.labelReleaseDate')"
                     :placeholder="$tc('sw-product.settingsForm.placeholderReleaseDate')"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
@@ -37,13 +36,16 @@
             <template #content="props">
 
                 <mt-text-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :error="productEanError"
                     :label="$tc('sw-product.settingsForm.labelEan')"
                     :placeholder="$tc('sw-product.settingsForm.placeholderEan')"
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>
@@ -59,13 +61,16 @@
             <template #content="props">
 
                 <mt-text-field
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     :error="productManufacturerNumberError"
                     :label="$tc('sw-product.settingsForm.labelManufacturerNumber')"
                     :placeholder="$tc('sw-product.settingsForm.placeholderManufacturerNumber')"
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url-template-card/sw-seo-url-template-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url-template-card/sw-seo-url-template-card.html.twig
@@ -43,7 +43,8 @@
                         {% block sw_seo_url_template_card_entries_input %}
 
                         <mt-text-field
-                            :map-inheritance="props"
+                            :is-inheritance-field="props.isInheritField"
+                            :is-inherited="props.isInherited"
                             :model-value="props.currentValue"
                             :disabled="props.isInherited"
                             :error="seoUrlTemplatesTemplateError[index]"
@@ -51,6 +52,8 @@
                             :label="getLabel(seoUrlTemplate)"
                             :placeholder="getPlaceholder(seoUrlTemplate)"
                             @update:model-value="props.updateCurrentValue"
+                            @inheritance-restore="props.restoreInheritance"
+                            @inheritance-remove="props.removeInheritance"
                         >
 
                             <template #suffix>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.html.twig
@@ -23,13 +23,16 @@
                     {% block sw_seo_url_card_seo_path_edit %}
 
                     <mt-text-field
-                        :map-inheritance="props"
+                        :is-inheritance-field="props.isInheritField"
+                        :is-inherited="props.isInherited"
                         :model-value="props.currentValue"
                         :disabled="props.isInherited || isHeadlessSalesChannel || !allowInput"
                         :disable-inheritance-toggle="isHeadlessSalesChannel"
                         :label="$tc('sw-seo-url.labelSeoPathInfo')"
                         :help-text="seoUrlHelptext"
                         @update:model-value="props.updateCurrentValue"
+                        @inheritance-restore="props.restoreInheritance"
+                        @inheritance-remove="props.removeInheritance"
                     />
                     {% endblock %}
                 </template>


### PR DESCRIPTION
### 1. Why is this change necessary?
The inheritance switch was not shown where some meteor components were used

### 2. What does this change do, exactly?
Map the properly the inheritance wrapper props to the meteor component props for inheritance


### 3. Describe each step to reproduce the issue or behaviour.
1. Create variants for a product
2. Go to a variant
3. some fields have not the inheritance switch

### 4. Please link to the relevant issues (if any).
- closes #8695
