### PR TITLE
fix: the warning about emptyOutDir on vite build

### DIFF
--- a/src/Administration/Resources/app/administration/vite.config.mts
+++ b/src/Administration/Resources/app/administration/vite.config.mts
@@ -189,6 +189,7 @@ export default defineConfig(({ command }) => {
             outDir: isProd
                 ? path.resolve(__dirname, '../../public/administration')
                 : path.resolve(process.env.PROJECT_ROOT as string, 'public/bundles/administration/administration'),
+            emptyOutDir: true,
 
             // generate .vite/manifest.json in outDir
             manifest: true,


### PR DESCRIPTION

### 1. Why is this change necessary?
A warning about not empty output folder on build is shown

### 2. What does this change do, exactly?
add the parameter `emptyOutDir` for the admin build

### 4. Please link to the relevant issues (if any).
- closes #7940