### PR TITLE
fix: "cannot read properties of undefined" error when token refre…

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-wrong-app-url-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-wrong-app-url-modal/index.js
@@ -39,7 +39,7 @@ Component.register('sw-app-wrong-app-url-modal', {
 
     computed: {
         isAppUrlReachable() {
-            return Shopware.Store.get('context').app.config.settings.appUrlReachable;
+            return Shopware.Store.get('context').app.config.settings?.appUrlReachable;
         },
 
         hasAppsThatRequireAppUrl() {


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/8705

### 2. What does this change do, exactly?

Add a optional chaining to make it safe

### 3. Describe each step to reproduce the issue or behaviour.

For me it isn't reproducible. But looking at the error this should fix it without any side effects
