### PR TITLE
fix: add HOST environment variable option to Vite to support docker

### DIFF
--- a/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import * as net from 'net';
 
@@ -242,4 +243,27 @@ export async function findAvailablePorts(startPort = 5173, requiredPorts = 1): P
     }
 
     return ports;
+}
+
+/**
+ * @private
+ * This function returns the IP address of the container
+ * if the application is running in a Docker container.
+ */
+export const getContainerIP = (): string|undefined => {
+    const interfaces = os.networkInterfaces();
+
+    return Object.values(interfaces)
+        .flatMap(ifaces => ifaces || [])
+        .find(iface => !iface.internal && iface.family === 'IPv4')
+        ?.address;
+};
+
+/**
+ * @private
+ * This function checks if a `.dockerenv` file exists in the root directory.
+ */
+export const isInsideDockerContainer = (): boolean => {
+    // Resolve root path
+    return fs.existsSync('/.dockerenv');
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The current Admin watcher does not work with Docker


### 2. What does this change do, exactly?

Make the HOST configurable and allow CORS.

The watcher should detect the docker environment automatically because of the `.dockerenv` file. If not you can still provide the Host manually:
```
// Fallback: manual setting host to the correct IP address of the Docker container
VITE_HOST=192.168.97.4 bin/watch-administration.sh
```