### PR TITLE
fix: Use correct translation keys in cart-alerts

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/checkout/cart-alerts.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/cart-alerts.html.twig
@@ -12,7 +12,7 @@
 
     {% block component_checkout_cart_alerts_warnings %}
         {% for error in page.cart.errors.warnings %}
-            {% set snippetName = "error.#{error.messageKey}" %}
+            {% set snippetName = "checkout.#{error.messageKey}" %}
 
             {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                 type: 'warning',
@@ -23,7 +23,7 @@
 
     {% block component_checkout_cart_alerts_errors %}
         {% for error in page.cart.errors.errors %}
-            {% set snippetName = "error.#{error.messageKey}" %}
+            {% set snippetName = "checkout.#{error.messageKey}" %}
 
             {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                 type: 'danger',


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, `cart-alert` uses the correct translation keys (`checkout.#{error.messageKey}` only for notices, but not for warnings and errors. Therefore, the key is displayed instead of the actual message.


### 2. What does this change do, exactly?
It changes the snippet names from `error.xyz` to `checkout.xyz` for cart warnings and errors.


### 3. Describe each step to reproduce the issue or behaviour.
1. Use `cart-alerts.html.twig` in the checkout page of your theme
2. Cause any cart error (e.g. by using an invalid address)
3. Go to checkout


### 4. Please link to the relevant issues (if any).
I have not found any existing matching issues.


### 5. Checklist
If I understood the contribution guidelines correctly, most of these steps are not needed for such a minor change.

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
