### PR TITLE
fix: error on user password change

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/index.js
@@ -47,9 +47,7 @@ Component.register('sw-verify-user-modal', {
 
                     const authObject = {
                         ...this.loginService.getBearerAuthentication(),
-                        ...{
-                            access: verifiedToken,
-                        },
+                        access: verifiedToken,
                     };
 
                     this.loginService.setBearerAuthentication(authObject);

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
@@ -303,19 +303,33 @@ export default {
             });
         },
 
-        checkEmail() {
+        async checkEmail() {
             if (!this.user.email) {
-                return Promise.resolve();
+                return true;
             }
 
-            return this.userValidationService
-                .checkUserEmail({
-                    email: this.user.email,
-                    id: this.user.id,
-                })
-                .then(({ emailIsUnique }) => {
-                    this.isEmailAlreadyInUse = !emailIsUnique;
+            const { emailIsUnique } = await this.userValidationService.checkUserEmail({
+                email: this.user.email,
+                id: this.user.id,
+            });
+
+            this.isEmailAlreadyInUse = !emailIsUnique;
+
+            if (this.isEmailAlreadyInUse) {
+                const expression = `user.${this.user.id}.email`;
+                const error = new ShopwareError({
+                    code: 'USER_EMAIL_ALREADY_EXISTS',
+                    detail: this.$tc('sw-users-permissions.users.user-detail.errorEmailUsed'),
                 });
+
+                Shopware.Store.get('error').addApiError({
+                    expression,
+                    error,
+                });
+                return false;
+            }
+
+            return true;
         },
 
         checkUsername() {
@@ -378,94 +392,54 @@ export default {
             this.confirmPasswordModal = true;
         },
 
-        saveUser(context) {
+        async saveUser(context) {
             this.isSaveSuccessful = false;
             this.isLoading = true;
-            let promises = [];
 
             if (this.currentUser.id === this.user.id) {
-                promises = [
-                    Shopware.Service('localeHelper').setLocaleWithId(this.user.localeId),
-                ];
+                await Shopware.Service('localeHelper').setLocaleWithId(this.user.localeId);
             }
 
-            return Promise.all(promises).then(() => {
-                this.checkEmail()
-                    .then(() => {
-                        if (this.isEmailAlreadyInUse) {
-                            const expression = `user.${this.user.id}.email`;
-                            const error = new ShopwareError({
-                                code: 'USER_EMAIL_ALREADY_EXISTS',
-                                detail: this.$tc('sw-users-permissions.users.user-detail.errorEmailUsed'),
-                            });
+            const isEmailValid = await this.checkEmail();
 
-                            Shopware.Store.get('error').addApiError({
-                                expression,
-                                error,
-                            });
+            if (!isEmailValid) {
+                return;
+            }
 
-                            return Promise.resolve();
-                        }
+            this.isLoading = true;
 
-                        this.isLoading = true;
-                        const titleSaveError = this.$tc('global.default.error');
-                        const messageSaveError = this.$tc(
-                            'sw-users-permissions.users.user-detail.notification.saveError.message',
-                            { name: this.fullName },
-                            0,
-                        );
+            try {
+                await this.userRepository.save(this.user, context);
 
-                        return this.userRepository
-                            .save(this.user, context)
-                            .then(() => {
-                                if (this.user.password) {
-                                    return this.loginService.verifyUserToken(this.user.password).then((verifiedToken) => {
-                                        Shopware.Store.get('context').api.authToken.access = verifiedToken;
-                                        const authObject = {
-                                            ...this.loginService.getBearerAuthentication(),
-                                            access: verifiedToken,
-                                        };
+                if (this.user.password) {
+                    await this.updateAuthToken();
+                }
+                await this.updateCurrentUser();
+                this.createdComponent();
 
-                                        this.loginService.setBearerAuthentication(authObject);
-
-                                        return this.updateCurrentUser();
-                                    });
-                                }
-
-                                return this.updateCurrentUser();
-                            })
-                            .then(() => {
-                                this.createdComponent();
-
-                                this.confirmPasswordModal = false;
-                                this.isSaveSuccessful = true;
-                            })
-                            .catch((exception) => {
-                                this.createNotificationError({
-                                    title: titleSaveError,
-                                    message: messageSaveError,
-                                });
-                                warn(this._name, exception.message, exception.response);
-                                this.isLoading = false;
-                                throw exception;
-                            })
-                            .finally(() => {
-                                this.isLoading = false;
-                            });
-                    })
-                    .catch(() => Promise.reject())
-                    .finally(() => {
-                        this.isLoading = false;
-                    });
-            });
+                this.confirmPasswordModal = false;
+                this.isSaveSuccessful = true;
+            } catch (exception) {
+                this.createNotificationError({
+                    title: this.$tc('global.default.error'),
+                    message: this.$tc(
+                        'sw-users-permissions.users.user-detail.notification.saveError.message',
+                        { name: this.fullName },
+                        0,
+                    ),
+                });
+                warn(this._name, exception.message, exception.response);
+                throw exception;
+            } finally {
+                this.isLoading = false;
+            }
         },
 
-        updateCurrentUser() {
-            return this.userService.getUser().then((response) => {
+        async updateCurrentUser() {
+            await this.userService.getUser().then((response) => {
                 const data = response.data;
                 delete data.password;
-
-                return Shopware.Store.get('session').setCurrentUser(data);
+                Shopware.Store.get('session').setCurrentUser(data);
             });
         },
 
@@ -524,6 +498,16 @@ export default {
 
         onCloseConfirmPasswordModal() {
             this.confirmPasswordModal = false;
+        },
+
+        async updateAuthToken() {
+            const verifiedToken = await this.loginService.verifyUserToken(this.user.password);
+            Shopware.Store.get('context').api.authToken.access = verifiedToken;
+            const authObject = {
+                ...this.loginService.getBearerAuthentication(),
+                access: verifiedToken,
+            };
+            this.loginService.setBearerAuthentication(authObject);
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
@@ -389,7 +389,7 @@ export default {
                 ];
             }
 
-            return Promise.all(promises).then(
+            return Promise.all(promises).then(() => {
                 this.checkEmail()
                     .then(() => {
                         if (this.isEmailAlreadyInUse) {
@@ -418,6 +418,20 @@ export default {
                         return this.userRepository
                             .save(this.user, context)
                             .then(() => {
+                                if (this.user.password) {
+                                    return this.loginService.verifyUserToken(this.user.password).then((verifiedToken) => {
+                                        Shopware.Store.get('context').api.authToken.access = verifiedToken;
+                                        const authObject = {
+                                            ...this.loginService.getBearerAuthentication(),
+                                            access: verifiedToken,
+                                        };
+
+                                        this.loginService.setBearerAuthentication(authObject);
+
+                                        return this.updateCurrentUser();
+                                    });
+                                }
+
                                 return this.updateCurrentUser();
                             })
                             .then(() => {
@@ -442,8 +456,8 @@ export default {
                     .catch(() => Promise.reject())
                     .finally(() => {
                         this.isLoading = false;
-                    }),
-            );
+                    });
+            });
         },
 
         updateCurrentUser() {


### PR DESCRIPTION
### 1. Why is this change necessary?
When the user changes the password in user settings, an error notification is shown, and the user is logged out. The password is changed, though.

### 2. What does this change do, exactly?
Fix the error by requesting a new auth token and saving it, only when the password is changed.


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Settings > User & permissions
2. type a new password in the field
3. Save using the previous password
4. Before the fix the user is logged out


### 4. Please link to the relevant issues (if any).
- closes #7606

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
