### PR TITLE
fix: Local mode of the `sw-one-to-many-grid`

### DIFF
--- a/changelog/_unreleased/2025-04-24-fix-local-mode-of-sw-one-to-many-grid.md
+++ b/changelog/_unreleased/2025-04-24-fix-local-mode-of-sw-one-to-many-grid.md
@@ -1,0 +1,8 @@
+---
+title: Fix local mode of `sw-one-to-many-grid`
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed the `sw-one-to-many-grid` to initialize the `dataSource` with the collection to fix the `localMode` of this component

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/index.js
@@ -39,6 +39,9 @@ Component.extend('sw-one-to-many-grid', 'sw-data-grid', {
                 Object,
             ],
             required: false,
+            default(props) {
+                return (props.localMode && props.collection) ? props.collection : null;
+            },
         },
         allowDelete: {
             type: Boolean,

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig
@@ -228,7 +228,6 @@
 
         <sw-one-to-many-grid
             :collection="discount.promotionDiscountPrices"
-            :data-source="discount.promotionDiscountPrices"
             :local-mode="true"
             :columns="currencyPriceColumns"
             :show-selection="false"


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the local mode of the `sw-one-to-many-grid` is broken, which was introduced by this commit: https://github.com/shopware/shopware/commit/dbcdecbd02e14499fd1258570000026d03674a0e

There was an attempted fix, for the advanced prices https://github.com/shopware/shopware/commit/a7157be5943c1eb0243032ea56744663151c0605 for this issue: https://github.com/shopware/shopware/issues/7747

But in other places this issue still occurs (for example when creating a new country and adding states: https://github.com/shopware/shopware/blob/2f859e8f55d121d4c4d442f7d2a8f47450b2ae70/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-state/sw-settings-country-state.html.twig#L65-L81) and also when plugins used this component this is now a break, for Shopware 6.6.10.

### 2. What does this change do, exactly?
This PRs always uses the collection, as `dataSource` if it is in local mode, as default.

Also this reverts the partial fix

### 3. Describe each step to reproduce the issue or behaviour.
Use `sw-one-to-many-grid` in `localMode`.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
