### PR TITLE
fix: Allow small size of `sw-simple-search-field`

### DIFF
--- a/changelog/_unreleased/2025-04-24-allow-small-size-of-sw-simple-search-field.md
+++ b/changelog/_unreleased/2025-04-24-allow-small-size-of-sw-simple-search-field.md
@@ -1,0 +1,8 @@
+---
+title: Allow small size of `sw-simple-search-field`
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed `sw-simple-search-field` component to allow for small input size

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-simple-search-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-simple-search-field/index.js
@@ -55,6 +55,12 @@ Component.register('sw-simple-search-field', {
             required: false,
         },
 
+        size: {
+            type: String,
+            required: false,
+            default: 'default',
+        },
+
         delay: {
             type: Number,
             required: false,

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-simple-search-field/sw-simple-search-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-simple-search-field/sw-simple-search-field.html.twig
@@ -8,6 +8,7 @@
         :placeholder="placeholder"
         v-bind="$attrs"
         :model-value="value"
+        :size="size"
         @update:model-value="onInput"
     />
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-simple-search-field/sw-simple-search-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-simple-search-field/sw-simple-search-field.scss
@@ -8,6 +8,10 @@
         margin-bottom: 0;
     }
 
+    .sw-simple-search-field__input.mt-field--small .mt-block-field__block {
+        min-height: 0;
+    }
+
     .sw-simple-search-field__input.sw-simple-search-field--default {
         .mt-block-field__block {
             border: none;


### PR DESCRIPTION
### 1. Why is this change necessary?
![image](https://github.com/user-attachments/assets/c673418f-833a-437a-84e9-e6c5bf806d04)

I am not sure, if there is some minimum height requirement for accessibility, but this makes it look like before (i.e. Shopware 6.6).

### 2. What does this change do, exactly?
![image](https://github.com/user-attachments/assets/d905d727-5681-4d09-81b8-ec9fc26e6ba8)

### 3. Describe each step to reproduce the issue or behaviour.
Look at the administration when creating a state of a country.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
