### PR TITLE
fix: sw-category-tree-field to avoid errors on delete search

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
@@ -180,6 +180,7 @@ Component.register('sw-category-tree-field', {
                 utils.debounce(() => {
                     const newElement = this.findTreeItemVNodeById(newValue.id).$el;
 
+                    if (!newElement) return;
                     let offsetValue = 0;
                     let foundTreeRoot = false;
                     let actualElement = newElement;
@@ -687,11 +688,13 @@ Component.register('sw-category-tree-field', {
             let foundInChildren = false;
 
             // recursion to find vnode
-            for (let i = 0; i < children.length; i += 1) {
-                foundInChildren = this.findTreeItemVNodeById(itemId, children[i].$children);
-                // stop when found in children
-                if (foundInChildren) {
-                    break;
+            if (children) {
+                for (let i = 0; i < children.length; i += 1) {
+                    foundInChildren = this.findTreeItemVNodeById(itemId, children[i].$children);
+                    // stop when found in children
+                    if (foundInChildren) {
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
There are some errors thrown in `sw-category-tree-field` when the search query is cleared.
See a screen recoding in the issue: #8472

### 2. What does this change do, exactly?
Add some conditions to avoid the errors


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Sales Channels > Storefront
2. type some query in the `Entry point main navigation`
3. Clear the query and see the errors in the dev tools console


### 4. Please link to the relevant issues (if any).
- closes #8472
