### PR TITLE
fix: clear http cache in cache clearer also in cluster mode

### DIFF
--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -45,6 +45,10 @@ class CacheClearer
             $adapter->clear();
         }
 
+        if ($clearHttp) {
+            $this->reverseProxyCache?->banAll();
+        }
+
         try {
             $this->invalidator->invalidateExpired();
         } catch (\Throwable $e) {
@@ -68,10 +72,6 @@ class CacheClearer
         $this->cleanupUrlGeneratorCacheFiles();
 
         $this->cleanupOldContainerCacheDirectories();
-
-        if ($clearHttp) {
-            $this->reverseProxyCache?->banAll();
-        }
     }
 
     public function clearContainerCache(): void

--- a/tests/integration/Core/Framework/Cache/CacheClearerTest.php
+++ b/tests/integration/Core/Framework/Cache/CacheClearerTest.php
@@ -201,6 +201,27 @@ class CacheClearerTest extends TestCase
         $cacheClearer->clearHttpCache();
     }
 
+    public function testClearWithClearHttpCacheClearsHTTPCacheInClusterMode(): void
+    {
+        $reverseProxyCache = $this->createMock(AbstractReverseProxyGateway::class);
+        $reverseProxyCache->expects($this->once())->method('banAll');
+
+        $cacheClearer = new CacheClearer(
+            [],
+            $this->createMock(CacheClearerInterface::class),
+            $reverseProxyCache,
+            $this->createMock(CacheInvalidator::class),
+            new Filesystem(),
+            $this->getKernel()->getCacheDir(),
+            'test',
+            true,
+            $this->createMock(MessageBusInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $cacheClearer->clear(true);
+    }
+
     public function testClearHttpCacheWithoutReverseProxy(): void
     {
         $pool = $this->createMock(CacheItemPoolInterface::class);


### PR DESCRIPTION
There was an early return when we are in cluster mode where the HTTP cache was not cleared, but the HTTP cache should be cleared in cluster mode
