### PR TITLE
fix: hide navigation popover on mouseleave

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -28,6 +28,8 @@ export default class NavbarPlugin extends Plugin {
         const closeEvent = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'mouseleave';
         const clickEvent = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
 
+        this.el.addEventListener('mouseleave', this._closeAllDropdowns.bind(this));
+
         this._topLevelLinks.forEach(el => {
             el.addEventListener(openEvent, this._toggleNavbar.bind(this, el));
             el.addEventListener(closeEvent, this._toggleNavbar.bind(this, el));
@@ -35,6 +37,7 @@ export default class NavbarPlugin extends Plugin {
                 el.addEventListener(clickEvent, this._navigateToLinkOnClick.bind(this, el));
             }
         });
+
         window.addEventListener('load', () => {
             this._setAriaCurrentPage();
         });
@@ -47,7 +50,6 @@ export default class NavbarPlugin extends Plugin {
             this._debounce(() => {
                 if (this._isMouseOver && currentDropdown?._menu && !currentDropdown._menu.classList.contains('show')) {
                     this._closeAllDropdowns();
-                    this.$emitter.publish('closeAllDropdowns');
                     currentDropdown.show();
                     this.$emitter.publish('showDropdown');
                 }
@@ -64,6 +66,8 @@ export default class NavbarPlugin extends Plugin {
                 dropdown.hide();
             }
         });
+
+        this.$emitter.publish('closeAllDropdowns');
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_main-navigation.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_main-navigation.scss
@@ -24,3 +24,21 @@ https://getbootstrap.com/docs/5.2/components/navs-tabs
         padding-bottom: 3px;
     }
 }
+
+.main-navigation-menu {
+    .dropdown-menu::after {
+        content: '';
+        position: absolute;
+        height: calc(1 * var(--#{$prefix}dropdown-spacer) + 1px);
+        left: 0;
+        right: 0;
+    }
+
+    .dropdown:not(.dropup) .dropdown-menu::after {
+        top: calc(-1 * var(--#{$prefix}dropdown-spacer) - 1px);
+    }
+
+    .dropup .dropdown-menu::after {
+        bottom: calc(-1 * var(--#{$prefix}dropdown-spacer) - 1px);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

![image](https://github.com/user-attachments/assets/e07522fd-c5d9-4ccb-9ee3-28df9caee910)

The storefront navigation popover only will be hidden if you click somewhere on the page.

### 2. What does this change do, exactly?
* Add a `mouseleave` event to the navigation container to hide the popover 
* Adjust some styles to adjust for the 2px gap (bootstrap popover/dropdown default) between the navbar and the popover 

### 3. Describe each step to reproduce the issue or behaviour.
Open the popover navigation and try to close it without clicking.

### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/8319
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->


### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
