### PR TITLE
fix: changed ThemeConfigField::$type property type to string|null

### DIFF
--- a/changelog/_unreleased/2025-04-25-added-default-value-for-themeconfigfield-type-property.md
+++ b/changelog/_unreleased/2025-04-25-added-default-value-for-themeconfigfield-type-property.md
@@ -1,6 +1,0 @@
----
-title: Added default value for ThemeConfigField::$type property
-issue: https://github.com/shopware/shopware/issues/8494
----
-# Storefront
-* Added default value for `\Shopware\Storefront\Theme\ThemeConfigField::$type` property (so property is included in the serialized config)

--- a/changelog/_unreleased/2025-04-25-added-default-value-for-themeconfigfield-type-property.md
+++ b/changelog/_unreleased/2025-04-25-added-default-value-for-themeconfigfield-type-property.md
@@ -1,0 +1,6 @@
+---
+title: Added default value for ThemeConfigField::$type property
+issue: https://github.com/shopware/shopware/issues/8494
+---
+# Storefront
+* Added default value for `\Shopware\Storefront\Theme\ThemeConfigField::$type` property (so property is included in the serialized config)

--- a/changelog/_unreleased/2025-04-25-changed-themeconfigfield-type-property-type.md
+++ b/changelog/_unreleased/2025-04-25-changed-themeconfigfield-type-property-type.md
@@ -1,0 +1,6 @@
+---
+title: Changed ThemeConfigField::$type property type
+issue: https://github.com/shopware/shopware/issues/8494
+---
+# Storefront
+* Changed `\Shopware\Storefront\Theme\ThemeConfigField::$type` type from `string` to `string|null`

--- a/src/Storefront/Theme/ThemeConfigField.php
+++ b/src/Storefront/Theme/ThemeConfigField.php
@@ -20,7 +20,7 @@ class ThemeConfigField extends Struct
      */
     protected ?array $helpText = null;
 
-    protected string $type = '';
+    protected ?string $type;
 
     /**
      * @deprecated tag:v6.8.0 - Property will be typed natively as array|string
@@ -84,6 +84,7 @@ class ThemeConfigField extends Struct
 
     public function getType(): string
     {
+        \assert($this->type !== null, 'Type must be set before retrieving');
         return $this->type;
     }
 

--- a/src/Storefront/Theme/ThemeConfigField.php
+++ b/src/Storefront/Theme/ThemeConfigField.php
@@ -20,7 +20,7 @@ class ThemeConfigField extends Struct
      */
     protected ?array $helpText = null;
 
-    protected string $type;
+    protected string $type = '';
 
     /**
      * @deprecated tag:v6.8.0 - Property will be typed natively as array|string

--- a/src/Storefront/Theme/ThemeConfigField.php
+++ b/src/Storefront/Theme/ThemeConfigField.php
@@ -82,13 +82,12 @@ class ThemeConfigField extends Struct
         $this->label = $label;
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
-        \assert($this->type !== null, 'Type must be set before retrieving');
         return $this->type;
     }
 
-    public function setType(string $type): void
+    public function setType(?string $type): void
     {
         $this->type = $type;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Since strict typing was introduced in version 6.7, non-initialized object properties can cause errors.

In this case `\Shopware\Storefront\Theme\ThemeConfigField::$type` is defined as string, but does not have default value.
In `\Shopware\Storefront\Theme\ThemeService::getThemeConfiguration` those fields are json encoded/decoded to receive an array. In some edge cases field is not initialized, which leads to missing key in the array, which leads to errors in few places.

### 2. What does this change do, exactly?

This change changes the property type from `string` to `?string`

### 3. Describe each step to reproduce the issue or behaviour.

1. Install a theme with custom configuration field (that is retrieved in the view).
2. Remove custom field from theme json and run `./bin/console theme:refresh`
3. Try to open a page with template that tries to retrieve the value.

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/8494

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
