### PR TITLE
feat: Add possibility to override form validation message

### DIFF
--- a/changelog/_unreleased/2025-04-29-changed-form-validation-to-check-for-custom-error-message.md
+++ b/changelog/_unreleased/2025-04-29-changed-form-validation-to-check-for-custom-error-message.md
@@ -1,0 +1,6 @@
+---
+title: Changed form validation to check for custom error message
+issue: 8265
+--- 
+# Storefront
+* Changed `form-validation.helper.js` `setFieldValidationMessage`-function to check for a `data-form-validation-error-message` on the field to override the error message.

--- a/src/Storefront/Resources/app/storefront/src/helper/form-validation.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/form-validation.helper.js
@@ -446,6 +446,7 @@ export default class FormValidation {
     /**
      * Sets the validation message within the feedback text of the form field.
      * Only the error message with the highest validation priority will be shown.
+     * Checks for a `data-form-validation-error-message` on the field to override.
      *
      * @param {HTMLElement} field
      * @param {string[]} validationErrors
@@ -484,9 +485,13 @@ export default class FormValidation {
          * You can define the validation priority simply by the order of validation rules.
          */
         const highestPriorityError = validationErrors[0];
-        const errorMessage = this.errorMessages.get(highestPriorityError);
 
-        if (errorMessage && errorMessage.length) {
+        let errorMessage = field.getAttribute('data-form-validation-error-message');
+        if (!errorMessage) {
+            errorMessage = this.errorMessages.get(highestPriorityError) || '';
+        }
+
+        if (errorMessage.length) {
             const errorText = document.createElement('div');
             errorText.classList.add(this.config.invalidFeedbackClass);
             errorText.textContent = errorMessage;

--- a/src/Storefront/Resources/app/storefront/test/helper/form-validation.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/form-validation.helper.test.js
@@ -379,4 +379,36 @@ describe('form-validation', () => {
 
         expect(invalidFields.length).toBe(0);
     });
+
+    test('should respect data-form-validation-error-message override', () => {
+        document.body.innerHTML = `
+            <form id="testForm">
+                <div class="form-group">
+                    <label for="username">Username</label>
+                    <input
+                      type="text"
+                      id="username"
+                      data-validation="required"
+                      data-form-validation-error-message="Username cannot be blank!"
+                      aria-describedby="username-feedback"
+                    >
+                    <div id="username-feedback" class="form-field-feedback"></div>
+                </div>
+            </form>
+        `;
+
+        const field = document.getElementById('username');
+        const feedback = document.getElementById('username-feedback');
+
+        // Mock visibility so it actually runs our override logic
+        field.checkVisibility = jest.fn().mockReturnValue(true);
+
+        // Trigger validation
+        formValidation.validateField(field);
+
+        // Should use the override, not the default "Input should not be empty."
+        expect(feedback.innerHTML).toBe(
+            `<div class="${formValidation.config.invalidFeedbackClass}">Username cannot be blank!</div>`
+        );
+    });
 });

--- a/src/Storefront/Resources/app/storefront/test/helper/form-validation.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/form-validation.helper.test.js
@@ -407,8 +407,7 @@ describe('form-validation', () => {
         formValidation.validateField(field);
 
         // Should use the override, not the default "Input should not be empty."
-        expect(feedback.innerHTML).toBe(
-            `<div class="${formValidation.config.invalidFeedbackClass}">Username cannot be blank!</div>`
-        );
+        expect(feedback.textContent).toBe('Username cannot be blank!');
+        expect(field.classList).toContain(formValidation.config.invalidClass);
     });
 });

--- a/src/Storefront/Resources/views/storefront/component/form/form-input.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/form/form-input.html.twig
@@ -78,7 +78,7 @@
                    {% if maxlength is not empty %}maxlength="{{ maxlength }}"{% endif %}
                    {% if validationRules is not empty %}data-validation="{{ validationRules }}"{% endif %}
                    {% if 'required' in validationRules %}aria-required="true"{% endif %}
-                   {% if attributes is not empty %}{% for key, value in attributes %}{% if value is not empty %}{{ key }}="{{ value }}"{% else %}{{ key }}{% endif %}{% endfor %}{% endif %}
+                   {% if attributes is not empty %}{% for key, value in attributes %}{% if value is not empty %}{{ key }}="{{ value }}" {% else %}{{ key }} {% endif %}{% endfor %}{% endif %}
                    {% if disabled is not empty %}disabled{% endif %}>
         {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/component/form/form-input.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/form/form-input.html.twig
@@ -78,7 +78,7 @@
                    {% if maxlength is not empty %}maxlength="{{ maxlength }}"{% endif %}
                    {% if validationRules is not empty %}data-validation="{{ validationRules }}"{% endif %}
                    {% if 'required' in validationRules %}aria-required="true"{% endif %}
-                   {% if attributes is not empty %}{% for key, value in attributes %}{% if value is not empty %}{{ key ~ '=' ~ value ~ ' ' }}{% endif %}{% endfor %}{% endif %}
+                   {% if attributes is not empty %}{% for key, value in attributes %}{% if value is not empty %}{{ key }}="{{ value }}"{% else %}{{ key }}{% endif %}{% endfor %}{% endif %}
                    {% if disabled is not empty %}disabled{% endif %}>
         {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
By default, all validation error messages are sourced from the central window.validationMessages map—even if an individual field needs a different, context-specific message. Supporting a data-form-validation-error-message attribute lets developers override the global text on a per-field basis

Needed for example in the CmsExtension Plugin, where you can set custom error messages
![{05ED1DD7-F456-4240-A594-E6E8A2E8A4A7}](https://github.com/user-attachments/assets/2c7e6a54-7090-4840-839f-e321c38783a4)
![{D9D84348-BE8E-4533-833B-C8E8BD57F6DE}](https://github.com/user-attachments/assets/75bfdf8c-4c2a-4360-8dac-0a368f2e0626)


### 2. What does this change do, exactly?
Enhances FormValidation#setFieldValidationMessage() so it first checks for a data-form-validation-error-message attribute on the failing <input> (or other form field).

If that attribute is present and non-empty, its value is used as the error text.

Otherwise, the existing behavior remains: the message from this.errorMessages.get(validatorName) is applied.


### 3. Describe each step to reproduce the issue or behaviour.
create a form field and set the custom error message:
```
{% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig' with {
                                                                        fieldName: field.technicalName,
                                                                        type: field.type,
                                                                        required: field.required,
                                                                        label: field.translated.label,
                                                                        placeholder: field.translated.placeholder,
                                                                        additionalClass: columnWidth,
                                                                        attributes: {
                                                                            'data-form-validation-error-message': field.translated.errorMessage
                                                                        },
                                                                    } %}
```

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/8265

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
