### PR TITLE
fix: main_category's category should be nullable

### DIFF
--- a/src/Core/Content/Seo/MainCategory/MainCategoryEntity.php
+++ b/src/Core/Content/Seo/MainCategory/MainCategoryEntity.php
@@ -22,7 +22,7 @@ class MainCategoryEntity extends Entity
 
     protected string $categoryVersionId;
 
-    protected CategoryEntity $category;
+    protected ?CategoryEntity $category = null;
 
     protected string $productId;
 
@@ -60,8 +60,15 @@ class MainCategoryEntity extends Entity
         $this->categoryId = $categoryId;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - return type will be nullable and condition will be removed
+     */
     public function getCategory(): CategoryEntity
     {
+        if ($this->category === null) {
+            return new CategoryEntity();
+        }
+
         return $this->category;
     }
 


### PR DESCRIPTION
I got the error `Typed property Shopware\\Core\\Content\\Seo\\MainCategory\\MainCategoryEntity::$category must not be accessed before initialization` when trying to load product with an assigned main_category, the reason is the `MainCategoryEntity's $category` property should be nullable