### PR TITLE
fix: CmsFormHandler with basic captcha does not submit form twice

### DIFF
--- a/changelog/_unreleased/2025-04-25-fix-form-submit-with-basic-captcha.md
+++ b/changelog/_unreleased/2025-04-25-fix-form-submit-with-basic-captcha.md
@@ -1,0 +1,6 @@
+---
+title: Fix cms-form submit with basic captcha
+issue: 8499
+---
+# Storefront
+* Changed `FormCmsHandler` to only add on submit event handler when no basic captcha is present, as the basic captcha triggers the submit as well, thus preventing cases where the form is submitted twice and the captcha is considered invalid on second request.

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
@@ -43,6 +43,11 @@ export default class FormCmsHandler extends Plugin {
     }
 
     _registerEvents() {
+        // submit is handled in basic captcha plugin, don't trigger submit twice
+        if (this._hasBasicCaptcha()) {
+            return;
+        }
+
         this.el.addEventListener('submit', this._handleSubmit.bind(this));
     }
 
@@ -69,6 +74,18 @@ export default class FormCmsHandler extends Plugin {
         } else {
             this._showValidation();
         }
+    }
+
+    /**
+     * Checks if basic captcha is enabled, then form submit is triggered over captcha plugin
+     *
+     * @return {boolean}
+     * @private
+     */
+    _hasBasicCaptcha() {
+        const captcha = this.el.querySelector('[data-basic-captcha]');
+
+        return !!captcha;
     }
 
     _showValidation() {
@@ -107,6 +124,8 @@ export default class FormCmsHandler extends Plugin {
     }
 
     _createResponse(changeContent, content) {
+        console.log(changeContent);
+        console.log(content);
         if (changeContent) {
             if (this._confirmationText) {
                 content = this._confirmationText;

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
@@ -124,8 +124,6 @@ export default class FormCmsHandler extends Plugin {
     }
 
     _createResponse(changeContent, content) {
-        console.log(changeContent);
-        console.log(content);
         if (changeContent) {
             if (this._confirmationText) {
                 content = this._confirmationText;


### PR DESCRIPTION
Fixes https://github.com/shopware/shopware/issues/8499


CmsFormHandler and BasicCaptcha plugin both listened on the same event and submittet the form twice, which could lead to the captcha being invalid on the second requests (can be tested with throttled connection)

Not happy with the solution, would prefer if we could specify that captcha plugin event listener has higher priority then CMsFormHandler and then we can stop propagation in captcha handler (or do not need to manually submit) -> so the two plugins are not coupled to each other, but based on my rusty JS knowledge I didn't found a clean way to achieve that 
