### PR TITLE
fix: double click event emitted by sw-button

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-button/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-button/index.js
@@ -24,7 +24,8 @@ Component.register('sw-button', {
     },
 
     methods: {
-        onClick() {
+        onClick(event) {
+            event.stopImmediatePropagation();
             // Important: Do not emit the click event again, it is already emitted by the button
 
             // Check if deprecated routerLink is used


### PR DESCRIPTION
### 1. Why is this change necessary?
`sw-button` is emitting the click event twice.


### 2. What does this change do, exactly?
stops the emitting of one of the internal listeners


### 3. Describe each step to reproduce the issue or behaviour.
1. add a `sw-button` to any view
2. add `@click` listener
3. see the listener called twice



### 4. Please link to the relevant issues (if any).
- closes #8856
