### PR TITLE
fix: convert query to UTF-8 before escaping

### DIFF
--- a/changelog/_unreleased/2025-04-28-fix-unprepared-statements-breaking-profiler.md
+++ b/changelog/_unreleased/2025-04-28-fix-unprepared-statements-breaking-profiler.md
@@ -1,0 +1,8 @@
+---
+title: Fix unprepared statements breaking profiler
+author: Melvin Achterhuis
+author_email: melvin@achterhuis.work
+author_github: @MelvinAchterhuis
+---
+# Core
+* Added `convert_encoding` Twig filter before escaping so it's guaranteed UTF-8 in `Core/Profiling/Resources/views/Collector/db.html.twig`

--- a/src/Core/Profiling/Resources/views/Collector/db.html.twig
+++ b/src/Core/Profiling/Resources/views/Collector/db.html.twig
@@ -208,14 +208,14 @@
 
                                 <div id="formatted-query-{{ i }}-{{ loop.parent.loop.index }}" class="sql-runnable hidden">
                                     {{ query.sql|doctrine_format_sql(highlight = true) }}
-                                    <button class="btn btn-sm hidden" data-clipboard-text="{{ query.sql|doctrine_format_sql(highlight = false)|e('html') }}">Copy</button>
+                                    <button class="btn btn-sm hidden" data-clipboard-text="{{ query.sql|doctrine_format_sql(highlight = false)|convert_encoding('UTF-8//TRANSLIT//IGNORE', 'UTF-8')|e('html') }}">Copy</button>
                                 </div>
 
                                 {% if query.runnable %}
                                     <div id="original-query-{{ i }}-{{ loop.parent.loop.index }}" class="sql-runnable hidden">
                                         {% set runnable_sql = (query.sql ~ ';')|doctrine_replace_query_parameters(query.params) %}
                                         {{ runnable_sql|doctrine_prettify_sql }}
-                                        <button class="btn btn-sm hidden" data-clipboard-text="{{ runnable_sql|e('html') }}">Copy</button>
+                                        <button class="btn btn-sm hidden" data-clipboard-text="{{ runnable_sql|convert_encoding('UTF-8//TRANSLIT//IGNORE', 'UTF-8')|e('html') }}">Copy</button>
                                     </div>
                                 {% endif %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When query is not prepared, the profiler throws an error when debugging queries in the Doctrine tab

### 2. What does this change do, exactly?
Converts the query to UTF-8 before escaping it in Twig
Solution used from https://github.com/doctrine/sql-formatter/issues/91#issuecomment-1701426684

### 3. Describe each step to reproduce the issue or behaviour.
Version 6.6.10.3

1. Transition order payment to `paid`
2. Open profiler 
3. Inspect query in Doctrine tab

### 4. Please link to the relevant issues (if any).
Closes #8738 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
