### PR TITLE
fix: Allow enriching seoUrls for search results's extensions

### DIFF
--- a/changelog/_unreleased/2025-04-28-inclue-seourls-for-suggestsearch-and-search-entities.md
+++ b/changelog/_unreleased/2025-04-28-inclue-seourls-for-suggestsearch-and-search-entities.md
@@ -1,0 +1,5 @@
+---
+title: Allow enriching seoUrls for search results's extensions
+---
+# Core
+* Changed `Shopware\Core\Content\Seo\SalesChannel\StoreApiSeoResolver` class to allow enriching seoUrls for the search results extension.

--- a/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+++ b/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
@@ -96,6 +96,10 @@ class StoreApiSeoResolver implements EventSubscriberInterface
             foreach ($struct->getEntities() as $entity) {
                 $this->findStruct($data, $entity);
             }
+
+            foreach ($struct->getExtensions() as $extension) {
+                $this->findStruct($data, $extension);
+            }
         }
 
         if ($struct instanceof Collection) {
@@ -117,7 +121,7 @@ class StoreApiSeoResolver implements EventSubscriberInterface
         }
 
         foreach ($struct->getVars() as $item) {
-            if ($item instanceof Collection) {
+            if ($item instanceof Collection || \is_array($item)) {
                 foreach ($item as $collectionItem) {
                     if ($collectionItem instanceof Struct) {
                         $this->findStruct($data, $collectionItem);

--- a/tests/unit/Core/Content/Seo/SalesChannel/MockSeoUrlAwareExtension.php
+++ b/tests/unit/Core/Content/Seo/SalesChannel/MockSeoUrlAwareExtension.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\SalesChannel;
+
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\Struct\Struct;
+
+/**
+ * @internal
+ */
+class MockSeoUrlAwareExtension extends Struct
+{
+    /**
+     * @var array<SalesChannelProductEntity>
+     */
+    protected array $searchResults = [];
+
+    public function addSearchResult(SalesChannelProductEntity $entity): void
+    {
+        $this->searchResults[] = $entity;
+    }
+}

--- a/tests/unit/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
@@ -80,6 +80,47 @@ class StoreApiSeoResolverTest extends TestCase
         static::assertNotEmpty($productEntity->getSeoUrls());
     }
 
+    public function testAddSeoInformationWithExtensions(): void
+    {
+        $request = new Request();
+        $request->headers->set(PlatformRequest::HEADER_INCLUDE_SEO_URLS, 'true');
+        $request->attributes->set(
+            PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT,
+            $this->createMock(SalesChannelContext::class),
+        );
+
+        $searchResult = new EntitySearchResult(
+            'product',
+            0,
+            new ProductCollection([]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext(),
+        );
+
+        $product = $this->createProductEntity();
+
+        $result = new MockSeoUrlAwareExtension();
+        $result->addSearchResult($product);
+
+        $searchResult->addExtension('multiSearchResult', $result);
+        $response = new ProductListResponse($searchResult);
+
+        $event = new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $response
+        );
+
+        static::assertEmpty($product->getSeoUrls());
+
+        $storeApiSeoResolver = $this->createStoreApiSeoResolver();
+        $storeApiSeoResolver->addSeoInformation($event);
+
+        static::assertNotEmpty($product->getSeoUrls());
+    }
+
     public function testResponseIsNotStoreApiResponse(): void
     {
         $event = new ResponseEvent(


### PR DESCRIPTION
Commercial issue: https://github.com/shopware/SwagCommercial/issues/489
Commercial usage: https://github.com/shopware/SwagCommercial/pull/571