### PR TITLE
fix: fix mt-colorpicker size in old sw-text-editor-deprecated

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
@@ -75,4 +75,15 @@ $sw-text-editor-toolbar-item-color-boxed: #9aa8b5;
             justify-self: end;
         }
     }
+
+    .mt-colorpicker .mt-field__addition,
+    .mt-colorpicker__previewWrapper {
+        width: 18px;
+        height: 18px;
+    }
+
+    .mt-colorpicker .mt-block-field__block {
+        min-height: auto;
+        padding-top: 4px;
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

See issue: https://github.com/shopware/shopware/issues/8915

### 2. What does this change do, exactly?

The new mt-colorpicker is used in the old sw-text-editor-deprecated. Therefore the styling for the specific colorpicker classes don't work anymore. I adjusted the new colorpicker styling so that it looks correct again:

<img width="933" alt="Bildschirmfoto 2025-04-30 um 08 33 49" src="https://github.com/user-attachments/assets/12062336-ee67-4ed1-ad6a-0ba47f072ee5" />



### 3. Describe each step to reproduce the issue or behaviour.

Go to Basic information module and see there the old text editor with correct colorpicker sizes admin#/sw/settings/basic/information/index
