### PR TITLE
fix: fix language switch height

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-language-switch/sw-language-switch.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-language-switch/sw-language-switch.scss
@@ -8,4 +8,8 @@
     .sw-language-switch__select {
         margin-bottom: 0;
     }
+
+    .sw-block-field__block {
+        height: auto;
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The language switch does not look correct with the height

### 2. What does this change do, exactly?
Fixes the height