### PR TITLE
fix: wrong icon size in compact upload button

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.scss
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.scss
@@ -98,6 +98,12 @@
     .sw-media-compact-upload-v2__browse-icon {
         width: 14px;
         height: 14px;
+
+        &.mt-icon > svg {
+            // Important is needed because the selector to be override is a id selector
+            width: 100% !important;
+            height: 100% !important;
+        }
     }
 
     .sw-media-compact-upload-v2__label {


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/8928

### 2. What does this change do, exactly?

Use the correct icon sizes now.

<img width="893" alt="Bildschirmfoto 2025-04-30 um 13 49 15" src="https://github.com/user-attachments/assets/e596c924-f4b3-445c-8ab1-a1730a2ec929" />