### PR TITLE
fix: Allow small size of `sw-select-rule-create`

### DIFF
--- a/changelog/_unreleased/2025-04-30-allow-small-size-of-sw-select-rule-create.md
+++ b/changelog/_unreleased/2025-04-30-allow-small-size-of-sw-select-rule-create.md
@@ -1,0 +1,8 @@
+---
+title: Allow small size of `sw-select-rule-create`
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed `sw-select-rule-create` component to allow for small input size

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
@@ -40,6 +40,12 @@ Component.register('sw-select-base', {
             required: false,
             default: false,
         },
+
+        size: {
+            type: String,
+            required: false,
+            default: 'default',
+        },
     },
 
     data() {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
@@ -4,6 +4,7 @@
     :class="swFieldClasses"
     v-bind="$attrs"
     :disabled="disabled"
+    :size="size"
 >
     <template #sw-field-input="{ identification, error, disabled, size, setFocusClass, removeFocusClass }">
         <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
@@ -102,8 +102,14 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
         padding: 4px 6px 0;
     }
 
-    &.sw-field--small .sw-select__selection {
-        padding: 4px 6px 0;
+    &.sw-field--small {
+        .sw-block-field__block {
+            height: auto;
+        }
+
+        .sw-select__selection {
+            padding: 4px 6px 0;
+        }
     }
 
     &.is--disabled {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
@@ -167,6 +167,11 @@ Component.register('sw-entity-single-select', {
             required: false,
             default: undefined,
         },
+        size: {
+            type: String,
+            required: false,
+            default: 'default',
+        },
     },
 
     data() {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
@@ -3,6 +3,7 @@
     ref="selectBase"
     class="sw-entity-single-select"
     :is-loading="isLoading"
+    :size="size"
     :disable-auto-close="disableAutoClose"
     v-bind="$attrs"
     :label="label"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/index.js
@@ -86,6 +86,12 @@ Component.register('sw-select-rule-create', {
                 return '';
             },
         },
+
+        size: {
+            type: String,
+            required: false,
+            default: 'default',
+        },
     },
 
     data() {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/sw-select-rule-create.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/sw-select-rule-create.html.twig
@@ -63,6 +63,7 @@
         entity="rule"
         :criteria="ruleFilter"
         :value="ruleId"
+        :size="size"
         v-bind="$attrs"
         show-clearable-button
         advanced-selection-component="sw-advanced-selection-rule"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
@@ -30,15 +30,6 @@
         padding: 25px;
         background-color: $color-gray-100;
         border-bottom: 1px solid $color-gray-300;
-
-        .sw-single-select__inner {
-            min-height: auto;
-            padding-top: 0;
-        }
-
-        .sw-single-select .sw-single-select__indicators {
-            top: 5px;
-        }
     }
 
     .sw-product-detail-context-prices__toolbar-selection {


### PR DESCRIPTION
### 1. Why is this change necessary?
The `sw-entity-single-select` did not allow for small size. Which resulted in strange display at some places, for example in the rule select.

### 2. What does this change do, exactly?
Add `size=small` behavior to the `sw-entity-single-select` (and the base select). This should fix the issue also in other places.

### 3. Describe each step to reproduce the issue or behaviour.
Use the admin.

### 4. Please link to the relevant issues (if any).
Closes https://github.com/shopware/shopware/issues/8908

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
