### PR TITLE
fix: add spacing to checkboxes in address modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form/sw-customer-address-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form/sw-customer-address-form.scss
@@ -2,4 +2,8 @@
     &__options {
         grid-column: 1 / 3;
     }
+
+    .sw-customer-address-form__set-default-billing-address-action {
+        margin-top: 0.5rem;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form/sw-customer-address-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form/sw-customer-address-form.scss
@@ -4,6 +4,6 @@
     }
 
     .sw-customer-address-form__set-default-billing-address-action {
-        margin-top: 0.5rem;
+        margin-top: var(--scale-size-8);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
fixes #8968

### 2. What does this change do, exactly?

Adds spacing between delivery and billing address.

![image](https://github.com/user-attachments/assets/8656160f-0b2f-49ba-8527-483bb9725e42)