### PR TITLE
fix: align payment, delivery and order status with status text and status history link

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.scss
@@ -23,12 +23,8 @@
         color: $color-gray-500;
     }
 
-    &__state-history-text,
     &__state-history-button {
         margin-bottom: 6px;
-    }
-
-    &__state-history-button {
         text-align: right;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.scss
@@ -16,7 +16,10 @@
     }
 
     &__state-container > * {
-        margin-top: auto;
+        &:not(:first-child) {
+            margin-top: 1.5rem;
+            align-self: center;
+        }
     }
 
     &__state-history-text {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

fixes #8967


### 2. What does this change do, exactly?

Fix alignment of  payment, delivery and order status with their status text and status history link.

![image](https://github.com/user-attachments/assets/91ad148a-65e5-4d7e-ac27-f87b4cde02e9)

![image](https://github.com/user-attachments/assets/d891cebd-271d-46c0-a81b-0ccb94cf91f6)

![image](https://github.com/user-attachments/assets/82f73b5c-9138-4fac-9875-d934f64b109f)


### 3. Describe each step to reproduce the issue or behaviour.

Go to Order Details > Details tab and observe that the Payment, Delivery, and Order sections; status dropdowns are misaligned with the status history text and status history link.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
#8967

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
