### PR TITLE
fix: remove specific color on icon-wishlist

### DIFF
--- a/changelog/_unreleased/2025-05-02-remove-specific-color-on-icon-wishlist.md
+++ b/changelog/_unreleased/2025-05-02-remove-specific-color-on-icon-wishlist.md
@@ -1,0 +1,10 @@
+---
+title: Remove specific color on icon-wishlist
+issue: 
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Storefront
+* Removed specific color from icon-wishlist to use the default icon color

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_product-wishlist.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_product-wishlist.scss
@@ -101,8 +101,6 @@ $box-standard-height-img: 200px;
 
     .icon-wishlist,
     .icon-wishlist-remove {
-        color: $gray-800;
-
         svg {
             top: 0;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
The icon uses a default color consistent with the established icon-wishlist specification.  This constraint limits the flexibility for alternative color assignments.

### 2. What does this change do, exactly?
Remove the dedicated color for icon-wishlist.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
