### PR TITLE
fix: Adjust tag proportions to display correctly

### DIFF
--- a/changelog/_unreleased/2025-05-02-fix-incorrect-proportions-of-tags-in-orders.md
+++ b/changelog/_unreleased/2025-05-02-fix-incorrect-proportions-of-tags-in-orders.md
@@ -1,0 +1,9 @@
+---
+title: Fix incorrect proportions of tags in orders
+issue: 8978
+author: Mahesh Bohara
+author_email: maheshbohara0101@gmail.com
+author_github: @maheshbohara
+---
+# Administration
+* Changed styling of .sw-label and .sw-select-selection-list__input-wrapper to correctly display tag proportions.

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
@@ -1,4 +1,13 @@
 .sw-entity-multi-select.sw-field--small {
+    .sw-block-field__block {
+        min-height: 48px;
+        height: auto;
+
+        .sw-select__selection {
+            padding: 4px 6px;
+        }
+    }
+
     .sw-select-selection-list {
         &__item-holder {
             margin: 0 2px;
@@ -6,6 +15,12 @@
             .sw-label {
                 height: 32px;
                 padding: 8px 12px;
+
+                &__dismiss {
+                    .icon--regular-times-s {
+                        padding-top: 2px;
+                    }
+                }
             }
         }
 
@@ -19,6 +34,10 @@
 
         .sw-select-selection-list__load-more {
             margin-top: 0;
+
+            &-button {
+                margin: 4px 6px 4px 0;
+            }
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
@@ -4,10 +4,16 @@
             margin: 0 2px;
 
             .sw-label {
-                margin: 0;
-                height: 24px;
-                line-height: 22px;
-                min-width: 0;
+                height: 32px;
+                padding: 8px 12px;
+            }
+        }
+
+        &__input-wrapper {
+            align-self: center;
+
+            input {
+                padding-bottom: 0;
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
See issue: #8978


### 2. What does this change do, exactly?
Fixes incorrect proportions of tags in orders.

![image](https://github.com/user-attachments/assets/185c3868-a5d8-4eed-8642-9196350caa41)



### 3. Describe each step to reproduce the issue or behaviour.
Go to Order Detail > General tab > Info section and observe that tags are not displayed correctly.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
#8978

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
