### PR TITLE
feat: track state changes performed by integrations

### DIFF
--- a/changelog/_unreleased/2025-05-02-track-status-changes-performed-by-integrations.md
+++ b/changelog/_unreleased/2025-05-02-track-status-changes-performed-by-integrations.md
@@ -6,7 +6,7 @@ author_github: @schneider-felix
 ---
 # Core
 * Added `integration_id` column to `state_machine_history`
-* Changed `StateMachineRegistry::transition` to store integration id
+* Changed `StateMachineRegistry::transition` to store integration ID
 ___
 # Administration
-* Changed order ui to show which integrations performed an order state change
+* Changed order UI to show which integration performed an order state change

--- a/changelog/_unreleased/2025-05-02-track-status-changes-performed-by-integrations.md
+++ b/changelog/_unreleased/2025-05-02-track-status-changes-performed-by-integrations.md
@@ -1,0 +1,12 @@
+---
+title: Track status changes performed by integrations
+author: Felix Schneider
+author_email: felix@wirduzen.de
+author_github: @schneider-felix
+---
+# Core
+* Added `integration_id` column to `state_machine_history`
+* Changed `StateMachineRegistry::transition` to store integration id
+___
+# Administration
+* Changed order ui to show which integrations performed an order state change

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/index.js
@@ -143,6 +143,17 @@ export default {
 
             return `sw-order-details-state-${this.position}`;
         },
+        lastChangeAuthorLabel() {
+            if(this.lastStateChange?.user) {
+                return `${this.lastStateChange.user.firstName  } ${  this.lastStateChange.user.lastName}`;
+            }
+            if (this.lastStateChange?.integration) {
+                const integrationLabel = this.lastStateChange.integration.label;
+                return `${integrationLabel} (${this.$t('sw-order.stateCard.labelIntegration')})`
+            }
+
+            return this.$t('sw-order.stateCard.labelSystemUser');
+        },
     },
 
     created() {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/index.js
@@ -102,6 +102,7 @@ export default {
             criteria.addFilter(Criteria.equals('referencedId', this.entity.id));
             criteria.addFilter(Criteria.equals('entityName', this.entityName));
             criteria.addAssociation('user');
+            criteria.addAssociation('integration');
             criteria.addSorting({ field: 'createdAt', order: 'DESC' });
 
             return criteria;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/index.js
@@ -143,6 +143,7 @@ export default {
 
             return `sw-order-details-state-${this.position}`;
         },
+        
         lastChangeAuthorLabel() {
             if(this.lastStateChange?.user) {
                 return `${this.lastStateChange.user.firstName  } ${  this.lastStateChange.user.lastName}`;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.html.twig
@@ -46,15 +46,7 @@
                         <sw-time-ago :date="lastStateChange.createdAt" />
                     </template>
                     <template #author>
-                        <template v-if="lastStateChange.user">
-                            {{ lastStateChange.user.firstName + ' ' + lastStateChange.user.lastName }}
-                        </template>
-                        <template v-else-if="lastStateChange.integration">
-                            {{ lastStateChange.integration.label }} ({{ $t('sw-order.stateCard.labelIntegration') }})
-                        </template>
-                        <template v-else>
-                            {{ $t('sw-order.stateCard.labelSystemUser') }}
-                        </template>
+                        {{ lastChangeAuthorLabel }}
                     </template>
                 </i18n-t>
             </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.html.twig
@@ -46,7 +46,15 @@
                         <sw-time-ago :date="lastStateChange.createdAt" />
                     </template>
                     <template #author>
-                        {{ lastStateChange.user ? lastStateChange.user.firstName + ' ' + lastStateChange.user.lastName : $tc('sw-order.stateCard.labelSystemUser') }}
+                        <template v-if="lastStateChange.user">
+                            {{ lastStateChange.user.firstName + ' ' + lastStateChange.user.lastName }}
+                        </template>
+                        <template v-else-if="lastStateChange.integration">
+                            {{ lastStateChange.integration.label }} ({{ $t('sw-order.stateCard.labelIntegration') }})
+                        </template>
+                        <template v-else>
+                            {{ $t('sw-order.stateCard.labelSystemUser') }}
+                        </template>
                     </template>
                 </i18n-t>
             </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/index.js
@@ -46,14 +46,21 @@ export default {
 
     methods: {
         userDisplayName(user) {
-            let userString = '';
-            if (user === null) {
-                userString = this.$tc('sw-order.stateCard.labelSystemUser');
-            } else {
-                userString = user.username;
-            }
+            return `${this.$tc('sw-order.stateCard.labelLastEditedBy')} ${user.username}`;
+        },
 
-            return `${this.$tc('sw-order.stateCard.labelLastEditedBy')} ${userString}`;
+        integrationDisplayName(integration) {
+            return this.$t('sw-order.stateCard.labelLastEditedByIntegration', { integrationName: integration.label });
+        },
+
+        getDisplayName(historyEntry) {
+            if (historyEntry.user !== null) {
+                return this.userDisplayName(historyEntry.user);
+            }
+            if (historyEntry.integration !== null) {
+                return this.integrationDisplayName(historyEntry.integration);
+            }
+            return this.$tc('sw-order.stateCard.labelSystemUser');
         },
 
         getIconFromState(stateName) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/sw-order-state-history-card-entry.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/sw-order-state-history-card-entry.html.twig
@@ -36,7 +36,7 @@
         <span
             v-tooltip="{
                 showDelay: 300,
-                message:userDisplayName(entry.user)
+                message:getDisplayName(entry)
             }"
             class="sw-order-state-card__date"
         >

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card/index.js
@@ -113,6 +113,7 @@ export default {
             criteria.addAssociation('fromStateMachineState');
             criteria.addAssociation('toStateMachineState');
             criteria.addAssociation('user');
+            criteria.addAssociation('integration');
             criteria.addSorting({
                 field: 'state_machine_history.createdAt',
                 order: 'ASC',

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
@@ -18,6 +18,9 @@ interface StateMachineHistoryData {
     user?: {
         username: string;
     };
+    integration?: {
+        label: string;
+    };
     entity: string;
     referencedId?: string;
 }
@@ -103,6 +106,7 @@ export default Component.wrapComponentConfig({
             criteria.addAssociation('fromStateMachineState');
             criteria.addAssociation('toStateMachineState');
             criteria.addAssociation('user');
+            criteria.addAssociation('integration');
             criteria.addSorting({
                 field: 'state_machine_history.createdAt',
                 order: 'ASC',
@@ -259,6 +263,7 @@ export default Component.wrapComponentConfig({
                 delivery: states.order_delivery,
                 createdAt: 'orderDateTime' in entry ? entry.orderDateTime : entry.createdAt,
                 user: 'user' in entry ? entry.user : undefined,
+                integration: 'integration' in entry ? entry.integration : undefined,
                 entity: 'entityName' in entry ? entry.entityName : entry.getEntityName(),
                 referencedId: 'referencedId' in entry ? entry.referencedId : entry.id,
             };

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
@@ -295,5 +295,17 @@ export default Component.wrapComponentConfig({
 
             return String(idx >= 0 ? idx + 1 : '');
         },
+
+        getStateChangeAuthor(item: StateMachineHistoryData): string {
+            if(item.user) {
+                return item.user.username;
+            }
+            if (item.integration) {
+                const integrationLabel = item.integration.label;
+                return `${integrationLabel} (${this.$t('sw-order.stateHistoryModal.labelIntegration')})`
+            }
+
+            return this.$t('sw-order.stateHistoryModal.labelSystemUser');
+        },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.html.twig
@@ -29,15 +29,7 @@
 
         {% block sw_order_state_history_modal_content_columns_user %}
         <template #column-user="{ item }">
-            <template v-if="item.user">
-                {{ item.user.username }}
-            </template>
-            <template v-else-if="item.integration">
-                {{ item.integration.label }} ({{ $t('sw-order.stateHistoryModal.labelIntegration') }})
-            </template>
-            <template v-else>
-                {{ $t('sw-order.stateHistoryModal.labelSystemUser') }}
-            </template>
+            {{ getStateChangeAuthor(item) }}
         </template>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.html.twig
@@ -29,7 +29,15 @@
 
         {% block sw_order_state_history_modal_content_columns_user %}
         <template #column-user="{ item }">
-            {{ item.user?.username ?? $tc('sw-order.stateHistoryModal.labelSystemUser') }}
+            <template v-if="item.user">
+                {{ item.user.username }}
+            </template>
+            <template v-else-if="item.integration">
+                {{ item.integration.label }} ({{ $t('sw-order.stateHistoryModal.labelIntegration') }})
+            </template>
+            <template v-else>
+                {{ $t('sw-order.stateHistoryModal.labelSystemUser') }}
+            </template>
         </template>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de-DE.json
@@ -326,7 +326,9 @@
       "labelErrorStateChange": "Beim Setzen des Status ist ein Fehler aufgetreten:",
       "labelErrorNoAction": "Kein neuer Zustand gewählt.",
       "labelNoTransactionState": "Keine Transaktionen vorhanden",
-      "labelNoDeliveryState": "Keine Lieferungen vorhanden"
+      "labelNoDeliveryState": "Keine Lieferungen vorhanden",
+      "labelLastEditedByIntegration": "Zuletzt geändert von {integrationName} (Integration)",
+      "labelIntegration": "Integration"
     },
     "assignMailTemplateCard": {
       "cardTitle": "E-Mail-Template zuweisen",
@@ -445,6 +447,7 @@
     "stateHistoryModal": {
       "modalTitle": "Statusverlauf",
       "labelSystemUser": "System",
+      "labelIntegration": "Integration",
       "column": {
         "createdAt": "Datum",
         "entity": "Geändert",

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en-GB.json
@@ -326,7 +326,9 @@
       "labelErrorStateChange": "An error occured while updating the status:",
       "labelErrorNoAction": "Status unchanged.",
       "labelNoTransactionState": "No transactions yet",
-      "labelNoDeliveryState": "No deliveries yet"
+      "labelNoDeliveryState": "No deliveries yet",
+      "labelLastEditedByIntegration": "Last edited by {integrationName} (Integration)",
+      "labelIntegration": "Integration"
     },
     "assignMailTemplateCard": {
       "cardTitle": "Assign email template",
@@ -445,6 +447,7 @@
     "stateHistoryModal": {
       "modalTitle": "Status history",
       "labelSystemUser": "System",
+      "labelIntegration": "Integration",
       "column": {
         "createdAt": "Date",
         "entity": "Changed",

--- a/src/Core/Migration/V6_7/Migration1746176773AddIntegrationIdStateHistory.php
+++ b/src/Core/Migration/V6_7/Migration1746176773AddIntegrationIdStateHistory.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 class Migration1746176773AddIntegrationIdStateHistory extends MigrationStep
 {
     public function getCreationTimestamp(): int
@@ -25,9 +25,5 @@ class Migration1746176773AddIntegrationIdStateHistory extends MigrationStep
         if ($columnAdded) {
             $connection->executeStatement('ALTER TABLE `state_machine_history` ADD CONSTRAINT `fk.state_machine_history.integration_id` FOREIGN KEY (`integration_id`) REFERENCES `integration` (`id`) ON DELETE NO ACTION ON UPDATE CASCADE');
         }
-    }
-
-    public function updateDestructive(Connection $connection): void
-    {
     }
 }

--- a/src/Core/Migration/V6_7/Migration1746176773AddIntegrationIdStateHistory.php
+++ b/src/Core/Migration/V6_7/Migration1746176773AddIntegrationIdStateHistory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1746176773AddIntegrationIdStateHistory extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1746176773;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $columnAdded = $this->addColumn($connection, 'state_machine_history', 'integration_id', 'BINARY(16)');
+        if ($columnAdded) {
+            $connection->executeStatement('ALTER TABLE `state_machine_history` ADD CONSTRAINT `fk.state_machine_history.integration_id` FOREIGN KEY (`integration_id`) REFERENCES `integration` (`id`) ON DELETE NO ACTION ON UPDATE CASCADE');
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/Integration/IntegrationDefinition.php
+++ b/src/Core/System/Integration/IntegrationDefinition.php
@@ -13,12 +13,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PasswordField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Integration\Aggregate\IntegrationRole\IntegrationRoleDefinition;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryDefinition;
 
 #[Package('fundamentals@framework')]
 class IntegrationDefinition extends EntityDefinition
@@ -65,6 +67,7 @@ class IntegrationDefinition extends EntityDefinition
             new DateTimeField('deleted_at', 'deletedAt'),
 
             (new OneToOneAssociationField('app', 'id', 'integration_id', AppDefinition::class, false))->addFlags(new RestrictDelete()),
+            new OneToManyAssociationField('stateMachineHistoryEntries', StateMachineHistoryDefinition::class, 'integration_id', 'id'),
             new ManyToManyAssociationField('aclRoles', AclRoleDefinition::class, IntegrationRoleDefinition::class, 'integration_id', 'acl_role_id'),
         ]);
     }

--- a/src/Core/System/Integration/IntegrationEntity.php
+++ b/src/Core/System/Integration/IntegrationEntity.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryCollection;
 
 #[Package('fundamentals@framework')]
 class IntegrationEntity extends Entity
@@ -30,6 +31,8 @@ class IntegrationEntity extends Entity
     protected ?AclRoleCollection $aclRoles = null;
 
     protected ?\DateTimeInterface $deletedAt = null;
+
+    protected ?StateMachineHistoryCollection $stateMachineHistoryEntries = null;
 
     public function getLabel(): string
     {
@@ -109,5 +112,15 @@ class IntegrationEntity extends Entity
     public function setDeletedAt(\DateTimeInterface $deletedAt): void
     {
         $this->deletedAt = $deletedAt;
+    }
+
+    public function getStateMachineHistoryEntries(): ?StateMachineHistoryCollection
+    {
+        return $this->stateMachineHistoryEntries;
+    }
+
+    public function setStateMachineHistoryEntries(StateMachineHistoryCollection $stateMachineHistoryEntries): void
+    {
+        $this->stateMachineHistoryEntries = $stateMachineHistoryEntries;
     }
 }

--- a/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryDefinition.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryDefinition.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Integration\IntegrationDefinition;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateDefinition;
 use Shopware\Core\System\StateMachine\StateMachineDefinition;
 use Shopware\Core\System\User\UserDefinition;
@@ -60,8 +61,10 @@ class StateMachineHistoryDefinition extends EntityDefinition
             (new ManyToOneAssociationField('toStateMachineState', 'to_state_id', StateMachineStateDefinition::class, 'id', false))->addFlags(new ApiAware()),
             new StringField('action_name', 'transitionActionName'),
             new FkField('user_id', 'userId', UserDefinition::class),
+            new FkField('integration_id', 'integrationId', IntegrationDefinition::class),
 
             new ManyToOneAssociationField('user', 'user_id', UserDefinition::class, 'id', false),
+            new ManyToOneAssociationField('integration', 'integration_id', IntegrationDefinition::class, 'id', false),
         ]);
     }
 }

--- a/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryEntity.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryEntity.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Integration\IntegrationEntity;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 use Shopware\Core\System\StateMachine\StateMachineEntity;
 use Shopware\Core\System\User\UserEntity;
@@ -35,6 +36,10 @@ class StateMachineHistoryEntity extends Entity
     protected ?string $userId = null;
 
     protected ?UserEntity $user = null;
+
+    protected ?string $integrationId = null;
+
+    protected ?IntegrationEntity $integration = null;
 
     protected string $transitionActionName;
 
@@ -156,5 +161,25 @@ class StateMachineHistoryEntity extends Entity
     public function setFromStateMachineState(StateMachineStateEntity $fromStateMachineState): void
     {
         $this->fromStateMachineState = $fromStateMachineState;
+    }
+
+    public function getIntegrationId(): ?string
+    {
+        return $this->integrationId;
+    }
+
+    public function setIntegrationId(?string $integrationId): void
+    {
+        $this->integrationId = $integrationId;
+    }
+
+    public function getIntegration(): ?IntegrationEntity
+    {
+        return $this->integration;
+    }
+
+    public function setIntegration(?IntegrationEntity $integration): void
+    {
+        $this->integration = $integration;
     }
 }

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -152,6 +152,7 @@ class StateMachineRegistry implements ResetInterface
                 'toStateId' => $toPlace->getId(),
                 'transitionActionName' => $transition->getTransitionName(),
                 'userId' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getUserId() : null,
+                'integrationId' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getIntegrationId() : null,
                 'referencedId' => $transition->getEntityId(),
                 'referencedVersionId' => $context->getVersionId(),
             ];

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -12,9 +12,11 @@ use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryStates;
 use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -22,6 +24,8 @@ use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMa
 use Shopware\Core\System\StateMachine\StateMachineException;
 use Shopware\Core\System\StateMachine\StateMachineRegistry;
 use Shopware\Core\System\StateMachine\Transition;
+use Shopware\Core\Test\Integration\Builder\Order\OrderBuilder;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -156,6 +160,58 @@ EOF;
         $toPlace = $stateCollection->get('toPlace');
         static::assertEquals(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $fromPlace->getTechnicalName());
         static::assertEquals(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $toPlace->getTechnicalName());
+    }
+
+    public function testStateMachineTransitionStoresUserAndIntegrationId(): void
+    {
+        $ids = new IdsCollection();
+
+        /** @var EntityRepository $userRepo */
+        $userRepo = self::getContainer()->get('user.repository');
+        $userId = $userRepo->searchIds((new Criteria())->setLimit(1), Context::createDefaultContext())->firstId();
+
+        $integration = [
+            'id' => $ids->get('integration-1'),
+            'label' => 'Integration 1',
+            'accessKey' => 'test123',
+            'secretAccessKey' => TestDefaults::HASHED_PASSWORD,
+        ];
+
+        /** @var EntityRepository $integrationRepo */
+        $integrationRepo = self::getContainer()->get('integration.repository');
+        $integrationRepo->create([$integration], Context::createDefaultContext());
+
+        static::assertNotNull($userId);
+
+        $orderBuilder = new OrderBuilder($ids, 'o-1');
+
+        /** @var EntityRepository $orderRepo */
+        $orderRepo = self::getContainer()->get('order.repository');
+        $orderRepo->create([$orderBuilder->build()], Context::createCLIContext());
+
+        $context = new Context(
+            new AdminApiSource($userId, $ids->get('integration-1'))
+        );
+
+        /** @var StateMachineRegistry $stateMachineRegistry */
+        $stateMachineRegistry = self::getContainer()->get(StateMachineRegistry::class);
+        $stateMachineRegistry->transition(
+            new Transition('order', $ids->get('o-1'), 'process', 'stateId'),
+            $context
+        );
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        /** @var array{integration_id: string, user_id: string}|false $historyData */
+        $historyData = $connection->fetchAssociative('SELECT LOWER(HEX(integration_id)) as integration_id, LOWER(HEX(user_id)) as user_id FROM `state_machine_history` WHERE referenced_id = :id AND referenced_version_id = :version ORDER BY created_at DESC LIMIT 1', [
+            'id' => Uuid::fromHexToBytes($ids->get('o-1')),
+            'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+        ]);
+
+        static::assertNotFalse($historyData);
+        static::assertEquals($ids->get('integration-1'), $historyData['integration_id']);
+        static::assertEquals($userId, $historyData['user_id']);
     }
 
     private function createOrderWithPartiallyReturnedDeliveryState(): string

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -166,8 +166,9 @@ EOF;
     {
         $ids = new IdsCollection();
 
-        /** @var EntityRepository $userRepo */
         $userRepo = self::getContainer()->get('user.repository');
+        static::assertInstanceOf(EntityRepository::class, $userRepo);
+
         $userId = $userRepo->searchIds((new Criteria())->setLimit(1), Context::createDefaultContext())->firstId();
 
         $integration = [
@@ -210,8 +211,8 @@ EOF;
         ]);
 
         static::assertNotFalse($historyData);
-        static::assertEquals($ids->get('integration-1'), $historyData['integration_id']);
-        static::assertEquals($userId, $historyData['user_id']);
+        static::assertSame($ids->get('integration-1'), $historyData['integration_id']);
+        static::assertSame($userId, $historyData['user_id']);
     }
 
     private function createOrderWithPartiallyReturnedDeliveryState(): string

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -178,41 +178,42 @@ EOF;
             'secretAccessKey' => TestDefaults::HASHED_PASSWORD,
         ];
 
-        /** @var EntityRepository $integrationRepo */
         $integrationRepo = self::getContainer()->get('integration.repository');
+        static::assertInstanceOf(EntityRepository::class, $integrationRepo);
         $integrationRepo->create([$integration], Context::createDefaultContext());
 
         static::assertNotNull($userId);
 
         $orderBuilder = new OrderBuilder($ids, 'o-1');
 
-        /** @var EntityRepository $orderRepo */
         $orderRepo = self::getContainer()->get('order.repository');
+        static::assertInstanceOf(EntityRepository::class, $orderRepo);
         $orderRepo->create([$orderBuilder->build()], Context::createCLIContext());
 
         $context = new Context(
             new AdminApiSource($userId, $ids->get('integration-1'))
         );
 
-        /** @var StateMachineRegistry $stateMachineRegistry */
         $stateMachineRegistry = self::getContainer()->get(StateMachineRegistry::class);
+        static::assertInstanceOf(StateMachineRegistry::class, $stateMachineRegistry);
         $stateMachineRegistry->transition(
             new Transition('order', $ids->get('o-1'), 'process', 'stateId'),
             $context
         );
 
-        /** @var Connection $connection */
         $connection = self::getContainer()->get(Connection::class);
+        static::assertInstanceOf(Connection::class, $connection);
 
-        /** @var array{integration_id: string, user_id: string}|false $historyData */
         $historyData = $connection->fetchAssociative('SELECT LOWER(HEX(integration_id)) as integration_id, LOWER(HEX(user_id)) as user_id FROM `state_machine_history` WHERE referenced_id = :id AND referenced_version_id = :version ORDER BY created_at DESC LIMIT 1', [
             'id' => Uuid::fromHexToBytes($ids->get('o-1')),
             'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
         ]);
 
         static::assertNotFalse($historyData);
-        static::assertSame($ids->get('integration-1'), $historyData['integration_id']);
-        static::assertSame($userId, $historyData['user_id']);
+        static::assertSame([
+            'integration_id' => $ids->get('integration-1'),
+            'user_id' => $userId,
+        ], $historyData);
     }
 
     private function createOrderWithPartiallyReturnedDeliveryState(): string

--- a/tests/migration/Core/V6_7/Migration1746176773AddIntegrationIdStateHistoryTest.php
+++ b/tests/migration/Core/V6_7/Migration1746176773AddIntegrationIdStateHistoryTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Types\BinaryType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_7\Migration1746176773AddIntegrationIdStateHistory;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1746176773AddIntegrationIdStateHistory::class)]
+class Migration1746176773AddIntegrationIdStateHistoryTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testMigration(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        $this->revertMigration($connection);
+
+        $migration = new Migration1746176773AddIntegrationIdStateHistory();
+        $migration->update($connection);
+        // Run twice to ensure idempotency
+        $migration->update($connection);
+
+        $manager = $connection->createSchemaManager();
+        $columns = $manager->listTableColumns('state_machine_history');
+        $foreignKeys = $manager->listTableForeignKeys('state_machine_history');
+
+        $filteredForeignKeys = array_filter($foreignKeys, static fn (ForeignKeyConstraint $key) => $key->getName() === 'fk.state_machine_history.integration_id');
+        $foreignKey = array_pop($filteredForeignKeys);
+
+        static::assertNotNull($foreignKey);
+        static::assertEquals(['id'], $foreignKey->getForeignColumns());
+        static::assertArrayHasKey('integration_id', $columns);
+        static::assertInstanceOf(BinaryType::class, $columns['integration_id']->getType());
+        static::assertEquals(16, $columns['integration_id']->getLength());
+        static::assertFalse($columns['integration_id']->getNotnull());
+    }
+
+    private function revertMigration(Connection $connection): void
+    {
+        if ($this->columnExists($connection, 'state_machine_history', 'integration_id')) {
+            $connection->executeStatement('ALTER TABLE `state_machine_history` DROP FOREIGN KEY `fk.state_machine_history.integration_id`');
+            $connection->executeStatement('ALTER TABLE `state_machine_history` DROP COLUMN `integration_id`');
+        }
+    }
+
+    private function columnExists(Connection $connection, string $table, string $column): bool
+    {
+        return \array_key_exists(
+            strtolower($column),
+            $connection->createSchemaManager()->listTableColumns($table)
+        );
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1746176773AddIntegrationIdStateHistoryTest.php
+++ b/tests/migration/Core/V6_7/Migration1746176773AddIntegrationIdStateHistoryTest.php
@@ -22,8 +22,8 @@ class Migration1746176773AddIntegrationIdStateHistoryTest extends TestCase
 
     public function testMigration(): void
     {
-        /** @var Connection $connection */
         $connection = self::getContainer()->get(Connection::class);
+        static::assertInstanceOf(Connection::class, $connection);
 
         $this->revertMigration($connection);
 
@@ -40,10 +40,10 @@ class Migration1746176773AddIntegrationIdStateHistoryTest extends TestCase
         $foreignKey = array_pop($filteredForeignKeys);
 
         static::assertNotNull($foreignKey);
-        static::assertEquals(['id'], $foreignKey->getForeignColumns());
+        static::assertSame(['id'], $foreignKey->getForeignColumns());
         static::assertArrayHasKey('integration_id', $columns);
         static::assertInstanceOf(BinaryType::class, $columns['integration_id']->getType());
-        static::assertEquals(16, $columns['integration_id']->getLength());
+        static::assertSame(16, $columns['integration_id']->getLength());
         static::assertFalse($columns['integration_id']->getNotnull());
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Most shops have integrations with some kind of external system. One common task performed by these systems is changing order states. Currently the admin only shows "System" in the state history if the state was changed by an integration. 

### 2. What does this change do, exactly?

It stores the integration id if a state change was performed by an integration and shows that integration in the admin ui.

It would be great if we could also store which flow triggered a state change in the future. But it dont't see a way to do something like this without adding more and more columns to state_machine_history. But maybe it would be fine to have one more column for flow_id.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
