### PR TITLE
fix: dashboard statistics time range field height

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.scss
@@ -57,4 +57,8 @@ $content-max-width: 960px;
     &__help-text {
         margin-left: 8px;
     }
+
+    .sw-block-field__block {
+        height: auto;
+    }
 }


### PR DESCRIPTION
fixes #8979

Before:
![image](https://github.com/user-attachments/assets/767c49a4-543b-4700-99a3-63a62f98441c)



After:
![image](https://github.com/user-attachments/assets/4c203a14-220e-4e4a-a63e-884824db2c98)

