### PR TITLE
fix: Properly set height of search field in `sw-card-filter` component

### DIFF
--- a/changelog/_unreleased/2025-05-02-fix-height-of-search-field-in-sw-card-filter-component.md
+++ b/changelog/_unreleased/2025-05-02-fix-height-of-search-field-in-sw-card-filter-component.md
@@ -1,0 +1,8 @@
+---
+title: Fix height of search field in `sw-card-filter` component
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed `sw-card-filter` to not set the height of the search field explicitly and instead use full height of the container element of the `sw-simple-search-field` component

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-card-filter/sw-card-filter.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-card-filter/sw-card-filter.scss
@@ -1,6 +1,5 @@
 .sw-card-filter {
     display: flex;
-    height: 30px;
 
     .sw-card-filter-container {
         flex: 1;
@@ -8,15 +7,5 @@
         &.hasFilter {
             padding-right: 20px;
         }
-
-        .sw-simple-search-field__input {
-            input {
-                height: 32px;
-            }
-        }
     }
-}
-
-.mt-card__toolbar .sw-card-filter {
-    width: 100%;
 }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-simple-search-field/sw-simple-search-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-simple-search-field/sw-simple-search-field.scss
@@ -3,17 +3,16 @@
 .sw-simple-search-field {
     position: relative;
     outline: none;
+    height: 100%;
 
     .mt-field.sw-simple-search-field__input {
+        height: 100%;
         margin-bottom: 0;
 
         .mt-block-field__block {
             min-height: auto;
+            height: 100%;
         }
-    }
-
-    .sw-simple-search-field__input.mt-field--small .mt-block-field__block {
-        min-height: 0;
     }
 
     .sw-simple-search-field__input.sw-simple-search-field--default {


### PR DESCRIPTION
### 1. Why is this change necessary?
While the PR #8800 almost fixed many issues of the `sw-simple-search-field` there is still a small problem, where it was used inside `sw-card-filter` as explicit heights were set (the search field is slightly higher than the button):
![image](https://github.com/user-attachments/assets/e43094f6-954a-4398-91fc-c0e5cf880b27)

### 2. What does this change do, exactly?
This PR removes some explicit heights, resulting in:
![image](https://github.com/user-attachments/assets/a7c0a949-fabb-4414-abb5-082e024ea270)

I also checked the different occurrences of the `sw-simple-search-field` and `sw-card-filter` and could not find any side effects.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
Maybe releates to https://github.com/shopware/shopware/issues/8965

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
