### PR TITLE
fix: allow product stream updater to be disabled correctly

### DIFF
--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -399,6 +399,7 @@
             <argument type="service" id="product.repository"/>
             <argument type="service" id="messenger.default_bus"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Indexing\ManyToManyIdFieldUpdater"/>
+            <argument>%shopware.product_stream.indexing%</argument>
             <tag name="shopware.entity_indexer"/>
         </service>
 

--- a/src/Core/Content/DependencyInjection/product_stream.xml
+++ b/src/Core/Content/DependencyInjection/product_stream.xml
@@ -26,7 +26,6 @@
             <argument type="service" id="serializer"/>
             <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
             <argument type="service" id="event_dispatcher"/>
-            <argument>%shopware.product_stream.indexing%</argument>
 
             <!-- needs to run before ProductStreamUpdater -->
             <tag name="shopware.entity_indexer" priority="100"/>

--- a/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
+++ b/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
@@ -36,7 +36,6 @@ class ProductStreamIndexer extends EntityIndexer
         private readonly SerializerInterface $serializer,
         private readonly ProductDefinition $productDefinition,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly bool $indexingEnabled,
     ) {
     }
 
@@ -50,10 +49,6 @@ class ProductStreamIndexer extends EntityIndexer
      */
     public function iterate(?array $offset): ?EntityIndexingMessage
     {
-        if (!$this->indexingEnabled) {
-            return null;
-        }
-
         $iterator = $this->iteratorFactory->createIterator($this->repository->getDefinition(), $offset);
 
         $ids = $iterator->fetch();
@@ -67,10 +62,6 @@ class ProductStreamIndexer extends EntityIndexer
 
     public function update(EntityWrittenContainerEvent $event): ?EntityIndexingMessage
     {
-        if (!$this->indexingEnabled) {
-            return null;
-        }
-
         $updates = $event->getPrimaryKeys(ProductStreamDefinition::ENTITY_NAME);
 
         if (!$updates) {

--- a/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
+++ b/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
@@ -64,8 +64,7 @@ class ProductStreamIndexerTest extends TestCase
             $this->repository,
             new Serializer([], [new JsonEncoder()]),
             $this->productDefinition,
-            $this->dispatcher,
-            true
+            $this->dispatcher
         );
     }
 
@@ -86,24 +85,6 @@ class ProductStreamIndexerTest extends TestCase
 
         $message = $this->indexer->iterate(['offset' => 10]);
         static::assertInstanceOf(ProductStreamIndexingMessage::class, $message);
-    }
-
-    public function testIterateDisabledDoesNothing(): void
-    {
-        $indexer = new ProductStreamIndexer(
-            $this->connection,
-            $this->iteratorFactory,
-            $this->repository,
-            new Serializer([], [new JsonEncoder()]),
-            $this->productDefinition,
-            $this->dispatcher,
-            false
-        );
-
-        static::assertNull($indexer->iterate(['offset' => 10]));
-
-        $event = $this->createMock(EntityWrittenContainerEvent::class);
-        static::assertNull($indexer->update($event));
     }
 
     public function testUpdateReturnNull(): void


### PR DESCRIPTION
> [!IMPORTANT]  
> This needs to be backported to 6.6

### 1. Why is this change necessary?

In https://github.com/shopware/shopware/commit/969b1346509464f64cfcc1e5801d4ee0e5fedc14 the feature to disable the product stream indexer was introduced. I talked to @shyim about this and we came to the conclusion that this was a mistake. Instead the ProductStreamUpdater should be disabled. 

### 2. What does this change do, exactly?

I changed the configuration to now disable the ProductStreamUpdater instead.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
