### PR TITLE
fix: Vite build with underscore in plugin class generates correct file path

### DIFF
--- a/changelog/_unreleased/2025-05-05-fix-admin-assets-with-underscores.md
+++ b/changelog/_unreleased/2025-05-05-fix-admin-assets-with-underscores.md
@@ -1,0 +1,6 @@
+---
+title: Fix admin assets with underscores in plugin names
+issue: 8976
+---
+# Administration
+- Changed the vite build to correctly generate the entrypoints for admin assets with underscores in the plugin name.

--- a/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
@@ -195,7 +195,7 @@ export function loadExtensions(): ExtensionDefinition[] {
                     isPlugin: true,
                     isApp: false,
                     technicalName: technicalName,
-                    technicalFolderName: technicalName.replace(/(-)/g, '').toLowerCase(),
+                    technicalFolderName: name.replace(/(-)/g, '').toLowerCase(),
                     basePath: path.resolve(process.env.PROJECT_ROOT as string, definition.basePath),
                     path: path.resolve(
                         process.env.PROJECT_ROOT as string,


### PR DESCRIPTION

### 1. Why is this change necessary?
Admin assets from plugins with underscore are not loaded with vite build

### 2. What does this change do, exactly?
Use the name as base for the folder name, not the technical name, the technical name has underscores converted to `-` for the folder name all dashes are removed again, leading to errors, the base for the folder should be the real name, that way it is consistent with where the assets are actually stored

### 3. Describe each step to reproduce the issue or behaviour.
add a plugin with an underscore in the main plugin class name, add admin js assets, build the admin, see that the assets can not be loaded

### 4. Please link to the relevant issues (if any).
fixes: https://github.com/shopware/shopware/issues/8976

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
