### PR TITLE
refactor: Add blocks for inputs in register and address forms

### DIFF
--- a/changelog/_unreleased/2025-05-05-add-blocks-for-inputs-for-address-and-register-form.md
+++ b/changelog/_unreleased/2025-05-05-add-blocks-for-inputs-for-address-and-register-form.md
@@ -1,0 +1,8 @@
+---
+title: Add blocks for inputs for address and register form
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Added blocks for input fields for the register and address fields

--- a/src/Storefront/Resources/views/storefront/component/account/register.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/register.html.twig
@@ -105,18 +105,20 @@
                                             })|sw_sanitize %}
                                         {% endif %}
 
-                                        {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-                                            type: 'password',
-                                            label: 'account.personalPasswordLabel'|trans|sw_sanitize,
-                                            id: 'personalPassword',
-                                            name: 'password',
-                                            autocomplete: 'new-password',
-                                            description: passwordFieldDescription,
-                                            violationPath: '/password',
-                                            validationRules: 'required,minLength',
-                                            minlength: config('core.loginRegistration.passwordMinLength'),
-                                            additionalClass: 'col-sm-6 js-form-field-toggle-guest-mode',
-                                        } %}
+                                        {% block component_account_register_personal_password_input %}
+                                            {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+                                                type: 'password',
+                                                label: 'account.personalPasswordLabel'|trans|sw_sanitize,
+                                                id: 'personalPassword',
+                                                name: 'password',
+                                                autocomplete: 'new-password',
+                                                description: passwordFieldDescription,
+                                                violationPath: '/password',
+                                                validationRules: 'required,minLength',
+                                                minlength: config('core.loginRegistration.passwordMinLength'),
+                                                additionalClass: 'col-sm-6 js-form-field-toggle-guest-mode',
+                                            } %}
+                                        {% endblock %}
                                     {% endblock %}
                                 {% endset %}
 

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal-company.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal-company.html.twig
@@ -14,16 +14,18 @@
                             {% set requiredMessage = 'error.VIOLATION::IS_BLANK_ERROR'|trans({ '%field%': 'address.companyNameLabel'|trans|sw_sanitize }) %}
                         {% endif %}
 
-                        {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-                            label: 'address.companyNameLabel'|trans|sw_sanitize,
-                            id: idPrefix ~ prefix ~ 'company',
-                            name: prefix ? prefix ~ '[company]' : 'company',
-                            value: address.get('company'),
-                            autocomplete: 'section-personal organization',
-                            violationPath: violationPath,
-                            validationRules: 'required',
-                            additionalClass: 'col-12',
-                        } %}
+                        {% block component_address_form_company_name_input %}
+                            {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+                                label: 'address.companyNameLabel'|trans|sw_sanitize,
+                                id: idPrefix ~ prefix ~ 'company',
+                                name: prefix ? prefix ~ '[company]' : 'company',
+                                value: address.get('company'),
+                                autocomplete: 'section-personal organization',
+                                violationPath: violationPath,
+                                validationRules: 'required',
+                                additionalClass: 'col-12',
+                            } %}
+                        {% endblock %}
                     {% endblock %}
                 </div>
                 <div class="row g-2">
@@ -34,14 +36,16 @@
                             {% set violationPath = "/#{prefix}/department" %}
                         {% endif %}
 
-                        {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-                            label: 'address.companyDepartmentLabel'|trans|sw_sanitize,
-                            id: idPrefix ~ prefix ~ 'department',
-                            name: prefix ? prefix ~ '[department]' : 'department',
-                            value: address.get('department'),
-                            violationPath: violationPath,
-                            additionalClass: 'col-md-6',
-                        } %}
+                        {% block component_address_form_company_department_input %}
+                            {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+                                label: 'address.companyDepartmentLabel'|trans|sw_sanitize,
+                                id: idPrefix ~ prefix ~ 'department',
+                                name: prefix ? prefix ~ '[department]' : 'department',
+                                value: address.get('department'),
+                                violationPath: violationPath,
+                                additionalClass: 'col-md-6',
+                            } %}
+                        {% endblock %}
                     {% endblock %}
 
                     {# ludtwig-ignore twig-block-name-snake-case #}

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal-vat-id.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal-vat-id.html.twig
@@ -13,12 +13,14 @@
         {% endif %}
     {% endfor %}
 
-    {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-        label: 'address.companyVatLabel'|trans|sw_sanitize,
-        id: 'vatIds',
-        name: 'vatIds[]',
-        value: vatIdValue,
-        violationPath: violationPath,
-        additionalClass: 'col-md-6',
-    } %}
+    {% block component_account_register_personal_vat_id_field_input %}
+        {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+            label: 'address.companyVatLabel'|trans|sw_sanitize,
+            id: 'vatIds',
+            name: 'vatIds[]',
+            value: vatIdValue,
+            violationPath: violationPath,
+            additionalClass: 'col-md-6',
+        } %}
+    {% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -55,23 +55,25 @@
                     </option>
                 {% endset %}
 
-                {% sw_include '@Storefront/storefront/component/form/form-select.html.twig' with {
-                    label: 'account.personalTypeLabel'|trans|sw_sanitize,
-                    id: idPrefix ~ prefix ~ '-accountType',
-                    name: prefix ? prefix ~ '[accountType]' : 'accountType',
-                    options: accountTypeOptions,
-                    validationRules: 'required',
-                    disabled: (onlyCompanyRegistration) ? 'true',
-                    additionalClass: 'col-md-6 contact-type',
-                    additionalSelectClass: 'contact-select',
-                    attributes: {
-                        'data-form-field-toggle': 'true',
-                        'data-form-field-toggle-target': toggleTarget,
-                        'data-form-field-toggle-value': constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS'),
-                        'data-form-field-toggle-scope': (scope == 'parent') ? 'parent' : 'all',
-                        'data-form-field-toggle-parent-selector': (scope == 'parent') ? parentSelector,
-                    },
-                } %}
+                {% block component_address_personal_account_type_select %}
+                    {% sw_include '@Storefront/storefront/component/form/form-select.html.twig' with {
+                        label: 'account.personalTypeLabel'|trans|sw_sanitize,
+                        id: idPrefix ~ prefix ~ '-accountType',
+                        name: prefix ? prefix ~ '[accountType]' : 'accountType',
+                        options: accountTypeOptions,
+                        validationRules: 'required',
+                        disabled: (onlyCompanyRegistration) ? 'true',
+                        additionalClass: 'col-md-6 contact-type',
+                        additionalSelectClass: 'contact-select',
+                        attributes: {
+                            'data-form-field-toggle': 'true',
+                            'data-form-field-toggle-target': toggleTarget,
+                            'data-form-field-toggle-value': constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS'),
+                            'data-form-field-toggle-scope': (scope == 'parent') ? 'parent' : 'all',
+                            'data-form-field-toggle-parent-selector': (scope == 'parent') ? parentSelector,
+                        },
+                    } %}
+                {% endblock %}
 
                 {% if onlyCompanyRegistration %}
                     {# This is rendered on the profile edit page if the customer registered via a custom commercial registration form. #}
@@ -104,14 +106,16 @@
                             {% endfor %}
                         {% endset %}
 
-                        {% sw_include '@Storefront/storefront/component/form/form-select.html.twig' with {
-                            label: 'account.personalSalutationLabel'|trans|sw_sanitize,
-                            id: idPrefix ~ prefix ~ 'personalSalutation',
-                            name: prefix ? prefix ~ '[salutationId]' : 'salutationId',
-                            options: salutationOptions,
-                            violationPath: '/salutationId',
-                            additionalClass: 'col-md-3 col-sm-6',
-                        } %}
+                        {% block component_address_personal_fields_salutation %}
+                            {% sw_include '@Storefront/storefront/component/form/form-select.html.twig' with {
+                                label: 'account.personalSalutationLabel'|trans|sw_sanitize,
+                                id: idPrefix ~ prefix ~ 'personalSalutation',
+                                name: prefix ? prefix ~ '[salutationId]' : 'salutationId',
+                                options: salutationOptions,
+                                violationPath: '/salutationId',
+                                additionalClass: 'col-md-3 col-sm-6',
+                            } %}
+                        {% endblock %}
                     {% endif %}
                 {% endblock %}
 
@@ -123,15 +127,17 @@
                             {% set violationPath = "/title" %}
                         {% endif %}
 
-                        {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-                            label: 'account.personalTitleLabel'|trans|sw_sanitize,
-                            id: idPrefix ~ prefix ~ 'personalTitle',
-                            name: prefix ? prefix ~ '[title]' : 'title',
-                            value: data.get('title'),
-                            autocomplete: 'section-personal honorific-prefix',
-                            violationPath: violationPath,
-                            additionalClass: 'col-md-3 col-sm-6',
-                        } %}
+                        {% block component_address_personal_fields_title_input %}
+                            {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+                                label: 'account.personalTitleLabel'|trans|sw_sanitize,
+                                id: idPrefix ~ prefix ~ 'personalTitle',
+                                name: prefix ? prefix ~ '[title]' : 'title',
+                                value: data.get('title'),
+                                autocomplete: 'section-personal honorific-prefix',
+                                violationPath: violationPath,
+                                additionalClass: 'col-md-3 col-sm-6',
+                            } %}
+                        {% endblock %}
                     {% endif %}
                 {% endblock %}
             </div>
@@ -154,16 +160,18 @@
                     {% set requiredMessage = "error.VIOLATION::IS_BLANK_ERROR"|trans({ '%field%': "account.personalFirstNameLabel"|trans|sw_sanitize }) %}
                 {% endif %}
 
-                {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-                    label: 'account.personalFirstNameLabel'|trans|sw_sanitize,
-                    id: idPrefix ~ prefix ~ '-personalFirstName',
-                    name: prefix ? prefix ~ '[firstName]' : 'firstName',
-                    value: (prefix and data.has(prefix)) ? data.get(prefix).get('firstName') : data.get('firstName'),
-                    autocomplete: 'section-personal given-name',
-                    violationPath: violationPath,
-                    validationRules: 'required',
-                    additionalClass: 'col-sm-6',
-                } %}
+                {% block component_address_personal_fields_first_name_input %}
+                    {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+                        label: 'account.personalFirstNameLabel'|trans|sw_sanitize,
+                        id: idPrefix ~ prefix ~ '-personalFirstName',
+                        name: prefix ? prefix ~ '[firstName]' : 'firstName',
+                        value: (prefix and data.has(prefix)) ? data.get(prefix).get('firstName') : data.get('firstName'),
+                        autocomplete: 'section-personal given-name',
+                        violationPath: violationPath,
+                        validationRules: 'required',
+                        additionalClass: 'col-sm-6',
+                    } %}
+                {% endblock %}
             {% endblock %}
 
             {% block component_address_personal_fields_last_name %}
@@ -179,16 +187,18 @@
                     {% set requiredMessage = "error.VIOLATION::IS_BLANK_ERROR"|trans({ '%field%': "account.personalLastNameLabel"|trans|sw_sanitize }) %}
                 {% endif %}
 
-                {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-                    label: 'account.personalLastNameLabel'|trans|sw_sanitize,
-                    id: idPrefix ~ prefix ~ '-personalLastName',
-                    name: prefix ? prefix ~ '[lastName]' : 'lastName',
-                    value: (prefix and data.has(prefix)) ? data.get(prefix).get('lastName') : data.get('lastName'),
-                    autocomplete: 'section-personal family-name',
-                    violationPath: violationPath,
-                    validationRules: 'required',
-                    additionalClass: 'col-sm-6',
-                } %}
+                {% block component_address_personal_fields_last_name_input %}
+                    {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+                        label: 'account.personalLastNameLabel'|trans|sw_sanitize,
+                        id: idPrefix ~ prefix ~ '-personalLastName',
+                        name: prefix ? prefix ~ '[lastName]' : 'lastName',
+                        value: (prefix and data.has(prefix)) ? data.get(prefix).get('lastName') : data.get('lastName'),
+                        autocomplete: 'section-personal family-name',
+                        violationPath: violationPath,
+                        validationRules: 'required',
+                        additionalClass: 'col-sm-6',
+                    } %}
+                {% endblock %}
             {% endblock %}
         </div>
     {% endblock %}
@@ -206,16 +216,18 @@
                             {% endif %}
 
                             {# This is only rendered on the customer profile edit page. #}
-                            {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-                                label: 'address.companyNameLabel'|trans|sw_sanitize,
-                                id: idPrefix ~ prefix ~ '-company',
-                                name: 'company',
-                                value: data.get('company'),
-                                autocomplete: 'section-personal organization',
-                                violationPath: violationPath,
-                                validationRules: 'required',
-                                additionalClass: 'col-sm-6',
-                            } %}
+                            {% block component_address_personal_company_name_input %}
+                                {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+                                    label: 'address.companyNameLabel'|trans|sw_sanitize,
+                                    id: idPrefix ~ prefix ~ '-company',
+                                    name: 'company',
+                                    value: data.get('company'),
+                                    autocomplete: 'section-personal organization',
+                                    violationPath: violationPath,
+                                    validationRules: 'required',
+                                    additionalClass: 'col-sm-6',
+                                } %}
+                            {% endblock %}
                         {% endblock %}
                     </div>
                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -106,7 +106,7 @@
                             {% endfor %}
                         {% endset %}
 
-                        {% block component_address_personal_fields_salutation %}
+                        {% block component_address_personal_fields_salutation_select %}
                             {% sw_include '@Storefront/storefront/component/form/form-select.html.twig' with {
                                 label: 'account.personalSalutationLabel'|trans|sw_sanitize,
                                 id: idPrefix ~ prefix ~ 'personalSalutation',


### PR DESCRIPTION
### 1. Why is this change necessary?
With the refactoring of the forms (https://github.com/shopware/shopware/pull/5901) the inputs cannot directly be overwritten (i.e. setting different attributes), without overwriting also independent logic (mostly form validation stuff).

### 2. What does this change do, exactly?
This PR adds back the blocks around the different inputs.

As most of these blocks already existed before 6.7 I am not sure, if this is a break, or if it is fine like this. As the content of these blocks now changes with the update.

Also the changes should probably be mentioned in the `UPGRADE-6-7.md` (the removed blocks are also missing there).

If you let me know, how this should be communicated and if the block names are fine like this, I can come up with a more extensive description in the changelog and the upgrade information.

### 3. Describe each step to reproduce the issue or behaviour.
Try to add placeholders again to the input fields.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
