### PR TITLE
chore: Remove unused variable declarations of `requiredMessage`

### DIFF
--- a/changelog/_unreleased/2025-05-05-remove-obsolete-requiredmessage-variable-declarations.md
+++ b/changelog/_unreleased/2025-05-05-remove-obsolete-requiredmessage-variable-declarations.md
@@ -1,0 +1,8 @@
+---
+title: Remove obsolete `requiredMessage` variable declarations
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Removed unused `requiredMessage` variable declaration from the form elements

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal-company.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal-company.html.twig
@@ -10,8 +10,6 @@
                             {% set violationPath = '/company' %}
                         {% elseif formViolations.getViolations("/#{prefix}/company") is not empty %}
                             {% set violationPath = "/#{prefix}/company" %}
-                        {% else %}
-                            {% set requiredMessage = 'error.VIOLATION::IS_BLANK_ERROR'|trans({ '%field%': 'address.companyNameLabel'|trans|sw_sanitize }) %}
                         {% endif %}
 
                         {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -150,8 +150,6 @@
                     {% set violationPath = "/#{prefix}/firstName" %}
                 {% elseif formViolations.getViolations("/firstName") is not empty and prefix === 'address' %}
                     {% set violationPath = "/firstName" %}
-                {% else %}
-                    {% set requiredMessage = "error.VIOLATION::IS_BLANK_ERROR"|trans({ '%field%': "account.personalFirstNameLabel"|trans|sw_sanitize }) %}
                 {% endif %}
 
                 {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
@@ -175,8 +173,6 @@
                     {% set violationPath = "/#{prefix}/lastName" %}
                 {% elseif formViolations.getViolations("/lastName") is not empty and prefix === 'address' %}
                     {% set violationPath = "/lastName" %}
-                {% else %}
-                    {% set requiredMessage = "error.VIOLATION::IS_BLANK_ERROR"|trans({ '%field%': "account.personalLastNameLabel"|trans|sw_sanitize }) %}
                 {% endif %}
 
                 {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
@@ -201,8 +197,6 @@
                         {% block component_address_personal_company_name %}
                             {% if formViolations.getViolations("/company") is not empty %}
                                 {% set violationPath = "/company" %}
-                            {% else %}
-                                {% set requiredMessage = "error.VIOLATION::IS_BLANK_ERROR"|trans({ '%field%': "address.companyNameLabel"|trans|sw_sanitize }) %}
                             {% endif %}
 
                             {# This is only rendered on the customer profile edit page. #}

--- a/src/Storefront/Resources/views/storefront/component/address/field/address-city-field.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/field/address-city-field.html.twig
@@ -3,9 +3,6 @@
         {% set violationPath = '/city' %}
     {% elseif formViolations.getViolations("/#{prefix}/city") is not empty %}
         {% set violationPath = "/#{prefix}/city" %}
-    {% else %}
-        {% set requiredMessage = 'error.VIOLATION::IS_BLANK_ERROR'|trans({ '%field%': 'address.cityLabel'|trans|sw_sanitize }) %}
-        {% set violationPath = null %}
     {% endif %}
 
     {% set cityAutocomplete = 'address-level2' %}

--- a/src/Storefront/Resources/views/storefront/component/address/field/address-street-field.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/field/address-street-field.html.twig
@@ -3,8 +3,6 @@
         {% set violationPath = '/street' %}
     {% elseif formViolations.getViolations("/#{prefix}/street") is not empty %}
         {% set violationPath = "/#{prefix}/street" %}
-    {% else %}
-        {% set requiredMessage = 'error.VIOLATION::IS_BLANK_ERROR'|trans({ '%field%': 'address.streetLabel'|trans|sw_sanitize }) %}
     {% endif %}
 
     {% set streetAutocomplete = 'address-line1' %}

--- a/src/Storefront/Resources/views/storefront/component/address/field/address-zipcode-field.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/field/address-zipcode-field.html.twig
@@ -5,8 +5,6 @@
         {% set violationPath = '/zipcode' %}
     {% elseif formViolations.getViolations("/#{prefix}/zipcode") is not empty %}
         {% set violationPath = "/#{prefix}/zipcode" %}
-    {% else %}
-        {% set requiredMessage = 'error.VIOLATION::IS_BLANK_ERROR'|trans({ '%field%': 'address.zipcodeLabel'|trans|sw_sanitize }) %}
     {% endif %}
 
     {% set zipCodeAutocomplete = 'postal-code' %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The variable `requiredMessage` is not needed anymore with the refactoring of the form validation and has probably been missed in the refactoring process.

### 2. What does this change do, exactly?
Remove the variable.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: at the template code.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
