### PR TITLE
fix: meteor transition issues

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-button-process/sw-button-process.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-button-process/sw-button-process.html.twig
@@ -1,9 +1,9 @@
 {% block sw_button_process %}
 <mt-button
     class="sw-button-process"
+    size="default"
     v-bind="$attrs"
     :variant="$attrs.variant || 'secondary'"
-    size="default"
 >
 
     <mt-icon

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-details-modal/sw-extension-permissions-details-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-details-modal/sw-extension-permissions-details-modal.html.twig
@@ -2,6 +2,7 @@
 <sw-modal
     class="sw-extension-permissions-details-modal"
     :title="modalTitle"
+    @modal-close="close"
 >
     {% block sw_extension_permissions_details_modal_content %}
     {% block sw_extension_permissions_details_modal_table %}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-rating-stars/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-rating-stars/index.js
@@ -50,9 +50,7 @@ export default {
         },
 
         starSize() {
-            return {
-                width: `${this.sizeValue * this.scaleFactor}px`,
-            };
+            return `${this.sizeValue * this.scaleFactor}px`;
         },
 
         partialStarSize() {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-rating-stars/sw-extension-rating-stars.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-rating-stars/sw-extension-rating-stars.html.twig
@@ -17,7 +17,7 @@
             {% block sw_extension_rating_stars_wrapper_stars_full_star %}
             <mt-icon
                 name="solid-star"
-                :style="starSize"
+                :size="starSize"
             />
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-ratings-summary/sw-extension-ratings-summary.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-ratings-summary/sw-extension-ratings-summary.scss
@@ -20,6 +20,7 @@
 
         .mt-progress-bar {
             height: 4px;
+            row-gap: 0;
 
             .mt-progress-bar__fill {
                 background: #667f99;
@@ -27,6 +28,11 @@
 
             .mt-progress-bar__track {
                 background: $color-gray-200;
+            }
+
+            .mt-field-label,
+            .mt-progress-bar__progress-label {
+                display: none;
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/index.ts
@@ -142,9 +142,7 @@ export default Shopware.Component.wrapComponentConfig({
                     .finally(() => {
                         this.isLoading = false;
                     });
-            }
-
-            if (this.invalidPromotionCodes.length > 0) {
+            } else if (this.invalidPromotionCodes.length > 0) {
                 this.openInvalidCodeModal();
             } else {
                 this.showError();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- Permission modal was not closing
- Rating stars are too large (missed transition to GitHub)
- Rating bar shouldn't have a label (missed transition to GitHub)
- Progress button should allow overriding the size attribute

### 2. What does this change do, exactly?
Fixes the mentioned issues

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- fixes #8982
- fixes #8983
- fixes #9002

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
