### PR TITLE
fix: promotion deletion cart error

### DIFF
--- a/changelog/_unreleased/2025-05-05-fixed-promotion-deletion-cart-error.md
+++ b/changelog/_unreleased/2025-05-05-fixed-promotion-deletion-cart-error.md
@@ -1,0 +1,9 @@
+---
+title: Fixed promotion deletion cart error
+issue: 8285
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `src/Core/Checkout/Promotion/Cart/PromotionCollector.php` to only use line items of type promotion for deletion notices.

--- a/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
@@ -171,8 +171,7 @@ class PromotionCollector implements CartDataCollectorInterface
             // addition notifications are handled as usual in the PromotionCalculator
             if ($behavior->isRecalculation()) {
                 $oldPromotions = $original->getLineItems()
-                    ->filterType(PromotionProcessor::LINE_ITEM_TYPE)
-                    ->filter(static fn (LineItem $item) => !$item->getReferencedId())
+                    ->filter(static fn (LineItem $item) => $item->getType() === PromotionProcessor::LINE_ITEM_TYPE && !$item->getReferencedId())
                     ->getElements();
                 $newPromotions = $discountLineItems->filter(static fn (LineItem $item) => !$item->getReferencedId())->getElements();
 

--- a/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
@@ -170,7 +170,10 @@ class PromotionCollector implements CartDataCollectorInterface
             // when being in a recalculation, having notifications about the removal of automatic promotion is desired
             // addition notifications are handled as usual in the PromotionCalculator
             if ($behavior->isRecalculation()) {
-                $oldPromotions = $original->getLineItems()->filter(static fn (LineItem $item) => !$item->getReferencedId())->getElements();
+                $oldPromotions = $original->getLineItems()
+                    ->filterType(PromotionProcessor::LINE_ITEM_TYPE)
+                    ->filter(static fn (LineItem $item) => !$item->getReferencedId())
+                    ->getElements();
                 $newPromotions = $discountLineItems->filter(static fn (LineItem $item) => !$item->getReferencedId())->getElements();
 
                 foreach (\array_diff_key($oldPromotions, $newPromotions) as $removedPromotion) {

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
@@ -92,6 +92,23 @@ class PromotionCollectorTest extends TestCase
         static::assertNull($promotionLast->getExtension(OrderConverter::ORIGINAL_ID));
     }
 
+    public function testCollectWithCreditLineItemInRecalculation(): void
+    {
+        $discountId = Uuid::randomHex();
+        $promotionId = Uuid::randomHex();
+
+        $cart = $this->prepareCart([$discountId], $promotionId);
+
+        $creditLineItem = new LineItem(Uuid::randomHex(), LineItem::CREDIT_LINE_ITEM_TYPE);
+        $cart->add($creditLineItem);
+
+        $cartDataCollection = new CartDataCollection();
+
+        $this->promotionCollector->collect($cartDataCollection, $cart, $this->context, new CartBehavior(isRecalculation: true));
+
+        static::assertEmpty($cart->getErrors()->getElements());
+    }
+
     public function testPromotionWithInvalidOrderCount(): void
     {
         $cart = $this->prepareCart([Uuid::randomHex(), Uuid::randomHex()], Uuid::randomHex(), 2, 1);


### PR DESCRIPTION

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Adding a credit line item to an existing order results in a promotion deleted notification

### 2. What does this change do, exactly?
The line items used for finding removed promotions missed a line item type filter step.

### 3. Describe each step to reproduce the issue or behaviour.
- Open existing order
- Add/Edit credit item

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
fixes #8285

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
