### PR TITLE
chore: Fully remove Aministration class from Core

### DIFF
--- a/src/Administration/Framework/Twig/ViteFileAccessorDecorator.php
+++ b/src/Administration/Framework/Twig/ViteFileAccessorDecorator.php
@@ -3,6 +3,7 @@
 namespace Shopware\Administration\Framework\Twig;
 
 use Pentatrion\ViteBundle\Service\FileAccessor;
+use Shopware\Core\Framework\Adapter\Twig\EntrypointAccessorInterface;
 use Shopware\Core\Framework\Bundle as ShopwareBundle;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Asset\Package as AssetPackage;
@@ -11,7 +12,7 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 #[Package('framework')]
-class ViteFileAccessorDecorator extends FileAccessor
+class ViteFileAccessorDecorator extends FileAccessor implements EntrypointAccessorInterface
 {
     private string $assetPath;
 

--- a/src/Administration/Resources/config/services.xml
+++ b/src/Administration/Resources/config/services.xml
@@ -174,5 +174,8 @@
             <argument type="service" id="kernel"/>
             <argument type="service" id="filesystem"/>
         </service>
+
+        <service id="Shopware\Core\Framework\Adapter\Twig\EntrypointAccessorInterface"
+            alias="Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator"/>
     </services>
 </container>

--- a/src/Core/Framework/Adapter/Twig/EntrypointAccessorDummy.php
+++ b/src/Core/Framework/Adapter/Twig/EntrypointAccessorDummy.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Twig;
+
+use Shopware\Core\Framework\Bundle as ShopwareBundle;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class EntrypointAccessorDummy implements EntrypointAccessorInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBundleData(ShopwareBundle $bundle): array
+    {
+        return [];
+    }
+}

--- a/src/Core/Framework/Adapter/Twig/EntrypointAccessorInterface.php
+++ b/src/Core/Framework/Adapter/Twig/EntrypointAccessorInterface.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Twig;
+
+use Shopware\Core\Framework\Bundle as ShopwareBundle;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+interface EntrypointAccessorInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBundleData(ShopwareBundle $bundle): array;
+}

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -3,8 +3,8 @@
 namespace Shopware\Core\Framework\Api\Controller;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator;
 use Shopware\Core\Content\Flow\Api\FlowActionCollector;
+use Shopware\Core\Framework\Adapter\Twig\EntrypointAccessorInterface;
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\EntitySchemaGenerator;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi3Generator;
@@ -58,7 +58,7 @@ class InfoController extends AbstractController
         private readonly SystemConfigService $systemConfigService,
         private readonly ApiRouteInfoResolver $apiRouteInfoResolver,
         private readonly InAppPurchase $inAppPurchase,
-        private readonly ?ViteFileAccessorDecorator $viteFileAccessorDecorator,
+        private readonly EntrypointAccessorInterface $entrypointAccessor,
         private readonly Filesystem $filesystem,
         private readonly ShopIdProvider $shopIdProvider,
     ) {
@@ -243,12 +243,7 @@ class InfoController extends AbstractController
                 continue;
             }
 
-            if (!$this->viteFileAccessorDecorator) {
-                // Admin bundle is not there, admin assets are not available
-                continue;
-            }
-
-            $viteEntryPoints = $this->viteFileAccessorDecorator->getBundleData($bundle);
+            $viteEntryPoints = $this->entrypointAccessor->getBundleData($bundle);
 
             $technicalBundleName = $this->getTechnicalBundleName($bundle);
             $styles = $viteEntryPoints['entryPoints'][$technicalBundleName]['css'] ?? [];

--- a/src/Core/Framework/DependencyInjection/api.xml
+++ b/src/Core/Framework/DependencyInjection/api.xml
@@ -172,7 +172,7 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Core\Framework\Api\Route\ApiRouteInfoResolver"/>
             <argument type="service" id="Shopware\Core\Framework\Store\InAppPurchase"/>
-            <argument type="service" id="Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator" on-invalid="null"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\EntrypointAccessorInterface"/>
             <argument type="service" id="filesystem"/>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
 

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -333,6 +333,10 @@ frame-ancestors 'none';
         </service>
 
         <!-- Twig -->
+        <service id="Shopware\Core\Framework\Adapter\Twig\EntrypointAccessorInterface"
+            class="Shopware\Core\Framework\Adapter\Twig\EntrypointAccessorDummy">
+        </service>
+
         <service id="Shopware\Core\Framework\Adapter\Twig\TemplateFinder" public="true">
             <argument type="service" id="twig"/>
             <argument type="service" id="twig.loader"/>

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -6,8 +6,8 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator;
 use Shopware\Core\Content\Flow\Api\FlowActionCollector;
+use Shopware\Core\Framework\Adapter\Twig\EntrypointAccessorInterface;
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\Controller\InfoController;
 use Shopware\Core\Framework\Api\Route\ApiRouteInfoResolver;
@@ -23,7 +23,6 @@ use Shopware\Core\Framework\Test\Store\StaticInAppPurchaseFactory;
 use Shopware\Core\Maintenance\System\Service\AppUrlVerifier;
 use Shopware\Core\Test\Stub\Symfony\StubKernel;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
-use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
@@ -183,12 +182,7 @@ class InfoControllerTest extends TestCase
             new StaticSystemConfigService(),
             $this->createMock(ApiRouteInfoResolver::class),
             $this->inAppPurchase,
-            new ViteFileAccessorDecorator(
-                [],
-                $this->createMock(UrlPackage::class),
-                $kernel,
-                new Filesystem(),
-            ),
+            $this->createMock(EntrypointAccessorInterface::class),
             new Filesystem(),
             $this->shopIdProvider,
         );


### PR DESCRIPTION

### 1. Why is this change necessary?

It fully removes Administration code from the Core package.

### 2. What does this change do, exactly?

Introduce a new `EntrypointAccessorInterface` in the Core that is injected in the `InfoController` instead of the `ViteFileAccessorDecorator` from the Admnistration. The interface only contains the relevant method that is used in the controller: `getBundleData()`

If the Administration bundle is not loaded a dummy implementation is configured that simply returns an empty array.

### 3. Describe each step to reproduce the issue or behaviour.

* Disable Admin bundle in `config/bundles.php`: The `EntrypointAccessorDummy` is used for `EntrypointAccessorInterface` (check with `debug:container EntrypointAccessorInterface`)
* Re-enable Admin bundle: The `ViteFileAccessorDecorator` is used instead
* The `/api/_info/config` route returns the `css` / `js` Entrypoint of the Administration Bundle

### 4. Please link to the relevant issues (if any).

- closes #8855
- relates #8872

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
