### PR TITLE
feat: force track_scores when search in explain mode

### DIFF
--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
@@ -74,6 +74,7 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
 
             if ($context->hasState(self::EXPLAIN_MODE)) {
                 $params['include_named_queries_score'] = true;
+                $params['track_scores'] = true;
             }
 
             $result = $this->client->search($params);

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcherTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcherTest.php
@@ -215,6 +215,7 @@ class ElasticsearchEntitySearcherTest extends TestCase
                 'index' => '',
                 'track_total_hits' => false,
                 'include_named_queries_score' => true,
+                'track_scores' => true,
                 'body' => [
                     'timeout' => '10s',
                     'from' => 0,


### PR DESCRIPTION
By default, when a custom sort is applied, the score is not tracked, but when previewing search results, we want to monitor this score