### PR TITLE
fix: remove extra closing curly brace (#9060)

### DIFF
--- a/changelog/_unreleased/2025-05-06-fix-remove-extra-closing-curly-brace.md
+++ b/changelog/_unreleased/2025-05-06-fix-remove-extra-closing-curly-brace.md
@@ -1,0 +1,9 @@
+---
+title: Remove extra closing curly brace
+issue: #9060
+author: Melvin Achterhuis
+author_email: melvin@achterhuis.work
+author_github: @MelvinAchterhuis
+---
+# Storefront
+* Changed `Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig`, removed extra closing curly brace in nav-item class attribute.

--- a/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
@@ -33,7 +33,7 @@
 
                             {% block layout_navbar_menu_item %}
                                 {% if category.type == 'folder' %}
-                                    <li class="nav-item nav-item-{{ id }}}">
+                                    <li class="nav-item nav-item-{{ id }}">
                                         <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2{% if hasChildren %} dropdown-toggle{% endif %}"
                                            href="#"
                                            {% if hasChildren %}data-bs-toggle="dropdown"{% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?

Removes extra unnecessary closing curly brace in nav-item class attribute 

### 2. What does this change do, exactly?

See 1

### 3. Describe each step to reproduce the issue or behaviour.

Create category with type folder and see curly brace in HTML output

### 4. Please link to the relevant issues (if any).
fixes #9060 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
