### PR TITLE
fix: fix styling in sw-entity-multi-select and dynamic product groups

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.scss
@@ -30,6 +30,8 @@
     .mt-block-field__block,
     .sw-block-field .sw-block-field__block {
         border: 0;
+        min-height: auto;
+        height: auto;
     }
 
     .sw-block-field.has--focus .sw-block-field__block {
@@ -61,6 +63,10 @@
 
     .sw-product-stream-value__placeholder {
         height: 100%;
+    }
+
+    .sw-label {
+        height: auto;
     }
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/8911

### 2. What does this change do, exactly?

Fix the styling:

<img width="1263" alt="Bildschirmfoto 2025-05-06 um 10 15 30" src="https://github.com/user-attachments/assets/6e4c7b21-47d4-40f8-a1f8-d3901456817f" />
<img width="1165" alt="Bildschirmfoto 2025-05-06 um 10 15 43" src="https://github.com/user-attachments/assets/4cbc76b4-11a9-4c2e-bd8d-47702c242b15" />
