### PR TITLE
chore(sw-tree-item): Fix icon size on dragging

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.html.twig
@@ -244,7 +244,7 @@
     </div>
     {% endblock %}
 
-    {# ToDO: Repeat statt duplicated Content #}
+    {# ToDo: Repeat instead of duplicated Content #}
     {% block sw_tree_item_children_transition %}
     <transition name="fade">
         {% block sw_tree_item_children_content %}

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
@@ -171,10 +171,7 @@ $sw-tree-item-color-text: $color-darkgray-200;
         }
 
         .icon--regular-chevron-right-xxs {
-            padding-top: 6px;
-            padding-right: 7px;
-            padding-bottom: 8px;
-            padding-left: 9px;
+            padding: 6px 7px 8px 9px;
         }
     }
 
@@ -319,6 +316,14 @@ $sw-tree-item-color-text: $color-darkgray-200;
 
         .sw-tree-item__children {
             display: none;
+        }
+
+        .icon--regular-chevron-down-xxs {
+            padding: 7px;
+        }
+
+        .icon--regular-chevron-right-xxs {
+            padding: 6px 7px 8px 9px;
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Icon is too big

### 2. What does this change do, exactly?
Add the adjustment classes also when the item will be dragged

### 3. Describe each step to reproduce the issue or behaviour.
- Go to categories
- Drag a category
- See huge item

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
