### PR TITLE
fix: Add padding bottom to category tree

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
@@ -43,7 +43,7 @@
         padding: 0;
 
         .tree-items {
-            padding: 16px 16px 0;
+            padding: 16px 16px 16px;
             width: max-content;
             min-width: 100%;
         }

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
@@ -43,7 +43,7 @@
         padding: 0;
 
         .tree-items {
-            padding: 16px 16px 16px;
+            padding: 16px;
             width: max-content;
             min-width: 100%;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
On small screens the horizontal scrollbar overlaps the bottom of the tree's input field causing the underline to be hidden.
This padding fix ensures that the last row of inputs is pushed up above the scrollbar so their bottom border remains fully visible and accessible

### 2. What does this change do, exactly?
It adjusts the .tree-items container’s padding to 16px
![image](https://github.com/user-attachments/assets/4b86027b-e4e8-4659-a33b-f05f21219582)


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
