### PR TITLE
fix: overflow issues in sw-entity-multi-select

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-selection-list/sw-select-selection-list.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-selection-list/sw-select-selection-list.scss
@@ -5,6 +5,7 @@
     flex-wrap: wrap;
     list-style: none;
     width: calc(100% - 30px);
+    overflow: hidden;
 
     .sw-select-selection-list__item-holder {
         max-width: 220px;
@@ -29,9 +30,11 @@
 
     .sw-select-selection-list__input-wrapper {
         flex: 1 1 0;
+        position: relative;
     }
 
     .sw-select-selection-list__input {
+        position: absolute;
         display: inline-block;
         min-width: 200px;
         padding: 12px 16px 12px 8px;

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-selection-list/sw-select-selection-list.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-selection-list/sw-select-selection-list.scss
@@ -34,9 +34,8 @@
     }
 
     .sw-select-selection-list__input {
-        position: absolute;
+        float: right;
         display: inline-block;
-        min-width: 200px;
         padding: 12px 16px 12px 8px;
 
         &::placeholder {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
@@ -24,3 +24,8 @@
         }
     }
 }
+
+.sw-entity-multi-select .sw-block-field__block {
+    min-height: 48px;
+    height: auto;
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The `sw-entity-multi-select` has overflowing issues caused by the input field always wrapping into the "next" line. 

### 2. What does this change do, exactly?
Use float on the input inside of it's flex-controlled container, so it snaps to the end of line, instead of always breaking into a new line.

### 3. Describe each step to reproduce the issue or behaviour.
Use any multi select (SalesChannel detail, Product detail, etc.)

Before:

![image](https://github.com/user-attachments/assets/18c17718-e9c9-4df1-bfb7-30d8766cd810)

After:

![image](https://github.com/user-attachments/assets/687b57fd-3ee5-44dc-bbae-28189d393c3a)

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/8914

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
