### PR TITLE
fix: added removed property for cart table

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig
@@ -16,6 +16,9 @@
         {% set infoColumnSize = infoColumnSize - 1 %}
     {% endif %}
 
+    {# @deprecated tag:v6.8.0 - Will be removed, use infoColumnSize wit a prefix instead. #}
+    {% set infoColumnClass = 'col-' ~ infoColumnSize %}
+
     {% block component_checkout_cart_header_element %}
         <li class="card-title cart-table-header" aria-hidden="true">
 

--- a/src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig
@@ -16,7 +16,7 @@
         {% set infoColumnSize = infoColumnSize - 1 %}
     {% endif %}
 
-    {# @deprecated tag:v6.8.0 - Will be removed, use infoColumnSize wit a prefix instead. #}
+    {# @deprecated tag:v6.8.0 - Will be removed, use infoColumnSize with a prefix instead. #}
     {% set infoColumnClass = 'col-' ~ infoColumnSize %}
 
     {% block component_checkout_cart_header_element %}


### PR DESCRIPTION
### 1. Why is this change necessary?
With https://github.com/shopware/shopware/pull/8005 a variable was removed without deprecation notice. Leads into broken themes like [commercial](https://github.com/shopware/SwagCommercial/blob/trunk/src/B2B/ShoppingList/Resources/views/storefront/component/checkout/cart-header.html.twig#L5).

### 2. What does this change do, exactly?
Re-added the old variable.

### 3. Describe each step to reproduce the issue or behaviour.
Overwrite the block and use the old variable

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/8005
- Closes https://github.com/shopware/SwagCommercial/issues/593

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
