### PR TITLE
fix: Add label and value property

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -435,6 +435,8 @@
             :label="$tc('sw-sales-channel.detail.productComparison.encoding')"
             :placeholder="$tc('sw-sales-channel.detail.productComparison.placeholderSelectEncoding')"
             :options="getEncodingOptions"
+            label-property="label"
+            value-property="id"
             :disabled="!acl.can('sales_channel.editor') || undefined"
             required
             :error="productExportEncodingError"
@@ -447,6 +449,8 @@
             :label="$tc('sw-sales-channel.detail.productComparison.fileFormat')"
             :placeholder="$tc('sw-sales-channel.detail.productComparison.placeholderSelectFileFormat')"
             :options="getFileFormatOptions"
+            label-property="label"
+            value-property="id"
             required
             :disabled="!acl.can('sales_channel.editor') || undefined"
             :error="productExportFileFormatError"
@@ -468,7 +472,7 @@
             :model-value="productExport.interval"
             :label="$tc('sw-sales-channel.detail.productComparison.interval')"
             :options="getIntervalOptions"
-            label-property="name"
+            label-property="label"
             value-property="id"
             :disabled="!acl.can('sales_channel.editor') || undefined"
             @update:model-value="changeInterval"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

**Note**: This PR does not include a fix for the template select visual bug (it doesn’t affect functionality). A separate ticket has been opened for that (https://github.com/shopware/shopware/issues/9132).

### 1. Why is this change necessary?
By default `<mt-select>` doesn’t know which keys on option objects to use for the visible text and the bound value.In our case we passed objects like : 

```
getEncodingOptions() {
  return [
    { id: 'ISO-8859-1', label: 'ISO-8859-1' },
    { id: 'UTF-8',     label: 'UTF-8'     },
  ];
}
```

### 2. What does this change do, exactly?
Using `label-property="label"` and  `value-property="id"` we explicitly instruct `<mt-select>` to render label in dropdown and bind those option's id back to v-model

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
