### PR TITLE
feat: added customer orders card title

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
@@ -193,7 +193,8 @@
       "emptyTitle": "Noch keine Bestellungen",
       "emptySearchTitle": "Keine Suchergebnisse",
       "emptySubline": "Hier kannst Du die Bestellungen Deiner Kunden verwalten",
-      "buttonCreateOrder": "Bestellung anlegen"
+      "buttonCreateOrder": "Bestellung anlegen",
+      "ordersTitle": "Bestellungen"
     },
     "imitateCustomerModal": {
       "modalTitle": "Anmelden als {firstname} {lastname}",

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
@@ -193,7 +193,8 @@
       "emptyTitle": "No orders yet",
       "emptySearchTitle": "No search result",
       "emptySubline": "Manage your customers' orders here",
-      "buttonCreateOrder": "Add order"
+      "buttonCreateOrder": "Add order",
+      "ordersTitle": "Orders"
     },
     "imitateCustomerModal": {
       "modalTitle": "Log in as {firstname} {lastname}",

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
@@ -1,6 +1,7 @@
 {% block sw_customer_detail_order_card %}
 <mt-card
     class="sw-customer-detail-order"
+    :title="$tc('sw-customer.detailOrder.ordersTitle')"
     position-identifier="sw-customer-detail-order"
 >
     {% block sw_customer_detail_order_card_toolbar %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The orders card had a missing `:title` attribute

### 2. What does this change do, exactly?
Adds the missing `:title` attribute

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/issues/8980 (fixes #8980)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
