### PR TITLE
[6.7.0.0] fix: NEXT-40000 - add order transaction transition action pay (#7652)

### DIFF
--- a/changelog/_unreleased/2024-12-19-rename-transaction-transition-action-pay-and-pay-partially.md
+++ b/changelog/_unreleased/2024-12-19-rename-transaction-transition-action-pay-and-pay-partially.md
@@ -1,0 +1,8 @@
+---
+title: Rename `order_transaction` transition action `pay` and `pay_partially`
+issue: NEXT-40000
+---
+# Core
+* Added migration `Shopware\Core\Migration\V6_7\Migration1742302302RenamePaidTransitionActions` to add duplicate transition names `paid/paid_partially/process` for respective `pay`, `pay_partially` and `do_pay`. The migration will remove the old transition names `pay/pay_partially/do_pay` destructively, according to the version selection mode in the future.
+* Added new method `Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler::paidPartially` to fulfill the new action name `paid_partially`
+* Deprecated method `Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler::payPartially` since the transition action `pay_partially` no longer exists

--- a/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandler.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandler.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransaction;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
 use Shopware\Core\System\StateMachine\Exception\IllegalTransitionException;
@@ -68,7 +69,7 @@ class OrderTransactionStateHandler
             new Transition(
                 OrderTransactionDefinition::ENTITY_NAME,
                 $transactionId,
-                StateMachineTransitionActions::ACTION_DO_PAY,
+                StateMachineTransitionActions::ACTION_PROCESS,
                 'stateId'
             ),
             $context
@@ -112,11 +113,28 @@ class OrderTransactionStateHandler
     }
 
     /**
+     * @deprecated tag:v6.8.0 - Will be removed. Use OrderTransactionStateHandler::paidPartially instead
+     *
      * @throws InconsistentCriteriaIdsException
      * @throws StateMachineException
      * @throws IllegalTransitionException
      */
     public function payPartially(string $transactionId, Context $context): void
+    {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0', 'OrderTransactionStateHandler::paidPartially')
+        );
+
+        $this->paidPartially($transactionId, $context);
+    }
+
+    /**
+     * @throws InconsistentCriteriaIdsException
+     * @throws StateMachineException
+     * @throws IllegalTransitionException
+     */
+    public function paidPartially(string $transactionId, Context $context): void
     {
         $this->stateMachineRegistry->transition(
             new Transition(

--- a/src/Core/Migration/V6_7/Migration1742302302RenamePaidTransitionActions.php
+++ b/src/Core/Migration/V6_7/Migration1742302302RenamePaidTransitionActions.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class Migration1742302302RenamePaidTransitionActions extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1742302302;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // create duplicate transitions, if they do not exist for:
+        // pay -> paid
+        // pay_partially -> paid_partially
+        // do_pay -> process
+        $query = <<<SQL
+            INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, custom_fields, created_at)
+                SELECT UNHEX(REPLACE(UUID(), "-", "")), t.state_machine_id, t.from_state_id, t.to_state_id, :newActionName, t.custom_fields, :createdAt
+                FROM `state_machine_transition` t
+                LEFT JOIN `state_machine_transition` existing
+                    ON t.state_machine_id = existing.state_machine_id
+                    AND t.from_state_id = existing.from_state_id
+                    AND t.to_state_id = existing.to_state_id
+                    AND existing.action_name = :newActionName
+                WHERE t.action_name = :oldActionName
+                    AND existing.id IS NULL
+            SQL;
+
+        $connection->executeStatement($query, [
+            'id' => Uuid::randomBytes(),
+            'newActionName' => 'paid',
+            'oldActionName' => 'pay',
+            'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $connection->executeStatement($query, [
+            'id' => Uuid::randomBytes(),
+            'newActionName' => 'paid_partially',
+            'oldActionName' => 'pay_partially',
+            'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $connection->executeStatement($query, [
+            'id' => Uuid::randomBytes(),
+            'newActionName' => 'process',
+            'oldActionName' => 'do_pay',
+            'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // remove old transition names
+        $connection->delete('state_machine_transition', ['action_name' => 'pay']);
+        $connection->delete('state_machine_transition', ['action_name' => 'pay_partially']);
+        $connection->delete('state_machine_transition', ['action_name' => 'do_pay']);
+    }
+}

--- a/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionActions.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionActions.php
@@ -9,6 +9,10 @@ final class StateMachineTransitionActions
 {
     public const ACTION_CANCEL = 'cancel';
     public const ACTION_COMPLETE = 'complete';
+
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed in 6.8.0. Use ACTION_PROCESS instead
+     */
     public const ACTION_DO_PAY = 'do_pay';
     public const ACTION_FAIL = 'fail';
     public const ACTION_PAID = 'paid';

--- a/tests/integration/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandlerTest.php
+++ b/tests/integration/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandlerTest.php
@@ -85,7 +85,7 @@ class OrderTransactionStateHandlerTest extends TestCase
                 'refund' => OrderTransactionStates::STATE_REFUNDED,
             ]],
             'Partially pay & Refund' => [[
-                'payPartially' => OrderTransactionStates::STATE_PARTIALLY_PAID,
+                'paidPartially' => OrderTransactionStates::STATE_PARTIALLY_PAID,
                 'refund' => OrderTransactionStates::STATE_REFUNDED,
             ]],
             'Pay & Partially Refund' => [[
@@ -98,7 +98,7 @@ class OrderTransactionStateHandlerTest extends TestCase
                 'fail' => OrderTransactionStates::STATE_FAILED,
             ]],
             'Partially Pay & Process & Pay' => [[
-                'payPartially' => OrderTransactionStates::STATE_PARTIALLY_PAID,
+                'paidPartially' => OrderTransactionStates::STATE_PARTIALLY_PAID,
                 'processUnconfirmed' => OrderTransactionStates::STATE_UNCONFIRMED,
                 'paid' => OrderTransactionStates::STATE_PAID,
             ]],
@@ -106,6 +106,14 @@ class OrderTransactionStateHandlerTest extends TestCase
                 'paid' => OrderTransactionStates::STATE_PAID,
                 'chargeback' => OrderTransactionStates::STATE_CHARGEBACK,
                 'cancel' => OrderTransactionStates::STATE_CANCELLED,
+            ]],
+            'Partially Pay & Pay' => [[
+                'paidPartially' => OrderTransactionStates::STATE_PARTIALLY_PAID,
+                'paid' => OrderTransactionStates::STATE_PAID,
+            ]],
+            'Remind & Pay' => [[
+                'remind' => OrderTransactionStates::STATE_REMINDED,
+                'paid' => OrderTransactionStates::STATE_PAID,
             ]],
         ];
     }

--- a/tests/integration/Core/Checkout/Order/Listener/OrderStateChangeEventListenerTest.php
+++ b/tests/integration/Core/Checkout/Order/Listener/OrderStateChangeEventListenerTest.php
@@ -56,7 +56,7 @@ class OrderStateChangeEventListenerTest extends TestCase
                 new Transition(
                     OrderTransactionDefinition::ENTITY_NAME,
                     $ids->get('transaction'),
-                    StateMachineTransitionActions::ACTION_DO_PAY,
+                    StateMachineTransitionActions::ACTION_PROCESS,
                     'stateId'
                 ),
                 Context::createDefaultContext()

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderServiceTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderServiceTest.php
@@ -376,7 +376,7 @@ class OrderServiceTest extends TestCase
 
         $this->orderService->orderTransactionStateTransition(
             $orderTransactionId,
-            'pay_partially',
+            'paid_partially',
             new RequestDataBag(),
             $this->salesChannelContext->getContext()
         );
@@ -432,7 +432,7 @@ class OrderServiceTest extends TestCase
 
         $this->orderService->orderTransactionStateTransition(
             $orderTransactionId,
-            'pay_partially',
+            'paid_partially',
             new RequestDataBag(['sendMail' => false]),
             $this->salesChannelContext->getContext()
         );

--- a/tests/migration/Core/V6_7/Migration1742302302RenamePaidTransitionActionsTest.php
+++ b/tests/migration/Core/V6_7/Migration1742302302RenamePaidTransitionActionsTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1742302302RenamePaidTransitionActions;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Migration1742302302RenamePaidTransitionActions::class)]
+class Migration1742302302RenamePaidTransitionActionsTest extends TestCase
+{
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->getContainer()->get(Connection::class);
+    }
+
+    public function testMigrationUpdate(): void
+    {
+        $stateMachineId = Uuid::randomBytes();
+        $fromStateId = Uuid::randomBytes();
+        $toStateId = Uuid::randomBytes();
+
+        $duplicateTransition1 = Uuid::randomBytes();
+        $duplicateTransition2 = Uuid::randomBytes();
+        $duplicateTransition3 = Uuid::randomBytes();
+        $validTransition = Uuid::randomBytes();
+
+        $this->connection->executeStatement('INSERT INTO `state_machine` (id, technical_name, created_at) VALUES (?, ?, ?)', [$stateMachineId, 'state_machine', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        $this->connection->executeStatement('INSERT INTO `state_machine_state` (id, state_machine_id, technical_name, created_at) VALUES (?, ?, ?, ?)', [$fromStateId, $stateMachineId, 'from_state', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_state` (id, state_machine_id, technical_name, created_at) VALUES (?, ?, ?, ?)', [$toStateId, $stateMachineId, 'to_state', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // Insert duplicate transitions
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition1, $stateMachineId, $fromStateId, $toStateId, 'pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition2, $stateMachineId, $fromStateId, $toStateId, 'do_pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition3, $stateMachineId, $fromStateId, $toStateId, 'paid', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // Insert a random transition
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$validTransition, $stateMachineId, $fromStateId, $toStateId, 'other_action', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        $migration = new Migration1742302302RenamePaidTransitionActions();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $remainingTransitions = $this->connection->fetchFirstColumn('SELECT id FROM `state_machine_transition` WHERE from_state_id = ? AND to_state_id = ?', [$fromStateId, $toStateId]);
+
+        static::assertContains($duplicateTransition1, $remainingTransitions);
+        static::assertContains($duplicateTransition2, $remainingTransitions);
+        static::assertContains($duplicateTransition3, $remainingTransitions);
+
+        static::assertContains($validTransition, $remainingTransitions);
+    }
+
+    public function testMigrationUpdateDestructive(): void
+    {
+        $stateMachineId = Uuid::randomBytes();
+        $fromStateId = Uuid::randomBytes();
+        $toStateId = Uuid::randomBytes();
+
+        $duplicateTransition1 = Uuid::randomBytes();
+        $duplicateTransition2 = Uuid::randomBytes();
+        $duplicateTransition3 = Uuid::randomBytes();
+        $validTransition = Uuid::randomBytes();
+
+        $this->connection->executeStatement('INSERT INTO `state_machine` (id, technical_name, created_at) VALUES (?, ?, ?)', [$stateMachineId, 'state_machine', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        $this->connection->executeStatement('INSERT INTO `state_machine_state` (id, state_machine_id, technical_name, created_at) VALUES (?, ?, ?, ?)', [$fromStateId, $stateMachineId, 'from_state', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_state` (id, state_machine_id, technical_name, created_at) VALUES (?, ?, ?, ?)', [$toStateId, $stateMachineId, 'to_state', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // Insert duplicate transitions
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition1, $stateMachineId, $fromStateId, $toStateId, 'pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition2, $stateMachineId, $fromStateId, $toStateId, 'do_pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition3, $stateMachineId, $fromStateId, $toStateId, 'paid', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // Insert a random transition
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$validTransition, $stateMachineId, $fromStateId, $toStateId, 'other_action', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        $migration = new Migration1742302302RenamePaidTransitionActions();
+        $migration->updateDestructive($this->connection);
+        $migration->updateDestructive($this->connection);
+
+        $remainingTransitions = $this->connection->fetchFirstColumn('SELECT id FROM `state_machine_transition` WHERE from_state_id = ? AND to_state_id = ?', [$fromStateId, $toStateId]);
+
+        static::assertNotContains($duplicateTransition1, $remainingTransitions);
+        static::assertNotContains($duplicateTransition2, $remainingTransitions);
+
+        static::assertContains($duplicateTransition3, $remainingTransitions);
+        static::assertContains($validTransition, $remainingTransitions);
+    }
+}

--- a/tests/unit/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandlerTest.php
+++ b/tests/unit/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandlerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
@@ -48,7 +49,7 @@ class OrderTransactionStateHandlerTest extends TestCase
 
     public function testProcess(): void
     {
-        $this->stateMachineRegistry(StateMachineTransitionActions::ACTION_DO_PAY);
+        $this->stateMachineRegistry(StateMachineTransitionActions::ACTION_PROCESS);
         $this->stateHandler->process($this->transactionId, Context::createDefaultContext());
     }
 
@@ -66,8 +67,16 @@ class OrderTransactionStateHandlerTest extends TestCase
 
     public function testPayPartially(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $this->stateMachineRegistry(StateMachineTransitionActions::ACTION_PAID_PARTIALLY);
         $this->stateHandler->payPartially($this->transactionId, Context::createDefaultContext());
+    }
+
+    public function testPaidPartially(): void
+    {
+        $this->stateMachineRegistry(StateMachineTransitionActions::ACTION_PAID_PARTIALLY);
+        $this->stateHandler->paidPartially($this->transactionId, Context::createDefaultContext());
     }
 
     public function testRefund(): void


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/7652

Original PR: https://github.com/shopware/shopware/pull/5803

### 1. Why is this change necessary?

Our transition names can be irritating at times. This PR aims to clean that up.

### 2. What does this change do, exactly?

The underlying migration first aims to create following duplicate order transaction transitions actions, if not existing:
| Old action | new action |
|--------|--------|
| do_pay | process |
| pay | paid |
| pay_partially | paid_partially | 

If run destructively, the migration will remove the old action names alltogether.

### 3. Describe each step to reproduce the issue or behaviour.

Just have a look at state_machine_transition.

### 4. Please link to the relevant issues (if any).

[https://shopware.atlassian.net/browse/NEXT-40000](https://shopware.atlassian.net/browse/NEXT-40000)
[https://github.com/shopware/shopware/issues/5795](https://github.com/shopware/shopware/issues/5795)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
