### PR TITLE
feat: remove global `controllerName` and `controllerAction` variables from templates

### DIFF
--- a/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
+++ b/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
@@ -8,5 +8,5 @@ author_github: @spigandromeda
 # Storefront
 * Added `is-active-route-{activeRoute}` CSS classes based on the active route to HTML body tag in `base.html.twig`, `single-cms-page.html.twig` and `error-maintenance.html.twig`. New CSS classes added to `_cart.scss`, `_checkout.scss`, `_confirm.scss`, `_finish.scss` and `_register.scss`.
 * Changed `showLineItemModal` condition in `product.html.twig` to use the active route instead of the `controllerName` and `controllerAction` variables.
-* Replaces the usage of `controllerName` and `controllerAction` in JS for analytics with `activeRoute`. Old variables are kept but deprecated.
-* Global `controllerName` and `controller` variables deprecated in `TemplateDataExtension`.
+* Removed the usage of `controllerName` and `controllerAction` in JS for analytics and replaced it with `activeRoute`. Old variables are kept but deprecated.
+* Added deprecations for `controllerName` and `controller` variables in `TemplateDataExtension`.

--- a/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
+++ b/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
@@ -1,0 +1,12 @@
+---
+title: Remove global controllerName and controllerAction variables from templates
+issue: 8285
+author: Martin Bens
+author_email: m.bens@shopware.com
+author_github: @spigandromeda
+---
+# Storefront
+* Added `is-active-route-{activeRoute}` CSS classes based on the active route to HTML body tag in `base.html.twig`, `single-cms-page.html.twig` and `error-maintenance.html.twig`. New CSS classes added to `_cart.scss`, `_checkout.scss`, `_confirm.scss`, `_finish.scss` and `_register.scss`.
+* Changed `showLineItemModal` condition in `product.html.twig` to use the active route instead of the `controllerName` and `controllerAction` variables.
+* Replaces the usage of `controllerName` and `controllerAction` in JS for analytics with `activeRoute`. Old variables are kept but deprecated.
+* Global `controllerName` and `controller` variables deprecated in `TemplateDataExtension`.

--- a/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
+++ b/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
@@ -1,6 +1,7 @@
 ---
 title: Remove global controllerName and controllerAction variables from templates
-issue: 39807
+issue: 7422
+jira_issue: NEXT-39807
 author: Martin Bens
 author_email: m.bens@shopware.com
 author_github: @spigandromeda
@@ -9,4 +10,17 @@ author_github: @spigandromeda
 * Added `is-active-route-{activeRoute}` CSS classes based on the active route to HTML body tag in `base.html.twig`, `single-cms-page.html.twig` and `error-maintenance.html.twig`. New CSS classes added to `_cart.scss`, `_checkout.scss`, `_confirm.scss`, `_finish.scss` and `_register.scss`.
 * Changed `showLineItemModal` condition in `product.html.twig` to use the active route instead of the `controllerName` and `controllerAction` variables.
 * Removed the usage of `controllerName` and `controllerAction` in JS for analytics and replaced it with `activeRoute`. Old variables are kept but deprecated.
-* Added deprecations for `controllerName` and `controllerAction` variables in `TemplateDataExtension`.
+* Deprecated `controllerName` and `controllerAction` variables in `TemplateDataExtension`.
+___
+# Upgrade Information
+Replace `controllerName` and `controllerAction` with `activeRoute`:
+* Twig: Use `activeRoute` instead of `controllerName`/`controllerAction`
+* CSS: Use `.is-active-route-*` instead of `.is-ctl-*` and `.is-act-*`
+* JS: Use `window.activeRoute` instead of `window.controllerName`/`window.actionName`
+* Routes use dots, CSS classes use dashes: `activeRoute|replace({'.': '-'})`
+___
+# Next Major Version Changes
+The following will be removed in Shopware 6.8.0:
+* Twig variables `controllerName` and `controllerAction`
+* CSS classes `is-ctl-*` and `is-act-*`
+* JavaScript window properties `window.controllerName` and `window.actionName`

--- a/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
+++ b/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
@@ -1,6 +1,6 @@
 ---
 title: Remove global controllerName and controllerAction variables from templates
-issue: 8285
+issue: 39807
 author: Martin Bens
 author_email: m.bens@shopware.com
 author_github: @spigandromeda

--- a/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
+++ b/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
@@ -9,4 +9,4 @@ author_github: @spigandromeda
 * Added `is-active-route-{activeRoute}` CSS classes based on the active route to HTML body tag in `base.html.twig`, `single-cms-page.html.twig` and `error-maintenance.html.twig`. New CSS classes added to `_cart.scss`, `_checkout.scss`, `_confirm.scss`, `_finish.scss` and `_register.scss`.
 * Changed `showLineItemModal` condition in `product.html.twig` to use the active route instead of the `controllerName` and `controllerAction` variables.
 * Removed the usage of `controllerName` and `controllerAction` in JS for analytics and replaced it with `activeRoute`. Old variables are kept but deprecated.
-* Added deprecations for `controllerName` and `controller` variables in `TemplateDataExtension`.
+* Added deprecations for `controllerName` and `controllerAction` variables in `TemplateDataExtension`.

--- a/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
+++ b/changelog/_unreleased/2025-05-07-remove-global-controller-name-and-controller-action-from-template.md
@@ -13,6 +13,7 @@ author_github: @spigandromeda
 * Deprecated `controllerName` and `controllerAction` variables in `TemplateDataExtension`.
 ___
 # Upgrade Information
+## Migration from controller variables to activeRoute
 Replace `controllerName` and `controllerAction` with `activeRoute`:
 * Twig: Use `activeRoute` instead of `controllerName`/`controllerAction`
 * CSS: Use `.is-active-route-*` instead of `.is-ctl-*` and `.is-act-*`
@@ -20,6 +21,7 @@ Replace `controllerName` and `controllerAction` with `activeRoute`:
 * Routes use dots, CSS classes use dashes: `activeRoute|replace({'.': '-'})`
 ___
 # Next Major Version Changes
+## Removal of deprecated controller variables
 The following will be removed in Shopware 6.8.0:
 * Twig variables `controllerName` and `controllerAction`
 * CSS classes `is-ctl-*` and `is-act-*`

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -42,6 +42,8 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
             return [];
         }
 
+        [$controllerName, $controllerAction] = $this->getControllerInfo($request);
+
         $themeId = $request->attributes->get(SalesChannelRequest::ATTRIBUTE_THEME_ID);
 
         $activeNavigationId = (string) $request->get('navigationId', $context->getSalesChannel()->getNavigationCategoryId());
@@ -59,10 +61,33 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
                 'showStagingBanner' => $this->showStagingBanner,
             ],
             'themeId' => $themeId, /** Not used in Twig template directly, but in @see \Shopware\Storefront\Framework\Twig\Extension\ConfigExtension::getThemeId */
+            /** @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it will be replaces with the "activeRoute" variable */
+            'controllerName' => $controllerName,
+            /** @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it will be replaces with the "activeRoute" variable */
+            'controllerAction' => $controllerAction,
             'context' => $context,
             'activeRoute' => $request->attributes->get('_route'),
             'formViolations' => $request->attributes->get('formViolations'),
         ];
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function getControllerInfo(Request $request): array
+    {
+        $controller = $request->attributes->getString('_controller');
+        if ($controller === '') {
+            return ['', ''];
+        }
+
+        $matches = [];
+        preg_match('/Controller\\\\(\w+)Controller::?(\w+)$/', $controller, $matches);
+        if ($matches) {
+            return [$matches[1], $matches[2]];
+        }
+
+        return ['', ''];
     }
 
     private function minSearchLength(SalesChannelContext $context): int

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -61,7 +61,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
                 'showStagingBanner' => $this->showStagingBanner,
             ],
             'themeId' => $themeId, /** Not used in Twig template directly, but in @see \Shopware\Storefront\Framework\Twig\Extension\ConfigExtension::getThemeId */
-            /** @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it will be replaces with the "activeRoute" variable */
+            /** @deprecated tag:v6.8.0 - Will be removed. Use the "activeRoute" variable instead */
             'controllerName' => $controllerName,
             /** @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it will be replaces with the "activeRoute" variable */
             'controllerAction' => $controllerAction,

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -42,8 +42,6 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
             return [];
         }
 
-        [$controllerName, $controllerAction] = $this->getControllerInfo($request);
-
         $themeId = $request->attributes->get(SalesChannelRequest::ATTRIBUTE_THEME_ID);
 
         $activeNavigationId = (string) $request->get('navigationId', $context->getSalesChannel()->getNavigationCategoryId());
@@ -61,31 +59,10 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
                 'showStagingBanner' => $this->showStagingBanner,
             ],
             'themeId' => $themeId, /** Not used in Twig template directly, but in @see \Shopware\Storefront\Framework\Twig\Extension\ConfigExtension::getThemeId */
-            'controllerName' => $controllerName,
-            'controllerAction' => $controllerAction,
             'context' => $context,
             'activeRoute' => $request->attributes->get('_route'),
             'formViolations' => $request->attributes->get('formViolations'),
         ];
-    }
-
-    /**
-     * @return array{0: string, 1: string}
-     */
-    private function getControllerInfo(Request $request): array
-    {
-        $controller = $request->attributes->getString('_controller');
-        if ($controller === '') {
-            return ['', ''];
-        }
-
-        $matches = [];
-        preg_match('/Controller\\\\(\w+)Controller::?(\w+)$/', $controller, $matches);
-        if ($matches) {
-            return [$matches[1], $matches[2]];
-        }
-
-        return ['', ''];
     }
 
     private function minSearchLength(SalesChannelContext $context): int

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -63,7 +63,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
             'themeId' => $themeId, /** Not used in Twig template directly, but in @see \Shopware\Storefront\Framework\Twig\Extension\ConfigExtension::getThemeId */
             /** @deprecated tag:v6.8.0 - Will be removed. Use the "activeRoute" variable instead */
             'controllerName' => $controllerName,
-            /** @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it will be replaces with the "activeRoute" variable */
+            /** @deprecated tag:v6.8.0 - Will be removed. Use the "activeRoute" variable instead */
             'controllerAction' => $controllerAction,
             'context' => $context,
             'activeRoute' => $request->attributes->get('_route'),

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
@@ -4,11 +4,10 @@ export default class AnalyticsEvent
 
     /* eslint-disable no-unused-vars */
     /**
-     * @param {string} controllerName
-     * @param {string} actionName
+     * @param {string} activeRoute
      * @returns {boolean}
      */
-    supports(controllerName, actionName) {
+    supports(activeRoute) {
         console.warn('[Google Analytics Plugin] Method \'supports\' was not overridden by `' + this.constructor.name + '`. Default return set to false.');
         return false;
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
@@ -10,10 +10,6 @@ export default class AnalyticsEvent
      * @returns {boolean}
      */
     supports(controllerName, actionName, activeRoute) {
-        if (controllerName || actionName) {
-            console.warn('[DEPRECATED] tag:v6.8.0 - The parameters "controllerName" and "actionName" in the Google Analytics supports() method are deprecated and will be removed. Please use the "activeRoute" parameter instead.');
-        }
-
         console.warn('[Google Analytics Plugin] Method \'supports\' was not overridden by `' + this.constructor.name + '`. Default return set to false.');
         return false;
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
@@ -10,6 +10,10 @@ export default class AnalyticsEvent
      * @returns {boolean}
      */
     supports(controllerName, actionName, activeRoute) {
+        if (controllerName || actionName) {
+            console.warn('[DEPRECATED] tag:v6.8.0 - The parameters "controllerName" and "actionName" in the Google Analytics supports() method are deprecated and will be removed. Please use the "activeRoute" parameter instead.');
+        }
+
         console.warn('[Google Analytics Plugin] Method \'supports\' was not overridden by `' + this.constructor.name + '`. Default return set to false.');
         return false;
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
@@ -4,8 +4,8 @@ export default class AnalyticsEvent
 
     /* eslint-disable no-unused-vars */
     /**
-     * @param {string} controllerName
-     * @param {string} actionName
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} activeRoute
      * @returns {boolean}
      */

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/analytics-event.js
@@ -4,10 +4,12 @@ export default class AnalyticsEvent
 
     /* eslint-disable no-unused-vars */
     /**
+     * @param {string} controllerName
+     * @param {string} actionName
      * @param {string} activeRoute
      * @returns {boolean}
      */
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         console.warn('[Google Analytics Plugin] Method \'supports\' was not overridden by `' + this.constructor.name + '`. Default return set to false.');
         return false;
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart-by-number.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart-by-number.event.js
@@ -2,6 +2,13 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class AddToCartByNumberEvent extends AnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.checkout.cart.page';
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart-by-number.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart-by-number.event.js
@@ -2,8 +2,8 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class AddToCartByNumberEvent extends AnalyticsEvent
 {
-    supports(controllerName, actionName) {
-        return controllerName === 'checkout' && actionName === 'cartpage';
+    supports(activeRoute) {
+        return activeRoute === 'frontend.checkout.cart.page';
     }
 
     execute() {

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart-by-number.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart-by-number.event.js
@@ -2,7 +2,7 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class AddToCartByNumberEvent extends AnalyticsEvent
 {
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.checkout.cart.page';
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart-by-number.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart-by-number.event.js
@@ -2,7 +2,6 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class AddToCartByNumberEvent extends AnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart.event.js
@@ -2,9 +2,17 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class AddToCartEvent extends EventAwareAnalyticsEvent
 {
-    supports() {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
+    supports(controllerName, actionName, activeRoute) {
         return true;
     }
+    /* eslint-enable no-unused-vars */
 
     getPluginName() {
         return 'AddToCart';

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout-on-cart.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout-on-cart.event.js
@@ -3,7 +3,7 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class BeginCheckoutOnCartEvent extends AnalyticsEvent
 {
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.checkout.cart.page';
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout-on-cart.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout-on-cart.event.js
@@ -3,8 +3,8 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class BeginCheckoutOnCartEvent extends AnalyticsEvent
 {
-    supports(controllerName, actionName) {
-        return controllerName === 'checkout' && actionName === 'cartpage';
+    supports(activeRoute) {
+        return activeRoute === 'frontend.checkout.cart.page';
     }
 
     execute() {

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout-on-cart.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout-on-cart.event.js
@@ -3,6 +3,13 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class BeginCheckoutOnCartEvent extends AnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.checkout.cart.page';
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout-on-cart.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout-on-cart.event.js
@@ -3,7 +3,6 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class BeginCheckoutOnCartEvent extends AnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/begin-checkout.event.js
@@ -3,9 +3,17 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class BeginCheckoutEvent extends EventAwareAnalyticsEvent
 {
-    supports() {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
+    supports(controllerName, actionName, activeRoute) {
         return !!document.querySelector('.begin-checkout-btn');
     }
+    /* eslint-enable no-unused-vars */
 
     getEvents() {
         return {

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/checkout-progress.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/checkout-progress.event.js
@@ -3,7 +3,6 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class CheckoutProgressEvent extends AnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/checkout-progress.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/checkout-progress.event.js
@@ -3,7 +3,7 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class CheckoutProgressEvent extends AnalyticsEvent
 {
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.checkout.cart.page';
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/checkout-progress.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/checkout-progress.event.js
@@ -3,8 +3,8 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class CheckoutProgressEvent extends AnalyticsEvent
 {
-    supports(controllerName, actionName) {
-        return controllerName === 'checkout' && actionName === 'confirmpage';
+    supports(activeRoute) {
+        return activeRoute === 'frontend.checkout.cart.page';
     }
 
     execute() {

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/checkout-progress.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/checkout-progress.event.js
@@ -3,6 +3,13 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class CheckoutProgressEvent extends AnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.checkout.cart.page';
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/login.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/login.event.js
@@ -2,6 +2,13 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class LoginEvent extends EventAwareAnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports(controllerName, actionName, activeRoute) {
         return (activeRoute === 'frontend.account.login.page') || (activeRoute === 'frontend.checkout.register.page');
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/login.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/login.event.js
@@ -2,7 +2,6 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class LoginEvent extends EventAwareAnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/login.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/login.event.js
@@ -2,8 +2,8 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class LoginEvent extends EventAwareAnalyticsEvent
 {
-    supports(controllerName, actionName) {
-        return (controllerName === 'auth' && actionName === 'loginpage') || (controllerName === 'register' && actionName === 'checkoutregisterpage');
+    supports(activeRoute) {
+        return (activeRoute === 'frontend.account.login.page') || (activeRoute === 'frontend.checkout.register.page');
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/login.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/login.event.js
@@ -2,7 +2,7 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class LoginEvent extends EventAwareAnalyticsEvent
 {
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         return (activeRoute === 'frontend.account.login.page') || (activeRoute === 'frontend.checkout.register.page');
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
@@ -3,8 +3,8 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class PurchaseEvent extends AnalyticsEvent
 {
-    supports(controllerName, actionName) {
-        return controllerName === 'checkout' && actionName === 'finishpage' && window.trackOrders;
+    supports(activeRoute) {
+        return activeRoute === 'frontend.checkout.finish.page' && window.trackOrders;
     }
 
     execute() {

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
@@ -3,7 +3,6 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class PurchaseEvent extends AnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
@@ -3,6 +3,13 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class PurchaseEvent extends AnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.checkout.finish.page' && window.trackOrders;
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
@@ -3,7 +3,7 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 
 export default class PurchaseEvent extends AnalyticsEvent
 {
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.checkout.finish.page' && window.trackOrders;
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/remove-from-cart.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/remove-from-cart.event.js
@@ -2,9 +2,17 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class RemoveFromCart extends AnalyticsEvent
 {
-    supports() {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
+    supports(controllerName, actionName, activeRoute) {
         return true;
     }
+    /* eslint-enable no-unused-vars */
 
     execute() {
         document.addEventListener('click', this._onRemoveFromCart.bind(this));

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/search-ajax.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/search-ajax.event.js
@@ -2,9 +2,17 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class SearchAjaxEvent extends EventAwareAnalyticsEvent
 {
-    supports() {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
+    supports(controllerName, actionName, activeRoute) {
         return true;
     }
+    /* eslint-enable no-unused-vars */
 
     getPluginName() {
         return 'SearchWidget';

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/sign-up.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/sign-up.event.js
@@ -2,8 +2,8 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class SignUpEvent extends EventAwareAnalyticsEvent
 {
-    supports(controllerName, actionName) {
-        return (controllerName === 'auth' && actionName === 'loginpage') || (controllerName === 'register' && actionName === 'checkoutregisterpage');
+    supports(activeRoute) {
+        return (activeRoute === 'frontend.account.login.page') || (activeRoute === 'frontend.checkout.register.page');
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/sign-up.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/sign-up.event.js
@@ -2,6 +2,13 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class SignUpEvent extends EventAwareAnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports(controllerName, actionName, activeRoute) {
         return (activeRoute === 'frontend.account.login.page') || (activeRoute === 'frontend.checkout.register.page');
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/sign-up.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/sign-up.event.js
@@ -2,7 +2,7 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class SignUpEvent extends EventAwareAnalyticsEvent
 {
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         return (activeRoute === 'frontend.account.login.page') || (activeRoute === 'frontend.checkout.register.page');
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/sign-up.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/sign-up.event.js
@@ -2,7 +2,6 @@ import EventAwareAnalyticsEvent from 'src/plugin/google-analytics/event-aware-an
 
 export default class SignUpEvent extends EventAwareAnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item-list.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item-list.event.js
@@ -2,6 +2,13 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewItemListEvent extends AnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports() {
         const listingWrapper = document.querySelector('.cms-element-product-listing-wrapper');
         return !!listingWrapper;

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item-list.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item-list.event.js
@@ -2,7 +2,6 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewItemListEvent extends AnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
@@ -2,7 +2,7 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewItemEvent extends AnalyticsEvent
 {
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.detail.page';
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
@@ -2,7 +2,6 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewItemEvent extends AnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
@@ -2,6 +2,13 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewItemEvent extends AnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.detail.page';
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
@@ -2,8 +2,8 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewItemEvent extends AnalyticsEvent
 {
-    supports(controllerName, actionName) {
-        return controllerName === 'product' && actionName === 'index';
+    supports(activeRoute) {
+        return activeRoute === 'frontend.detail.page';
     }
 
     execute() {

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-search-results.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-search-results.js
@@ -2,8 +2,8 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewSearchResults extends AnalyticsEvent
 {
-    supports(controllerName, actionName) {
-        return controllerName === 'search' && actionName === 'search';
+    supports(activeRoute) {
+        return activeRoute === 'frontend.search.page';
     }
 
     execute() {

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-search-results.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-search-results.js
@@ -2,7 +2,7 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewSearchResults extends AnalyticsEvent
 {
-    supports(activeRoute) {
+    supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.search.page';
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-search-results.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-search-results.js
@@ -2,7 +2,6 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewSearchResults extends AnalyticsEvent
 {
-    /* eslint-disable no-unused-vars */
     /**
      * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
      * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-search-results.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-search-results.js
@@ -2,6 +2,13 @@ import AnalyticsEvent from 'src/plugin/google-analytics/analytics-event';
 
 export default class ViewSearchResults extends AnalyticsEvent
 {
+    /* eslint-disable no-unused-vars */
+    /**
+     * @param {string} controllerName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} actionName @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead.
+     * @param {string} activeRoute
+     * @returns {boolean}
+     */
     supports(controllerName, actionName, activeRoute) {
         return activeRoute === 'frontend.search.page';
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
@@ -47,15 +47,9 @@ export default class GoogleAnalyticsPlugin extends Plugin
 
         /** @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. */
         this.controllerName = window.controllerName;
-        if (this.controllerName !== undefined) {
-            console.warn('[DEPRECATED] tag:v6.8.0 - The global variable "window.controllerName" is deprecated and will be removed. Please use "window.activeRoute" instead.');
-        }
-        
+
         /** @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. */
         this.actionName = window.actionName;
-        if (this.actionName !== undefined) {
-            console.warn('[DEPRECATED] tag:v6.8.0 - The global variable "window.actionName" is deprecated and will be removed. Please use "window.activeRoute" instead.');
-        }
         
         this.activeRoute = window.activeRoute;
         this.events = [];

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
@@ -47,8 +47,16 @@ export default class GoogleAnalyticsPlugin extends Plugin
 
         /** @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. */
         this.controllerName = window.controllerName;
+        if (this.controllerName !== undefined) {
+            console.warn('[DEPRECATED] tag:v6.8.0 - The global variable "window.controllerName" is deprecated and will be removed. Please use "window.activeRoute" instead.');
+        }
+        
         /** @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. */
         this.actionName = window.actionName;
+        if (this.actionName !== undefined) {
+            console.warn('[DEPRECATED] tag:v6.8.0 - The global variable "window.actionName" is deprecated and will be removed. Please use "window.activeRoute" instead.');
+        }
+        
         this.activeRoute = window.activeRoute;
         this.events = [];
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
@@ -45,6 +45,8 @@ export default class GoogleAnalyticsPlugin extends Plugin
         gtag('js', new Date());
         gtag('config', window.gtagTrackingId, window.gtagConfig);
 
+        this.controllerName = window.controllerName;
+        this.actionName = window.actionName;
         this.activeRoute = window.activeRoute;
         this.events = [];
 
@@ -75,7 +77,7 @@ export default class GoogleAnalyticsPlugin extends Plugin
 
     handleEvents() {
         this.events.forEach(event => {
-            if (!event.supports(this.activeRoute)) {
+            if (!event.supports(this.controllerName, this.actionName, this.activeRoute)) {
                 return;
             }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
@@ -45,7 +45,9 @@ export default class GoogleAnalyticsPlugin extends Plugin
         gtag('js', new Date());
         gtag('config', window.gtagTrackingId, window.gtagConfig);
 
+        /** @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. */
         this.controllerName = window.controllerName;
+        /** @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. */
         this.actionName = window.actionName;
         this.activeRoute = window.activeRoute;
         this.events = [];

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/google-analytics.plugin.js
@@ -45,8 +45,7 @@ export default class GoogleAnalyticsPlugin extends Plugin
         gtag('js', new Date());
         gtag('config', window.gtagTrackingId, window.gtagConfig);
 
-        this.controllerName = window.controllerName;
-        this.actionName = window.actionName;
+        this.activeRoute = window.activeRoute;
         this.events = [];
 
         this.registerDefaultEvents();
@@ -76,7 +75,7 @@ export default class GoogleAnalyticsPlugin extends Plugin
 
     handleEvents() {
         this.events.forEach(event => {
-            if (!event.supports(this.controllerName, this.actionName)) {
+            if (!event.supports(this.activeRoute)) {
                 return;
             }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
@@ -1,4 +1,4 @@
-.is-act-cartpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+.is-act-cartpage, // @deprecated tag:v6.8.0 - Body class `is-act-cartpage` will be removed, use active route class `is-active-route-frontend-checkout-cart-page` instead.
 .is-active-route-frontend-checkout-cart-page {
     .checkout {
         .checkout-container {

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
@@ -1,4 +1,4 @@
-.is-act-cartpage {
+.is-active-route-frontend-checkout-cart-page {
     .checkout {
         .checkout-container {
             @extend .row;

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
@@ -1,3 +1,4 @@
+.is-act-cartpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
 .is-active-route-frontend-checkout-cart-page {
     .checkout {
         .checkout-container {

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_checkout.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_checkout.scss
@@ -11,8 +11,11 @@
     cursor: pointer;
 }
 
-.is-ctl-checkout,
-.is-act-checkoutregisterpage {
+.is-active-route-frontend-checkout-cart-page,
+.is-active-route-frontend-checkout-confirm-page,
+.is-active-route-frontend-checkout-finish-page,
+.is-active-route-frontend-checkout-info,
+.is-active-route-frontend-cart-offcanvas {
     .footer-minimal {
         .footer-service-menu-list {
             display: block;

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_checkout.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_checkout.scss
@@ -11,8 +11,8 @@
     cursor: pointer;
 }
 
-.is-ctl-checkout, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
-.is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+.is-ctl-checkout, // @deprecated tag:v6.8.0 - Body class `is-ctl-checkout` will be removed, use active route classes starting with `is-active-route-frontend-checkout-*` instead.
+.is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Body class `is-act-checkoutregisterpage` will be removed, use active route class `is-active-route-frontend-checkout-register-page` instead.
 .is-active-route-frontend-checkout-cart-page,
 .is-active-route-frontend-checkout-confirm-page,
 .is-active-route-frontend-checkout-finish-page,

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_checkout.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_checkout.scss
@@ -11,6 +11,8 @@
     cursor: pointer;
 }
 
+.is-ctl-checkout, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+.is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
 .is-active-route-frontend-checkout-cart-page,
 .is-active-route-frontend-checkout-confirm-page,
 .is-active-route-frontend-checkout-finish-page,

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
@@ -1,3 +1,5 @@
+.is-act-confirmpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+.is-ctl-accountorder, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
 .is-active-route-frontend-checkout-confirm-page,
 .is-active-route-frontend-account-order-page,
 .is-active-route-frontend-account-order-cancel,

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
@@ -1,5 +1,5 @@
 .is-act-confirmpage, // @deprecated tag:v6.8.0 - Body class `is-act-confirmpage` will be removed, use active route classes starting with `is-active-route-*` instead.
-.is-ctl-accountorder, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+.is-ctl-accountorder, // @deprecated tag:v6.8.0 - Body class `is-ctl-accountorder` will be removed, use active route classes starting with `is-active-route-frontend-account-*` instead.
 .is-active-route-frontend-checkout-confirm-page,
 .is-active-route-frontend-account-order-page,
 .is-active-route-frontend-account-order-cancel,

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
@@ -1,5 +1,9 @@
-.is-act-confirmpage,
-.is-ctl-accountorder {
+.is-active-route-frontend-checkout-confirm-page,
+.is-active-route-frontend-account-order-page,
+.is-active-route-frontend-account-order-cancel,
+.is-active-route-frontend-account-order-single-page,
+.is-active-route-widgets-account-order-detail,
+.is-active-route-frontend-account-edit-order-page {
     .checkout {
         padding-top: 70px;
 

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
@@ -1,4 +1,4 @@
-.is-act-confirmpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+.is-act-confirmpage, // @deprecated tag:v6.8.0 - Body class `is-act-confirmpage` will be removed, use active route classes starting with `is-active-route-*` instead.
 .is-ctl-accountorder, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
 .is-active-route-frontend-checkout-confirm-page,
 .is-active-route-frontend-account-order-page,

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_finish.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_finish.scss
@@ -1,4 +1,4 @@
-.is-act-finishpage {
+.is-active-route-frontend-checkout-finish-page {
     .checkout {
         padding-top: 70px;
 

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_finish.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_finish.scss
@@ -1,4 +1,4 @@
-.is-act-finishpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+.is-act-finishpage, // @deprecated tag:v6.8.0 - Body class `is-act-finishpage` will be removed, use active route class `is-active-route-frontend-checkout-finish-page` instead.
 .is-active-route-frontend-checkout-finish-page {
     .checkout {
         padding-top: 70px;

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_finish.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_finish.scss
@@ -1,3 +1,4 @@
+.is-act-finishpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
 .is-active-route-frontend-checkout-finish-page {
     .checkout {
         padding-top: 70px;

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
@@ -1,3 +1,4 @@
+.is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
 .is-active-route-frontend-checkout-register-page {
     .checkout {
         padding-top: 70px;
@@ -19,6 +20,7 @@
 }
 
 @include media-breakpoint-up(lg) {
+    .is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
     .is-active-route-frontend-checkout-register-page {
         .checkout {
             .checkout-main {

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
@@ -20,7 +20,7 @@
 }
 
 @include media-breakpoint-up(lg) {
-    .is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+    .is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Body class `is-act-checkoutregisterpage` will be removed, use active route class `is-active-route-frontend-checkout-register-page` instead.
     .is-active-route-frontend-checkout-register-page {
         .checkout {
             .checkout-main {

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
@@ -1,4 +1,4 @@
-.is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Will be removed, use active route class instead (see class selectors here).
+.is-act-checkoutregisterpage, // @deprecated tag:v6.8.0 - Body class `is-act-checkoutregisterpage` will be removed, use active route class `is-active-route-frontend-checkout-register-page` instead.
 .is-active-route-frontend-checkout-register-page {
     .checkout {
         padding-top: 70px;

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
@@ -1,4 +1,4 @@
-.is-act-checkoutregisterpage {
+.is-active-route-frontend-checkout-register-page {
     .checkout {
         padding-top: 70px;
 
@@ -19,7 +19,7 @@
 }
 
 @include media-breakpoint-up(lg) {
-    .is-act-checkoutregisterpage {
+    .is-active-route-frontend-checkout-register-page {
         .checkout {
             .checkout-main {
                 margin-bottom: 0;

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -19,7 +19,7 @@
     <body class="{% block base_body_classes %}
         {%- if controllerName is not empty -%}is-ctl-{{ controllerName|lower }} {% endif -%}
         {%- if controllerAction is not empty -%}is-act-{{ controllerAction|lower }} {% endif -%}
-        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'%this%': '.', '%that%': '-'}) }}{%- endif -%}
+        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'.': '-'}) }}{%- endif -%}
     {%- endblock %}">
 
     {% block base_body_skip_to_content %}

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block base_body %}
-    <body class="{% block base_body_classes %}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %}{% endblock %}">
+    <body class="{% block base_body_classes %}is-active-route-{% if activeRoute is not empty %}{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endif %}{% endblock %}">
 
     {% block base_body_skip_to_content %}
         {% sw_include '@Storefront/storefront/component/skip-to-content.html.twig' with {

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block base_body %}
-    <body class="{% block base_body_classes %}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %} is-active-route-{% if activeRoute is not empty %}{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endif %}{% endblock %}">
+    <body class="{% block base_body_classes %}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %} is-active-route-{% if activeRoute is not empty %}{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endif %}{% endblock %}">
 
     {% block base_body_skip_to_content %}
         {% sw_include '@Storefront/storefront/component/skip-to-content.html.twig' with {

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block base_body %}
-    <body class="{% block base_body_classes %}is-active-route-{% if activeRoute is not empty %}{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endif %}{% endblock %}">
+    <body class="{% block base_body_classes %}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %} is-active-route-{% if activeRoute is not empty %}{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endif %}{% endblock %}">
 
     {% block base_body_skip_to_content %}
         {% sw_include '@Storefront/storefront/component/skip-to-content.html.twig' with {

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -16,7 +16,11 @@
 
 {% block base_body %}
     {# @deprecated tag:v6.8.0 - CSS classes `is-ctl-*` and `is-act-*` will be removed, use `is-active-route-*` instead. #}
-    <body class="{% block base_body_classes %}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %} is-active-route-{% if activeRoute is not empty %}{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endif %}{% endblock %}">
+    <body class="{% block base_body_classes %}
+        {%- if controllerName is not empty -%}is-ctl-{{ controllerName|lower }} {% endif -%}
+        {%- if controllerAction is not empty -%}is-act-{{ controllerAction|lower }} {% endif -%}
+        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'%this%': '.', '%that%': '-'}) }}{%- endif -%}
+    {%- endblock %}">
 
     {% block base_body_skip_to_content %}
         {% sw_include '@Storefront/storefront/component/skip-to-content.html.twig' with {

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -15,7 +15,8 @@
 {% endblock %}
 
 {% block base_body %}
-    <body class="{% block base_body_classes %}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %} is-active-route-{% if activeRoute is not empty %}{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endif %}{% endblock %}">
+    {# @deprecated tag:v6.8.0 - CSS classes `is-ctl-*` and `is-act-*` will be removed, use `is-active-route-*` instead. #}
+    <body class="{% block base_body_classes %}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %} is-active-route-{% if activeRoute is not empty %}{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endif %}{% endblock %}">
 
     {% block base_body_skip_to_content %}
         {% sw_include '@Storefront/storefront/component/skip-to-content.html.twig' with {

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -8,6 +8,10 @@
                 {% block component_head_analytics_gtag_config %}
                     window.gtagActive = true;
                     window.gtagURL = '{{ trackingUrl }}{{ trackingId }}';
+                    {# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}
+                    window.controllerName = '{{ controllerName|lower }}';
+                    {# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}
+                    window.actionName = '{{ controllerAction|lower }}';
                     window.activeRoute = '{{ activeRoute}}';
                     window.trackOrders = '{{ storefrontAnalytics.isTrackOrders() }}';
                     window.gtagTrackingId = '{{ trackingId }}';

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -8,8 +8,7 @@
                 {% block component_head_analytics_gtag_config %}
                     window.gtagActive = true;
                     window.gtagURL = '{{ trackingUrl }}{{ trackingId }}';
-                    window.controllerName = '{{ controllerName|lower }}';
-                    window.actionName = '{{ controllerAction|lower }}';
+                    window.activeRoute = '{{ activeRoute}}';
                     window.trackOrders = '{{ storefrontAnalytics.isTrackOrders() }}';
                     window.gtagTrackingId = '{{ trackingId }}';
                     window.dataLayer = window.dataLayer || [];

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -10,7 +10,7 @@
                     window.gtagURL = '{{ trackingUrl }}{{ trackingId }}';
                     {# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}
                     window.controllerName = '{{ controllerName|lower }}';
-                    {# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}
+                    {# @deprecated tag:v6.8.0 - window.actionName will be removed, use window.activeRoute instead. #}
                     window.actionName = '{{ controllerAction|lower }}';
                     window.activeRoute = '{{ activeRoute}}';
                     window.trackOrders = '{{ storefrontAnalytics.isTrackOrders() }}';

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -8,10 +8,9 @@
                 {% block component_head_analytics_gtag_config %}
                     window.gtagActive = true;
                     window.gtagURL = '{{ trackingUrl }}{{ trackingId }}';
-                    {# @deprecated tag:v6.8.0 - window.controllerName 
-                    will be removed, use window.activeRoute instead. #}
+                    {# @deprecated tag:v6.8.0 - Global variable `window.controllerName` will be removed, use `window.activeRoute` instead. #}
                     window.controllerName = '{{ controllerName|lower }}';
-                    {# @deprecated tag:v6.8.0 - window.actionName will be removed, use window.activeRoute instead. #}
+                    {# @deprecated tag:v6.8.0 - Global variable `window.actionName` will be removed, use `window.activeRoute` instead. #}
                     window.actionName = '{{ controllerAction|lower }}';
                     window.activeRoute = '{{ activeRoute }}';
                     window.trackOrders = '{{ storefrontAnalytics.isTrackOrders() }}';

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -13,7 +13,7 @@
                     window.controllerName = '{{ controllerName|lower }}';
                     {# @deprecated tag:v6.8.0 - window.actionName will be removed, use window.activeRoute instead. #}
                     window.actionName = '{{ controllerAction|lower }}';
-                    window.activeRoute = '{{ activeRoute}}';
+                    window.activeRoute = '{{ activeRoute }}';
                     window.trackOrders = '{{ storefrontAnalytics.isTrackOrders() }}';
                     window.gtagTrackingId = '{{ trackingId }}';
                     window.dataLayer = window.dataLayer || [];

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -8,7 +8,8 @@
                 {% block component_head_analytics_gtag_config %}
                     window.gtagActive = true;
                     window.gtagURL = '{{ trackingUrl }}{{ trackingId }}';
-                    {# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}
+                    {# @deprecated tag:v6.8.0 - window.controllerName 
+                    will be removed, use window.activeRoute instead. #}
                     window.controllerName = '{{ controllerName|lower }}';
                     {# @deprecated tag:v6.8.0 - window.actionName will be removed, use window.activeRoute instead. #}
                     window.actionName = '{{ controllerAction|lower }}';

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
@@ -38,7 +38,7 @@
                             <div class="line-item-info">
                                 {% block component_line_item_type_product_info_row %}
                                     <div class="row line-item-row">
-                                        {% set showLineItemModal = controllerAction is same as('confirmPage') %}
+                                        {% set showLineItemModal = activeRoute is same as('frontend.checkout.confirm.page') %}
 
                                         {% if nestingLevel < 1 %}
                                             {% block component_line_item_type_product_image %}

--- a/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
@@ -13,7 +13,8 @@
 {% endblock %}
 
 {% block single_cms_page_body %}
-    <body class="{% block single_cms_page_body_classes %}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}is-ctl-{{ controllerName|lower }}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
+    {# @deprecated tag:v6.8.0 - CSS classes `is-ctl-*` and `is-act-*` will be removed, use `is-active-route-*` instead. #}
+    <body class="{% block single_cms_page_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
         {% block single_cms_page_body_inner %}
             {% block single_cms_page_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block single_cms_page_body %}
-    <body class="{% block single_cms_page_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
+    <body class="{% block single_cms_page_body_classes %}is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
         {% block single_cms_page_body_inner %}
             {% block single_cms_page_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
@@ -17,7 +17,7 @@
     <body class="{% block single_cms_page_body_classes %}
         {%- if controllerName is not empty -%}is-ctl-{{ controllerName|lower }} {% endif -%}
         {%- if controllerAction is not empty -%}is-act-{{ controllerAction|lower }} {% endif -%}
-        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'%this%': '.', '%that%': '-'}) }}{%- endif -%}
+        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'.': '-'}) }}{%- endif -%}
     {%- endblock %}">
         {% block single_cms_page_body_inner %}
             {% block single_cms_page_noscript %}

--- a/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block single_cms_page_body %}
-    <body class="{% block single_cms_page_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
+    <body class="{% block single_cms_page_body_classes %}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}is-ctl-{{ controllerName|lower }}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
         {% block single_cms_page_body_inner %}
             {% block single_cms_page_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
@@ -14,7 +14,11 @@
 
 {% block single_cms_page_body %}
     {# @deprecated tag:v6.8.0 - CSS classes `is-ctl-*` and `is-act-*` will be removed, use `is-active-route-*` instead. #}
-    <body class="{% block single_cms_page_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
+    <body class="{% block single_cms_page_body_classes %}
+        {%- if controllerName is not empty -%}is-ctl-{{ controllerName|lower }} {% endif -%}
+        {%- if controllerAction is not empty -%}is-act-{{ controllerAction|lower }} {% endif -%}
+        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'%this%': '.', '%that%': '-'}) }}{%- endif -%}
+    {%- endblock %}">
         {% block single_cms_page_body_inner %}
             {% block single_cms_page_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block single_cms_page_body %}
-    <body class="{% block single_cms_page_body_classes %}is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
+    <body class="{% block single_cms_page_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
         {% block single_cms_page_body_inner %}
             {% block single_cms_page_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block error_maintenance_body %}
-    <body class="{% block error_maintenance_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
+    <body class="{% block error_maintenance_body_classes %}is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
         {% block error_maintenance_body_inner %}
             {% block error_maintenance_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -13,7 +13,8 @@
 {% endblock %}
 
 {% block error_maintenance_body %}
-    <body class="{% block error_maintenance_body_classes %}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}is-ctl-{{ controllerName|lower }}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
+    {# @deprecated tag:v6.8.0 - CSS classes `is-ctl-*` and `is-act-*` will be removed, use `is-active-route-*` instead. #}
+    <body class="{% block error_maintenance_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
         {% block error_maintenance_body_inner %}
             {% block error_maintenance_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -14,7 +14,11 @@
 
 {% block error_maintenance_body %}
     {# @deprecated tag:v6.8.0 - CSS classes `is-ctl-*` and `is-act-*` will be removed, use `is-active-route-*` instead. #}
-    <body class="{% block error_maintenance_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
+    <body class="{% block error_maintenance_body_classes %}
+        {%- if controllerName is not empty -%}is-ctl-{{ controllerName|lower }} {% endif -%}
+        {%- if controllerAction is not empty -%}is-act-{{ controllerAction|lower }} {% endif -%}
+        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'%this%': '.', '%that%': '-'}) }}{%- endif -%}
+    {%- endblock %}">
         {% block error_maintenance_body_inner %}
             {% block error_maintenance_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block error_maintenance_body %}
-    <body class="{% block error_maintenance_body_classes %}is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
+    <body class="{% block error_maintenance_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
         {% block error_maintenance_body_inner %}
             {% block error_maintenance_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block error_maintenance_body %}
-    <body class="{% block error_maintenance_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
+    <body class="{% block error_maintenance_body_classes %}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #}is-ctl-{{ controllerName|lower }}{# @deprecated tag:v6.8.0 - Will be removed, use activeRoute instead. #} is-act-{{ controllerAction|lower }} is-active-route-{{ activeRoute|replace({'%this%': ".", '%that%': "-"}) }}{% endblock %}">
         {% block error_maintenance_body_inner %}
             {% block error_maintenance_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -17,7 +17,7 @@
     <body class="{% block error_maintenance_body_classes %}
         {%- if controllerName is not empty -%}is-ctl-{{ controllerName|lower }} {% endif -%}
         {%- if controllerAction is not empty -%}is-act-{{ controllerAction|lower }} {% endif -%}
-        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'%this%': '.', '%that%': '-'}) }}{%- endif -%}
+        {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'.': '-'}) }}{%- endif -%}
     {%- endblock %}">
         {% block error_maintenance_body_inner %}
             {% block error_maintenance_noscript %}


### PR DESCRIPTION
Resolves https://github.com/shopware/shopware/issues/7422

The `controllerName` and `controllerAction` variables used to be relics from SW5. This PR deprecates them from the Twig template variables and adds the usage of the `activeRoute` as a replacement in Twig, JS and CSS.

Deprecations could be added to the usage in src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig and src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig.

After the deprecation, this will be a BC break that should be discussed, first.