### PR TITLE
fix: check if config fields value 'type' is set

### DIFF
--- a/src/Storefront/Theme/ResolvedConfigLoader.php
+++ b/src/Storefront/Theme/ResolvedConfigLoader.php
@@ -39,7 +39,7 @@ class ResolvedConfigLoader extends AbstractResolvedConfigLoader
         }
 
         foreach ($config['fields'] as $key => $data) {
-            if ($data['type'] === 'media' && $data['value'] && Uuid::isValid($data['value'])) {
+            if (isset($data['type']) && $data['type'] === 'media' && $data['value'] && Uuid::isValid($data['value'])) {
                 $mediaItems[$data['value']][] = $key;
             }
             $resolvedConfig[$key] = $data['value'];


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The type of a theme config value can now be null: https://github.com/shopware/shopware/pull/8843/files
Accordingly, we also need to check if the array key exists in the ResolvedConfigLoader. Otherwise, this can lead to a critical error when using, for example, the ThemeConfigValueAccessor.

### 2. What does this change do, exactly?
Prevent error due to not existing arraykey

### 3. Describe each step to reproduce the issue or behaviour.
1. create a theme with config-values
2. create a child-theme
3. install and activate the themes
4. change a value in your child-theme
5. remove the value from the base-theme
6. Use the ThemeConfigValueAccessor in anyway for e.g. in a StorefrontSubscriber -> error undefined arraykey 'type'

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
https://github.com/shopware/shopware/issues/8494

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
