### PR TITLE
fix: display admin UI correctly when staging mode enabled

### DIFF
--- a/changelog/_unreleased/2025-05-07-fix-admin-ui-when-staging-mode-enabled.md
+++ b/changelog/_unreleased/2025-05-07-fix-admin-ui-when-staging-mode-enabled.md
@@ -1,0 +1,9 @@
+---
+title: Fix admin ui when staging mode enabled
+issue: #9137
+author: Melvin Achterhuis
+author_email: melvin@achterhuis.work
+author_github: MelvinAchterhuis
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.scss`, adjusted `grid-column` to display the admin UI correctly when staging mode is enabled.

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.scss
@@ -23,7 +23,7 @@
     }
 
     .sw-staging-bar {
-        grid-column: 1 / 3;
+        grid-column: 1 / 4;
         display: flex;
         justify-content: center;
         background: rgb(61, 68, 77);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Fixes the admin UI when staging mode is enabled

### 2. What does this change do, exactly?
Adjust grid column scss on the .sw-staging-bar class

### 3. Describe each step to reproduce the issue or behaviour.
1. Enable staging mode
2. Build admin js
3. Login admin

### 4. Please link to the relevant issues (if any).
#9137 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
