### PR TITLE
fix: Added origin directive to vite.config.mts to allow requests from APP_URL

### DIFF
--- a/changelog/_unreleased/2025-05-07-Fix-admin-watcher-vite-origin-host-for-ddev.md
+++ b/changelog/_unreleased/2025-05-07-Fix-admin-watcher-vite-origin-host-for-ddev.md
@@ -1,0 +1,8 @@
+---
+title: "Fix admin watcher Vite origin host for DDEV"
+author: "Benny Poensgen"
+author_email: "poensgen@vanwittlaer.de"
+author_github: "vanWittlaer"
+---
+# Core
+- Fixed an issue with the admin watcher where the Vite origin host was not correctly set for DDEV environments.

--- a/src/Administration/Resources/app/administration/vite.config.mts
+++ b/src/Administration/Resources/app/administration/vite.config.mts
@@ -73,6 +73,10 @@ export default defineConfig(({ command }) => {
                     secure: false,
                 },
             },
+            // DDEV_PRIMARY_URL is initialised in ddev environment only
+            origin: process.env.DDEV_PRIMARY_URL
+                ? `${process.env.DDEV_PRIMARY_URL.replace(/:\d+$/, "")}:` + (Number(process.env.ADMIN_PORT) || 5173)
+                : undefined,
         },
 
         // IIFE to return different plugins for dev and  prod


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When running admin watcher in ddev environment, the Vite needs to be aware of the ddev project url like project-name.ddev.site

### 2. What does this change do, exactly?
This change adds an origin directive to vite.config.mts and sets the origin host based on the APP_URL env variable.


### 3. Describe each step to reproduce the issue or behaviour.
Bring up Shopware 6.7.0.0-RC3 in a ddev environment and test the admin watcher.

### 4. Please link to the relevant issues (if any).
Solves the problem of running admin watcher under ddev described in https://github.com/shopware/shopware/issues/9092

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
