### PR TITLE
fix: ElasticsearchIndexer should ultilize logAndThrown helper

### DIFF
--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
@@ -177,7 +177,7 @@ class ElasticsearchIndexer
             $errors[] = [
                 'index' => $item['_index'],
                 'id' => $item['_id'],
-                'type' => $item['error']['type'] ?? $item['_type'],
+                'type' => $item['error']['type'] ?? ($item['_type'] ?? 'n/a'),
                 'reason' => $item['error']['reason'] ?? $item['result'],
             ];
 
@@ -279,7 +279,9 @@ class ElasticsearchIndexer
         if (\is_array($result) && isset($result['errors']) && $result['errors']) {
             $errors = $this->parseErrors($result);
 
-            throw ElasticsearchException::indexingError($errors);
+            $this->helper->logAndThrowException(
+                ElasticsearchException::indexingError($errors)
+            );
         }
     }
 

--- a/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -326,9 +326,16 @@ class ElasticsearchIndexerTest extends TestCase
             ->method('error')
             ->with('failed to parse');
 
-        $indexer = $this->getIndexer($logger);
+        $this->helper->expects($this->once())->method('logAndThrowException')->with(ElasticsearchException::indexingError([
+            [
+                'index' => 'foo',
+                'id' => '1',
+                'type' => 'mapper_parsing_exception',
+                'reason' => 'failed to parse',
+            ],
+        ]));
 
-        static::expectException(ElasticsearchException::class);
+        $indexer = $this->getIndexer($logger);
 
         $indexer($message);
     }


### PR DESCRIPTION
An error thrown during Elasticsearch indexing shouldn't block other processes