### PR TITLE
fix: add missing cms_block_version_id

### DIFF
--- a/src/Core/Migration/V6_7/Migration1733136208AddH1ToCmsCategoryListing.php
+++ b/src/Core/Migration/V6_7/Migration1733136208AddH1ToCmsCategoryListing.php
@@ -76,6 +76,7 @@ class Migration1733136208AddH1ToCmsCategoryListing extends MigrationStep
             'id' => Uuid::randomBytes(),
             'locked' => 1,
             'cms_block_id' => $categoryNameBlock['id'],
+            'cms_block_version_id' => $sectionVersionId,
             'type' => 'text',
             'slot' => 'content',
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),


### PR DESCRIPTION
### 1. Why is this change necessary?
Closes #9105

### 2. What does this change do, exactly?
Add the missing cms_block_version_id field.

### 3. Describe each step to reproduce the issue or behaviour.
See issue description.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
