### PR TITLE
fix: Elasticsearch Index mapping should be updated post system update

### DIFF
--- a/changelog/_unreleased/2025-05-08-elasticsearch-index-s-mapping-should-be-updated-post-update.md
+++ b/changelog/_unreleased/2025-05-08-elasticsearch-index-s-mapping-should-be-updated-post-update.md
@@ -1,0 +1,6 @@
+---
+title: Elasticsearch index's mapping should be updated post update
+---
+# Core
+* Changed method `\Shopware\Elasticsearch\Framework\SystemUpdateListener::__invoke` to call `\Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater::update` post update
+* Changed method `\Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater::update` to mark the entities as needs to be re-indexed if the updated mapping is not compatible

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
@@ -177,7 +177,7 @@ class ElasticsearchIndexer
             $errors[] = [
                 'index' => $item['_index'],
                 'id' => $item['_id'],
-                'type' => $item['error']['type'] ?? $item['_type'],
+                'type' => $item['error']['type'] ?? ($item['_type'] ?? 'n/a'),
                 'reason' => $item['error']['reason'] ?? $item['result'],
             ];
 

--- a/src/Elasticsearch/Framework/Indexing/IndexMappingUpdater.php
+++ b/src/Elasticsearch/Framework/Indexing/IndexMappingUpdater.php
@@ -4,10 +4,12 @@ namespace Shopware\Elasticsearch\Framework\Indexing;
 
 use OpenSearch\Client;
 use OpenSearch\Common\Exceptions\BadRequest400Exception;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\ElasticsearchRegistry;
+use Shopware\Elasticsearch\Framework\SystemUpdateListener;
 use Shopware\Elasticsearch\Product\ElasticsearchProductException;
 
 #[Package('framework')]
@@ -20,12 +22,27 @@ class IndexMappingUpdater
         private readonly ElasticsearchRegistry $registry,
         private readonly ElasticsearchHelper $elasticsearchHelper,
         private readonly Client $client,
-        private readonly IndexMappingProvider $indexMappingProvider
+        private readonly IndexMappingProvider $indexMappingProvider,
+        private readonly AbstractKeyValueStorage $storage
     ) {
     }
 
     public function update(Context $context): void
     {
+        if (!$this->elasticsearchHelper->allowIndexing()) {
+            return;
+        }
+
+        $entitiesToReindex = $this->storage->get(SystemUpdateListener::CONFIG_KEY, []) ?? [];
+
+        if (\is_string($entitiesToReindex)) {
+            $entitiesToReindex = \json_decode($entitiesToReindex, true);
+        }
+
+        if (!\is_array($entitiesToReindex)) {
+            $entitiesToReindex = [];
+        }
+
         foreach ($this->registry->getDefinitions() as $definition) {
             $indexName = $this->elasticsearchHelper->getIndexName($definition->getEntityDefinition());
 
@@ -35,10 +52,18 @@ class IndexMappingUpdater
                     'body' => $this->indexMappingProvider->build($definition, $context),
                 ]);
             } catch (BadRequest400Exception $exception) {
-                if (str_contains($exception->getMessage(), 'cannot be changed from type')) {
-                    throw ElasticsearchProductException::cannotChangeCustomFieldType($exception);
+                if (str_contains($exception->getMessage(), 'cannot be changed from type') || str_contains($exception->getMessage(), 'can\'t merge a non object mapping')) {
+                    $entitiesToReindex[] = $definition->getEntityDefinition()->getEntityName();
+
+                    $exception = ElasticsearchProductException::cannotChangeFieldType($exception);
                 }
+
+                $this->elasticsearchHelper->logAndThrowException($exception);
             }
+        }
+
+        if (!empty($entitiesToReindex)) {
+            $this->storage->set(SystemUpdateListener::CONFIG_KEY, \array_values(\array_unique($entitiesToReindex)));
         }
     }
 }

--- a/src/Elasticsearch/Framework/SystemUpdateListener.php
+++ b/src/Elasticsearch/Framework/SystemUpdateListener.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
 use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer;
+use Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -24,12 +25,15 @@ class SystemUpdateListener
     public function __construct(
         private readonly AbstractKeyValueStorage $storage,
         private readonly ElasticsearchIndexer $indexer,
-        private readonly MessageBusInterface $messageBus
+        private readonly MessageBusInterface $messageBus,
+        private readonly IndexMappingUpdater $mappingUpdater
     ) {
     }
 
     public function __invoke(UpdatePostFinishEvent $event): void
     {
+        $this->mappingUpdater->update($event->getContext());
+
         $entitiesToReindex = $this->storage->get(self::CONFIG_KEY, []);
 
         if (empty($entitiesToReindex)) {

--- a/src/Elasticsearch/Product/ElasticsearchProductException.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductException.php
@@ -13,12 +13,25 @@ class ElasticsearchProductException extends HttpException
     public const ES_PRODUCT_CONFIG_NOT_FOUND = 'ELASTICSEARCH_PRODUCT__CONFIGURATION_NOT_FOUND';
     public const ES_PRODUCT_CANNOT_CHANGE_CUSTOM_FIELD_TYPE = 'ELASTICSEARCH_PRODUCT__CANNOT_CHANGE_CUSTOM_FIELD_TYPE';
 
+    public const ES_PRODUCT_CANNOT_CHANGE_FIELD_TYPE = 'ELASTICSEARCH_PRODUCT__CANNOT_CHANGE_FIELD_TYPE';
+
     public static function configNotFound(): self
     {
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::ES_PRODUCT_CONFIG_NOT_FOUND,
             'Configuration for product elasticsearch definition not found',
+        );
+    }
+
+    public static function cannotChangeFieldType(BadRequest400Exception $previous): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::ES_PRODUCT_CANNOT_CHANGE_FIELD_TYPE,
+            'One or more fields already exist in the index with different types. Please reset the index and rebuild it.',
+            [],
+            $previous,
         );
     }
 

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -94,6 +94,7 @@
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchHelper"/>
             <argument type="service" id="OpenSearch\Client"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\Indexing\IndexMappingProvider"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage"/>
         </service>
 
         <service id="Shopware\Elasticsearch\Framework\Command\ElasticsearchIndexingCommand">
@@ -365,6 +366,7 @@
             <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer"/>
             <argument type="service" id="messenger.default_bus"/>
+            <argument type="service" id="Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater"/>
 
             <tag name="kernel.event_listener"/>
         </service>

--- a/tests/unit/Elasticsearch/Framework/Indexing/IndexMappingUpdaterTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/IndexMappingUpdaterTest.php
@@ -3,15 +3,21 @@
 namespace Shopware\Tests\Unit\Elasticsearch\Framework\Indexing;
 
 use OpenSearch\Client;
+use OpenSearch\Common\Exceptions\BadRequest400Exception;
 use OpenSearch\Namespaces\IndicesNamespace;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\ElasticsearchRegistry;
 use Shopware\Elasticsearch\Framework\Indexing\IndexMappingProvider;
 use Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater;
+use Shopware\Elasticsearch\Framework\SystemUpdateListener;
 use Shopware\Elasticsearch\Product\ElasticsearchProductDefinition;
+use Shopware\Elasticsearch\Product\ElasticsearchProductException;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -19,9 +25,52 @@ use Shopware\Elasticsearch\Product\ElasticsearchProductDefinition;
 #[CoversClass(IndexMappingUpdater::class)]
 class IndexMappingUpdaterTest extends TestCase
 {
+    public function testUpdateWithoutIndexingEnabled(): void
+    {
+        $elasticsearchHelper = $this->createMock(ElasticsearchHelper::class);
+        $elasticsearchHelper->expects($this->once())->method('allowIndexing')->willReturn(false);
+
+        $registry = new ElasticsearchRegistry([
+            $this->createMock(ElasticsearchProductDefinition::class),
+        ]);
+
+        $client = $this->createMock(Client::class);
+        $indicesNamespace = $this->createMock(IndicesNamespace::class);
+        $indicesNamespace
+            ->expects($this->never())
+            ->method('putMapping')
+            ->with([
+                'index' => 'index',
+                'body' => [
+                    'foo' => '1',
+                ],
+            ]);
+
+        $storage = $this->createMock(AbstractKeyValueStorage::class);
+        $storage->expects($this->never())->method('set');
+
+        $indexMappingProvider = $this->createMock(IndexMappingProvider::class);
+        $indexMappingProvider
+            ->expects($this->never())
+            ->method('build')
+            ->willReturn(['foo' => '1']);
+
+        $updater = new IndexMappingUpdater(
+            $registry,
+            $elasticsearchHelper,
+            $client,
+            $indexMappingProvider,
+            $storage
+        );
+
+        $updater->update(Context::createDefaultContext());
+    }
+
     public function testUpdate(): void
     {
         $elasticsearchHelper = $this->createMock(ElasticsearchHelper::class);
+        $elasticsearchHelper->expects($this->once())->method('allowIndexing')->willReturn(true);
+
         $elasticsearchHelper->method('getIndexName')->willReturn('index');
 
         $registry = new ElasticsearchRegistry([
@@ -53,7 +102,67 @@ class IndexMappingUpdaterTest extends TestCase
             $registry,
             $elasticsearchHelper,
             $client,
-            $indexMappingProvider
+            $indexMappingProvider,
+            $this->createMock(AbstractKeyValueStorage::class),
+        );
+
+        $updater->update(Context::createDefaultContext());
+    }
+
+    public function testUpdateWithError(): void
+    {
+        $elasticsearchHelper = $this->createMock(ElasticsearchHelper::class);
+        $elasticsearchHelper->method('getIndexName')->willReturn('index');
+        $elasticsearchHelper->expects($this->once())->method('allowIndexing')->willReturn(true);
+
+        $definition = $this->createMock(ElasticsearchProductDefinition::class);
+        $definition
+            ->method('getEntityDefinition')
+            ->willReturn(new ProductDefinition());
+
+        $registry = new ElasticsearchRegistry([$definition]);
+
+        $client = $this->createMock(Client::class);
+        $indicesNamespace = $this->createMock(IndicesNamespace::class);
+        $indicesNamespace
+            ->expects($this->once())
+            ->method('putMapping')
+            ->with([
+                'index' => 'index',
+                'body' => [
+                    'foo' => '1',
+                ],
+            ])->willThrowException(new BadRequest400Exception('can\'t merge a non object mapping [completion] with an object mapping', Response::HTTP_BAD_REQUEST));
+
+        $client
+            ->method('indices')
+            ->willReturn($indicesNamespace);
+
+        $indexMappingProvider = $this->createMock(IndexMappingProvider::class);
+        $indexMappingProvider
+            ->method('build')
+            ->willReturn(['foo' => '1']);
+
+        $elasticsearchHelper->expects($this->once())->method('logAndThrowException')->with(
+            static::callback(static function (ElasticsearchProductException $exception) {
+                return $exception->getMessage() === 'One or more fields already exist in the index with different types. Please reset the index and rebuild it.';
+            }),
+        );
+
+        $storage = $this->createMock(AbstractKeyValueStorage::class);
+        $storage->expects($this->once())
+            ->method('set')
+            ->with(
+                SystemUpdateListener::CONFIG_KEY,
+                ['product'],
+            );
+
+        $updater = new IndexMappingUpdater(
+            $registry,
+            $elasticsearchHelper,
+            $client,
+            $indexMappingProvider,
+            $storage,
         );
 
         $updater->update(Context::createDefaultContext());

--- a/tests/unit/Elasticsearch/Framework/SystemUpdateListenerTest.php
+++ b/tests/unit/Elasticsearch/Framework/SystemUpdateListenerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Test\Stub\MessageBus\CollectingMessageBus;
 use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer;
 use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexingMessage;
 use Shopware\Elasticsearch\Framework\Indexing\IndexerOffset;
+use Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater;
 use Shopware\Elasticsearch\Framework\SystemUpdateListener;
 
 /**
@@ -22,10 +23,16 @@ class SystemUpdateListenerTest extends TestCase
     {
         $messageBus = new CollectingMessageBus();
 
+        $mappingUpdater = $this->createMock(IndexMappingUpdater::class);
+        $mappingUpdater
+            ->expects($this->once())
+            ->method('update');
+
         $listener = new SystemUpdateListener(
             $this->createMock(AbstractKeyValueStorage::class),
             $this->createMock(ElasticsearchIndexer::class),
-            $messageBus
+            $messageBus,
+            $mappingUpdater
         );
 
         $listener($this->createMock(UpdatePostFinishEvent::class));
@@ -36,6 +43,11 @@ class SystemUpdateListenerTest extends TestCase
     public function testShouldScheduleWithValues(): void
     {
         $messageBus = new CollectingMessageBus();
+
+        $mappingUpdater = $this->createMock(IndexMappingUpdater::class);
+        $mappingUpdater
+            ->expects($this->once())
+            ->method('update');
 
         $storage = $this->createMock(AbstractKeyValueStorage::class);
         $storage
@@ -58,7 +70,8 @@ class SystemUpdateListenerTest extends TestCase
         $listener = new SystemUpdateListener(
             $storage,
             $indexer,
-            $messageBus
+            $messageBus,
+            $mappingUpdater
         );
 
         $listener($this->createMock(UpdatePostFinishEvent::class));


### PR DESCRIPTION
* Changed method `\Shopware\Elasticsearch\Framework\SystemUpdateListener::__invoke` to call `\Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater::update` post update
* Changed method `\Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater::update` to mark the entities as needs to be re-indexed if the updated mapping is not compatible
