### PR TITLE
fix: Misaligned search icon in generate variants modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-selection/sw-product-variants-configurator-selection.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-selection/sw-product-variants-configurator-selection.scss
@@ -13,7 +13,7 @@ $sw-product-variants-configurator-selection-search-background: $color-gray-100;
         margin: 0;
     }
 
-    .mt-icon.sw-simple-search-field__search-icon.icon--regular-search-s.mt-icon--small {
+    & + .mt-icon.sw-simple-search-field__search-icon {
         right: 45px;
     }
 }


### PR DESCRIPTION
### Solution 
The correct selection for the search icon in SCSS is needed.

![Screenshot 2025-05-08 at 17 15 03](https://github.com/user-attachments/assets/3db7f17d-2c21-4210-a23e-16061f78e495)
