### PR TITLE
fix: Write category search to correct container

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-modal/index.js
@@ -109,7 +109,7 @@ export default {
             // eslint-disable-next-line max-len
             const cardSectionSecondaryHeight = `${this.$refs?.category?.$refs?.cardSectionSecondary?.$el?.offsetHeight ?? 0}px`;
 
-            this.productContainerStyle['grid-template-rows'] =
+            this.categoryContainerStyle['grid-template-rows'] =
                 `auto calc(${this.tabContentHeight} - (${tabContentGutter} + ${alertHeight} + ${
                     cardSectionSecondaryHeight
                 }))`;
@@ -121,7 +121,7 @@ export default {
             // eslint-disable-next-line max-len
             const cardSectionSecondaryHeight = `${this.$refs?.productGroup?.$refs?.cardSectionSecondary?.$el?.offsetHeight ?? 0}px`;
 
-            this.productContainerStyle['grid-template-rows'] =
+            this.productGroupContainerStyle['grid-template-rows'] =
                 `auto calc(${this.tabContentHeight} - (${tabContentGutter} + ${alertHeight} + ${
                     cardSectionSecondaryHeight
                 }))`;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Both category container and product group container tabs were both writing the grid heights into product container 

### 2. What does this change do, exactly?
Each tab's container style object now receives its own computed `grid-template-rows`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
