### PR TITLE
fix: Do not dump opcache preload file if warmup directory is used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
         "lcobucci/clock": "^3.1.0",
         "lcobucci/jwt": "^5.5",
         "league/flysystem": "^3.10.3",
+        "league/flysystem-local": "^3.29.0",
         "league/flysystem-memory": "^3.10.3",
         "league/mime-type-detection": "^1.13.0",
         "league/oauth2-server": "^9.1",

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -339,24 +340,36 @@ class Kernel extends HttpKernel
     {
         parent::dumpContainer($cache, $container, $class, $baseClass);
         $cacheDir = $container->getParameter('kernel.cache_dir');
-        $cacheName = basename($cacheDir);
-        $fileName = substr(basename($cache->getPath()), 0, -3) . 'preload.php';
 
-        file_put_contents(\dirname($cacheDir) . '/CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
+        // Do not dump the preload file if the cache dir is a warmup dir.
+        // See https://github.com/symfony/symfony/blob/v7.2.6/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L115-L117
+        if (str_ends_with($cacheDir, '_')) {
+            return;
+        }
 
-        $preloadFile = \dirname($cacheDir) . '/opcache-preload.php';
+        $fileSystem = new Filesystem();
 
-        $loader = <<<PHP
+        $rootCacheDir = \dirname($cacheDir);
+        $fileSystem->dumpFile($rootCacheDir . \DIRECTORY_SEPARATOR . 'CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
+
+        $preloadFileName = $rootCacheDir . \DIRECTORY_SEPARATOR . 'opcache-preload.php';
+        $cacheDirectoryName = basename($cacheDir);
+        $containerPreloadFileName = $container->getParameter('kernel.container_class') . '.preload.php';
+
+        $preloadFileContent = <<<PHP
 <?php
 
 require_once __DIR__ . '/#CACHE_PATH#';
 PHP;
 
-        file_put_contents($preloadFile, str_replace(
-            ['#CACHE_PATH#'],
-            [$cacheName . '/' . $fileName],
-            $loader
-        ));
+        $fileSystem->dumpFile(
+            $preloadFileName,
+            str_replace(
+                '#CACHE_PATH#',
+                $cacheDirectoryName . \DIRECTORY_SEPARATOR . $containerPreloadFileName,
+                $preloadFileContent,
+            )
+        );
     }
 
     private function addApiRoutes(RoutingConfigurator $routes): void

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -5,6 +5,9 @@ namespace Shopware\Core;
 use Composer\Autoload\ClassLoader;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Api\Controller\FallbackController;
@@ -20,7 +23,6 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -36,7 +38,6 @@ class Kernel extends HttpKernel
     use MicroKernelTrait;
 
     final public const CONFIG_EXTS = '.{php,xml,yaml,yml}';
-
     /**
      * @var string Fallback version if nothing is provided via kernel constructor
      */
@@ -50,6 +51,10 @@ class Kernel extends HttpKernel
 
     private bool $rebooting = false;
 
+    private FilesystemOperator $filesystem;
+
+    private string $cacheRootDir;
+
     /**
      * @internal
      */
@@ -60,7 +65,8 @@ class Kernel extends HttpKernel
         private string $cacheId,
         string $version,
         Connection $connection,
-        protected string $projectDir
+        protected string $projectDir,
+        ?FilesystemOperator $filesystem = null,
     ) {
         date_default_timezone_set('UTC');
 
@@ -70,6 +76,8 @@ class Kernel extends HttpKernel
         $versionArray = VersionParser::parseShopwareVersion($version);
         $this->shopwareVersion = $versionArray['version'];
         $this->shopwareVersionRevision = $versionArray['revision'];
+        $this->cacheRootDir = EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()) . '/var/cache';
+        $this->filesystem = $filesystem ?? new Filesystem(new LocalFilesystemAdapter($this->cacheRootDir));
     }
 
     /**
@@ -176,8 +184,8 @@ class Kernel extends HttpKernel
     public function getCacheDir(): string
     {
         return \sprintf(
-            '%s/var/cache/%s_h%s',
-            EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()),
+            '%s/%s_h%s',
+            $this->cacheRootDir,
             $this->getEnvironment(),
             $this->getCacheHash(),
         );
@@ -261,7 +269,6 @@ class Kernel extends HttpKernel
 
     /**
      * {@inheritdoc}
-     *
      * @return array<string, mixed>
      */
     protected function getKernelParameters(): array
@@ -326,7 +333,8 @@ class Kernel extends HttpKernel
      */
     protected function initializeDatabaseConnectionVariables(): void
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', 'The method initializeDatabaseConnectionVariables is deprecated and will be removed in 6.8.0.0. All MySQL connection variables are configured in ' . MySQLFactory::class);
+        Feature::triggerDeprecationOrThrow('v6.8.0.0',
+            'The method initializeDatabaseConnectionVariables is deprecated and will be removed in 6.8.0.0. All MySQL connection variables are configured in ' . MySQLFactory::class);
 
         self::$connection = self::getConnection();
     }
@@ -338,19 +346,15 @@ class Kernel extends HttpKernel
     {
         parent::dumpContainer($cache, $container, $class, $baseClass);
 
+        $this->filesystem->write('CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
+
         $cacheDir = $container->getParameter('kernel.cache_dir');
-        $rootCacheDir = \dirname($cacheDir);
-
-        $fileSystem = new Filesystem();
-        $fileSystem->dumpFile($rootCacheDir . \DIRECTORY_SEPARATOR . 'CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
-
         // Do not dump the preload file if the cache dir is a warmup dir.
         // See https://github.com/symfony/symfony/blob/v7.2.6/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L115-L117
         if (str_ends_with($cacheDir, '_')) {
             return;
         }
 
-        $preloadFileName = $rootCacheDir . \DIRECTORY_SEPARATOR . 'opcache-preload.php';
         $cacheDirectoryName = basename($cacheDir);
         $containerPreloadFileName = $container->getParameter('kernel.container_class') . '.preload.php';
 
@@ -360,8 +364,8 @@ class Kernel extends HttpKernel
 require_once __DIR__ . '/#CACHE_PATH#';
 PHP;
 
-        $fileSystem->dumpFile(
-            $preloadFileName,
+        $this->filesystem->write(
+            'opcache-preload.php',
             str_replace(
                 '#CACHE_PATH#',
                 $cacheDirectoryName . \DIRECTORY_SEPARATOR . $containerPreloadFileName,

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -75,6 +75,7 @@ class Kernel extends HttpKernel
         $versionArray = VersionParser::parseShopwareVersion($version);
         $this->shopwareVersion = $versionArray['version'];
         $this->shopwareVersionRevision = $versionArray['revision'];
+
         $this->cacheRootDir = EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()) . '/var/cache';
         $this->filesystem = $filesystem ?? new Filesystem(new LocalFilesystemAdapter($this->cacheRootDir));
     }

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -26,7 +26,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel as HttpKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
@@ -80,9 +79,6 @@ class Kernel extends HttpKernel
         $this->filesystem = $filesystem ?? new Filesystem(new LocalFilesystemAdapter($this->cacheRootDir));
     }
 
-    /**
-     * @return iterable<BundleInterface>
-     */
     public function registerBundles(): iterable
     {
         /** @var array<class-string<Bundle>, array<string, bool>> $bundles */
@@ -268,8 +264,7 @@ class Kernel extends HttpKernel
     }
 
     /**
-     * {@inheritdoc}
-     * @return array<string, mixed>
+     * @return array<string, array<string, mixed>|bool|string|int|float|\UnitEnum|null>
      */
     protected function getKernelParameters(): array
     {
@@ -333,15 +328,14 @@ class Kernel extends HttpKernel
      */
     protected function initializeDatabaseConnectionVariables(): void
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0',
-            'The method initializeDatabaseConnectionVariables is deprecated and will be removed in 6.8.0.0. All MySQL connection variables are configured in ' . MySQLFactory::class);
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'The method initializeDatabaseConnectionVariables is deprecated and will be removed in 6.8.0.0. All MySQL connection variables are configured in ' . MySQLFactory::class
+        );
 
         self::$connection = self::getConnection();
     }
 
-    /**
-     * Dumps the preload file to an always known location outside the generated cache folder name
-     */
     protected function dumpContainer(ConfigCache $cache, ContainerBuilder $container, string $class, string $baseClass): void
     {
         parent::dumpContainer($cache, $container, $class, $baseClass);
@@ -349,6 +343,7 @@ class Kernel extends HttpKernel
         $this->filesystem->write('CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
 
         $cacheDir = $container->getParameter('kernel.cache_dir');
+
         // Do not dump the preload file if the cache dir is a warmup dir.
         // See https://github.com/symfony/symfony/blob/v7.2.6/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L115-L117
         if (str_ends_with($cacheDir, '_')) {
@@ -356,7 +351,7 @@ class Kernel extends HttpKernel
         }
 
         $cacheDirectoryName = basename($cacheDir);
-        $containerPreloadFileName = $container->getParameter('kernel.container_class') . '.preload.php';
+        $containerPreloadFileName = $class . '.preload.php';
 
         $preloadFileContent = <<<PHP
 <?php
@@ -364,6 +359,7 @@ class Kernel extends HttpKernel
 require_once __DIR__ . '/#CACHE_PATH#';
 PHP;
 
+        // Dumps the preload file to an always known location outside the generated cache folder name
         $this->filesystem->write(
             'opcache-preload.php',
             str_replace(

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -339,18 +339,18 @@ class Kernel extends HttpKernel
     protected function dumpContainer(ConfigCache $cache, ContainerBuilder $container, string $class, string $baseClass): void
     {
         parent::dumpContainer($cache, $container, $class, $baseClass);
+
         $cacheDir = $container->getParameter('kernel.cache_dir');
+        $rootCacheDir = \dirname($cacheDir);
+
+        $fileSystem = new Filesystem();
+        $fileSystem->dumpFile($rootCacheDir . \DIRECTORY_SEPARATOR . 'CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
 
         // Do not dump the preload file if the cache dir is a warmup dir.
         // See https://github.com/symfony/symfony/blob/v7.2.6/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L115-L117
         if (str_ends_with($cacheDir, '_')) {
             return;
         }
-
-        $fileSystem = new Filesystem();
-
-        $rootCacheDir = \dirname($cacheDir);
-        $fileSystem->dumpFile($rootCacheDir . \DIRECTORY_SEPARATOR . 'CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
 
         $preloadFileName = $rootCacheDir . \DIRECTORY_SEPARATOR . 'opcache-preload.php';
         $cacheDirectoryName = basename($cacheDir);

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -52,8 +52,6 @@ class Kernel extends HttpKernel
 
     /**
      * @internal
-     *
-     * {@inheritdoc}
      */
     public function __construct(
         string $environment,
@@ -69,9 +67,9 @@ class Kernel extends HttpKernel
         parent::__construct($environment, $debug);
         self::$connection = $connection;
 
-        $version = VersionParser::parseShopwareVersion($version);
-        $this->shopwareVersion = $version['version'];
-        $this->shopwareVersionRevision = $version['revision'];
+        $versionArray = VersionParser::parseShopwareVersion($version);
+        $this->shopwareVersion = $versionArray['version'];
+        $this->shopwareVersionRevision = $versionArray['revision'];
     }
 
     /**
@@ -81,7 +79,7 @@ class Kernel extends HttpKernel
     {
         /** @var array<class-string<Bundle>, array<string, bool>> $bundles */
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
-        $instanciatedBundleNames = [];
+        $instantiatedBundleNames = [];
 
         $kernelParameters = $this->getKernelParameters();
 
@@ -90,11 +88,11 @@ class Kernel extends HttpKernel
                 /** @var ShopwareBundle|Bundle $bundle */
                 $bundle = new $class();
 
-                if ($this->isBundleRegistered($bundle, $instanciatedBundleNames)) {
+                if ($this->isBundleRegistered($bundle, $instantiatedBundleNames)) {
                     continue;
                 }
 
-                $instanciatedBundleNames[] = $bundle->getName();
+                $instantiatedBundleNames[] = $bundle->getName();
 
                 yield $bundle;
 
@@ -105,17 +103,17 @@ class Kernel extends HttpKernel
                 $classLoader = new ClassLoader();
                 $parameters = new AdditionalBundleParameters($classLoader, new KernelPluginCollection(), $kernelParameters);
                 foreach ($bundle->getAdditionalBundles($parameters) as $additionalBundle) {
-                    if ($this->isBundleRegistered($additionalBundle, $instanciatedBundleNames)) {
+                    if ($this->isBundleRegistered($additionalBundle, $instantiatedBundleNames)) {
                         continue;
                     }
 
-                    $instanciatedBundleNames[] = $additionalBundle->getName();
+                    $instantiatedBundleNames[] = $additionalBundle->getName();
                     yield $additionalBundle;
                 }
             }
         }
 
-        yield from $this->pluginLoader->getBundles($kernelParameters, $instanciatedBundleNames);
+        yield from $this->pluginLoader->getBundles($kernelParameters, $instantiatedBundleNames);
     }
 
     public function getProjectDir(): string
@@ -134,7 +132,7 @@ class Kernel extends HttpKernel
 
     public function boot(): void
     {
-        if ($this->booted === true) {
+        if ($this->booted) {
             if ($this->debug) {
                 $this->startTime = microtime(true);
             }
@@ -407,11 +405,11 @@ PHP;
     }
 
     /**
-     * @param array<int, string> $instanciatedBundleNames
+     * @param array<int, string> $instantiatedBundleNames
      */
-    private function isBundleRegistered(Bundle|ShopwareBundle $bundle, array $instanciatedBundleNames): bool
+    private function isBundleRegistered(Bundle|ShopwareBundle $bundle, array $instantiatedBundleNames): bool
     {
-        return \array_key_exists($bundle->getName(), $instanciatedBundleNames)
+        return \array_key_exists($bundle->getName(), $instantiatedBundleNames)
             || \array_key_exists($bundle->getName(), $this->bundles);
     }
 }

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -80,6 +80,7 @@
         "lcobucci/clock": "^3.1.0",
         "lcobucci/jwt": "^5.5",
         "league/flysystem": "^3.10.3",
+        "league/flysystem-local": "^3.29.0",
         "league/flysystem-memory": "^3.10.3",
         "league/mime-type-detection": "^1.13.0",
         "league/oauth2-server": "^9.1",

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -53,7 +53,7 @@ class KernelTest extends TestCase
         (new SymfonyFilesystem())->remove($tmpDir);
     }
 
-    public function testDumpContainerDoesNotDumpPreloadFile(): void
+    public function testDumpContainerDoesNotDumpPreloadFileIfWarmupCacheDirIsGiven(): void
     {
         $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
         $kernel = $this->createKernel($fileSystem);
@@ -61,6 +61,7 @@ class KernelTest extends TestCase
         $tmpDir = __DIR__ . '/tmpToBeRemoved';
 
         $containerBuilder = new ContainerBuilder();
+        // An underscore at the end indicates a warmup cache directory
         $containerBuilder->setParameter('kernel.cache_dir', 'www/shopware/var/cache/fooBar_h123abc_');
         $containerBuilder->compile();
 
@@ -73,6 +74,7 @@ class KernelTest extends TestCase
         );
 
         static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
+        // Do not create the preload file in warmup cache
         static::assertFalse($fileSystem->fileExists('opcache-preload.php'));
 
         (new SymfonyFilesystem())->remove($tmpDir);

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -5,10 +5,17 @@ declare(strict_types=1);
 namespace Shopware\Tests\Unit\Core;
 
 use Doctrine\DBAL\Connection;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
+use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
 use Shopware\Core\Kernel;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
 /**
  * @internal
@@ -18,16 +25,70 @@ class KernelTest extends TestCase
 {
     public function testGetCacheDir(): void
     {
-        $kernel = new Kernel(
+        static::assertStringStartsWith('www/shopware/var/cache/fooBar_h', $this->createKernel()->getCacheDir());
+    }
+
+    public function testDumpContainerDumpsPreloadFile(): void
+    {
+        $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $kernel = $this->createKernel($fileSystem);
+
+        $tmpDir = __DIR__ . '/tmpToBeRemoved';
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.cache_dir', 'www/shopware/var/cache/fooBar_h123abc');
+        $containerBuilder->compile();
+
+        ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
+            $kernel,
+            new ConfigCache($tmpDir . '/cache', true),
+            $containerBuilder,
+            'Shopware_Core_KernelDevDebugContainer',
+            'Container',
+        );
+
+        static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
+        static::assertTrue($fileSystem->fileExists('opcache-preload.php'));
+
+        (new SymfonyFilesystem())->remove($tmpDir);
+    }
+
+    public function testDumpContainerDoesNotDumpPreloadFile(): void
+    {
+        $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $kernel = $this->createKernel($fileSystem);
+
+        $tmpDir = __DIR__ . '/tmpToBeRemoved';
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.cache_dir', 'www/shopware/var/cache/fooBar_h123abc_');
+        $containerBuilder->compile();
+
+        ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
+            $kernel,
+            new ConfigCache($tmpDir . '/cache', true),
+            $containerBuilder,
+            'Shopware_Core_KernelDevDebugContainer',
+            'Container',
+        );
+
+        static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
+        static::assertFalse($fileSystem->fileExists('opcache-preload.php'));
+
+        (new SymfonyFilesystem())->remove($tmpDir);
+    }
+
+    private function createKernel(?FilesystemOperator $filesystem = null): Kernel
+    {
+        return new Kernel(
             'fooBar',
             true,
             $this->createMock(StaticKernelPluginLoader::class),
             'cacheId',
             '6.6.6',
             $this->createMock(Connection::class),
-            'www/shopware'
+            'www/shopware',
+            $filesystem,
         );
-
-        static::assertStringStartsWith('www/shopware/var/cache/fooBar_h', $kernel->getCacheDir());
     }
 }

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -23,25 +23,34 @@ use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 #[CoversClass(Kernel::class)]
 class KernelTest extends TestCase
 {
+    private string $tmpProjectDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpProjectDir = __DIR__ . '/tmpToBeRemoved';
+    }
+
+    protected function tearDown(): void
+    {
+        (new SymfonyFilesystem())->remove($this->tmpProjectDir);
+    }
+
     public function testGetCacheDir(): void
     {
-        static::assertStringStartsWith('www/shopware/var/cache/fooBar_h', $this->createKernel()->getCacheDir());
+        static::assertStringStartsWith($this->tmpProjectDir . '/var/cache/fooBar_h', $this->createKernel()->getCacheDir());
     }
 
     public function testDumpContainerDumpsPreloadFile(): void
     {
         $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
-        $kernel = $this->createKernel($fileSystem);
-
-        $tmpDir = __DIR__ . '/tmpToBeRemoved';
 
         $containerBuilder = new ContainerBuilder();
-        $containerBuilder->setParameter('kernel.cache_dir', 'www/shopware/var/cache/fooBar_h123abc');
+        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
         $containerBuilder->compile();
 
         ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
-            $kernel,
-            new ConfigCache($tmpDir . '/cache', true),
+            $this->createKernel($fileSystem),
+            new ConfigCache($this->tmpProjectDir . '/cache-file', true),
             $containerBuilder,
             'Shopware_Core_KernelDevDebugContainer',
             'Container',
@@ -49,35 +58,49 @@ class KernelTest extends TestCase
 
         static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
         static::assertTrue($fileSystem->fileExists('opcache-preload.php'));
+    }
 
-        (new SymfonyFilesystem())->remove($tmpDir);
+    public function testDumpContainerDumpsPreloadFileWithoutGivenFileSystem(): void
+    {
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
+        $containerBuilder->compile();
+
+        ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
+            $this->createKernel(),
+            new ConfigCache($this->tmpProjectDir . '/cache-file', true),
+            $containerBuilder,
+            'Shopware_Core_KernelDevDebugContainer',
+            'Container',
+        );
+
+        $fileSystem = new SymfonyFilesystem();
+
+        static::assertTrue($fileSystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
+        static::assertTrue($fileSystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
     }
 
     public function testDumpContainerDoesNotDumpPreloadFileIfWarmupCacheDirIsGiven(): void
     {
         $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
-        $kernel = $this->createKernel($fileSystem);
-
-        $tmpDir = __DIR__ . '/tmpToBeRemoved';
 
         $containerBuilder = new ContainerBuilder();
         // An underscore at the end indicates a warmup cache directory
-        $containerBuilder->setParameter('kernel.cache_dir', 'www/shopware/var/cache/fooBar_h123abc_');
+        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc_');
         $containerBuilder->compile();
 
         ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
-            $kernel,
-            new ConfigCache($tmpDir . '/cache', true),
+            $this->createKernel($fileSystem),
+            new ConfigCache($this->tmpProjectDir . '/cache', true),
             $containerBuilder,
             'Shopware_Core_KernelDevDebugContainer',
             'Container',
         );
 
         static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
+
         // Do not create the preload file in warmup cache
         static::assertFalse($fileSystem->fileExists('opcache-preload.php'));
-
-        (new SymfonyFilesystem())->remove($tmpDir);
     }
 
     private function createKernel(?FilesystemOperator $filesystem = null): Kernel
@@ -89,7 +112,7 @@ class KernelTest extends TestCase
             'cacheId',
             '6.6.6',
             $this->createMock(Connection::class),
-            'www/shopware',
+            $this->tmpProjectDir,
             $filesystem,
         );
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

While using `bin/console cache:clear` the cache is also warmed up. This mechanic in Symfony creates an additional container cache directory: https://github.com/symfony/symfony/blob/v7.2.6/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L115-L117

Therefore it could happen, that then the opcache preloading file is dumped with the wrong container hash. 

### 2. What does this change do, exactly?

Check for the underscore at the end of the cache directory. If there is one, do nothing. 

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/shopware/shopware/issues/7811#issuecomment-2847922185

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/7811

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
