### PR TITLE
fix: missing getSlots method in sw-select-field using deprecated prop

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-field/index.ts
@@ -26,4 +26,11 @@ Component.register('sw-select-field', {
             default: false,
         },
     },
+
+    methods: {
+        getSlots() {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+            return this.$slots;
+        },
+    },
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

https://github.com/shopware/shopware/issues/9124

### 2. What does this change do, exactly?

Add the missing method