### PR TITLE
fix: link to admin profile

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-profile/extension/sw-admin-menu/sw-admin-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/extension/sw-admin-menu/sw-admin-menu.html.twig
@@ -3,7 +3,7 @@
     v-if="acl.can('user.update_profile')"
     class="sw-admin-menu__navigation-list-item"
 >
-    <mt-link
+    <router-link
         class="sw-admin-menu__navigation-link sw-admin-menu__profile-item"
         :to="{ name: 'sw.profile.index', params: { currentUser } }"
     >
@@ -13,7 +13,7 @@
             size="16px"
         />
         {{ $tc('sw-profile.general.headlineProfile') }}
-    </mt-link>
+    </router-link>
 </li>
 
 {% parent %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes an issue where the link to the admin profile page was not working.

### 2. What does this change do, exactly?
Instead of the `mt-link`, we use the `router-link` component.

### 3. Describe each step to reproduce the issue or behaviour.
I could not reproduce that both solutions were working for me.
Need to ask the community if this fixes the issue, but with that change, the DOM href looks good.

Before:
![image](https://github.com/user-attachments/assets/7adfc6e1-2c78-4e5c-9dce-1f879d584b6d)

After:
![image](https://github.com/user-attachments/assets/6ee46d33-4cca-495d-b5c4-75c6b1008031)

### 4. Please link to the relevant issues (if any).
closes: #8920 

<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123


In case of issue existing only on Jira, link to the Jira issue.
- Community Discussion see [here](https://shopwarecommunity.slack.com/archives/C088R4V0R9P/p1746772210329529).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
