### PR TITLE
fix: correct tags placeholder text alignment

### DIFF
--- a/changelog/_unreleased/2025-05-09-fixed-misalignment-of-add-tags-placeholder-in-order-edit-view.md
+++ b/changelog/_unreleased/2025-05-09-fixed-misalignment-of-add-tags-placeholder-in-order-edit-view.md
@@ -1,0 +1,9 @@
+---
+title: Fixed misalignment of 'Add tags...' placeholder in order edit view
+issue: 9207
+author: Mahesh Bohara
+author_email: maheshbohara0101@gmail.com
+author_github: @maheshbohara
+---
+# Administration
+* Added vertical padding to the placeholder text to correct its alignment.

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
@@ -28,7 +28,8 @@
             align-self: center;
 
             input {
-                padding-bottom: 0;
+                padding-top: 8px;
+                padding-bottom: 8px;
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
See issue: #9207


### 2. What does this change do, exactly?
Fixes misaligned tags placeholder text.

![image](https://github.com/user-attachments/assets/25374a46-84a1-4b81-bcfd-85af4106eac1)



### 3. Describe each step to reproduce the issue or behaviour.
Open the order add/edit screen and check the vertical alignment of the "Add tags..." placeholder text.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
fixes #9207

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
