### PR TITLE
fix: Page format in bulk-download PDF of uploaded documents

### DIFF
--- a/src/Core/Checkout/Document/Service/DocumentMerger.php
+++ b/src/Core/Checkout/Document/Service/DocumentMerger.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Checkout\Document\Service;
 use setasign\Fpdi\PdfParser\StreamReader;
 use setasign\Fpdi\Tfpdf\Fpdi;
 use Shopware\Core\Checkout\Document\DocumentCollection;
-use Shopware\Core\Checkout\Document\DocumentConfigurationFactory;
 use Shopware\Core\Checkout\Document\DocumentEntity;
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
@@ -81,8 +80,6 @@ final class DocumentMerger
                 continue;
             }
 
-            $config = DocumentConfigurationFactory::createConfiguration($document->getConfig());
-
             $media = $context->scope(Context::SYSTEM_SCOPE, fn (Context $context): string => $this->mediaService->loadFileStream($documentMediaId, $context)->getContents());
 
             $numPages = $this->fpdi->setSourceFile(StreamReader::createByString($media));
@@ -94,7 +91,13 @@ final class DocumentMerger
                 if (!\is_array($size)) {
                     continue;
                 }
-                $this->fpdi->AddPage($config->getPageOrientation() ?? 'portrait', $config->getPageSize());
+                $this->fpdi->AddPage(
+                    $size['orientation'],
+                    [
+                        $size[0], // width
+                        $size[1], // height
+                    ],
+                );
                 $this->fpdi->useTemplate($template);
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

See issue: https://github.com/shopware/shopware/issues/9232

### 2. What does this change do, exactly?
Instead of using the document size from the document config, which is missing for uploaded documents, the page size is take from the actual source PDF document. Therefore the page sizes are always preserved. This even fixes the page formats for PDFs with different page sizes in one document.

### 3. Describe each step to reproduce the issue or behaviour.
See issue

### 4. Please link to the relevant issues (if any).

- closes #9232


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
