### PR TITLE
fix: changed text when edit locked cms page in table view

### DIFF
--- a/changelog/_unreleased/2025-09-05-changed-text-when-edit-locked-cms-page.md
+++ b/changelog/_unreleased/2025-09-05-changed-text-when-edit-locked-cms-page.md
@@ -1,0 +1,10 @@
+---
+title: Changed text when editing locked CMS page in table view
+issue: #9051
+author: Melvin Achterhuis
+author_email: melvin@achterhuis.work
+author_github: @MelvinAchterhuis
+---
+
+# Administration
+* Added new snippet to `src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig` that is shown when editing a locked CMS page in table view.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
@@ -308,7 +308,12 @@
                                             class="sw-cms-list__context-menu-item-edit"
                                             :disabled="!acl.can('cms.editor') || undefined"
                                         >
-                                            {{ $tc('sw-cms.components.cmsListItem.edit') }}
+                                            <template v-if="item.locked">
+                                                {{ $tc('sw-cms.components.cmsListItem.view') }}
+                                            </template>
+                                            <template v-else>
+                                                {{ $tc('sw-cms.components.cmsListItem.edit') }}
+                                            </template>
                                         </sw-context-menu-item>
                                         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -813,6 +813,7 @@
         "rename": "Umbenennen",
         "delete": "Löschen",
         "duplicate": "Duplizieren",
+        "view": "Vorschau",
         "addPreviewImage": "Vorschau hinzufügen",
         "setAsDefaultProductList": "Als Standard für Kategorieseiten festlegen",
         "setAsDefaultProductDetail": "Als Standard für Produkseiten festlegen",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -813,6 +813,7 @@
         "rename": "Rename",
         "delete": "Delete",
         "duplicate": "Duplicate",
+        "view": "View",
         "addPreviewImage": "Add preview image",
         "setAsDefaultProductList": "Set as product listing default",
         "setAsDefaultProductDetail": "Set as product page default",


### PR DESCRIPTION
### 1. Why is this change necessary?

Locked page can't be edited, only viewed

### 2. What does this change do, exactly?

Show correct text by adding a new snippet

### 3. Describe each step to reproduce the issue or behaviour.

Shopping Experiences -> Table view -> Trigger context menu on locked CMS page

### 4. Please link to the relevant issues (if any).
fixes #9051 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
