### PR TITLE
fix: add createTextEditorDataMappingButton to component helper

### DIFF
--- a/changelog/_unreleased/2025-05-09-export-createtexteditordatamappingbutton-through-global-shopware-component-helper.md
+++ b/changelog/_unreleased/2025-05-09-export-createtexteditordatamappingbutton-through-global-shopware-component-helper.md
@@ -1,0 +1,35 @@
+---
+title: export createTextEditorDataMappingButton through global Shopware component helper
+issue: #9012
+author: Iván Tajes Vidal
+author_email: tajespasarela@gmail.com
+author_github: @Iván Tajes Vidal
+---
+# Administration
+* Added the `createTextEditorDataMappingButton` method to the global Shopware component helper.
+
+___
+
+# Upgrade Information
+
+## Added the `createTextEditorDataMappingButton` method to the global Shopware component helper
+
+ This change is a breaking change. The `createTextEditorDataMappingButton` method is now available through the global Shopware component helper.
+    This method allows you to create a button that opens the text editor data mapping modal. The button can be used in your custom components to provide a consistent user experience when working with text editor data mapping.
+
+
+## Example usage
+
+```javascript
+const { createTextEditorDataMappingButton } = Component.getComponentHelper();
+
+const button = createTextEditorDataMappingButton({
+    data: {
+        text: 'Hello World',
+        html: '<p>Hello World</p>'
+    },
+    onSave: (data) => {
+        console.log('Data saved:', data);
+    }
+});
+```

--- a/src/Administration/Resources/app/administration/src/app/init/component-helper.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/component-helper.init.spec.js
@@ -17,5 +17,6 @@ describe('src/app/init/component-helper.init.ts', () => {
         expect(componentHelper.hasOwnProperty('mapPageErrors')).toBe(true);
         expect(componentHelper.hasOwnProperty('mapPropertyErrors')).toBe(true);
         expect(componentHelper.hasOwnProperty('mapSystemConfigErrors')).toBe(true);
+        expect(componentHelper.hasOwnProperty('createTextEditorDataMappingButton')).toBe(true);
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/init/component-helper.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/component-helper.init.ts
@@ -10,6 +10,8 @@ import {
     mapActions as mapVuexActions,
 } from 'vuex';
 import { mapState, mapActions } from 'pinia';
+// eslint-disable-next-line max-len
+import createTextEditorDataMappingButton from 'src/app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-cms-data-mapping/index';
 
 import * as mapErrors from 'src/app/service/map-errors.service';
 
@@ -20,6 +22,7 @@ const componentHelper: ComponentHelper = {
     mapVuexMutations,
     mapVuexGetters,
     mapVuexActions,
+    createTextEditorDataMappingButton,
     ...mapErrors,
 };
 

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -130,6 +130,8 @@ import type { SwProfileStore } from './module/sw-profile/store/sw-profile.store'
 import type { SwPromotionDetailStore } from './module/sw-promotion-v2/page/sw-promotion-v2-detail/store';
 import type { SwFlowStore } from './module/sw-flow/store/flow.store';
 import type { SwBulkStore } from './app/store/sw-bulk-edit.store';
+// eslint-disable-next-line max-len
+import type createTextEditorDataMappingButton from './app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-cms-data-mapping';
 
 // trick to make it an "external module" to support global type extension
 
@@ -351,6 +353,7 @@ declare global {
         mapSystemConfigErrors: typeof mapErrors.mapSystemConfigErrors;
         mapCollectionPropertyErrors: typeof mapErrors.mapCollectionPropertyErrors;
         mapPageErrors: typeof mapErrors.mapPageErrors;
+        createTextEditorDataMappingButton: typeof createTextEditorDataMappingButton;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix the missing access to sw-text-editor-toolbar-button-cms-data-mapping from extensions  [#9012](https://github.com/shopware/shopware/issues/9012)

### 2. What does this change do, exactly?

Add it to the global `Shopware.Component.getComponentHelper()`

- closes #9012
