### PR TITLE
feat: AllowHtml / Object Field / Runtime support for attribute entities

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -79,5 +79,6 @@ return [
 
         // Exclude the backwards-incompatible change for the new parameter
         'ADDED: Parameter prefixMatch was added to Method __construct\(\) of class Shopware\\\\Elasticsearch\\\\Product\\\\SearchFieldConfig',
+        'ADDED: Parameter runtime was added to Method __construct\(\) of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Attribute\\\\Field'
     ],
 ];

--- a/changelog/_unreleased/2025-01-02-add-allow-html-entity-attribute.md
+++ b/changelog/_unreleased/2025-01-02-add-allow-html-entity-attribute.md
@@ -1,0 +1,8 @@
+---
+title: Add AllowHtml Attribute support
+author: Raffaele Carelle
+author_email: raffaele.carelle@gmail.com
+author_github: @raffaelecarelle
+---
+# Core
+* Added `Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowHtml` to manage respectively flag on Entity

--- a/src/Core/Framework/DataAbstractionLayer/Attribute/AllowHtml.php
+++ b/src/Core/Framework/DataAbstractionLayer/Attribute/AllowHtml.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Attribute;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class AllowHtml
+{
+    public function __construct(public bool $sanitized = false)
+    {
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Attribute/Field.php
+++ b/src/Core/Framework/DataAbstractionLayer/Attribute/Field.php
@@ -12,12 +12,14 @@ class Field
 
     /**
      * @param bool|array{admin-api: bool, store-api: bool} $api
+     * @param bool|array<string> $runtime
      */
     public function __construct(
         public string $type,
         public bool $translated = false,
         public bool|array $api = false,
         public ?string $column = null,
+        public bool|array $runtime = false,
     ) {
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Attribute/FieldType.php
+++ b/src/Core/Framework/DataAbstractionLayer/Attribute/FieldType.php
@@ -19,4 +19,5 @@ enum FieldType: string
     public const DATE = 'date';
     public const DATE_INTERVAL = 'date-interval';
     public const TIME_ZONE = 'time-zone';
+    public const OBJECT = 'object';
 }

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -4,6 +4,8 @@ namespace Shopware\Core\Framework\DataAbstractionLayer;
 
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowEmptyString as AllowEmptyStringAttr;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowHtml as AllowHtmlAttr;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AutoIncrement;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\CustomFields as CustomFieldsAttr;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
@@ -34,6 +36,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\EnumField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field as DalField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowEmptyString;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AsArray;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
@@ -286,6 +290,15 @@ class AttributeEntityCompiler
         if ($inherited = $this->getAttribute($property, Inherited::class)) {
             $instance = $inherited->newInstance();
             $flags[Inherited::class] = ['class' => Inherited::class, 'args' => ['reversed' => $instance->reversed]];
+        }
+
+        if ($this->getAttribute($property, AllowEmptyStringAttr::class)) {
+            $flags[AllowEmptyString::class] = ['class' => AllowEmptyString::class];
+        }
+
+        if ($attr = $this->getAttribute($property, AllowHtmlAttr::class)) {
+            $instance = $attr->newInstance();
+            $flags[AllowHtml::class] = ['class' => AllowHtml::class, 'args' => ['sanitized' => $instance->sanitized]];
         }
 
         if ($field->api !== false) {

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\DataAbstractionLayer;
 
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
-use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowEmptyString as AllowEmptyStringAttr;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowHtml as AllowHtmlAttr;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AutoIncrement;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\CustomFields as CustomFieldsAttr;
@@ -36,7 +35,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\EnumField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field as DalField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowEmptyString;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AsArray;
@@ -44,6 +42,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SetNullOnDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\WriteProtected;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
@@ -53,6 +52,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ObjectField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
@@ -204,6 +204,7 @@ class AttributeEntityCompiler
 
         return match ($field->type) {
             FieldType::INT => IntField::class,
+            FieldType::OBJECT => ObjectField::class,
             FieldType::TEXT => LongTextField::class,
             FieldType::FLOAT => FloatField::class,
             FieldType::BOOL => BoolField::class,
@@ -292,10 +293,6 @@ class AttributeEntityCompiler
             $flags[Inherited::class] = ['class' => Inherited::class, 'args' => ['reversed' => $instance->reversed]];
         }
 
-        if ($this->getAttribute($property, AllowEmptyStringAttr::class)) {
-            $flags[AllowEmptyString::class] = ['class' => AllowEmptyString::class];
-        }
-
         if ($attr = $this->getAttribute($property, AllowHtmlAttr::class)) {
             $instance = $attr->newInstance();
             $flags[AllowHtml::class] = ['class' => AllowHtml::class, 'args' => ['sanitized' => $instance->sanitized]];
@@ -313,6 +310,14 @@ class AttributeEntityCompiler
             }
 
             $flags[ApiAware::class] = ['class' => ApiAware::class, 'args' => $aware];
+        }
+
+        if ($field->runtime !== false) {
+            $depends = [];
+            if (\is_array($field->runtime)) {
+                $depends = $field->runtime;
+            }
+            $flags[Runtime::class] = ['class' => Runtime::class, 'args' => $depends];
         }
 
         if ($protection = $this->getAttribute($property, Protection::class)) {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -133,6 +133,8 @@ class AttributeEntityIntegrationTest extends TestCase
             [
                 'id' => $ids->create('first-key'),
                 'string' => 'string',
+                'emptyString' => '',
+                'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
                 'transString' => 'transString',
                 'differentName' => 'storageString',
             ],
@@ -154,6 +156,7 @@ class AttributeEntityIntegrationTest extends TestCase
         static::assertInstanceOf(AttributeEntity::class, $record);
         static::assertSame($ids->get('first-key'), $record->id);
         static::assertSame('string', $record->string);
+        static::assertSame('<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>', $record->htmlString);
         static::assertSame('transString', $record->getTranslation('transString'));
         static::assertSame('storageString', $record->differentName);
 
@@ -207,6 +210,8 @@ class AttributeEntityIntegrationTest extends TestCase
         $data = [
             'id' => $ids->get('first-key'),
             'string' => 'string',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
+            'emptyString' => '',
             'text' => 'text',
             'int' => 1,
             'float' => 1.1,
@@ -329,6 +334,8 @@ class AttributeEntityIntegrationTest extends TestCase
             'orders' => null,
             'translations' => null,
             'customFields' => null,
+            'emptyString' => '',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
         ], $json);
     }
 
@@ -357,6 +364,8 @@ class AttributeEntityIntegrationTest extends TestCase
         $data = [
             'id' => $ids->get('first-key'),
             'string' => 'string',
+            'emptyString' => '',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
             'transString' => 'transString',
             'follow' => self::currency($ids->get('currency-1'), 'ABC'),
         ];
@@ -410,6 +419,7 @@ class AttributeEntityIntegrationTest extends TestCase
             'id' => $ids->get('first-key'),
             'string' => 'string',
             'transString' => 'transString',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
             'aggs' => [
                 ['id' => $ids->get('agg-1'), 'number' => 'agg-1'],
                 ['id' => $ids->get('agg-2'), 'number' => 'agg-2'],
@@ -476,6 +486,7 @@ class AttributeEntityIntegrationTest extends TestCase
             'id' => $ids->get('first-key'),
             'string' => 'string',
             'transString' => 'transString',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
             'currency' => self::currency($ids->get('currency-1'), 'ABC'),
         ];
 
@@ -561,6 +572,7 @@ class AttributeEntityIntegrationTest extends TestCase
             'id' => $ids->get('first-key'),
             'string' => 'string',
             'transString' => 'transString',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
             'currencies' => [
                 self::currency($ids->get('currency-1'), 'ABC'),
                 self::currency($ids->get('currency-2'), 'DEF'),
@@ -621,6 +633,7 @@ class AttributeEntityIntegrationTest extends TestCase
             'id' => $ids->get('first-key'),
             'string' => 'string',
             'transString' => 'transString',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
             'stateId' => $stateId,
         ];
 
@@ -695,6 +708,8 @@ class AttributeEntityIntegrationTest extends TestCase
         $data = [
             'id' => $ids->get('first-key'),
             'string' => 'string',
+            'emptyString' => '',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
             'transString' => [
                 'en-GB' => 'transString',
                 'de-DE' => 'transString-de',
@@ -750,6 +765,8 @@ class AttributeEntityIntegrationTest extends TestCase
         $data = [
             'id' => $ids->get('first-key'),
             'string' => 'string',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
+            'emptyString' => '',
             'transString' => 'transString',
         ];
 
@@ -797,6 +814,7 @@ class AttributeEntityIntegrationTest extends TestCase
             'id' => $ids->get('first-key'),
             'string' => 'string',
             'transString' => 'transString',
+            'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
             'orders' => [
                 self::order($ids->get('order-1'), $this->getStateMachineState(), $this->getValidCountryId()),
                 self::order($ids->get('order-2'), $this->getStateMachineState(), $this->getValidCountryId()),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -26,9 +26,13 @@ use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Api\ResponseFields;
+use Shopware\Core\System\SalesChannel\Api\StructEncoder;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntity;
@@ -121,6 +125,23 @@ class AttributeEntityIntegrationTest extends TestCase
         static::assertSame('attribute_entity_id', $field->getStorageName());
         static::assertSame('id', $field->getReferenceField());
         static::assertSame('attribute_entity', $field->getReferenceEntity());
+    }
+
+    public function testEncodingWithRuntimeField(): void
+    {
+        $entity = new AttributeEntity();
+        $entity->assign([
+            'id' => Uuid::randomHex(),
+            'object' => new ArrayStruct([
+                'foo' => 'bar',
+            ]),
+        ]);
+
+        $data = $this->getContainer()->get(StructEncoder::class)->encode($entity, new ResponseFields([]));
+
+        static::assertArrayHasKey('object', $data);
+        static::assertArrayHasKey('foo', $data['object']);
+        static::assertSame('bar', $data['object']['foo']);
     }
 
     public function testCrudRoot(): void
@@ -336,6 +357,7 @@ class AttributeEntityIntegrationTest extends TestCase
             'customFields' => null,
             'emptyString' => '',
             'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
+            'notEncoded' => 'will be not encoded in api',
         ], $json);
     }
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -355,7 +355,6 @@ class AttributeEntityIntegrationTest extends TestCase
             'orders' => null,
             'translations' => null,
             'customFields' => null,
-            'emptyString' => '',
             'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
             'notEncoded' => 'will be not encoded in api',
         ], $json);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
@@ -4,6 +4,8 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture
 
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderStates;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowEmptyString;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AutoIncrement;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Field;
@@ -164,4 +166,8 @@ class AttributeEntity extends EntityStruct
      */
     #[Translations]
     public ?array $translations = null;
+
+    #[Field(type: FieldType::STRING)]
+    #[AllowHtml]
+    public string $htmlString;
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
@@ -4,7 +4,6 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture
 
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderStates;
-use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowEmptyString;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AutoIncrement;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
@@ -28,6 +27,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\PriceFieldSeria
 use Shopware\Core\Framework\DataAbstractionLayer\FieldType\DateInterval;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
 use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 
@@ -170,4 +170,9 @@ class AttributeEntity extends EntityStruct
     #[Field(type: FieldType::STRING)]
     #[AllowHtml]
     public string $htmlString;
+
+    #[Field(type: FieldType::OBJECT, runtime: true)]
+    public ?Struct $object;
+
+    public string $notEncoded = 'will be not encoded in api';
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/schema.sql
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/schema.sql
@@ -8,6 +8,8 @@ DROP TABLE IF EXISTS `attribute_entity`;
 CREATE TABLE `attribute_entity` (
     `id` BINARY(16) NOT NULL,
     `string` VARCHAR(255) NOT NULL,
+    `empty_string` VARCHAR(255) DEFAULT '' NOT NULL,
+    `html_string` VARCHAR(255) NOT NULL,
     `text` LONGTEXT NULL,
     `int` INT(11) NULL,
     `float` DOUBLE NULL,


### PR DESCRIPTION
- AllowHtml is a backport https://github.com/shopware/shopware/commit/e6c4b016d442f13f58ede31ae1e5a0be7a16cfd6
- Runtime fields and object fields are not supported yet. They are required for implementation like sales channel product calculated prodct properties.