### PR TITLE
chore: Fix sidebar filter panel reset button width

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-sidebar-filter-panel/sw-sidebar-filter-panel.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-sidebar-filter-panel/sw-sidebar-filter-panel.scss
@@ -11,8 +11,8 @@
 
         a {
             float: left;
-            width: 100%;
             padding-left: 15px;
+            margin-right: auto;
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently the "reset all" button in `sw-sidebar-filter-panel` is much wider than the actual text leading to accidental clicks when trying to close the panel.

#### Before


https://github.com/user-attachments/assets/27b159b3-60fe-4cf8-9619-2c4778c74c9e

#### After


https://github.com/user-attachments/assets/d3cc3d68-876f-4b30-8030-3b9e909834af




### 2. What does this change do, exactly?

Turn the overhanging width into margin.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open any filter panel.
2. Activate a filter
3. Click between `X` and `Reset all` 

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
