### PR TITLE
fix: Do not dump opcache preload file if warmup directory is used [6.6.x] 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
         "lcobucci/clock": "^3.1.0",
         "lcobucci/jwt": "^5.5",
         "league/flysystem": "^3.10.3",
+        "league/flysystem-local": "^3.29.0",
         "league/flysystem-memory": "^3.10.3",
         "league/mime-type-detection": "^1.13.0",
         "league/oauth2-server": "^8.5",

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -5,6 +5,9 @@ namespace Shopware\Core;
 use Composer\Autoload\ClassLoader;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Api\Controller\FallbackController;
@@ -24,7 +27,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel as HttpKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
@@ -36,7 +38,6 @@ class Kernel extends HttpKernel
     use MicroKernelTrait;
 
     final public const CONFIG_EXTS = '.{php,xml,yaml,yml}';
-
     /**
      * @var string Fallback version if nothing is provided via kernel constructor
      */
@@ -67,10 +68,12 @@ class Kernel extends HttpKernel
 
     private bool $rebooting = false;
 
+    private FilesystemOperator $filesystem;
+
+    private string $cacheRootDir;
+
     /**
      * @internal
-     *
-     * {@inheritdoc}
      */
     public function __construct(
         string $environment,
@@ -79,28 +82,35 @@ class Kernel extends HttpKernel
         private string $cacheId,
         string $version,
         Connection $connection,
-        protected string $projectDir
+        protected string $projectDir,
+        ?FilesystemOperator $filesystem = null,
     ) {
         date_default_timezone_set('UTC');
 
         parent::__construct($environment, $debug);
         self::$connection = $connection;
 
+<<<<<<< HEAD
         $this->pluginLoader = $pluginLoader;
 
         $version = VersionParser::parseShopwareVersion($version);
         $this->shopwareVersion = $version['version'];
         $this->shopwareVersionRevision = $version['revision'];
+=======
+        $versionArray = VersionParser::parseShopwareVersion($version);
+        $this->shopwareVersion = $versionArray['version'];
+        $this->shopwareVersionRevision = $versionArray['revision'];
+
+        $this->cacheRootDir = EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()) . '/var/cache';
+        $this->filesystem = $filesystem ?? new Filesystem(new LocalFilesystemAdapter($this->cacheRootDir));
+>>>>>>> 0ff5f8c753 (fix: Do not dump opcache preload file if warmup directory is used (#9200))
     }
 
-    /**
-     * @return iterable<BundleInterface>
-     */
     public function registerBundles(): iterable
     {
         /** @var array<class-string<Bundle>, array<string, bool>> $bundles */
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
-        $instanciatedBundleNames = [];
+        $instantiatedBundleNames = [];
 
         $kernelParameters = $this->getKernelParameters();
 
@@ -109,11 +119,11 @@ class Kernel extends HttpKernel
                 /** @var ShopwareBundle|Bundle $bundle */
                 $bundle = new $class();
 
-                if ($this->isBundleRegistered($bundle, $instanciatedBundleNames)) {
+                if ($this->isBundleRegistered($bundle, $instantiatedBundleNames)) {
                     continue;
                 }
 
-                $instanciatedBundleNames[] = $bundle->getName();
+                $instantiatedBundleNames[] = $bundle->getName();
 
                 yield $bundle;
 
@@ -124,22 +134,26 @@ class Kernel extends HttpKernel
                 $classLoader = new ClassLoader();
                 $parameters = new AdditionalBundleParameters($classLoader, new KernelPluginCollection(), $kernelParameters);
                 foreach ($bundle->getAdditionalBundles($parameters) as $additionalBundle) {
-                    if ($this->isBundleRegistered($additionalBundle, $instanciatedBundleNames)) {
+                    if ($this->isBundleRegistered($additionalBundle, $instantiatedBundleNames)) {
                         continue;
                     }
 
-                    $instanciatedBundleNames[] = $additionalBundle->getName();
+                    $instantiatedBundleNames[] = $additionalBundle->getName();
                     yield $additionalBundle;
                 }
             }
         }
 
+<<<<<<< HEAD
         if ((!Feature::has('v6.7.0.0') || !Feature::isActive('v6.7.0.0')) && !isset($bundles[Service::class])) {
             Feature::triggerDeprecationOrThrow('v6.7.0.0', \sprintf('The %s bundle should be added to config/bundles.php', Service::class));
             yield new Service();
         }
 
         yield from $this->pluginLoader->getBundles($kernelParameters, $instanciatedBundleNames);
+=======
+        yield from $this->pluginLoader->getBundles($kernelParameters, $instantiatedBundleNames);
+>>>>>>> 0ff5f8c753 (fix: Do not dump opcache preload file if warmup directory is used (#9200))
     }
 
     public function getProjectDir(): string
@@ -158,7 +172,7 @@ class Kernel extends HttpKernel
 
     public function boot(): void
     {
-        if ($this->booted === true) {
+        if ($this->booted) {
             if ($this->debug) {
                 $this->startTime = microtime(true);
             }
@@ -204,8 +218,13 @@ class Kernel extends HttpKernel
     public function getCacheDir(): string
     {
         return \sprintf(
+<<<<<<< HEAD
             '%s/var/cache/%s_h%s%s',
             EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()),
+=======
+            '%s/%s_h%s',
+            $this->cacheRootDir,
+>>>>>>> 0ff5f8c753 (fix: Do not dump opcache preload file if warmup directory is used (#9200))
             $this->getEnvironment(),
             $this->getCacheHash(),
             EnvironmentHelper::getVariable('TEST_TOKEN') ?? ''
@@ -289,9 +308,7 @@ class Kernel extends HttpKernel
     }
 
     /**
-     * {@inheritdoc}
-     *
-     * @return array<string, mixed>
+     * @return array<string, array<string, mixed>|bool|string|int|float|\UnitEnum|null>
      */
     protected function getKernelParameters(): array
     {
@@ -352,10 +369,17 @@ class Kernel extends HttpKernel
 
     protected function initializeDatabaseConnectionVariables(): void
     {
+<<<<<<< HEAD
         /**
          * @deprecated tag:v6.7.0 - remove if-clause, we have already SQL_SET_DEFAULT_SESSION_VARIABLES which is documented does the same
          */
         $shopwareSkipConnectionVariables = EnvironmentHelper::getVariable('SHOPWARE_SKIP_CONNECTION_VARIABLES', false);
+=======
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'The method initializeDatabaseConnectionVariables is deprecated and will be removed in 6.8.0.0. All MySQL connection variables are configured in ' . MySQLFactory::class
+        );
+>>>>>>> 0ff5f8c753 (fix: Do not dump opcache preload file if warmup directory is used (#9200))
 
         if ($shopwareSkipConnectionVariables) {
             return;
@@ -388,31 +412,38 @@ class Kernel extends HttpKernel
         }
     }
 
-    /**
-     * Dumps the preload file to an always known location outside the generated cache folder name
-     */
     protected function dumpContainer(ConfigCache $cache, ContainerBuilder $container, string $class, string $baseClass): void
     {
         parent::dumpContainer($cache, $container, $class, $baseClass);
+
+        $this->filesystem->write('CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
+
         $cacheDir = $container->getParameter('kernel.cache_dir');
-        $cacheName = basename($cacheDir);
-        $fileName = substr(basename($cache->getPath()), 0, -3) . 'preload.php';
 
-        file_put_contents(\dirname($cacheDir) . '/CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
+        // Do not dump the preload file if the cache dir is a warmup dir.
+        // See https://github.com/symfony/symfony/blob/v7.2.6/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L115-L117
+        if (str_ends_with($cacheDir, '_')) {
+            return;
+        }
 
-        $preloadFile = \dirname($cacheDir) . '/opcache-preload.php';
+        $cacheDirectoryName = basename($cacheDir);
+        $containerPreloadFileName = $class . '.preload.php';
 
-        $loader = <<<PHP
+        $preloadFileContent = <<<PHP
 <?php
 
 require_once __DIR__ . '/#CACHE_PATH#';
 PHP;
 
-        file_put_contents($preloadFile, str_replace(
-            ['#CACHE_PATH#'],
-            [$cacheName . '/' . $fileName],
-            $loader
-        ));
+        // Dumps the preload file to an always known location outside the generated cache folder name
+        $this->filesystem->write(
+            'opcache-preload.php',
+            str_replace(
+                '#CACHE_PATH#',
+                $cacheDirectoryName . \DIRECTORY_SEPARATOR . $containerPreloadFileName,
+                $preloadFileContent,
+            )
+        );
     }
 
     private function addApiRoutes(RoutingConfigurator $routes): void
@@ -450,11 +481,11 @@ PHP;
     }
 
     /**
-     * @param array<int, string> $instanciatedBundleNames
+     * @param array<int, string> $instantiatedBundleNames
      */
-    private function isBundleRegistered(Bundle|ShopwareBundle $bundle, array $instanciatedBundleNames): bool
+    private function isBundleRegistered(Bundle|ShopwareBundle $bundle, array $instantiatedBundleNames): bool
     {
-        return \array_key_exists($bundle->getName(), $instanciatedBundleNames)
+        return \array_key_exists($bundle->getName(), $instantiatedBundleNames)
             || \array_key_exists($bundle->getName(), $this->bundles);
     }
 }

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -5,9 +5,6 @@ namespace Shopware\Core;
 use Composer\Autoload\ClassLoader;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DBALException;
-use League\Flysystem\Filesystem;
-use League\Flysystem\FilesystemOperator;
-use League\Flysystem\Local\LocalFilesystemAdapter;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Api\Controller\FallbackController;
@@ -24,6 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -69,8 +67,6 @@ class Kernel extends HttpKernel
 
     private bool $rebooting = false;
 
-    private FilesystemOperator $filesystem;
-
     private string $cacheRootDir;
 
     /**
@@ -84,7 +80,6 @@ class Kernel extends HttpKernel
         string $version,
         Connection $connection,
         protected string $projectDir,
-        ?FilesystemOperator $filesystem = null,
     ) {
         date_default_timezone_set('UTC');
 
@@ -98,7 +93,6 @@ class Kernel extends HttpKernel
         $this->shopwareVersionRevision = $versionArray['revision'];
 
         $this->cacheRootDir = EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()) . '/var/cache';
-        $this->filesystem = $filesystem ?? new Filesystem(new LocalFilesystemAdapter($this->cacheRootDir));
     }
 
     public function registerBundles(): iterable
@@ -395,7 +389,8 @@ class Kernel extends HttpKernel
     {
         parent::dumpContainer($cache, $container, $class, $baseClass);
 
-        $this->filesystem->write('CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
+        $filesystem = new Filesystem();
+        $filesystem->dumpFile($this->cacheRootDir . \DIRECTORY_SEPARATOR . 'CACHEDIR.TAG', 'Signature: 8a477f597d28d172789f06886806bc55');
 
         $cacheDir = $container->getParameter('kernel.cache_dir');
 
@@ -415,8 +410,8 @@ require_once __DIR__ . '/#CACHE_PATH#';
 PHP;
 
         // Dumps the preload file to an always known location outside the generated cache folder name
-        $this->filesystem->write(
-            'opcache-preload.php',
+        $filesystem->dumpFile(
+            $this->cacheRootDir . \DIRECTORY_SEPARATOR . 'opcache-preload.php',
             str_replace(
                 '#CACHE_PATH#',
                 $cacheDirectoryName . \DIRECTORY_SEPARATOR . $containerPreloadFileName,

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -90,20 +90,14 @@ class Kernel extends HttpKernel
         parent::__construct($environment, $debug);
         self::$connection = $connection;
 
-<<<<<<< HEAD
         $this->pluginLoader = $pluginLoader;
 
-        $version = VersionParser::parseShopwareVersion($version);
-        $this->shopwareVersion = $version['version'];
-        $this->shopwareVersionRevision = $version['revision'];
-=======
         $versionArray = VersionParser::parseShopwareVersion($version);
         $this->shopwareVersion = $versionArray['version'];
         $this->shopwareVersionRevision = $versionArray['revision'];
 
         $this->cacheRootDir = EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()) . '/var/cache';
         $this->filesystem = $filesystem ?? new Filesystem(new LocalFilesystemAdapter($this->cacheRootDir));
->>>>>>> 0ff5f8c753 (fix: Do not dump opcache preload file if warmup directory is used (#9200))
     }
 
     public function registerBundles(): iterable
@@ -144,16 +138,12 @@ class Kernel extends HttpKernel
             }
         }
 
-<<<<<<< HEAD
         if ((!Feature::has('v6.7.0.0') || !Feature::isActive('v6.7.0.0')) && !isset($bundles[Service::class])) {
             Feature::triggerDeprecationOrThrow('v6.7.0.0', \sprintf('The %s bundle should be added to config/bundles.php', Service::class));
             yield new Service();
         }
 
-        yield from $this->pluginLoader->getBundles($kernelParameters, $instanciatedBundleNames);
-=======
         yield from $this->pluginLoader->getBundles($kernelParameters, $instantiatedBundleNames);
->>>>>>> 0ff5f8c753 (fix: Do not dump opcache preload file if warmup directory is used (#9200))
     }
 
     public function getProjectDir(): string
@@ -218,13 +208,8 @@ class Kernel extends HttpKernel
     public function getCacheDir(): string
     {
         return \sprintf(
-<<<<<<< HEAD
-            '%s/var/cache/%s_h%s%s',
-            EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()),
-=======
-            '%s/%s_h%s',
+            '%s/%s_h%s%s',
             $this->cacheRootDir,
->>>>>>> 0ff5f8c753 (fix: Do not dump opcache preload file if warmup directory is used (#9200))
             $this->getEnvironment(),
             $this->getCacheHash(),
             EnvironmentHelper::getVariable('TEST_TOKEN') ?? ''
@@ -369,18 +354,10 @@ class Kernel extends HttpKernel
 
     protected function initializeDatabaseConnectionVariables(): void
     {
-<<<<<<< HEAD
         /**
          * @deprecated tag:v6.7.0 - remove if-clause, we have already SQL_SET_DEFAULT_SESSION_VARIABLES which is documented does the same
          */
         $shopwareSkipConnectionVariables = EnvironmentHelper::getVariable('SHOPWARE_SKIP_CONNECTION_VARIABLES', false);
-=======
-        Feature::triggerDeprecationOrThrow(
-            'v6.8.0.0',
-            'The method initializeDatabaseConnectionVariables is deprecated and will be removed in 6.8.0.0. All MySQL connection variables are configured in ' . MySQLFactory::class
-        );
->>>>>>> 0ff5f8c753 (fix: Do not dump opcache preload file if warmup directory is used (#9200))
-
         if ($shopwareSkipConnectionVariables) {
             return;
         }

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -38,6 +38,7 @@ class Kernel extends HttpKernel
     use MicroKernelTrait;
 
     final public const CONFIG_EXTS = '.{php,xml,yaml,yml}';
+
     /**
      * @var string Fallback version if nothing is provided via kernel constructor
      */
@@ -358,6 +359,7 @@ class Kernel extends HttpKernel
          * @deprecated tag:v6.7.0 - remove if-clause, we have already SQL_SET_DEFAULT_SESSION_VARIABLES which is documented does the same
          */
         $shopwareSkipConnectionVariables = EnvironmentHelper::getVariable('SHOPWARE_SKIP_CONNECTION_VARIABLES', false);
+
         if ($shopwareSkipConnectionVariables) {
             return;
         }

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -80,6 +80,7 @@
         "lcobucci/clock": "^3.1.0",
         "lcobucci/jwt": "^5.5",
         "league/flysystem": "^3.10.3",
+        "league/flysystem-local": "^3.29.0",
         "league/flysystem-memory": "^3.10.3",
         "league/mime-type-detection": "^1.13.0",
         "league/oauth2-server": "^8.5",

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Shopware\Tests\Unit\Core;
 
 use Doctrine\DBAL\Connection;
-use League\Flysystem\Filesystem;
-use League\Flysystem\FilesystemOperator;
-use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
@@ -15,7 +12,7 @@ use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
 use Shopware\Core\Kernel;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -25,14 +22,17 @@ class KernelTest extends TestCase
 {
     private string $tmpProjectDir;
 
+    private Filesystem $filesystem;
+
     protected function setUp(): void
     {
         $this->tmpProjectDir = __DIR__ . '/tmpToBeRemoved';
+        $this->filesystem = new Filesystem();
     }
 
     protected function tearDown(): void
     {
-        (new SymfonyFilesystem())->remove($this->tmpProjectDir);
+        $this->filesystem->remove($this->tmpProjectDir);
     }
 
     public function testGetCacheDir(): void
@@ -41,26 +41,6 @@ class KernelTest extends TestCase
     }
 
     public function testDumpContainerDumpsPreloadFile(): void
-    {
-        $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
-
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
-        $containerBuilder->compile();
-
-        ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
-            $this->createKernel($fileSystem),
-            new ConfigCache($this->tmpProjectDir . '/cache-file', true),
-            $containerBuilder,
-            'Shopware_Core_KernelDevDebugContainer',
-            'Container',
-        );
-
-        static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
-        static::assertTrue($fileSystem->fileExists('opcache-preload.php'));
-    }
-
-    public function testDumpContainerDumpsPreloadFileWithoutGivenFileSystem(): void
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
@@ -74,36 +54,32 @@ class KernelTest extends TestCase
             'Container',
         );
 
-        $fileSystem = new SymfonyFilesystem();
-
-        static::assertTrue($fileSystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
-        static::assertTrue($fileSystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
+        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
+        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
     }
 
     public function testDumpContainerDoesNotDumpPreloadFileIfWarmupCacheDirIsGiven(): void
     {
-        $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
-
         $containerBuilder = new ContainerBuilder();
         // An underscore at the end indicates a warmup cache directory
         $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc_');
         $containerBuilder->compile();
 
         ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
-            $this->createKernel($fileSystem),
+            $this->createKernel(),
             new ConfigCache($this->tmpProjectDir . '/cache', true),
             $containerBuilder,
             'Shopware_Core_KernelDevDebugContainer',
             'Container',
         );
 
-        static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
+        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
 
         // Do not create the preload file in warmup cache
-        static::assertFalse($fileSystem->fileExists('opcache-preload.php'));
+        static::assertFalse($this->filesystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
     }
 
-    private function createKernel(?FilesystemOperator $filesystem = null): Kernel
+    private function createKernel(): Kernel
     {
         return new Kernel(
             'fooBar',
@@ -112,8 +88,7 @@ class KernelTest extends TestCase
             'cacheId',
             '6.6.6',
             $this->createMock(Connection::class),
-            $this->tmpProjectDir,
-            $filesystem,
+            $this->tmpProjectDir
         );
     }
 }

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core;
+
+use Doctrine\DBAL\Connection;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
+use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
+use Shopware\Core\Kernel;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+
+/**
+ * @internal
+ */
+#[CoversClass(Kernel::class)]
+class KernelTest extends TestCase
+{
+    private string $tmpProjectDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpProjectDir = __DIR__ . '/tmpToBeRemoved';
+    }
+
+    protected function tearDown(): void
+    {
+        (new SymfonyFilesystem())->remove($this->tmpProjectDir);
+    }
+
+    public function testGetCacheDir(): void
+    {
+        static::assertStringStartsWith($this->tmpProjectDir . '/var/cache/fooBar_h', $this->createKernel()->getCacheDir());
+    }
+
+    public function testDumpContainerDumpsPreloadFile(): void
+    {
+        $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
+        $containerBuilder->compile();
+
+        ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
+            $this->createKernel($fileSystem),
+            new ConfigCache($this->tmpProjectDir . '/cache-file', true),
+            $containerBuilder,
+            'Shopware_Core_KernelDevDebugContainer',
+            'Container',
+        );
+
+        static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
+        static::assertTrue($fileSystem->fileExists('opcache-preload.php'));
+    }
+
+    public function testDumpContainerDumpsPreloadFileWithoutGivenFileSystem(): void
+    {
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
+        $containerBuilder->compile();
+
+        ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
+            $this->createKernel(),
+            new ConfigCache($this->tmpProjectDir . '/cache-file', true),
+            $containerBuilder,
+            'Shopware_Core_KernelDevDebugContainer',
+            'Container',
+        );
+
+        $fileSystem = new SymfonyFilesystem();
+
+        static::assertTrue($fileSystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
+        static::assertTrue($fileSystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
+    }
+
+    public function testDumpContainerDoesNotDumpPreloadFileIfWarmupCacheDirIsGiven(): void
+    {
+        $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
+
+        $containerBuilder = new ContainerBuilder();
+        // An underscore at the end indicates a warmup cache directory
+        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc_');
+        $containerBuilder->compile();
+
+        ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
+            $this->createKernel($fileSystem),
+            new ConfigCache($this->tmpProjectDir . '/cache', true),
+            $containerBuilder,
+            'Shopware_Core_KernelDevDebugContainer',
+            'Container',
+        );
+
+        static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
+
+        // Do not create the preload file in warmup cache
+        static::assertFalse($fileSystem->fileExists('opcache-preload.php'));
+    }
+
+    private function createKernel(?FilesystemOperator $filesystem = null): Kernel
+    {
+        return new Kernel(
+            'fooBar',
+            true,
+            $this->createMock(StaticKernelPluginLoader::class),
+            'cacheId',
+            '6.6.6',
+            $this->createMock(Connection::class),
+            $this->tmpProjectDir,
+            $filesystem,
+        );
+    }
+}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/9200

### 1. Why is this change necessary?

While using `bin/console cache:clear` the cache is also warmed up. This mechanic in Symfony creates an additional container cache directory: https://github.com/symfony/symfony/blob/v7.2.6/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php#L115-L117

Therefore it could happen, that then the opcache preloading file is dumped with the wrong container hash. 

### 2. What does this change do, exactly?

Check for the underscore at the end of the cache directory. If there is one, do nothing. 

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/shopware/shopware/issues/7811#issuecomment-2847922185

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/7811

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
