### PR TITLE
fix: Description of the author-github option of the `changelog:create` command

### DIFF
--- a/src/Core/Framework/Changelog/Command/ChangelogCreateCommand.php
+++ b/src/Core/Framework/Changelog/Command/ChangelogCreateCommand.php
@@ -40,7 +40,7 @@ class ChangelogCreateCommand extends Command
             ->addOption('flag', null, InputOption::VALUE_OPTIONAL, 'Feature Flag ID')
             ->addOption('author', null, InputOption::VALUE_OPTIONAL, 'The author of code changes')
             ->addOption('author-email', null, InputOption::VALUE_OPTIONAL, 'The author email of code changes')
-            ->addOption('author-github', null, InputOption::VALUE_OPTIONAL, 'The author email of code changes')
+            ->addOption('author-github', null, InputOption::VALUE_OPTIONAL, 'The author Github name of code changes, without leading "@"')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Use the --dry-run argument to preview the changelog content and prevent actually writing to file.');
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Read :-)

### 2. What does this change do, exactly?
Fix the description.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
