### PR TITLE
fix: promotion admin issues

### DIFF
--- a/changelog/_unreleased/2025-05-09-solve-admin-promotion-issues.md
+++ b/changelog/_unreleased/2025-05-09-solve-admin-promotion-issues.md
@@ -4,6 +4,7 @@ issue: #8649
 ---
 # Core
 * Changed `Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscountPrice\PromotionDiscountPriceEntity` properties `promotionDiscount` and `currency` to be nullable
+___
 # Administration
 * Removed `src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig` discount value digit option
 * Removed `src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig` discount max value help text condition

--- a/changelog/_unreleased/2025-05-09-solve-admin-promotion-issues.md
+++ b/changelog/_unreleased/2025-05-09-solve-admin-promotion-issues.md
@@ -1,0 +1,12 @@
+---
+title: Solve admin promotion issues
+issue: #8649
+---
+# Core
+* Changed `Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscountPrice\PromotionDiscountPriceEntity` properties `promotionDiscount` and `currency` to be nullable
+# Administration
+* Removed `src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig` discount value digit option
+* Removed `src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig` discount max value help text condition
+* Changed `Administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js`.
+  * Deprecated `maxValueAdvancedPricesTooltip`
+  * Recalculate advanced prices, if discount value or max value has changed

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -445,7 +445,7 @@ export default {
             this.discount.value = discountHandler.getFixedValue(this.discount.value, this.discount.type);
         },
 
-        onDiscountValueChanged: Utils.debounce(function debounceBla(value) {
+        onDiscountValueChanged: Utils.debounce(function debounceUpdateValue(value) {
             this.discount.value = discountHandler.getFixedValue(value, this.discount.type);
 
             this.recalculatePrices();
@@ -455,7 +455,7 @@ export default {
         // so the value cannot be cleared anymore.
         // If the user removes the value, it will be 0 and converted
         // into NULL, which means no max value applies anymore.
-        onMaxValueChanged: Utils.debounce(function debounceBla(value) {
+        onMaxValueChanged: Utils.debounce(function debounceUpdateMaxValue(value) {
             if (value === 0) {
                 // clear max value
                 this.discount.maxValue = null;
@@ -494,7 +494,7 @@ export default {
                 if (currencyMapping[price.currencyId] === undefined) {
                     this.discount.promotionDiscountPrices.remove(price.id);
                 } else {
-                    const setPrice = (basePrice ?? discountHandler.getMinValue()) * (currencyMapping[price.currencyId] ?? 0);
+                    const setPrice = (basePrice ?? discountHandler.getMinValue()) * currencyMapping[price.currencyId];
 
                     price.price = setPrice < discountHandler.getMinValue() ? discountHandler.getMinValue() : setPrice;
                 }

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -3,7 +3,7 @@ import template from './sw-promotion-discount-component.html.twig';
 import './sw-promotion-discount-component.scss';
 import DiscountHandler from './handler';
 
-const { Mixin } = Shopware;
+const { Mixin, Utils } = Shopware;
 const { Criteria } = Shopware.Data;
 const discountHandler = new DiscountHandler();
 
@@ -182,6 +182,7 @@ export default {
             return this.discount.type === DiscountTypes.PERCENTAGE && this.discount.maxValue !== null;
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed without replacement */
         maxValueAdvancedPricesTooltip() {
             if (
                 this.discount.type === DiscountTypes.PERCENTAGE &&
@@ -444,22 +445,26 @@ export default {
             this.discount.value = discountHandler.getFixedValue(this.discount.value, this.discount.type);
         },
 
-        onDiscountValueChanged(value) {
+        onDiscountValueChanged: Utils.debounce(function debounceBla(value) {
             this.discount.value = discountHandler.getFixedValue(value, this.discount.type);
-        },
+
+            this.recalculatePrices();
+        }, 500),
 
         // The number field does not allow a NULL input
         // so the value cannot be cleared anymore.
         // If the user removes the value, it will be 0 and converted
         // into NULL, which means no max value applies anymore.
-        onMaxValueChanged(value) {
+        onMaxValueChanged: Utils.debounce(function debounceBla(value) {
             if (value === 0) {
                 // clear max value
                 this.discount.maxValue = null;
                 // clear any currency values if max value is gone
                 this.clearAdvancedPrices();
+            } else {
+                this.recalculatePrices();
             }
-        },
+        }, 500),
 
         onClickAdvancedPrices() {
             this.currencies.forEach((currency) => {
@@ -475,6 +480,25 @@ export default {
                 }
             });
             this.displayAdvancedPrices = true;
+        },
+
+        recalculatePrices() {
+            const basePrice = this.showMaxValueAdvancedPrices ? this.discount.maxValue : this.discount.value;
+
+            const currencyMapping = {};
+            this.currencies.forEach((currency) => {
+                currencyMapping[currency.id] = currency.factor;
+            });
+
+            [...this.discount.promotionDiscountPrices].forEach((price) => {
+                if (currencyMapping[price.currencyId] === undefined) {
+                    this.discount.promotionDiscountPrices.remove(price.id);
+                } else {
+                    const setPrice = (basePrice ?? discountHandler.getMinValue()) * (currencyMapping[price.currencyId] ?? 0);
+
+                    price.price = setPrice < discountHandler.getMinValue() ? discountHandler.getMinValue() : setPrice;
+                }
+            });
         },
 
         prepareAdvancedPrices(currency, basePrice) {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -490,15 +490,14 @@ export default {
                 currencyMapping[currency.id] = currency.factor;
             });
 
-            [...this.discount.promotionDiscountPrices].forEach((price) => {
-                if (currencyMapping[price.currencyId] === undefined) {
-                    this.discount.promotionDiscountPrices.remove(price.id);
-                } else {
+            this.discount.promotionDiscountPrices = this.discount.promotionDiscountPrices
+                .filter((price) => currencyMapping[price.currencyId] !== undefined)
+                .map((price) => {
                     const setPrice = (basePrice ?? discountHandler.getMinValue()) * currencyMapping[price.currencyId];
+                    price.price = Math.min(setPrice, discountHandler.getMinValue());
 
-                    price.price = setPrice < discountHandler.getMinValue() ? discountHandler.getMinValue() : setPrice;
-                }
-            });
+                    return price;
+                });
         },
 
         prepareAdvancedPrices(currency, basePrice) {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig
@@ -142,7 +142,6 @@
             class="sw-promotion-discount-component__discount-value"
             validation="required"
             required
-            :digits="50"
             :model-value="discount.value"
             :label="$tc('sw-promotion.detail.main.discounts.labelValue')"
             :placeholder="$tc('sw-promotion.detail.main.discounts.placeholderValue')"
@@ -167,7 +166,7 @@
         <mt-number-field
             v-model="discount.maxValue"
             :label="$tc('sw-promotion.detail.main.discounts.labelMaxValue')"
-            :help-text="maxValueAdvancedPricesTooltip"
+            :help-text="$tc('sw-promotion.detail.main.discounts.helpTextMaxValueAdvancedPrices')"
             :disabled="isEditingDisabled"
             @update:model-value="onMaxValueChanged"
         >

--- a/src/Core/Checkout/Promotion/Aggregate/PromotionDiscountPrice/PromotionDiscountPriceEntity.php
+++ b/src/Core/Checkout/Promotion/Aggregate/PromotionDiscountPrice/PromotionDiscountPriceEntity.php
@@ -19,9 +19,9 @@ class PromotionDiscountPriceEntity extends Entity
 
     protected float $price;
 
-    protected PromotionDiscountEntity $promotionDiscount;
+    protected ?PromotionDiscountEntity $promotionDiscount = null;
 
-    protected CurrencyEntity $currency;
+    protected ?CurrencyEntity $currency = null;
 
     public function getCurrencyId(): string
     {
@@ -53,22 +53,22 @@ class PromotionDiscountPriceEntity extends Entity
         $this->price = $price;
     }
 
-    public function getCurrency(): CurrencyEntity
+    public function getCurrency(): ?CurrencyEntity
     {
         return $this->currency;
     }
 
-    public function setCurrency(CurrencyEntity $currency): void
+    public function setCurrency(?CurrencyEntity $currency): void
     {
         $this->currency = $currency;
     }
 
-    public function getPromotionDiscount(): PromotionDiscountEntity
+    public function getPromotionDiscount(): ?PromotionDiscountEntity
     {
         return $this->promotionDiscount;
     }
 
-    public function setPromotionDiscount(PromotionDiscountEntity $promotionDiscount): void
+    public function setPromotionDiscount(?PromotionDiscountEntity $promotionDiscount): void
     {
         $this->promotionDiscount = $promotionDiscount;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
There are multiple issues for promotion discounts in the administration.
- https://github.com/shopware/shopware/issues/8649

### 2. What does this change do, exactly?
Makes Entity properties nullable
Recalculate advanced prices after change
Remove help text conditions

Open will be "The link disappears if the maximum discount value is set to 0 and reappears if it is set to a negative or positive number.".
If max value is 0 it will lead into `null` and then we will not have any advanced prices

### 3. Describe each step to reproduce the issue or behaviour.
Go into the administration promotion discount page (`/admin#/sw/promotion/v2/detail/UUID/discounts`) and try different configurations 

### 4. Please link to the relevant issues (if any).
- closes #8649

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
