### PR TITLE
fix: Use Symfony Filesystem for dumping opcache preloading files

### DIFF
--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Shopware\Tests\Unit\Core;
 
 use Doctrine\DBAL\Connection;
-use League\Flysystem\Filesystem;
-use League\Flysystem\FilesystemOperator;
-use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
@@ -15,7 +12,7 @@ use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
 use Shopware\Core\Kernel;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -25,14 +22,17 @@ class KernelTest extends TestCase
 {
     private string $tmpProjectDir;
 
+    private Filesystem $filesystem;
+
     protected function setUp(): void
     {
         $this->tmpProjectDir = __DIR__ . '/tmpToBeRemoved';
+        $this->filesystem = new Filesystem();
     }
 
     protected function tearDown(): void
     {
-        (new SymfonyFilesystem())->remove($this->tmpProjectDir);
+        $this->filesystem->remove($this->tmpProjectDir);
     }
 
     public function testGetCacheDir(): void
@@ -41,26 +41,6 @@ class KernelTest extends TestCase
     }
 
     public function testDumpContainerDumpsPreloadFile(): void
-    {
-        $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
-
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
-        $containerBuilder->compile();
-
-        ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
-            $this->createKernel($fileSystem),
-            new ConfigCache($this->tmpProjectDir . '/cache-file', true),
-            $containerBuilder,
-            'Shopware_Core_KernelDevDebugContainer',
-            'Container',
-        );
-
-        static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
-        static::assertTrue($fileSystem->fileExists('opcache-preload.php'));
-    }
-
-    public function testDumpContainerDumpsPreloadFileWithoutGivenFileSystem(): void
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
@@ -74,36 +54,32 @@ class KernelTest extends TestCase
             'Container',
         );
 
-        $fileSystem = new SymfonyFilesystem();
-
-        static::assertTrue($fileSystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
-        static::assertTrue($fileSystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
+        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
+        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
     }
 
     public function testDumpContainerDoesNotDumpPreloadFileIfWarmupCacheDirIsGiven(): void
     {
-        $fileSystem = new Filesystem(new InMemoryFilesystemAdapter());
-
         $containerBuilder = new ContainerBuilder();
         // An underscore at the end indicates a warmup cache directory
         $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc_');
         $containerBuilder->compile();
 
         ReflectionHelper::getMethod(Kernel::class, 'dumpContainer')->invoke(
-            $this->createKernel($fileSystem),
+            $this->createKernel(),
             new ConfigCache($this->tmpProjectDir . '/cache', true),
             $containerBuilder,
             'Shopware_Core_KernelDevDebugContainer',
             'Container',
         );
 
-        static::assertTrue($fileSystem->fileExists('CACHEDIR.TAG'));
+        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
 
         // Do not create the preload file in warmup cache
-        static::assertFalse($fileSystem->fileExists('opcache-preload.php'));
+        static::assertFalse($this->filesystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
     }
 
-    private function createKernel(?FilesystemOperator $filesystem = null): Kernel
+    private function createKernel(): Kernel
     {
         return new Kernel(
             'fooBar',
@@ -113,7 +89,6 @@ class KernelTest extends TestCase
             '6.6.6',
             $this->createMock(Connection::class),
             $this->tmpProjectDir,
-            $filesystem,
         );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

As discussed with @shyim it is better to use the Symfony Filesystem for this purpose instead:
https://github.com/shopware/shopware/pull/9200#discussion_r2082933740

### 2. What does this change do, exactly?

Use the slimmer class for file operations

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
