### PR TITLE
fix: fix product entity stringify should use translated name

### DIFF
--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -259,7 +259,7 @@ class ProductEntity extends Entity implements \Stringable
 
     public function __toString(): string
     {
-        return (string) $this->getName();
+        return (string) ($this->getTranslation('name') ?? $this->getName());
     }
 
     public function getProductReviews(): ?ProductReviewCollection

--- a/tests/integration/Core/Content/Product/ProductEntityTest.php
+++ b/tests/integration/Core/Content/Product/ProductEntityTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Product;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class ProductEntityTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    #[DataProvider('productProvider')]
+    public function testStringifyProduct(ProductEntity $entity, string $expected): void
+    {
+        static::assertSame($expected, $this->renderTestTemplate($entity));
+    }
+
+    /**
+     * @return iterable<string, array{0: ProductEntity, 1: string}>
+     */
+    public static function productProvider(): iterable
+    {
+        $product = new ProductEntity();
+        $product->setId('fooId');
+
+        $productWithEmptyName = clone $product;
+        $productWithEmptyName->setName(null);
+        $productWithEmptyName->setTranslated([]);
+
+        $productWithName = clone $product;
+        $productWithName->setName('foo');
+        $productWithName->setTranslated([]);
+
+        $productWithTranslatedName = clone $product;
+        $productWithTranslatedName->setName(null);
+        $productWithTranslatedName->setTranslated([
+            'name' => 'translated foo',
+        ]);
+
+        $productWithNameAndTranslatedName = clone $product;
+        $productWithNameAndTranslatedName->setName('foo');
+        $productWithNameAndTranslatedName->setTranslated([
+            'name' => 'translated foo',
+        ]);
+
+        yield 'product with empty name' => [$productWithEmptyName, 'empty'];
+        yield 'product with name' => [$productWithName, 'foo'];
+        yield 'product with translated name' => [$productWithTranslatedName, 'translated foo'];
+        yield 'product with name and translated name' => [$productWithNameAndTranslatedName, 'translated foo'];
+    }
+
+    private function renderTestTemplate(ProductEntity $entity): string
+    {
+        $twig = static::getContainer()->get('twig');
+
+        $originalLoader = $twig->getLoader();
+        $twig->setLoader(new ArrayLoader([
+            'test.html.twig' => '{% if page.product is empty %}empty{% else %}{{ page.product }}{% endif %}',
+        ]));
+        $output = $twig->render('test.html.twig', ['page' => ['product' => $entity]]);
+        $twig->setLoader($originalLoader);
+
+        return $output;
+    }
+}

--- a/tests/unit/Core/Content/Product/ProductEntityTest.php
+++ b/tests/unit/Core/Content/Product/ProductEntityTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ProductEntity::class)]
+class ProductEntityTest extends TestCase
+{
+    public function testStringify(): void
+    {
+        $entity = new ProductEntity();
+        $entity->setId('fooId');
+
+        static::assertSame('', (string) $entity);
+
+        $entity->setName('foo');
+
+        static::assertSame('foo', (string) $entity);
+
+        $entity->setTranslated([
+            'name' => 'translated foo',
+        ]);
+
+        static::assertSame('translated foo', (string) $entity);
+    }
+}


### PR DESCRIPTION
Please see the description of the linked issue #5086

According: https://twig.symfony.com/doc/3.x/tests/empty.html

> For objects that implement the __toString() magic method (and not Countable), it will check if an empty string is returned.

