### PR TITLE
feat: Only set initial country id if it's not previously defined [6.6.x]

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
@@ -539,8 +539,9 @@
 
         <div class="row g-2 country-and-state-form-elements" data-country-state-select="true" data-country-state-select-options="{{ options|json_encode }}">
             {% block component_address_form_country %}
-
-                {% set initialCountryId = null %}
+                {% if initialCountryId is not defined %}
+                    {% set initialCountryId = null %}
+                {% endif %}
 
                 {% if data.get('countryId') %}
                     {% set initialCountryId = data.get('countryId') %}


### PR DESCRIPTION
Backports #9083 to 6.6.10.0. Note: I am unsure if this should target 6.6.x or 6.6.10.0 branch.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Allows plugins or themes to more easily override the initial country id, for example using https://store.shopware.com/en/memo207344308277f/default-registration-country.html

### 2. What does this change do, exactly?
`initialCountryId` could previously be overridden by extending block `component_address_form_country_select`. However this block has been removed and replaced by including a form component, meaning the existing override is no longer possible. There are also no other blocks in this template that could facilitate an override. Developers would have to override the entire template file.
The change in this PR allows plugins to simply extend the block, set the initial id, and call `{{ parent() }}`. 

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
