### PR TITLE
ci: Set default node version to 22.x

### DIFF
--- a/.github/actions/ats/action.yaml
+++ b/.github/actions/ats/action.yaml
@@ -120,7 +120,7 @@ runs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 22
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: build shopware
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -297,7 +297,7 @@ jobs:
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         working-directory: new-shopware/tests/acceptance

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4
         with:
-          node-version: 20
+          node-version: 22
       - name: install packages
         working-directory: src/Storefront/Resources/app/storefront
         run: |

--- a/devenv.nix
+++ b/devenv.nix
@@ -27,7 +27,7 @@ in {
 
   languages.javascript = {
     enable = lib.mkDefault true;
-    package = lib.mkDefault pkgs.nodejs_20;
+    package = lib.mkDefault pkgs.nodejs_22;
   };
 
   languages.php = {


### PR DESCRIPTION
### 1. Why is this change necessary?
The current node version for the release is `20.x`, but this node version is only in maintenance mode: https://nodejs.org/en/about/previous-releases

And this version should probably not be changed while within the major release cycle and the store plugins should also be built with that specific node version (or is this knowledge/assumption deprecated?).

There would also be version 24.x available, but this might be too early to use.

### 2. What does this change do, exactly?
Bump the node version to 22.x

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
