### PR TITLE
fix: insert variable button shows empty popover

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-cms-data-mapping/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-cms-data-mapping/index.ts
@@ -15,6 +15,7 @@ export default (getAvailableDataMappings: () => string[]): CustomButton => {
         position: 14000,
         // @ts-expect-error
         label: Shopware.Snippet.t('sw-text-editor-toolbar-button-cms-data-mapping.label') as string,
+        disabled: () => !dataMappings?.length,
         children: dataMappings.map((dataMapping) => ({
             name: dataMapping,
             label: dataMapping,

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-cms-data-mapping/sw-text-editor-toolbar-button-cms-data-mapping.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-cms-data-mapping/sw-text-editor-toolbar-button-cms-data-mapping.spec.ts
@@ -14,6 +14,7 @@ describe('src/app/component/meteor-wrapper/mt-text-editor/mt-text-editor-toolbar
             name: 'cms-data-mapping',
             position: 14000,
             label: 'sw-text-editor-toolbar-button-cms-data-mapping.label',
+            disabled: expect.any(Function) as () => boolean,
             children: [
                 {
                     name: 'dataMapping1',


### PR DESCRIPTION


### 1. Why is this change necessary?
Fixes this issue: https://github.com/shopware/shopware/issues/9011
The `insert variable` button in the cms text editor shows an empty popover

### 2. What does this change do, exactly?
This PR makes the button disabled when there are no mappings for that button.
As the `insert variable` only works for product page layouts.


### 4. Please link to the relevant issues (if any).
- closes #9011 
