### PR TITLE
fix: the cms config modal throws an error on close

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -158,6 +158,8 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         onCloseSettingsModal() {
+            if(!this.showElementSettings) return;
+
             const childComponent = this.$refs.elementComponentRef as {
                 handleUpdateContent: () => void;
             };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
@@ -105,7 +105,7 @@
 
     {% block sw_cms_slot_content_settings_modal %}
     <sw-modal
-        v-if="showElementSettings"
+        v-show="showElementSettings"
         class="sw-cms-slot__config-modal"
         :variant="modalVariant"
         :title="$tc('sw-cms.detail.title.elementSettingsModal')"
@@ -113,7 +113,7 @@
     >
         {% block sw_cms_slot_content_settings_modal_component %}
         <component
-            :is="elementConfig.configComponent"
+            :is="elementConfig?.configComponent"
             ref="elementComponentRef"
             v-model:element="element"
             :element-data="elementConfig"


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes this issue: https://github.com/shopware/shopware/issues/9010
The problem is caused by the `sw-modal` as it is manually attached to the end of the body when mounted and removed, when closed.

### 2. What does this change do, exactly?
This PR changes a `v-if` to `v-show` to avoid the error.
A possible solution using `teleport` will be tested.
But this is a quick fix to avoid the side effects of a refactor of the `sw-modal` for the RC.

### 4. Please link to the relevant issues (if any).
- closes #9010 
