### PR TITLE
chore: Replace assertEquals with assertSame in misc tests

### DIFF
--- a/tests/devops/Core/DevOps/Docs/Command/Script/ScriptReferenceGeneratorTest.php
+++ b/tests/devops/Core/DevOps/Docs/Command/Script/ScriptReferenceGeneratorTest.php
@@ -28,7 +28,7 @@ class ScriptReferenceGeneratorTest extends TestCase
 
         foreach ($generators as $generator) {
             foreach ($generator->generate() as $filename => $content) {
-                static::assertEquals(
+                static::assertSame(
                     $content,
                     file_get_contents($filename),
                     <<<MSG

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoAssertOnResponseObject/shopware-unit-test.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoAssertOnResponseObject/shopware-unit-test.php
@@ -17,18 +17,18 @@ class BarTest extends TestCase
 
         $expected = new Response();
         // not allowed
-        static::assertEquals($expected, $response);
+        static::assertSame($expected, $response);
 
         $this->assertFoo($expected, $response);
 
         // allowed
-        static::assertEquals($expected->getStatusCode(), $response->getStatusCode());
+        static::assertSame($expected->getStatusCode(), $response->getStatusCode());
 
         // allowed
         AssertResponseHelper::assertResponseEquals($expected, $response);
 
         // allowed
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
     }
 
     public function testRedirects(): void
@@ -44,6 +44,6 @@ class BarTest extends TestCase
     public function assertFoo(mixed $expected, mixed $actual): void
     {
         // allowed
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 }

--- a/tests/devops/Core/Test/DataAbstractionLayerValidateCommandTest.php
+++ b/tests/devops/Core/Test/DataAbstractionLayerValidateCommandTest.php
@@ -19,7 +19,7 @@ class DataAbstractionLayerValidateCommandTest extends TestCase
         $commandTester = new CommandTester(static::getContainer()->get(DataAbstractionLayerValidateCommand::class));
         $commandTester->execute([]);
 
-        static::assertEquals(
+        static::assertSame(
             0,
             $commandTester->getStatusCode(),
             "\"bin/console dal:validate\" returned errors:\n" . $commandTester->getDisplay()

--- a/tests/integration/Administration/RateLimiter/RateLimiterTest.php
+++ b/tests/integration/Administration/RateLimiter/RateLimiterTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Test\RateLimiter\DisableRateLimiterCompilerPass;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Test\Integration\Traits\CustomerTestTrait;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -69,10 +70,10 @@ class RateLimiterTest extends TestCase
 
             if ($i >= 10) {
                 static::assertArrayHasKey('errors', $response);
-                static::assertEquals(429, $response['errors'][0]['status']);
-                static::assertEquals('FRAMEWORK__NOTIFICATION_THROTTLED', $response['errors'][0]['code']);
+                static::assertSame(Response::HTTP_TOO_MANY_REQUESTS, (int) $response['errors'][0]['status']);
+                static::assertSame('FRAMEWORK__NOTIFICATION_THROTTLED', $response['errors'][0]['code']);
             } else {
-                static::assertEquals(200, $client->getResponse()->getStatusCode());
+                static::assertSame(200, $client->getResponse()->getStatusCode());
             }
         }
     }

--- a/tests/integration/Administration/Snippet/SnippetFinderTest.php
+++ b/tests/integration/Administration/Snippet/SnippetFinderTest.php
@@ -70,7 +70,7 @@ class SnippetFinderTest extends TestCase
             ],
         ];
 
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testValidSnippetMergeWithMultipleLanguageFiles(): void

--- a/tests/migration/Core/ImportTranslationTraitTest.php
+++ b/tests/migration/Core/ImportTranslationTraitTest.php
@@ -67,9 +67,9 @@ class ImportTranslationTraitTest extends TestCase
         static::assertArrayHasKey($ids->get('german'), $translations);
         static::assertArrayHasKey($ids->get('en-2'), $translations);
 
-        static::assertEquals('en name', $translations[Defaults::LANGUAGE_SYSTEM]['name']);
-        static::assertEquals('en name', $translations[$ids->get('en-2')]['name']);
-        static::assertEquals('de name', $translations[$ids->get('german')]['name']);
+        static::assertSame('en name', $translations[Defaults::LANGUAGE_SYSTEM]['name']);
+        static::assertSame('en name', $translations[$ids->get('en-2')]['name']);
+        static::assertSame('de name', $translations[$ids->get('german')]['name']);
     }
 
     private function createLanguages(IdsCollection $ids): void

--- a/tests/migration/Core/MigrationForeignDefaultLanguageTest.php
+++ b/tests/migration/Core/MigrationForeignDefaultLanguageTest.php
@@ -85,7 +85,7 @@ class MigrationForeignDefaultLanguageTest extends TestCase
             ]
         );
         static::assertIsArray($templateDefault);
-        static::assertEquals('Password recovery', $templateDefault['subject']);
+        static::assertSame('Password recovery', $templateDefault['subject']);
 
         $deDeLanguage = $connection->fetchAssociative(
             'SELECT * FROM `language` WHERE `name` = :name',
@@ -105,7 +105,7 @@ class MigrationForeignDefaultLanguageTest extends TestCase
         );
 
         static::assertIsArray($templateDeDe);
-        static::assertEquals('Password-Wiederherstellung', $templateDeDe['subject']);
+        static::assertSame('Password-Wiederherstellung', $templateDeDe['subject']);
 
         $orgConnection->beginTransaction();
     }
@@ -195,7 +195,7 @@ class MigrationForeignDefaultLanguageTest extends TestCase
             ]
         );
         static::assertIsArray($templateDefault);
-        static::assertEquals('Password recovery', $templateDefault['subject']);
+        static::assertSame('Password recovery', $templateDefault['subject']);
 
         $templateDeLu = $connection->fetchAssociative(
             'SELECT subject FROM mail_template_translation
@@ -286,7 +286,7 @@ class MigrationForeignDefaultLanguageTest extends TestCase
             ]
         );
         static::assertIsArray($templateDefault);
-        static::assertEquals('Password recovery', $templateDefault['subject']);
+        static::assertSame('Password recovery', $templateDefault['subject']);
 
         $templateEnGb = $connection->fetchAssociative(
             'SELECT subject FROM mail_template_translation
@@ -297,7 +297,7 @@ class MigrationForeignDefaultLanguageTest extends TestCase
             ]
         );
         static::assertIsArray($templateEnGb);
-        static::assertEquals('Password recovery', $templateEnGb['subject']);
+        static::assertSame('Password recovery', $templateEnGb['subject']);
 
         $orgConnection->beginTransaction();
     }

--- a/tests/migration/Core/MigrationLoaderTest.php
+++ b/tests/migration/Core/MigrationLoaderTest.php
@@ -84,8 +84,8 @@ class MigrationLoaderTest extends TestCase
         static::assertNull($migrations[0]['message']);
         static::assertNotNull($migrations[0]['class']);
         static::assertNotNull($migrations[0]['creation_timestamp']);
-        static::assertEquals(1, $migrationsObjects[0]->getCreationTimestamp());
-        static::assertEquals(2, $migrationsObjects[1]->getCreationTimestamp());
+        static::assertSame(1, $migrationsObjects[0]->getCreationTimestamp());
+        static::assertSame(2, $migrationsObjects[1]->getCreationTimestamp());
     }
 
     public function testItGetsCorrectMigrationTimestamps(): void
@@ -94,8 +94,8 @@ class MigrationLoaderTest extends TestCase
         $migrations = $collection->getActiveMigrationTimestamps();
 
         static::assertCount(2, $migrations);
-        static::assertEquals(1, $migrations[0]);
-        static::assertEquals(2, $migrations[1]);
+        static::assertSame(1, $migrations[0]);
+        static::assertSame(2, $migrations[1]);
     }
 
     public function testThatInvalidMigrationClassesThrowOnLazyInit(): void

--- a/tests/migration/Core/V6_6/Migration1663402950SetDoubleOptinCustomerActiveTest.php
+++ b/tests/migration/Core/V6_6/Migration1663402950SetDoubleOptinCustomerActiveTest.php
@@ -31,7 +31,7 @@ class Migration1663402950SetDoubleOptinCustomerActiveTest extends TestCase
     {
         $customerId = Uuid::randomBytes();
         $countAffectedRows = $this->addCustomerWithDoubleOptInButNotConfirmed($customerId);
-        static::assertEquals(1, $countAffectedRows);
+        static::assertSame(1, $countAffectedRows);
         static::assertFalse($this->checkCustomerIsActive($customerId));
 
         $migration = new Migration1663402950SetDoubleOptinCustomerActive();

--- a/tests/migration/Core/V6_6/Migration1673249981MigrateIsNewCustomerRuleTest.php
+++ b/tests/migration/Core/V6_6/Migration1673249981MigrateIsNewCustomerRuleTest.php
@@ -65,8 +65,8 @@ class Migration1673249981MigrateIsNewCustomerRuleTest extends TestCase
         static::assertCount(0, $this->getIsNewCustomerConditions());
         static::assertNull($this->getTestRule()['payload'], 'the migrated rule payload should be empty');
         $value = json_decode((string) $this->getDaysSinceFirstLoginConditions()['value'], true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals('=', $value['operator']);
-        static::assertEquals(0, $value['daysPassed']);
+        static::assertSame('=', $value['operator']);
+        static::assertSame(0, $value['daysPassed']);
 
         $this->removeTestConditions();
     }

--- a/tests/migration/Core/V6_6/Migration1696262484AddDefaultSendMailOptionsTest.php
+++ b/tests/migration/Core/V6_6/Migration1696262484AddDefaultSendMailOptionsTest.php
@@ -58,13 +58,13 @@ class Migration1696262484AddDefaultSendMailOptionsTest extends TestCase
 
         $connection->executeStatement($sql, $params);
 
-        static::assertEquals('-bs', $this->getValue($connection));
+        static::assertSame('-bs', $this->getValue($connection));
 
         $migration = new Migration1696262484AddDefaultSendMailOptions();
         $migration->update($connection);
         $migration->update($connection);
 
-        static::assertEquals('-bs', $this->getValue($connection));
+        static::assertSame('-bs', $this->getValue($connection));
     }
 
     public function testDefaultValue(): void
@@ -88,13 +88,13 @@ class Migration1696262484AddDefaultSendMailOptionsTest extends TestCase
 
         $connection->executeStatement($sql, $params);
 
-        static::assertEquals('-t', $this->getValue($connection));
+        static::assertSame('-t', $this->getValue($connection));
 
         $migration = new Migration1696262484AddDefaultSendMailOptions();
         $migration->update($connection);
         $migration->update($connection);
 
-        static::assertEquals('-t -i', $this->getValue($connection));
+        static::assertSame('-t -i', $this->getValue($connection));
     }
 
     private function getValue(Connection $connection): string|false

--- a/tests/migration/Core/V6_6/Migration1701688920FixDownloadLinkMailTest.php
+++ b/tests/migration/Core/V6_6/Migration1701688920FixDownloadLinkMailTest.php
@@ -54,8 +54,8 @@ class Migration1701688920FixDownloadLinkMailTest extends TestCase
             $deLangId
         );
 
-        static::assertEquals($mailTemplateTranslationDe['htmlDe'], $mailTemplateTranslationDe['content_html']);
-        static::assertEquals($mailTemplateTranslationDe['plainDe'], $mailTemplateTranslationDe['content_plain']);
+        static::assertSame($mailTemplateTranslationDe['htmlDe'], $mailTemplateTranslationDe['content_html']);
+        static::assertSame($mailTemplateTranslationDe['plainDe'], $mailTemplateTranslationDe['content_plain']);
 
         $mailTemplateTranslationEn = $this->getMailTemplateTranslation(
             $connection,
@@ -63,8 +63,8 @@ class Migration1701688920FixDownloadLinkMailTest extends TestCase
             $enLangId
         );
 
-        static::assertEquals($mailTemplateTranslationEn['htmlEn'], $mailTemplateTranslationEn['content_html']);
-        static::assertEquals($mailTemplateTranslationEn['plainEn'], $mailTemplateTranslationEn['content_plain']);
+        static::assertSame($mailTemplateTranslationEn['htmlEn'], $mailTemplateTranslationEn['content_html']);
+        static::assertSame($mailTemplateTranslationEn['plainEn'], $mailTemplateTranslationEn['content_plain']);
     }
 
     /**

--- a/tests/migration/Core/V6_6/Migration1702982372FixProductCrossSellingSortByPriceTest.php
+++ b/tests/migration/Core/V6_6/Migration1702982372FixProductCrossSellingSortByPriceTest.php
@@ -18,7 +18,7 @@ class Migration1702982372FixProductCrossSellingSortByPriceTest extends TestCase
 {
     public function testGetCreationTimestamp(): void
     {
-        static::assertEquals('1702982372', (new Migration1702982372FixProductCrossSellingSortByPrice())->getCreationTimestamp());
+        static::assertSame(1702982372, (new Migration1702982372FixProductCrossSellingSortByPrice())->getCreationTimestamp());
     }
 
     public function testMigrationChangesSortBy(): void
@@ -51,6 +51,6 @@ class Migration1702982372FixProductCrossSellingSortByPriceTest extends TestCase
         SELECT `sort_by` from `product_cross_selling` WHERE `id` = :id
         ', ['id' => $crossSellingId])->fetchOne();
 
-        static::assertEquals('cheapestPrice', $sortBy);
+        static::assertSame('cheapestPrice', $sortBy);
     }
 }

--- a/tests/migration/Core/V6_6/Migration1703850843FixSearchConfigTest.php
+++ b/tests/migration/Core/V6_6/Migration1703850843FixSearchConfigTest.php
@@ -72,7 +72,7 @@ class Migration1703850843FixSearchConfigTest extends TestCase
                 continue;
             }
 
-            static::assertEquals($item, json_decode($result[$id], true));
+            static::assertSame($item, json_decode($result[$id], true));
         }
     }
 

--- a/tests/migration/Core/V6_6/Migration1707807389ChangeAvailableDefaultTest.php
+++ b/tests/migration/Core/V6_6/Migration1707807389ChangeAvailableDefaultTest.php
@@ -22,6 +22,6 @@ class Migration1707807389ChangeAvailableDefaultTest extends TestCase
 
         $available = $connection->fetchOne('SELECT COLUMN_DEFAULT FROM information_schema.COLUMNS WHERE TABLE_NAME = "product" AND COLUMN_NAME = "available"');
 
-        static::assertEquals('0', $available);
+        static::assertSame('0', $available);
     }
 }

--- a/tests/migration/Core/V6_6/Migration1718615305AddEuToCountryTableTest.php
+++ b/tests/migration/Core/V6_6/Migration1718615305AddEuToCountryTableTest.php
@@ -43,10 +43,10 @@ class Migration1718615305AddEuToCountryTableTest extends TestCase
             static::fail('Column "is_eu" not found in "country" table');
         }
 
-        static::assertEquals('is_eu', $columns[$isEuColumnKey]['Field']);
-        static::assertEquals('tinyint(1)', $columns[$isEuColumnKey]['Type']);
-        static::assertEquals('NO', $columns[$isEuColumnKey]['Null']);
-        static::assertEquals('0', $columns[$isEuColumnKey]['Default']);
+        static::assertSame('is_eu', $columns[$isEuColumnKey]['Field']);
+        static::assertSame('tinyint(1)', $columns[$isEuColumnKey]['Type']);
+        static::assertSame('NO', $columns[$isEuColumnKey]['Null']);
+        static::assertSame('0', $columns[$isEuColumnKey]['Default']);
     }
 
     public function testEuCountriesAreMarkedAsEu(): void

--- a/tests/migration/Core/V6_6/Migration1739198249FixOrderDeliveryStateMachineNameTest.php
+++ b/tests/migration/Core/V6_6/Migration1739198249FixOrderDeliveryStateMachineNameTest.php
@@ -59,7 +59,7 @@ class Migration1739198249FixOrderDeliveryStateMachineNameTest extends TestCase
         );
 
         foreach ($germanNames as $germanName) {
-            static::assertEquals('Versandstatus', $germanName);
+            static::assertSame('Versandstatus', $germanName);
         }
 
         $englishNames = $this->connection->fetchFirstColumn(
@@ -75,14 +75,14 @@ class Migration1739198249FixOrderDeliveryStateMachineNameTest extends TestCase
         );
 
         foreach ($englishNames as $englishName) {
-            static::assertEquals('Delivery state', $englishName);
+            static::assertSame('Delivery state', $englishName);
         }
     }
 
     private function executeMigration(): void
     {
         $migration = new Migration1739198249FixOrderDeliveryStateMachineName();
-        static::assertEquals($migration->getCreationTimestamp(), 1739198249);
+        static::assertSame($migration->getCreationTimestamp(), 1739198249);
 
         $this->rollback();
 

--- a/tests/migration/Core/V6_7/Migration1697112043TemporaryPaymentAndShippingTechnicalNamesTest.php
+++ b/tests/migration/Core/V6_7/Migration1697112043TemporaryPaymentAndShippingTechnicalNamesTest.php
@@ -70,7 +70,7 @@ class Migration1697112043TemporaryPaymentAndShippingTechnicalNamesTest extends T
             ['ids' => ArrayParameterType::BINARY],
         );
 
-        static::assertEquals([
+        static::assertSame([
             [
                 'id' => $this->ids->get('payment-method'),
                 'technical_name' => 'temporary_' . $this->ids->get('payment-method'),
@@ -81,7 +81,7 @@ class Migration1697112043TemporaryPaymentAndShippingTechnicalNamesTest extends T
             ],
         ], $paymentMethods);
 
-        static::assertEquals([
+        static::assertSame([
             [
                 'id' => $this->ids->get('shipping-method'),
                 'technical_name' => 'temporary_' . $this->ids->get('shipping-method'),

--- a/tests/migration/Core/V6_7/Migration1742484083TransitionToAddressInputFieldArrangementTest.php
+++ b/tests/migration/Core/V6_7/Migration1742484083TransitionToAddressInputFieldArrangementTest.php
@@ -62,7 +62,7 @@ class Migration1742484083TransitionToAddressInputFieldArrangementTest extends Te
             [Migration1742484083TransitionToAddressInputFieldArrangement::OLD_CONFIG_KEY]
         );
 
-        static::assertEquals([], $oldConfiguration);
+        static::assertSame([], $oldConfiguration);
     }
 
     public function testNotOverrideExistingConfig(): void
@@ -92,7 +92,7 @@ class Migration1742484083TransitionToAddressInputFieldArrangementTest extends Te
             $newConfiguration[$uuid]['configuration_value'] = json_decode($c['configuration_value'], true);
         }
 
-        static::assertEquals([
+        static::assertSame([
             '' => ['configuration_value' => ['_value' => 'city-state-zip']],
             Uuid::fromHexToBytes(TestDefaults::SALES_CHANNEL) => ['configuration_value' => ['_value' => 'city-zip-state']],
         ], $newConfiguration);
@@ -132,7 +132,7 @@ class Migration1742484083TransitionToAddressInputFieldArrangementTest extends Te
             $newConfiguration[$uuid]['configuration_value'] = json_decode($c['configuration_value'], true);
         }
 
-        static::assertEquals([
+        static::assertSame([
             '' => ['configuration_value' => ['_value' => 'zip-city-state']],
             Uuid::fromHexToBytes(TestDefaults::SALES_CHANNEL) => ['configuration_value' => ['_value' => 'city-zip-state']],
         ], $newConfiguration);

--- a/tests/unit/Administration/AdministrationTest.php
+++ b/tests/unit/Administration/AdministrationTest.php
@@ -25,7 +25,7 @@ class AdministrationTest extends TestCase
     {
         $administration = new Administration();
 
-        static::assertEquals(-1, $administration->getTemplatePriority());
+        static::assertSame(-1, $administration->getTemplatePriority());
     }
 
     public function testBundle(): void

--- a/tests/unit/Administration/Controller/AdminSearchControllerTest.php
+++ b/tests/unit/Administration/Controller/AdminSearchControllerTest.php
@@ -97,7 +97,7 @@ class AdminSearchControllerTest extends TestCase
         $result = \json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertNotFalse($result);
         static::assertArrayHasKey('data', $result);
-        static::assertEquals(
+        static::assertSame(
             [
                 ProductDefinition::class => [
                     'status' => '403',

--- a/tests/unit/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/unit/Administration/Controller/AdministrationControllerTest.php
@@ -138,7 +138,7 @@ class AdministrationControllerTest extends TestCase
         $response = $controller->index(new Request(), $this->context);
 
         static::assertNotFalse($response->getContent());
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testCheckCustomerEmailValidWithoutException(): void
@@ -148,7 +148,7 @@ class AdministrationControllerTest extends TestCase
 
         $response = $controller->checkCustomerEmailValid($request, $this->context);
         static::assertNotFalse($response->getContent());
-        static::assertEquals(
+        static::assertSame(
             json_encode(['isValid' => true]),
             $response->getContent()
         );
@@ -161,7 +161,7 @@ class AdministrationControllerTest extends TestCase
 
         $response = $controller->checkCustomerEmailValid($request, $this->context);
         static::assertNotFalse($response->getContent());
-        static::assertEquals(
+        static::assertSame(
             json_encode(['isValid' => true]),
             $response->getContent()
         );
@@ -251,8 +251,8 @@ class AdministrationControllerTest extends TestCase
             ->willThrowException(new UnableToReadFile());
         $response = $controller->pluginIndex('foo');
 
-        static::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        static::assertEquals('Plugin index.html not found', $response->getContent());
+        static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        static::assertSame('Plugin index.html not found', $response->getContent());
     }
 
     public function testPluginIndexReturnsUnchangedFileIfNoReplaceableStringIsFound(): void
@@ -266,8 +266,8 @@ class AdministrationControllerTest extends TestCase
             ->willReturn($fileContent);
         $response = $controller->pluginIndex('foo');
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        static::assertEquals($fileContent, $response->getContent());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame($fileContent, $response->getContent());
     }
 
     public function testPluginIndexReplacesAsset(): void
@@ -287,7 +287,7 @@ class AdministrationControllerTest extends TestCase
 
         $response = $controller->pluginIndex('foo');
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         $content = $response->getContent();
         static::assertIsString($content);
@@ -358,7 +358,7 @@ class AdministrationControllerTest extends TestCase
         $controller = $this->createAdministrationController();
         $response = $controller->sanitizeHtml(new Request([], ['html' => '<br/>', 'field' => '']), $this->context);
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertNotFalse($response->getContent());
         static::assertJsonStringEqualsJsonString('{"preview":""}', $response->getContent());
     }
@@ -385,7 +385,7 @@ class AdministrationControllerTest extends TestCase
         $controller = $this->createAdministrationController();
         $response = $controller->sanitizeHtml(new Request([], ['html' => '<p>test</p>', 'field' => 'test_entity.id']), $this->context);
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertNotFalse($response->getContent());
         static::assertJsonStringEqualsJsonString('{"preview":"test"}', $response->getContent());
     }
@@ -400,7 +400,7 @@ class AdministrationControllerTest extends TestCase
         $controller = $this->createAdministrationController();
         $response = $controller->sanitizeHtml(new Request([], ['html' => $html, 'field' => 'test_entity.idAllowHtml']), $this->context);
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertNotFalse($response->getContent());
         static::assertJsonStringEqualsJsonString('{"preview":"' . $html . '"}', $response->getContent());
     }
@@ -420,7 +420,7 @@ class AdministrationControllerTest extends TestCase
             $this->context
         );
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertNotFalse($response->getContent());
         static::assertJsonStringEqualsJsonString('{"preview":"' . $sanitized . '"}', $response->getContent());
     }

--- a/tests/unit/Administration/Controller/UserConfigControllerTest.php
+++ b/tests/unit/Administration/Controller/UserConfigControllerTest.php
@@ -92,7 +92,7 @@ class UserConfigControllerTest extends TestCase
 
         static::assertNotFalse($response->getContent());
         static::assertJsonStringEqualsJsonString('{}', $response->getContent());
-        static::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
     }
 
     public function testUpdateConfigPerformsMassUpsertEmptyWhenPostUpdateConfigs(): void
@@ -108,6 +108,6 @@ class UserConfigControllerTest extends TestCase
 
         static::assertNotFalse($response->getContent());
         static::assertJsonStringEqualsJsonString('{}', $response->getContent());
-        static::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
     }
 }

--- a/tests/unit/Administration/Framework/Routing/KnownIps/KnownIpsCollectorTest.php
+++ b/tests/unit/Administration/Framework/Routing/KnownIps/KnownIpsCollectorTest.php
@@ -36,6 +36,6 @@ class KnownIpsCollectorTest extends TestCase
     public function testCollectIpsWithNoIpGiven(): void
     {
         $als = new KnownIpsCollector();
-        static::assertEquals([], $als->collectIps(new Request(server: [''])));
+        static::assertSame([], $als->collectIps(new Request(server: [''])));
     }
 }

--- a/tests/unit/Administration/Framework/Routing/NotFound/AdministrationNotFoundSubscriberTest.php
+++ b/tests/unit/Administration/Framework/Routing/NotFound/AdministrationNotFoundSubscriberTest.php
@@ -23,7 +23,7 @@ class AdministrationNotFoundSubscriberTest extends TestCase
 {
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 KernelEvents::EXCEPTION => 'onError',
             ],

--- a/tests/unit/Administration/Service/AdminSearcherTest.php
+++ b/tests/unit/Administration/Service/AdminSearcherTest.php
@@ -85,6 +85,6 @@ class AdminSearcherTest extends TestCase
         $productResult = $result['product'];
         static::assertArrayHasKey('data', $productResult);
         static::assertArrayHasKey('total', $productResult);
-        static::assertEquals(0, $productResult['total']);
+        static::assertSame(0, $productResult['total']);
     }
 }

--- a/tests/unit/Administration/Snippet/AppAdministrationSnippetPersisterTest.php
+++ b/tests/unit/Administration/Snippet/AppAdministrationSnippetPersisterTest.php
@@ -76,7 +76,7 @@ class AppAdministrationSnippetPersisterTest extends TestCase
         try {
             $persister->updateSnippets($appEntity, $snippets, Context::createDefaultContext());
         } catch (\Exception $exception) {
-            static::assertEquals($expectedExceptionMessage, $exception->getMessage());
+            static::assertSame($expectedExceptionMessage, $exception->getMessage());
 
             $exceptionWasThrown = true;
         } finally {

--- a/tests/unit/Administration/Snippet/CachedSnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/CachedSnippetFinderTest.php
@@ -42,7 +42,7 @@ class CachedSnippetFinderTest extends TestCase
         $cachedSnippetFinder = new CachedSnippetFinder($this->snippetFinder, $this->cache);
         $result = $cachedSnippetFinder->findSnippets('test');
 
-        static::assertEquals($snippets, $cacheItem->get());
+        static::assertSame($snippets, $cacheItem->get());
         static::assertSame($snippets, $result);
     }
 

--- a/tests/unit/Administration/Snippet/SnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/SnippetFinderTest.php
@@ -44,7 +44,7 @@ class SnippetFinderTest extends TestCase
 
         $expectedSnippets = $this->getSnippetFixtures();
         $key = array_key_first($expectedSnippets);
-        static::assertEquals($expectedSnippets[$key], $snippets[$key]);
+        static::assertSame($expectedSnippets[$key], $snippets[$key]);
     }
 
     public function testNoSnippetsFound(): void
@@ -140,7 +140,7 @@ class SnippetFinderTest extends TestCase
         $result = $snippetFinder->findSnippets('en-GB');
         $result = array_intersect_key($result, $before); // filter out all others snippets
 
-        static::assertEquals($after, $result);
+        static::assertSame($after, $result);
     }
 
     /**

--- a/tests/unit/Administration/System/SalesChannel/Subscriber/SalesChannelUserConfigSubscriberTest.php
+++ b/tests/unit/Administration/System/SalesChannel/Subscriber/SalesChannelUserConfigSubscriberTest.php
@@ -38,7 +38,7 @@ class SalesChannelUserConfigSubscriberTest extends TestCase
 
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals([
+        static::assertSame([
             SalesChannelEvents::SALES_CHANNEL_DELETED => 'onSalesChannelDeleted',
         ], $this->salesChannelUserConfigSubscriber->getSubscribedEvents());
     }

--- a/tests/unit/Core/DevOps/System/Command/SyncComposerVersionCommandTest.php
+++ b/tests/unit/Core/DevOps/System/Command/SyncComposerVersionCommandTest.php
@@ -56,10 +56,10 @@ class SyncComposerVersionCommandTest extends TestCase
         $tester->execute([]);
 
         $bundle1Json = json_decode((string) file_get_contents($this->projectDir . '/src/Bundle1/composer.json'), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals('5.3.0', $bundle1Json['require']['symfony/symfony']);
+        static::assertSame('5.3.0', $bundle1Json['require']['symfony/symfony']);
 
         $webInstaller = json_decode((string) file_get_contents($this->projectDir . '/src/WebInstaller/composer.json'), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals('5.2.0', $webInstaller['require']['symfony/symfony']);
+        static::assertSame('5.2.0', $webInstaller['require']['symfony/symfony']);
 
         static::assertSame(Command::SUCCESS, $tester->getStatusCode());
     }
@@ -73,7 +73,7 @@ class SyncComposerVersionCommandTest extends TestCase
 
         $bundle1Json = json_decode((string) file_get_contents($this->projectDir . '/src/Bundle1/composer.json'), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals('5.2.0', $bundle1Json['require']['symfony/symfony']);
+        static::assertSame('5.2.0', $bundle1Json['require']['symfony/symfony']);
         static::assertSame(Command::FAILURE, $tester->getStatusCode());
     }
 }

--- a/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
+++ b/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
@@ -27,21 +27,21 @@ class AnnotationTagTesterTest extends TestCase
     {
         $version = AnnotationTagTester::getPlatformVersionFromGitTag('v6.4.0.0');
 
-        static::assertEquals('6.4.0.0', $version);
+        static::assertSame('6.4.0.0', $version);
     }
 
     public function testGetVersionFromGitTagReturnsCorrectVersionFromOldVersioning(): void
     {
         $version = AnnotationTagTester::getPlatformVersionFromGitTag('v6.1.0');
 
-        static::assertEquals('6.1.0', $version);
+        static::assertSame('6.1.0', $version);
     }
 
     public function testGetVersionFromGitTagAllowsHighVersions(): void
     {
         $version = AnnotationTagTester::getPlatformVersionFromGitTag('v200.123.1.36');
 
-        static::assertEquals('200.123.1.36', $version);
+        static::assertSame('200.123.1.36', $version);
     }
 
     public function testGetVersionFromGitTagsValidatesThatVersionIsStartingWithV(): void
@@ -90,7 +90,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $version = AnnotationTagTester::getVersionFromManifestFileName('manifest-1.0.xsd');
 
-        static::assertEquals('1.0', $version);
+        static::assertSame('1.0', $version);
     }
 
     public function testGetVersionFromManifestFileNameReturnsNullIfFileNameIsInWrongSchema(): void

--- a/tests/unit/Core/DevOps/Test/Command/MakeCoverageTestCommandTest.php
+++ b/tests/unit/Core/DevOps/Test/Command/MakeCoverageTestCommandTest.php
@@ -110,8 +110,8 @@ class MakeCoverageTestCommandTest extends TestCase
         static::assertTrue($fileSystem->exists($this->projectDir . '/tests/migration/Core/V6_5/Migration1670854818RemoveEventActionTableTest.php'));
         static::assertIsString($devOpsTest = file_get_contents($this->projectDir . '/tests/unit/Core/DevOps/DevOpsTest.php'));
         static::assertIsString($migrationTest = file_get_contents($this->projectDir . '/tests/migration/Core/V6_5/Migration1670854818RemoveEventActionTableTest.php'));
-        static::assertEquals($this->getDevOpsTestTemplate(), $devOpsTest);
-        static::assertEquals($this->getMigrationTestTemplate(), $migrationTest);
+        static::assertSame($this->getDevOpsTestTemplate(), $devOpsTest);
+        static::assertSame($this->getMigrationTestTemplate(), $migrationTest);
 
         static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/Test/Command/not-a-classTest.php'));
         static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php'));

--- a/tests/unit/Core/Installer/Configuration/AdminConfigurationServiceTest.php
+++ b/tests/unit/Core/Installer/Configuration/AdminConfigurationServiceTest.php
@@ -24,11 +24,11 @@ class AdminConfigurationServiceTest extends TestCase
             ->with(
                 'user',
                 static::callback(static function (array $data) use ($localeId): bool {
-                    static::assertEquals('admin', $data['username']);
-                    static::assertEquals('first', $data['first_name']);
-                    static::assertEquals('last', $data['last_name']);
-                    static::assertEquals('test@test.com', $data['email']);
-                    static::assertEquals($localeId, $data['locale_id']);
+                    static::assertSame('admin', $data['username']);
+                    static::assertSame('first', $data['first_name']);
+                    static::assertSame('last', $data['last_name']);
+                    static::assertSame('test@test.com', $data['email']);
+                    static::assertSame($localeId, $data['locale_id']);
                     static::assertTrue($data['admin']);
                     static::assertTrue($data['active']);
 

--- a/tests/unit/Core/Installer/Controller/ShopConfigurationControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/ShopConfigurationControllerTest.php
@@ -203,7 +203,7 @@ class ShopConfigurationControllerTest extends TestCase
         static::assertSame('/installer/finish', $response->getTargetUrl());
 
         static::assertFalse($session->has(DatabaseConnectionInformation::class));
-        static::assertEquals($expectedAdmin, $session->get('ADMIN_USER'));
+        static::assertSame($expectedAdmin, $session->get('ADMIN_USER'));
     }
 
     public function testPostConfigurationRouteOnError(): void
@@ -295,7 +295,7 @@ class ShopConfigurationControllerTest extends TestCase
         $this->translator->method('trans')->willReturnCallback(fn (string $key): string => $translations[$key]);
 
         $this->twig->expects($this->once())->method('render')->willReturnCallback(function (string $view, array $parameters): string {
-            static::assertEquals('@Installer/installer/shop-configuration.html.twig', $view);
+            static::assertSame('@Installer/installer/shop-configuration.html.twig', $view);
             static::assertArrayHasKey('countryIsos', $parameters);
 
             $countryIsos = $parameters['countryIsos'];

--- a/tests/unit/Core/Installer/Finish/UniqueIdGeneratorTest.php
+++ b/tests/unit/Core/Installer/Finish/UniqueIdGeneratorTest.php
@@ -23,11 +23,11 @@ class UniqueIdGeneratorTest extends TestCase
         $id = $idGenerator->getUniqueId();
 
         // assert that the generated id is the same on multiple calls
-        static::assertEquals($id, $idGenerator->getUniqueId());
+        static::assertSame($id, $idGenerator->getUniqueId());
 
         unlink(__DIR__ . '/.uniqueid.txt');
 
         // assert that the generated id is different on a new call
-        static::assertNotEquals($id, $idGenerator->getUniqueId());
+        static::assertNotSame($id, $idGenerator->getUniqueId());
     }
 }

--- a/tests/unit/Core/Installer/InstallerKernelTest.php
+++ b/tests/unit/Core/Installer/InstallerKernelTest.php
@@ -35,7 +35,7 @@ class InstallerKernelTest extends TestCase
         // the default revision changes per commit, if it is set we expect that it is correct
         static::assertTrue($kernel->getContainer()->hasParameter('kernel.shopware_version_revision'));
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'FrameworkBundle' => FrameworkBundle::class,
                 'TwigBundle' => TwigBundle::class,

--- a/tests/unit/Core/Installer/Requirements/ConfigurationRequirementsValidatorTest.php
+++ b/tests/unit/Core/Installer/Requirements/ConfigurationRequirementsValidatorTest.php
@@ -45,10 +45,10 @@ class ConfigurationRequirementsValidatorTest extends TestCase
         foreach ($expectedChecks as $index => $expected) {
             /** @var SystemCheck $check */
             $check = $checks->get($index);
-            static::assertEquals($expected->getStatus(), $check->getStatus());
-            static::assertEquals($expected->getName(), $check->getName());
-            static::assertEquals($expected->getRequiredValue(), $check->getRequiredValue());
-            static::assertEquals($expected->getInstalledValue(), $check->getInstalledValue());
+            static::assertSame($expected->getStatus(), $check->getStatus());
+            static::assertSame($expected->getName(), $check->getName());
+            static::assertSame($expected->getRequiredValue(), $check->getRequiredValue());
+            static::assertSame($expected->getInstalledValue(), $check->getInstalledValue());
         }
     }
 

--- a/tests/unit/Core/Installer/Requirements/Struct/SystemCheckTest.php
+++ b/tests/unit/Core/Installer/Requirements/Struct/SystemCheckTest.php
@@ -18,10 +18,10 @@ class SystemCheckTest extends TestCase
     {
         $check = new SystemCheck('name', RequirementCheck::STATUS_SUCCESS, 'requiredValue', 'installedValue');
 
-        static::assertEquals('name', $check->getName());
-        static::assertEquals('requiredValue', $check->getRequiredValue());
-        static::assertEquals('installedValue', $check->getInstalledValue());
-        static::assertEquals(RequirementCheck::STATUS_SUCCESS, $check->getStatus());
+        static::assertSame('name', $check->getName());
+        static::assertSame('requiredValue', $check->getRequiredValue());
+        static::assertSame('installedValue', $check->getInstalledValue());
+        static::assertSame(RequirementCheck::STATUS_SUCCESS, $check->getStatus());
     }
 
     public function testEmptyNameThrowsException(): void

--- a/tests/unit/Core/Maintenance/System/Struct/DatabaseConnectionInformationTest.php
+++ b/tests/unit/Core/Maintenance/System/Struct/DatabaseConnectionInformationTest.php
@@ -272,7 +272,7 @@ class DatabaseConnectionInformationTest extends TestCase
 
         $info = DatabaseConnectionInformation::fromEnv();
 
-        static::assertSame($expected->getVars(), $info->getVars());
+        static::assertEquals($expected->getVars(), $info->getVars());
     }
 
     public static function validEnvProvider(): \Generator

--- a/tests/unit/Core/Profiling/Controller/ProfilerControllerTest.php
+++ b/tests/unit/Core/Profiling/Controller/ProfilerControllerTest.php
@@ -38,7 +38,7 @@ class ProfilerControllerTest extends TestCase
             ->willReturn(null);
 
         $response = $controller->explainAction('some-token', 'some-panel', 'default', 5);
-        static::assertEquals('This profile does not exist.', $response->getContent());
+        static::assertSame('This profile does not exist.', $response->getContent());
     }
 
     public function testErrorIsReturnedIfPanelDoesNotExist(): void
@@ -55,7 +55,7 @@ class ProfilerControllerTest extends TestCase
             ->willReturn($profile);
 
         $response = $controller->explainAction('some-token', 'some-panel', 'default', 5);
-        static::assertEquals('This collector does not exist.', $response->getContent());
+        static::assertSame('This collector does not exist.', $response->getContent());
     }
 
     public function testErrorIsReturnedIfPanelIsIncorrect(): void
@@ -89,7 +89,7 @@ class ProfilerControllerTest extends TestCase
         });
 
         $response = $controller->explainAction('some-token', 'some-panel', 'default', 5);
-        static::assertEquals('This collector does not exist.', $response->getContent());
+        static::assertSame('This collector does not exist.', $response->getContent());
     }
 
     public function testErrorIsReturnedIfQueryDoesNotExist(): void
@@ -125,7 +125,7 @@ class ProfilerControllerTest extends TestCase
             5
         );
 
-        static::assertEquals('This query does not exist.', $response->getContent());
+        static::assertSame('This query does not exist.', $response->getContent());
     }
 
     public function testErrorIsReturnedIfQueryIsNotExplainable(): void
@@ -175,7 +175,7 @@ class ProfilerControllerTest extends TestCase
             0
         );
 
-        static::assertEquals('This query cannot be explained.', $response->getContent());
+        static::assertSame('This query cannot be explained.', $response->getContent());
     }
 
     public function testExplainQuery(): void
@@ -219,6 +219,6 @@ class ProfilerControllerTest extends TestCase
             0
         );
 
-        static::assertEquals('', $response->getContent());
+        static::assertSame('', $response->getContent());
     }
 }

--- a/tests/unit/Core/Profiling/Doctrine/ConnectionProfilerTest.php
+++ b/tests/unit/Core/Profiling/Doctrine/ConnectionProfilerTest.php
@@ -27,7 +27,7 @@ class ConnectionProfilerTest extends TestCase
         $c->lateCollect();
         $c = unserialize(serialize($c));
         static::assertInstanceOf(ConnectionProfiler::class, $c);
-        static::assertEquals(['default'], $c->getConnections());
+        static::assertSame(['default'], $c->getConnections());
     }
 
     public function testCollectQueryCount(): void
@@ -36,7 +36,7 @@ class ConnectionProfilerTest extends TestCase
         $c->lateCollect();
         $c = unserialize(serialize($c));
         static::assertInstanceOf(ConnectionProfiler::class, $c);
-        static::assertEquals(0, $c->getQueryCount());
+        static::assertSame(0, $c->getQueryCount());
 
         $queries = [
             ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 0],
@@ -45,7 +45,7 @@ class ConnectionProfilerTest extends TestCase
         $c->lateCollect();
         $c = unserialize(serialize($c));
         static::assertInstanceOf(ConnectionProfiler::class, $c);
-        static::assertEquals(1, $c->getQueryCount());
+        static::assertSame(1, $c->getQueryCount());
     }
 
     public function testCollectTime(): void
@@ -54,7 +54,7 @@ class ConnectionProfilerTest extends TestCase
         $c->lateCollect();
         $c = unserialize(serialize($c));
         static::assertInstanceOf(ConnectionProfiler::class, $c);
-        static::assertEquals(0, $c->getTime());
+        static::assertSame(0.0, $c->getTime());
 
         $queries = [
             ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 10],
@@ -63,7 +63,7 @@ class ConnectionProfilerTest extends TestCase
         $c->lateCollect();
         $c = unserialize(serialize($c));
         static::assertInstanceOf(ConnectionProfiler::class, $c);
-        static::assertEquals(10, $c->getTime());
+        static::assertSame(10.0, $c->getTime());
 
         $queries = [
             ['sql' => 'SELECT * FROM table1', 'params' => [], 'types' => [], 'executionMS' => 10],
@@ -104,7 +104,7 @@ class ConnectionProfilerTest extends TestCase
         $c = unserialize(serialize($c));
         static::assertInstanceOf(ConnectionProfiler::class, $c);
 
-        static::assertEquals([], $c->getQueries());
+        static::assertSame([], $c->getQueries());
     }
 
     /**
@@ -135,7 +135,7 @@ class ConnectionProfilerTest extends TestCase
         } elseif (\is_string($expected)) {
             static::assertStringMatchesFormat($expected, $collectedParam);
         } else {
-            static::assertEquals($expected, $collectedParam);
+            static::assertSame($expected, $collectedParam);
         }
 
         static::assertTrue($collectedQueries['default'][0]['explainable']);
@@ -168,11 +168,11 @@ class ConnectionProfilerTest extends TestCase
 
         $collectedQueries = $c->getQueries();
         static::assertInstanceOf(Data::class, $collectedQueries['default'][0]['params']);
-        static::assertEquals([], $collectedQueries['default'][0]['params']->getValue());
+        static::assertSame([], $collectedQueries['default'][0]['params']->getValue());
         static::assertTrue($collectedQueries['default'][0]['explainable']);
         static::assertTrue($collectedQueries['default'][0]['runnable']);
         static::assertInstanceOf(Data::class, $collectedQueries['default'][1]['params']);
-        static::assertEquals([], $collectedQueries['default'][1]['params']->getValue());
+        static::assertSame([], $collectedQueries['default'][1]['params']->getValue());
         static::assertTrue($collectedQueries['default'][1]['explainable']);
         static::assertTrue($collectedQueries['default'][1]['runnable']);
     }
@@ -205,7 +205,7 @@ class ConnectionProfilerTest extends TestCase
         } elseif (\is_string($expected)) {
             static::assertStringMatchesFormat($expected, $collectedParam);
         } else {
-            static::assertEquals($expected, $collectedParam);
+            static::assertSame($expected, $collectedParam);
         }
 
         static::assertTrue($collectedQueries['default'][0]['explainable']);

--- a/tests/unit/Core/Profiling/ProfilingTest.php
+++ b/tests/unit/Core/Profiling/ProfilingTest.php
@@ -16,6 +16,6 @@ class ProfilingTest extends TestCase
     {
         $profiling = new Profiling();
 
-        static::assertEquals(-2, $profiling->getTemplatePriority());
+        static::assertSame(-2, $profiling->getTemplatePriority());
     }
 }

--- a/tests/unit/Core/Profiling/Subscriber/ActiveRulesDataCollectorSubscriberTest.php
+++ b/tests/unit/Core/Profiling/Subscriber/ActiveRulesDataCollectorSubscriberTest.php
@@ -66,17 +66,17 @@ class ActiveRulesDataCollectorSubscriberTest extends TestCase
 
         $data = $subscriber->getData();
 
-        static::assertEquals(1, $subscriber->getMatchingRuleCount());
+        static::assertSame(1, $subscriber->getMatchingRuleCount());
         static::assertArrayHasKey($ruleId, $data);
 
         $rule = $data[$ruleId];
         static::assertInstanceOf(RuleEntity::class, $rule);
-        static::assertEquals(100, $rule->getPriority());
-        static::assertEquals('Demo rule', $rule->getName());
+        static::assertSame(100, $rule->getPriority());
+        static::assertSame('Demo rule', $rule->getName());
 
         $subscriber->reset();
 
-        static::assertEquals(0, $subscriber->getMatchingRuleCount());
+        static::assertSame(0, $subscriber->getMatchingRuleCount());
     }
 
     public function testEmptyRuleIds(): void
@@ -98,6 +98,6 @@ class ActiveRulesDataCollectorSubscriberTest extends TestCase
 
     public function testTemplate(): void
     {
-        static::assertEquals('@Profiling/Collector/rules.html.twig', ActiveRulesDataCollectorSubscriber::getTemplate());
+        static::assertSame('@Profiling/Collector/rules.html.twig', ActiveRulesDataCollectorSubscriber::getTemplate());
     }
 }

--- a/tests/unit/Core/Profiling/Twig/DoctrineExtensionTest.php
+++ b/tests/unit/Core/Profiling/Twig/DoctrineExtensionTest.php
@@ -19,7 +19,7 @@ class DoctrineExtensionTest extends TestCase
         $parameters = [1, 2];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
-        static::assertEquals('a=1 OR (1)::string OR b=2', $result);
+        static::assertSame('a=1 OR (1)::string OR b=2', $result);
     }
 
     public function testReplaceQueryParametersWithStartingIndexAtOne(): void
@@ -32,7 +32,7 @@ class DoctrineExtensionTest extends TestCase
         ];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
-        static::assertEquals('a=1 OR b=2', $result);
+        static::assertSame('a=1 OR b=2', $result);
     }
 
     public function testReplaceQueryParameters(): void
@@ -45,7 +45,7 @@ class DoctrineExtensionTest extends TestCase
         ];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
-        static::assertEquals('a=1 OR b=2', $result);
+        static::assertSame('a=1 OR b=2', $result);
     }
 
     public function testReplaceQueryParametersWithNamedIndex(): void
@@ -58,7 +58,7 @@ class DoctrineExtensionTest extends TestCase
         ];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
-        static::assertEquals('a=1 OR b=2', $result);
+        static::assertSame('a=1 OR b=2', $result);
     }
 
     public function testReplaceQueryParametersWithEmptyArray(): void
@@ -70,39 +70,39 @@ class DoctrineExtensionTest extends TestCase
         ];
 
         $result = $extension->replaceQueryParameters($query, $parameters);
-        static::assertEquals('IN (NULL)', $result);
+        static::assertSame('IN (NULL)', $result);
     }
 
     public function testEscapeBinaryParameter(): void
     {
         $binaryString = pack('H*', '9d40b8c1417f42d099af4782ec4b20b6');
-        static::assertEquals('0x9D40B8C1417F42D099AF4782EC4B20B6', DoctrineExtension::escapeFunction($binaryString));
+        static::assertSame('0x9D40B8C1417F42D099AF4782EC4B20B6', DoctrineExtension::escapeFunction($binaryString));
     }
 
     public function testEscapeStringParameter(): void
     {
-        static::assertEquals('\'test string\'', DoctrineExtension::escapeFunction('test string'));
+        static::assertSame('\'test string\'', DoctrineExtension::escapeFunction('test string'));
     }
 
     public function testEscapeArrayParameter(): void
     {
-        static::assertEquals('1, NULL, \'test\', foo, NULL', DoctrineExtension::escapeFunction([1, null, 'test', new DummyClass('foo'), []]));
+        static::assertSame('1, NULL, \'test\', foo, NULL', DoctrineExtension::escapeFunction([1, null, 'test', new DummyClass('foo'), []]));
     }
 
     public function testEscapeObjectParameter(): void
     {
         $object = new DummyClass('bar');
-        static::assertEquals('bar', DoctrineExtension::escapeFunction($object));
+        static::assertSame('bar', DoctrineExtension::escapeFunction($object));
     }
 
     public function testEscapeNullParameter(): void
     {
-        static::assertEquals('NULL', DoctrineExtension::escapeFunction(null));
+        static::assertSame('NULL', DoctrineExtension::escapeFunction(null));
     }
 
     public function testEscapeBooleanParameter(): void
     {
-        static::assertEquals('1', DoctrineExtension::escapeFunction(true));
+        static::assertSame('1', DoctrineExtension::escapeFunction(true));
     }
 
     public function testItUsesCssOnThePreTag(): void

--- a/tests/unit/Core/Service/AllServiceInstallerTest.php
+++ b/tests/unit/Core/Service/AllServiceInstallerTest.php
@@ -46,8 +46,8 @@ class AllServiceInstallerTest extends TestCase
             ->method('install')
             ->willReturnCallback(function (ServiceRegistryEntry $serviceRegistryEntry) use ($matcher): bool {
                 match ($matcher->numberOfInvocations()) {
-                    1 => $this->assertEquals('Service1', $serviceRegistryEntry->name),
-                    2 => $this->assertEquals('Service2', $serviceRegistryEntry->name),
+                    1 => $this->assertSame('Service1', $serviceRegistryEntry->name),
+                    2 => $this->assertSame('Service2', $serviceRegistryEntry->name),
                     default => throw new \UnhandledMatchError(),
                 };
 
@@ -81,7 +81,7 @@ class AllServiceInstallerTest extends TestCase
             $serviceLifeCycle->expects($this->once())
                 ->method('install')
                 ->willReturnCallback(function (ServiceRegistryEntry $serviceRegistryEntry): bool {
-                    $this->assertEquals('Service1', $serviceRegistryEntry->name);
+                    $this->assertSame('Service1', $serviceRegistryEntry->name);
 
                     return true;
                 });
@@ -142,7 +142,7 @@ class AllServiceInstallerTest extends TestCase
         $serviceLifeCycle->expects($this->exactly(1))
             ->method('install')
             ->willReturnCallback(function (ServiceRegistryEntry $serviceRegistryEntry): bool {
-                $this->assertEquals('Service2', $serviceRegistryEntry->name);
+                $this->assertSame('Service2', $serviceRegistryEntry->name);
 
                 return true;
             });

--- a/tests/unit/Core/Service/AppInfoTest.php
+++ b/tests/unit/Core/Service/AppInfoTest.php
@@ -40,17 +40,17 @@ class AppInfoTest extends TestCase
     {
         $appInfo = AppInfo::fromNameAndArray('TestApp', ['app-version' => '1.0.0', 'app-hash' => 'a453f', 'app-revision' => '1.0.0-a453f', 'app-zip-url' => 'https://website.com/zip']);
 
-        static::assertEquals('1.0.0', $appInfo->version);
-        static::assertEquals('a453f', $appInfo->hash);
-        static::assertEquals('1.0.0-a453f', $appInfo->revision);
-        static::assertEquals('https://website.com/zip', $appInfo->zipUrl);
+        static::assertSame('1.0.0', $appInfo->version);
+        static::assertSame('a453f', $appInfo->hash);
+        static::assertSame('1.0.0-a453f', $appInfo->revision);
+        static::assertSame('https://website.com/zip', $appInfo->zipUrl);
     }
 
     public function testToArray(): void
     {
         $appInfo = new AppInfo('TestApp', '1.0.0', 'a453f', '1.0.0-a453f', 'https://website.com/zip');
 
-        static::assertEquals(
+        static::assertSame(
             ['version' => '1.0.0', 'hash' => 'a453f', 'revision' => '1.0.0-a453f', 'zip-url' => 'https://website.com/zip'],
             $appInfo->toArray()
         );

--- a/tests/unit/Core/Service/ServiceClientFactoryTest.php
+++ b/tests/unit/Core/Service/ServiceClientFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Service;
 
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -101,10 +102,12 @@ class ServiceClientFactoryTest extends TestCase
 
         static::assertIsArray($headers);
         static::assertArrayHasKey('Content-Type', $headers);
-        static::assertEquals('application/json', $headers['Content-Type']);
-        static::assertEquals($context, $config[AuthMiddleware::APP_REQUEST_CONTEXT]);
+        static::assertSame('application/json', $headers['Content-Type']);
+        static::assertSame($context, $config[AuthMiddleware::APP_REQUEST_CONTEXT]);
         static::assertArrayHasKey('base_uri', $config);
-        static::assertEquals('https://example.com', $config['base_uri']);
+        $baseUri = $config['base_uri'];
+        static::assertInstanceOf(Uri::class, $baseUri);
+        static::assertSame('https://example.com', $baseUri->__toString());
     }
 
     public function testAuthenticatedClientThrowsExceptionWhenAppSecretNull(): void

--- a/tests/unit/Core/Service/ServiceExceptionTest.php
+++ b/tests/unit/Core/Service/ServiceExceptionTest.php
@@ -20,9 +20,9 @@ class ServiceExceptionTest extends TestCase
     {
         $e = ServiceException::notFound('name', 'MyCoolService');
 
-        static::assertEquals(Response::HTTP_NOT_FOUND, $e->getStatusCode());
-        static::assertEquals(ServiceException::NOT_FOUND, $e->getErrorCode());
-        static::assertEquals('Could not find service with name "MyCoolService"', $e->getMessage());
+        static::assertSame(Response::HTTP_NOT_FOUND, $e->getStatusCode());
+        static::assertSame(ServiceException::NOT_FOUND, $e->getErrorCode());
+        static::assertSame('Could not find service with name "MyCoolService"', $e->getMessage());
     }
 
     public function testUpdateRequiresAdminApiSource(): void
@@ -30,18 +30,18 @@ class ServiceExceptionTest extends TestCase
         $source = new ShopApiSource(Uuid::randomHex());
         $e = ServiceException::updateRequiresAdminApiSource($source);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(ServiceException::SERVICE_UPDATE_REQUIRES_ADMIN_API_SOURCE, $e->getErrorCode());
-        static::assertEquals('Updating a service requires Shopware\Core\Framework\Api\Context\AdminApiSource, but got Shopware\Core\Framework\Api\Context\ShopApiSource', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(ServiceException::SERVICE_UPDATE_REQUIRES_ADMIN_API_SOURCE, $e->getErrorCode());
+        static::assertSame('Updating a service requires Shopware\Core\Framework\Api\Context\AdminApiSource, but got Shopware\Core\Framework\Api\Context\ShopApiSource', $e->getMessage());
     }
 
     public function testUpdateRequiresIntegration(): void
     {
         $e = ServiceException::updateRequiresIntegration();
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(ServiceException::SERVICE_UPDATE_REQUIRES_INTEGRATION, $e->getErrorCode());
-        static::assertEquals('Updating a service requires an integration', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(ServiceException::SERVICE_UPDATE_REQUIRES_INTEGRATION, $e->getErrorCode());
+        static::assertSame('Updating a service requires an integration', $e->getMessage());
     }
 
     public function testRequestFailed(): void
@@ -51,9 +51,9 @@ class ServiceExceptionTest extends TestCase
 
         $e = ServiceException::requestFailed($response);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(ServiceException::SERVICE_REQUEST_TRANSPORT_ERROR, $e->getErrorCode());
-        static::assertEquals('Error performing request. Response code: 404', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(ServiceException::SERVICE_REQUEST_TRANSPORT_ERROR, $e->getErrorCode());
+        static::assertSame('Error performing request. Response code: 404', $e->getMessage());
     }
 
     public function testRequestFailedWithErrors(): void
@@ -64,18 +64,18 @@ class ServiceExceptionTest extends TestCase
 
         $e = ServiceException::requestFailed($response);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(ServiceException::SERVICE_REQUEST_TRANSPORT_ERROR, $e->getErrorCode());
-        static::assertEquals('Error performing request. Response code: 404. Errors: ["Error 1","Error 2"]', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(ServiceException::SERVICE_REQUEST_TRANSPORT_ERROR, $e->getErrorCode());
+        static::assertSame('Error performing request. Response code: 404. Errors: ["Error 1","Error 2"]', $e->getMessage());
     }
 
     public function testRequestTransportError(): void
     {
         $e = ServiceException::requestTransportError();
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(ServiceException::SERVICE_REQUEST_TRANSPORT_ERROR, $e->getErrorCode());
-        static::assertEquals('Error performing request', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(ServiceException::SERVICE_REQUEST_TRANSPORT_ERROR, $e->getErrorCode());
+        static::assertSame('Error performing request', $e->getMessage());
     }
 
     public function testRequestTransportErrorWithPrevious(): void
@@ -83,27 +83,27 @@ class ServiceExceptionTest extends TestCase
         $previous = new \Exception('Some error');
         $e = ServiceException::requestTransportError($previous);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(ServiceException::SERVICE_REQUEST_TRANSPORT_ERROR, $e->getErrorCode());
-        static::assertEquals('Error performing request. Error: Some error', $e->getMessage());
-        static::assertEquals($previous, $e->getPrevious());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(ServiceException::SERVICE_REQUEST_TRANSPORT_ERROR, $e->getErrorCode());
+        static::assertSame('Error performing request. Error: Some error', $e->getMessage());
+        static::assertSame($previous, $e->getPrevious());
     }
 
     public function testMissingAppVersionInfo(): void
     {
         $e = ServiceException::missingAppVersionInfo();
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(ServiceException::SERVICE_MISSING_APP_VERSION_INFO, $e->getErrorCode());
-        static::assertEquals('Error downloading app. The version information was missing.', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(ServiceException::SERVICE_MISSING_APP_VERSION_INFO, $e->getErrorCode());
+        static::assertSame('Error downloading app. The version information was missing.', $e->getMessage());
     }
 
     public function testCannotWriteAppToDestination(): void
     {
         $e = ServiceException::cannotWriteAppToDestination('/some/path');
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(ServiceException::SERVICE_CANNOT_WRITE_APP, $e->getErrorCode());
-        static::assertEquals('Error writing app zip to file "/some/path"', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(ServiceException::SERVICE_CANNOT_WRITE_APP, $e->getErrorCode());
+        static::assertSame('Error writing app zip to file "/some/path"', $e->getMessage());
     }
 }

--- a/tests/unit/Core/Service/ServiceRegistryClientTest.php
+++ b/tests/unit/Core/Service/ServiceRegistryClientTest.php
@@ -49,8 +49,8 @@ class ServiceRegistryClientTest extends TestCase
 
         $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
 
-        static::assertEquals([], $registryClient->getAll());
-        static::assertEquals('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertSame([], $registryClient->getAll());
+        static::assertSame('https://www.shopware.com/services.json', $response->getRequestUrl());
     }
 
     public function testFailRequestReturnsEmptyListOfServices(): void
@@ -61,8 +61,8 @@ class ServiceRegistryClientTest extends TestCase
 
         $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
 
-        static::assertEquals([], $registryClient->getAll());
-        static::assertEquals('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertSame([], $registryClient->getAll());
+        static::assertSame('https://www.shopware.com/services.json', $response->getRequestUrl());
     }
 
     public function testSuccessfulRequestReturnsListOfServices(): void
@@ -84,17 +84,17 @@ class ServiceRegistryClientTest extends TestCase
 
         static::assertCount(2, $entries);
         static::assertContainsOnlyInstancesOf(ServiceRegistryEntry::class, $entries);
-        static::assertEquals('MyCoolService1', $entries[0]->name);
-        static::assertEquals('My Cool Service 1', $entries[0]->description);
-        static::assertEquals('https://coolservice1.com', $entries[0]->host);
-        static::assertEquals('/app-endpoint', $entries[0]->appEndpoint);
+        static::assertSame('MyCoolService1', $entries[0]->name);
+        static::assertSame('My Cool Service 1', $entries[0]->description);
+        static::assertSame('https://coolservice1.com', $entries[0]->host);
+        static::assertSame('/app-endpoint', $entries[0]->appEndpoint);
         static::assertNull($entries[0]->licenseSyncEndPoint);
-        static::assertEquals('MyCoolService2', $entries[1]->name);
-        static::assertEquals('My Cool Service 2', $entries[1]->description);
-        static::assertEquals('https://coolservice2.com', $entries[1]->host);
-        static::assertEquals('/app-endpoint', $entries[1]->appEndpoint);
-        static::assertEquals('https://www.shopware.com/services.json', $response->getRequestUrl());
-        static::assertEquals('/license-sync-endpoint', $entries[1]->licenseSyncEndPoint);
+        static::assertSame('MyCoolService2', $entries[1]->name);
+        static::assertSame('My Cool Service 2', $entries[1]->description);
+        static::assertSame('https://coolservice2.com', $entries[1]->host);
+        static::assertSame('/app-endpoint', $entries[1]->appEndpoint);
+        static::assertSame('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertSame('/license-sync-endpoint', $entries[1]->licenseSyncEndPoint);
     }
 
     public function testServicesAreFetchedAndCached(): void

--- a/tests/unit/Core/Service/ServiceRegistryEntryTest.php
+++ b/tests/unit/Core/Service/ServiceRegistryEntryTest.php
@@ -16,10 +16,10 @@ class ServiceRegistryEntryTest extends TestCase
     {
         $entry = new ServiceRegistryEntry('MyCoolService', 'My Cool Service', 'https://some-service.com', '/service/lifecycle/choose-app');
 
-        static::assertEquals('MyCoolService', $entry->name);
-        static::assertEquals('https://some-service.com', $entry->host);
-        static::assertEquals('My Cool Service', $entry->description);
-        static::assertEquals('/service/lifecycle/choose-app', $entry->appEndpoint);
+        static::assertSame('MyCoolService', $entry->name);
+        static::assertSame('https://some-service.com', $entry->host);
+        static::assertSame('My Cool Service', $entry->description);
+        static::assertSame('/service/lifecycle/choose-app', $entry->appEndpoint);
     }
 
     public function testServiceRegistryEntryDefaultsToActivateOnInstall(): void

--- a/tests/unit/Core/Service/ServiceSourceResolverTest.php
+++ b/tests/unit/Core/Service/ServiceSourceResolverTest.php
@@ -34,7 +34,7 @@ class ServiceSourceResolverTest extends TestCase
             $this->createMock(Filesystem::class),
             $this->createMock(EventDispatcherInterface::class)
         );
-        static::assertEquals('service', $source->name());
+        static::assertSame('service', $source->name());
     }
 
     public function testSupportsOnlyConsidersServiceTypes(): void
@@ -154,7 +154,7 @@ class ServiceSourceResolverTest extends TestCase
 
         $fs = $source->filesystem($app);
 
-        static::assertEquals('/some/tmp/path/MyCoolService', $fs->location);
+        static::assertSame('/some/tmp/path/MyCoolService', $fs->location);
     }
 
     #[DataProvider('appProvider')]
@@ -185,7 +185,7 @@ class ServiceSourceResolverTest extends TestCase
 
         $fs = $source->filesystem($app);
 
-        static::assertEquals('/some/tmp/path/MyCoolService', $fs->location);
+        static::assertSame('/some/tmp/path/MyCoolService', $fs->location);
     }
 
     public function testFilesystemForAppDownloadsServiceUsingClient(): void
@@ -228,7 +228,7 @@ class ServiceSourceResolverTest extends TestCase
 
         $fs = $source->filesystem($app);
 
-        static::assertEquals('/some/tmp/path/MyCoolService', $fs->location);
+        static::assertSame('/some/tmp/path/MyCoolService', $fs->location);
     }
 
     public function testIfLatestVersionIsNotInstalledServiceIsUpdatedFirst(): void
@@ -269,6 +269,6 @@ class ServiceSourceResolverTest extends TestCase
 
         $fs = $source->filesystem($app);
 
-        static::assertEquals('/some/tmp/path/MyCoolService', $fs->location);
+        static::assertSame('/some/tmp/path/MyCoolService', $fs->location);
     }
 }

--- a/tests/unit/Core/Service/Subscriber/InstalledExtensionsListingLoadedSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/InstalledExtensionsListingLoadedSubscriberTest.php
@@ -45,6 +45,6 @@ class InstalledExtensionsListingLoadedSubscriberTest extends TestCase
         static::assertCount(1, $event->extensionCollection);
         $ext = $event->extensionCollection->first();
         static::assertNotNull($ext);
-        static::assertEquals('Ext1', $ext->getName());
+        static::assertSame('Ext1', $ext->getName());
     }
 }

--- a/tests/unit/Core/Service/Subscriber/LicenseSyncSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/LicenseSyncSubscriberTest.php
@@ -72,7 +72,7 @@ class LicenseSyncSubscriberTest extends TestCase
             SystemConfigChangedEvent::class => 'syncLicense',
         ];
 
-        static::assertEquals($expectedEvents, LicenseSyncSubscriber::getSubscribedEvents());
+        static::assertSame($expectedEvents, LicenseSyncSubscriber::getSubscribedEvents());
     }
 
     public function testLicenseSyncWithValidLicense(): void

--- a/tests/unit/Core/Service/Subscriber/WebhookManagerSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/WebhookManagerSubscriberTest.php
@@ -109,7 +109,7 @@ class WebhookManagerSubscriberTest extends TestCase
         $subscriber->filterDuplicates($event);
 
         static::assertCount(4, $event->webhooks);
-        static::assertEquals(
+        static::assertSame(
             [
                 $this->ids->get('wh-3'),
                 $this->ids->get('wh-5'),

--- a/tests/unit/Core/Test/PHPUnit/Extension/Common/TimeKeeperTest.php
+++ b/tests/unit/Core/Test/PHPUnit/Extension/Common/TimeKeeperTest.php
@@ -24,7 +24,7 @@ class TimeKeeperTest extends TestCase
 
         $duration = $timeKeeper->stop($testIdentifier, $stoppedTime);
 
-        static::assertEquals(1, $duration->seconds());
+        static::assertSame(1, $duration->seconds());
     }
 
     public function testStopWithoutStartShouldReturnZeroDuration(): void
@@ -35,6 +35,6 @@ class TimeKeeperTest extends TestCase
 
         $duration = $timeKeeper->stop($testIdentifier, $stoppedTime);
 
-        static::assertEquals(0, $duration->seconds());
+        static::assertSame(0, $duration->seconds());
     }
 }

--- a/tests/unit/Core/Test/PHPUnit/Extension/DatabaseDiff/DbStateTest.php
+++ b/tests/unit/Core/Test/PHPUnit/Extension/DatabaseDiff/DbStateTest.php
@@ -37,7 +37,7 @@ class DbStateTest extends TestCase
 
         $dbState->rememberCurrentDbState();
 
-        static::assertEquals(['table1' => 10, 'table2' => 20], $dbState->tableCounts);
+        static::assertSame(['table1' => 10, 'table2' => 20], $dbState->tableCounts);
     }
 
     public function testGetDiff(): void
@@ -58,6 +58,6 @@ class DbStateTest extends TestCase
 
         $diff = $dbState->getDiff();
 
-        static::assertEquals(['added' => ['table3'], 'deleted' => ['table2'], 'changed' => ['table1' => 5]], $diff);
+        static::assertSame(['added' => ['table3'], 'deleted' => ['table2'], 'changed' => ['table1' => 5]], $diff);
     }
 }

--- a/tests/unit/Core/Test/Stub/Framework/IdsCollectionTest.php
+++ b/tests/unit/Core/Test/Stub/Framework/IdsCollectionTest.php
@@ -22,11 +22,11 @@ class IdsCollectionTest extends TestCase
 
         $ids->set('foo', $id);
 
-        static::assertEquals($id, $ids->get('foo'));
-        static::assertEquals($id, $ids->get('test'));
-        static::assertEquals([$id], array_values($ids->getList(['test'])));
-        static::assertEquals([['id' => $id]], $ids->getIdArray(['test']));
-        static::assertEquals(Uuid::fromHexToBytes($id), $ids->getBytes('test'));
-        static::assertEquals([['id' => $id]], $ids->getIdArray(['test']));
+        static::assertSame($id, $ids->get('foo'));
+        static::assertSame($id, $ids->get('test'));
+        static::assertSame([$id], array_values($ids->getList(['test'])));
+        static::assertSame([['id' => $id]], $ids->getIdArray(['test']));
+        static::assertSame(Uuid::fromHexToBytes($id), $ids->getBytes('test'));
+        static::assertSame([['id' => $id]], $ids->getIdArray(['test']));
     }
 }

--- a/tests/unit/Core/Test/Stub/Framework/Util/StaticFilesystemTest.php
+++ b/tests/unit/Core/Test/Stub/Framework/Util/StaticFilesystemTest.php
@@ -31,8 +31,8 @@ class StaticFilesystemTest extends TestCase
             'one.php' => 'content1',
         ]);
 
-        static::assertEquals('/app-root/one.php', $fs->path('one.php'));
-        static::assertEquals('/app-root/two.php', $fs->path('two.php'));
+        static::assertSame('/app-root/one.php', $fs->path('one.php'));
+        static::assertSame('/app-root/two.php', $fs->path('two.php'));
     }
 
     public function testReadThrowsExceptionWhenFileDoesNotExist(): void
@@ -52,7 +52,7 @@ class StaticFilesystemTest extends TestCase
             'one.php' => 'content1',
         ]);
 
-        static::assertEquals('content1', $fs->read('one.php'));
+        static::assertSame('content1', $fs->read('one.php'));
     }
 
     public function testFindFiles(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/9317

### 2. What does this change do, exactly?

Replace `assertEquals` with `assertSame`