### PR TITLE
chore: Replace assertEquals with assertSame in Storefront, Elasticsearch tests

### DIFF
--- a/tests/integration/Elasticsearch/Admin/AdminSearchControllerTest.php
+++ b/tests/integration/Elasticsearch/Admin/AdminSearchControllerTest.php
@@ -72,7 +72,7 @@ class AdminSearchControllerTest extends TestCase
         $this->getBrowser()->request('POST', '/api/_admin/es-search', [], [], [], json_encode($data, \JSON_THROW_ON_ERROR) ?: null);
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $content = json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
@@ -82,12 +82,12 @@ class AdminSearchControllerTest extends TestCase
 
         $content = $content['data']['promotion'];
 
-        static::assertEquals(\count($expectedPromotions), $content['total']);
+        static::assertSame(\count($expectedPromotions), $content['total']);
 
         foreach ($expectedPromotions as $expectedPromotion) {
             $id = $ids->get($expectedPromotion);
             static::assertNotEmpty($content['data'][$id]);
-            static::assertEquals($id, $content['data'][$id]['id']);
+            static::assertSame($id, $content['data'][$id]['id']);
         }
     }
 

--- a/tests/integration/Elasticsearch/Product/SearchCasesTest.php
+++ b/tests/integration/Elasticsearch/Product/SearchCasesTest.php
@@ -58,7 +58,7 @@ class SearchCasesTest extends TestCase
             $scores[self::$ids->getKey((string) $item['id'])] = $item['_score'];
         }
 
-        static::assertEquals(
+        static::assertSame(
             $best,
             self::$ids->getKey((string) $result->firstId()),
             print_r($scores, true)

--- a/tests/integration/Elasticsearch/Product/StopwordTokenFilterTest.php
+++ b/tests/integration/Elasticsearch/Product/StopwordTokenFilterTest.php
@@ -38,7 +38,7 @@ class StopwordTokenFilterTest extends TestCase
 
         sort($expected);
         sort($keywords);
-        static::assertEquals($expected, $keywords);
+        static::assertSame($expected, $keywords);
     }
 
     /**

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -94,10 +94,10 @@ class AuthControllerTest extends TestCase
         $session = $this->getSession();
 
         $newContextToken = $session->get('sw-context-token');
-        static::assertNotEquals($contextToken, $newContextToken);
+        static::assertNotSame($contextToken, $newContextToken);
 
         $newSessionId = $session->getId();
-        static::assertNotEquals($sessionId, $newSessionId);
+        static::assertNotSame($sessionId, $newSessionId);
 
         $oldCartExists = $connection->fetchOne('SELECT 1 FROM cart WHERE token = ?', [$contextToken]);
         static::assertFalse($oldCartExists);
@@ -126,7 +126,7 @@ class AuthControllerTest extends TestCase
 
         static::assertInstanceOf(RedirectResponse::class, $redirectResponse);
         static::assertStringStartsWith('/account/login', $redirectResponse->getTargetUrl());
-        static::assertNotEquals($contextToken, $this->getSession()->get('sw-context-token'));
+        static::assertNotSame($contextToken, $this->getSession()->get('sw-context-token'));
     }
 
     public function testDoNotLogoutWhenSalesChannelIdChangedIfCustomerScopeIsOff(): void
@@ -221,10 +221,10 @@ class AuthControllerTest extends TestCase
         $session = $this->getSession();
 
         $newContextToken = $session->get('sw-context-token');
-        static::assertNotEquals($contextToken, $newContextToken);
+        static::assertNotSame($contextToken, $newContextToken);
 
         $newSessionId = $session->getId();
-        static::assertNotEquals($sessionId, $newSessionId);
+        static::assertNotSame($sessionId, $newSessionId);
     }
 
     public function testOneUserUseOneContextAcrossSessions(): void
@@ -260,8 +260,8 @@ class AuthControllerTest extends TestCase
         $secondTimeLoginSessionId = $secondTimeLogin->getId();
         $secondTimeLoginContextToken = $secondTimeLogin->get(PlatformRequest::HEADER_CONTEXT_TOKEN);
 
-        static::assertNotEquals($firstTimeLoginSessionId, $secondTimeLoginSessionId);
-        static::assertNotEquals($firstTimeLoginContextToken, $secondTimeLoginContextToken);
+        static::assertNotSame($firstTimeLoginSessionId, $secondTimeLoginSessionId);
+        static::assertNotSame($firstTimeLoginContextToken, $secondTimeLoginContextToken);
     }
 
     public function testMergedHintIsAdded(): void

--- a/tests/integration/Storefront/Controller/CheckoutControllerTest.php
+++ b/tests/integration/Storefront/Controller/CheckoutControllerTest.php
@@ -489,7 +489,7 @@ class CheckoutControllerTest extends TestCase
 
         $response = $browser->getResponse();
 
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $content = json_decode((string) $response->getContent(), true);
 
@@ -542,7 +542,7 @@ class CheckoutControllerTest extends TestCase
         $request = $this->createRequest($salesChannelContext);
 
         $response = static::getContainer()->get(CheckoutController::class)->info($request, $salesChannelContext);
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertStringContainsString((string) $cart->getPrice()->getTotalPrice(), (string) $response->getContent());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
@@ -560,7 +560,7 @@ class CheckoutControllerTest extends TestCase
         $request = $this->createRequest($salesChannelContext);
 
         $response = static::getContainer()->get(CheckoutController::class)->info($request, $salesChannelContext);
-        static::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         static::assertEmpty($response->getContent());
     }
 

--- a/tests/integration/Storefront/Controller/CmsControllerTest.php
+++ b/tests/integration/Storefront/Controller/CmsControllerTest.php
@@ -32,7 +32,7 @@ class CmsControllerTest extends TestCase
     public function testCmsPageLoadedHookScriptsAreExecuted(): void
     {
         $response = $this->request('GET', '/widgets/cms/' . $this->ids->get('page'), []);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -42,7 +42,7 @@ class CmsControllerTest extends TestCase
     public function testCmsPageLoadedHookScriptsAreExecutedForFullPage(): void
     {
         $response = $this->request('GET', '/page/cms/' . $this->ids->get('page'), []);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -52,7 +52,7 @@ class CmsControllerTest extends TestCase
     public function testCmsPageLoadedHookScriptsAreExecutedForCategory(): void
     {
         $response = $this->request('GET', '/widgets/cms/navigation/' . $this->ids->get('category'), []);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 

--- a/tests/integration/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/integration/Storefront/Controller/CountryStateControllerTest.php
@@ -133,7 +133,7 @@ class CountryStateControllerTest extends TestCase
 
         static::assertArrayHasKey(CountryStateDataPageletLoadedHook::HOOK_NAME, $traces);
 
-        static::assertEquals(['16'], $traces['country-state-data-pagelet-loaded'][0]['output']);
+        static::assertSame([16], $traces['country-state-data-pagelet-loaded'][0]['output']);
     }
 }
 

--- a/tests/integration/Storefront/Controller/DocumentControllerTest.php
+++ b/tests/integration/Storefront/Controller/DocumentControllerTest.php
@@ -121,9 +121,9 @@ class DocumentControllerTest extends TestCase
 
         $response = $browser->getResponse();
 
-        static::assertEquals(200, $response->getStatusCode());
-        static::assertEquals($expectedFileContent, $response->getContent());
-        static::assertEquals($expectedContentType, $response->headers->get('content-type'));
+        static::assertSame(200, $response->getStatusCode());
+        static::assertSame($expectedFileContent, $response->getContent());
+        static::assertSame($expectedContentType, $response->headers->get('content-type'));
 
         // Customer are unable to view the document without valid deepLinkCode
         $browser->request(
@@ -132,7 +132,7 @@ class DocumentControllerTest extends TestCase
             $this->tokenize('frontend.account.order.single.document', [])
         );
 
-        static::assertEquals(404, $browser->getResponse()->getStatusCode());
+        static::assertSame(404, $browser->getResponse()->getStatusCode());
     }
 
     private function login(string $email): KernelBrowser

--- a/tests/integration/Storefront/Controller/LandingPageControllerTest.php
+++ b/tests/integration/Storefront/Controller/LandingPageControllerTest.php
@@ -37,7 +37,7 @@ class LandingPageControllerTest extends TestCase
     {
         $response = $this->request('GET', '/myUrl', []);
 
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 

--- a/tests/integration/Storefront/Controller/MaintenanceControllerTest.php
+++ b/tests/integration/Storefront/Controller/MaintenanceControllerTest.php
@@ -45,7 +45,7 @@ class MaintenanceControllerTest extends TestCase
         $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/');
         $response = $browser->getResponse();
 
-        static::assertEquals(503, $response->getStatusCode());
+        static::assertSame(503, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -55,7 +55,7 @@ class MaintenanceControllerTest extends TestCase
     public function testMaintenancePageLoadedHookScriptsAreExecutedForSinglePage(): void
     {
         $response = $this->request('GET', '/maintenance/singlepage/' . $this->ids->get('page'), []);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -35,7 +35,7 @@ class NavigationControllerTest extends TestCase
     public function testNavigationPageLoadedHookScriptsAreExecuted(): void
     {
         $response = $this->request('GET', '/', []);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -46,7 +46,7 @@ class NavigationControllerTest extends TestCase
     {
         $response = $this->request('GET', '/my-navigation/', []);
 
-        static::assertEquals(200, $response->getStatusCode(), print_r($response->getContent(), true));
+        static::assertSame(200, $response->getStatusCode(), print_r($response->getContent(), true));
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -56,7 +56,7 @@ class NavigationControllerTest extends TestCase
     public function testMenuOffcanvasPageletLoadedHookScriptsAreExecuted(): void
     {
         $response = $this->request('GET', '/widgets/menu/offcanvas', []);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 

--- a/tests/integration/Storefront/Controller/NewsletterControllerTest.php
+++ b/tests/integration/Storefront/Controller/NewsletterControllerTest.php
@@ -61,7 +61,7 @@ class NewsletterControllerTest extends TestCase
         /** @var NewsletterRecipientEntity $recipientEntry */
         $recipientEntry = $repo->search($criteria, Context::createDefaultContext())->first();
 
-        static::assertEquals('direct', (string) $recipientEntry->getStatus());
+        static::assertSame('direct', (string) $recipientEntry->getStatus());
         $this->validateRecipientData($recipientEntry);
     }
 
@@ -111,7 +111,7 @@ class NewsletterControllerTest extends TestCase
         /** @var NewsletterRecipientEntity $recipientEntry */
         $recipientEntry = $repo->search($criteria, Context::createDefaultContext())->first();
 
-        static::assertEquals('optIn', (string) $recipientEntry->getStatus());
+        static::assertSame('optIn', (string) $recipientEntry->getStatus());
         $this->validateRecipientData($recipientEntry);
     }
 

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -102,7 +102,7 @@ class ProductControllerTest extends TestCase
 
         $this->checkStatusCode($response);
         static::assertInstanceOf(JsonResponse::class, $response);
-        static::assertEquals($productId, $content['productId']);
+        static::assertSame($productId, $content['productId']);
         static::assertStringContainsString($productId, $content['url']);
     }
 
@@ -251,27 +251,27 @@ class ProductControllerTest extends TestCase
         $crawler->filter('.product-detail-configurator .product-detail-configurator-option-label')
             ->each(static function (Crawler $option) use ($blue, $green, $red, $xl, $l, &$blueFound, &$greenFound, &$redFound, &$xlFound, &$lFound, &$mFound): void {
                 if ($option->innerText() === 'blue') {
-                    static::assertEquals($blue, $option->matches('.is-combinable'));
+                    static::assertSame($blue, $option->matches('.is-combinable'));
                     $blueFound = true;
                 }
 
                 if ($option->innerText() === 'green') {
-                    static::assertEquals($green, $option->matches('.is-combinable'));
+                    static::assertSame($green, $option->matches('.is-combinable'));
                     $greenFound = true;
                 }
 
                 if ($option->innerText() === 'red') {
-                    static::assertEquals($red, $option->matches('.is-combinable'));
+                    static::assertSame($red, $option->matches('.is-combinable'));
                     $redFound = true;
                 }
 
                 if ($option->innerText() === 'xl') {
-                    static::assertEquals($xl, $option->matches('.is-combinable'));
+                    static::assertSame($xl, $option->matches('.is-combinable'));
                     $xlFound = true;
                 }
 
                 if ($option->innerText() === 'l') {
-                    static::assertEquals($l, $option->matches('.is-combinable'));
+                    static::assertSame($l, $option->matches('.is-combinable'));
                     $lFound = true;
                 }
 

--- a/tests/integration/Storefront/Controller/ScriptControllerTest.php
+++ b/tests/integration/Storefront/Controller/ScriptControllerTest.php
@@ -43,7 +43,7 @@ class ScriptControllerTest extends TestCase
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);
 
         static::assertArrayHasKey('foo', $body);
-        static::assertEquals('bar', $body['foo']);
+        static::assertSame('bar', $body['foo']);
     }
 
     public function testGetApiEndpointWithSlashInHookName(): void
@@ -62,7 +62,7 @@ class ScriptControllerTest extends TestCase
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);
 
         static::assertArrayHasKey('foo', $body);
-        static::assertEquals('bar', $body['foo']);
+        static::assertSame('bar', $body['foo']);
     }
 
     public function testPostApiEndpoint(): void
@@ -86,7 +86,7 @@ class ScriptControllerTest extends TestCase
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);
 
         static::assertArrayHasKey('foo', $body);
-        static::assertEquals('bar', $body['foo']);
+        static::assertSame('bar', $body['foo']);
     }
 
     public function testRenderTemplate(): void

--- a/tests/integration/Storefront/Controller/SearchControllerTest.php
+++ b/tests/integration/Storefront/Controller/SearchControllerTest.php
@@ -52,7 +52,7 @@ class SearchControllerTest extends TestCase
     public function testSearchPageLoadedHookScriptsAreExecuted(): void
     {
         $response = $this->request('GET', '/search', ['search' => 'test']);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -62,7 +62,7 @@ class SearchControllerTest extends TestCase
     public function testSuggestPageLoadedHookScriptsAreExecuted(): void
     {
         $response = $this->request('GET', '/suggest', ['search' => 'test']);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -72,7 +72,7 @@ class SearchControllerTest extends TestCase
     public function testSearchWidgetLoadedHookScriptsAreExecuted(): void
     {
         $response = $this->request('GET', '/widgets/search', ['search' => 'test']);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 

--- a/tests/integration/Storefront/Controller/SitemapControllerTest.php
+++ b/tests/integration/Storefront/Controller/SitemapControllerTest.php
@@ -19,7 +19,7 @@ class SitemapControllerTest extends TestCase
     public function testSitemapPageLoadedHookScriptsAreExecuted(): void
     {
         $response = $this->request('GET', '/sitemap.xml', []);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 

--- a/tests/integration/Storefront/Controller/WishlistControllerTest.php
+++ b/tests/integration/Storefront/Controller/WishlistControllerTest.php
@@ -95,7 +95,7 @@ class WishlistControllerTest extends TestCase
 
         $browser->request('POST', $_SERVER['APP_URL'] . '/wishlist/guest-pagelet', $this->tokenize('frontend.wishlist.guestPage.pagelet', ['productIds' => [$productId]]));
 
-        static::assertEquals(Response::HTTP_NOT_FOUND, $browser->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_NOT_FOUND, $browser->getResponse()->getStatusCode());
     }
 
     public function testWishlistGuestPagelet(): void
@@ -108,7 +108,7 @@ class WishlistControllerTest extends TestCase
             static::assertInstanceOf(EntitySearchResult::class, $result = $event->getParameters()['searchResult']);
             static::assertCount(1, $result);
             static::assertInstanceOf(Entity::class, $result->first());
-            static::assertEquals($productId, $result->first()->get('id'));
+            static::assertSame($productId, $result->first()->get('id'));
         });
 
         $browser->request('POST', $_SERVER['APP_URL'] . '/wishlist/guest-pagelet', $this->tokenize('frontend.wishlist.guestPage.pagelet', ['productIds' => [$productId]]));
@@ -225,12 +225,12 @@ class WishlistControllerTest extends TestCase
         $flashBag = $session->getFlashBag();
 
         static::assertNotEmpty($successFlash = $flashBag->get('success'));
-        static::assertEquals('You have successfully added the product to your wishlist.', $successFlash[0]);
+        static::assertSame('You have successfully added the product to your wishlist.', $successFlash[0]);
 
         $browser->request('GET', $_SERVER['APP_URL'] . '/wishlist/add-after-login/' . $productId);
 
         static::assertNotEmpty($warningFlash = $flashBag->get('warning'));
-        static::assertEquals('Product has already been added to your wishlist.', $warningFlash[0]);
+        static::assertSame('Product has already been added to your wishlist.', $warningFlash[0]);
     }
 
     public function testWishlistPageLoadedHookScriptsAreExecuted(): void
@@ -239,7 +239,7 @@ class WishlistControllerTest extends TestCase
 
         $browser->request('GET', '/wishlist');
         $response = $browser->getResponse();
-        static::assertEquals(200, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -249,7 +249,7 @@ class WishlistControllerTest extends TestCase
     public function testGuestWishlistPageLoadedHookScriptsAreExecuted(): void
     {
         $response = $this->request('GET', '/wishlist', []);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -266,7 +266,7 @@ class WishlistControllerTest extends TestCase
         );
         $response = $browser->getResponse();
 
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -279,7 +279,7 @@ class WishlistControllerTest extends TestCase
 
         $browser->request('GET', '/widgets/wishlist');
         $response = $browser->getResponse();
-        static::assertEquals(200, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -292,7 +292,7 @@ class WishlistControllerTest extends TestCase
 
         $browser->request('GET', '/wishlist/merge/pagelet');
         $response = $browser->getResponse();
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 

--- a/tests/integration/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
+++ b/tests/integration/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
@@ -71,7 +71,7 @@ class CartMergedSubscriberTest extends TestCase
 
         static::assertNotEmpty($infoFlash = $session->getFlashBag()->get('info'));
 
-        static::assertEquals('checkout.cart-merged-hint', $infoFlash[0]);
+        static::assertSame('checkout.cart-merged-hint', $infoFlash[0]);
     }
 
     /**

--- a/tests/integration/Storefront/Framework/App/AppStateServiceThemeTest.php
+++ b/tests/integration/Storefront/Framework/App/AppStateServiceThemeTest.php
@@ -131,8 +131,8 @@ class AppStateServiceThemeTest extends TestCase
         $eventWasReceived = false;
         $onAppDeactivation = function (AppDeactivatedEvent $event) use (&$eventWasReceived, $appId, $context): void {
             $eventWasReceived = true;
-            static::assertEquals($appId, $event->getApp()->getId());
-            static::assertEquals($context, $event->getContext());
+            static::assertSame($appId, $event->getApp()->getId());
+            static::assertSame($context, $event->getContext());
         };
         $this->eventDispatcher->addListener(AppDeactivatedEvent::class, $onAppDeactivation);
 
@@ -144,7 +144,7 @@ class AppStateServiceThemeTest extends TestCase
         $criteria->addFilter(new EqualsFilter('appId', $appId));
         $criteria->addFilter(new EqualsFilter('active', true));
 
-        static::assertEquals(0, $this->templateRepo->search($criteria, $context)->getTotal());
+        static::assertSame(0, $this->templateRepo->search($criteria, $context)->getTotal());
 
         $this->eventDispatcher->removeListener(AppDeactivatedEvent::class, $onAppDeactivation);
     }
@@ -162,8 +162,8 @@ class AppStateServiceThemeTest extends TestCase
         $eventWasReceived = false;
         $onAppActivation = function (AppActivatedEvent $event) use (&$eventWasReceived, $appId, $context): void {
             $eventWasReceived = true;
-            static::assertEquals($appId, $event->getApp()->getId());
-            static::assertEquals($context, $event->getContext());
+            static::assertSame($appId, $event->getApp()->getId());
+            static::assertSame($context, $event->getContext());
         };
         $this->eventDispatcher->addListener(AppActivatedEvent::class, $onAppActivation);
 
@@ -177,7 +177,7 @@ class AppStateServiceThemeTest extends TestCase
 
         // We expect 1 storefront twig template and svg image to be stored in the DB
         $expectedTemplates = 2;
-        static::assertEquals($expectedTemplates, $this->templateRepo->search($criteria, $context)->getTotal());
+        static::assertSame($expectedTemplates, $this->templateRepo->search($criteria, $context)->getTotal());
 
         $this->eventDispatcher->removeListener(AppActivatedEvent::class, $onAppActivation);
     }

--- a/tests/integration/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
+++ b/tests/integration/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
@@ -40,9 +40,9 @@ class SalesChannelCreateStorefrontCommandTest extends TestCase
 
         $saleChannelId = $commandTester->getInput()->getOption('id');
 
-        $countSaleChannelId = $this->connection->fetchOne('SELECT COUNT(id) FROM sales_channel WHERE id = :id', ['id' => Uuid::fromHexToBytes($saleChannelId)]);
+        $countSaleChannelId = (int) $this->connection->fetchOne('SELECT COUNT(id) FROM sales_channel WHERE id = :id', ['id' => Uuid::fromHexToBytes($saleChannelId)]);
 
-        static::assertEquals(1, $countSaleChannelId);
+        static::assertSame(1, $countSaleChannelId);
 
         $getIsoCodeSql = <<<'SQL'
             SELECT snippet_set.iso
@@ -52,7 +52,7 @@ class SalesChannelCreateStorefrontCommandTest extends TestCase
         SQL;
         $isoCodeResult = $this->connection->fetchOne($getIsoCodeSql, ['saleChannelId' => Uuid::fromHexToBytes($saleChannelId)]);
 
-        static::assertEquals($isoCodeExpected, $isoCodeResult);
+        static::assertSame($isoCodeExpected, $isoCodeResult);
 
         $commandTester->assertCommandIsSuccessful();
     }

--- a/tests/integration/Storefront/Framework/Controller/XmlHttpRequestableInterfaceTest.php
+++ b/tests/integration/Storefront/Framework/Controller/XmlHttpRequestableInterfaceTest.php
@@ -17,7 +17,7 @@ class XmlHttpRequestableInterfaceTest extends TestCase
         $client = $this->createSalesChannelBrowser(null, true);
         $client->request('GET', 'http://localhost/');
 
-        static::assertEquals(200, $client->getResponse()->getStatusCode());
+        static::assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testAccessDeniedForXmlHttpRequest(): void
@@ -26,7 +26,7 @@ class XmlHttpRequestableInterfaceTest extends TestCase
 
         $client->xmlHttpRequest('GET', 'http://localhost/');
 
-        static::assertEquals(403, $client->getResponse()->getStatusCode());
+        static::assertSame(403, $client->getResponse()->getStatusCode());
     }
 
     public function testPageletLoads(): void
@@ -35,7 +35,7 @@ class XmlHttpRequestableInterfaceTest extends TestCase
 
         $client->request('GET', 'http://localhost/checkout/offcanvas');
 
-        static::assertEquals(200, $client->getResponse()->getStatusCode());
+        static::assertSame(200, $client->getResponse()->getStatusCode());
     }
 
     public function testPageletLoadsForXmlHttpRequest(): void
@@ -44,6 +44,6 @@ class XmlHttpRequestableInterfaceTest extends TestCase
 
         $client->xmlHttpRequest('GET', 'http://localhost/checkout/offcanvas');
 
-        static::assertEquals(200, $client->getResponse()->getStatusCode());
+        static::assertSame(200, $client->getResponse()->getStatusCode());
     }
 }

--- a/tests/integration/Storefront/Framework/Cookie/AppCookieProviderTest.php
+++ b/tests/integration/Storefront/Framework/Cookie/AppCookieProviderTest.php
@@ -38,7 +38,7 @@ class AppCookieProviderTest extends TestCase
 
         $result = $this->appCookieProvider->getCookieGroups();
 
-        static::assertEquals(['test'], $result);
+        static::assertSame(['test'], $result);
     }
 
     public function testItAddsSingleCookieFromApp(): void
@@ -103,7 +103,7 @@ class AppCookieProviderTest extends TestCase
 
         $result = $this->appCookieProvider->getCookieGroups();
         static::assertCount(1, $result);
-        static::assertEquals('cookie.groupRequired', $result[0]['snippet_name']);
+        static::assertSame('cookie.groupRequired', $result[0]['snippet_name']);
         static::assertCount(3, $result[0]['entries']);
         usort($result[0]['entries'], fn (array $a, array $b): int => $a['snippet_name'] <=> $b['snippet_name']);
 
@@ -133,7 +133,7 @@ class AppCookieProviderTest extends TestCase
 
         $result = $this->appCookieProvider->getCookieGroups();
         static::assertCount(1, $result);
-        static::assertEquals('App Cookies', $result[0]['snippet_name']);
+        static::assertSame('App Cookies', $result[0]['snippet_name']);
         static::assertCount(3, $result[0]['entries']);
         usort($result[0]['entries'], fn (array $a, array $b): int => $a['snippet_name'] <=> $b['snippet_name']);
 

--- a/tests/integration/Storefront/Framework/Media/StorefrontMediaUploaderTest.php
+++ b/tests/integration/Storefront/Framework/Media/StorefrontMediaUploaderTest.php
@@ -33,7 +33,7 @@ class StorefrontMediaUploaderTest extends TestCase
         $result = $this->getUploadService()->upload($file, 'test', 'documents', Context::createDefaultContext());
 
         $repo = static::getContainer()->get('media.repository');
-        static::assertEquals(1, $repo->search(new Criteria([$result]), Context::createDefaultContext())->getTotal());
+        static::assertSame(1, $repo->search(new Criteria([$result]), Context::createDefaultContext())->getTotal());
         $this->removeMedia($result);
     }
 
@@ -61,7 +61,7 @@ class StorefrontMediaUploaderTest extends TestCase
         $result = $this->getUploadService()->upload($file, 'test', 'images', Context::createDefaultContext());
 
         $repo = static::getContainer()->get('media.repository');
-        static::assertEquals(1, $repo->search(new Criteria([$result]), Context::createDefaultContext())->getTotal());
+        static::assertSame(1, $repo->search(new Criteria([$result]), Context::createDefaultContext())->getTotal());
         $this->removeMedia($result);
     }
 

--- a/tests/integration/Storefront/Framework/Routing/StorefrontRoutingTest.php
+++ b/tests/integration/Storefront/Framework/Routing/StorefrontRoutingTest.php
@@ -94,10 +94,10 @@ class StorefrontRoutingTest extends TestCase
         static::assertSame($case->getPathInfo(), $pathInfo, var_export($case, true));
 
         $matches = $this->router->matchRequest($transformedRequest);
-        static::assertEquals($case->route, $matches['_route']);
+        static::assertSame($case->route, $matches['_route']);
 
         $matches = $this->router->match($transformedRequest->getPathInfo());
-        static::assertEquals($case->route, $matches['_route']);
+        static::assertSame($case->route, $matches['_route']);
 
         // test seo url generation
         $host = $transformedRequest->attributes->get(RequestTransformer::SALES_CHANNEL_ABSOLUTE_BASE_URL)

--- a/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
@@ -49,7 +49,7 @@ class SeoActionControllerTest extends TestCase
         $result = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertNotEmpty($result['errors']);
-        static::assertEquals(400, $response->getStatusCode());
+        static::assertSame(400, $response->getStatusCode());
     }
 
     public function testValidateInvalidTwigSyntax(): void
@@ -67,7 +67,7 @@ class SeoActionControllerTest extends TestCase
         $result = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertNotEmpty($result['errors'] ?? []);
-        static::assertEquals(400, $response->getStatusCode());
+        static::assertSame(400, $response->getStatusCode());
     }
 
     public function testValidateInvalidDataUsage(): void
@@ -85,7 +85,7 @@ class SeoActionControllerTest extends TestCase
         $result = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertNotEmpty($result['errors'] ?? []);
-        static::assertEquals(400, $response->getStatusCode());
+        static::assertSame(400, $response->getStatusCode());
     }
 
     public function testValidateValid(): void
@@ -107,7 +107,7 @@ class SeoActionControllerTest extends TestCase
         $result = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayNotHasKey('errors', $result);
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
     }
 
     public function testGetSeoContext(): void
@@ -140,7 +140,7 @@ class SeoActionControllerTest extends TestCase
         $this->getBrowser()->request('POST', '/api/_action/seo-url-template/context', [], [], [], json_encode($data, \JSON_THROW_ON_ERROR));
 
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $content = $response->getContent();
         static::assertIsString($content);
@@ -163,12 +163,12 @@ class SeoActionControllerTest extends TestCase
 
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(200, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
         $content = $response->getContent();
         static::assertIsString($content);
         $data = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals('test', $data[0]['seoPathInfo']);
+        static::assertSame('test', $data[0]['seoPathInfo']);
     }
 
     public function testPreviewWithBrokenTemplate(): void
@@ -186,12 +186,12 @@ class SeoActionControllerTest extends TestCase
 
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(400, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(400, $response->getStatusCode(), (string) $response->getContent());
         $content = $response->getContent();
         static::assertIsString($content);
         $data = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals('FRAMEWORK__INVALID_SEO_TEMPLATE', $data['errors'][0]['code']);
+        static::assertSame('FRAMEWORK__INVALID_SEO_TEMPLATE', $data['errors'][0]['code']);
     }
 
     public function testPreviewWithSalesChannel(): void
@@ -213,7 +213,7 @@ class SeoActionControllerTest extends TestCase
         $this->getBrowser()->request('POST', '/api/_action/seo-url-template/preview', $data);
 
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(200, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
         $content = $response->getContent();
         static::assertIsString($content);
 
@@ -238,9 +238,9 @@ class SeoActionControllerTest extends TestCase
         $result = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $result);
-        static::assertEquals(404, $response->getStatusCode());
+        static::assertSame(404, $response->getStatusCode());
 
-        static::assertEquals(SeoUrlRouteNotFoundException::ERROR_CODE, $result['errors'][0]['code']);
+        static::assertSame(SeoUrlRouteNotFoundException::ERROR_CODE, $result['errors'][0]['code']);
     }
 
     public function testUpdateDefaultCanonical(): void
@@ -263,13 +263,13 @@ class SeoActionControllerTest extends TestCase
         // modify canonical
         $this->getBrowser()->request('PATCH', '/api/_action/seo-url/canonical', $seoUrl);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
 
         $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
         static::assertCount(1, $seoUrls);
         $seoUrl = $seoUrls[0]['attributes'];
         static::assertTrue($seoUrl['isModified']);
-        static::assertEquals($newSeoPathInfo, $seoUrl['seoPathInfo']);
+        static::assertSame($newSeoPathInfo, $seoUrl['seoPathInfo']);
 
         $productUpdate = [
             'id' => $id,
@@ -282,7 +282,7 @@ class SeoActionControllerTest extends TestCase
         static::assertCount(1, $seoUrls);
         $seoUrl = $seoUrls[0]['attributes'];
         static::assertTrue($seoUrl['isModified']);
-        static::assertEquals($newSeoPathInfo, $seoUrl['seoPathInfo']);
+        static::assertSame($newSeoPathInfo, $seoUrl['seoPathInfo']);
     }
 
     public function testUpdateCanonicalWithCustomSalesChannel(): void
@@ -306,13 +306,13 @@ class SeoActionControllerTest extends TestCase
         // modify canonical
         $this->getBrowser()->request('PATCH', '/api/_action/seo-url/canonical', $seoUrl);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
 
         $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
         static::assertCount(1, $seoUrls);
         $seoUrl = $seoUrls[0]['attributes'];
         static::assertTrue($seoUrl['isModified']);
-        static::assertEquals($newSeoPathInfo, $seoUrl['seoPathInfo']);
+        static::assertSame($newSeoPathInfo, $seoUrl['seoPathInfo']);
 
         $newProductNumber = Uuid::randomHex();
         $productUpdate = [
@@ -327,7 +327,7 @@ class SeoActionControllerTest extends TestCase
         static::assertCount(1, $seoUrls);
         $seoUrl = $seoUrls[0]['attributes'];
         static::assertTrue($seoUrl['isModified']);
-        static::assertEquals($newSeoPathInfo, $seoUrl['seoPathInfo']);
+        static::assertSame($newSeoPathInfo, $seoUrl['seoPathInfo']);
     }
 
     public function testUpdateDefaultCanonicalForHeadlessBehavesCorrectly(): void
@@ -352,7 +352,7 @@ class SeoActionControllerTest extends TestCase
         // modify canonical
         $this->getBrowser()->request('PATCH', '/api/_action/seo-url/canonical', $seoUrl);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
 
         $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
 
@@ -384,7 +384,7 @@ class SeoActionControllerTest extends TestCase
             ];
         }
         $this->getBrowser()->request('GET', '/api/product/' . $id . '/seoUrls', $params);
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
 
         $content = $this->getBrowser()->getResponse()->getContent();
 

--- a/tests/integration/Storefront/Framework/Seo/MainCategory/MainCategoryExtensionTest.php
+++ b/tests/integration/Storefront/Framework/Seo/MainCategory/MainCategoryExtensionTest.php
@@ -86,8 +86,8 @@ class MainCategoryExtensionTest extends TestCase
 
         $mainCategory = $mainCategories->filterBySalesChannelId($salesChannelId)->first();
         static::assertInstanceOf(MainCategoryEntity::class, $mainCategory);
-        static::assertEquals($salesChannelId, $mainCategory->getSalesChannelId());
-        static::assertEquals($categories->firstId(), $mainCategory->getCategoryId());
+        static::assertSame($salesChannelId, $mainCategory->getSalesChannelId());
+        static::assertSame($categories->firstId(), $mainCategory->getCategoryId());
     }
 
     private function createTestProduct(): string

--- a/tests/integration/Storefront/Framework/Seo/SeoUrl/SeoUrlTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrl/SeoUrlTest.php
@@ -78,7 +78,7 @@ class SeoUrlTest extends TestCase
 
         $seoUrl = $seoUrls->first();
         static::assertInstanceOf(SeoUrlEntity::class, $seoUrl);
-        static::assertEquals('coolUrl', $seoUrl->getSeoPathInfo());
+        static::assertSame('coolUrl', $seoUrl->getSeoPathInfo());
     }
 
     public function testLandingPageUpdate(): void
@@ -118,8 +118,8 @@ class SeoUrlTest extends TestCase
         static::assertNull($seoUrl->getIsCanonical());
         static::assertFalse($seoUrl->getIsDeleted());
 
-        static::assertEquals('/landingPage/' . $id, $seoUrl->getPathInfo());
-        static::assertEquals($id, $seoUrl->getForeignKey());
+        static::assertSame('/landingPage/' . $id, $seoUrl->getPathInfo());
+        static::assertSame($id, $seoUrl->getForeignKey());
 
         /** @var SeoUrlCollection $urls */
         $urls = $first->getSeoUrls();
@@ -131,8 +131,8 @@ class SeoUrlTest extends TestCase
         static::assertTrue($seoUrl->getIsCanonical());
         static::assertFalse($seoUrl->getIsDeleted());
 
-        static::assertEquals('/landingPage/' . $id, $seoUrl->getPathInfo());
-        static::assertEquals($id, $seoUrl->getForeignKey());
+        static::assertSame('/landingPage/' . $id, $seoUrl->getPathInfo());
+        static::assertSame($id, $seoUrl->getForeignKey());
     }
 
     public function testSearchProduct(): void
@@ -154,7 +154,7 @@ class SeoUrlTest extends TestCase
         $seoUrls = $product->getSeoUrls();
         $seoUrl = $seoUrls->first();
         static::assertInstanceOf(SeoUrlEntity::class, $seoUrl);
-        static::assertEquals('foo-bar/P1234', $seoUrl->getSeoPathInfo());
+        static::assertSame('foo-bar/P1234', $seoUrl->getSeoPathInfo());
     }
 
     public function testSearchProductForHeadlessSalesChannelHasCorrectUrl(): void
@@ -526,7 +526,7 @@ class SeoUrlTest extends TestCase
         static::assertTrue($seoUrl->getIsCanonical());
         static::assertFalse($seoUrl->getIsDeleted());
 
-        static::assertEquals('awesome v2', $seoUrl->getSeoPathInfo());
+        static::assertSame('awesome v2', $seoUrl->getSeoPathInfo());
     }
 
     public function testUpdate(): void
@@ -566,8 +566,8 @@ class SeoUrlTest extends TestCase
         static::assertTrue($seoUrl->getIsCanonical());
         static::assertFalse($seoUrl->getIsDeleted());
 
-        static::assertEquals('/detail/' . $id, $seoUrl->getPathInfo());
-        static::assertEquals($id, $seoUrl->getForeignKey());
+        static::assertSame('/detail/' . $id, $seoUrl->getPathInfo());
+        static::assertSame($id, $seoUrl->getForeignKey());
     }
 
     /**
@@ -582,7 +582,7 @@ class SeoUrlTest extends TestCase
 
             /** @var CategoryEntity $category */
             $category = $categoryRepository->search($criteria, $context)->first();
-            static::assertEquals($case['categoryId'], $category->getId());
+            static::assertSame($case['categoryId'], $category->getId());
 
             /** @var SeoUrlCollection $seoUrls */
             $seoUrls = $category->getSeoUrls();
@@ -610,7 +610,7 @@ class SeoUrlTest extends TestCase
                 ->filterByProperty('salesChannelId', $salesChannelId)
                 ->first();
             static::assertInstanceOf(SeoUrlEntity::class, $canonicalUrl);
-            static::assertEquals($case['expected'], $canonicalUrl->getSeoPathInfo());
+            static::assertSame($case['expected'], $canonicalUrl->getSeoPathInfo());
         }
     }
 

--- a/tests/integration/Storefront/Framework/Seo/SeoUrlTemplateRepositoryTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrlTemplateRepositoryTest.php
@@ -69,8 +69,8 @@ class SeoUrlTemplateRepositoryTest extends TestCase
 
         $first = $repo->search(new Criteria([$id]), $context)->getEntities()->first();
         static::assertNotNull($first);
-        static::assertEquals($update['id'], $first->getId());
-        static::assertEquals($update['routeName'], $first->getRouteName());
+        static::assertSame($update['id'], $first->getId());
+        static::assertSame($update['routeName'], $first->getRouteName());
     }
 
     public function testDelete(): void
@@ -92,7 +92,7 @@ class SeoUrlTemplateRepositoryTest extends TestCase
         $result = $repo->delete([['id' => $id]], $context);
         $event = $result->getEventByEntityName(SeoUrlTemplateDefinition::ENTITY_NAME);
         static::assertNotNull($event);
-        static::assertEquals([$id], $event->getIds());
+        static::assertSame([$id], $event->getIds());
 
         $first = $repo->search(new Criteria([$id]), $context)->getEntities()->first();
         static::assertNull($first);

--- a/tests/integration/Storefront/Framework/Twig/Extension/SlugifyExtensionTwigFilterTest.php
+++ b/tests/integration/Storefront/Framework/Twig/Extension/SlugifyExtensionTwigFilterTest.php
@@ -17,7 +17,7 @@ class SlugifyExtensionTwigFilterTest extends TestCase
     #[DataProvider('sampleAnchorIdProvider')]
     public function testSlugifyAnchorIds(?string $input, ?string $expected): void
     {
-        static::assertEquals($expected, $this->renderTestTemplate($input), 'Slugify needed for plugins missing or invalid.');
+        static::assertSame($expected, $this->renderTestTemplate($input), 'Slugify needed for plugins missing or invalid.');
     }
 
     /**

--- a/tests/integration/Storefront/Page/NavigationPageTest.php
+++ b/tests/integration/Storefront/Page/NavigationPageTest.php
@@ -71,7 +71,7 @@ class NavigationPageTest extends TestCase
 
         $seoUrl = $seoUrlHandler->replace($canonical, $request->getHost(), $context);
 
-        static::assertEquals('/', $seoUrl);
+        static::assertSame('/', $seoUrl);
     }
 
     protected function getPageLoader(): NavigationPageLoader

--- a/tests/integration/Storefront/Page/ProductPageTest.php
+++ b/tests/integration/Storefront/Page/ProductPageTest.php
@@ -161,7 +161,7 @@ class ProductPageTest extends TestCase
 
         $product = $context->getContext()->scope(Context::SYSTEM_SCOPE, fn (): ProductEntity => $this->getRandomProduct($context, 10, false, $productCmsPageData));
 
-        static::assertEquals($cmsPageId, $product->getCmsPageId());
+        static::assertSame($cmsPageId, $product->getCmsPageId());
         $request = new Request([], [], ['productId' => $product->getId()]);
 
         $event = null;
@@ -170,7 +170,7 @@ class ProductPageTest extends TestCase
         $page = $this->getPageLoader()->load($request, $context);
 
         static::assertInstanceOf(CmsPageEntity::class, $page->getCmsPage());
-        static::assertEquals($cmsPageId, $page->getCmsPage()->getId());
+        static::assertSame($cmsPageId, $page->getCmsPage()->getId());
 
         static::assertSame(StorefrontPageTestConstants::PRODUCT_NAME, $page->getProduct()->getName());
         self::assertPageEvent(ProductPageLoadedEvent::class, $event, $context, $request, $page);

--- a/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -113,7 +113,7 @@ class DatabaseConfigLoaderTest extends TestCase
             strrpos($themeConfig['fields']['media-field']['value'], '?') ?: null
         );
 
-        static::assertEquals($mediaURL, $entityUrlWithoutQueryString);
+        static::assertSame($mediaURL, $entityUrlWithoutQueryString);
     }
 
     public function testEmptyMediaConfigurationLoading(): void
@@ -155,7 +155,7 @@ class DatabaseConfigLoaderTest extends TestCase
 
         $mediaURL = null;
 
-        static::assertEquals($mediaURL, $themeConfig['fields']['media-field']['value']);
+        static::assertSame($mediaURL, $themeConfig['fields']['media-field']['value']);
     }
 
     public function testNonExistentMediaConfigurationLoading(): void
@@ -197,7 +197,7 @@ class DatabaseConfigLoaderTest extends TestCase
 
         $mediaURL = self::MEDIA_ID;
 
-        static::assertEquals($mediaURL, $themeConfig['fields']['media-field']['value']);
+        static::assertSame($mediaURL, $themeConfig['fields']['media-field']['value']);
     }
 
     /**
@@ -270,7 +270,7 @@ class DatabaseConfigLoaderTest extends TestCase
 
         foreach ($expected as $field => $value) {
             static::assertArrayHasKey($field, $fields);
-            static::assertEquals($value, $fields[$field]['value']);
+            static::assertSame($value, $fields[$field]['value']);
         }
     }
 

--- a/tests/integration/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactoryTest.php
+++ b/tests/integration/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactoryTest.php
@@ -32,9 +32,9 @@ class StorefrontPluginConfigurationFactoryTest extends TestCase
         $theme = $this->getBundle('TestTheme', $basePath, true);
         $config = $this->configFactory->createFromBundle($theme);
 
-        static::assertEquals('TestTheme', $config->getTechnicalName());
+        static::assertSame('TestTheme', $config->getTechnicalName());
         static::assertTrue($config->getIsTheme());
-        static::assertEquals(
+        static::assertSame(
             'app/storefront/src/main.js',
             $config->getStorefrontEntryFilepath()
         );
@@ -49,14 +49,14 @@ class StorefrontPluginConfigurationFactoryTest extends TestCase
             '@Storefront' => [],
             'app/storefront/dist/js/main.js' => [],
         ], $config->getScriptFiles());
-        static::assertEquals([
+        static::assertSame([
             '@Storefront',
             '@Plugins',
             '@SwagTheme',
         ], $config->getViewInheritance());
-        static::assertEquals(['app/storefront/dist/assets'], $config->getAssetPaths());
-        static::assertEquals('app/storefront/dist/assets/preview.jpg', $config->getPreviewMedia());
-        static::assertEquals([
+        static::assertSame(['app/storefront/dist/assets'], $config->getAssetPaths());
+        static::assertSame('app/storefront/dist/assets/preview.jpg', $config->getPreviewMedia());
+        static::assertSame([
             'fields' => [
                 'sw-image' => [
                     'type' => 'media',
@@ -64,7 +64,7 @@ class StorefrontPluginConfigurationFactoryTest extends TestCase
                 ],
             ],
         ], $config->getThemeConfig());
-        static::assertEquals([
+        static::assertSame([
             'custom-icons' => 'app/storefront/src/assets/icon-pack/custom-icons',
         ], $config->getIconSets());
     }
@@ -139,6 +139,6 @@ class StorefrontPluginConfigurationFactoryTest extends TestCase
             $flatFiles[$file->getFilepath()] = $file->getResolveMapping();
         }
 
-        static::assertEquals($expected, $flatFiles);
+        static::assertSame($expected, $flatFiles);
     }
 }

--- a/tests/integration/Storefront/Theme/ThemeInheritanceBuilderTest.php
+++ b/tests/integration/Storefront/Theme/ThemeInheritanceBuilderTest.php
@@ -58,7 +58,7 @@ class ThemeInheritanceBuilderTest extends TestCase
             ['InheritanceWithConfig' => true, 'Storefront' => true]
         );
 
-        static::assertEquals(['InheritanceWithConfig', 'Storefront'], array_keys($inheritance));
+        static::assertSame(['InheritanceWithConfig', 'Storefront'], array_keys($inheritance));
     }
 
     public function testEnsurePlugins(): void
@@ -77,7 +77,7 @@ class ThemeInheritanceBuilderTest extends TestCase
             ['InheritanceWithConfig' => true, 'Storefront' => true]
         );
 
-        static::assertEquals(['PayPal', 'InheritanceWithConfig', 'Storefront'], array_keys($inheritance));
+        static::assertSame(['PayPal', 'InheritanceWithConfig', 'Storefront'], array_keys($inheritance));
     }
 
     public function testConfigWithoutStorefrontDefined(): void
@@ -96,7 +96,7 @@ class ThemeInheritanceBuilderTest extends TestCase
             ['ConfigWithoutStorefrontDefined' => true]
         );
 
-        static::assertEquals(['PayPal', 'ConfigWithoutStorefrontDefined'], array_keys($inheritance));
+        static::assertSame(['PayPal', 'ConfigWithoutStorefrontDefined'], array_keys($inheritance));
     }
 
     public function testPluginWildcardAndExplicit(): void
@@ -116,7 +116,7 @@ class ThemeInheritanceBuilderTest extends TestCase
             ['PluginWildcardAndExplicit' => true, 'Storefront' => true]
         );
 
-        static::assertEquals(['CustomProducts', 'PluginWildcardAndExplicit', 'PayPal', 'Storefront'], array_keys($inheritance));
+        static::assertSame(['CustomProducts', 'PluginWildcardAndExplicit', 'PayPal', 'Storefront'], array_keys($inheritance));
     }
 
     public function testThemeWithoutStorefront(): void
@@ -136,7 +136,7 @@ class ThemeInheritanceBuilderTest extends TestCase
             ['ThemeWithoutStorefront' => true, 'Storefront' => true]
         );
 
-        static::assertEquals(['CustomProducts', 'ThemeWithoutStorefront', 'PayPal'], array_keys($inheritance));
+        static::assertSame(['CustomProducts', 'ThemeWithoutStorefront', 'PayPal'], array_keys($inheritance));
     }
 
     public function testMultiInheritance(): void
@@ -163,7 +163,7 @@ class ThemeInheritanceBuilderTest extends TestCase
             ['ThemeWithMultiInheritance' => true]
         );
 
-        static::assertEquals(
+        static::assertSame(
             ['ThemeWithMultiInheritance', 'ThemeC', 'PayPal', 'ThemeB', 'ThemeA'],
             array_keys($inheritance)
         );

--- a/tests/integration/Storefront/Theme/ThemeLifecycleHandlerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeLifecycleHandlerTest.php
@@ -233,7 +233,7 @@ class ThemeLifecycleHandlerTest extends TestCase
         try {
             $this->themeLifecycleHandler->handleThemeUninstall($uninstalledConfig, Context::createDefaultContext());
         } catch (ThemeAssignmentException $e) {
-            static::assertEquals(
+            static::assertSame(
                 [TestDefaults::SALES_CHANNEL],
                 array_keys($e->getAssignedSalesChannels() ?? [])
             );

--- a/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
+++ b/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
@@ -114,11 +114,11 @@ class ThemeLifecycleServiceTest extends TestCase
 
         static::assertTrue($themeEntity->isActive());
         static::assertInstanceOf(MediaCollection::class, $themeEntity->getMedia());
-        static::assertEquals(2, $themeEntity->getMedia()->count());
+        static::assertCount(2, $themeEntity->getMedia());
 
         $themeDefaultFolderId = $this->getThemeMediaDefaultFolderId();
         foreach ($themeEntity->getMedia() as $media) {
-            static::assertEquals($themeDefaultFolderId, $media->getMediaFolderId());
+            static::assertSame($themeDefaultFolderId, $media->getMediaFolderId());
         }
     }
 
@@ -134,7 +134,7 @@ class ThemeLifecycleServiceTest extends TestCase
         $parentThemeEntity = $this->getTheme($parentBundle);
         $themeEntity = $this->getTheme($bundle);
 
-        static::assertEquals($parentThemeEntity->getId(), $themeEntity->getParentThemeId());
+        static::assertSame($parentThemeEntity->getId(), $themeEntity->getParentThemeId());
     }
 
     public function testThemeRefreshWithParentTheme(): void
@@ -149,13 +149,13 @@ class ThemeLifecycleServiceTest extends TestCase
         $parentThemeEntity = $this->getTheme($parentBundle);
         $themeEntity = $this->getTheme($bundle);
 
-        static::assertEquals($parentThemeEntity->getId(), $themeEntity->getParentThemeId());
+        static::assertSame($parentThemeEntity->getId(), $themeEntity->getParentThemeId());
 
         $bundle->setConfigInheritance([]);
         $this->themeLifecycleService->refreshTheme($parentBundle, $this->context);
 
         $themeEntity = $this->getTheme($bundle);
-        static::assertEquals($parentThemeEntity->getId(), $themeEntity->getParentThemeId());
+        static::assertSame($parentThemeEntity->getId(), $themeEntity->getParentThemeId());
     }
 
     public function testYouCanUpdateConfigToAddNewMedia(): void
@@ -171,7 +171,7 @@ class ThemeLifecycleServiceTest extends TestCase
 
         static::assertTrue($themeEntity->isActive());
         static::assertInstanceOf(MediaCollection::class, $themeEntity->getMedia());
-        static::assertEquals(3, $themeEntity->getMedia()->count());
+        static::assertCount(3, $themeEntity->getMedia());
     }
 
     public function testItWontThrowIfMediaHasRestrictDeleteAssociation(): void
@@ -180,13 +180,13 @@ class ThemeLifecycleServiceTest extends TestCase
 
         $this->themeLifecycleService->refreshTheme($bundle, $this->context);
 
-        $shopwareLogoId = $this->getMedia('shopware_logo');
-        $this->createCmsPage($shopwareLogoId->getId());
+        $shopwareLogo = $this->getMedia('shopware_logo');
+        $this->createCmsPage($shopwareLogo->getId());
 
         $this->themeLifecycleService->refreshTheme($bundle, $this->context);
 
         // assert that the file shopware_logo was not deleted and is assigned to same media entity as before
-        static::assertEquals($shopwareLogoId, $this->getMedia('shopware_logo'));
+        static::assertEquals($shopwareLogo, $this->getMedia('shopware_logo'));
     }
 
     public function testItDontRenamesThemeMediaIfItExistsBeforeAndIsSame(): void
@@ -263,7 +263,7 @@ class ThemeLifecycleServiceTest extends TestCase
 
         static::assertTrue($themeEntity->isActive());
         static::assertInstanceOf(MediaCollection::class, $themeEntity->getMedia());
-        static::assertEquals(2, $themeEntity->getMedia()->count());
+        static::assertCount(2, $themeEntity->getMedia());
 
         foreach ($themeEntity->getMedia() as $media) {
             static::assertNull($media->getMediaFolderId());
@@ -294,7 +294,7 @@ class ThemeLifecycleServiceTest extends TestCase
         $this->themeLifecycleService->refreshTheme($bundle, $this->context);
 
         $theme = $this->getTheme($bundle);
-        static::assertEquals($previewMediaId, $theme->getPreviewMediaId());
+        static::assertSame($previewMediaId, $theme->getPreviewMediaId());
     }
 
     public function testItSkipsTranslationsIfLanguageIsNotAvailable(): void
@@ -308,13 +308,11 @@ class ThemeLifecycleServiceTest extends TestCase
 
         static::assertInstanceOf(ThemeTranslationCollection::class, $theme->getTranslations());
         static::assertCount(1, $theme->getTranslations());
-        static::assertEquals('en-GB', $theme->getTranslations()->first()?->getLanguage()?->getLocale()?->getCode());
-        static::assertEquals([
-            'fields.sw-image' => 'test label',
-        ], $theme->getTranslations()->first()?->getLabels());
-        static::assertEquals([
-            'fields.sw-image' => 'test help',
-        ], $theme->getTranslations()->first()?->getHelpTexts());
+        $firstTranslation = $theme->getTranslations()->first();
+        static::assertNotNull($firstTranslation);
+        static::assertSame('en-GB', $firstTranslation->getLanguage()?->getLocale()?->getCode());
+        static::assertSame(['fields.sw-image' => 'test label'], $firstTranslation->getLabels());
+        static::assertSame(['fields.sw-image' => 'test help'], $firstTranslation->getHelpTexts());
     }
 
     public function testItUsesEnglishTranslationsAsFallbackIfDefaultLanguageIsNotProvided(): void
@@ -329,18 +327,18 @@ class ThemeLifecycleServiceTest extends TestCase
         static::assertInstanceOf(ThemeTranslationCollection::class, $theme->getTranslations());
         static::assertCount(2, $theme->getTranslations());
         $translation = $this->getTranslationByLocale('xx-XX', $theme->getTranslations());
-        static::assertEquals([
+        static::assertSame([
             'fields.sw-image' => 'test label',
         ], $translation->getLabels());
-        static::assertEquals([
+        static::assertSame([
             'fields.sw-image' => 'test help',
         ], $translation->getHelpTexts());
 
         $germanTranslation = $this->getTranslationByLocale('de-DE', $theme->getTranslations());
-        static::assertEquals([
+        static::assertSame([
             'fields.sw-image' => 'Test label',
         ], $germanTranslation->getLabels());
-        static::assertEquals([
+        static::assertSame([
             'fields.sw-image' => 'Test Hilfe',
         ], $germanTranslation->getHelpTexts());
     }
@@ -357,11 +355,11 @@ class ThemeLifecycleServiceTest extends TestCase
         $ids = $themeMedia->getIds();
 
         static::assertTrue($themeEntity->isActive());
-        static::assertEquals(2, $themeMedia->count());
+        static::assertCount(2, $themeMedia);
 
         $themeDefaultFolderId = $this->getThemeMediaDefaultFolderId();
         foreach ($themeMedia as $media) {
-            static::assertEquals($themeDefaultFolderId, $media->getMediaFolderId());
+            static::assertSame($themeDefaultFolderId, $media->getMediaFolderId());
         }
 
         $this->themeLifecycleService->removeTheme($bundle->getTechnicalName(), $this->context);
@@ -382,7 +380,7 @@ class ThemeLifecycleServiceTest extends TestCase
 
         static::assertInstanceOf(ThemeCollection::class, $themeEntity->getDependentThemes());
         // check if we have no dependent Themes
-        static::assertEquals(0, $themeEntity->getDependentThemes()->count());
+        static::assertCount(0, $themeEntity->getDependentThemes());
 
         // clone theme and make it child
         $this->themeRepository->clone($themeEntity->getId(), $this->context, $childId, new CloneBehavior([
@@ -399,13 +397,13 @@ class ThemeLifecycleServiceTest extends TestCase
         $ids = $themeMedia->getIds();
 
         static::assertTrue($themeEntity->isActive());
-        static::assertEquals(2, $themeMedia->count());
+        static::assertCount(2, $themeMedia);
         static::assertInstanceOf(ThemeCollection::class, $themeEntity->getDependentThemes());
-        static::assertEquals(1, $themeEntity->getDependentThemes()->count());
+        static::assertCount(1, $themeEntity->getDependentThemes());
 
         $themeDefaultFolderId = $this->getThemeMediaDefaultFolderId();
         foreach ($themeMedia as $media) {
-            static::assertEquals($themeDefaultFolderId, $media->getMediaFolderId());
+            static::assertSame($themeDefaultFolderId, $media->getMediaFolderId());
         }
 
         $this->themeLifecycleService->removeTheme($bundle->getTechnicalName(), $this->context);
@@ -413,7 +411,7 @@ class ThemeLifecycleServiceTest extends TestCase
         // check whether the theme is no longer in the table and the associated media have been deleted
         static::assertFalse($this->hasTheme($bundle));
         static::assertCount(0, $this->mediaRepository->searchIds(new Criteria($ids), Context::createDefaultContext())->getIds());
-        static::assertEquals(0, $this->themeRepository->search(new Criteria([$childId, $themeEntity->getId()]), $this->context)->count());
+        static::assertCount(0, $this->themeRepository->search(new Criteria([$childId, $themeEntity->getId()]), $this->context));
     }
 
     private function getThemeConfig(): StorefrontPluginConfiguration

--- a/tests/unit/Elasticsearch/Admin/AdminElasticsearchHelperTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminElasticsearchHelperTest.php
@@ -18,10 +18,10 @@ class AdminElasticsearchHelperTest extends TestCase
     {
         $searchHelper = new AdminElasticsearchHelper($adminEsEnabled, $refreshIndices, $adminIndexPrefix);
 
-        static::assertEquals($adminEsEnabled, $searchHelper->getEnabled());
-        static::assertEquals($refreshIndices, $searchHelper->getRefreshIndices());
-        static::assertEquals($adminIndexPrefix, $searchHelper->getPrefix());
-        static::assertEquals($adminIndexPrefix . '-promotion-listing', $searchHelper->getIndex('promotion-listing'));
+        static::assertSame($adminEsEnabled, $searchHelper->getEnabled());
+        static::assertSame($refreshIndices, $searchHelper->getRefreshIndices());
+        static::assertSame($adminIndexPrefix, $searchHelper->getPrefix());
+        static::assertSame($adminIndexPrefix . '-promotion-listing', $searchHelper->getIndex('promotion-listing'));
     }
 
     public function testSetEnable(): void
@@ -30,8 +30,8 @@ class AdminElasticsearchHelperTest extends TestCase
 
         static::assertFalse($searchHelper->getEnabled());
         static::assertFalse($searchHelper->getRefreshIndices());
-        static::assertEquals('sw-admin', $searchHelper->getPrefix());
-        static::assertEquals('sw-admin-promotion-listing', $searchHelper->getIndex('promotion-listing'));
+        static::assertSame('sw-admin', $searchHelper->getPrefix());
+        static::assertSame('sw-admin-promotion-listing', $searchHelper->getIndex('promotion-listing'));
 
         $searchHelper->setEnabled(true);
 

--- a/tests/unit/Elasticsearch/Admin/AdminSearchControllerTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminSearchControllerTest.php
@@ -89,7 +89,7 @@ class AdminSearchControllerTest extends TestCase
         $request->request->set('term', 'test');
         $response = $controller->elastic($request, Context::createDefaultContext());
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         $content = $response->getContent();
         static::assertIsString($content);
@@ -98,9 +98,9 @@ class AdminSearchControllerTest extends TestCase
 
         static::assertNotEmpty($data['promotion']);
 
-        static::assertEquals(1, $data['promotion']['total']);
+        static::assertSame(1, $data['promotion']['total']);
         static::assertNotEmpty($data['promotion']['data']);
-        static::assertEquals('promotion-listing', $data['promotion']['indexer']);
-        static::assertEquals('sw-admin-promotion-listing', $data['promotion']['index']);
+        static::assertSame('promotion-listing', $data['promotion']['indexer']);
+        static::assertSame('sw-admin-promotion-listing', $data['promotion']['index']);
     }
 }

--- a/tests/unit/Elasticsearch/Admin/AdminSearcherTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminSearcherTest.php
@@ -123,9 +123,9 @@ class AdminSearcherTest extends TestCase
 
         static::assertNotEmpty($data['product']);
 
-        static::assertEquals(1, $data['product']['total']);
-        static::assertEquals('product-listing', $data['product']['indexer']);
-        static::assertEquals('sw-admin-product-listing', $data['product']['index']);
+        static::assertSame(1, $data['product']['total']);
+        static::assertSame('product-listing', $data['product']['indexer']);
+        static::assertSame('sw-admin-product-listing', $data['product']['index']);
     }
 
     public function testSearchWithLimit(): void
@@ -207,9 +207,9 @@ class AdminSearcherTest extends TestCase
 
         static::assertNotEmpty($data['product']);
 
-        static::assertEquals(1, $data['product']['total']);
-        static::assertEquals('product-listing', $data['product']['indexer']);
-        static::assertEquals('sw-admin-product-listing', $data['product']['index']);
+        static::assertSame(1, $data['product']['total']);
+        static::assertSame('product-listing', $data['product']['indexer']);
+        static::assertSame('sw-admin-product-listing', $data['product']['index']);
     }
 
     public function testSearchWithUndefinedIndexer(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/CategoryAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/CategoryAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class CategoryAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/CmsPageAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/CmsPageAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class CmsPageAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/CustomerAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/CustomerAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class CustomerAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/CustomerGroupAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/CustomerGroupAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class CustomerGroupAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/LandingPageAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/LandingPageAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class LandingPageAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/ManufacturerAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/ManufacturerAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class ManufacturerAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/MediaAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/MediaAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class MediaAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/NewsletterRecipientAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/NewsletterRecipientAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class NewsletterRecipientAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class OrderAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/PaymentMethodAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/PaymentMethodAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class PaymentMethodAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/ProductAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/ProductAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class ProductAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/ProductStreamAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/ProductStreamAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class ProductStreamAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/PromotionAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/PromotionAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class PromotionAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/PropertyGroupAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/PropertyGroupAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class PropertyGroupAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/SalesChannelAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/SalesChannelAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class SalesChannelAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/Admin/Indexer/ShippingMethodAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/ShippingMethodAdminSearchIndexerTest.php
@@ -84,7 +84,7 @@ class ShippingMethodAdminSearchIndexerTest extends TestCase
 
         $data = $indexer->globalData($result, $context);
 
-        static::assertEquals($result['total'], $data['total']);
+        static::assertSame($result['total'], $data['total']);
     }
 
     public function testFetching(): void

--- a/tests/unit/Elasticsearch/ElasticsearchTest.php
+++ b/tests/unit/Elasticsearch/ElasticsearchTest.php
@@ -21,7 +21,7 @@ class ElasticsearchTest extends TestCase
     {
         $elasticsearch = new Elasticsearch();
 
-        static::assertEquals(-1, $elasticsearch->getTemplatePriority());
+        static::assertSame(-1, $elasticsearch->getTemplatePriority());
     }
 
     public function testBundle(): void

--- a/tests/unit/Elasticsearch/Event/ElasticsearchCustomFieldsMappingEventTest.php
+++ b/tests/unit/Elasticsearch/Event/ElasticsearchCustomFieldsMappingEventTest.php
@@ -35,7 +35,7 @@ class ElasticsearchCustomFieldsMappingEventTest extends TestCase
 
         $mappings = $event->getMappings();
 
-        static::assertEquals(
+        static::assertSame(
             ['field1' => 'text'],
             $mappings
         );

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntityAggregatorTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntityAggregatorTest.php
@@ -190,11 +190,6 @@ class ElasticsearchEntityAggregatorTest extends TestCase
 
         $dispatcher->addListener(ElasticsearchEntityAggregatorSearchedEvent::class, static function (ElasticsearchEntityAggregatorSearchedEvent $event) use (&$searchedEventDispatched): void {
             $searchedEventDispatched = true;
-            static::assertEquals([
-                'hits' => [
-                    'hits' => [],
-                ],
-            ], $event->result);
         });
 
         $aggregator = new ElasticsearchEntityAggregator(

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearchHydratorTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearchHydratorTest.php
@@ -39,7 +39,7 @@ class ElasticsearchEntitySearchHydratorTest extends TestCase
 
         $idSearchResult = $this->hydrator->hydrate($definition, $criteria, $this->context, $result);
 
-        static::assertEquals(0, $idSearchResult->getTotal());
+        static::assertSame(0, $idSearchResult->getTotal());
         static::assertEmpty($idSearchResult->getIds());
     }
 
@@ -66,8 +66,8 @@ class ElasticsearchEntitySearchHydratorTest extends TestCase
 
         $idSearchResult = $this->hydrator->hydrate($definition, $criteria, $this->context, $result);
 
-        static::assertEquals(2, $idSearchResult->getTotal());
-        static::assertEquals(['1', '2'], $idSearchResult->getIds());
+        static::assertSame(2, $idSearchResult->getTotal());
+        static::assertSame(['1', '2'], $idSearchResult->getIds());
     }
 
     public function testHydrateWithoutTotal(): void
@@ -95,7 +95,7 @@ class ElasticsearchEntitySearchHydratorTest extends TestCase
 
         $idSearchResult = $this->hydrator->hydrate($definition, $criteria, $this->context, $result);
 
-        static::assertEquals(2, $idSearchResult->getTotal());
+        static::assertSame(2, $idSearchResult->getTotal());
     }
 
     public function testHydrateWithExactTotal(): void
@@ -115,7 +115,7 @@ class ElasticsearchEntitySearchHydratorTest extends TestCase
 
         $idSearchResult = $this->hydrator->hydrate($definition, $criteria, $this->context, $result);
 
-        static::assertEquals(2, $idSearchResult->getTotal());
+        static::assertSame(2, $idSearchResult->getTotal());
 
         $criteria->addGroupField(new FieldGrouping('displayGroup'));
         $result = [
@@ -131,7 +131,7 @@ class ElasticsearchEntitySearchHydratorTest extends TestCase
 
         $idSearchResult = $this->hydrator->hydrate($definition, $criteria, $this->context, $result);
 
-        static::assertEquals(3, $idSearchResult->getTotal());
+        static::assertSame(3, $idSearchResult->getTotal());
 
         $criteria->addPostFilter(new EqualsFilter('field', 'value'));
         $result = [
@@ -149,7 +149,7 @@ class ElasticsearchEntitySearchHydratorTest extends TestCase
 
         $idSearchResult = $this->hydrator->hydrate($definition, $criteria, $this->context, $result);
 
-        static::assertEquals(3, $idSearchResult->getTotal());
+        static::assertSame(3, $idSearchResult->getTotal());
     }
 
     public function testHydrateWithNestedHits(): void
@@ -193,8 +193,8 @@ class ElasticsearchEntitySearchHydratorTest extends TestCase
 
         $idSearchResult = $this->hydrator->hydrate($definition, $criteria, $this->context, $result);
 
-        static::assertEquals(2, $idSearchResult->getTotal());
-        static::assertEquals(['2', '3'], $idSearchResult->getIds());
+        static::assertSame(2, $idSearchResult->getTotal());
+        static::assertSame(['2', '3'], $idSearchResult->getIds());
     }
 
     public function testHydrateWithIdSorting(): void
@@ -220,7 +220,7 @@ class ElasticsearchEntitySearchHydratorTest extends TestCase
 
         $idSearchResult = $this->hydrator->hydrate($definition, $criteria, $this->context, $result);
 
-        static::assertEquals(2, $idSearchResult->getTotal());
-        static::assertEquals(['2', '1'], $idSearchResult->getIds());
+        static::assertSame(2, $idSearchResult->getTotal());
+        static::assertSame(['2', '1'], $idSearchResult->getIds());
     }
 }

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcherTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcherTest.php
@@ -66,7 +66,7 @@ class ElasticsearchEntitySearcherTest extends TestCase
             $context
         );
 
-        static::assertEquals(0, $result->getTotal());
+        static::assertSame(0, $result->getTotal());
     }
 
     public function testWithCriteriaLimitOfZero(): void
@@ -105,7 +105,7 @@ class ElasticsearchEntitySearcherTest extends TestCase
             $context
         );
 
-        static::assertEquals(0, $result->getTotal());
+        static::assertSame(0, $result->getTotal());
     }
 
     public function testSearchWithCount(): void
@@ -294,11 +294,6 @@ class ElasticsearchEntitySearcherTest extends TestCase
 
         $dispatcher->addListener(ElasticsearchEntitySearcherSearchedEvent::class, static function (ElasticsearchEntitySearcherSearchedEvent $event) use (&$searchedEventDispatched): void {
             $searchedEventDispatched = true;
-            static::assertEquals([
-                'hits' => [
-                    'hits' => [],
-                ],
-            ], $event->result);
         });
 
         $searcher = new ElasticsearchEntitySearcher(
@@ -357,6 +352,6 @@ class ElasticsearchEntitySearcherTest extends TestCase
             $context
         );
 
-        static::assertEquals(0, $result->getTotal());
+        static::assertSame(0, $result->getTotal());
     }
 }

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchFieldBuilderTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchFieldBuilderTest.php
@@ -210,7 +210,7 @@ class ElasticsearchFieldBuilderTest extends TestCase
             ],
         ]]);
 
-        static::assertEquals([
+        static::assertSame([
             'type' => 'date',
             'format' => 'yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis',
             'ignore_malformed' => true,
@@ -226,7 +226,7 @@ class ElasticsearchFieldBuilderTest extends TestCase
     {
         $nestedFields = ElasticsearchFieldBuilder::nested(['name' => AbstractElasticsearchDefinition::KEYWORD_FIELD + AbstractElasticsearchDefinition::SEARCH_FIELD]);
 
-        static::assertEquals([
+        static::assertSame([
             'type' => 'nested',
             'properties' => [
                 'id' => AbstractElasticsearchDefinition::KEYWORD_FIELD,

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchFieldMapperTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchFieldMapperTest.php
@@ -109,8 +109,8 @@ class ElasticsearchFieldMapperTest extends TestCase
          * Specifically check, that this case does not happen anymore:
          * https://github.com/shopware/shopware/issues/4459 (comments)
          **/
-        static::assertNotEquals($formatted[$deLanguageId]['cf_bar'], \INF);
-        static::assertNotEquals($formatted[$enLanguageId]['cf_bar'], \INF);
+        static::assertNotSame($formatted[$deLanguageId]['cf_bar'], \INF);
+        static::assertNotSame($formatted[$enLanguageId]['cf_bar'], \INF);
 
         static::assertEquals([
             $deLanguageId => [

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchIndexingUtilsTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchIndexingUtilsTest.php
@@ -49,7 +49,7 @@ class ElasticsearchIndexingUtilsTest extends TestCase
         $formatted = $utils->getCustomFieldTypes(ProductDefinition::ENTITY_NAME, new Context(new SystemSource()));
         $utils->getCustomFieldTypes(ProductDefinition::ENTITY_NAME, new Context(new SystemSource()));
 
-        static::assertEquals([
+        static::assertSame([
             'cf_bool' => 'bool',
             'cf_foo' => 'text',
             'cf_baz' => 'int',
@@ -61,20 +61,20 @@ class ElasticsearchIndexingUtilsTest extends TestCase
         $input1 = '<p>This is <b>bold</b> text.</p>';
         $expected1 = 'This is bold text.';
         $result1 = ElasticsearchIndexingUtils::stripText($input1);
-        static::assertEquals($expected1, $result1);
+        static::assertSame($expected1, $result1);
 
         $input2 = 'This is a short text.';
         $result2 = ElasticsearchIndexingUtils::stripText($input2);
-        static::assertEquals($input2, $result2);
+        static::assertSame($input2, $result2);
 
         $input3 = str_repeat('a', 32766);
         $result3 = ElasticsearchIndexingUtils::stripText($input3);
-        static::assertEquals($input3, $result3);
+        static::assertSame($input3, $result3);
 
         $input4 = str_repeat('a', 33000);
         $expected4 = mb_substr($input4, 0, 32766);
         $result4 = ElasticsearchIndexingUtils::stripText($input4);
-        static::assertEquals($expected4, $result4);
+        static::assertSame($expected4, $result4);
     }
 
     public function testParseJsonWithValidJson(): void
@@ -86,7 +86,7 @@ class ElasticsearchIndexingUtilsTest extends TestCase
 
         $result = ElasticsearchIndexingUtils::parseJson($record, $field);
 
-        static::assertEquals(['key' => 'value'], $result);
+        static::assertSame(['key' => 'value'], $result);
     }
 
     public function testParseJsonWithNonExistField(): void
@@ -96,7 +96,7 @@ class ElasticsearchIndexingUtilsTest extends TestCase
 
         $result = ElasticsearchIndexingUtils::parseJson($record, $field);
 
-        static::assertEquals([], $result);
+        static::assertSame([], $result);
     }
 
     public function testParseJsonWithInvalidJson(): void

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchLanguageProviderTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchLanguageProviderTest.php
@@ -30,7 +30,7 @@ class ElasticsearchLanguageProviderTest extends TestCase
                 static::assertTrue($criteria->hasEqualsFilter('fooo'));
                 $sortings = $criteria->getSorting();
                 static::assertCount(1, $sortings);
-                static::assertEquals('id', $sortings[0]->getField());
+                static::assertSame('id', $sortings[0]->getField());
 
                 return new EntitySearchResult('foo', 0, new LanguageCollection(), null, $criteria, Context::createDefaultContext());
             });

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchRangeAggregationTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchRangeAggregationTest.php
@@ -22,7 +22,7 @@ class ElasticsearchRangeAggregationTest extends TestCase
 
         $agg = new ElasticsearchRangeAggregation('test-name', 'test-field', $ranges);
 
-        static::assertEquals([
+        static::assertSame([
             'ranges' => [
                 'field' => 'test-field',
                 'ranges' => $ranges,

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchRegistryTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchRegistryTest.php
@@ -31,6 +31,6 @@ class ElasticsearchRegistryTest extends TestCase
         static::assertFalse($registry->has('category'));
         static::assertNull($registry->get('category'));
 
-        static::assertEquals(['product'], $registry->getDefinitionNames());
+        static::assertSame(['product'], $registry->getDefinitionNames());
     }
 }

--- a/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -126,7 +126,7 @@ class ElasticsearchIndexerTest extends TestCase
 
         $eventDispatcher->addListener(ElasticsearchIndexIteratorEvent::class, function (ElasticsearchIndexIteratorEvent $event) use (&$eventDispatched, $query): void {
             $eventDispatched = true;
-            static::assertEquals($query, $event->iterator);
+            static::assertSame($query, $event->iterator);
         });
 
         $indexer = $this->getIndexer(eventDispatcher: $eventDispatcher);

--- a/tests/unit/Elasticsearch/Framework/Indexing/IndexerOffsetTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/IndexerOffsetTest.php
@@ -26,21 +26,21 @@ class IndexerOffsetTest extends TestCase
             $timestamp
         );
 
-        static::assertEquals(ProductDefinition::ENTITY_NAME, $offset->getDefinition());
+        static::assertSame(ProductDefinition::ENTITY_NAME, $offset->getDefinition());
         static::assertTrue($offset->hasNextDefinition());
         static::assertSame($timestamp, $offset->getTimestamp());
         static::assertNull($offset->getLastId());
 
         $offset->selectNextDefinition();
 
-        static::assertEquals(ProductManufacturerDefinition::ENTITY_NAME, $offset->getDefinition());
+        static::assertSame(ProductManufacturerDefinition::ENTITY_NAME, $offset->getDefinition());
         static::assertEmpty($offset->getDefinitions());
         static::assertFalse($offset->hasNextDefinition());
 
         $offset->resetDefinitions();
 
-        static::assertEquals(ProductDefinition::ENTITY_NAME, $offset->getDefinition());
-        static::assertEquals(
+        static::assertSame(ProductDefinition::ENTITY_NAME, $offset->getDefinition());
+        static::assertSame(
             [
                 ProductManufacturerDefinition::ENTITY_NAME,
             ],
@@ -48,7 +48,7 @@ class IndexerOffsetTest extends TestCase
         );
 
         $offset->setLastId(['offset' => 42]);
-        static::assertEquals(['offset' => 42], $offset->getLastId());
+        static::assertSame(['offset' => 42], $offset->getLastId());
     }
 
     public function testSerialize(): void

--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -525,7 +525,7 @@ class ElasticsearchProductDefinitionTest extends TestCase
 
         $queries = $query->toArray();
 
-        static::assertEquals([
+        static::assertSame([
             'match' => [
                 'name' => [
                     'query' => 'test',

--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductExceptionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductExceptionTest.php
@@ -19,9 +19,9 @@ class ElasticsearchProductExceptionTest extends TestCase
         $previous = new BadRequest400Exception('test');
         $e = ElasticsearchProductException::cannotChangeCustomFieldType($previous);
 
-        static::assertEquals('One or more custom fields already exist in the index with different types. Please reset the index and rebuild it.', $e->getMessage());
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('ELASTICSEARCH_PRODUCT__CANNOT_CHANGE_CUSTOM_FIELD_TYPE', $e->getErrorCode());
+        static::assertSame('One or more custom fields already exist in the index with different types. Please reset the index and rebuild it.', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('ELASTICSEARCH_PRODUCT__CANNOT_CHANGE_CUSTOM_FIELD_TYPE', $e->getErrorCode());
         static::assertSame($previous, $e->getPrevious());
     }
 }

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -106,7 +106,7 @@ class ProductSearchQueryBuilderTest extends TestCase
 
         $parsed = $builder->build($criteria, Context::createDefaultContext());
 
-        static::assertSame($expected, $parsed->toArray());
+        static::assertEquals($expected, $parsed->toArray());
     }
 
     /**

--- a/tests/unit/Elasticsearch/Product/SearchConfigLoaderTest.php
+++ b/tests/unit/Elasticsearch/Product/SearchConfigLoaderTest.php
@@ -48,7 +48,7 @@ class SearchConfigLoaderTest extends TestCase
 
         $result = $loader->load($context);
 
-        static::assertEquals($expectedResult, $result);
+        static::assertSame($expectedResult, $result);
     }
 
     public function testLoadWithNoResult(): void

--- a/tests/unit/Elasticsearch/Profiler/ClientProfilerTest.php
+++ b/tests/unit/Elasticsearch/Profiler/ClientProfilerTest.php
@@ -41,7 +41,7 @@ class ClientProfilerTest extends TestCase
         static::assertCount(1, $profiler->getCalledRequests());
         $requests = $profiler->getCalledRequests();
         static::assertSame($expectedUrl, $requests[0]['url']);
-        static::assertEquals($request, $requests[0]['request']);
+        static::assertSame($request, $requests[0]['request']);
 
         $profiler->resetRequests();
         static::assertCount(0, $profiler->getCalledRequests());
@@ -71,7 +71,7 @@ class ClientProfilerTest extends TestCase
         static::assertCount(1, $profiler->getCalledRequests());
         $requests = $profiler->getCalledRequests();
         static::assertSame($expectedUrl, $requests[0]['url']);
-        static::assertEquals($request, $requests[0]['request']);
+        static::assertSame($request, $requests[0]['request']);
 
         $profiler->resetRequests();
         static::assertCount(0, $profiler->getCalledRequests());
@@ -98,7 +98,7 @@ class ClientProfilerTest extends TestCase
         static::assertCount(1, $profiler->getCalledRequests());
         $requests = $profiler->getCalledRequests();
         static::assertSame('http://localhost:9200/_bulk', $requests[0]['url']);
-        static::assertEquals($request, $requests[0]['request']);
+        static::assertSame($request, $requests[0]['request']);
 
         $profiler->resetRequests();
         static::assertCount(0, $profiler->getCalledRequests());
@@ -124,7 +124,7 @@ class ClientProfilerTest extends TestCase
         static::assertCount(1, $profiler->getCalledRequests());
         $requests = $profiler->getCalledRequests();
         static::assertSame('http://localhost:9200/_scripts/numeric_translated_field_sorting', $requests[0]['url']);
-        static::assertEquals($params, $requests[0]['request']);
+        static::assertSame($params, $requests[0]['request']);
 
         $profiler->resetRequests();
         static::assertCount(0, $profiler->getCalledRequests());

--- a/tests/unit/Elasticsearch/Profiler/DataCollectorTest.php
+++ b/tests/unit/Elasticsearch/Profiler/DataCollectorTest.php
@@ -79,11 +79,11 @@ class DataCollectorTest extends TestCase
             new Response()
         );
 
-        static::assertEquals(1500, $collector->getTime());
-        static::assertEquals(5, $collector->getRequestAmount());
+        static::assertSame(1500.0, $collector->getTime());
+        static::assertSame(5, $collector->getRequestAmount());
         static::assertCount(5, $collector->getRequests());
-        static::assertEquals(['status' => 'green'], $collector->getClusterInfo());
-        static::assertEquals(['indices' => ['index1' => ['status' => 'green'], 'index2' => ['status' => 'green']]], $collector->getIndices());
+        static::assertSame(['status' => 'green'], $collector->getClusterInfo());
+        static::assertSame(['indices' => ['index1' => ['status' => 'green'], 'index2' => ['status' => 'green']]], $collector->getIndices());
     }
 
     public function testReset(): void
@@ -109,11 +109,11 @@ class DataCollectorTest extends TestCase
             new Response()
         );
 
-        static::assertEquals(1200, $collector->getTime());
+        static::assertSame(1200.0, $collector->getTime());
 
         $collector->reset();
         static::assertCount(0, $collector->getRequests());
-        static::assertEquals(0, $collector->getTime());
+        static::assertSame(0.0, $collector->getTime());
     }
 
     public function testDisabled(): void
@@ -135,7 +135,7 @@ class DataCollectorTest extends TestCase
             new Response()
         );
 
-        static::assertEquals(0, $collector->getTime());
+        static::assertSame(0.0, $collector->getTime());
     }
 
     public function testCollectAdminSource(): void
@@ -195,8 +195,8 @@ class DataCollectorTest extends TestCase
             new Response()
         );
 
-        static::assertEquals(900, $collector->getTime());
-        static::assertEquals(2, $collector->getRequestAmount());
+        static::assertSame(900.0, $collector->getTime());
+        static::assertSame(2, $collector->getRequestAmount());
         static::assertCount(2, $collector->getRequests());
 
         $client = $this->createMock(ClientProfiler::class);
@@ -228,8 +228,8 @@ class DataCollectorTest extends TestCase
             new Response()
         );
 
-        static::assertEquals(1500, $collector->getTime());
-        static::assertEquals(5, $collector->getRequestAmount());
+        static::assertSame(1500.0, $collector->getTime());
+        static::assertSame(5, $collector->getRequestAmount());
         static::assertCount(5, $collector->getRequests());
     }
 }

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -174,7 +174,7 @@ class TokenQueryBuilderTest extends TestCase
         $query = $this->tokenQueryBuilder->build('product', $term, $config, $context);
 
         static::assertNotNull($query);
-        static::assertEquals($expected, $query->toArray());
+        static::assertSame($expected, $query->toArray());
     }
 
     /**

--- a/tests/unit/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
+++ b/tests/unit/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
@@ -84,7 +84,7 @@ class StorefrontCartFacadeTest extends TestCase
 
         $controlCart = $this->getCart();
         $controlCart->setErrors($this->getCartErrorCollection(true));
-        static::assertNotEquals($controlCart, $returnedCart);
+        static::assertNotSame($controlCart, $returnedCart);
     }
 
     public function testGetBlockedPaymentMethodAllowFallback(): void
@@ -123,7 +123,7 @@ class StorefrontCartFacadeTest extends TestCase
 
         $controlCart = $this->getCart();
         $controlCart->setErrors($this->getCartErrorCollection(false, true));
-        static::assertNotEquals($controlCart, $returnedCart);
+        static::assertNotSame($controlCart, $returnedCart);
     }
 
     public function testGetBlockedPaymentAndShippingMethodAllowFallback(): void
@@ -174,7 +174,7 @@ class StorefrontCartFacadeTest extends TestCase
 
         $controlCart = $this->getCart();
         $controlCart->setErrors($this->getCartErrorCollection(true, true));
-        static::assertNotEquals($controlCart, $returnedCart);
+        static::assertNotSame($controlCart, $returnedCart);
     }
 
     public function testGetBlockedShippingMethodNoFallback(): void

--- a/tests/unit/Storefront/Controller/AuthControllerTest.php
+++ b/tests/unit/Storefront/Controller/AuthControllerTest.php
@@ -104,7 +104,7 @@ class AuthControllerTest extends TestCase
         static::assertArrayHasKey('frontend.account.login.page', $this->controller->redirected);
         static::assertArrayHasKey('danger', $this->controller->flashBag);
         static::assertArrayHasKey(0, $this->controller->flashBag['danger']);
-        static::assertEquals('account.orderGuestLoginWrongCredentials', $this->controller->flashBag['danger'][0]);
+        static::assertSame('account.orderGuestLoginWrongCredentials', $this->controller->flashBag['danger'][0]);
     }
 
     public function testGenerateAccountRecoveryThrowsConstraintException(): void

--- a/tests/unit/Storefront/Controller/CartLineItemControllerTest.php
+++ b/tests/unit/Storefront/Controller/CartLineItemControllerTest.php
@@ -390,7 +390,7 @@ class CartLineItemControllerTest extends TestCase
 
         $response = $this->controller->addProductByNumber($request, $context);
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         static::assertArrayHasKey('danger', $session->getFlashBag()->peekAll());
     }
@@ -660,7 +660,7 @@ class CartLineItemControllerTest extends TestCase
                 $expectedLineitem = new LineItem($id1, LineItem::PRODUCT_LINE_ITEM_TYPE);
                 $expectedLineitem2 = new LineItem($id2, LineItem::PRODUCT_LINE_ITEM_TYPE);
                 $expectedLineitems = [$expectedLineitem, $expectedLineitem2];
-                static::assertEquals($expectedLineitems, $lineItems);
+                static::assertSame($expectedLineitems, $lineItems);
 
                 return $cart;
             });

--- a/tests/unit/Storefront/Controller/CmsControllerTest.php
+++ b/tests/unit/Storefront/Controller/CmsControllerTest.php
@@ -81,7 +81,7 @@ class CmsControllerTest extends TestCase
 
         $this->controller->page($ids->get('page'), new Request(), $this->createMock(SalesChannelContext::class));
 
-        static::assertEquals($cmsRouteResponse->getCmsPage(), $this->controller->renderStorefrontParameters['cmsPage']);
+        static::assertSame($cmsRouteResponse->getCmsPage(), $this->controller->renderStorefrontParameters['cmsPage']);
     }
 
     public function testPageFullReturn(): void
@@ -93,7 +93,7 @@ class CmsControllerTest extends TestCase
 
         $this->controller->pageFull($ids->get('page'), new Request(), $this->createMock(SalesChannelContext::class));
 
-        static::assertEquals($cmsRouteResponse->getCmsPage(), $this->controller->renderStorefrontParameters['page']['cmsPage']);
+        static::assertSame($cmsRouteResponse->getCmsPage(), $this->controller->renderStorefrontParameters['page']['cmsPage']);
     }
 
     public function testCategoryNoId(): void
@@ -115,7 +115,7 @@ class CmsControllerTest extends TestCase
 
         $this->controller->category($ids->get('category'), new Request(), $this->createMock(SalesChannelContext::class));
 
-        static::assertEquals($categoryRouteResponse->getCategory()->getCmsPage(), $this->controller->renderStorefrontParameters['cmsPage']);
+        static::assertSame($categoryRouteResponse->getCategory()->getCmsPage(), $this->controller->renderStorefrontParameters['cmsPage']);
     }
 
     public function testCategoryPageNotFound(): void
@@ -153,7 +153,7 @@ class CmsControllerTest extends TestCase
 
         $response = $this->controller->filter($ids->get('navigation'), $request, $this->createMock(SalesChannelContext::class));
 
-        static::assertEquals(
+        static::assertSame(
             json_encode($testAggregations, \JSON_THROW_ON_ERROR),
             json_encode(json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR), \JSON_THROW_ON_ERROR)
         );
@@ -180,7 +180,7 @@ class CmsControllerTest extends TestCase
 
         static::assertInstanceOf(SalesChannelProductEntity::class, $this->controller->renderStorefrontParameters['product']);
 
-        static::assertEquals(
+        static::assertSame(
             $this->controller->renderStorefrontParameters,
             [
                 'product' => $this->controller->renderStorefrontParameters['product'],

--- a/tests/unit/Storefront/Controller/ProductControllerTest.php
+++ b/tests/unit/Storefront/Controller/ProductControllerTest.php
@@ -199,7 +199,7 @@ class ProductControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertSame('frontend.product.reviews', $this->controller->forwardToRoute);
-        static::assertEquals(
+        static::assertSame(
             [
                 'productId' => $ids->get('productId'),
                 'success' => 1,
@@ -220,7 +220,7 @@ class ProductControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertSame('frontend.product.reviews', $this->controller->forwardToRoute);
-        static::assertEquals(
+        static::assertSame(
             [
                 'productId' => $ids->get('productId'),
                 'success' => 2,
@@ -303,7 +303,7 @@ class ProductControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertSame('storefront/component/review/review.html.twig', $this->controller->renderStorefrontView);
-        static::assertEquals(
+        static::assertSame(
             [
                 'reviews' => $reviewResult,
                 'ratingSuccess' => null,

--- a/tests/unit/Storefront/Controller/SearchControllerTest.php
+++ b/tests/unit/Storefront/Controller/SearchControllerTest.php
@@ -155,7 +155,7 @@ class SearchControllerTest extends TestCase
 
         $response = $this->searchController->search($context, $request);
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testSearchWithNoProductsFound(): void
@@ -222,7 +222,7 @@ class SearchControllerTest extends TestCase
 
         $response = $this->searchController->search($context, $request);
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testSearchWithoutSearchParameterShouldRedirectToHomePage(): void
@@ -324,11 +324,11 @@ class SearchControllerTest extends TestCase
         $response = $this->searchController->search($context, $request);
 
         static::assertInstanceOf(RedirectResponse::class, $response);
-        static::assertEquals(302, $response->getStatusCode());
+        static::assertSame(302, $response->getStatusCode());
         static::assertInstanceOf(StorefrontRedirectEvent::class, $redirectEvent);
-        static::assertEquals(Response::HTTP_FOUND, $redirectEvent->getStatus());
-        static::assertEquals('frontend.detail.page', $redirectEvent->getRoute());
-        static::assertEquals([
+        static::assertSame(Response::HTTP_FOUND, $redirectEvent->getStatus());
+        static::assertSame('frontend.detail.page', $redirectEvent->getRoute());
+        static::assertSame([
             'productId' => '123',
         ], $redirectEvent->getParameters());
     }

--- a/tests/unit/Storefront/Controller/VerificationHashControllerTest.php
+++ b/tests/unit/Storefront/Controller/VerificationHashControllerTest.php
@@ -22,9 +22,9 @@ class VerificationHashControllerTest extends TestCase
         $controller = new VerificationHashController($systemConfigMock);
         $response = $controller->load();
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        static::assertEquals('TheVerificationHash123', $response->getContent());
-        static::assertEquals('text/plain', $response->headers->get('Content-Type'));
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame('TheVerificationHash123', $response->getContent());
+        static::assertSame('text/plain', $response->headers->get('Content-Type'));
     }
 
     public function testGetVerificationHashEmpty(): void
@@ -35,8 +35,8 @@ class VerificationHashControllerTest extends TestCase
         $controller = new VerificationHashController($systemConfigMock);
         $response = $controller->load();
 
-        static::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        static::assertEquals('', $response->getContent());
-        static::assertEquals('text/plain', $response->headers->get('Content-Type'));
+        static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        static::assertSame('', $response->getContent());
+        static::assertSame('text/plain', $response->headers->get('Content-Type'));
     }
 }

--- a/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
+++ b/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
@@ -47,12 +47,12 @@ class CartMergedSubscriberTest extends TestCase
         $subscriber->addCartMergedNoticeFlash($cartMergedEvent);
 
         static::assertNotEmpty($infoFlash = $session->getFlashBag()->get('info'));
-        static::assertEquals('checkout.cart-merged-hint', $infoFlash[0]);
+        static::assertSame('checkout.cart-merged-hint', $infoFlash[0]);
     }
 
     public function testGetSubscribedEventsReturnsAddCartMergedNoticeFlash(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [CartMergedEvent::class => 'addCartMergedNoticeFlash'],
             CartMergedSubscriber::getSubscribedEvents()
         );

--- a/tests/unit/Storefront/Framework/App/Template/IconTemplateLoaderTest.php
+++ b/tests/unit/Storefront/Framework/App/Template/IconTemplateLoaderTest.php
@@ -45,7 +45,7 @@ class IconTemplateLoaderTest extends TestCase
         $templates = $this->templateLoader->getTemplatePathsForApp($this->manifest);
         \sort($templates);
 
-        static::assertEquals(
+        static::assertSame(
             ['app/storefront/src/assets/icon-pack/custom-icons/activity.svg', 'storefront/layout/header/logo.html.twig'],
             $templates
         );

--- a/tests/unit/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
+++ b/tests/unit/Storefront/Framework/Command/SalesChannelCreateStorefrontCommandTest.php
@@ -115,7 +115,7 @@ class SalesChannelCreateStorefrontCommandTest extends TestCase
 
         $status = $cmd->run($input, $output);
 
-        static::assertEquals(SalesChannelCreateStorefrontCommand::SUCCESS, $status);
+        static::assertSame(SalesChannelCreateStorefrontCommand::SUCCESS, $status);
     }
 
     /**

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderInvalidatorTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderInvalidatorTest.php
@@ -22,7 +22,7 @@ class CachedDomainLoaderInvalidatorTest extends TestCase
 {
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [EntityWrittenContainerEvent::class => [['invalidate', 2000]]],
             CachedDomainLoaderInvalidator::getSubscribedEvents()
         );
@@ -46,7 +46,7 @@ class CachedDomainLoaderInvalidatorTest extends TestCase
 
         $invalidationSubscriber->invalidate($event);
 
-        static::assertEquals([CachedDomainLoader::CACHE_KEY], $mockedInvalidator->getForceInvalidatedTags());
+        static::assertSame([CachedDomainLoader::CACHE_KEY], $mockedInvalidator->getForceInvalidatedTags());
     }
 
     public function testInvalidateIsNotCalledForNonSalesChannelWrites(): void
@@ -67,6 +67,6 @@ class CachedDomainLoaderInvalidatorTest extends TestCase
 
         $invalidationSubscriber->invalidate($event);
 
-        static::assertEquals([], $mockedInvalidator->getForceInvalidatedTags());
+        static::assertSame([], $mockedInvalidator->getForceInvalidatedTags());
     }
 }

--- a/tests/unit/Storefront/Framework/Routing/MaintenanceModeResolverTest.php
+++ b/tests/unit/Storefront/Framework/Routing/MaintenanceModeResolverTest.php
@@ -78,7 +78,7 @@ class MaintenanceModeResolverTest extends TestCase
     #[DataProvider('maintenanceModeActiveProvider')]
     public function testIsMaintenanceRequest(Request $request, bool $expected): void
     {
-        static::assertEquals(
+        static::assertSame(
             (new MaintenanceModeResolver($this->getRequestStack($request), new CoreMaintenanceModeResolver(new EventDispatcher())))->isMaintenanceRequest($request),
             $expected
         );

--- a/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -38,7 +38,7 @@ class RequestTransformerTest extends TestCase
         $originalRequest = Request::create($requestUri);
         $transformedRequest = $requestTransformer->transform($originalRequest);
 
-        static::assertEquals($originalRequest, $transformedRequest);
+        static::assertSame($originalRequest, $transformedRequest);
     }
 
     public function testSalesChannelIsRequired(): void

--- a/tests/unit/Storefront/Framework/Routing/SalesChannelMappingExceptionTest.php
+++ b/tests/unit/Storefront/Framework/Routing/SalesChannelMappingExceptionTest.php
@@ -15,8 +15,8 @@ class SalesChannelMappingExceptionTest extends TestCase
     public function testException(): void
     {
         $exception = new SalesChannelMappingException('test');
-        static::assertEquals('Unable to find a matching sales channel for the request: "test". Please make sure the domain mapping is correct.', $exception->getMessage());
-        static::assertEquals('FRAMEWORK__INVALID_SALES_CHANNEL_MAPPING', $exception->getErrorCode());
-        static::assertEquals(404, $exception->getStatusCode());
+        static::assertSame('Unable to find a matching sales channel for the request: "test". Please make sure the domain mapping is correct.', $exception->getMessage());
+        static::assertSame('FRAMEWORK__INVALID_SALES_CHANNEL_MAPPING', $exception->getErrorCode());
+        static::assertSame(404, $exception->getStatusCode());
     }
 }

--- a/tests/unit/Storefront/Framework/Routing/TemplateDataSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/TemplateDataSubscriberTest.php
@@ -63,15 +63,15 @@ class TemplateDataSubscriberTest extends TestCase
         static::assertArrayHasKey('0', $events[StorefrontRenderEvent::class]);
         static::assertIsArray($events[StorefrontRenderEvent::class][0]);
         static::assertArrayHasKey('0', $events[StorefrontRenderEvent::class][0]);
-        static::assertEquals('addHreflang', $events[StorefrontRenderEvent::class][0][0]);
+        static::assertSame('addHreflang', $events[StorefrontRenderEvent::class][0][0]);
 
         static::assertArrayHasKey('1', $events[StorefrontRenderEvent::class]);
         static::assertIsArray($events[StorefrontRenderEvent::class][1]);
-        static::assertEquals('addShopIdParameter', $events[StorefrontRenderEvent::class][1][0]);
+        static::assertSame('addShopIdParameter', $events[StorefrontRenderEvent::class][1][0]);
 
         static::assertArrayHasKey('2', $events[StorefrontRenderEvent::class]);
         static::assertIsArray($events[StorefrontRenderEvent::class][2]);
-        static::assertEquals('addIconSetConfig', $events[StorefrontRenderEvent::class][2][0]);
+        static::assertSame('addIconSetConfig', $events[StorefrontRenderEvent::class][2][0]);
     }
 
     public function testAddHreflangWithNullRoute(): void
@@ -173,7 +173,7 @@ class TemplateDataSubscriberTest extends TestCase
 
         $this->subscriber->addShopIdParameter($event);
 
-        static::assertEquals('123', $event->getParameters()['appShopId']);
+        static::assertSame('123', $event->getParameters()['appShopId']);
     }
 
     public function testAddIconSetConfigWithNoTheme(): void

--- a/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
+++ b/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
@@ -37,7 +37,7 @@ class NavigationPageSeoUrlRouteTest extends TestCase
         /** @var MultiFilter $multiFilter */
         $multiFilter = $filters[0];
         static::assertInstanceOf(MultiFilter::class, $multiFilter);
-        static::assertEquals('AND', $multiFilter->getOperator());
+        static::assertSame('AND', $multiFilter->getOperator());
         $multiFilterQueries = $multiFilter->getQueries();
 
         static::assertCount(2, $multiFilterQueries);
@@ -50,7 +50,7 @@ class NavigationPageSeoUrlRouteTest extends TestCase
 
         $notFilter = $multiFilterQueries[1];
         static::assertInstanceOf(NotFilter::class, $notFilter);
-        static::assertEquals('OR', $notFilter->getOperator());
+        static::assertSame('OR', $notFilter->getOperator());
 
         $notFilterQueries = $notFilter->getQueries();
         static::assertCount(2, $notFilterQueries);
@@ -61,7 +61,7 @@ class NavigationPageSeoUrlRouteTest extends TestCase
         string $field,
         string|bool $value
     ): void {
-        static::assertEquals($field, $equalsFilter->getField());
-        static::assertEquals($value, $equalsFilter->getValue());
+        static::assertSame($field, $equalsFilter->getField());
+        static::assertSame($value, $equalsFilter->getValue());
     }
 }

--- a/tests/unit/Storefront/Framework/Twig/Extension/IconCacheTwigFilterTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Extension/IconCacheTwigFilterTest.php
@@ -60,7 +60,7 @@ class IconCacheTwigFilterTest extends TestCase
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
 
         $rendered = $controller->testRenderStorefront('@StorefrontTest/test/base.html.twig', $salesChannelContext);
-        static::assertEquals(str_replace(' ', '', '<span class="icon icon-minus-large icon-xs icon-filter-panel-item-toggle" aria-hidden="true">
+        static::assertSame(str_replace(' ', '', '<span class="icon icon-minus-large icon-xs icon-filter-panel-item-toggle" aria-hidden="true">
                                         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><defs><path id="icons-solid-minus-large" d="M2 9h12c.5523 0 1-.4477 1-1s-.4477-1-1-1H2c-.5523 0-1 .4477-1 1s.4477 1 1 1z" /></defs><use xlink:href="#icons-solid-minus-large" fill="#758CA3" fill-rule="evenodd" /></svg>
                     </span><span class="icon icon-minus-large icon-xs icon-filter-panel-item-toggle" aria-hidden="true">
                                         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><use xlink:href="#icons-solid-minus-large" fill="#758CA3" fill-rule="evenodd" /></svg>

--- a/tests/unit/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
@@ -24,7 +24,7 @@ class UrlEncodingTwigFilterTest extends TestCase
     {
         $filter = new UrlEncodingTwigFilter();
         $url = 'https://shopware.com:80/some/thing';
-        static::assertEquals($url, $filter->encodeUrl($url));
+        static::assertSame($url, $filter->encodeUrl($url));
     }
 
     public function testReturnsNullsIfNoUrlIsGiven(): void
@@ -37,20 +37,20 @@ class UrlEncodingTwigFilterTest extends TestCase
     {
         $filter = new UrlEncodingTwigFilter();
         $url = 'https://shopware.com/some/thing';
-        static::assertEquals($url, $filter->encodeUrl($url));
+        static::assertSame($url, $filter->encodeUrl($url));
     }
 
     public function testRespectsQueryParameter(): void
     {
         $filter = new UrlEncodingTwigFilter();
         $url = 'https://shopware.com/some/thing?a=3&b=25';
-        static::assertEquals($url, $filter->encodeUrl($url));
+        static::assertSame($url, $filter->encodeUrl($url));
     }
 
     public function testReturnsEncodedPathsWithoutHostAndScheme(): void
     {
         $filter = new UrlEncodingTwigFilter();
-        static::assertEquals(
+        static::assertSame(
             'shopware.com/some/thing',
             $filter->encodeUrl('shopware.com/some/thing')
         );
@@ -59,7 +59,7 @@ class UrlEncodingTwigFilterTest extends TestCase
     public function testItEncodesSpaces(): void
     {
         $filter = new UrlEncodingTwigFilter();
-        static::assertEquals(
+        static::assertSame(
             'https://shopware.com:80/so%20me/thing%20new.jpg',
             $filter->encodeUrl('https://shopware.com:80/so me/thing new.jpg')
         );
@@ -68,7 +68,7 @@ class UrlEncodingTwigFilterTest extends TestCase
     public function testItEncodesSpecialCharacters(): void
     {
         $filter = new UrlEncodingTwigFilter();
-        static::assertEquals(
+        static::assertSame(
             'https://shopware.com:80/so%20me/thing%20new.jpg',
             $filter->encodeUrl('https://shopware.com:80/so me/thing new.jpg')
         );

--- a/tests/unit/Storefront/Page/Account/Login/AccountLoginPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Login/AccountLoginPageLoaderTest.php
@@ -144,10 +144,12 @@ class AccountLoginPageLoaderTest extends TestCase
 
         $page = $this->pageLoader->load(new Request(), $this->createMock(SalesChannelContext::class));
 
-        static::assertEquals($countries, $page->getCountries());
+        static::assertSame($countries, $page->getCountries());
         static::assertSame($salutationsSorted, $page->getSalutations());
-        static::assertEquals('translated | testshop', $page->getMetaInformation()?->getMetaTitle());
-        static::assertEquals('noindex,follow', $page->getMetaInformation()?->getRobots());
+        $metaInformation = $page->getMetaInformation();
+        static::assertNotNull($metaInformation);
+        static::assertSame('translated | testshop', $metaInformation->getMetaTitle());
+        static::assertSame('noindex,follow', $metaInformation->getRobots());
         $events = $this->eventDispatcher->getEvents();
 
         static::assertCount(1, $events);

--- a/tests/unit/Storefront/Page/Account/Order/AccountOrderEditPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Order/AccountOrderEditPageLoaderTest.php
@@ -137,9 +137,11 @@ class AccountOrderEditPageLoaderTest extends TestCase
 
         $page = $this->pageLoader->load(new Request(), Generator::generateSalesChannelContext());
 
-        static::assertEquals($order, $page->getOrder());
-        static::assertEquals('translated | testshop', $page->getMetaInformation()?->getMetaTitle());
-        static::assertEquals('noindex,follow', $page->getMetaInformation()?->getRobots());
+        static::assertSame($order, $page->getOrder());
+        $metaInformation = $page->getMetaInformation();
+        static::assertNotNull($metaInformation);
+        static::assertSame('translated | testshop', $metaInformation->getMetaTitle());
+        static::assertSame('noindex,follow', $metaInformation->getRobots());
 
         static::assertSame([$remainingPaymentMethod], array_values($page->getPaymentMethods()->getElements()));
 

--- a/tests/unit/Storefront/Page/Account/Overview/AccountOverviewPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Overview/AccountOverviewPageLoaderTest.php
@@ -104,9 +104,11 @@ class AccountOverviewPageLoaderTest extends TestCase
         $customer = new CustomerEntity();
         $page = $this->pageLoader->load(new Request(), $this->createMock(SalesChannelContext::class), $customer);
 
-        static::assertEquals($order, $page->getNewestOrder());
-        static::assertEquals('translated | testshop', $page->getMetaInformation()?->getMetaTitle());
-        static::assertEquals('noindex,follow', $page->getMetaInformation()?->getRobots());
+        static::assertSame($order, $page->getNewestOrder());
+        $metaInformation = $page->getMetaInformation();
+        static::assertNotNull($metaInformation);
+        static::assertSame('translated | testshop', $metaInformation->getMetaTitle());
+        static::assertSame('noindex,follow', $metaInformation->getRobots());
 
         $events = $this->eventDispatcher->getEvents();
         static::assertCount(2, $events);

--- a/tests/unit/Storefront/Page/Account/Profile/AccountProfilePageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Profile/AccountProfilePageLoaderTest.php
@@ -114,8 +114,10 @@ class AccountProfilePageLoaderTest extends TestCase
         $page = $this->pageLoader->load(new Request(), $salesChannelContext);
 
         static::assertSame($salutationsSorted, $page->getSalutations());
-        static::assertEquals('translated | testshop', $page->getMetaInformation()?->getMetaTitle());
-        static::assertEquals('noindex,follow', $page->getMetaInformation()?->getRobots());
+        $metaInformation = $page->getMetaInformation();
+        static::assertNotNull($metaInformation);
+        static::assertSame('translated | testshop', $metaInformation->getMetaTitle());
+        static::assertSame('noindex,follow', $metaInformation->getRobots());
 
         $events = $this->eventDispatcher->getEvents();
         static::assertCount(2, $events);

--- a/tests/unit/Storefront/Page/Cms/DefaultMediaResolverTest.php
+++ b/tests/unit/Storefront/Page/Cms/DefaultMediaResolverTest.php
@@ -50,7 +50,7 @@ class DefaultMediaResolverTest extends TestCase
         $media = $resolver->getDefaultCmsMediaEntity('media/path/');
 
         static::assertInstanceOf(MediaEntity::class, $media);
-        static::assertEquals([
+        static::assertSame([
             'title' => 'media-title',
             'alt' => 'media-title',
         ], $media->getTranslated());

--- a/tests/unit/Storefront/Page/Product/ProductPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Product/ProductPageLoaderTest.php
@@ -55,7 +55,7 @@ class ProductPageLoaderTest extends TestCase
         $slot = $page->getCmsPage()?->getSections()?->first()?->getBlocks()?->first()?->getSlots()?->first()?->getSlot();
         static::assertIsString($slot);
 
-        static::assertEquals($reviews, json_decode($slot, true, 512, \JSON_THROW_ON_ERROR));
+        static::assertSame($reviews, json_decode($slot, true, 512, \JSON_THROW_ON_ERROR));
     }
 
     /**

--- a/tests/unit/Storefront/Theme/CachedResolvedConfigLoaderInvalidatorTest.php
+++ b/tests/unit/Storefront/Theme/CachedResolvedConfigLoaderInvalidatorTest.php
@@ -30,7 +30,7 @@ class CachedResolvedConfigLoaderInvalidatorTest extends TestCase
 
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 ThemeConfigChangedEvent::class => 'invalidate',
                 ThemeAssignedEvent::class => 'assigned',
@@ -55,7 +55,7 @@ class CachedResolvedConfigLoaderInvalidatorTest extends TestCase
             Translator::tag($salesChannelId),
         ];
 
-        static::assertEquals(
+        static::assertSame(
             $expectedInvalidatedTags,
             $this->cacheInvalidator->getInvalidatedTags()
         );
@@ -70,7 +70,7 @@ class CachedResolvedConfigLoaderInvalidatorTest extends TestCase
 
         $expectedInvalidatedTags = ['theme-config-' . $themeId];
 
-        static::assertEquals(
+        static::assertSame(
             $expectedInvalidatedTags,
             $this->cacheInvalidator->getInvalidatedTags()
         );
@@ -87,7 +87,7 @@ class CachedResolvedConfigLoaderInvalidatorTest extends TestCase
 
         $expectedInvalidatedTags = ['theme-config-' . $themeId];
 
-        static::assertEquals(
+        static::assertSame(
             $expectedInvalidatedTags,
             $this->cacheInvalidator->getInvalidatedTags()
         );

--- a/tests/unit/Storefront/Theme/CompilerConfigurationTest.php
+++ b/tests/unit/Storefront/Theme/CompilerConfigurationTest.php
@@ -25,7 +25,7 @@ class CompilerConfigurationTest extends TestCase
             'test' => 'value',
         ]);
 
-        static::assertEquals('value', $config->getValue('test'));
+        static::assertSame('value', $config->getValue('test'));
     }
 
     public function testGetWholeConfiguration(): void
@@ -34,7 +34,7 @@ class CompilerConfigurationTest extends TestCase
             'test' => 'value',
         ]);
 
-        static::assertEquals([
+        static::assertSame([
             'test' => 'value',
         ], $config->getConfiguration());
     }

--- a/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigDumperTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigDumperTest.php
@@ -44,10 +44,10 @@ class StaticFileConfigDumperTest extends TestCase
         $location = StaticFileAvailableThemeProvider::THEME_INDEX;
 
         $dumper->dumpConfig(Context::createDefaultContext());
-        static::assertEquals('{"test":"test"}', $privateFileSystem->read($location));
+        static::assertSame('{"test":"test"}', $privateFileSystem->read($location));
 
         $dumper->dumpConfigFromEvent();
-        static::assertEquals('{"test":"test"}', $privateFileSystem->read($location));
+        static::assertSame('{"test":"test"}', $privateFileSystem->read($location));
     }
 
     public function testDumpConfigInVar(): void
@@ -70,7 +70,7 @@ class StaticFileConfigDumperTest extends TestCase
 
     public function testgetSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 ThemeConfigChangedEvent::class => 'dumpConfigFromEvent',
                 ThemeAssignedEvent::class => 'dumpConfigFromEvent',

--- a/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
+++ b/tests/unit/Storefront/Theme/DatabaseSalesChannelThemeLoaderTest.php
@@ -44,11 +44,11 @@ class DatabaseSalesChannelThemeLoaderTest extends TestCase
         $salesChannelId = Uuid::randomHex();
 
         $actualTheme = $this->themeLoader->load($salesChannelId);
-        static::assertEquals($expectedTheme, $actualTheme);
+        static::assertSame($expectedTheme, $actualTheme);
 
         $otherSalesChannelId = Uuid::randomHex();
         $secondAttempt = $this->themeLoader->load($otherSalesChannelId);
-        static::assertEquals([], $secondAttempt);
+        static::assertSame([], $secondAttempt);
     }
 
     public function testLoadMultiple(): void
@@ -84,10 +84,10 @@ class DatabaseSalesChannelThemeLoaderTest extends TestCase
         $salesChannelId = Uuid::randomHex();
 
         $actualTheme = $this->themeLoader->load($salesChannelId);
-        static::assertEquals($expectedTheme, $actualTheme);
+        static::assertSame($expectedTheme, $actualTheme);
 
         $otherSalesChannelId = Uuid::randomHex();
         $secondAttempt = $this->themeLoader->load($otherSalesChannelId);
-        static::assertEquals([], $secondAttempt);
+        static::assertSame([], $secondAttempt);
     }
 }

--- a/tests/unit/Storefront/Theme/MD5ThemePathBuilderTest.php
+++ b/tests/unit/Storefront/Theme/MD5ThemePathBuilderTest.php
@@ -17,7 +17,7 @@ class MD5ThemePathBuilderTest extends TestCase
         $builder = new MD5ThemePathBuilder();
         $path = $builder->assemblePath('salesChannelId', 'themeId');
 
-        static::assertEquals('5c7a1cfde64c7f4533daa5a0c06c0a39', $path);
+        static::assertSame('5c7a1cfde64c7f4533daa5a0c06c0a39', $path);
     }
 
     public function testGenerateNewPathEqualsAssemblePath(): void
@@ -25,14 +25,14 @@ class MD5ThemePathBuilderTest extends TestCase
         $builder = new MD5ThemePathBuilder();
         $path = $builder->generateNewPath('salesChannelId', 'themeId', 'foo');
 
-        static::assertEquals($builder->assemblePath('salesChannelId', 'themeId'), $path);
+        static::assertSame($builder->assemblePath('salesChannelId', 'themeId'), $path);
     }
 
     public function testGenerateNewPathEqualsIgnoresSeed(): void
     {
         $builder = new MD5ThemePathBuilder();
 
-        static::assertEquals(
+        static::assertSame(
             $builder->generateNewPath('salesChannelId', 'themeId', 'foo'),
             $builder->generateNewPath('salesChannelId', 'themeId', 'bar')
         );

--- a/tests/unit/Storefront/Theme/Message/CompileThemeMessageTest.php
+++ b/tests/unit/Storefront/Theme/Message/CompileThemeMessageTest.php
@@ -21,9 +21,9 @@ class CompileThemeMessageTest extends TestCase
         $context = Context::createDefaultContext();
         $message = new CompileThemeMessage(TestDefaults::SALES_CHANNEL, $themeId, true, $context);
 
-        static::assertEquals($themeId, $message->getThemeId());
-        static::assertEquals(TestDefaults::SALES_CHANNEL, $message->getSalesChannelId());
+        static::assertSame($themeId, $message->getThemeId());
+        static::assertSame(TestDefaults::SALES_CHANNEL, $message->getSalesChannelId());
         static::assertTrue($message->isWithAssets());
-        static::assertEquals($context, $message->getContext());
+        static::assertSame($context, $message->getContext());
     }
 }

--- a/tests/unit/Storefront/Theme/Message/DeleteThemeFilesMessageTest.php
+++ b/tests/unit/Storefront/Theme/Message/DeleteThemeFilesMessageTest.php
@@ -18,8 +18,8 @@ class DeleteThemeFilesMessageTest extends TestCase
     {
         $message = new DeleteThemeFilesMessage('path', 'salesChannel', 'theme');
 
-        static::assertEquals('path', $message->getThemePath());
-        static::assertEquals('salesChannel', $message->getSalesChannelId());
-        static::assertEquals('theme', $message->getThemeId());
+        static::assertSame('path', $message->getThemePath());
+        static::assertSame('salesChannel', $message->getSalesChannelId());
+        static::assertSame('theme', $message->getThemeId());
     }
 }

--- a/tests/unit/Storefront/Theme/ScssPhpCompilerTest.php
+++ b/tests/unit/Storefront/Theme/ScssPhpCompilerTest.php
@@ -23,7 +23,7 @@ class ScssPhpCompilerTest extends TestCase
             '$background: #123456; background-color: $background;'
         );
 
-        static::assertEquals('background-color: #123456; ', preg_replace('/\r?\n$/', ' ', $compiled), $compiled);
+        static::assertSame('background-color: #123456; ', preg_replace('/\r?\n$/', ' ', $compiled), $compiled);
     }
 
     public function testCompilesWithConfig(): void
@@ -40,6 +40,6 @@ class ScssPhpCompilerTest extends TestCase
             '$background: #123456; background-color: $background;'
         );
 
-        static::assertEquals('background-color:#123456', preg_replace('/\r?\n$/', ' ', $compiled), $compiled);
+        static::assertSame('background-color:#123456', preg_replace('/\r?\n$/', ' ', $compiled), $compiled);
     }
 }

--- a/tests/unit/Storefront/Theme/SeedingThemePathBuilderTest.php
+++ b/tests/unit/Storefront/Theme/SeedingThemePathBuilderTest.php
@@ -20,7 +20,7 @@ class SeedingThemePathBuilderTest extends TestCase
 
         $path = $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'theme');
 
-        static::assertEquals($path, $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'theme'));
+        static::assertSame($path, $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'theme'));
     }
 
     public function testAssembledPathAfterSavingIsTheSameAsPreviouslyGenerated(): void
@@ -30,11 +30,11 @@ class SeedingThemePathBuilderTest extends TestCase
         $generatedPath = $pathBuilder->generateNewPath(TestDefaults::SALES_CHANNEL, 'theme', 'foo');
 
         // assert seeding is taking into account when generating a new path
-        static::assertNotEquals($generatedPath, $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'theme'));
+        static::assertNotSame($generatedPath, $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'theme'));
 
         $pathBuilder->saveSeed(TestDefaults::SALES_CHANNEL, 'theme', 'foo');
 
         // assert that the path is the same after saving
-        static::assertEquals($generatedPath, $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'theme'));
+        static::assertSame($generatedPath, $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'theme'));
     }
 }

--- a/tests/unit/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationTest.php
+++ b/tests/unit/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationTest.php
@@ -15,6 +15,6 @@ class StorefrontPluginConfigurationTest extends TestCase
     public function testAssetName(): void
     {
         $config = new StorefrontPluginConfiguration('SwagPayPal');
-        static::assertEquals('swag-pay-pal', $config->getAssetName());
+        static::assertSame('swag-pay-pal', $config->getAssetName());
     }
 }

--- a/tests/unit/Storefront/Theme/StorefrontPluginConfigurationFactoryTest.php
+++ b/tests/unit/Storefront/Theme/StorefrontPluginConfigurationFactoryTest.php
@@ -40,8 +40,8 @@ class StorefrontPluginConfigurationFactoryTest extends TestCase
 
         $config = $configurationFactory->createFromBundle($themePluginBundle);
 
-        static::assertEquals('TestTheme', $config->getName());
-        static::assertEquals(
+        static::assertSame('TestTheme', $config->getName());
+        static::assertSame(
             [
                 'name' => 'TestTheme',
                 'author' => 'Shopware AG',

--- a/tests/unit/Storefront/Theme/StorefrontPluginConfigurationTest.php
+++ b/tests/unit/Storefront/Theme/StorefrontPluginConfigurationTest.php
@@ -23,6 +23,6 @@ class StorefrontPluginConfigurationTest extends TestCase
     {
         $config = new StorefrontPluginConfiguration('name');
 
-        static::assertEquals('name', $config->getTechnicalName());
+        static::assertSame('name', $config->getTechnicalName());
     }
 }

--- a/tests/unit/Storefront/Theme/Subscriber/PluginLifecycleSubscriberTest.php
+++ b/tests/unit/Storefront/Theme/Subscriber/PluginLifecycleSubscriberTest.php
@@ -43,7 +43,7 @@ class PluginLifecycleSubscriberTest extends TestCase
 
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 PluginPostActivateEvent::class => 'pluginPostActivate',
                 PluginPreUpdateEvent::class => 'pluginUpdate',

--- a/tests/unit/Storefront/Theme/Subscriber/ThemeCompilerEnrichScssVarSubscriberTest.php
+++ b/tests/unit/Storefront/Theme/Subscriber/ThemeCompilerEnrichScssVarSubscriberTest.php
@@ -138,7 +138,7 @@ class ThemeCompilerEnrichScssVarSubscriberTest extends TestCase
 
     public function testgetSubscribedEventsReturnsOnlyOneTypeOfEvent(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 ThemeCompilerEnrichScssVariablesEvent::class => 'enrichExtensionVars',
             ],

--- a/tests/unit/Storefront/Theme/Subscriber/UnusedMediaSubscriberTest.php
+++ b/tests/unit/Storefront/Theme/Subscriber/UnusedMediaSubscriberTest.php
@@ -22,7 +22,7 @@ class UnusedMediaSubscriberTest extends TestCase
 {
     public function testSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 UnusedMediaSearchEvent::class => 'removeUsedMedia',
             ],
@@ -76,6 +76,6 @@ class UnusedMediaSubscriberTest extends TestCase
         $listener = new UnusedMediaSubscriber($themeRepository, $themeService);
         $listener->removeUsedMedia($event);
 
-        static::assertEquals([$mediaId4, $mediaId5], $event->getUnusedIds());
+        static::assertSame([$mediaId4, $mediaId5], $event->getUnusedIds());
     }
 }

--- a/tests/unit/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/unit/Storefront/Theme/ThemeCompilerTest.php
@@ -446,7 +446,7 @@ PHP_EOL,
 
         $expected = $styles . MockThemeCompilerConcatenatedSubscriber::STYLES_CONCAT;
 
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testCompileWithoutAssets(): void
@@ -462,7 +462,7 @@ PHP_EOL,
         $config->setAssetPaths(['bla']);
 
         $pathBuilder = new MD5ThemePathBuilder();
-        static::assertEquals('9a11a759d278b4a55cb5e2c3414733c1', $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'test'));
+        static::assertSame('9a11a759d278b4a55cb5e2c3414733c1', $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'test'));
 
         try {
             $pathBuilder->getDecorated();
@@ -512,7 +512,7 @@ PHP_EOL,
         $compiler = $this->getThemeCompiler();
 
         $pathBuilder = new MD5ThemePathBuilder();
-        static::assertEquals('9a11a759d278b4a55cb5e2c3414733c1', $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'test'));
+        static::assertSame('9a11a759d278b4a55cb5e2c3414733c1', $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'test'));
 
         try {
             $pathBuilder->getDecorated();
@@ -551,7 +551,7 @@ PHP_EOL,
         $config->setAssetPaths(['assets']);
 
         $pathBuilder = new MD5ThemePathBuilder();
-        static::assertEquals('9a11a759d278b4a55cb5e2c3414733c1', $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'test'));
+        static::assertSame('9a11a759d278b4a55cb5e2c3414733c1', $pathBuilder->assemblePath(TestDefaults::SALES_CHANNEL, 'test'));
 
         $wasThrown = false;
 

--- a/tests/unit/Storefront/Theme/ThemeFileResolverTest.php
+++ b/tests/unit/Storefront/Theme/ThemeFileResolverTest.php
@@ -167,7 +167,7 @@ class ThemeFileResolverTest extends TestCase
         $actual = $scriptFiles->getFilepaths();
         $expected = array_unique($scriptFiles->getFilepaths());
 
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testParentThemeIncludesPlugins(): void

--- a/tests/unit/Storefront/Theme/ThemeFilesystemResolverTest.php
+++ b/tests/unit/Storefront/Theme/ThemeFilesystemResolverTest.php
@@ -38,7 +38,7 @@ class ThemeFilesystemResolverTest extends TestCase
         $pluginConfig = new StorefrontPluginConfiguration('Storefront');
         $fs = $resolver->getFilesystemForStorefrontConfig($pluginConfig);
 
-        static::assertEquals($bundle->getPath(), $fs->location);
+        static::assertSame($bundle->getPath(), $fs->location);
     }
 
     public function testGetFilesystemDelegatesToAppSourceResolverForApps(): void
@@ -54,7 +54,7 @@ class ThemeFilesystemResolverTest extends TestCase
 
         $fs = $resolver->getFilesystemForStorefrontConfig($pluginConfig);
 
-        static::assertEquals('/app-root', $fs->location);
+        static::assertSame('/app-root', $fs->location);
     }
 
     public function testGetFilesystemForPluginUsesBundleBasePath(): void
@@ -79,6 +79,6 @@ class ThemeFilesystemResolverTest extends TestCase
 
         $fs = $resolver->getFilesystemForStorefrontConfig($pluginConfig);
 
-        static::assertEquals('/some/project/custom/plugins/CoolPlugin', $fs->location);
+        static::assertSame('/some/project/custom/plugins/CoolPlugin', $fs->location);
     }
 }

--- a/tests/unit/Storefront/Theme/ThemeScriptsTest.php
+++ b/tests/unit/Storefront/Theme/ThemeScriptsTest.php
@@ -38,7 +38,7 @@ class ThemeScriptsTest extends TestCase
             $this->createMock(AbstractConfigLoader::class)
         );
 
-        static::assertEquals([], $themeScripts->getThemeScripts());
+        static::assertSame([], $themeScripts->getThemeScripts());
     }
 
     public function testGetThemeScriptsWhenAdminRequest(): void
@@ -55,7 +55,7 @@ class ThemeScriptsTest extends TestCase
             $this->createMock(AbstractConfigLoader::class)
         );
 
-        static::assertEquals([], $themeScripts->getThemeScripts());
+        static::assertSame([], $themeScripts->getThemeScripts());
     }
 
     public function testNotExistingTheme(): void
@@ -77,7 +77,7 @@ class ThemeScriptsTest extends TestCase
             $this->createMock(AbstractConfigLoader::class)
         );
 
-        static::assertEquals([], $themeScripts->getThemeScripts());
+        static::assertSame([], $themeScripts->getThemeScripts());
     }
 
     public function testLoadPaths(): void
@@ -117,8 +117,8 @@ class ThemeScriptsTest extends TestCase
             $this->createMock(AbstractConfigLoader::class)
         );
 
-        static::assertEquals(['js/foo/foo.js'], $themeScripts->getThemeScripts());
-        static::assertEquals(['js/foo/foo.js'], $themeScripts->getThemeScripts());
+        static::assertSame(['js/foo/foo.js'], $themeScripts->getThemeScripts());
+        static::assertSame(['js/foo/foo.js'], $themeScripts->getThemeScripts());
     }
 
     public function testInheritsFromBase(): void
@@ -160,6 +160,6 @@ class ThemeScriptsTest extends TestCase
             $this->createMock(AbstractConfigLoader::class)
         );
 
-        static::assertEquals(['js/foo/foo.js'], $themeScripts->getThemeScripts());
+        static::assertSame(['js/foo/foo.js'], $themeScripts->getThemeScripts());
     }
 }

--- a/tests/unit/Storefront/Theme/Twig/ThemeNamespaceHierarchyBuilderTest.php
+++ b/tests/unit/Storefront/Theme/Twig/ThemeNamespaceHierarchyBuilderTest.php
@@ -40,7 +40,7 @@ class ThemeNamespaceHierarchyBuilderTest extends TestCase
     {
         $events = $this->builder->getSubscribedEvents();
 
-        static::assertEquals([
+        static::assertSame([
             KernelEvents::REQUEST,
             KernelEvents::EXCEPTION,
             DocumentTemplateRendererParameterEvent::class,
@@ -149,7 +149,7 @@ class ThemeNamespaceHierarchyBuilderTest extends TestCase
 
         $hierarchy = $this->builder->buildNamespaceHierarchy(['a', 'b']);
 
-        static::assertEquals($bundles, $hierarchy);
+        static::assertSame($bundles, $hierarchy);
     }
 
     public function testItPassesBundlesAndThemesToBuilder(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/9317

### 2. What does this change do, exactly?

Replace `assertEquals` with `assertSame`