### PR TITLE
chore: Replace assertEquals with assertSame in content unit tests

### DIFF
--- a/tests/unit/Core/Content/Category/DataAbstractionLayer/CategoryNonExistentExceptionHandlerTest.php
+++ b/tests/unit/Core/Content/Category/DataAbstractionLayer/CategoryNonExistentExceptionHandlerTest.php
@@ -21,7 +21,7 @@ class CategoryNonExistentExceptionHandlerTest extends TestCase
     {
         $handler = new CategoryNonExistentExceptionHandler();
 
-        static::assertEquals(ExceptionHandlerInterface::PRIORITY_DEFAULT, $handler->getPriority());
+        static::assertSame(ExceptionHandlerInterface::PRIORITY_DEFAULT, $handler->getPriority());
 
         $afterException = new ForeignKeyConstraintViolationException(
             Exception::new(new \PDOException('SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`shopware`.`category`, CONSTRAINT `fk.category.after_category_id` FOREIGN KEY (`after_category_id`, `after_category_version_id`) REFERENCES `category` (`id`, `version_id`) ON DELETE SET NULL O)')),
@@ -31,7 +31,7 @@ class CategoryNonExistentExceptionHandlerTest extends TestCase
         $matched = $handler->matchException($afterException);
 
         static::assertInstanceOf(CategoryException::class, $matched);
-        static::assertEquals('Category to insert after not found.', $matched->getMessage());
+        static::assertSame('Category to insert after not found.', $matched->getMessage());
 
         static::assertNull($handler->matchException(new \Exception('Some other exception')));
     }

--- a/tests/unit/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockCollectionTest.php
+++ b/tests/unit/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockCollectionTest.php
@@ -44,7 +44,7 @@ class CmsBlockCollectionTest extends TestCase
         /** @var CmsSlotEntity $lastSlot */
         $lastSlot = $collection->getSlots()->last();
 
-        static::assertEquals(['overwrite' => true], $lastSlot->getConfig());
+        static::assertSame(['overwrite' => true], $lastSlot->getConfig());
     }
 
     private function getBlock(): CmsBlockEntity

--- a/tests/unit/Core/Content/Cms/Aggregate/CmsSlot/CmsSlotCollectionTest.php
+++ b/tests/unit/Core/Content/Cms/Aggregate/CmsSlot/CmsSlotCollectionTest.php
@@ -28,10 +28,10 @@ class CmsSlotCollectionTest extends TestCase
         static::assertInstanceOf(CmsSlotEntity::class, $collection->getSlot('top'));
         static::assertInstanceOf(CmsSlotEntity::class, $collection->getSlot('bottom'));
 
-        static::assertEquals('left', $collection->getSlot('left')->getSlot());
-        static::assertEquals('right', $collection->getSlot('right')->getSlot());
-        static::assertEquals('top', $collection->getSlot('top')->getSlot());
-        static::assertEquals('bottom', $collection->getSlot('bottom')->getSlot());
+        static::assertSame('left', $collection->getSlot('left')->getSlot());
+        static::assertSame('right', $collection->getSlot('right')->getSlot());
+        static::assertSame('top', $collection->getSlot('top')->getSlot());
+        static::assertSame('bottom', $collection->getSlot('bottom')->getSlot());
     }
 
     public function testGetSlotAfterAdding(): void
@@ -46,14 +46,14 @@ class CmsSlotCollectionTest extends TestCase
         static::assertInstanceOf(CmsSlotEntity::class, $collection->getSlot('top'));
         static::assertInstanceOf(CmsSlotEntity::class, $collection->getSlot('bottom'));
 
-        static::assertEquals('top', $collection->getSlot('top')->getSlot());
-        static::assertEquals('bottom', $collection->getSlot('bottom')->getSlot());
+        static::assertSame('top', $collection->getSlot('top')->getSlot());
+        static::assertSame('bottom', $collection->getSlot('bottom')->getSlot());
         static::assertNull($collection->getSlot('left'));
 
         $collection->add($leftSlot);
 
         static::assertNotNull($collection->getSlot('left'));
-        static::assertEquals('left', $collection->getSlot('left')->getSlot());
+        static::assertSame('left', $collection->getSlot('left')->getSlot());
     }
 
     private function getSlot(string $slotName): CmsSlotEntity

--- a/tests/unit/Core/Content/Cms/Command/CreatePageCommandTest.php
+++ b/tests/unit/Core/Content/Cms/Command/CreatePageCommandTest.php
@@ -102,7 +102,7 @@ class CreatePageCommandTest extends TestCase
         static::assertSame('landing_page', $cmsPage['type']);
         static::assertCount(4, $cmsPage['blocks']);
 
-        static::assertEquals([[
+        static::assertSame([[
             ['id' => 'deleted-page-id-1'],
             ['id' => 'deleted-page-id-2'],
             ['id' => 'deleted-page-id-3'],

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
@@ -143,8 +143,8 @@ class CmsSlotsDataResolverTest extends TestCase
             ->willReturnCallback(function (Extension $extension) use ($slots, $resolverContext, $criteriaCollection) {
                 switch (true) {
                     case $extension instanceof CmsSlotsDataResolveExtension:
-                        static::assertEquals($slots, $extension->slots);
-                        static::assertEquals($resolverContext, $extension->resolverContext);
+                        static::assertSame($slots, $extension->slots);
+                        static::assertSame($resolverContext, $extension->resolverContext);
 
                         if ($extension->result) {
                             static::assertInstanceOf(CmsSlotCollection::class, $extension->result);
@@ -154,17 +154,17 @@ class CmsSlotsDataResolverTest extends TestCase
                         return $extension;
                     case $extension instanceof CmsSlotsDataCollectExtension:
                         static::assertCount(1, $extension->slots);
-                        static::assertEquals($resolverContext, $extension->resolverContext);
+                        static::assertSame($resolverContext, $extension->resolverContext);
 
                         if ($extension->result) {
-                            static::assertEquals(['slot-1' => $criteriaCollection], $extension->result);
+                            static::assertSame(['slot-1' => $criteriaCollection], $extension->result);
                         }
 
                         return $extension;
                     case $extension instanceof CmsSlotsDataEnrichExtension:
-                        static::assertEquals($slots, $extension->slots);
-                        static::assertEquals(['slot-1' => $criteriaCollection], $extension->criteriaList);
-                        static::assertEquals($resolverContext, $extension->resolverContext);
+                        static::assertSame($slots, $extension->slots);
+                        static::assertSame(['slot-1' => $criteriaCollection], $extension->criteriaList);
+                        static::assertSame($resolverContext, $extension->resolverContext);
 
                         if ($extension->result) {
                             static::assertInstanceOf(CmsSlotCollection::class, $extension->result);

--- a/tests/unit/Core/Content/Cms/DataResolver/Element/TextCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/Element/TextCmsElementResolverTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\TextStruct;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -292,7 +293,7 @@ class TextCmsElementResolverTest extends TestCase
         $actualReleaseDate = new \DateTime();
         $actualReleaseDate->setTimestamp((int) $formatter->parse($content));
 
-        static::assertEquals($releaseDate, $actualReleaseDate);
+        static::assertSame($releaseDate->format(Defaults::STORAGE_DATE_TIME_FORMAT), $actualReleaseDate->format(Defaults::STORAGE_DATE_TIME_FORMAT));
     }
 
     private function createSlot(): CmsSlotEntity

--- a/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
+++ b/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
@@ -21,7 +21,7 @@ class CmsVersionMergeSubscriberTest extends TestCase
             BeforeVersionMergeEvent::class => 'onBeforeVersionMerge',
         ];
 
-        static::assertEquals($expectedEvents, CmsVersionMergeSubscriber::getSubscribedEvents());
+        static::assertSame($expectedEvents, CmsVersionMergeSubscriber::getSubscribedEvents());
     }
 
     /**
@@ -45,7 +45,7 @@ class CmsVersionMergeSubscriberTest extends TestCase
 
         $subscriber->onBeforeVersionMerge($event);
 
-        static::assertEquals($expectedWrites, $event->writes);
+        static::assertSame($expectedWrites, $event->writes);
     }
 
     public static function versionMergeEventDataProvider(): \Generator

--- a/tests/unit/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php
+++ b/tests/unit/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php
@@ -17,7 +17,7 @@ class UnusedMediaSubscriberTest extends TestCase
 {
     public function testSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 UnusedMediaSearchEvent::class => 'removeUsedMedia',
             ],

--- a/tests/unit/Core/Content/ContactForm/Event/ContactFormEventTest.php
+++ b/tests/unit/Core/Content/ContactForm/Event/ContactFormEventTest.php
@@ -37,6 +37,6 @@ class ContactFormEventTest extends TestCase
         $storer->restore($flow);
 
         static::assertArrayHasKey('contactFormData', $flow->data());
-        static::assertEquals(['foo' => 'bar', 'bar' => 'baz'], $flow->data()['contactFormData']);
+        static::assertSame(['foo' => 'bar', 'bar' => 'baz'], $flow->data()['contactFormData']);
     }
 }

--- a/tests/unit/Core/Content/ContactForm/SalesChannel/ContactFormRouteTest.php
+++ b/tests/unit/Core/Content/ContactForm/SalesChannel/ContactFormRouteTest.php
@@ -71,8 +71,8 @@ class ContactFormRouteTest extends TestCase
         $mock = $this->createMock(DataValidator::class);
         $mock->method('validate')->willReturnCallback(function (array $data, DataValidationDefinition $definition) use ($properties, $constraints): void {
             foreach ($properties as $propertyName => $value) {
-                static::assertEquals($value, $data[$propertyName] ?? null);
-                static::assertEquals($definition->getProperties()[$propertyName] ?? null, $constraints);
+                static::assertSame($value, $data[$propertyName] ?? null);
+                static::assertSame($definition->getProperties()[$propertyName] ?? null, $constraints);
             }
         });
 

--- a/tests/unit/Core/Content/Flow/Controller/TriggerFlowControllerTest.php
+++ b/tests/unit/Core/Content/Flow/Controller/TriggerFlowControllerTest.php
@@ -108,9 +108,9 @@ class TriggerFlowControllerTest extends TestCase
         $context = Context::createDefaultContext();
 
         $response = $this->triggerFlowController->trigger('custom.checkout.event', $request, $context);
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertIsString($response->getContent());
-        static::assertEquals('The trigger `custom.checkout.event`successfully dispatched!', json_decode($response->getContent(), true)['message']);
+        static::assertSame('The trigger `custom.checkout.event`successfully dispatched!', json_decode($response->getContent(), true)['message']);
     }
 
     public function testTriggerWithValidAware(): void
@@ -119,8 +119,8 @@ class TriggerFlowControllerTest extends TestCase
         $context = Context::createDefaultContext();
 
         $response = $this->triggerFlowController->trigger('custom.checkout.event', $request, $context);
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertIsString($response->getContent());
-        static::assertEquals('The trigger `custom.checkout.event`successfully dispatched!', json_decode($response->getContent(), true)['message']);
+        static::assertSame('The trigger `custom.checkout.event`successfully dispatched!', json_decode($response->getContent(), true)['message']);
     }
 }

--- a/tests/unit/Core/Content/Flow/DataAbstractionLayer/FieldSerializer/FlowTemplateConfigFieldSerializerTest.php
+++ b/tests/unit/Core/Content/Flow/DataAbstractionLayer/FieldSerializer/FlowTemplateConfigFieldSerializerTest.php
@@ -79,9 +79,9 @@ class FlowTemplateConfigFieldSerializerTest extends TestCase
         static::assertArrayHasKey('displayGroup', $data['sequences'][0]);
         static::assertArrayHasKey('trueCase', $data['sequences'][0]);
 
-        static::assertEquals(1, $data['sequences'][0]['position']);
-        static::assertEquals(1, $data['sequences'][0]['displayGroup']);
-        static::assertEquals(0, $data['sequences'][0]['trueCase']);
+        static::assertSame(1, $data['sequences'][0]['position']);
+        static::assertSame(1, $data['sequences'][0]['displayGroup']);
+        static::assertSame(0, $data['sequences'][0]['trueCase']);
     }
 
     public function testFieldArgumentNotInstanceOfFlowTemplateConfigField(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessActionTest.php
@@ -52,12 +52,12 @@ class GrantDownloadAccessActionTest extends TestCase
 
     public function testGetName(): void
     {
-        static::assertEquals('action.grant.download.access', $this->action->getName());
+        static::assertSame('action.grant.download.access', $this->action->getName());
     }
 
     public function testGetRequirements(): void
     {
-        static::assertEquals([OrderAware::class], $this->action->requirements());
+        static::assertSame([OrderAware::class], $this->action->requirements());
     }
 
     /**
@@ -75,7 +75,7 @@ class GrantDownloadAccessActionTest extends TestCase
 
         $this->action->handleFlow($flow);
 
-        static::assertEquals($expectedPayload, $this->updatePayload);
+        static::assertSame($expectedPayload, $this->updatePayload);
     }
 
     public static function orderProvider(): \Generator

--- a/tests/unit/Core/Content/Flow/Dispatching/BufferedFlowExecutionTriggersListenerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/BufferedFlowExecutionTriggersListenerTest.php
@@ -42,7 +42,7 @@ class BufferedFlowExecutionTriggersListenerTest extends TestCase
     public function testRegistersBufferedFlowExecutionTriggers(): void
     {
         if (Feature::isActive('FLOW_EXECUTION_AFTER_BUSINESS_PROCESS')) {
-            static::assertEquals(
+            static::assertSame(
                 [
                     'kernel.terminate' => 'triggerBufferedFlowExecution',
                     'Symfony\Component\Messenger\Event\WorkerMessageHandledEvent' => 'triggerBufferedFlowExecution',

--- a/tests/unit/Core/Content/Flow/Dispatching/FlowExecutorTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/FlowExecutorTest.php
@@ -494,7 +494,7 @@ class FlowExecutorTest extends TestCase
 
         $this->flowExecutor->executeIf($ifSequence, $flow);
 
-        static::assertEquals($trueCaseSequence, $flow->getFlowState()->currentSequence);
+        static::assertSame($trueCaseSequence, $flow->getFlowState()->currentSequence);
     }
 
     public function testActionExecutedInTransactionWhenItImplementsTransactional(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/FlowFactoryTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/FlowFactoryTest.php
@@ -38,9 +38,9 @@ class FlowFactoryTest extends TestCase
         $flowFactory = new FlowFactory([$orderStorer]);
         $flow = $flowFactory->create($awareEvent);
 
-        static::assertEquals($ids->get('orderId'), $flow->getStore('orderId'));
+        static::assertSame($ids->get('orderId'), $flow->getStore('orderId'));
         static::assertInstanceOf(SystemSource::class, $flow->getContext()->getSource());
-        static::assertEquals(Context::SYSTEM_SCOPE, $flow->getContext()->getScope());
+        static::assertSame(Context::SYSTEM_SCOPE, $flow->getContext()->getScope());
     }
 
     public function testRestore(): void
@@ -73,9 +73,9 @@ class FlowFactoryTest extends TestCase
         $flow = $flowFactory->restore('checkout.order.placed', $awareEvent->getContext(), $storedData);
 
         static::assertInstanceOf(OrderEntity::class, $flow->getData('order'));
-        static::assertEquals($ids->get('orderId'), $flow->getData('order')->getId());
+        static::assertSame($ids->get('orderId'), $flow->getData('order')->getId());
 
         static::assertInstanceOf(SystemSource::class, $flow->getContext()->getSource());
-        static::assertEquals(Context::SYSTEM_SCOPE, $flow->getContext()->getScope());
+        static::assertSame(Context::SYSTEM_SCOPE, $flow->getContext()->getScope());
     }
 }

--- a/tests/unit/Core/Content/Flow/Dispatching/StorableFlowTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/StorableFlowTest.php
@@ -27,7 +27,7 @@ class StorableFlowTest extends TestCase
 
     public function testGetName(): void
     {
-        static::assertEquals('checkout.order.place', $this->storableFlow->getName());
+        static::assertSame('checkout.order.place', $this->storableFlow->getName());
     }
 
     public function testGetContext(): void
@@ -37,7 +37,7 @@ class StorableFlowTest extends TestCase
 
     public function testGetConfig(): void
     {
-        static::assertEquals(['config' => 'value'], $this->storableFlow->getConfig());
+        static::assertSame(['config' => 'value'], $this->storableFlow->getConfig());
     }
 
     public function testGetFlowState(): void
@@ -47,7 +47,7 @@ class StorableFlowTest extends TestCase
 
         $this->storableFlow->setFlowState(new FlowState());
 
-        static::assertEquals(new FlowState(), $this->storableFlow->getFlowState());
+        static::assertSame(new FlowState(), $this->storableFlow->getFlowState());
     }
 
     public function testStop(): void
@@ -62,29 +62,29 @@ class StorableFlowTest extends TestCase
 
     public function testStored(): void
     {
-        static::assertEquals([], $this->storableFlow->stored());
+        static::assertSame([], $this->storableFlow->stored());
         static::assertNull($this->storableFlow->getStore('id'));
 
         $this->storableFlow->setStore('id', '123345');
 
-        static::assertEquals(['id' => '123345'], $this->storableFlow->stored());
-        static::assertEquals('123345', $this->storableFlow->getStore('id'));
+        static::assertSame(['id' => '123345'], $this->storableFlow->stored());
+        static::assertSame('123345', $this->storableFlow->getStore('id'));
     }
 
     public function testData(): void
     {
-        static::assertEquals([], $this->storableFlow->data());
+        static::assertSame([], $this->storableFlow->data());
         static::assertNull($this->storableFlow->getData('id'));
 
         $this->storableFlow->setData('id', '123345');
 
-        static::assertEquals(['id' => '123345'], $this->storableFlow->data());
-        static::assertEquals('123345', $this->storableFlow->getData('id'));
+        static::assertSame(['id' => '123345'], $this->storableFlow->data());
+        static::assertSame('123345', $this->storableFlow->getData('id'));
 
         $callback = fn () => 'Data';
 
         $this->storableFlow->setData('data', $callback);
-        static::assertEquals('Data', $this->storableFlow->getData('data'));
+        static::assertSame('Data', $this->storableFlow->getData('data'));
     }
 
     public function testLazy(): void
@@ -93,6 +93,6 @@ class StorableFlowTest extends TestCase
 
         $this->storableFlow->lazy('order', $callback);
 
-        static::assertEquals('Order Data', $this->storableFlow->getData('order'));
+        static::assertSame('Order Data', $this->storableFlow->getData('order'));
     }
 }

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorerTest.php
@@ -120,9 +120,9 @@ class A11yRenderedDocumentStorerTest extends TestCase
         static::assertArrayHasKey('documentId', $res[0]);
         static::assertArrayHasKey('deepLinkCode', $res[0]);
         static::assertArrayHasKey('fileExtension', $res[0]);
-        static::assertEquals('id', $res[0]['documentId']);
-        static::assertEquals('code1', $res[0]['deepLinkCode']);
-        static::assertEquals('html', $res[0]['fileExtension']);
+        static::assertSame('id', $res[0]['documentId']);
+        static::assertSame('code1', $res[0]['deepLinkCode']);
+        static::assertSame('html', $res[0]['fileExtension']);
     }
 
     public function testLazyLoadNoEntity(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorerTest.php
@@ -82,7 +82,7 @@ class CustomerGroupStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $customerGroup = $storable->getData('customerGroup');
 
-        static::assertEquals($customerGroup, $entity);
+        static::assertSame($customerGroup, $entity);
     }
 
     public function testLazyLoadNullEntity(): void
@@ -96,7 +96,7 @@ class CustomerGroupStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $customerGroup = $storable->getData('customerGroup');
 
-        static::assertEquals($customerGroup, $entity);
+        static::assertSame($customerGroup, $entity);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorerTest.php
@@ -83,7 +83,7 @@ class CustomerRecoveryStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('customerRecovery');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullEntity(): void
@@ -97,7 +97,7 @@ class CustomerRecoveryStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('customerRecovery');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerStorerTest.php
@@ -95,7 +95,7 @@ class CustomerStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('customer');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullEntity(): void
@@ -109,7 +109,7 @@ class CustomerStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('customer');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/MailStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/MailStorerTest.php
@@ -69,9 +69,9 @@ class MailStorerTest extends TestCase
 
         static::assertInstanceOf(MailRecipientStruct::class, $flow->getData(MailAware::MAIL_STRUCT));
 
-        static::assertEquals('test', $flow->getData(MailAware::MAIL_STRUCT)->getRecipients()['firstName']);
-        static::assertEquals('bcc', $flow->getData(MailAware::MAIL_STRUCT)->getBcc());
-        static::assertEquals('cc', $flow->getData(MailAware::MAIL_STRUCT)->getCc());
+        static::assertSame('test', $flow->getData(MailAware::MAIL_STRUCT)->getRecipients()['firstName']);
+        static::assertSame('bcc', $flow->getData(MailAware::MAIL_STRUCT)->getBcc());
+        static::assertSame('cc', $flow->getData(MailAware::MAIL_STRUCT)->getCc());
     }
 
     public function testRestoreHasDataOrder(): void
@@ -92,7 +92,7 @@ class MailStorerTest extends TestCase
         static::assertTrue($flow->hasData(MailAware::MAIL_STRUCT));
 
         static::assertInstanceOf(MailRecipientStruct::class, $flow->getData(MailAware::MAIL_STRUCT));
-        static::assertEquals('barfoo', $flow->getData(MailAware::MAIL_STRUCT)->getRecipients()['foo@bar.com']);
+        static::assertSame('barfoo', $flow->getData(MailAware::MAIL_STRUCT)->getRecipients()['foo@bar.com']);
         static::assertNull($flow->getData(MailAware::MAIL_STRUCT)->getBcc());
         static::assertNull($flow->getData(MailAware::MAIL_STRUCT)->getCc());
     }
@@ -114,7 +114,7 @@ class MailStorerTest extends TestCase
         static::assertTrue($flow->hasData(MailAware::MAIL_STRUCT));
 
         static::assertInstanceOf(MailRecipientStruct::class, $flow->getData(MailAware::MAIL_STRUCT));
-        static::assertEquals('barfoo', $flow->getData(MailAware::MAIL_STRUCT)->getRecipients()['foo@bar.com']);
+        static::assertSame('barfoo', $flow->getData(MailAware::MAIL_STRUCT)->getRecipients()['foo@bar.com']);
         static::assertNull($flow->getData(MailAware::MAIL_STRUCT)->getBcc());
         static::assertNull($flow->getData(MailAware::MAIL_STRUCT)->getCc());
     }

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorerTest.php
@@ -82,7 +82,7 @@ class NewsletterRecipientStorerTest extends TestCase
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('newsletterRecipient');
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullEntity(): void
@@ -96,7 +96,7 @@ class NewsletterRecipientStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('newsletterRecipient');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderStorerTest.php
@@ -83,7 +83,7 @@ class OrderStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('order');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullEntity(): void
@@ -97,7 +97,7 @@ class OrderStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('order');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorerTest.php
@@ -83,7 +83,7 @@ class OrderTransactionStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('orderTransaction');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullEntity(): void
@@ -97,7 +97,7 @@ class OrderTransactionStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('orderTransaction');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/ProductStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/ProductStorerTest.php
@@ -85,7 +85,7 @@ class ProductStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('product');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullEntity(): void
@@ -99,7 +99,7 @@ class ProductStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('product');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/UserStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/UserStorerTest.php
@@ -83,7 +83,7 @@ class UserStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('userRecovery');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullEntity(): void
@@ -97,7 +97,7 @@ class UserStorerTest extends TestCase
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('userRecovery');
 
-        static::assertEquals($res, $entity);
+        static::assertSame($res, $entity);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Exception/CustomTriggerByNameNotFoundExceptionTest.php
+++ b/tests/unit/Core/Content/Flow/Exception/CustomTriggerByNameNotFoundExceptionTest.php
@@ -18,8 +18,8 @@ class CustomTriggerByNameNotFoundExceptionTest extends TestCase
     public function testException(): void
     {
         $exception = new CustomTriggerByNameNotFoundException('event_name_test');
-        static::assertEquals('The provided event name event_name_test is invalid or uninstalled and no custom trigger could be found.', $exception->getMessage());
-        static::assertEquals('ADMINISTRATION__CUSTOM_TRIGGER_BY_NAME_NOT_FOUND', $exception->getErrorCode());
-        static::assertEquals(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame('The provided event name event_name_test is invalid or uninstalled and no custom trigger could be found.', $exception->getMessage());
+        static::assertSame('ADMINISTRATION__CUSTOM_TRIGGER_BY_NAME_NOT_FOUND', $exception->getErrorCode());
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
     }
 }

--- a/tests/unit/Core/Content/Flow/FlowExceptionTest.php
+++ b/tests/unit/Core/Content/Flow/FlowExceptionTest.php
@@ -25,9 +25,9 @@ class FlowExceptionTest extends TestCase
     {
         $e = FlowException::customTriggerByNameNotFound('myEvent');
 
-        static::assertEquals(Response::HTTP_NOT_FOUND, $e->getStatusCode());
-        static::assertEquals(FlowException::CUSTOM_TRIGGER_BY_NAME_NOT_FOUND, $e->getErrorCode());
-        static::assertEquals('The provided event name myEvent is invalid or uninstalled and no custom trigger could be found.', $e->getMessage());
+        static::assertSame(Response::HTTP_NOT_FOUND, $e->getStatusCode());
+        static::assertSame(FlowException::CUSTOM_TRIGGER_BY_NAME_NOT_FOUND, $e->getErrorCode());
+        static::assertSame('The provided event name myEvent is invalid or uninstalled and no custom trigger could be found.', $e->getMessage());
     }
 
     #[DisabledFeatures(['v6.8.0.0'])]
@@ -36,18 +36,18 @@ class FlowExceptionTest extends TestCase
         $e = FlowException::customTriggerByNameNotFound('myEvent');
 
         static::assertInstanceOf(CustomTriggerByNameNotFoundException::class, $e);
-        static::assertEquals(Response::HTTP_NOT_FOUND, $e->getStatusCode());
-        static::assertEquals('ADMINISTRATION__CUSTOM_TRIGGER_BY_NAME_NOT_FOUND', $e->getErrorCode());
-        static::assertEquals('The provided event name myEvent is invalid or uninstalled and no custom trigger could be found.', $e->getMessage());
+        static::assertSame(Response::HTTP_NOT_FOUND, $e->getStatusCode());
+        static::assertSame('ADMINISTRATION__CUSTOM_TRIGGER_BY_NAME_NOT_FOUND', $e->getErrorCode());
+        static::assertSame('The provided event name myEvent is invalid or uninstalled and no custom trigger could be found.', $e->getMessage());
     }
 
     public function testMethodNotCompatible(): void
     {
         $e = FlowException::methodNotCompatible('myMethod', 'myClass');
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(FlowException::METHOD_NOT_COMPATIBLE, $e->getErrorCode());
-        static::assertEquals('Method myMethod is not compatible for myClass class', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(FlowException::METHOD_NOT_COMPATIBLE, $e->getErrorCode());
+        static::assertSame('Method myMethod is not compatible for myClass class', $e->getMessage());
     }
 
     /**
@@ -82,9 +82,9 @@ class FlowExceptionTest extends TestCase
     {
         $e = FlowException::transactionFailed($previous);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals($code, $e->getErrorCode());
-        static::assertEquals($message, $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame($code, $e->getErrorCode());
+        static::assertSame($message, $e->getMessage());
         static::assertSame($previous, $e->getPrevious());
     }
 }

--- a/tests/unit/Core/Content/Flow/Rule/OrderCreatedByAdminRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderCreatedByAdminRuleTest.php
@@ -34,7 +34,7 @@ class OrderCreatedByAdminRuleTest extends TestCase
 
     public function testGetName(): void
     {
-        static::assertEquals('orderCreatedByAdmin', $this->rule->getName());
+        static::assertSame('orderCreatedByAdmin', $this->rule->getName());
     }
 
     public function testRuleConfig(): void
@@ -83,7 +83,7 @@ class OrderCreatedByAdminRuleTest extends TestCase
         );
 
         $match = $rule->match($scope);
-        static::assertEquals($match, $isMatching);
+        static::assertSame($match, $isMatching);
     }
 
     public static function getCaseTestMatchValues(): \Generator

--- a/tests/unit/Core/Content/Flow/Rule/OrderDeliveryStatusRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderDeliveryStatusRuleTest.php
@@ -105,7 +105,7 @@ class OrderDeliveryStatusRuleTest extends TestCase
         static::assertArrayHasKey('operatorSet', $configData);
         $operators = RuleConfig::OPERATOR_SET_STRING;
 
-        static::assertEquals([
+        static::assertSame([
             'operators' => $operators,
             'isMatchAny' => true,
         ], $configData['operatorSet']);

--- a/tests/unit/Core/Content/Flow/Rule/OrderDocumentTypeRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderDocumentTypeRuleTest.php
@@ -110,7 +110,7 @@ class OrderDocumentTypeRuleTest extends TestCase
         $operators = RuleConfig::OPERATOR_SET_STRING;
         $operators[] = Rule::OPERATOR_EMPTY;
 
-        static::assertEquals([
+        static::assertSame([
             'operators' => $operators,
             'isMatchAny' => true,
         ], $configData['operatorSet']);

--- a/tests/unit/Core/Content/Flow/Rule/OrderDocumentTypeSentRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderDocumentTypeSentRuleTest.php
@@ -131,7 +131,7 @@ class OrderDocumentTypeSentRuleTest extends TestCase
         $operators = RuleConfig::OPERATOR_SET_STRING;
         $operators[] = Rule::OPERATOR_EMPTY;
 
-        static::assertEquals([
+        static::assertSame([
             'operators' => $operators,
             'isMatchAny' => true,
         ], $configData['operatorSet']);

--- a/tests/unit/Core/Content/Flow/Rule/OrderTagRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderTagRuleTest.php
@@ -37,7 +37,7 @@ class OrderTagRuleTest extends TestCase
 
     public function testGetName(): void
     {
-        static::assertEquals('orderTag', $this->rule->getName());
+        static::assertSame('orderTag', $this->rule->getName());
     }
 
     public function testRuleConfig(): void

--- a/tests/unit/Core/Content/Flow/Rule/OrderTransactionStatusRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderTransactionStatusRuleTest.php
@@ -94,7 +94,7 @@ class OrderTransactionStatusRuleTest extends TestCase
         static::assertArrayHasKey('operatorSet', $configData);
         $operators = RuleConfig::OPERATOR_SET_STRING;
 
-        static::assertEquals([
+        static::assertSame([
             'operators' => $operators,
             'isMatchAny' => true,
         ], $configData['operatorSet']);

--- a/tests/unit/Core/Content/Flow/TransactionFailedExceptionTest.php
+++ b/tests/unit/Core/Content/Flow/TransactionFailedExceptionTest.php
@@ -20,9 +20,9 @@ class TransactionFailedExceptionTest extends TestCase
         $previous = new \Exception('broken');
         $e = TransactionFailedException::because($previous);
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(TransactionFailedException::TRANSACTION_FAILED, $e->getErrorCode());
-        static::assertEquals('Transaction failed because an exception occurred. Exception: broken', $e->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(TransactionFailedException::TRANSACTION_FAILED, $e->getErrorCode());
+        static::assertSame('Transaction failed because an exception occurred. Exception: broken', $e->getMessage());
         static::assertSame($previous, $e->getPrevious());
     }
 }

--- a/tests/unit/Core/Content/ImportExport/Service/DownloadServiceTest.php
+++ b/tests/unit/Core/Content/ImportExport/Service/DownloadServiceTest.php
@@ -63,7 +63,7 @@ class DownloadServiceTest extends TestCase
         $downloadService = new DownloadService($fileSystem, $fileRepository);
         $response = $downloadService->createFileResponse(Context::createDefaultContext(), $fileId, $accessToken);
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertIsString($header = $response->headers->get('Content-Disposition'));
         static::assertStringContainsString($expectOutputFilename, $header);
     }

--- a/tests/unit/Core/Content/ImportExport/Service/SupportedFeaturesServiceTest.php
+++ b/tests/unit/Core/Content/ImportExport/Service/SupportedFeaturesServiceTest.php
@@ -162,7 +162,7 @@ class SupportedFeaturesServiceTest extends TestCase
 
         $supportedFeaturesService = new SupportedFeaturesService($entities, []);
 
-        static::assertEquals($entities, $supportedFeaturesService->getEntities());
+        static::assertSame($entities, $supportedFeaturesService->getEntities());
     }
 
     public function testGetFileTypes(): void
@@ -171,7 +171,7 @@ class SupportedFeaturesServiceTest extends TestCase
 
         $supportedFeaturesService = new SupportedFeaturesService([], $fileTypes);
 
-        static::assertEquals($fileTypes, $supportedFeaturesService->getFileTypes());
+        static::assertSame($fileTypes, $supportedFeaturesService->getFileTypes());
     }
 
     public function testGetUploadFileSizeLimit(): void
@@ -183,7 +183,7 @@ class SupportedFeaturesServiceTest extends TestCase
 
         $supportedFeaturesService = new SupportedFeaturesService([], []);
 
-        static::assertEquals(2 * 1024 * 1024 * 1024, $supportedFeaturesService->getUploadFileSizeLimit());
+        static::assertSame(2 * 1024 * 1024 * 1024, $supportedFeaturesService->getUploadFileSizeLimit());
 
         IniMock::withIniMock([]);
     }

--- a/tests/unit/Core/Content/ImportExport/Strategy/Import/BatchImportStrategyTest.php
+++ b/tests/unit/Core/Content/ImportExport/Strategy/Import/BatchImportStrategyTest.php
@@ -41,8 +41,8 @@ class BatchImportStrategyTest extends ImportStrategyTestCase
 
         $result = $this->strategy->import(['some' => 'data'], [], $config, $progress, $context);
 
-        static::assertEquals([], $result->results);
-        static::assertEquals([], $result->failedRecords);
+        static::assertSame([], $result->results);
+        static::assertSame([], $result->failedRecords);
     }
 
     #[DataProvider('importProvider')]
@@ -63,9 +63,9 @@ class BatchImportStrategyTest extends ImportStrategyTestCase
 
         $result = $this->strategy->commit($config, $progress, $context);
 
-        static::assertEquals([$writeResult], $result->results);
-        static::assertEquals([], $result->failedRecords);
-        static::assertEquals(2, $progress->getProcessedRecords());
+        static::assertSame([$writeResult], $result->results);
+        static::assertSame([], $result->failedRecords);
+        static::assertSame(2, $progress->getProcessedRecords());
     }
 
     public function testFailedCommit(): void
@@ -107,8 +107,8 @@ class BatchImportStrategyTest extends ImportStrategyTestCase
 
         $result = $this->strategy->commit($config, $progress, $context);
 
-        static::assertEquals([$writeResult], $result->results);
-        static::assertEquals([
+        static::assertSame([$writeResult], $result->results);
+        static::assertSame([
             ['some' => 'data', '_error' => 'Error'],
         ], $result->failedRecords);
     }

--- a/tests/unit/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategyTest.php
+++ b/tests/unit/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategyTest.php
@@ -46,9 +46,9 @@ class OneByOneImportStrategyTest extends ImportStrategyTestCase
 
         $result = $this->strategy->import($record, [], $config, $progress, Context::createDefaultContext());
 
-        static::assertEquals([$writeResult], $result->results);
-        static::assertEquals([], $result->failedRecords);
-        static::assertEquals(1, $progress->getProcessedRecords());
+        static::assertSame([$writeResult], $result->results);
+        static::assertSame([], $result->failedRecords);
+        static::assertSame(1, $progress->getProcessedRecords());
     }
 
     public function testFailedImport(): void
@@ -85,8 +85,8 @@ class OneByOneImportStrategyTest extends ImportStrategyTestCase
 
         $result = $this->strategy->import($record, [], $config, $progress, Context::createDefaultContext());
 
-        static::assertEquals([], $result->results);
-        static::assertEquals([
+        static::assertSame([], $result->results);
+        static::assertSame([
             ['some' => 'data', '_error' => 'Error'],
         ], $result->failedRecords);
     }
@@ -98,7 +98,7 @@ class OneByOneImportStrategyTest extends ImportStrategyTestCase
 
         $result = $this->strategy->commit($config, $progress, Context::createDefaultContext());
 
-        static::assertEquals([], $result->results);
-        static::assertEquals([], $result->failedRecords);
+        static::assertSame([], $result->results);
+        static::assertSame([], $result->failedRecords);
     }
 }

--- a/tests/unit/Core/Content/Mail/Service/MailAttachmentsBuilderTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailAttachmentsBuilderTest.php
@@ -91,7 +91,7 @@ class MailAttachmentsBuilderTest extends TestCase
 
         $attachments = $this->attachmentsBuilder->buildAttachments($context, $mailTemplate, $extension, [], Uuid::randomHex());
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     'content' => 'foo',

--- a/tests/unit/Core/Content/Mail/Service/MailAttachmentsConfigTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailAttachmentsConfigTest.php
@@ -32,11 +32,11 @@ class MailAttachmentsConfigTest extends TestCase
             $orderId
         );
 
-        static::assertEquals($context, $attachmentsConfig->getContext());
-        static::assertEquals($mailTemplate, $attachmentsConfig->getMailTemplate());
-        static::assertEquals($extension, $attachmentsConfig->getExtension());
-        static::assertEquals($evenConfig, $attachmentsConfig->getEventConfig());
-        static::assertEquals($orderId, $attachmentsConfig->getOrderId());
+        static::assertSame($context, $attachmentsConfig->getContext());
+        static::assertSame($mailTemplate, $attachmentsConfig->getMailTemplate());
+        static::assertSame($extension, $attachmentsConfig->getExtension());
+        static::assertSame($evenConfig, $attachmentsConfig->getEventConfig());
+        static::assertSame($orderId, $attachmentsConfig->getOrderId());
 
         $attachmentsConfig = $this->getMockBuilder(MailAttachmentsConfig::class)
             ->disableOriginalConstructor()
@@ -49,10 +49,10 @@ class MailAttachmentsConfigTest extends TestCase
         $attachmentsConfig->setEventConfig($evenConfig);
         $attachmentsConfig->setOrderId($orderId);
 
-        static::assertEquals($context, $attachmentsConfig->getContext());
-        static::assertEquals($mailTemplate, $attachmentsConfig->getMailTemplate());
-        static::assertEquals($extension, $attachmentsConfig->getExtension());
-        static::assertEquals($evenConfig, $attachmentsConfig->getEventConfig());
-        static::assertEquals($orderId, $attachmentsConfig->getOrderId());
+        static::assertSame($context, $attachmentsConfig->getContext());
+        static::assertSame($mailTemplate, $attachmentsConfig->getMailTemplate());
+        static::assertSame($extension, $attachmentsConfig->getExtension());
+        static::assertSame($evenConfig, $attachmentsConfig->getEventConfig());
+        static::assertSame($orderId, $attachmentsConfig->getOrderId());
     }
 }

--- a/tests/unit/Core/Content/Mail/Service/MailFactoryTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailFactoryTest.php
@@ -65,7 +65,7 @@ class MailFactoryTest extends TestCase
 
         static::assertCount(1, $mail->getAttachments());
 
-        static::assertEquals($attachments, $mail->getAttachmentUrls());
+        static::assertSame($attachments, $mail->getAttachmentUrls());
 
         static::assertSame('ccMailRecipient@example.com', $mail->getCc()[0]->getAddress());
 

--- a/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
@@ -199,7 +199,7 @@ class MailServiceTest extends TestCase
         static::assertNull($email);
         static::assertNotNull($beforeValidateEvent);
         static::assertInstanceOf(MailErrorEvent::class, $mailErrorEvent);
-        static::assertEquals(Level::Warning, $mailErrorEvent->getLogLevel());
+        static::assertSame(Level::Warning, $mailErrorEvent->getLogLevel());
         static::assertNotNull($mailErrorEvent->getMessage());
 
         $message = 'Could not render Mail-Subject with error message: cannot render';
@@ -325,7 +325,7 @@ class MailServiceTest extends TestCase
         static::assertNull($email);
         static::assertNotNull($beforeValidateEvent);
         static::assertInstanceOf(MailErrorEvent::class, $mailErrorEvent);
-        static::assertEquals(Level::Error, $mailErrorEvent->getLogLevel());
+        static::assertSame(Level::Error, $mailErrorEvent->getLogLevel());
         static::assertNotNull($mailErrorEvent->getMessage());
         static::assertSame('Could not send mail with error message: Mail sending failed', $mailErrorEvent->getMessage());
         static::assertSame('Content html', $mailErrorEvent->getTemplate());

--- a/tests/unit/Core/Content/Mail/Service/MailTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailTest.php
@@ -22,7 +22,7 @@ class MailTest extends TestCase
         $mail = new Mail();
         $mail->addAttachmentUrl('foobar');
 
-        static::assertEquals(['foobar'], $mail->getAttachmentUrls());
+        static::assertSame(['foobar'], $mail->getAttachmentUrls());
 
         $attachmentsConfig = new MailAttachmentsConfig(
             Context::createDefaultContext(),
@@ -34,6 +34,6 @@ class MailTest extends TestCase
 
         $mail->setMailAttachmentsConfig($attachmentsConfig);
 
-        static::assertEquals($attachmentsConfig, $mail->getMailAttachmentsConfig());
+        static::assertSame($attachmentsConfig, $mail->getMailAttachmentsConfig());
     }
 }

--- a/tests/unit/Core/Content/MailTemplate/Api/MailActionControllerTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Api/MailActionControllerTest.php
@@ -99,7 +99,7 @@ class MailActionControllerTest extends TestCase
         );
 
         $response = $mailActionController->build($data, $context);
-        static::assertEquals('"rendered"', $response->getContent());
+        static::assertSame('"rendered"', $response->getContent());
     }
 
     public function testBuildWithoutTemplateData(): void
@@ -127,7 +127,7 @@ class MailActionControllerTest extends TestCase
         );
 
         $response = $mailActionController->build($data, $context);
-        static::assertEquals('"rendered"', $response->getContent());
+        static::assertSame('"rendered"', $response->getContent());
     }
 
     public function testBuildWithoutTemplateContentThrows(): void

--- a/tests/unit/Core/Content/MailTemplate/Service/Event/MailBeforeSentEventTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/Event/MailBeforeSentEventTest.php
@@ -39,7 +39,7 @@ class MailBeforeSentEventTest extends TestCase
         $storer->restore($flow);
 
         static::assertArrayHasKey('data', $flow->data());
-        static::assertEquals(['foo' => 'bar'], $flow->data()['data']);
+        static::assertSame(['foo' => 'bar'], $flow->data()['data']);
     }
 
     public function testInstantiate(): void

--- a/tests/unit/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEventTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEventTest.php
@@ -38,8 +38,8 @@ class MailBeforeValidateEventTest extends TestCase
 
         static::assertArrayHasKey('data', $flow->data());
         static::assertArrayHasKey('templateData', $flow->data());
-        static::assertEquals(['foo' => 'bar'], $flow->data()['data']);
-        static::assertEquals(['template' => 'data'], $flow->data()['templateData']);
+        static::assertSame(['foo' => 'bar'], $flow->data()['data']);
+        static::assertSame(['template' => 'data'], $flow->data()['templateData']);
     }
 
     public function testInstantiate(): void

--- a/tests/unit/Core/Content/MailTemplate/Service/Event/MailErrorEventTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/Event/MailErrorEventTest.php
@@ -34,7 +34,7 @@ class MailErrorEventTest extends TestCase
         $storer->restore($flow);
 
         static::assertArrayHasKey('name', $flow->data());
-        static::assertEquals('mail.sent.error', $flow->getData('name'));
+        static::assertSame('mail.sent.error', $flow->getData('name'));
     }
 
     public function testInstantiate(): void

--- a/tests/unit/Core/Content/MailTemplate/Service/Event/MailSentEventTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/Event/MailSentEventTest.php
@@ -40,9 +40,9 @@ class MailSentEventTest extends TestCase
         static::assertArrayHasKey('contents', $flow->data());
         static::assertArrayHasKey('recipients', $flow->data());
 
-        static::assertEquals('my-subject', $flow->data()['subject']);
-        static::assertEquals(['foo' => 'bar'], $flow->data()['recipients']);
-        static::assertEquals(['mixed' => 'content'], $flow->data()['contents']);
+        static::assertSame('my-subject', $flow->data()['subject']);
+        static::assertSame(['foo' => 'bar'], $flow->data()['recipients']);
+        static::assertSame(['mixed' => 'content'], $flow->data()['contents']);
     }
 
     public function testInstantiate(): void

--- a/tests/unit/Core/Content/Media/Cms/DefaultMediaResolverTest.php
+++ b/tests/unit/Core/Content/Media/Cms/DefaultMediaResolverTest.php
@@ -93,8 +93,8 @@ class DefaultMediaResolverTest extends TestCase
         $result = $this->mediaResolver->getDefaultCmsMediaEntity('bundles/storefront/assets/default/cms/shopware.jpg');
 
         static::assertInstanceOf(MediaEntity::class, $result);
-        static::assertEquals('shopware', $result->getFileName());
-        static::assertEquals('image/jpeg', $result->getMimeType());
-        static::assertEquals('jpg', $result->getFileExtension());
+        static::assertSame('shopware', $result->getFileName());
+        static::assertSame('image/jpeg', $result->getMimeType());
+        static::assertSame('jpg', $result->getFileExtension());
     }
 }

--- a/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
@@ -55,7 +55,7 @@ class RemoteThumbnailLoaderTest extends TestCase
         $actual = [$entity->get('id') => $entity->get('url')];
 
         static::assertArrayHasKey($ids->get('media'), $actual);
-        static::assertEquals($expected['media'], $actual[$ids->get('media')]);
+        static::assertSame($expected['media'], $actual[$ids->get('media')]);
 
         if (\count($thumbnailSizes) > 0) {
             static::assertIsIterable($entity->get('thumbnails'));

--- a/tests/unit/Core/Content/Media/Event/MediaUploadedEventTest.php
+++ b/tests/unit/Core/Content/Media/Event/MediaUploadedEventTest.php
@@ -30,9 +30,9 @@ class MediaUploadedEventTest extends TestCase
             $context
         );
 
-        static::assertEquals('media.uploaded', $mediaUploadEvent->getName());
-        static::assertEquals($mediaId, $mediaUploadEvent->getMediaId());
-        static::assertEquals(
+        static::assertSame('media.uploaded', $mediaUploadEvent->getName());
+        static::assertSame($mediaId, $mediaUploadEvent->getMediaId());
+        static::assertSame(
             $context,
             $mediaUploadEvent->getContext()
         );
@@ -61,7 +61,7 @@ class MediaUploadedEventTest extends TestCase
         $storer->restore($flow);
 
         static::assertArrayHasKey('mediaId', $flow->data());
-        static::assertEquals('media-id', $flow->data()['mediaId']);
+        static::assertSame('media-id', $flow->data()['mediaId']);
     }
 
     public function testGetWebhookPayload(): void
@@ -73,7 +73,7 @@ class MediaUploadedEventTest extends TestCase
             $context
         );
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'mediaId' => $mediaId,
             ],

--- a/tests/unit/Core/Content/Media/Event/UnusedMediaSearchEventTest.php
+++ b/tests/unit/Core/Content/Media/Event/UnusedMediaSearchEventTest.php
@@ -18,7 +18,7 @@ class UnusedMediaSearchEventTest extends TestCase
     public function testGetIds(): void
     {
         $event = new UnusedMediaSearchEvent(['1', '2', '3']);
-        static::assertEquals(['1', '2', '3'], $event->getUnusedIds());
+        static::assertSame(['1', '2', '3'], $event->getUnusedIds());
     }
 
     /**
@@ -30,7 +30,7 @@ class UnusedMediaSearchEventTest extends TestCase
     {
         $event = new UnusedMediaSearchEvent(['1', '2', '3']);
         $event->markAsUsed($idsToRemove);
-        static::assertEquals($expectedIds, $event->getUnusedIds());
+        static::assertSame($expectedIds, $event->getUnusedIds());
     }
 
     /**

--- a/tests/unit/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/unit/Core/Content/Media/File/FileSaverTest.php
@@ -176,8 +176,8 @@ class FileSaverTest extends TestCase
         $update = $this->mediaRepository->updates[0];
 
         static::assertCount(1, $update);
-        static::assertEquals($mediaId, $update[0]['id']);
-        static::assertEquals('foo', $update[0]['fileName']);
+        static::assertSame($mediaId, $update[0]['id']);
+        static::assertSame('foo', $update[0]['fileName']);
 
         static::assertArrayHasKey(0, $this->messageBus->getMessages());
         static::assertEquals($message, $this->messageBus->getMessages()[0]->getMessage());
@@ -246,8 +246,8 @@ class FileSaverTest extends TestCase
         $update = $this->mediaRepository->updates[0];
 
         static::assertCount(1, $update);
-        static::assertEquals($mediaId, $update[0]['id']);
-        static::assertEquals('foo', $update[0]['fileName']);
+        static::assertSame($mediaId, $update[0]['id']);
+        static::assertSame('foo', $update[0]['fileName']);
 
         static::assertEmpty($this->messageBus->getMessages());
     }
@@ -341,8 +341,8 @@ class FileSaverTest extends TestCase
         $update = $this->mediaRepository->updates[0];
 
         static::assertCount(1, $update);
-        static::assertEquals($mediaId, $update[0]['id']);
-        static::assertEquals('foobar', $update[0]['fileName']);
+        static::assertSame($mediaId, $update[0]['id']);
+        static::assertSame('foobar', $update[0]['fileName']);
     }
 
     public function testRenameMediaWithInvalidThumbnail(): void
@@ -459,7 +459,7 @@ class FileSaverTest extends TestCase
         $update = $this->mediaRepository->updates[0];
 
         static::assertCount(1, $update);
-        static::assertEquals($mediaId, $update[0]['id']);
-        static::assertEquals('foobar', $update[0]['fileName']);
+        static::assertSame($mediaId, $update[0]['id']);
+        static::assertSame('foobar', $update[0]['fileName']);
     }
 }

--- a/tests/unit/Core/Content/Media/MediaEntityTest.php
+++ b/tests/unit/Core/Content/Media/MediaEntityTest.php
@@ -28,7 +28,7 @@ class MediaEntityTest extends TestCase
             $media->setFileExtension($ext);
         }
 
-        static::assertEquals($expected, $media->getFileNameIncludingExtension());
+        static::assertSame($expected, $media->getFileNameIncludingExtension());
     }
 
     /**

--- a/tests/unit/Core/Content/Media/MediaHydratorTest.php
+++ b/tests/unit/Core/Content/Media/MediaHydratorTest.php
@@ -91,11 +91,11 @@ class MediaHydratorTest extends TestCase
         static::assertSame(100, $first->getFileSize());
         static::assertSame('foo.jpg', $first->getFileName());
         static::assertInstanceOf(\DateTimeInterface::class, $first->getUploadedAt());
-        static::assertEquals($date->format(Defaults::STORAGE_DATE_TIME_FORMAT), $first->getUploadedAt()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame($date->format(Defaults::STORAGE_DATE_TIME_FORMAT), $first->getUploadedAt()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
         static::assertInstanceOf(\DateTimeInterface::class, $first->getCreatedAt());
-        static::assertEquals($date->format(Defaults::STORAGE_DATE_TIME_FORMAT), $first->getCreatedAt()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame($date->format(Defaults::STORAGE_DATE_TIME_FORMAT), $first->getCreatedAt()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
         static::assertInstanceOf(\DateTimeInterface::class, $first->getUpdatedAt());
-        static::assertEquals($date->format(Defaults::STORAGE_DATE_TIME_FORMAT), $first->getUpdatedAt()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame($date->format(Defaults::STORAGE_DATE_TIME_FORMAT), $first->getUpdatedAt()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
         static::assertSame('media/foo.jpg', $first->getPath());
         static::assertFalse($first->isPrivate());
     }

--- a/tests/unit/Core/Content/Media/MediaType/SpatialObjectTypeTest.php
+++ b/tests/unit/Core/Content/Media/MediaType/SpatialObjectTypeTest.php
@@ -16,6 +16,6 @@ class SpatialObjectTypeTest extends TestCase
 {
     public function testName(): void
     {
-        static::assertEquals('SPATIAL_OBJECT', (new SpatialObjectType())->getName());
+        static::assertSame('SPATIAL_OBJECT', (new SpatialObjectType())->getName());
     }
 }

--- a/tests/unit/Core/Content/Media/Metadata/MetadataLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Metadata/MetadataLoaderTest.php
@@ -172,6 +172,6 @@ class MetadataLoaderTest extends TestCase
 
         $metadata = $metadataLoader->loadFromFile($file, $type);
 
-        static::assertEquals($expected, $metadata);
+        static::assertSame($expected, $metadata);
     }
 }

--- a/tests/unit/Core/Content/Media/Subscriber/CustomFieldsUnusedMediaSubscriberTest.php
+++ b/tests/unit/Core/Content/Media/Subscriber/CustomFieldsUnusedMediaSubscriberTest.php
@@ -17,7 +17,7 @@ class CustomFieldsUnusedMediaSubscriberTest extends TestCase
 {
     public function testSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 UnusedMediaSearchEvent::class => 'removeUsedMedia',
             ],

--- a/tests/unit/Core/Content/Media/Subscriber/MediaCreationSubscriberTest.php
+++ b/tests/unit/Core/Content/Media/Subscriber/MediaCreationSubscriberTest.php
@@ -34,7 +34,7 @@ class MediaCreationSubscriberTest extends TestCase
 
     public function testSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 EntityWriteEvent::class => 'beforeWrite',
             ],

--- a/tests/unit/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/unit/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -113,7 +113,7 @@ class ThumbnailServiceTest extends TestCase
 
         $deleted = $this->thumbnailRepository->deletes[0][0] ?? [];
         static::assertArrayHasKey('id', $deleted);
-        static::assertEquals($expected, $deleted);
+        static::assertSame($expected, $deleted);
         static::assertSame(1, $result);
     }
 
@@ -228,7 +228,7 @@ class ThumbnailServiceTest extends TestCase
         $this->thumbnailService->deleteThumbnails($mediaEntity, $this->context);
 
         $deleted = $this->thumbnailRepository->deletes[0][0] ?? [];
-        static::assertEquals($expected, $deleted);
+        static::assertSame($expected, $deleted);
     }
 
     public function testDeleteThumbnailThrowsMediaContainsNoThumbnailException(): void
@@ -260,7 +260,7 @@ class ThumbnailServiceTest extends TestCase
         $method = ReflectionHelper::getMethod(ThumbnailService::class, 'calculateThumbnailSize');
         $calculatedSize = $method->invokeArgs($this->thumbnailService, [$imageSize, $thumbnailSizeEntity, $mediaFolderConfigEntity]);
 
-        static::assertEquals($expectedSize, $calculatedSize);
+        static::assertSame($expectedSize, $calculatedSize);
     }
 
     /**

--- a/tests/unit/Core/Content/Media/Thumbnail/ThumbnailSizeCalculatorTest.php
+++ b/tests/unit/Core/Content/Media/Thumbnail/ThumbnailSizeCalculatorTest.php
@@ -34,7 +34,7 @@ class ThumbnailSizeCalculatorTest extends TestCase
         $thumbnailSizeCalculator = new ThumbnailSizeCalculator();
         $calculatedSize = $thumbnailSizeCalculator->calculate($imageSize, $thumbnailSizeEntity);
 
-        static::assertEquals($expectedSize, $calculatedSize);
+        static::assertSame($expectedSize, $calculatedSize);
     }
 
     /**

--- a/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -83,7 +83,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media1, $media2], $media);
+        static::assertSame([$media1, $media2], $media);
     }
 
     public function testGetNotUsedMediaWithPaging(): void
@@ -109,8 +109,8 @@ class UnusedMediaPurgerTest extends TestCase
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
-                    self::assertEquals(0, $criteria->getOffset());
-                    self::assertEquals(50, $criteria->getLimit());
+                    self::assertNull($criteria->getOffset());
+                    self::assertSame(50, $criteria->getLimit());
 
                     return [$id1, $id2];
                 },
@@ -123,8 +123,8 @@ class UnusedMediaPurgerTest extends TestCase
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
-                    self::assertEquals(50, $criteria->getOffset());
-                    self::assertEquals(50, $criteria->getLimit());
+                    self::assertSame(50, $criteria->getOffset());
+                    self::assertSame(50, $criteria->getLimit());
 
                     return [$id3, $id4];
                 },
@@ -143,7 +143,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media1, $media2, $media3, $media4], $media);
+        static::assertSame([$media1, $media2, $media3, $media4], $media);
     }
 
     public function testGetNotUsedMediaOnlyFetchesSingleResultSetIfLimitAndOffsetSupplied(): void
@@ -184,7 +184,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia(4, 0)));
 
-        static::assertEquals([$media1, $media2, $media3, $media4], $media);
+        static::assertSame([$media1, $media2, $media3, $media4], $media);
     }
 
     public function testGetNotUsedMediaCorrectlyAppliesOneToOneAssociationToCriteria(): void
@@ -212,7 +212,7 @@ class UnusedMediaPurgerTest extends TestCase
                     self::assertCount(1, $filters);
 
                     self::assertInstanceOf(EqualsFilter::class, $filters[0]);
-                    self::assertEquals('media.meta.id', $filters[0]->getField());
+                    self::assertSame('media.meta.id', $filters[0]->getField());
                     self::assertNull($filters[0]->getValue());
 
                     return [$id1, $id2];
@@ -230,7 +230,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media1, $media2], $media);
+        static::assertSame([$media1, $media2], $media);
     }
 
     public function testGetNotUsedMediaCorrectlyAppliesOneToManyAssociationToCriteria(): void
@@ -257,7 +257,7 @@ class UnusedMediaPurgerTest extends TestCase
                     self::assertCount(1, $filters);
 
                     self::assertInstanceOf(EqualsFilter::class, $filters[0]);
-                    self::assertEquals('media.productMedia.mediaId', $filters[0]->getField());
+                    self::assertSame('media.productMedia.mediaId', $filters[0]->getField());
                     self::assertNull($filters[0]->getValue());
 
                     return [$id1, $id2];
@@ -275,7 +275,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media1, $media2], $media);
+        static::assertSame([$media1, $media2], $media);
     }
 
     public function testGetNotUsedMediaCorrectlyAppliesManyToManyAssociationToCriteria(): void
@@ -309,7 +309,7 @@ class UnusedMediaPurgerTest extends TestCase
                     self::assertCount(1, $filters);
 
                     self::assertInstanceOf(EqualsFilter::class, $filters[0]);
-                    self::assertEquals('media.galleries.id', $filters[0]->getField());
+                    self::assertSame('media.galleries.id', $filters[0]->getField());
                     self::assertNull($filters[0]->getValue());
 
                     return [$id1, $id2];
@@ -327,7 +327,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media1, $media2], $media);
+        static::assertSame([$media1, $media2], $media);
     }
 
     public function testGetNotUsedMediaIgnoresAggregateEntities(): void
@@ -368,7 +368,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media1, $media2], $media);
+        static::assertSame([$media1, $media2], $media);
     }
 
     public function testGetNotUsedMediaAppliesFolderRestrictionToCriteriaIfPresent(): void
@@ -392,8 +392,8 @@ class UnusedMediaPurgerTest extends TestCase
                     self::assertCount(1, $filters);
 
                     self::assertInstanceOf(EqualsAnyFilter::class, $filters[0]);
-                    self::assertEquals('media.mediaFolder.id', $filters[0]->getField());
-                    self::assertEquals(['id1', 'id2', 'id3', 'id4'], $filters[0]->getValue());
+                    self::assertSame('media.mediaFolder.id', $filters[0]->getField());
+                    self::assertSame(['id1', 'id2', 'id3', 'id4'], $filters[0]->getValue());
 
                     return [$id1, $id2];
                 },
@@ -426,7 +426,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $connection, new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia(null, null, null, 'media_gallery')));
 
-        static::assertEquals([$media1, $media2], $media);
+        static::assertSame([$media1, $media2], $media);
     }
 
     public function testGetNotUsedMediaSkipsAssociationIfNoFkeyFound(): void
@@ -467,7 +467,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media1, $media2], $media);
+        static::assertSame([$media1, $media2], $media);
     }
 
     public function testGetNotUsedMediaSkipsNonValidAssociations(): void
@@ -507,7 +507,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media1, $media2], $media);
+        static::assertSame([$media1, $media2], $media);
     }
 
     public function testGetNotUsedMediaDoesNotFetchMediaIfRemovedByListener(): void
@@ -549,7 +549,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), $eventDispatcher);
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([$media2], $media);
+        static::assertSame([$media2], $media);
     }
 
     public function testGetNotUsedMediaDoesNotFetchAnyMediaIfAllRemovedByListener(): void
@@ -586,7 +586,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), $eventDispatcher);
         $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
 
-        static::assertEquals([], $media);
+        static::assertSame([], $media);
     }
 
     public function testDeleteNotUsedMediaOnlyAppliesValidAssociationsToCriteria(): void
@@ -617,7 +617,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $media1->getId()],
@@ -654,8 +654,8 @@ class UnusedMediaPurgerTest extends TestCase
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
-                    self::assertEquals(0, $criteria->getOffset());
-                    self::assertEquals(50, $criteria->getLimit());
+                    self::assertSame(0, $criteria->getOffset());
+                    self::assertSame(50, $criteria->getLimit());
 
                     return [$id1, $id2];
                 },
@@ -663,8 +663,8 @@ class UnusedMediaPurgerTest extends TestCase
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
-                    self::assertEquals(50, $criteria->getOffset());
-                    self::assertEquals(50, $criteria->getLimit());
+                    self::assertSame(50, $criteria->getOffset());
+                    self::assertSame(50, $criteria->getLimit());
 
                     return [$id3, $id4];
                 },
@@ -676,7 +676,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $media1->getId()],
@@ -723,7 +723,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia(4, 0);
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -760,7 +760,7 @@ class UnusedMediaPurgerTest extends TestCase
                     self::assertCount(1, $filters);
 
                     self::assertInstanceOf(EqualsFilter::class, $filters[0]);
-                    self::assertEquals('media.meta.id', $filters[0]->getField());
+                    self::assertSame('media.meta.id', $filters[0]->getField());
                     self::assertNull($filters[0]->getValue());
 
                     return [$id1, $id2];
@@ -775,7 +775,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -809,7 +809,7 @@ class UnusedMediaPurgerTest extends TestCase
                     self::assertCount(1, $filters);
 
                     self::assertInstanceOf(EqualsFilter::class, $filters[0]);
-                    self::assertEquals('media.productMedia.mediaId', $filters[0]->getField());
+                    self::assertSame('media.productMedia.mediaId', $filters[0]->getField());
                     self::assertNull($filters[0]->getValue());
 
                     return [$id1, $id2];
@@ -824,7 +824,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -865,7 +865,7 @@ class UnusedMediaPurgerTest extends TestCase
                     self::assertCount(1, $filters);
 
                     self::assertInstanceOf(EqualsFilter::class, $filters[0]);
-                    self::assertEquals('media.galleries.id', $filters[0]->getField());
+                    self::assertSame('media.galleries.id', $filters[0]->getField());
                     self::assertNull($filters[0]->getValue());
 
                     return [$id1, $id2];
@@ -880,7 +880,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -925,7 +925,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -960,7 +960,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia(null, null, null, 'product');
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -991,8 +991,8 @@ class UnusedMediaPurgerTest extends TestCase
                     self::assertCount(1, $filters);
 
                     self::assertInstanceOf(EqualsAnyFilter::class, $filters[0]);
-                    self::assertEquals('media.mediaFolder.id', $filters[0]->getField());
-                    self::assertEquals(['id1', 'id2', 'id3', 'id4'], $filters[0]->getValue());
+                    self::assertSame('media.mediaFolder.id', $filters[0]->getField());
+                    self::assertSame(['id1', 'id2', 'id3', 'id4'], $filters[0]->getValue());
 
                     return [$id1, $id2];
                 },
@@ -1022,7 +1022,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $connection, new EventDispatcher());
         $purger->deleteNotUsedMedia(null, null, null, 'media_gallery');
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -1067,7 +1067,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -1111,7 +1111,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id1],
@@ -1158,7 +1158,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), $eventDispatcher);
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $id2],
@@ -1204,7 +1204,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), $eventDispatcher);
         $purger->deleteNotUsedMedia();
 
-        static::assertEquals(
+        static::assertSame(
             [],
             $repo->deletes
         );
@@ -1228,7 +1228,7 @@ class UnusedMediaPurgerTest extends TestCase
                 fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 [$id1, $id2],
                 function (Criteria $criteria) use ($id1, $id2) {
-                    static::assertEquals([$id1, $id2], $criteria->getIds());
+                    static::assertSame([$id1, $id2], $criteria->getIds());
 
                     return [$id1];
                 },
@@ -1240,7 +1240,7 @@ class UnusedMediaPurgerTest extends TestCase
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
         $purger->deleteNotUsedMedia(null, null, 3);
 
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     ['id' => $media1->getId()],

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
@@ -36,6 +36,6 @@ class NewsletterRegisterEventTest extends TestCase
         $storer->restore($flow);
 
         static::assertArrayHasKey('url', $flow->data());
-        static::assertEquals('my-url', $flow->data()['url']);
+        static::assertSame('my-url', $flow->data()['url']);
     }
 }

--- a/tests/unit/Core/Content/Newsletter/Subscriber/NewsletterRecipientSalutationSubscriberTest.php
+++ b/tests/unit/Core/Content/Newsletter/Subscriber/NewsletterRecipientSalutationSubscriberTest.php
@@ -34,7 +34,7 @@ class NewsletterRecipientSalutationSubscriberTest extends TestCase
 
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals([
+        static::assertSame([
             NewsletterEvents::NEWSLETTER_RECIPIENT_WRITTEN_EVENT => 'setDefaultSalutation',
         ], $this->salutationSubscriber->getSubscribedEvents());
     }

--- a/tests/unit/Core/Content/Product/Cleanup/CleanupUnusedDownloadMediaTaskTest.php
+++ b/tests/unit/Core/Content/Product/Cleanup/CleanupUnusedDownloadMediaTaskTest.php
@@ -14,11 +14,11 @@ class CleanupUnusedDownloadMediaTaskTest extends TestCase
 {
     public function testGetTaskName(): void
     {
-        static::assertEquals('product_download.media.cleanup', CleanupUnusedDownloadMediaTask::getTaskName());
+        static::assertSame('product_download.media.cleanup', CleanupUnusedDownloadMediaTask::getTaskName());
     }
 
     public function testGetDefaultInterval(): void
     {
-        static::assertEquals(2628000, CleanupUnusedDownloadMediaTask::getDefaultInterval());
+        static::assertSame(2628000, CleanupUnusedDownloadMediaTask::getDefaultInterval());
     }
 }

--- a/tests/unit/Core/Content/Product/Cms/ManufacturerLogoCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ManufacturerLogoCmsElementResolverTest.php
@@ -60,7 +60,7 @@ class ManufacturerLogoCmsElementResolverTest extends TestCase
 
         $criteria = array_shift($definitionData);
         static::assertInstanceOf(Criteria::class, $criteria);
-        static::assertEquals(['media-1'], $criteria->getIds());
+        static::assertSame(['media-1'], $criteria->getIds());
     }
 
     public function testCollectReturnsNullWithEmptyConfig(): void

--- a/tests/unit/Core/Content/Product/Cms/ProductBoxCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductBoxCmsElementResolverTest.php
@@ -170,7 +170,7 @@ class ProductBoxCmsElementResolverTest extends TestCase
 
         $product = $productBoxStruct->getProduct();
         static::assertNotNull($product);
-        static::assertEquals($productId, $product->getId());
+        static::assertSame($productId, $product->getId());
     }
 
     #[DataProvider('enrichDataProvider')]

--- a/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
@@ -142,7 +142,7 @@ class ProductStreamProcessorTest extends TestCase
         $slider = $slot->getData();
         static::assertInstanceOf(ProductSliderStruct::class, $slider);
         static::assertSame('product-stream-1', $slider->getStreamId());
-        static::assertEquals($products, $slider->getProducts());
+        static::assertSame($products, $slider->getProducts());
     }
 
     public function testEnrichDoesNothingWithoutEntitySearchResult(): void

--- a/tests/unit/Core/Content/Product/Cms/Type/ProductBoxTypeDataResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/Type/ProductBoxTypeDataResolverTest.php
@@ -170,7 +170,7 @@ class ProductBoxTypeDataResolverTest extends TestCase
             static::assertNotSame($product, $productBoxStruct->getProduct());
 
             $serializedProduct = json_encode($product);
-            static::assertNotEquals(\JSON_ERROR_RECURSION, json_last_error());
+            static::assertNotSame(\JSON_ERROR_RECURSION, json_last_error());
             static::assertNotFalse($serializedProduct);
         }
     }

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/StockUpdate/StockUpdateFilterProviderTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/StockUpdate/StockUpdateFilterProviderTest.php
@@ -21,6 +21,6 @@ class StockUpdateFilterProviderTest extends TestCase
 
         $provider = new StockUpdateFilterProvider([$filter]);
 
-        static::assertEquals(['id3'], $provider->filterProductIdsForStockUpdates($ids, Context::createDefaultContext()));
+        static::assertSame(['id3'], $provider->filterProductIdsForStockUpdates($ids, Context::createDefaultContext()));
     }
 }

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/UpdatedStatesTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/UpdatedStatesTest.php
@@ -16,12 +16,12 @@ class UpdatedStatesTest extends TestCase
     {
         $updatedStates = new UpdatedStates('foobar', ['foo'], ['bar']);
 
-        static::assertEquals('foobar', $updatedStates->getId());
-        static::assertEquals(['foo'], $updatedStates->getOldStates());
-        static::assertEquals(['bar'], $updatedStates->getNewStates());
+        static::assertSame('foobar', $updatedStates->getId());
+        static::assertSame(['foo'], $updatedStates->getOldStates());
+        static::assertSame(['bar'], $updatedStates->getNewStates());
 
         $updatedStates->setNewStates(['foo']);
 
-        static::assertEquals(['foo'], $updatedStates->getNewStates());
+        static::assertSame(['foo'], $updatedStates->getNewStates());
     }
 }

--- a/tests/unit/Core/Content/Product/Events/ProductStatesBeforeChangeEventTest.php
+++ b/tests/unit/Core/Content/Product/Events/ProductStatesBeforeChangeEventTest.php
@@ -21,12 +21,12 @@ class ProductStatesBeforeChangeEventTest extends TestCase
 
         $event = new ProductStatesBeforeChangeEvent($updatedStates, $context);
 
-        static::assertEquals($updatedStates, $event->getUpdatedStates());
-        static::assertEquals($context, $event->getContext());
+        static::assertSame($updatedStates, $event->getUpdatedStates());
+        static::assertSame($context, $event->getContext());
 
         $updatedStates = [new UpdatedStates('foobar', ['foo'], ['baz'])];
         $event->setUpdatedStates($updatedStates);
 
-        static::assertEquals($updatedStates, $event->getUpdatedStates());
+        static::assertSame($updatedStates, $event->getUpdatedStates());
     }
 }

--- a/tests/unit/Core/Content/Product/Events/ProductStatesChangedEventTest.php
+++ b/tests/unit/Core/Content/Product/Events/ProductStatesChangedEventTest.php
@@ -21,7 +21,7 @@ class ProductStatesChangedEventTest extends TestCase
 
         $event = new ProductStatesChangedEvent($updatedStates, $context);
 
-        static::assertEquals($updatedStates, $event->getUpdatedStates());
-        static::assertEquals($context, $event->getContext());
+        static::assertSame($updatedStates, $event->getUpdatedStates());
+        static::assertSame($context, $event->getContext());
     }
 }

--- a/tests/unit/Core/Content/Product/Exception/VariantNotFoundExceptionTest.php
+++ b/tests/unit/Core/Content/Product/Exception/VariantNotFoundExceptionTest.php
@@ -26,9 +26,9 @@ class VariantNotFoundExceptionTest extends TestCase
 
         $exception = new VariantNotFoundException($ids->get('productId'), $options);
 
-        static::assertEquals('CONTENT__PRODUCT_VARIANT_NOT_FOUND', $exception->getErrorCode());
-        static::assertEquals(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
-        static::assertEquals(
+        static::assertSame('CONTENT__PRODUCT_VARIANT_NOT_FOUND', $exception->getErrorCode());
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(
             'Variant for productId ' . $ids->get('productId') . ' with options ' . \json_encode($options, \JSON_THROW_ON_ERROR) . ' not found.',
             $exception->getMessage()
         );

--- a/tests/unit/Core/Content/Product/Hook/Pricing/CheapestPriceFacadeTest.php
+++ b/tests/unit/Core/Content/Product/Hook/Pricing/CheapestPriceFacadeTest.php
@@ -54,8 +54,8 @@ class CheapestPriceFacadeTest extends TestCase
 
         $price->change($update);
 
-        static::assertEquals($unit, $price->getUnit());
-        static::assertEquals($tax, $price->getTaxes()->getAmount());
+        static::assertSame($unit, $price->getUnit());
+        static::assertSame($tax, $price->getTaxes()->getAmount());
     }
 
     public function testChangeWithPriceFacade(): void
@@ -76,7 +76,7 @@ class CheapestPriceFacadeTest extends TestCase
             )
         );
 
-        static::assertEquals(5, $price->getUnit());
+        static::assertSame(5.0, $price->getUnit());
     }
 
     public function testChangeWithNullFacade(): void
@@ -90,7 +90,7 @@ class CheapestPriceFacadeTest extends TestCase
 
         $price->change(null);
 
-        static::assertEquals(10, $price->getUnit());
+        static::assertSame(10.0, $price->getUnit());
     }
 
     public function testReset(): void
@@ -104,7 +104,7 @@ class CheapestPriceFacadeTest extends TestCase
 
         $price->reset();
 
-        static::assertEquals(10, $price->getUnit());
+        static::assertSame(10.0, $price->getUnit());
     }
 
     public static function providerChange(): \Generator

--- a/tests/unit/Core/Content/Product/Hook/Pricing/ProductPricingHookTest.php
+++ b/tests/unit/Core/Content/Product/Hook/Pricing/ProductPricingHookTest.php
@@ -33,12 +33,12 @@ class ProductPricingHookTest extends TestCase
         );
         $productPricingHook = new ProductPricingHook([$productProxy], $salesChannelContext);
 
-        static::assertEquals([$productProxy], $productPricingHook->getProducts());
+        static::assertSame([$productProxy], $productPricingHook->getProducts());
     }
 
     public function testGetServiceIds(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 RepositoryFacadeHookFactory::class,
                 PriceFactoryFactory::class,
@@ -53,7 +53,7 @@ class ProductPricingHookTest extends TestCase
     {
         $productPricingHook = new ProductPricingHook([], static::createMock(SalesChannelContext::class));
 
-        static::assertEquals('product-pricing', $productPricingHook->getName());
+        static::assertSame('product-pricing', $productPricingHook->getName());
     }
 
     public function testGetSalesChannelContext(): void
@@ -61,6 +61,6 @@ class ProductPricingHookTest extends TestCase
         $salesChannelContext = static::createMock(SalesChannelContext::class);
         $productPricingHook = new ProductPricingHook([], $salesChannelContext);
 
-        static::assertEquals($salesChannelContext, $productPricingHook->getSalesChannelContext());
+        static::assertSame($salesChannelContext, $productPricingHook->getSalesChannelContext());
     }
 }

--- a/tests/unit/Core/Content/Product/Hook/ProductProxyTest.php
+++ b/tests/unit/Core/Content/Product/Hook/ProductProxyTest.php
@@ -51,7 +51,7 @@ class ProductProxyTest extends TestCase
         static::assertInstanceOf(PriceFacade::class, $proxy->calculatedPrice, 'Proxy should return a facade for the calculated price');
         static::assertInstanceOf(PriceCollectionFacade::class, $proxy->calculatedPrices, 'Proxy should return a facade for the calculated prices');
         static::assertInstanceOf(PriceFacade::class, $proxy->calculatedCheapestPrice, 'Proxy should return a facade for the calculated cheapest price');
-        static::assertEquals('foo', $proxy->name, 'Proxy should return the same value as the original object');
+        static::assertSame('foo', $proxy->name, 'Proxy should return the same value as the original object');
 
         static::assertArrayHasKey('stock', $proxy, 'Proxy should be able to check if a property exists');
     }
@@ -64,10 +64,10 @@ class ProductProxyTest extends TestCase
             $this->createMock(ScriptPriceStubs::class)
         );
 
-        static::assertEquals('foo', $proxy->name, 'Proxy should return the same value as the original object');
+        static::assertSame('foo', $proxy->name, 'Proxy should return the same value as the original object');
 
-        static::expectException(ProductException::class);
-        static::expectExceptionMessage('Manipulation of pricing proxy field name is not allowed');
+        $this->expectException(ProductException::class);
+        $this->expectExceptionMessage('Manipulation of pricing proxy field name is not allowed');
 
         $proxy->offsetUnset('name');
     }
@@ -80,10 +80,10 @@ class ProductProxyTest extends TestCase
             $this->createMock(ScriptPriceStubs::class)
         );
 
-        static::assertEquals('foo', $proxy->name, 'Proxy should return the same value as the original object');
+        static::assertSame('foo', $proxy->name, 'Proxy should return the same value as the original object');
 
-        static::expectException(ProductException::class);
-        static::expectExceptionMessage('Manipulation of pricing proxy field name is not allowed');
+        $this->expectException(ProductException::class);
+        $this->expectExceptionMessage('Manipulation of pricing proxy field name is not allowed');
 
         $proxy->name = 'bar';
     }

--- a/tests/unit/Core/Content/Product/ProductDefinitionTest.php
+++ b/tests/unit/Core/Content/Product/ProductDefinitionTest.php
@@ -40,6 +40,6 @@ class ProductDefinitionTest extends TestCase
         sort($expected);
         sort($keys);
 
-        static::assertEquals($expected, $keys);
+        static::assertSame($expected, $keys);
     }
 }

--- a/tests/unit/Core/Content/Product/ProductExceptionTest.php
+++ b/tests/unit/Core/Content/Product/ProductExceptionTest.php
@@ -19,10 +19,10 @@ class ProductExceptionTest extends TestCase
 
         $exception = ProductException::invalidCheapestPriceFacade($productId);
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        static::assertEquals(ProductException::PRODUCT_INVALID_CHEAPEST_PRICE_FACADE, $exception->getErrorCode());
-        static::assertEquals('Cheapest price facade for product product-id-1 is invalid', $exception->getMessage());
-        static::assertEquals(['id' => $productId], $exception->getParameters());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(ProductException::PRODUCT_INVALID_CHEAPEST_PRICE_FACADE, $exception->getErrorCode());
+        static::assertSame('Cheapest price facade for product product-id-1 is invalid', $exception->getMessage());
+        static::assertSame(['id' => $productId], $exception->getParameters());
     }
 
     public function testSortingNotFound(): void
@@ -31,19 +31,19 @@ class ProductExceptionTest extends TestCase
 
         $exception = ProductException::sortingNotFoundException($key);
 
-        static::assertEquals(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
-        static::assertEquals(ProductException::SORTING_NOT_FOUND, $exception->getErrorCode());
-        static::assertEquals('Could not find sorting with key "value"', $exception->getMessage());
-        static::assertEquals(['entity' => 'sorting', 'field' => 'key', 'value' => $key], $exception->getParameters());
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(ProductException::SORTING_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Could not find sorting with key "value"', $exception->getMessage());
+        static::assertSame(['entity' => 'sorting', 'field' => 'key', 'value' => $key], $exception->getParameters());
     }
 
     public function testInvalidPriceDefinition(): void
     {
         $exception = ProductException::invalidPriceDefinition();
 
-        static::assertEquals(Response::HTTP_CONFLICT, $exception->getStatusCode());
-        static::assertEquals(ProductException::PRODUCT_INVALID_PRICE_DEFINITION_CODE, $exception->getErrorCode());
-        static::assertEquals('Provided price definition is invalid.', $exception->getMessage());
+        static::assertSame(Response::HTTP_CONFLICT, $exception->getStatusCode());
+        static::assertSame(ProductException::PRODUCT_INVALID_PRICE_DEFINITION_CODE, $exception->getErrorCode());
+        static::assertSame('Provided price definition is invalid.', $exception->getMessage());
     }
 
     public function testProxyManipulationNotAllowed(): void
@@ -53,10 +53,10 @@ class ProductExceptionTest extends TestCase
 
         $exception = ProductException::proxyManipulationNotAllowed($property);
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        static::assertEquals(ProductException::PRODUCT_PROXY_MANIPULATION_NOT_ALLOWED_CODE, $exception->getErrorCode());
-        static::assertEquals('Manipulation of pricing proxy field property is not allowed', $exception->getMessage());
-        static::assertEquals(['property' => $property], $exception->getParameters());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(ProductException::PRODUCT_PROXY_MANIPULATION_NOT_ALLOWED_CODE, $exception->getErrorCode());
+        static::assertSame('Manipulation of pricing proxy field property is not allowed', $exception->getMessage());
+        static::assertSame(['property' => $property], $exception->getParameters());
     }
 
     public function testCategoryNotFound(): void
@@ -65,27 +65,27 @@ class ProductExceptionTest extends TestCase
 
         $exception = ProductException::categoryNotFound($categoryId);
 
-        static::assertEquals(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
-        static::assertEquals(ProductException::CATEGORY_NOT_FOUND, $exception->getErrorCode());
-        static::assertEquals('Could not find category with id "category-id"', $exception->getMessage());
-        static::assertEquals(['entity' => 'category', 'field' => 'id', 'value' => $categoryId], $exception->getParameters());
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(ProductException::CATEGORY_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Could not find category with id "category-id"', $exception->getMessage());
+        static::assertSame(['entity' => 'category', 'field' => 'id', 'value' => $categoryId], $exception->getParameters());
     }
 
     public function testConfigurationOptionAlreadyExists(): void
     {
         $exception = ProductException::configurationOptionAlreadyExists();
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
-        static::assertEquals(ProductException::PRODUCT_CONFIGURATION_OPTION_ALREADY_EXISTS, $exception->getErrorCode());
-        static::assertEquals('Configuration option already exists', $exception->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(ProductException::PRODUCT_CONFIGURATION_OPTION_ALREADY_EXISTS, $exception->getErrorCode());
+        static::assertSame('Configuration option already exists', $exception->getMessage());
     }
 
     public function testInvalidOptionsParameter(): void
     {
         $exception = ProductException::invalidOptionsParameter();
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
-        static::assertEquals(ProductException::PRODUCT_INVALID_OPTIONS_PARAMETER, $exception->getErrorCode());
-        static::assertEquals('The parameter options is invalid.', $exception->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(ProductException::PRODUCT_INVALID_OPTIONS_PARAMETER, $exception->getErrorCode());
+        static::assertSame('The parameter options is invalid.', $exception->getMessage());
     }
 }

--- a/tests/unit/Core/Content/Product/ProductVariationBuilderTest.php
+++ b/tests/unit/Core/Content/Product/ProductVariationBuilderTest.php
@@ -31,7 +31,7 @@ class ProductVariationBuilderTest extends TestCase
 
         $builder->build($product);
 
-        static::assertEquals($expected, $product->get('variation'));
+        static::assertSame($expected, $product->get('variation'));
     }
 
     public static function buildingProvider(): \Generator

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -110,8 +110,8 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load('1', new Request(), $this->context, new Criteria());
 
-        static::assertEquals('4', $result->getProduct()->getCmsPageId());
-        static::assertEquals('mainVariant', $result->getProduct()->getUniqueIdentifier());
+        static::assertSame('4', $result->getProduct()->getCmsPageId());
+        static::assertSame('mainVariant', $result->getProduct()->getUniqueIdentifier());
     }
 
     public function testLoadBestVariant(): void
@@ -145,8 +145,8 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load($this->idsCollection->get('product1'), new Request(), $this->context, new Criteria());
 
-        static::assertEquals(4, $result->getProduct()->getCmsPageId());
-        static::assertEquals('BestVariant', $result->getProduct()->getUniqueIdentifier());
+        static::assertSame('4', $result->getProduct()->getCmsPageId());
+        static::assertSame('BestVariant', $result->getProduct()->getUniqueIdentifier());
         static::assertTrue($result->getProduct()->getAvailable());
     }
 
@@ -186,7 +186,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load($productId, new Request(), $this->context, new Criteria());
 
-        static::assertEquals('2', $result->getProduct()->getUniqueIdentifier());
+        static::assertSame('2', $result->getProduct()->getUniqueIdentifier());
         static::assertTrue($result->getProduct()->getAvailable());
     }
 
@@ -210,7 +210,7 @@ class ProductDetailRouteTest extends TestCase
             ->with(static::callback(function (Criteria $criteria) use ($variantId): bool {
                 $ids = $criteria->getIds();
                 static::assertCount(1, $ids);
-                static::assertEquals($variantId, reset($ids));
+                static::assertSame($variantId, reset($ids));
 
                 return true;
             }))
@@ -231,7 +231,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load(Uuid::randomHex(), new Request(), $this->context, new Criteria());
 
-        static::assertEquals($variantId, $result->getProduct()->getUniqueIdentifier());
+        static::assertSame($variantId, $result->getProduct()->getUniqueIdentifier());
         static::assertTrue($result->getProduct()->getAvailable());
     }
 
@@ -263,8 +263,8 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load($this->idsCollection->get('product2'), new Request(), $this->context, new Criteria());
 
-        static::assertEquals('4', $result->getProduct()->getCmsPageId());
-        static::assertEquals('BestVariant', $result->getProduct()->getUniqueIdentifier());
+        static::assertSame('4', $result->getProduct()->getCmsPageId());
+        static::assertSame('BestVariant', $result->getProduct()->getUniqueIdentifier());
     }
 
     public function testLoadProductNotFound(): void

--- a/tests/unit/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
@@ -94,8 +94,8 @@ class FindProductVariantRouteTest extends TestCase
 
         $response = $this->route->load($this->ids->get('productId'), $request, $this->createMock(SalesChannelContext::class));
 
-        static::assertEquals($this->ids->get('found1'), $response->getFoundCombination()->getVariantId());
-        static::assertEquals($options, $response->getFoundCombination()->getOptions());
+        static::assertSame($this->ids->get('found1'), $response->getFoundCombination()->getVariantId());
+        static::assertSame($options, $response->getFoundCombination()->getOptions());
     }
 
     public function testLoadFirstVariantNotFound(): void
@@ -149,7 +149,7 @@ class FindProductVariantRouteTest extends TestCase
 
         $response = $this->route->load($this->ids->get('productId'), $request, $this->createMock(SalesChannelContext::class));
 
-        static::assertEquals($this->ids->get('found1'), $response->getFoundCombination()->getVariantId());
+        static::assertSame($this->ids->get('found1'), $response->getFoundCombination()->getVariantId());
     }
 
     public function testLoadNoVariantFound(): void
@@ -206,7 +206,7 @@ class FindProductVariantRouteTest extends TestCase
         try {
             $this->route->load($this->ids->get('productId'), $request, $this->createMock(SalesChannelContext::class));
         } catch (VariantNotFoundException $e) {
-            static::assertEquals('CONTENT__PRODUCT_VARIANT_NOT_FOUND', $e->getErrorCode());
+            static::assertSame('CONTENT__PRODUCT_VARIANT_NOT_FOUND', $e->getErrorCode());
 
             throw $e;
         }

--- a/tests/unit/Core/Content/Product/SalesChannel/FindVariant/FoundCombinationTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/FindVariant/FoundCombinationTest.php
@@ -25,7 +25,7 @@ class FoundCombinationTest extends TestCase
 
         $foundCombo = new FoundCombination($ids->get('variantId'), $options);
 
-        static::assertEquals($ids->get('variantId'), $foundCombo->getVariantId());
-        static::assertEquals($options, $foundCombo->getOptions());
+        static::assertSame($ids->get('variantId'), $foundCombo->getVariantId());
+        static::assertSame($options, $foundCombo->getOptions());
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/Filter/ManufacturerFilterHandlerTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/Filter/ManufacturerFilterHandlerTest.php
@@ -48,21 +48,21 @@ class ManufacturerFilterHandlerTest extends TestCase
         $filter = $this->handler->create($request, $context);
 
         static::assertInstanceOf(Filter::class, $filter);
-        static::assertEquals('manufacturer', $filter->getName());
+        static::assertSame('manufacturer', $filter->getName());
         static::assertTrue($filter->isFiltered());
 
         $aggregations = $filter->getAggregations();
         static::assertCount(1, $aggregations);
         static::assertInstanceOf(EntityAggregation::class, $aggregations[0]);
-        static::assertEquals('manufacturer', $aggregations[0]->getName());
-        static::assertEquals('product.manufacturerId', $aggregations[0]->getField());
-        static::assertEquals('product_manufacturer', $aggregations[0]->getEntity());
+        static::assertSame('manufacturer', $aggregations[0]->getName());
+        static::assertSame('product.manufacturerId', $aggregations[0]->getField());
+        static::assertSame('product_manufacturer', $aggregations[0]->getEntity());
 
         $criteriaFilter = $filter->getFilter();
         static::assertInstanceOf(EqualsAnyFilter::class, $criteriaFilter);
-        static::assertEquals('product.manufacturerId', $criteriaFilter->getField());
-        static::assertEquals($manufacturerIds, $criteriaFilter->getValue());
-        static::assertEquals($manufacturerIds, $filter->getValues());
+        static::assertSame('product.manufacturerId', $criteriaFilter->getField());
+        static::assertSame($manufacturerIds, $criteriaFilter->getValue());
+        static::assertSame($manufacturerIds, $filter->getValues());
     }
 
     public function testCreateWithEmptyManufacturerIds(): void
@@ -76,19 +76,19 @@ class ManufacturerFilterHandlerTest extends TestCase
         $filter = $this->handler->create($request, $context);
 
         static::assertInstanceOf(Filter::class, $filter);
-        static::assertEquals('manufacturer', $filter->getName());
+        static::assertSame('manufacturer', $filter->getName());
         static::assertFalse($filter->isFiltered());
 
         $aggregations = $filter->getAggregations();
         static::assertCount(1, $aggregations);
         static::assertInstanceOf(EntityAggregation::class, $aggregations[0]);
-        static::assertEquals('manufacturer', $aggregations[0]->getName());
-        static::assertEquals('product.manufacturerId', $aggregations[0]->getField());
-        static::assertEquals('product_manufacturer', $aggregations[0]->getEntity());
+        static::assertSame('manufacturer', $aggregations[0]->getName());
+        static::assertSame('product.manufacturerId', $aggregations[0]->getField());
+        static::assertSame('product_manufacturer', $aggregations[0]->getEntity());
 
         $criteriaFilter = $filter->getFilter();
         static::assertInstanceOf(EqualsAnyFilter::class, $criteriaFilter);
-        static::assertEquals('product.manufacturerId', $criteriaFilter->getField());
+        static::assertSame('product.manufacturerId', $criteriaFilter->getField());
         static::assertEmpty($criteriaFilter->getValue());
 
         static::assertEmpty($filter->getValues());

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/Filter/PropertyFilterHandlerTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/Filter/PropertyFilterHandlerTest.php
@@ -308,28 +308,28 @@ class PropertyFilterHandlerTest extends TestCase
 
         $color = $properties->getEntities()->first();
         static::assertInstanceOf(Entity::class, $color);
-        static::assertEquals('color', $color->get('id'));
+        static::assertSame('color', $color->get('id'));
 
         $options = $color->get('options');
         static::assertInstanceOf(EntityCollection::class, $options);
         static::assertCount(2, $options);
 
         static::assertInstanceOf(Entity::class, $options->first());
-        static::assertEquals('red', $options->first()->get('id'));
+        static::assertSame('red', $options->first()->get('id'));
         static::assertInstanceOf(Entity::class, $options->last());
-        static::assertEquals('green', $options->last()->get('id'));
+        static::assertSame('green', $options->last()->get('id'));
 
         $size = $properties->getEntities()->last();
         static::assertInstanceOf(Entity::class, $size);
-        static::assertEquals('size', $size->get('id'));
+        static::assertSame('size', $size->get('id'));
 
         $options = $size->get('options');
         static::assertInstanceOf(EntityCollection::class, $options);
         static::assertCount(2, $options);
         static::assertInstanceOf(Entity::class, $options->first());
-        static::assertEquals('l', $options->first()->get('id'));
+        static::assertSame('l', $options->first()->get('id'));
         static::assertInstanceOf(Entity::class, $options->last());
-        static::assertEquals('xl', $options->last()->get('id'));
+        static::assertSame('xl', $options->last()->get('id'));
     }
 
     public static function createProvider(): \Generator

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/LoadPreviewExtensionTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/LoadPreviewExtensionTest.php
@@ -37,6 +37,6 @@ class LoadPreviewExtensionTest extends TestCase
         );
 
         static::assertIsArray($result);
-        static::assertEquals(['5441aebfd9d048338476f88ba7f07c76' => '5441aebfd9d048338476f88ba7f07c76'], $result);
+        static::assertSame(['5441aebfd9d048338476f88ba7f07c76' => '5441aebfd9d048338476f88ba7f07c76'], $result);
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/Processor/AggregationProcessorTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/Processor/AggregationProcessorTest.php
@@ -75,7 +75,7 @@ class AggregationProcessorTest extends TestCase
 
         $processor->process(new Request(), $result, $context);
 
-        static::assertEquals(['foo'], $result->getCurrentFilter('foo'));
+        static::assertSame(['foo'], $result->getCurrentFilter('foo'));
     }
 
     public function testReduceAggregationBehavior(): void
@@ -100,7 +100,7 @@ class AggregationProcessorTest extends TestCase
         $filter = $agg->getFilter();
         $filter = \array_shift($filter);
         static::assertInstanceOf(EqualsFilter::class, $filter);
-        static::assertEquals('bar', $filter->getField());
+        static::assertSame('bar', $filter->getField());
 
         $agg = $criteria->getAggregation('bar');
         static::assertInstanceOf(FilterAggregation::class, $agg);

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/Processor/PagingListingProcessorTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/Processor/PagingListingProcessorTest.php
@@ -79,8 +79,8 @@ class PagingListingProcessorTest extends TestCase
 
         $processor->prepare($request, $criteria, $context);
 
-        static::assertEquals(($page - 1) * $limit, $criteria->getOffset());
-        static::assertEquals($limit, $criteria->getLimit());
+        static::assertSame(($page - 1) * $limit, $criteria->getOffset());
+        static::assertSame($limit, $criteria->getLimit());
     }
 
     public function testProcess(): void
@@ -100,7 +100,7 @@ class PagingListingProcessorTest extends TestCase
 
         $processor->process($request, $result, $context);
 
-        static::assertEquals(2, $result->getPage());
-        static::assertEquals(10, $result->getLimit());
+        static::assertSame(2, $result->getPage());
+        static::assertSame(10, $result->getLimit());
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/Processor/SortingListingProcessorTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/Processor/SortingListingProcessorTest.php
@@ -122,7 +122,7 @@ class SortingListingProcessorTest extends TestCase
             $this->createMock(SalesChannelContext::class)
         );
 
-        static::assertEquals($expected, $result->getSorting());
+        static::assertSame($expected, $result->getSorting());
     }
 
     #[DataProvider('wrongSortingTypeProvider')]

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingCriteriaExtensionTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingCriteriaExtensionTest.php
@@ -45,6 +45,6 @@ class ProductListingCriteriaExtensionTest extends TestCase
         );
 
         static::assertInstanceOf(Criteria::class, $result);
-        static::assertEquals([], $result->getFilters());
+        static::assertSame([], $result->getFilters());
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderExtensionsTests.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderExtensionsTests.php
@@ -59,7 +59,7 @@ class ProductListingLoaderExtensionsTests extends TestCase
 
         static::assertInstanceOf(IdSearchResult::class, $result);
 
-        static::assertEquals(['plugin-id'], $result->getIds());
+        static::assertSame(['plugin-id'], $result->getIds());
     }
 
     public function testResolveListingExtension(): void
@@ -103,6 +103,6 @@ class ProductListingLoaderExtensionsTests extends TestCase
 
         static::assertInstanceOf(EntitySearchResult::class, $result);
 
-        static::assertEquals(['plugin-id'], array_values($result->getIds()));
+        static::assertSame(['plugin-id'], array_values($result->getIds()));
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Price/ReferencePriceDtoTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Price/ReferencePriceDtoTest.php
@@ -46,9 +46,9 @@ class ReferencePriceDtoTest extends TestCase
     {
         $referencePrice = new ReferencePriceDto(1, 2, 'unit-id');
 
-        static::assertEquals(1, $referencePrice->getPurchase());
-        static::assertEquals(2, $referencePrice->getReference());
-        static::assertEquals('unit-id', $referencePrice->getUnitId());
+        static::assertSame(1.0, $referencePrice->getPurchase());
+        static::assertSame(2.0, $referencePrice->getReference());
+        static::assertSame('unit-id', $referencePrice->getUnitId());
     }
 
     public function testSetter(): void
@@ -58,8 +58,8 @@ class ReferencePriceDtoTest extends TestCase
         $referencePrice->setReference(4);
         $referencePrice->setUnitId('unit-id-2');
 
-        static::assertEquals(3, $referencePrice->getPurchase());
-        static::assertEquals(4, $referencePrice->getReference());
-        static::assertEquals('unit-id-2', $referencePrice->getUnitId());
+        static::assertSame(3.0, $referencePrice->getPurchase());
+        static::assertSame(4.0, $referencePrice->getReference());
+        static::assertSame('unit-id-2', $referencePrice->getUnitId());
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEventTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEventTest.php
@@ -28,12 +28,12 @@ class ReviewFormEventTest extends TestCase
 
         $event = new ReviewFormEvent($context, $salesChannelId, $mailRecipientStruct, $data, $productId, $customerId);
 
-        static::assertEquals($context, $event->getContext());
-        static::assertEquals($salesChannelId, $event->getSalesChannelId());
-        static::assertEquals($mailRecipientStruct, $event->getMailStruct());
-        static::assertEquals($data->all(), $event->getReviewFormData());
-        static::assertEquals($productId, $event->getProductId());
-        static::assertEquals($customerId, $event->getCustomerId());
+        static::assertSame($context, $event->getContext());
+        static::assertSame($salesChannelId, $event->getSalesChannelId());
+        static::assertSame($mailRecipientStruct, $event->getMailStruct());
+        static::assertSame($data->all(), $event->getReviewFormData());
+        static::assertSame($productId, $event->getProductId());
+        static::assertSame($customerId, $event->getCustomerId());
     }
 
     public function testScalarValuesCorrectly(): void
@@ -56,6 +56,6 @@ class ReviewFormEventTest extends TestCase
         $storer->restore($flow);
 
         static::assertArrayHasKey('reviewFormData', $flow->data());
-        static::assertEquals(['foo' => 'bar', 'bar' => 'baz'], $flow->data()['reviewFormData']);
+        static::assertSame(['foo' => 'bar', 'bar' => 'baz'], $flow->data()['reviewFormData']);
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/MatrixElementTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/MatrixElementTest.php
@@ -29,9 +29,9 @@ class MatrixElementTest extends TestCase
 
         $element = new MatrixElement($points, $count, $percent);
 
-        static::assertEquals($points, $element->getPoints());
-        static::assertEquals($count, $element->getCount());
-        static::assertEquals($percent, $element->getPercent());
+        static::assertSame($points, $element->getPoints());
+        static::assertSame($count, $element->getCount());
+        static::assertSame($percent, $element->getPercent());
     }
 
     /**
@@ -43,7 +43,7 @@ class MatrixElementTest extends TestCase
         $expected = 2;
         $this->element->setPoints($expected);
 
-        static::assertEquals($expected, $this->element->getPoints());
+        static::assertSame($expected, $this->element->getPoints());
     }
 
     /**
@@ -55,7 +55,7 @@ class MatrixElementTest extends TestCase
         $expected = 2;
         $this->element->setCount($expected);
 
-        static::assertEquals($expected, $this->element->getCount());
+        static::assertSame($expected, $this->element->getCount());
     }
 
     /**
@@ -67,6 +67,6 @@ class MatrixElementTest extends TestCase
         $expected = 0.35;
         $this->element->setPercent($expected);
 
-        static::assertEquals($expected, $this->element->getPercent());
+        static::assertSame($expected, $this->element->getPercent());
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
@@ -94,6 +94,6 @@ class ProductReviewsWidgetLoadedHookTest extends TestCase
 
         $productReviewsWidgetLoadedHook = $this->controller->calledHook;
 
-        static::assertEquals($reviewResult, $productReviewsWidgetLoadedHook->getReviews());
+        static::assertSame($reviewResult, $productReviewsWidgetLoadedHook->getReviews());
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/RatingMatrixTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/RatingMatrixTest.php
@@ -23,7 +23,7 @@ class RatingMatrixTest extends TestCase
     public function testThatConstantsAreSetLikeExpected(): void
     {
         $matrix = new RatingMatrix([]);
-        static::assertEquals(5, $matrix->getMaxPoints());
+        static::assertSame(5, $matrix->getMaxPoints());
     }
 
     /**
@@ -38,9 +38,9 @@ class RatingMatrixTest extends TestCase
         $matrix = new RatingMatrix($aggregation);
         $expectedScore = round($expectedScore, 4);
         $actual = round($matrix->getAverageRating(), 4);
-        static::assertEquals($expectedScore, $actual, 'expected score does not match');
-        static::assertEquals($reviewCounts, $matrix->getTotalReviewCount(), 'expected total review count does not match');
-        static::assertEquals($total, $matrix->getPointSum(), 'expected total review points does not match');
+        static::assertSame($expectedScore, $actual, 'expected score does not match');
+        static::assertSame($reviewCounts, $matrix->getTotalReviewCount(), 'expected total review count does not match');
+        static::assertSame($total, $matrix->getPointSum(), 'expected total review points does not match');
     }
 
     /**
@@ -86,12 +86,12 @@ class RatingMatrixTest extends TestCase
         $matrix = new RatingMatrix($aggregation);
         $expectedRatingScore = 3.2;
         $expectedReviewCounts = 2 * ($oneCount + $twoCount + $threeCount + $fourCount + $fiveCount);
-        $expectedTotal = 32;
+        $expectedTotal = 32.0;
 
         static::assertCount(5, $matrix->getMatrix());
-        static::assertEquals($expectedRatingScore, $matrix->getAverageRating());
-        static::assertEquals($expectedReviewCounts, $matrix->getTotalReviewCount());
-        static::assertEquals($expectedTotal, $matrix->getPointSum());
+        static::assertSame($expectedRatingScore, $matrix->getAverageRating());
+        static::assertSame($expectedReviewCounts, $matrix->getTotalReviewCount());
+        static::assertSame($expectedTotal, $matrix->getPointSum());
     }
 
     /**
@@ -116,9 +116,9 @@ class RatingMatrixTest extends TestCase
         for ($i = 1; $i <= $matrix->getMaxPoints(); ++$i) {
             $matrixElement = $matrixElements[$i];
             $expected = round($ratingCounts[$i] * 100 / $totalReviews, 4);
-            static::assertEquals($i, $matrixElement->getPoints(), \sprintf('The rating with %d points has errors!', $i));
-            static::assertEquals($ratingCounts[$i], $matrixElement->getCount(), \sprintf('The count of reviews with %d points has errors!', $i));
-            static::assertEquals($expected, round($matrixElement->getPercent(), 4), \sprintf('Calculation of percentage with %d points has errors!', $i));
+            static::assertSame($i, $matrixElement->getPoints(), \sprintf('The rating with %d points has errors!', $i));
+            static::assertSame($ratingCounts[$i], $matrixElement->getCount(), \sprintf('The count of reviews with %d points has errors!', $i));
+            static::assertSame($expected, round($matrixElement->getPercent(), 4), \sprintf('Calculation of percentage with %d points has errors!', $i));
         }
     }
 
@@ -151,9 +151,9 @@ class RatingMatrixTest extends TestCase
         for ($i = 1; $i <= $matrix->getMaxPoints(); ++$i) {
             $matrixElement = $matrixElements[$i];
             $expected = round($expectedCounts[$i] * 100 / $totalReviews, 4);
-            static::assertEquals($i, $matrixElement->getPoints(), \sprintf('The rating with %d points has errors!', $i));
-            static::assertEquals($expectedCounts[$i], $matrixElement->getCount(), \sprintf('The count of reviews with %d points has errors!', $i));
-            static::assertEquals($expected, round($matrixElement->getPercent(), 4), \sprintf('Calculation of percentage with %d points has errors!', $i));
+            static::assertSame($i, $matrixElement->getPoints(), \sprintf('The rating with %d points has errors!', $i));
+            static::assertSame($expectedCounts[$i], $matrixElement->getCount(), \sprintf('The count of reviews with %d points has errors!', $i));
+            static::assertSame($expected, round($matrixElement->getPercent(), 4), \sprintf('Calculation of percentage with %d points has errors!', $i));
         }
     }
 
@@ -172,9 +172,9 @@ class RatingMatrixTest extends TestCase
         $matrix = new RatingMatrix($stars);
 
         static::assertCount(5, $matrix->getMatrix());
-        static::assertEquals(2.4, round($matrix->getAverageRating(), 1));
-        static::assertEquals(9, $matrix->getTotalReviewCount());
-        static::assertEquals(21.6, $matrix->getPointSum());
+        static::assertSame(2.4, round($matrix->getAverageRating(), 1));
+        static::assertSame(9, $matrix->getTotalReviewCount());
+        static::assertSame(21.6, $matrix->getPointSum());
     }
 
     /**

--- a/tests/unit/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRouteTest.php
@@ -68,7 +68,7 @@ class ResolvedCriteriaProductSuggestRouteTest extends TestCase
         static::assertInstanceOf(Criteria::class, $decorated->criteria);
         $fields = $decorated->criteria->getFilterFields();
 
-        static::assertEquals($expected, $fields);
+        static::assertSame($expected, $fields);
     }
 
     public function testEvents(): void

--- a/tests/unit/Core/Content/Product/Stock/LoadProductStockSubscriberTest.php
+++ b/tests/unit/Core/Content/Product/Stock/LoadProductStockSubscriberTest.php
@@ -49,13 +49,13 @@ class LoadProductStockSubscriberTest extends TestCase
 
         $subscriber->salesChannelLoaded($event);
 
-        static::assertEquals(10, $p1->getStock());
+        static::assertSame(10, $p1->getStock());
         static::assertFalse($p1->getAvailable());
-        static::assertEquals(5, $p1->getMinPurchase());
+        static::assertSame(5, $p1->getMinPurchase());
         static::assertTrue($p1->hasExtension('stock_data'));
         static::assertSame($stock1, $p1->getExtension('stock_data'));
 
-        static::assertEquals(12, $p2->getStock());
+        static::assertSame(12, $p2->getStock());
         static::assertTrue($p2->getAvailable());
         static::assertNull($p2->getMinPurchase());
         static::assertTrue($p2->hasExtension('stock_data'));
@@ -89,13 +89,13 @@ class LoadProductStockSubscriberTest extends TestCase
 
         $subscriber->salesChannelLoaded($event);
 
-        static::assertEquals(10, $p1->get('stock'));
+        static::assertSame(10, $p1->get('stock'));
         static::assertFalse($p1->get('available'));
-        static::assertEquals(5, $p1->get('minPurchase'));
+        static::assertSame(5, $p1->get('minPurchase'));
         static::assertTrue($p1->hasExtension('stock_data'));
         static::assertSame($stock1, $p1->getExtension('stock_data'));
 
-        static::assertEquals(12, $p2->get('stock'));
+        static::assertSame(12, $p2->get('stock'));
         static::assertTrue($p2->get('available'));
         static::assertNull($p2->get('minPurchase'));
         static::assertTrue($p2->hasExtension('stock_data'));

--- a/tests/unit/Core/Content/Product/Stock/OrderStockSubscriberTest.php
+++ b/tests/unit/Core/Content/Product/Stock/OrderStockSubscriberTest.php
@@ -240,11 +240,11 @@ class OrderStockSubscriberTest extends TestCase
 
                 foreach ($expectedUpdates as $i => $expectedUpdate) {
                     static::assertInstanceOf(StockAlteration::class, $changes[$i]);
-                    static::assertEquals($expectedUpdate['lineItemId'], $changes[$i]->lineItemId);
-                    static::assertEquals($expectedUpdate['productId'], $changes[$i]->productId);
+                    static::assertSame($expectedUpdate['lineItemId'], $changes[$i]->lineItemId);
+                    static::assertSame($expectedUpdate['productId'], $changes[$i]->productId);
 
-                    static::assertEquals($expectedUpdate['quantityBefore'], $changes[$i]->quantityBefore);
-                    static::assertEquals($expectedUpdate['newQuantity'], $changes[$i]->newQuantity);
+                    static::assertSame($expectedUpdate['quantityBefore'], $changes[$i]->quantityBefore);
+                    static::assertSame($expectedUpdate['newQuantity'], $changes[$i]->newQuantity);
                 }
 
                 return true;
@@ -632,15 +632,15 @@ class OrderStockSubscriberTest extends TestCase
                 static::assertInstanceOf(StockAlteration::class, $changes[0]);
                 static::assertInstanceOf(StockAlteration::class, $changes[1]);
 
-                static::assertEquals($this->ids->get('item-1'), $changes[0]->lineItemId);
-                static::assertEquals($this->ids->get('product-1'), $changes[0]->productId);
-                static::assertEquals($quantityBefore, $changes[0]->quantityBefore);
-                static::assertEquals($quantityAfter, $changes[0]->newQuantity);
+                static::assertSame($this->ids->get('item-1'), $changes[0]->lineItemId);
+                static::assertSame($this->ids->get('product-1'), $changes[0]->productId);
+                static::assertSame($quantityBefore, $changes[0]->quantityBefore);
+                static::assertSame($quantityAfter, $changes[0]->newQuantity);
 
-                static::assertEquals($this->ids->get('item-2'), $changes[1]->lineItemId);
-                static::assertEquals($this->ids->get('product-2'), $changes[1]->productId);
-                static::assertEquals($quantityBefore, $changes[1]->quantityBefore);
-                static::assertEquals($quantityAfter, $changes[1]->newQuantity);
+                static::assertSame($this->ids->get('item-2'), $changes[1]->lineItemId);
+                static::assertSame($this->ids->get('product-2'), $changes[1]->productId);
+                static::assertSame($quantityBefore, $changes[1]->quantityBefore);
+                static::assertSame($quantityAfter, $changes[1]->newQuantity);
 
                 return true;
             }));

--- a/tests/unit/Core/Content/Product/Stock/StockAlterationTest.php
+++ b/tests/unit/Core/Content/Product/Stock/StockAlterationTest.php
@@ -16,18 +16,18 @@ class StockAlterationTest extends TestCase
     {
         $alteration = new StockAlteration('12345', '67890', 10, 5);
 
-        static::assertEquals('12345', $alteration->lineItemId);
-        static::assertEquals('67890', $alteration->productId);
-        static::assertEquals(10, $alteration->quantityBefore);
-        static::assertEquals(5, $alteration->newQuantity);
-        static::assertEquals(5, $alteration->quantityDelta());
+        static::assertSame('12345', $alteration->lineItemId);
+        static::assertSame('67890', $alteration->productId);
+        static::assertSame(10, $alteration->quantityBefore);
+        static::assertSame(5, $alteration->newQuantity);
+        static::assertSame(5, $alteration->quantityDelta());
 
         $alteration = new StockAlteration('12345', '67890', 3, 10);
 
-        static::assertEquals('12345', $alteration->lineItemId);
-        static::assertEquals('67890', $alteration->productId);
-        static::assertEquals(3, $alteration->quantityBefore);
-        static::assertEquals(10, $alteration->newQuantity);
-        static::assertEquals(-7, $alteration->quantityDelta());
+        static::assertSame('12345', $alteration->lineItemId);
+        static::assertSame('67890', $alteration->productId);
+        static::assertSame(3, $alteration->quantityBefore);
+        static::assertSame(10, $alteration->newQuantity);
+        static::assertSame(-7, $alteration->quantityDelta());
     }
 }

--- a/tests/unit/Core/Content/Product/Stock/StockDataTest.php
+++ b/tests/unit/Core/Content/Product/Stock/StockDataTest.php
@@ -18,15 +18,15 @@ class StockDataTest extends TestCase
         $stock = new StockData('12345', 10, true, 2, 5, true);
         $stock->addArrayExtension('extraData', ['foo' => 'bar']);
 
-        static::assertEquals('12345', $stock->productId);
-        static::assertEquals(10, $stock->stock);
+        static::assertSame('12345', $stock->productId);
+        static::assertSame(10, $stock->stock);
         static::assertTrue($stock->available);
-        static::assertEquals(2, $stock->minPurchase);
-        static::assertEquals(5, $stock->maxPurchase);
+        static::assertSame(2, $stock->minPurchase);
+        static::assertSame(5, $stock->maxPurchase);
         static::assertTrue($stock->isCloseout);
 
         static::assertInstanceOf(ArrayStruct::class, $stock->getExtension('extraData'));
-        static::assertEquals(['foo' => 'bar'], $stock->getExtension('extraData')->all());
+        static::assertSame(['foo' => 'bar'], $stock->getExtension('extraData')->all());
     }
 
     public function testDefaultValues(): void
@@ -49,11 +49,11 @@ class StockDataTest extends TestCase
             'isCloseout' => true,
         ]);
 
-        static::assertEquals('12345', $stock->productId);
-        static::assertEquals(10, $stock->stock);
+        static::assertSame('12345', $stock->productId);
+        static::assertSame(10, $stock->stock);
         static::assertTrue($stock->available);
-        static::assertEquals(2, $stock->minPurchase);
-        static::assertEquals(5, $stock->maxPurchase);
+        static::assertSame(2, $stock->minPurchase);
+        static::assertSame(5, $stock->maxPurchase);
         static::assertTrue($stock->isCloseout);
     }
 }

--- a/tests/unit/Core/Content/Product/Stock/StockLoadRequestTest.php
+++ b/tests/unit/Core/Content/Product/Stock/StockLoadRequestTest.php
@@ -16,6 +16,6 @@ class StockLoadRequestTest extends TestCase
     {
         $stockRequest = new StockLoadRequest(['product-1', 'product-2']);
 
-        static::assertEquals(['product-1', 'product-2'], $stockRequest->productIds);
+        static::assertSame(['product-1', 'product-2'], $stockRequest->productIds);
     }
 }

--- a/tests/unit/Core/Content/Product/Stock/StockStorageTest.php
+++ b/tests/unit/Core/Content/Product/Stock/StockStorageTest.php
@@ -30,7 +30,7 @@ class StockStorageTest extends TestCase
 
         $stockStorage = new StockStorage($connection, $dispatcher);
 
-        static::assertEquals(
+        static::assertSame(
             [],
             $stockStorage->load(new StockLoadRequest(array_values($productIds)), $salesChannelContext)->all()
         );

--- a/tests/unit/Core/Content/ProductExport/Event/ProductExportLoggingEventTest.php
+++ b/tests/unit/Core/Content/ProductExport/Event/ProductExportLoggingEventTest.php
@@ -31,6 +31,6 @@ class ProductExportLoggingEventTest extends TestCase
         $storer->restore($flow);
 
         static::assertArrayHasKey('name', $flow->data());
-        static::assertEquals('custom-name', $flow->data()['name']);
+        static::assertSame('custom-name', $flow->data()['name']);
     }
 }

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
@@ -70,7 +70,7 @@ class ProductExportRendererTest extends TestCase
 
         $rendered = $renderer->renderHeader($productExport, $this->context);
 
-        static::assertEquals($expected, $rendered);
+        static::assertSame($expected, $rendered);
     }
 
     public function testRenderHeaderError(): void
@@ -143,7 +143,7 @@ class ProductExportRendererTest extends TestCase
 
         $rendered = $renderer->renderFooter($productExport, $this->context);
 
-        static::assertEquals($expected, $rendered);
+        static::assertSame($expected, $rendered);
     }
 
     /**
@@ -174,7 +174,7 @@ class ProductExportRendererTest extends TestCase
 
         $rendered = $renderer->renderBody($productExport, $this->context, $data);
 
-        static::assertEquals($expected, $rendered);
+        static::assertSame($expected, $rendered);
     }
 
     public function testRenderFooterError(): void

--- a/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
+++ b/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
@@ -206,6 +206,6 @@ class ProductStreamIndexerTest extends TestCase
         $this->iteratorFactory->expects($this->once())->method('createIterator')->willReturn(new OffsetQuery($queryBuilder));
 
         $total = $this->indexer->getTotal();
-        static::assertEquals(1, $total);
+        static::assertSame(1, $total);
     }
 }

--- a/tests/unit/Core/Content/Property/PropertySortTest.php
+++ b/tests/unit/Core/Content/Property/PropertySortTest.php
@@ -67,7 +67,7 @@ class PropertySortTest extends TestCase
             $equalsArray[] = $letterArray[$x];
         }
 
-        static::assertEquals(
+        static::assertSame(
             $equalsArray,
             array_column($propertyOptionsArray, 'name')
         );
@@ -89,7 +89,7 @@ class PropertySortTest extends TestCase
             $equalsArray[] = $x;
         }
 
-        static::assertEquals(
+        static::assertSame(
             $equalsArray,
             array_column($propertyOptionsArray, 'position')
         );
@@ -106,7 +106,7 @@ class PropertySortTest extends TestCase
         static::assertNotNull($propertyGroup);
         $propertyOptionsArray = json_decode(json_encode($propertyGroup->getOptions(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             $this->notShuffledPosition,
             array_column($propertyOptionsArray, 'position')
         );
@@ -123,7 +123,7 @@ class PropertySortTest extends TestCase
         static::assertNotNull($propertyGroup);
         $propertyOptionsArray = json_decode(json_encode($propertyGroup->getOptions(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             $this->notShuffledName,
             array_column($propertyOptionsArray, 'name')
         );

--- a/tests/unit/Core/Content/Rule/RuleCollectionTest.php
+++ b/tests/unit/Core/Content/Rule/RuleCollectionTest.php
@@ -39,7 +39,7 @@ class RuleCollectionTest extends TestCase
 
         $collection = new RuleCollection([$ruleA, $ruleB, $ruleC, $ruleD, $ruleE]);
 
-        static::assertEquals([
+        static::assertSame([
             'a' => [$ruleA->getId(), $ruleE->getId()],
             'b' => [$ruleA->getId(), $ruleB->getId()],
             'c' => [$ruleB->getId(), $ruleC->getId()],

--- a/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -156,7 +156,7 @@ class CategoryUrlProviderTest extends TestCase
         $this->queryBuilder
             ->method('andWhere')
             ->willReturnCallback(function ($parameter) {
-                $this->assertNotEquals(
+                $this->assertNotSame(
                     '`category`.id NOT IN (:categoryIds)',
                     $parameter,
                     'andWhere should never be called with category ID exclusion'

--- a/tests/unit/Core/Content/Sitemap/SalesChannel/SitemapFileRouteTest.php
+++ b/tests/unit/Core/Content/Sitemap/SalesChannel/SitemapFileRouteTest.php
@@ -35,6 +35,6 @@ class SitemapFileRouteTest extends TestCase
 
         $response = $route->getSitemapFile($request, $context, $filePath);
 
-        static::assertEquals('Hello World!', $response->getContent());
+        static::assertSame('Hello World!', $response->getContent());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/9317

### 2. What does this change do, exactly?

Replace `assertEquals` with `assertSame`