### PR TITLE
chore: Replace assertEquals with assertSame in system tests

### DIFF
--- a/tests/integration/Core/System/Country/Repository/CountryRepositoryTest.php
+++ b/tests/integration/Core/System/Country/Repository/CountryRepositoryTest.php
@@ -62,7 +62,7 @@ class CountryRepositoryTest extends TestCase
 
         static::assertCount(2, $result->getIds());
 
-        static::assertEquals(
+        static::assertSame(
             [$recordA, $recordB],
             $result->getIds()
         );

--- a/tests/integration/Core/System/Country/Repository/CountryStateRepositoryTest.php
+++ b/tests/integration/Core/System/Country/Repository/CountryStateRepositoryTest.php
@@ -68,7 +68,7 @@ class CountryStateRepositoryTest extends TestCase
 
         static::assertCount(2, $result->getIds());
 
-        static::assertEquals(
+        static::assertSame(
             [$recordA, $recordB],
             $result->getIds()
         );

--- a/tests/integration/Core/System/Country/SalesChannel/CountryStateRouteTest.php
+++ b/tests/integration/Core/System/Country/SalesChannel/CountryStateRouteTest.php
@@ -107,7 +107,7 @@ class CountryStateRouteTest extends TestCase
         static::assertNotNull($response['elements']);
         static::assertCount(2, $response['elements']);
 
-        static::assertEquals([
+        static::assertSame([
             'Baden-Württemberg', 'Bavaria',
         ], array_map(fn (array $state) => $state['name'], $response['elements']));
     }

--- a/tests/integration/Core/System/Currency/CurrencyRuleTest.php
+++ b/tests/integration/Core/System/Currency/CurrencyRuleTest.php
@@ -60,11 +60,11 @@ class CurrencyRuleTest extends TestCase
             $errors = iterator_to_array($stackException->getErrors());
             static::assertCount(2, $errors);
 
-            static::assertEquals('/0/value/currencyIds', $errors[0]['source']['pointer']);
-            static::assertEquals(NotBlank::IS_BLANK_ERROR, $errors[0]['code']);
+            static::assertSame('/0/value/currencyIds', $errors[0]['source']['pointer']);
+            static::assertSame(NotBlank::IS_BLANK_ERROR, $errors[0]['code']);
 
-            static::assertEquals('/0/value/operator', $errors[1]['source']['pointer']);
-            static::assertEquals(NotBlank::IS_BLANK_ERROR, $errors[1]['code']);
+            static::assertSame('/0/value/operator', $errors[1]['source']['pointer']);
+            static::assertSame(NotBlank::IS_BLANK_ERROR, $errors[1]['code']);
         }
     }
 
@@ -86,8 +86,8 @@ class CurrencyRuleTest extends TestCase
             $errors = iterator_to_array($stackException->getErrors());
             static::assertCount(1, $errors);
 
-            static::assertEquals('/0/value/currencyIds', $errors[0]['source']['pointer']);
-            static::assertEquals(NotBlank::IS_BLANK_ERROR, $errors[0]['code']);
+            static::assertSame('/0/value/currencyIds', $errors[0]['source']['pointer']);
+            static::assertSame(NotBlank::IS_BLANK_ERROR, $errors[0]['code']);
         }
     }
 
@@ -109,8 +109,8 @@ class CurrencyRuleTest extends TestCase
             $errors = iterator_to_array($stackException->getErrors());
             static::assertCount(1, $errors);
 
-            static::assertEquals('/0/value/currencyIds', $errors[0]['source']['pointer']);
-            static::assertEquals(Type::INVALID_TYPE_ERROR, $errors[0]['code']);
+            static::assertSame('/0/value/currencyIds', $errors[0]['source']['pointer']);
+            static::assertSame(Type::INVALID_TYPE_ERROR, $errors[0]['code']);
         }
     }
 
@@ -132,13 +132,13 @@ class CurrencyRuleTest extends TestCase
             $errors = iterator_to_array($stackException->getErrors());
             static::assertCount(3, $errors);
 
-            static::assertEquals('/0/value/currencyIds', $errors[0]['source']['pointer']);
-            static::assertEquals('/0/value/currencyIds', $errors[1]['source']['pointer']);
-            static::assertEquals('/0/value/currencyIds', $errors[2]['source']['pointer']);
+            static::assertSame('/0/value/currencyIds', $errors[0]['source']['pointer']);
+            static::assertSame('/0/value/currencyIds', $errors[1]['source']['pointer']);
+            static::assertSame('/0/value/currencyIds', $errors[2]['source']['pointer']);
 
-            static::assertEquals(ArrayOfUuid::INVALID_TYPE_CODE, $errors[0]['code']);
-            static::assertEquals(ArrayOfUuid::INVALID_TYPE_CODE, $errors[1]['code']);
-            static::assertEquals(ArrayOfUuid::INVALID_TYPE_CODE, $errors[2]['code']);
+            static::assertSame(ArrayOfUuid::INVALID_TYPE_CODE, $errors[0]['code']);
+            static::assertSame(ArrayOfUuid::INVALID_TYPE_CODE, $errors[1]['code']);
+            static::assertSame(ArrayOfUuid::INVALID_TYPE_CODE, $errors[2]['code']);
         }
     }
 
@@ -160,11 +160,11 @@ class CurrencyRuleTest extends TestCase
             $errors = iterator_to_array($stackException->getErrors());
             static::assertCount(2, $errors);
 
-            static::assertEquals('/0/value/currencyIds', $errors[0]['source']['pointer']);
-            static::assertEquals('/0/value/currencyIds', $errors[1]['source']['pointer']);
+            static::assertSame('/0/value/currencyIds', $errors[0]['source']['pointer']);
+            static::assertSame('/0/value/currencyIds', $errors[1]['source']['pointer']);
 
-            static::assertEquals(ArrayOfUuid::INVALID_TYPE_CODE, $errors[0]['code']);
-            static::assertEquals(ArrayOfUuid::INVALID_TYPE_CODE, $errors[1]['code']);
+            static::assertSame(ArrayOfUuid::INVALID_TYPE_CODE, $errors[0]['code']);
+            static::assertSame(ArrayOfUuid::INVALID_TYPE_CODE, $errors[1]['code']);
         }
     }
 

--- a/tests/integration/Core/System/Currency/Repository/CurrencyRepositoryTest.php
+++ b/tests/integration/Core/System/Currency/Repository/CurrencyRepositoryTest.php
@@ -84,7 +84,7 @@ class CurrencyRepositoryTest extends TestCase
 
         static::assertCount(2, $result->getIds());
 
-        static::assertEquals(
+        static::assertSame(
             [$recordA, $recordB],
             $result->getIds()
         );
@@ -119,7 +119,7 @@ class CurrencyRepositoryTest extends TestCase
         $deleteEventElement = $this->currencyRepository->delete([['id' => $recordA]], $context)->getEventByEntityName(CurrencyDefinition::ENTITY_NAME);
 
         static::assertNotNull($deleteEventElement);
-        static::assertEquals($recordA, $deleteEventElement->getWriteResults()[0]->getPrimaryKey());
+        static::assertSame($recordA, $deleteEventElement->getWriteResults()[0]->getPrimaryKey());
     }
 
     public function testDeleteDefaultCurrency(): void

--- a/tests/integration/Core/System/CustomEntity/Xml/Config/CmsAwareAndAdminUiTest.php
+++ b/tests/integration/Core/System/CustomEntity/Xml/Config/CmsAwareAndAdminUiTest.php
@@ -105,7 +105,7 @@ class CmsAwareAndAdminUiTest extends TestCase
 
         $appEntity = $apps->first();
         static::assertNotNull($appEntity);
-        static::assertEquals(self::APP_NAME, $appEntity->getName());
+        static::assertSame(self::APP_NAME, $appEntity->getName());
 
         return $appEntity;
     }
@@ -251,7 +251,7 @@ class CmsAwareAndAdminUiTest extends TestCase
         static::assertCount(2, $cmsAwareAndAdminUiSettings);
 
         static::assertIsString($flagsJson = file_get_contents(__DIR__ . '/_fixtures/other/flags.json'));
-        static::assertEquals(
+        static::assertSame(
             $this->jsonDecode($flagsJson),
             $this->jsonDecode($cmsAwareAndAdminUiSettings['flags'])
         );
@@ -262,7 +262,7 @@ class CmsAwareAndAdminUiTest extends TestCase
      */
     private function assertCmsAwareAndAdminUiIsUninstalled(): void
     {
-        static::assertEquals(
+        static::assertSame(
             0,
             $this->connection->executeQuery(
                 'SELECT COUNT(*) FROM custom_entity'

--- a/tests/integration/Core/System/Integration/IntegrationRepositoryTest.php
+++ b/tests/integration/Core/System/Integration/IntegrationRepositoryTest.php
@@ -51,8 +51,8 @@ class IntegrationRepositoryTest extends TestCase
             ->first();
 
         static::assertNotNull($entity);
-        static::assertEquals(1, $entities->count());
-        static::assertEquals('My app', $entity->getLabel());
+        static::assertCount(1, $entities);
+        static::assertSame('My app', $entity->getLabel());
     }
 
     public function testCreationAdminDefaultsToFalse(): void
@@ -78,8 +78,8 @@ class IntegrationRepositoryTest extends TestCase
             ->first();
 
         static::assertNotNull($entity);
-        static::assertEquals(1, $entities->count());
-        static::assertEquals('My app', $entity->getLabel());
+        static::assertCount(1, $entities);
+        static::assertSame('My app', $entity->getLabel());
         static::assertFalse($entity->getAdmin());
     }
 
@@ -107,8 +107,8 @@ class IntegrationRepositoryTest extends TestCase
             ->first();
 
         static::assertNotNull($entity);
-        static::assertEquals(1, $entities->count());
-        static::assertEquals('My app', $entity->getLabel());
+        static::assertCount(1, $entities);
+        static::assertSame('My app', $entity->getLabel());
         static::assertTrue($entity->getAdmin());
     }
 }

--- a/tests/integration/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelDefinitionTest.php
+++ b/tests/integration/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelDefinitionTest.php
@@ -104,8 +104,8 @@ class NumberRangeSalesChannelDefinitionTest extends TestCase
         $numberRangeSalesChannel = $getNumberRangeSalesChannels->first();
 
         static::assertInstanceOf(NumberRangeSalesChannelEntity::class, $numberRangeSalesChannel);
-        static::assertEquals($numberRangeId, $numberRangeSalesChannel->getNumberRangeId());
-        static::assertEquals(TestDefaults::SALES_CHANNEL, $numberRangeSalesChannel->getSalesChannelId());
-        static::assertEquals($numberRangeId, $numberRangeSalesChannel->getNumberRangeTypeId());
+        static::assertSame($numberRangeId, $numberRangeSalesChannel->getNumberRangeId());
+        static::assertSame(TestDefaults::SALES_CHANNEL, $numberRangeSalesChannel->getSalesChannelId());
+        static::assertSame($numberRangeId, $numberRangeSalesChannel->getNumberRangeTypeId());
     }
 }

--- a/tests/integration/Core/System/NumberRange/Command/MigrateIncrementStorageCommandTest.php
+++ b/tests/integration/Core/System/NumberRange/Command/MigrateIncrementStorageCommandTest.php
@@ -56,7 +56,7 @@ class MigrateIncrementStorageCommandTest extends TestCase
 
         $after = $this->arrayStorage->list();
         static::assertNotEmpty($after);
-        static::assertEquals($this->sqlStorage->list(), $this->arrayStorage->list());
+        static::assertSame($this->sqlStorage->list(), $this->arrayStorage->list());
     }
 
     public function testMigrateWithUserAbort(): void
@@ -68,7 +68,7 @@ class MigrateIncrementStorageCommandTest extends TestCase
         $this->tester->setInputs(['no']);
         $this->tester->execute(['from' => 'SQL', 'to' => 'Array']);
 
-        static::assertEquals(Command::FAILURE, $this->tester->getStatusCode());
+        static::assertSame(Command::FAILURE, $this->tester->getStatusCode());
 
         static::assertEmpty($this->arrayStorage->list());
     }

--- a/tests/integration/Core/System/NumberRange/NumberRangeValueGeneratorTest.php
+++ b/tests/integration/Core/System/NumberRange/NumberRangeValueGeneratorTest.php
@@ -42,25 +42,25 @@ class NumberRangeValueGeneratorTest extends TestCase
     public function testGenerateStandardPattern(): void
     {
         $value = $this->getGenerator('Pre_{n}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals('Pre_5_suf', $value);
+        static::assertSame('Pre_5_suf', $value);
     }
 
     public function testGenerateDatePattern(): void
     {
         $value = $this->getGenerator('Pre_{date}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals('Pre_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_suf', $value);
+        static::assertSame('Pre_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_suf', $value);
     }
 
     public function testGenerateDateWithFormatPattern(): void
     {
         $value = $this->getGenerator('Pre_{date_ymd}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals('Pre_' . date('ymd') . '_suf', $value);
+        static::assertSame('Pre_' . date('ymd') . '_suf', $value);
     }
 
     public function testGenerateAllPatterns(): void
     {
         $value = $this->getGenerator('Pre_{date}_{date_ymd}_{n}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals(
+        static::assertSame(
             'Pre_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_' . date('ymd') . '_5_suf',
             $value
         );
@@ -69,7 +69,7 @@ class NumberRangeValueGeneratorTest extends TestCase
     public function testGenerateExtraCharsAllPatterns(): void
     {
         $value = $this->getGenerator('Pre_!"§$%&/()=_{date}_{date_ymd}_{n}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals(
+        static::assertSame(
             'Pre_!"§$%&/()=_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_' . date('ymd') . '_5_suf',
             $value
         );
@@ -80,25 +80,25 @@ class NumberRangeValueGeneratorTest extends TestCase
         /** @var NumberRangeValueGenerator $realGenerator */
         $realGenerator = static::getContainer()->get(NumberRangeValueGeneratorInterface::class);
         $value = $realGenerator->getValue('product', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('SW10000', $value);
+        static::assertSame('SW10000', $value);
         $value = $realGenerator->getValue('product', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('SW10001', $value);
+        static::assertSame('SW10001', $value);
         $value = $realGenerator->getValue('product', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('SW10002', $value);
+        static::assertSame('SW10002', $value);
 
         $value = $realGenerator->getValue('order', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('10000', $value);
+        static::assertSame('10000', $value);
         $value = $realGenerator->getValue('order', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('10001', $value);
+        static::assertSame('10001', $value);
         $value = $realGenerator->getValue('order', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('10002', $value);
+        static::assertSame('10002', $value);
 
         $value = $realGenerator->getValue('customer', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('10000', $value);
+        static::assertSame('10000', $value);
         $value = $realGenerator->getValue('customer', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('10001', $value);
+        static::assertSame('10001', $value);
         $value = $realGenerator->getValue('customer', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('10002', $value);
+        static::assertSame('10002', $value);
     }
 
     public function testIncreaseStartNumberInConfiguration(): void
@@ -107,7 +107,7 @@ class NumberRangeValueGeneratorTest extends TestCase
         $realGenerator = static::getContainer()->get(NumberRangeValueGeneratorInterface::class);
 
         $value = $realGenerator->getValue('order', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('10000', $value);
+        static::assertSame('10000', $value);
 
         /** @var EntityRepository<NumberRangeTypeCollection> $numberRange */
         $numberRange = static::getContainer()->get('number_range_type.repository');
@@ -133,7 +133,7 @@ class NumberRangeValueGeneratorTest extends TestCase
         ]], $this->context);
 
         $value = $realGenerator->getValue('order', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
-        static::assertEquals('20000', $value);
+        static::assertSame('20000', $value);
     }
 
     private function getGenerator(string $pattern): NumberRangeValueGenerator

--- a/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementSqlStorageTest.php
+++ b/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementSqlStorageTest.php
@@ -38,8 +38,8 @@ class IncrementSqlStorageTest extends TestCase
 
         $this->storage->set($config['id'], 10);
 
-        static::assertEquals(11, $this->storage->reserve($config));
-        static::assertEquals(12, $this->storage->reserve($config));
+        static::assertSame(11, $this->storage->reserve($config));
+        static::assertSame(12, $this->storage->reserve($config));
     }
 
     public function testReserveReturnsWithoutStart(): void
@@ -52,8 +52,8 @@ class IncrementSqlStorageTest extends TestCase
 
         $this->storage->set($config['id'], 10);
 
-        static::assertEquals(11, $this->storage->reserve($config));
-        static::assertEquals(12, $this->storage->reserve($config));
+        static::assertSame(11, $this->storage->reserve($config));
+        static::assertSame(12, $this->storage->reserve($config));
     }
 
     public function testReserveReturnsWithoutStartAndUnset(): void
@@ -64,8 +64,8 @@ class IncrementSqlStorageTest extends TestCase
             'pattern' => 'n',
         ];
 
-        static::assertEquals(1, $this->storage->reserve($config));
-        static::assertEquals(2, $this->storage->reserve($config));
+        static::assertSame(1, $this->storage->reserve($config));
+        static::assertSame(2, $this->storage->reserve($config));
     }
 
     public function testReserveReturnsStartValueIfItIsHigherThanCurrentIncrement(): void
@@ -78,8 +78,8 @@ class IncrementSqlStorageTest extends TestCase
 
         $this->storage->set($config['id'], 5);
 
-        static::assertEquals(10, $this->storage->reserve($config));
-        static::assertEquals(11, $this->storage->reserve($config));
+        static::assertSame(10, $this->storage->reserve($config));
+        static::assertSame(11, $this->storage->reserve($config));
     }
 
     public function testReserveReturnsStartValueIfNoValueIsSet(): void
@@ -90,8 +90,8 @@ class IncrementSqlStorageTest extends TestCase
             'pattern' => 'n',
         ];
 
-        static::assertEquals(10, $this->storage->reserve($config));
-        static::assertEquals(11, $this->storage->reserve($config));
+        static::assertSame(10, $this->storage->reserve($config));
+        static::assertSame(11, $this->storage->reserve($config));
     }
 
     public function testPreviewIfValueIsNotSetAndNoStart(): void
@@ -102,8 +102,8 @@ class IncrementSqlStorageTest extends TestCase
             'pattern' => 'n',
         ];
 
-        static::assertEquals(1, $this->storage->preview($config));
-        static::assertEquals(1, $this->storage->preview($config));
+        static::assertSame(1, $this->storage->preview($config));
+        static::assertSame(1, $this->storage->preview($config));
     }
 
     public function testPreviewWillReturnStartValueIfNoValueIsSet(): void
@@ -114,8 +114,8 @@ class IncrementSqlStorageTest extends TestCase
             'pattern' => 'n',
         ];
 
-        static::assertEquals(10, $this->storage->preview($config));
-        static::assertEquals(10, $this->storage->preview($config));
+        static::assertSame(10, $this->storage->preview($config));
+        static::assertSame(10, $this->storage->preview($config));
     }
 
     public function testPreviewWillReturnStartValueIfItHigherThanCurrentIncrementValue(): void
@@ -128,8 +128,8 @@ class IncrementSqlStorageTest extends TestCase
 
         $this->storage->set($config['id'], 5);
 
-        static::assertEquals(10, $this->storage->preview($config));
-        static::assertEquals(10, $this->storage->preview($config));
+        static::assertSame(10, $this->storage->preview($config));
+        static::assertSame(10, $this->storage->preview($config));
     }
 
     public function testPreviewWillReturnNextValueIfIncrementIsHigherThanStartValue(): void
@@ -142,8 +142,8 @@ class IncrementSqlStorageTest extends TestCase
 
         $this->storage->set($config['id'], 15);
 
-        static::assertEquals(16, $this->storage->preview($config));
-        static::assertEquals(16, $this->storage->preview($config));
+        static::assertSame(16, $this->storage->preview($config));
+        static::assertSame(16, $this->storage->preview($config));
     }
 
     public function testSetAndList(): void
@@ -159,6 +159,6 @@ class IncrementSqlStorageTest extends TestCase
             $this->storage->set($id, $value);
         }
 
-        static::assertEquals($states, $this->storage->list());
+        static::assertSame($states, $this->storage->list());
     }
 }

--- a/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementStorageRegistryTest.php
+++ b/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementStorageRegistryTest.php
@@ -64,7 +64,7 @@ class IncrementStorageRegistryTest extends TestCase
 
         $registry->migrate('Array', 'SQL');
 
-        static::assertEquals($arrayStorage->list(), $sqlStorage->list());
+        static::assertSame($arrayStorage->list(), $sqlStorage->list());
     }
 
     public function testMigrateFromSqlStorage(): void
@@ -78,7 +78,7 @@ class IncrementStorageRegistryTest extends TestCase
             $sqlStorage->set($key, $value);
         }
 
-        static::assertEquals($states, $sqlStorage->list());
+        static::assertSame($states, $sqlStorage->list());
         $arrayStorage = new IncrementArrayStorage([]);
 
         $registry = new IncrementStorageRegistry(
@@ -95,7 +95,7 @@ class IncrementStorageRegistryTest extends TestCase
 
         $registry->migrate('SQL', 'Array');
 
-        static::assertEquals($sqlStorage->list(), $arrayStorage->list());
+        static::assertSame($sqlStorage->list(), $arrayStorage->list());
     }
 
     public function testMigrateWithUnknownFromStorageThrows(): void

--- a/tests/integration/Core/System/SalesChannel/Context/CartRestorerTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/CartRestorerTest.php
@@ -434,14 +434,14 @@ class CartRestorerTest extends TestCase
         $cartMergedEvent = $this->events[CartMergedEvent::class];
         static::assertInstanceOf(CartMergedEvent::class, $cartMergedEvent);
 
-        static::assertEquals(1, $cartMergedEvent->getPreviousCart()->getLineItems()->count());
-        static::assertEquals($cartMergedEvent->getCart()->getToken(), $cartMergedEvent->getPreviousCart()->getToken());
+        static::assertCount(1, $cartMergedEvent->getPreviousCart()->getLineItems());
+        static::assertSame($cartMergedEvent->getCart()->getToken(), $cartMergedEvent->getPreviousCart()->getToken());
 
         static::assertIsString($productLineItem1->getReferencedId());
         static::assertNotNull($p1 = $restoreCart->getLineItems()->get($productLineItem1->getReferencedId()));
-        static::assertEquals(1, $p1->getQuantity());
+        static::assertSame(1, $p1->getQuantity());
         static::assertNotNull($savedItem = $restoreCart->getLineItems()->get($savedLineItem->getId()));
-        static::assertEquals($savedLineItemQuantity + $guestProductQuantity, $savedItem->getQuantity());
+        static::assertSame($savedLineItemQuantity + $guestProductQuantity, $savedItem->getQuantity());
     }
 
     public function testCartMergedEventIsFiredWithCustomerCart(): void
@@ -484,8 +484,8 @@ class CartRestorerTest extends TestCase
         $event = $this->events[CartMergedEvent::class];
 
         static::assertNotNull($event->getPreviousCart());
-        static::assertEquals(0, $event->getPreviousCart()->getLineItems()->count());
-        static::assertEquals($event->getCart()->getToken(), $event->getPreviousCart()->getToken());
+        static::assertCount(0, $event->getPreviousCart()->getLineItems());
+        static::assertSame($event->getCart()->getToken(), $event->getPreviousCart()->getToken());
 
         static::assertIsString($productLineItem1->getReferencedId());
         static::assertNotNull($p1 = $restoreCart->getLineItems()->get($productLineItem1->getReferencedId()));

--- a/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextPersisterTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextPersisterTest.php
@@ -67,7 +67,7 @@ class SalesChannelContextPersisterTest extends TestCase
         $this->contextPersister->save($token, [], TestDefaults::SALES_CHANNEL, $customerId);
 
         static::assertNotEmpty($result = $this->contextPersister->load($token, TestDefaults::SALES_CHANNEL, $customerId));
-        static::assertEquals($token, $result['token']);
+        static::assertSame($token, $result['token']);
     }
 
     public function testLoadNotExisting(): void
@@ -117,7 +117,7 @@ class SalesChannelContextPersisterTest extends TestCase
         static::assertNotEmpty($result);
 
         static::assertEquals($expected, $result);
-        static::assertEquals($token, $result['token']);
+        static::assertSame($token, $result['token']);
     }
 
     public function testSaveMergesWithExisting(): void
@@ -230,12 +230,12 @@ class SalesChannelContextPersisterTest extends TestCase
 
         $contextPayload1 = $this->contextPersister->load(Uuid::randomHex(), $salesChannel1['id'], $customerId);
         static::assertNotEmpty($contextPayload1);
-        static::assertEquals($token1, $contextPayload1['token']);
+        static::assertSame($token1, $contextPayload1['token']);
 
         $contextPayload2 = $this->contextPersister->load(Uuid::randomHex(), $salesChannel2['id'], $customerId);
 
         static::assertNotEmpty($contextPayload2);
-        static::assertEquals($token2, $contextPayload2['token']);
+        static::assertSame($token2, $contextPayload2['token']);
     }
 
     public function testReplaceWithoutExistingContext(): void
@@ -352,7 +352,7 @@ class SalesChannelContextPersisterTest extends TestCase
 
         // check token is valid here
         static::assertNotEmpty($result = $this->contextPersister->load($token, TestDefaults::SALES_CHANNEL, $customerId));
-        static::assertEquals($token, $result['token']);
+        static::assertSame($token, $result['token']);
 
         if ($preserveToken) {
             $this->contextPersister->revokeAllCustomerTokens($customerId, $preserveToken);

--- a/tests/integration/Core/System/SalesChannel/Repository/SalesChannelRepositoryTest.php
+++ b/tests/integration/Core/System/SalesChannel/Repository/SalesChannelRepositoryTest.php
@@ -126,42 +126,42 @@ class SalesChannelRepositoryTest extends TestCase
         $salesChannel = $this->salesChannelRepository->search($criteria1, $context)->get($salesChannelId);
 
         static::assertInstanceOf(SalesChannelEntity::class, $salesChannel);
-        static::assertEquals($name, $salesChannel->getName());
-        static::assertEquals($accessKey, $salesChannel->getAccessKey());
+        static::assertSame($name, $salesChannel->getName());
+        static::assertSame($accessKey, $salesChannel->getAccessKey());
 
         static::assertInstanceOf(SalesChannelTypeEntity::class, $salesChannel->getType());
-        static::assertEquals($cover, $salesChannel->getType()->getCoverUrl());
-        static::assertEquals($icon, $salesChannel->getType()->getIconName());
-        static::assertEquals($screenshots, $salesChannel->getType()->getScreenshotUrls());
-        static::assertEquals($typeName, $salesChannel->getType()->getName());
-        static::assertEquals($manufacturer, $salesChannel->getType()->getManufacturer());
-        static::assertEquals($description, $salesChannel->getType()->getDescription());
-        static::assertEquals($descriptionLong, $salesChannel->getType()->getDescriptionLong());
+        static::assertSame($cover, $salesChannel->getType()->getCoverUrl());
+        static::assertSame($icon, $salesChannel->getType()->getIconName());
+        static::assertSame($screenshots, $salesChannel->getType()->getScreenshotUrls());
+        static::assertSame($typeName, $salesChannel->getType()->getName());
+        static::assertSame($manufacturer, $salesChannel->getType()->getManufacturer());
+        static::assertSame($description, $salesChannel->getType()->getDescription());
+        static::assertSame($descriptionLong, $salesChannel->getType()->getDescriptionLong());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('currency.salesChannels.id', $salesChannelId));
         $currency = $this->currencyRepository->search($criteria, $context);
-        static::assertEquals(1, $currency->count());
+        static::assertCount(1, $currency);
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('language.salesChannels.id', $salesChannelId));
         $language = $this->languageRepository->search($criteria, $context);
-        static::assertEquals(1, $language->count());
+        static::assertCount(1, $language);
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('payment_method.salesChannels.id', $salesChannelId));
         $paymentMethod = $this->paymentMethodRepository->search($criteria, $context);
-        static::assertEquals(1, $paymentMethod->count());
+        static::assertCount(1, $paymentMethod);
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('country.salesChannels.id', $salesChannelId));
         $country = $this->countryRepository->search($criteria, $context);
-        static::assertEquals(1, $country->count());
+        static::assertCount(1, $country);
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('shipping_method.salesChannels.id', $salesChannelId));
         $shippingMethod = $this->shippingMethodRepository->search($criteria, $context);
-        static::assertEquals(1, $shippingMethod->count());
+        static::assertCount(1, $shippingMethod);
     }
 
     public function testTaxCalculationDefault(): void

--- a/tests/integration/Core/System/SalesChannel/SalesChannel/ContextSwitchRouteTest.php
+++ b/tests/integration/Core/System/SalesChannel/SalesChannel/ContextSwitchRouteTest.php
@@ -50,7 +50,7 @@ class ContextSwitchRouteTest extends TestCase
         $this->getSalesChannelBrowser()->request('PATCH', '/store-api/context', ['shippingMethodId' => $testId]);
         $content = json_decode($this->getSalesChannelBrowser()->getResponse()->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             \sprintf('The "shipping_method" entity with id "%s" does not exist.', $testId),
             $content['errors'][0]['detail'] ?? null
         );
@@ -61,7 +61,7 @@ class ContextSwitchRouteTest extends TestCase
         $this->getSalesChannelBrowser()->request('PATCH', '/store-api/context', ['paymentMethodId' => $testId]);
         $content = json_decode($this->getSalesChannelBrowser()->getResponse()->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             \sprintf('The "payment_method" entity with id "%s" does not exist.', $testId),
             $content['errors'][0]['detail'] ?? null
         );
@@ -78,7 +78,7 @@ class ContextSwitchRouteTest extends TestCase
         $content = json_decode($this->getSalesChannelBrowser()->getResponse()->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_FORBIDDEN, $this->getSalesChannelBrowser()->getResponse()->getStatusCode());
 
-        static::assertEquals(
+        static::assertSame(
             'Customer is not logged in.',
             $content['errors'][0]['detail'] ?? null
         );
@@ -90,7 +90,7 @@ class ContextSwitchRouteTest extends TestCase
         $content = json_decode($this->getSalesChannelBrowser()->getResponse()->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_FORBIDDEN, $this->getSalesChannelBrowser()->getResponse()->getStatusCode());
 
-        static::assertEquals(
+        static::assertSame(
             'Customer is not logged in.',
             $content['errors'][0]['detail'] ?? null
         );
@@ -133,14 +133,14 @@ class ContextSwitchRouteTest extends TestCase
         static::assertArrayHasKey('/countryStateId', $mapped);
         static::assertArrayHasKey('/languageId', $mapped);
 
-        static::assertEquals('This value should be of type string.', $mapped['/currencyId']);
-        static::assertEquals('This value should be of type string.', $mapped['/billingAddressId']);
-        static::assertEquals('This value should be of type string.', $mapped['/shippingAddressId']);
-        static::assertEquals('This value should be of type string.', $mapped['/paymentMethodId']);
-        static::assertEquals('This value should be of type string.', $mapped['/shippingMethodId']);
-        static::assertEquals('This value should be of type string.', $mapped['/countryId']);
-        static::assertEquals('This value should be of type string.', $mapped['/countryStateId']);
-        static::assertEquals('This value should be of type string.', $mapped['/languageId']);
+        static::assertSame('This value should be of type string.', $mapped['/currencyId']);
+        static::assertSame('This value should be of type string.', $mapped['/billingAddressId']);
+        static::assertSame('This value should be of type string.', $mapped['/shippingAddressId']);
+        static::assertSame('This value should be of type string.', $mapped['/paymentMethodId']);
+        static::assertSame('This value should be of type string.', $mapped['/shippingMethodId']);
+        static::assertSame('This value should be of type string.', $mapped['/countryId']);
+        static::assertSame('This value should be of type string.', $mapped['/countryStateId']);
+        static::assertSame('This value should be of type string.', $mapped['/languageId']);
     }
 
     public function testUpdateContextWithLoggedInCustomerAndNonExistingAddresses(): void
@@ -157,7 +157,7 @@ class ContextSwitchRouteTest extends TestCase
         static::assertSame(Response::HTTP_BAD_REQUEST, $this->getSalesChannelBrowser()->getResponse()->getStatusCode());
         $content = json_decode($this->getSalesChannelBrowser()->getResponse()->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             \sprintf('The "customer_address" entity with id "%s" does not exist.', $testId),
             $content['errors'][0]['detail'] ?? null
         );
@@ -169,7 +169,7 @@ class ContextSwitchRouteTest extends TestCase
         static::assertSame(Response::HTTP_BAD_REQUEST, $this->getSalesChannelBrowser()->getResponse()->getStatusCode());
         $content = json_decode($this->getSalesChannelBrowser()->getResponse()->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             \sprintf('The "customer_address" entity with id "%s" does not exist.', $testId),
             $content['errors'][0]['detail'] ?? null
         );
@@ -209,7 +209,7 @@ class ContextSwitchRouteTest extends TestCase
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), print_r($content, true));
 
-        static::assertEquals(
+        static::assertSame(
             \sprintf('The "language" entity with id "%s" does not exist.', $id),
             $content['errors'][0]['detail'] ?? null
         );
@@ -288,7 +288,7 @@ class ContextSwitchRouteTest extends TestCase
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), print_r($content, true));
 
-        static::assertEquals(
+        static::assertSame(
             \sprintf('The "currency" entity with id "%s" does not exist.', $id),
             $content['errors'][0]['detail'] ?? null
         );

--- a/tests/integration/Core/System/Snippet/Files/AppSnippetFileLoaderTest.php
+++ b/tests/integration/Core/System/Snippet/Files/AppSnippetFileLoaderTest.php
@@ -58,23 +58,23 @@ class AppSnippetFileLoaderTest extends TestCase
         static::assertCount(2, $collection);
 
         $snippetFile = $collection->getSnippetFilesByIso('de-DE')[0];
-        static::assertEquals('storefront.de-DE', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.de-DE', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/Apps/AppWithSnippets/Resources/snippet/storefront.de-DE.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('de-DE', $snippetFile->getIso());
-        static::assertEquals('shopware AG', $snippetFile->getAuthor());
+        static::assertSame('de-DE', $snippetFile->getIso());
+        static::assertSame('shopware AG', $snippetFile->getAuthor());
         static::assertFalse($snippetFile->isBase());
 
         $snippetFile = $collection->getSnippetFilesByIso('en-GB')[0];
-        static::assertEquals('storefront.en-GB', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.en-GB', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/Apps/AppWithSnippets/Resources/snippet/storefront.en-GB.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('en-GB', $snippetFile->getIso());
-        static::assertEquals('shopware AG', $snippetFile->getAuthor());
+        static::assertSame('en-GB', $snippetFile->getIso());
+        static::assertSame('shopware AG', $snippetFile->getAuthor());
         static::assertFalse($snippetFile->isBase());
     }
 
@@ -100,23 +100,23 @@ class AppSnippetFileLoaderTest extends TestCase
         static::assertCount(2, $collection);
 
         $snippetFile = $collection->getSnippetFilesByIso('de-DE')[0];
-        static::assertEquals('storefront.de-DE', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.de-DE', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/Apps/AppWithBaseSnippets/Resources/snippet/storefront.de-DE.base.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('de-DE', $snippetFile->getIso());
-        static::assertEquals('shopware AG', $snippetFile->getAuthor());
+        static::assertSame('de-DE', $snippetFile->getIso());
+        static::assertSame('shopware AG', $snippetFile->getAuthor());
         static::assertTrue($snippetFile->isBase());
 
         $snippetFile = $collection->getSnippetFilesByIso('en-GB')[0];
-        static::assertEquals('storefront.en-GB', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.en-GB', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/Apps/AppWithBaseSnippets/Resources/snippet/storefront.en-GB.base.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('en-GB', $snippetFile->getIso());
-        static::assertEquals('shopware AG', $snippetFile->getAuthor());
+        static::assertSame('en-GB', $snippetFile->getIso());
+        static::assertSame('shopware AG', $snippetFile->getAuthor());
         static::assertTrue($snippetFile->isBase());
     }
 

--- a/tests/integration/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/integration/Core/System/Snippet/SnippetServiceTest.php
@@ -82,7 +82,7 @@ class SnippetServiceTest extends TestCase
 
         $snippets = $service->getStorefrontSnippets($this->getCatalog([], $locale), $snippetSetId);
 
-        static::assertEquals([
+        static::assertSame([
             'foo.baz' => 'foo_baz_override0',
             'foo.bas' => 'foo_bas_override_db',
             'bar' => 'bar_default2',
@@ -122,7 +122,7 @@ class SnippetServiceTest extends TestCase
 
         $snippets = $service->getStorefrontSnippets($this->getCatalog([], $locale), $snippetSetId);
 
-        static::assertEquals([
+        static::assertSame([
             'foo.bar' => 'foo_bar_override',
             'foo.bas' => 'foo_bas_default1',
             'baz.bar' => 'baz_bar_default2',
@@ -181,7 +181,7 @@ json
         $service = $this->getSnippetService($snippetFile);
         $result = $service->getRegionFilterItems(Context::createDefaultContext());
 
-        static::assertEquals([
+        static::assertSame([
             'bar',
             'foo',
             'test',

--- a/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
+++ b/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
@@ -68,7 +68,7 @@ class StateMachineActionControllerTest extends TestCase
         static::assertIsString($response);
         $response = json_decode($response, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(Response::HTTP_NOT_FOUND, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_NOT_FOUND, $this->getBrowser()->getResponse()->getStatusCode());
         static::assertArrayHasKey('errors', $response);
     }
 
@@ -80,13 +80,13 @@ class StateMachineActionControllerTest extends TestCase
 
         $this->getBrowser()->request('GET', '/api/_action/state-machine/order/' . $orderId . '/state');
 
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
         $response = $this->getBrowser()->getResponse()->getContent();
         static::assertIsString($response);
         $response = json_decode($response, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertCount(2, $response['transitions']);
-        static::assertEquals('cancel', $response['transitions'][0]['actionName']);
+        static::assertSame('cancel', $response['transitions'][0]['actionName']);
         static::assertStringEndsWith('/_action/state-machine/order/' . $orderId . '/state/cancel', $response['transitions'][0]['url']);
     }
 
@@ -111,7 +111,7 @@ class StateMachineActionControllerTest extends TestCase
         static::assertIsString($responseString);
         $response = json_decode($responseString, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_OK,
             $this->getBrowser()->getResponse()->getStatusCode(),
             $responseString
@@ -121,7 +121,7 @@ class StateMachineActionControllerTest extends TestCase
         static::assertTrue(Uuid::isValid($stateId));
 
         $destinationStateTechnicalName = $response['data']['attributes']['technicalName'];
-        static::assertEquals($transitionTechnicalName, $destinationStateTechnicalName);
+        static::assertSame($transitionTechnicalName, $destinationStateTechnicalName);
 
         // test whether the state history was written
         $criteria = new Criteria();
@@ -136,12 +136,12 @@ class StateMachineActionControllerTest extends TestCase
 
         $toStateMachineState = $historyEntry->getToStateMachineState();
         static::assertInstanceOf(StateMachineStateEntity::class, $toStateMachineState);
-        static::assertEquals($destinationStateTechnicalName, $toStateMachineState->getTechnicalName());
+        static::assertSame($destinationStateTechnicalName, $toStateMachineState->getTechnicalName());
 
-        static::assertEquals(static::getContainer()->get(OrderDefinition::class)->getEntityName(), $historyEntry->getEntityName());
+        static::assertSame(static::getContainer()->get(OrderDefinition::class)->getEntityName(), $historyEntry->getEntityName());
 
-        static::assertEquals($orderId, $historyEntry->getReferencedId());
-        static::assertEquals(Defaults::LIVE_VERSION, $historyEntry->getReferencedVersionId());
+        static::assertSame($orderId, $historyEntry->getReferencedId());
+        static::assertSame(Defaults::LIVE_VERSION, $historyEntry->getReferencedVersionId());
     }
 
     public function testTransitionToNotAllowedState(): void
@@ -156,7 +156,7 @@ class StateMachineActionControllerTest extends TestCase
         static::assertIsString($response);
         $response = json_decode($response, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $this->getBrowser()->getResponse()->getStatusCode());
         static::assertArrayHasKey('errors', $response);
     }
 
@@ -221,7 +221,7 @@ class StateMachineActionControllerTest extends TestCase
         /** @var OrderEntity $order */
         $order = $orderRepository->search(new Criteria([$orderId]), $salesChannelContext->getContext())->first();
 
-        static::assertEquals($order->getLanguageId(), $this->getDeDeLanguageId());
+        static::assertSame($order->getLanguageId(), $this->getDeDeLanguageId());
     }
 
     public function testOrderCartEn(): void
@@ -285,7 +285,7 @@ class StateMachineActionControllerTest extends TestCase
         /** @var OrderEntity $order */
         $order = $orderRepository->search(new Criteria([$orderId]), $salesChannelContext->getContext())->first();
 
-        static::assertEquals($order->getLanguageId(), Defaults::LANGUAGE_SYSTEM);
+        static::assertSame($order->getLanguageId(), Defaults::LANGUAGE_SYSTEM);
     }
 
     private function createShippingMethod(): string

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -99,9 +99,9 @@ EOF;
         $stateMachine = $this->stateMachineRegistry->getStateMachine($this->stateMachineName, $context);
 
         static::assertNotNull($stateMachine->getStates());
-        static::assertEquals(3, $stateMachine->getStates()->count());
+        static::assertCount(3, $stateMachine->getStates());
         static::assertNotNull($stateMachine->getTransitions());
-        static::assertEquals(4, $stateMachine->getTransitions()->count());
+        static::assertCount(4, $stateMachine->getTransitions());
     }
 
     public function testStateMachineAvailableTransitionShouldIncludeReOpenAndReTourTransition(): void
@@ -119,12 +119,12 @@ EOF;
         foreach ($availableTransitions as $transition) {
             if ($transition->getActionName() === 'reopen') {
                 $reopenActionExisted = true;
-                static::assertEquals(OrderDeliveryStates::STATE_OPEN, $transition->getToStateMachineState()?->getTechnicalName());
+                static::assertSame(OrderDeliveryStates::STATE_OPEN, $transition->getToStateMachineState()?->getTechnicalName());
             }
 
             if ($transition->getActionName() === 'retour') {
                 $retourActionExisted = true;
-                static::assertEquals(OrderDeliveryStates::STATE_RETURNED, $transition->getToStateMachineState()?->getTechnicalName());
+                static::assertSame(OrderDeliveryStates::STATE_RETURNED, $transition->getToStateMachineState()?->getTechnicalName());
             }
         }
 
@@ -143,8 +143,8 @@ EOF;
         static::assertNotEmpty($stateCollection->get('toPlace'));
         $fromPlace = $stateCollection->get('fromPlace');
         $toPlace = $stateCollection->get('toPlace');
-        static::assertEquals(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $fromPlace->getTechnicalName());
-        static::assertEquals(OrderDeliveryStates::STATE_RETURNED, $toPlace->getTechnicalName());
+        static::assertSame(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $fromPlace->getTechnicalName());
+        static::assertSame(OrderDeliveryStates::STATE_RETURNED, $toPlace->getTechnicalName());
     }
 
     public function testStateMachineRegistryUnnecessaryTransition(): void
@@ -158,8 +158,8 @@ EOF;
         static::assertNotEmpty($stateCollection->get('toPlace'));
         $fromPlace = $stateCollection->get('fromPlace');
         $toPlace = $stateCollection->get('toPlace');
-        static::assertEquals(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $fromPlace->getTechnicalName());
-        static::assertEquals(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $toPlace->getTechnicalName());
+        static::assertSame(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $fromPlace->getTechnicalName());
+        static::assertSame(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $toPlace->getTechnicalName());
     }
 
     public function testStateMachineTransitionStoresUserAndIntegrationId(): void

--- a/tests/integration/Core/System/SystemConfig/Facade/SystemConfigFacadeTest.php
+++ b/tests/integration/Core/System/SystemConfig/Facade/SystemConfigFacadeTest.php
@@ -54,7 +54,7 @@ class SystemConfigFacadeTest extends TestCase
             new Script('test', '', new \DateTimeImmutable())
         );
 
-        static::assertEquals($result, $facade->get('test.value', $salesChannelId));
+        static::assertSame($result, $facade->get('test.value', $salesChannelId));
     }
 
     /**
@@ -115,7 +115,7 @@ class SystemConfigFacadeTest extends TestCase
             new Script('test', '', new \DateTimeImmutable(), $appInfo)
         );
 
-        static::assertEquals('generic', $facade->get('test.value'));
+        static::assertSame('generic', $facade->get('test.value'));
     }
 
     public function testGetAppConfigForAppWithoutPermission(): void
@@ -129,7 +129,7 @@ class SystemConfigFacadeTest extends TestCase
             new Script('test', '', new \DateTimeImmutable(), $appInfo)
         );
 
-        static::assertEquals('test', $facade->app('testValue'));
+        static::assertSame('test', $facade->app('testValue'));
     }
 
     public function testGetAppConfigForApp(): void
@@ -143,7 +143,7 @@ class SystemConfigFacadeTest extends TestCase
             new Script('test', '', new \DateTimeImmutable(), $appInfo)
         );
 
-        static::assertEquals('test', $facade->app('testValue'));
+        static::assertSame('test', $facade->app('testValue'));
     }
 
     public function testGetAppConfigThrowsWithoutApp(): void
@@ -184,8 +184,8 @@ class SystemConfigFacadeTest extends TestCase
         $extension = $page->getExtension('systemConfigExtension');
         static::assertInstanceOf(ArrayStruct::class, $extension);
 
-        static::assertEquals('system_config', $extension->get('systemConfig'));
-        static::assertEquals('app_config', $extension->get('appConfig'));
+        static::assertSame('system_config', $extension->get('systemConfig'));
+        static::assertSame('app_config', $extension->get('appConfig'));
     }
 
     private function installApp(string $appDir): ScriptAppInformation

--- a/tests/integration/Core/System/SystemConfig/SystemConfigServiceTest.php
+++ b/tests/integration/Core/System/SystemConfig/SystemConfigServiceTest.php
@@ -206,22 +206,22 @@ class SystemConfigServiceTest extends TestCase
     {
         $this->systemConfigService->set('foo.bar', 0.0);
         $actual = $this->systemConfigService->get('foo.bar');
-        static::assertEquals(0.0, $actual);
+        static::assertSame(0.0, $actual);
     }
 
     public function testSetGetSalesChannel(): void
     {
         $this->systemConfigService->set('foo.bar', 'test');
         $actual = $this->systemConfigService->get('foo.bar', TestDefaults::SALES_CHANNEL);
-        static::assertEquals('test', $actual);
+        static::assertSame('test', $actual);
 
         $this->systemConfigService->set('foo.bar', 'override', TestDefaults::SALES_CHANNEL);
         $actual = $this->systemConfigService->get('foo.bar', TestDefaults::SALES_CHANNEL);
-        static::assertEquals('override', $actual);
+        static::assertSame('override', $actual);
 
         $this->systemConfigService->set('foo.bar', '', TestDefaults::SALES_CHANNEL);
         $actual = $this->systemConfigService->get('foo.bar', TestDefaults::SALES_CHANNEL);
-        static::assertEquals('', $actual);
+        static::assertSame('', $actual);
     }
 
     public function testSetGetSalesChannelBool(): void
@@ -238,16 +238,16 @@ class SystemConfigServiceTest extends TestCase
     public function testGetDomainNoData(): void
     {
         $actual = $this->systemConfigService->getDomain('foo');
-        static::assertEquals([], $actual);
+        static::assertSame([], $actual);
 
         $actual = $this->systemConfigService->getDomain('foo', null, true);
-        static::assertEquals([], $actual);
+        static::assertSame([], $actual);
 
         $actual = $this->systemConfigService->getDomain('foo', TestDefaults::SALES_CHANNEL);
-        static::assertEquals([], $actual);
+        static::assertSame([], $actual);
 
         $actual = $this->systemConfigService->getDomain('foo', TestDefaults::SALES_CHANNEL, true);
-        static::assertEquals([], $actual);
+        static::assertSame([], $actual);
     }
 
     public function testGetDomain(): void
@@ -263,7 +263,7 @@ class SystemConfigServiceTest extends TestCase
             'foo.c' => 'c',
         ];
         $actual = $this->systemConfigService->getDomain('foo');
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
 
         $expected = [
             'foo.a' => 'a',
@@ -271,13 +271,13 @@ class SystemConfigServiceTest extends TestCase
             'foo.c' => 'c override',
         ];
         $actual = $this->systemConfigService->getDomain('foo', TestDefaults::SALES_CHANNEL, true);
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
 
         $expected = [
             'foo.c' => 'c override',
         ];
         $actual = $this->systemConfigService->getDomain('foo', TestDefaults::SALES_CHANNEL);
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testGetDomainInherit(): void
@@ -289,7 +289,7 @@ class SystemConfigServiceTest extends TestCase
         $expected = ['foo.bar' => 'test'];
         $actual = $this->systemConfigService->getDomain('foo', TestDefaults::SALES_CHANNEL, true);
 
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testGetDomainInheritWithBooleanValue(): void
@@ -311,7 +311,7 @@ class SystemConfigServiceTest extends TestCase
     {
         $this->systemConfigService->set('foo.a', 'a');
         $actual = $this->systemConfigService->getDomain('foo.');
-        static::assertEquals(['foo.a' => 'a'], $actual);
+        static::assertSame(['foo.a' => 'a'], $actual);
     }
 
     public function testDeleteNonExisting(): void
@@ -329,7 +329,7 @@ class SystemConfigServiceTest extends TestCase
         $actual = $this->systemConfigService->get('foo');
         static::assertNull($actual);
         $actual = $this->systemConfigService->get('foo', TestDefaults::SALES_CHANNEL);
-        static::assertEquals('bar override', $actual);
+        static::assertSame('bar override', $actual);
 
         $this->systemConfigService->delete('foo', TestDefaults::SALES_CHANNEL);
         $actual = $this->systemConfigService->get('foo', TestDefaults::SALES_CHANNEL);
@@ -373,7 +373,7 @@ class SystemConfigServiceTest extends TestCase
         $called = false;
 
         $this->addEventListener($eventDispatcher, SystemConfigChangedHook::class, function (SystemConfigChangedHook $event) use (&$called): void {
-            static::assertEquals([
+            static::assertSame([
                 'changes' => ['foo.bar'],
                 'salesChannelId' => TestDefaults::SALES_CHANNEL,
             ], $event->getWebhookPayload());

--- a/tests/integration/Core/System/Tag/Service/FilterTagIdsServiceTest.php
+++ b/tests/integration/Core/System/Tag/Service/FilterTagIdsServiceTest.php
@@ -57,8 +57,8 @@ class FilterTagIdsServiceTest extends TestCase
             Context::createDefaultContext()
         );
 
-        static::assertEquals(5, $filteredTagIdsStruct->getTotal());
-        static::assertEquals(
+        static::assertSame(5, $filteredTagIdsStruct->getTotal());
+        static::assertSame(
             [
                 $this->ids->get('a'),
                 $this->ids->get('b'),
@@ -86,8 +86,8 @@ class FilterTagIdsServiceTest extends TestCase
             Context::createDefaultContext()
         );
 
-        static::assertEquals(2, $filteredTagIdsStruct->getTotal());
-        static::assertEquals(
+        static::assertSame(2, $filteredTagIdsStruct->getTotal());
+        static::assertSame(
             [
                 $this->ids->get('unassigned'),
                 $this->ids->get('unique'),
@@ -112,8 +112,8 @@ class FilterTagIdsServiceTest extends TestCase
             Context::createDefaultContext()
         );
 
-        static::assertEquals(5, $filteredTagIdsStruct->getTotal());
-        static::assertEquals(
+        static::assertSame(5, $filteredTagIdsStruct->getTotal());
+        static::assertSame(
             [
                 $this->ids->get('e'),
                 $this->ids->get('d'),
@@ -139,8 +139,8 @@ class FilterTagIdsServiceTest extends TestCase
                 $context
             );
 
-            static::assertEquals(2, $filteredTagIdsStruct->getTotal());
-            static::assertEquals(
+            static::assertSame(2, $filteredTagIdsStruct->getTotal());
+            static::assertSame(
                 [
                     $this->ids->get('g'),
                     $this->ids->get('f'),
@@ -158,8 +158,8 @@ class FilterTagIdsServiceTest extends TestCase
             $versionContext
         );
 
-        static::assertEquals(2, $filteredTagIdsStruct->getTotal());
-        static::assertEquals(
+        static::assertSame(2, $filteredTagIdsStruct->getTotal());
+        static::assertSame(
             [
                 $this->ids->get('f'),
                 $this->ids->get('g'),
@@ -180,22 +180,22 @@ class FilterTagIdsServiceTest extends TestCase
         $request->request->set('assignmentFilter', ['categories']);
         $filteredTagIdsStruct = $this->filterTagIdsService->filterIds($request, $criteria, $context);
 
-        static::assertEquals(5, $filteredTagIdsStruct->getTotal());
+        static::assertSame(5, $filteredTagIdsStruct->getTotal());
 
         $request->request->set('assignmentFilter', ['categories', 'orders']);
         $filteredTagIdsStruct = $this->filterTagIdsService->filterIds($request, $criteria, $context);
 
-        static::assertEquals(6, $filteredTagIdsStruct->getTotal());
+        static::assertSame(6, $filteredTagIdsStruct->getTotal());
 
         $request->request->set('assignmentFilter', ['categories', 'products']);
         $filteredTagIdsStruct = $this->filterTagIdsService->filterIds($request, $criteria, $context);
 
-        static::assertEquals(7, $filteredTagIdsStruct->getTotal());
+        static::assertSame(7, $filteredTagIdsStruct->getTotal());
 
         $request->request->set('assignmentFilter', ['invalid']);
         $filteredTagIdsStruct = $this->filterTagIdsService->filterIds($request, $criteria, $context);
 
-        static::assertEquals(9, $filteredTagIdsStruct->getTotal());
+        static::assertSame(9, $filteredTagIdsStruct->getTotal());
     }
 
     private function prepareTestData(): void

--- a/tests/integration/Core/System/UsageData/EntitySync/IterateEntityMessageHandlerTest.php
+++ b/tests/integration/Core/System/UsageData/EntitySync/IterateEntityMessageHandlerTest.php
@@ -103,8 +103,8 @@ class IterateEntityMessageHandlerTest extends TestCase
 
         static::assertInstanceOf(DispatchEntityMessage::class, $entitySyncMessage);
 
-        static::assertEquals('product', $entitySyncMessage->entityName);
-        static::assertEquals([
+        static::assertSame('product', $entitySyncMessage->entityName);
+        static::assertSame([
             ['id' => $productIds->get('product-from-the-past')],
             ['id' => $productIds->get('product-created-on-last-run-date')],
             ['id' => $productIds->get('product-created-today')],
@@ -157,8 +157,8 @@ class IterateEntityMessageHandlerTest extends TestCase
 
         static::assertInstanceOf(DispatchEntityMessage::class, $entitySyncMessage);
 
-        static::assertEquals('product', $entitySyncMessage->entityName);
-        static::assertEquals([
+        static::assertSame('product', $entitySyncMessage->entityName);
+        static::assertSame([
             ['id' => $productIds->get('product-created-on-last-run-date')],
             ['id' => $productIds->get('product-created-today')],
         ], array_values($entitySyncMessage->primaryKeys));
@@ -213,7 +213,7 @@ class IterateEntityMessageHandlerTest extends TestCase
         $entitySyncMessage = $dispatchedMessages[0]->getMessage();
 
         static::assertInstanceOf(DispatchEntityMessage::class, $entitySyncMessage);
-        static::assertEquals(
+        static::assertSame(
             [
                 ['id' => $ids->get('product-from-the-past')],
             ],
@@ -280,25 +280,25 @@ class IterateEntityMessageHandlerTest extends TestCase
 
         $connection = static::getContainer()->get(Connection::class);
 
-        static::assertEquals(1, $connection->update(
+        static::assertSame(1, $connection->update(
             '`product`',
             ['`created_at`' => '2023-05-24', '`updated_at`' => null],
             ['`product_number`' => 'product-from-the-past'],
         ));
 
-        static::assertEquals(1, $connection->update(
+        static::assertSame(1, $connection->update(
             '`product`',
             ['`created_at`' => '2023-08-02', '`updated_at`' => null],
             ['`product_number`' => 'product-created-on-last-run-date'],
         ));
 
-        static::assertEquals(1, $connection->update(
+        static::assertSame(1, $connection->update(
             '`product`',
             ['`created_at`' => '2023-08-03', '`updated_at`' => null],
             ['`product_number`' => 'product-created-today'],
         ));
 
-        static::assertEquals(1, $connection->update(
+        static::assertSame(1, $connection->update(
             '`product`',
             ['`created_at`' => '2022-08-02', '`updated_at`' => '2023-08-02'],
             ['`product_number`' => 'product-updated-today'],

--- a/tests/integration/Core/System/UsageData/Services/EntityDefinitionServiceTest.php
+++ b/tests/integration/Core/System/UsageData/Services/EntityDefinitionServiceTest.php
@@ -56,7 +56,7 @@ class EntityDefinitionServiceTest extends TestCase
         }
 
         // assert with an empty array in order to get the diff in the error message
-        static::assertEquals([], $problematicEntities, 'Expected that tagged entities with more than one primary key (without the VersionField) only have many-to-many associations with an corresponding ManyToManyIdField.');
+        static::assertSame([], $problematicEntities, 'Expected that tagged entities with more than one primary key (without the VersionField) only have many-to-many associations with an corresponding ManyToManyIdField.');
     }
 
     public function testTaggedEntitiesHaveCreatedAndUpdatedFields(): void
@@ -73,6 +73,6 @@ class EntityDefinitionServiceTest extends TestCase
         }
 
         // assert with an empty array in order to get the diff in the error message
-        static::assertEquals([], $problematicEntities, 'Expected that tagged entities have created_at and updated_at fields.');
+        static::assertSame([], $problematicEntities, 'Expected that tagged entities have created_at and updated_at fields.');
     }
 }

--- a/tests/integration/Core/System/UsageData/Subscriber/EntityDeleteSubscriberTest.php
+++ b/tests/integration/Core/System/UsageData/Subscriber/EntityDeleteSubscriberTest.php
@@ -80,7 +80,7 @@ class EntityDeleteSubscriberTest extends TestCase
 
         $result['entity_ids'] = \json_decode($result['entity_ids'], true, flags: \JSON_THROW_ON_ERROR);
 
-        static::assertEquals([
+        static::assertSame([
             'entity_name' => 'product',
             'entity_ids' => ['id' => $productIds->get('product-to-delete')],
             'deleted_at' => '2023-08-30 00:00:00.000',
@@ -207,7 +207,7 @@ class EntityDeleteSubscriberTest extends TestCase
 
         $result['entity_ids'] = \json_decode($result['entity_ids'], true, flags: \JSON_THROW_ON_ERROR);
 
-        static::assertEquals([
+        static::assertSame([
             'entity_name' => 'acl_user_role',
             'entity_ids' => [
                 'userId' => $userId,

--- a/tests/integration/Core/System/User/Api/UserRecoveryControllerTest.php
+++ b/tests/integration/Core/System/User/Api/UserRecoveryControllerTest.php
@@ -42,7 +42,7 @@ class UserRecoveryControllerTest extends TestCase
             ]
         );
 
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
     }
 
     public function testUpdateUserPasswordWithInvalidHash(): void
@@ -59,7 +59,7 @@ class UserRecoveryControllerTest extends TestCase
             ]
         );
 
-        static::assertEquals(400, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(400, $this->getBrowser()->getResponse()->getStatusCode());
     }
 
     public function testCreateUserRecovery(): void
@@ -89,7 +89,7 @@ class UserRecoveryControllerTest extends TestCase
             ]
         );
 
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
 
         $criteria = new Criteria();
         $criteria->setLimit(1);

--- a/tests/integration/Core/System/User/Recovery/UserRecoveryServiceTest.php
+++ b/tests/integration/Core/System/User/Recovery/UserRecoveryServiceTest.php
@@ -168,7 +168,7 @@ class UserRecoveryServiceTest extends TestCase
 
         $passwordAfter = $userAfter->getPassword();
 
-        static::assertNotEquals($passwordBefore, $passwordAfter);
+        static::assertNotSame($passwordBefore, $passwordAfter);
     }
 
     public function testGetUserByHash(): void

--- a/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
+++ b/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
@@ -26,7 +26,7 @@ class CurrencyRuleTest extends TestCase
     {
         $rule = new CurrencyRule();
 
-        static::assertEquals('currency', $rule->getName());
+        static::assertSame('currency', $rule->getName());
     }
 
     public function testGetConstraints(): void
@@ -44,7 +44,7 @@ class CurrencyRuleTest extends TestCase
         $rule = new CurrencyRule();
         $ruleConfig = $rule->getConfig();
 
-        static::assertEquals([
+        static::assertSame([
             'operatorSet' => [
                 'operators' => [
                     Rule::OPERATOR_EQ,

--- a/tests/unit/Core/System/CustomEntity/CustomEntityEntityTest.php
+++ b/tests/unit/Core/System/CustomEntity/CustomEntityEntityTest.php
@@ -17,19 +17,19 @@ class CustomEntityEntityTest extends TestCase
         $entity = new CustomEntityEntity();
 
         $entity->setId('123');
-        static::assertEquals('123', $entity->getId());
+        static::assertSame('123', $entity->getId());
 
         $entity->setName('Test Entity');
-        static::assertEquals('Test Entity', $entity->getName());
+        static::assertSame('Test Entity', $entity->getName());
 
         $entity->setStoreApiAware(true);
         static::assertTrue($entity->getStoreApiAware());
 
         $entity->setAppId('app-123');
-        static::assertEquals('app-123', $entity->getAppId());
+        static::assertSame('app-123', $entity->getAppId());
 
         $entity->setPluginId('plugin-123');
-        static::assertEquals('plugin-123', $entity->getPluginId());
+        static::assertSame('plugin-123', $entity->getPluginId());
 
         $fields = [
             [
@@ -41,17 +41,17 @@ class CustomEntityEntityTest extends TestCase
         ];
 
         $entity->setFields($fields);
-        static::assertEquals($fields, $entity->getFields());
+        static::assertSame($fields, $entity->getFields());
 
         $flags = [];
 
         $entity->setFlags($flags);
-        static::assertEquals($flags, $entity->getFlags());
+        static::assertSame($flags, $entity->getFlags());
 
         $entity->setCustomFieldsAware(true);
         static::assertTrue($entity->getCustomFieldsAware());
 
         $entity->setLabelProperty('name');
-        static::assertEquals('name', $entity->getLabelProperty());
+        static::assertSame('name', $entity->getLabelProperty());
     }
 }

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaTest.php
@@ -40,7 +40,6 @@ class AdminUiXmlSchemaTest extends TestCase
             'System/CustomEntity/Xml/Config/AdminUi/admin-ui-1.0.xsd',
             AdminUiXmlSchema::XSD_FILEPATH
         );
-        static::assertEquals('admin-ui.xml', AdminUiXmlSchema::FILENAME);
     }
 
     public function testCreateFromXmlFileMinSetting(): void
@@ -147,12 +146,12 @@ class AdminUiXmlSchemaTest extends TestCase
             AdminUiXmlSchema::createFromXmlFile('invalid_path');
             static::fail('no Exception was thrown');
         } catch (CustomEntityXmlParsingException $exception) {
-            static::assertEquals(
+            static::assertSame(
                 'Unable to parse file "invalid_path". Message: Resource "invalid_path" is not a file.',
                 $exception->getMessage()
             );
-            static::assertEquals('SYSTEM_CUSTOM_ENTITY__XML_PARSE_ERROR', $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+            static::assertSame('SYSTEM_CUSTOM_ENTITY__XML_PARSE_ERROR', $exception->getErrorCode());
+            static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
         }
     }
 
@@ -167,8 +166,8 @@ class AdminUiXmlSchemaTest extends TestCase
                 'System/CustomEntity/Xml/Config/AdminUi/../../../_fixtures/AdminUiXmlSchemaTest/admin-ui.invalid.xml". Message: [ERROR 1871] Element \'ERROR\': This element is not expected. Expected is ( field ).',
                 $exception->getMessage()
             );
-            static::assertEquals('SYSTEM_CUSTOM_ENTITY__XML_PARSE_ERROR', $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+            static::assertSame('SYSTEM_CUSTOM_ENTITY__XML_PARSE_ERROR', $exception->getErrorCode());
+            static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
         }
     }
 
@@ -207,7 +206,7 @@ class AdminUiXmlSchemaTest extends TestCase
     private function checkEntity(array $entities, string $name): Entity
     {
         static::assertInstanceOf(Entity::class, $entities[$name]);
-        static::assertEquals($name, $entities[$name]->getName());
+        static::assertSame($name, $entities[$name]->getName());
 
         return $entities[$name];
     }
@@ -236,7 +235,7 @@ class AdminUiXmlSchemaTest extends TestCase
         Tab $tab,
         string $tabName
     ): array {
-        static::assertEquals($tabName, $tab->getName());
+        static::assertSame($tabName, $tab->getName());
 
         return $tab->getCards();
     }
@@ -249,7 +248,7 @@ class AdminUiXmlSchemaTest extends TestCase
         string $tabName,
         array $refs
     ): void {
-        static::assertEquals($tabName, $card->getName());
+        static::assertSame($tabName, $card->getName());
 
         $fields = $card->getFields();
         static::assertCount(\count($refs), $fields);

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidatorTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidatorTest.php
@@ -31,12 +31,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
             $this->validate('invalidReferences/inColumns');
             static::fail('no Exception was thrown');
         } catch (CustomEntityConfigurationException $exception) {
-            static::assertEquals(
+            static::assertSame(
                 'In `admin-ui.xml` the entity `ce_invalid_ref_in_columns` has invalid references (regarding `entities.xml`) inside of `<listing>`: i_am_an_invalid_reference',
                 $exception->getMessage()
             );
-            static::assertEquals(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+            static::assertSame(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
 
@@ -46,12 +46,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
             $this->validate('invalidReferences/inCard');
             static::fail('no Exception was thrown');
         } catch (CustomEntityConfigurationException $exception) {
-            static::assertEquals(
+            static::assertSame(
                 'In `admin-ui.xml` the entity `ce_invalid_ref_in_card` has invalid references (regarding `entities.xml`) inside of `<detail>`: i_am_an_invalid_reference',
                 $exception->getMessage()
             );
-            static::assertEquals(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+            static::assertSame(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
 
@@ -62,12 +62,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
             static::fail('no Exception was thrown');
         } catch (CustomEntityConfigurationException $exception) {
             // Exception is thrown in listing first
-            static::assertEquals(
+            static::assertSame(
                 'In `admin-ui.xml` the entity `ce_invalid_ref_complex` has invalid references (regarding `entities.xml`) inside of `<listing>`: i_am_an_invalid_reference',
                 $exception->getMessage()
             );
-            static::assertEquals(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+            static::assertSame(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
 
@@ -77,12 +77,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
             $this->validate('duplicateReferences/inColumns');
             static::fail('no Exception was thrown');
         } catch (CustomEntityConfigurationException $exception) {
-            static::assertEquals(
+            static::assertSame(
                 'In `admin-ui.xml`, the entity `ce_duplicate_ref_in_columns` only allows unique fields per xml element, but found the following duplicates inside of `<listing>`: test_string',
                 $exception->getMessage()
             );
-            static::assertEquals(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+            static::assertSame(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
 
@@ -92,12 +92,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
             $this->validate('duplicateReferences/inCard');
             static::fail('no Exception was thrown');
         } catch (CustomEntityConfigurationException $exception) {
-            static::assertEquals(
+            static::assertSame(
                 'In `admin-ui.xml`, the entity `ce_duplicate_ref_in_card` only allows unique fields per xml element, but found the following duplicates inside of `<detail>`: test_string',
                 $exception->getMessage()
             );
-            static::assertEquals(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+            static::assertSame(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
 
@@ -108,12 +108,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
             static::fail('no Exception was thrown');
         } catch (CustomEntityConfigurationException $exception) {
             // Exception is thrown in listing first
-            static::assertEquals(
+            static::assertSame(
                 'In `admin-ui.xml`, the entity `ce_duplicate_ref_complex` only allows unique fields per xml element, but found the following duplicates inside of `<listing>`: test_float',
                 $exception->getMessage()
             );
-            static::assertEquals(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+            static::assertSame(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
 

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/XmlElements/ColumnTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/XmlElements/ColumnTest.php
@@ -25,8 +25,8 @@ class ColumnTest extends TestCase
         }
 
         $column = Column::fromXml($columnElement);
-        static::assertEquals($result, $column->isHidden());
-        static::assertEquals('column ref', $column->getRef());
+        static::assertSame($result, $column->isHidden());
+        static::assertSame('column ref', $column->getRef());
     }
 
     public static function provider(): \Generator

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/CmsAware/CmsAwareFieldsTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/CmsAware/CmsAwareFieldsTest.php
@@ -39,55 +39,55 @@ class CmsAwareFieldsTest extends TestCase
 
         static::assertInstanceOf(StringField::class, $actualCmsAwareFields['sw_title']);
         $swTitle = $actualCmsAwareFields['sw_title']->toArray(self::TEST_LOCALE);
-        static::assertEquals('string', $swTitle['type']);
+        static::assertSame('string', $swTitle['type']);
         static::assertTrue($swTitle['translatable']);
         static::assertFalse($swTitle['required']);
 
         static::assertInstanceOf(TextField::class, $actualCmsAwareFields['sw_content']);
         $swDescription = $actualCmsAwareFields['sw_content']->toArray(self::TEST_LOCALE);
-        static::assertEquals('text', $swDescription['type']);
+        static::assertSame('text', $swDescription['type']);
         static::assertTrue($swDescription['translatable']);
         static::assertFalse($swDescription['required']);
         static::assertFalse($swDescription['allowHtml']);
 
         static::assertInstanceOf(ManyToOneField::class, $actualCmsAwareFields['sw_cms_page']);
         $swCmsPage = $actualCmsAwareFields['sw_cms_page']->toArray(self::TEST_LOCALE);
-        static::assertEquals('many-to-one', $swCmsPage['type']);
+        static::assertSame('many-to-one', $swCmsPage['type']);
         static::assertFalse($swCmsPage['required']);
-        static::assertEquals('cms_page', $swCmsPage['reference']);
+        static::assertSame('cms_page', $swCmsPage['reference']);
         static::assertFalse($swCmsPage['inherited']);
-        static::assertEquals('set-null', $swCmsPage['onDelete']);
+        static::assertSame('set-null', $swCmsPage['onDelete']);
 
         static::assertInstanceOf(JsonField::class, $actualCmsAwareFields['sw_slot_config']);
         $swCategories = $actualCmsAwareFields['sw_slot_config']->toArray(self::TEST_LOCALE);
-        static::assertEquals('json', $swCategories['type']);
+        static::assertSame('json', $swCategories['type']);
         static::assertFalse($swCategories['required']);
 
         static::assertInstanceOf(ManyToManyField::class, $actualCmsAwareFields['sw_categories']);
         $swCategories = $actualCmsAwareFields['sw_categories']->toArray(self::TEST_LOCALE);
-        static::assertEquals('many-to-many', $swCategories['type']);
+        static::assertSame('many-to-many', $swCategories['type']);
         static::assertFalse($swCategories['required']);
-        static::assertEquals('category', $swCategories['reference']);
+        static::assertSame('category', $swCategories['reference']);
         static::assertFalse($swCategories['inherited']);
-        static::assertEquals('cascade', $swCategories['onDelete']);
+        static::assertSame('cascade', $swCategories['onDelete']);
 
         static::assertInstanceOf(ManyToOneField::class, $actualCmsAwareFields['sw_og_image']);
         $swMedia = $actualCmsAwareFields['sw_og_image']->toArray(self::TEST_LOCALE);
-        static::assertEquals('many-to-one', $swMedia['type']);
+        static::assertSame('many-to-one', $swMedia['type']);
         static::assertFalse($swMedia['required']);
-        static::assertEquals('media', $swMedia['reference']);
+        static::assertSame('media', $swMedia['reference']);
         static::assertFalse($swMedia['inherited']);
-        static::assertEquals('set-null', $swMedia['onDelete']);
+        static::assertSame('set-null', $swMedia['onDelete']);
 
         static::assertInstanceOf(StringField::class, $actualCmsAwareFields['sw_seo_meta_title']);
         $swSeoMetaTitle = $actualCmsAwareFields['sw_seo_meta_title']->toArray(self::TEST_LOCALE);
-        static::assertEquals('string', $swSeoMetaTitle['type']);
+        static::assertSame('string', $swSeoMetaTitle['type']);
         static::assertTrue($swSeoMetaTitle['translatable']);
         static::assertFalse($swSeoMetaTitle['required']);
 
         static::assertInstanceOf(StringField::class, $actualCmsAwareFields['sw_seo_meta_description']);
         $swSeoMetaDescription = $actualCmsAwareFields['sw_seo_meta_description']->toArray(self::TEST_LOCALE);
-        static::assertEquals('string', $swSeoMetaDescription['type']);
+        static::assertSame('string', $swSeoMetaDescription['type']);
         static::assertTrue($swSeoMetaDescription['translatable']);
         static::assertFalse($swSeoMetaDescription['required']);
     }

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentServiceTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentServiceTest.php
@@ -176,10 +176,10 @@ class CustomEntityEnrichmentServiceTest extends TestCase
 
             $adminUi = $enrichedCustomEntity->getFlags()['admin-ui'];
             static::assertInstanceOf(AdminUiEntity::class, $adminUi);
-            static::assertEquals('sw-content', $adminUi->getVars()['navigationParent']);
-            static::assertEquals(50, $adminUi->getVars()['position']);
-            static::assertEquals('regular-tools-alt', $adminUi->getVars()['icon']);
-            static::assertEquals('#f00', $adminUi->getVars()['color']);
+            static::assertSame('sw-content', $adminUi->getVars()['navigationParent']);
+            static::assertSame(50, $adminUi->getVars()['position']);
+            static::assertSame('regular-tools-alt', $adminUi->getVars()['icon']);
+            static::assertSame('#f00', $adminUi->getVars()['color']);
 
             $listingColumns = $adminUi->getListing()->getColumns()->getContent();
             static::assertCount(3, $listingColumns);
@@ -196,20 +196,20 @@ class CustomEntityEnrichmentServiceTest extends TestCase
             $detailTabs = $adminUi->getDetail()->getTabs()->getContent();
             static::assertCount(2, $detailTabs);
             static::assertCount(2, $detailTabs[0]->getCards());
-            static::assertEquals('firstTab', $detailTabs[0]->getName());
+            static::assertSame('firstTab', $detailTabs[0]->getName());
             static::assertCount(2, $detailTabs[1]->getCards());
-            static::assertEquals('secondTab', $detailTabs[1]->getName());
+            static::assertSame('secondTab', $detailTabs[1]->getName());
 
             $exampleCards = $detailTabs[1]->getCards();
             static::assertCount(2, $exampleCards);
-            static::assertEquals('testWithAll', $exampleCards[0]->getName());
+            static::assertSame('testWithAll', $exampleCards[0]->getName());
 
             $exampleCardFields = $exampleCards[0]->getFields();
             static::assertCount(4, $exampleCardFields);
-            static::assertEquals('test_string', $exampleCardFields[0]->getRef());
-            static::assertEquals('test_text', $exampleCardFields[1]->getRef());
-            static::assertEquals('test_int', $exampleCardFields[2]->getRef());
-            static::assertEquals('test_float', $exampleCardFields[3]->getRef());
+            static::assertSame('test_string', $exampleCardFields[0]->getRef());
+            static::assertSame('test_text', $exampleCardFields[1]->getRef());
+            static::assertSame('test_int', $exampleCardFields[2]->getRef());
+            static::assertSame('test_float', $exampleCardFields[3]->getRef());
         }
     }
 
@@ -275,18 +275,18 @@ class CustomEntityEnrichmentServiceTest extends TestCase
             static::assertCount(2, $enrichedCustomEntity->getFlags());
             static::assertNotNull($enrichedCustomEntity->getFlags()['cms-aware']);
             static::assertNotNull($enrichedCustomEntity->getFlags()['admin-ui']);
-            static::assertEquals(
+            static::assertSame(
                 self::EXPECTED_CMS_AWARE_ENTITY_NAMES['allFlags'],
                 $enrichedCustomEntity->getFlags()['cms-aware']['name'],
             );
-            static::assertEquals(
+            static::assertSame(
                 self::EXPECTED_ADMIN_UI_ENTITY_NAMES['allFlags'],
                 $enrichedCustomEntity->getFlags()['admin-ui']->getName(),
             );
 
             $adminUi = $enrichedCustomEntity->getFlags()['admin-ui'];
-            static::assertEquals('sw-content', $adminUi->getVars()['navigationParent']);
-            static::assertEquals(50, $adminUi->getVars()['position']);
+            static::assertSame('sw-content', $adminUi->getVars()['navigationParent']);
+            static::assertSame(50, $adminUi->getVars()['position']);
 
             $listingColumns = $adminUi->getListing()->getColumns()->getContent();
             static::assertCount(3, $listingColumns);
@@ -334,7 +334,7 @@ class CustomEntityEnrichmentServiceTest extends TestCase
             static::assertCount(1, $enrichedCustomEntity->getFlags());
             static::assertNotNull($enrichedCustomEntity->getFlags()['cms-aware']);
             static::assertArrayNotHasKey('admin-ui', $enrichedCustomEntity->getFlags());
-            static::assertEquals(
+            static::assertSame(
                 self::EXPECTED_CMS_AWARE_ENTITY_NAMES['cmsAwareOnly'],
                 $enrichedCustomEntity->getFlags()['cms-aware']['name'],
             );
@@ -372,13 +372,13 @@ class CustomEntityEnrichmentServiceTest extends TestCase
             static::assertArrayNotHasKey('cms-aware', $enrichedCustomEntity->getFlags());
             $adminUi = $enrichedCustomEntity->getFlags()['admin-ui'];
             static::assertInstanceOf(AdminUiEntity::class, $adminUi);
-            static::assertEquals(
+            static::assertSame(
                 self::EXPECTED_ADMIN_UI_ENTITY_NAMES['adminUiOnly'],
                 $adminUi->getName(),
             );
 
-            static::assertEquals('sw-content', $adminUi->getVars()['navigationParent']);
-            static::assertEquals(50, $adminUi->getVars()['position']);
+            static::assertSame('sw-content', $adminUi->getVars()['navigationParent']);
+            static::assertSame(50, $adminUi->getVars()['position']);
 
             $listingColumns = $adminUi->getListing()->getColumns()->getContent();
             static::assertCount(3, $listingColumns);
@@ -436,12 +436,12 @@ class CustomEntityEnrichmentServiceTest extends TestCase
             );
             static::fail('no Exception was thrown');
         } catch (CustomEntityConfigurationException $exception) {
-            static::assertEquals(
+            static::assertSame(
                 'The entities ce_not_defined0, ce_not_defined1 are not given in the entities.xml but are configured in admin-ui.xml',
                 $exception->getMessage()
             );
-            static::assertEquals(CustomEntityConfigurationException::ENTITY_NOT_GIVEN_CODE, $exception->getErrorCode());
-            static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+            static::assertSame(CustomEntityConfigurationException::ENTITY_NOT_GIVEN_CODE, $exception->getErrorCode());
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
 

--- a/tests/unit/Core/System/CustomEntity/Xml/EntityTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/EntityTest.php
@@ -39,9 +39,9 @@ class EntityTest extends TestCase
         static::assertCount(2, $fields);
 
         static::assertInstanceOf(StringField::class, $fields[0]);
-        static::assertEquals('id', $fields[0]->getName());
+        static::assertSame('id', $fields[0]->getName());
         static::assertInstanceOf(StringField::class, $fields[1]);
-        static::assertEquals('name', $fields[1]->getName());
+        static::assertSame('name', $fields[1]->getName());
         static::assertTrue($fields[1]->isTranslatable());
     }
 
@@ -88,7 +88,7 @@ class EntityTest extends TestCase
         $field = $entity->getField('name');
 
         static::assertInstanceOf(StringField::class, $field);
-        static::assertEquals('name', $field->getName());
+        static::assertSame('name', $field->getName());
 
         static::assertNull($entity->getField('label'));
     }

--- a/tests/unit/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPassTest.php
+++ b/tests/unit/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPassTest.php
@@ -48,7 +48,7 @@ class SalesChannelEntityCompilerPassTest extends TestCase
 
         $methodCalls = $container->getDefinition('sales_channel_definition.' . ProductDefinition::class)->getMethodCalls();
         static::assertCount(2, $methodCalls);
-        static::assertEquals('addExtension', $methodCalls[1][0]);
+        static::assertSame('addExtension', $methodCalls[1][0]);
         static::assertInstanceOf(Reference::class, $methodCalls[1][1][0]);
         static::assertSame(ProductEntityExtension::class, (string) $methodCalls[1][1][0]);
     }
@@ -72,7 +72,7 @@ class SalesChannelEntityCompilerPassTest extends TestCase
 
         $methodCalls = $container->getDefinition('sales_channel_definition.' . ProductDefinition::class)->getMethodCalls();
         static::assertCount(2, $methodCalls);
-        static::assertEquals('addExtension', $methodCalls[1][0]);
+        static::assertSame('addExtension', $methodCalls[1][0]);
         static::assertInstanceOf(Definition::class, $methodCalls[1][1][0]);
         static::assertSame(FilteredBulkEntityExtension::class, $methodCalls[1][1][0]->getClass());
     }
@@ -109,7 +109,7 @@ class SalesChannelEntityCompilerPassTest extends TestCase
         $methodCalls = $container->getDefinition('sales_channel_definition.test_attribute_entity.definition')->getMethodCalls();
 
         static::assertCount(2, $methodCalls);
-        static::assertEquals('addExtension', $methodCalls[1][0]);
+        static::assertSame('addExtension', $methodCalls[1][0]);
         static::assertInstanceOf(Reference::class, $methodCalls[1][1][0]);
         static::assertSame(AttributeEntityExtension::class, (string) $methodCalls[1][1][0]);
     }

--- a/tests/unit/Core/System/Locale/LanguageLocaleCodeProviderTest.php
+++ b/tests/unit/Core/System/Locale/LanguageLocaleCodeProviderTest.php
@@ -37,9 +37,9 @@ class LanguageLocaleCodeProviderTest extends TestCase
     {
         $this->languageLoader->expects($this->once())->method('loadLanguages')->willReturn($this->createData());
 
-        static::assertEquals('en-GB', $this->languageLocaleProvider->getLocaleForLanguageId($this->ids->get('language-en')));
-        static::assertEquals('de-DE', $this->languageLocaleProvider->getLocaleForLanguageId($this->ids->get('language-de')));
-        static::assertEquals('parent-locale', $this->languageLocaleProvider->getLocaleForLanguageId($this->ids->get('language-child')));
+        static::assertSame('en-GB', $this->languageLocaleProvider->getLocaleForLanguageId($this->ids->get('language-en')));
+        static::assertSame('de-DE', $this->languageLocaleProvider->getLocaleForLanguageId($this->ids->get('language-de')));
+        static::assertSame('parent-locale', $this->languageLocaleProvider->getLocaleForLanguageId($this->ids->get('language-child')));
     }
 
     public function testGetLocaleForLanguageIdThrowsWhenLanguageIsNotFound(): void

--- a/tests/unit/Core/System/NumberRange/ValueGenerator/IncrementRedisStorageTest.php
+++ b/tests/unit/Core/System/NumberRange/ValueGenerator/IncrementRedisStorageTest.php
@@ -54,7 +54,7 @@ class IncrementRedisStorageTest extends TestCase
             ->with($this->getKey($config['id']))
             ->willReturn(10);
 
-        static::assertEquals(10, $this->storage->reserve($config));
+        static::assertSame(10, $this->storage->reserve($config));
     }
 
     public function testReserveWithoutStart(): void
@@ -73,7 +73,7 @@ class IncrementRedisStorageTest extends TestCase
             ->with($this->getKey($config['id']))
             ->willReturn(10);
 
-        static::assertEquals(10, $this->storage->reserve($config));
+        static::assertSame(10, $this->storage->reserve($config));
     }
 
     public function testReserveDoesNotLockIfIncrementValueEqualsStart(): void
@@ -92,7 +92,7 @@ class IncrementRedisStorageTest extends TestCase
             ->with($this->getKey($config['id']))
             ->willReturn(5);
 
-        static::assertEquals(5, $this->storage->reserve($config));
+        static::assertSame(5, $this->storage->reserve($config));
     }
 
     public function testReserveDoesSetStartValueIfItCanAcquireLock(): void
@@ -125,7 +125,7 @@ class IncrementRedisStorageTest extends TestCase
             ->with($this->getKey($config['id']), 5)
             ->willReturn(10);
 
-        static::assertEquals(10, $this->storage->reserve($config));
+        static::assertSame(10, $this->storage->reserve($config));
     }
 
     public function testReserveDoesNotSetStartValueIfItCanNotAcquireLock(): void
@@ -156,7 +156,7 @@ class IncrementRedisStorageTest extends TestCase
         $this->redisMock->expects($this->never())
             ->method('incrBy');
 
-        static::assertEquals(5, $this->storage->reserve($config));
+        static::assertSame(5, $this->storage->reserve($config));
     }
 
     public function testPreviewIfValueIsNotSetAndNoStart(): void
@@ -172,7 +172,7 @@ class IncrementRedisStorageTest extends TestCase
             ->with($this->getKey($config['id']))
             ->willReturn(null);
 
-        static::assertEquals(1, $this->storage->preview($config));
+        static::assertSame(1, $this->storage->preview($config));
     }
 
     public function testPreviewWillReturnStartValueIfNoValueIsSet(): void
@@ -188,7 +188,7 @@ class IncrementRedisStorageTest extends TestCase
             ->with($this->getKey($config['id']))
             ->willReturn(null);
 
-        static::assertEquals(10, $this->storage->preview($config));
+        static::assertSame(10, $this->storage->preview($config));
     }
 
     public function testPreviewWillReturnStartValueIfIncrementValueIsLower(): void
@@ -204,7 +204,7 @@ class IncrementRedisStorageTest extends TestCase
             ->with($this->getKey($config['id']))
             ->willReturn(8);
 
-        static::assertEquals(10, $this->storage->preview($config));
+        static::assertSame(10, $this->storage->preview($config));
     }
 
     public function testList(): void

--- a/tests/unit/Core/System/SalesChannel/Api/StoreApiResponseListenerTest.php
+++ b/tests/unit/Core/System/SalesChannel/Api/StoreApiResponseListenerTest.php
@@ -106,7 +106,7 @@ class StoreApiResponseListenerTest extends TestCase
         static::assertIsString($content, 'Response content is not a string.');
         $decoded = json_decode($content, true);
         static::assertIsArray($decoded, 'Decoded JSON is not an array.');
-        static::assertEquals(['encoded' => 'data'], $decoded);
+        static::assertSame(['encoded' => 'data'], $decoded);
     }
 
     public function testEncodeResponseWithDifferentStatusCode(): void
@@ -145,7 +145,7 @@ class StoreApiResponseListenerTest extends TestCase
         static::assertIsString($content, 'Response content is not a string.');
         $decoded = json_decode($content, true);
         static::assertIsArray($decoded, 'Decoded JSON is not an array.');
-        static::assertEquals(['encoded' => 'data'], $decoded);
+        static::assertSame(['encoded' => 'data'], $decoded);
     }
 
     public function testEncodeResponsePreservesHeaders(): void
@@ -185,6 +185,6 @@ class StoreApiResponseListenerTest extends TestCase
         static::assertIsString($content, 'Response content is not a string.');
         $decoded = json_decode($content, true);
         static::assertIsArray($decoded, 'Decoded JSON is not an array.');
-        static::assertEquals(['encoded' => 'data'], $decoded);
+        static::assertSame(['encoded' => 'data'], $decoded);
     }
 }

--- a/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
+++ b/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
@@ -72,7 +72,7 @@ class StructEncoderTest extends TestCase
 
         static::assertArrayNotHasKey('cheapestPrice', $encoded);
         static::assertArrayHasKey('name', $encoded);
-        static::assertEquals('test', $encoded['name']);
+        static::assertSame('test', $encoded['name']);
     }
 
     public function testNoneMappedFieldsAreNotExposed(): void
@@ -88,7 +88,7 @@ class StructEncoderTest extends TestCase
 
         static::assertArrayNotHasKey('notExposed', $encoded);
         static::assertArrayHasKey('name', $encoded);
-        static::assertEquals('test', $encoded['name']);
+        static::assertSame('test', $encoded['name']);
     }
 
     public function testExtensionAreSupported(): void
@@ -159,7 +159,7 @@ class StructEncoderTest extends TestCase
         ];
 
         static::assertArrayHasKey('customFields', $encoded);
-        static::assertEquals($expectedCustomFields, $encoded['customFields']);
+        static::assertSame($expectedCustomFields, $encoded['customFields']);
     }
 
     public function testCustomFieldsFieldIsBlocked(): void
@@ -190,7 +190,7 @@ class StructEncoderTest extends TestCase
         ];
 
         static::assertArrayHasKey('customFields', $encoded);
-        static::assertEquals($expectedCustomFields, $encoded['customFields']);
+        static::assertSame($expectedCustomFields, $encoded['customFields']);
     }
 
     public function testCustomFieldsFieldIsBlockedInNestedArray(): void

--- a/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
@@ -34,12 +34,12 @@ class SalesChannelContextTest extends TestCase
 
         $salesChannelContext->setAreaRuleIds($areaRuleIds);
 
-        static::assertEquals($areaRuleIds, $salesChannelContext->getAreaRuleIds());
+        static::assertSame($areaRuleIds, $salesChannelContext->getAreaRuleIds());
 
-        static::assertEquals([$idA, $idB], $salesChannelContext->getRuleIdsByAreas(['a']));
-        static::assertEquals([$idA, $idB, $idC, $idD], $salesChannelContext->getRuleIdsByAreas(['a', 'b']));
-        static::assertEquals([$idA, $idB], $salesChannelContext->getRuleIdsByAreas(['a', 'c']));
-        static::assertEquals([$idC], $salesChannelContext->getRuleIdsByAreas(['d']));
-        static::assertEquals([], $salesChannelContext->getRuleIdsByAreas(['f']));
+        static::assertSame([$idA, $idB], $salesChannelContext->getRuleIdsByAreas(['a']));
+        static::assertSame([$idA, $idB, $idC, $idD], $salesChannelContext->getRuleIdsByAreas(['a', 'b']));
+        static::assertSame([$idA, $idB], $salesChannelContext->getRuleIdsByAreas(['a', 'c']));
+        static::assertSame([$idC], $salesChannelContext->getRuleIdsByAreas(['d']));
+        static::assertSame([], $salesChannelContext->getRuleIdsByAreas(['f']));
     }
 }

--- a/tests/unit/Core/System/SalesChannel/StoreApiCustomFieldMapperTest.php
+++ b/tests/unit/Core/System/SalesChannel/StoreApiCustomFieldMapperTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\System\SalesChannel;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
@@ -53,7 +54,9 @@ class StoreApiCustomFieldMapperTest extends TestCase
             'date' => '2020-01-01T00:00:00+00:00',
         ]));
 
-        static::assertEquals(new \DateTimeImmutable('2020-01-01T00:00:00+00:00'), $mappedValues['date']);
+        $date = $mappedValues['date'];
+        static::assertInstanceOf(\DateTimeInterface::class, $date);
+        static::assertSame((new \DateTimeImmutable('2020-01-01T00:00:00+00:00'))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $date->format(Defaults::STORAGE_DATE_TIME_FORMAT));
         unset($mappedValues['date']);
 
         static::assertSame(

--- a/tests/unit/Core/System/Snippet/Files/GenericSnippetFileTest.php
+++ b/tests/unit/Core/System/Snippet/Files/GenericSnippetFileTest.php
@@ -29,11 +29,11 @@ class GenericSnippetFileTest extends TestCase
             $ids->get('technicalName'),
         );
 
-        static::assertEquals($ids->get('name'), $exception->getName());
-        static::assertEquals($ids->get('author'), $exception->getAuthor());
-        static::assertEquals($ids->get('iso'), $exception->getIso());
-        static::assertEquals($isBase, $exception->isBase());
-        static::assertEquals($ids->get('path'), $exception->getPath());
-        static::assertEquals($ids->get('technicalName'), $exception->getTechnicalName());
+        static::assertSame($ids->get('name'), $exception->getName());
+        static::assertSame($ids->get('author'), $exception->getAuthor());
+        static::assertSame($ids->get('iso'), $exception->getIso());
+        static::assertSame($isBase, $exception->isBase());
+        static::assertSame($ids->get('path'), $exception->getPath());
+        static::assertSame($ids->get('technicalName'), $exception->getTechnicalName());
     }
 }

--- a/tests/unit/Core/System/Snippet/Files/SnippetFileLoaderTest.php
+++ b/tests/unit/Core/System/Snippet/Files/SnippetFileLoaderTest.php
@@ -47,24 +47,24 @@ class SnippetFileLoaderTest extends TestCase
         static::assertCount(2, $collection);
 
         $snippetFile = $collection->getSnippetFilesByIso('de-DE')[0];
-        static::assertEquals('storefront.de-DE', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.de-DE', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/ShopwareBundleWithSnippets/Resources/snippet/storefront.de-DE.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('de-DE', $snippetFile->getIso());
-        static::assertEquals('Shopware', $snippetFile->getAuthor());
+        static::assertSame('de-DE', $snippetFile->getIso());
+        static::assertSame('Shopware', $snippetFile->getAuthor());
         static::assertFalse($snippetFile->isBase());
 
         $snippetFile = $collection->getSnippetFilesByIso('en-GB')[0];
-        static::assertEquals('storefront.en-GB', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.en-GB', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/ShopwareBundleWithSnippets/Resources/snippet/storefront.en-GB.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('en-GB', $snippetFile->getIso());
-        static::assertEquals('Shopware', $snippetFile->getAuthor());
-        static::assertEquals('ShopwareBundleWithSnippets', $snippetFile->getTechnicalName());
+        static::assertSame('en-GB', $snippetFile->getIso());
+        static::assertSame('Shopware', $snippetFile->getAuthor());
+        static::assertSame('ShopwareBundleWithSnippets', $snippetFile->getTechnicalName());
         static::assertFalse($snippetFile->isBase());
     }
 
@@ -111,24 +111,24 @@ class SnippetFileLoaderTest extends TestCase
         static::assertCount(2, $collection);
 
         $snippetFile = $collection->getSnippetFilesByIso('xx-XX')[0];
-        static::assertEquals('test', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('test', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/ShopwareBundleWithSnippets/Resources/snippet/storefront.de-DE.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('xx-XX', $snippetFile->getIso());
-        static::assertEquals('test Author', $snippetFile->getAuthor());
+        static::assertSame('xx-XX', $snippetFile->getIso());
+        static::assertSame('test Author', $snippetFile->getAuthor());
         static::assertTrue($snippetFile->isBase());
 
         $snippetFile = $collection->getSnippetFilesByIso('yy-YY')[0];
-        static::assertEquals('test', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('test', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/ShopwareBundleWithSnippets/Resources/snippet/storefront.en-GB.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('yy-YY', $snippetFile->getIso());
-        static::assertEquals('test Author', $snippetFile->getAuthor());
-        static::assertEquals('ShopwareBundleWithSnippets', $snippetFile->getTechnicalName());
+        static::assertSame('yy-YY', $snippetFile->getIso());
+        static::assertSame('test Author', $snippetFile->getAuthor());
+        static::assertSame('ShopwareBundleWithSnippets', $snippetFile->getTechnicalName());
         static::assertTrue($snippetFile->isBase());
     }
 
@@ -163,24 +163,24 @@ class SnippetFileLoaderTest extends TestCase
         static::assertCount(2, $collection);
 
         $snippetFile = $collection->getSnippetFilesByIso('de-DE')[0];
-        static::assertEquals('storefront.de-DE', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.de-DE', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/SnippetSet/Resources/snippet/storefront.de-DE.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('de-DE', $snippetFile->getIso());
-        static::assertEquals('Plugin Manufacturer', $snippetFile->getAuthor());
+        static::assertSame('de-DE', $snippetFile->getIso());
+        static::assertSame('Plugin Manufacturer', $snippetFile->getAuthor());
         static::assertFalse($snippetFile->isBase());
 
         $snippetFile = $collection->getSnippetFilesByIso('en-GB')[0];
-        static::assertEquals('storefront.en-GB', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.en-GB', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/SnippetSet/Resources/snippet/storefront.en-GB.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('en-GB', $snippetFile->getIso());
-        static::assertEquals('Plugin Manufacturer', $snippetFile->getAuthor());
-        static::assertEquals('SnippetSet', $snippetFile->getTechnicalName());
+        static::assertSame('en-GB', $snippetFile->getIso());
+        static::assertSame('Plugin Manufacturer', $snippetFile->getAuthor());
+        static::assertSame('SnippetSet', $snippetFile->getTechnicalName());
         static::assertFalse($snippetFile->isBase());
     }
 
@@ -215,24 +215,24 @@ class SnippetFileLoaderTest extends TestCase
         static::assertCount(2, $collection);
 
         $snippetFile = $collection->getSnippetFilesByIso('de-DE')[0];
-        static::assertEquals('storefront.de-DE', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.de-DE', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/BaseSnippetSet/Resources/snippet/storefront.de-DE.base.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('de-DE', $snippetFile->getIso());
-        static::assertEquals('Plugin Manufacturer', $snippetFile->getAuthor());
-        static::assertEquals('BaseSnippetSet', $snippetFile->getTechnicalName());
+        static::assertSame('de-DE', $snippetFile->getIso());
+        static::assertSame('Plugin Manufacturer', $snippetFile->getAuthor());
+        static::assertSame('BaseSnippetSet', $snippetFile->getTechnicalName());
         static::assertTrue($snippetFile->isBase());
 
         $snippetFile = $collection->getSnippetFilesByIso('en-GB')[0];
-        static::assertEquals('storefront.en-GB', $snippetFile->getName());
-        static::assertEquals(
+        static::assertSame('storefront.en-GB', $snippetFile->getName());
+        static::assertSame(
             __DIR__ . '/_fixtures/BaseSnippetSet/Resources/snippet/storefront.en-GB.base.json',
             $snippetFile->getPath()
         );
-        static::assertEquals('en-GB', $snippetFile->getIso());
-        static::assertEquals('Plugin Manufacturer', $snippetFile->getAuthor());
+        static::assertSame('en-GB', $snippetFile->getIso());
+        static::assertSame('Plugin Manufacturer', $snippetFile->getAuthor());
         static::assertTrue($snippetFile->isBase());
     }
 }

--- a/tests/unit/Core/System/Snippet/SnippetExceptionTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetExceptionTest.php
@@ -19,17 +19,17 @@ class SnippetExceptionTest extends TestCase
     {
         $exception = SnippetException::invalidFilterName();
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
-        static::assertEquals(SnippetException::SNIPPET_INVALID_FILTER_NAME, $exception->getErrorCode());
-        static::assertEquals('Snippet filter name is invalid.', $exception->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(SnippetException::SNIPPET_INVALID_FILTER_NAME, $exception->getErrorCode());
+        static::assertSame('Snippet filter name is invalid.', $exception->getMessage());
     }
 
     public function testInvalidLimitQuery(): void
     {
         $exception = SnippetException::invalidLimitQuery(0);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
-        static::assertEquals(SnippetException::SNIPPET_INVALID_LIMIT_QUERY, $exception->getErrorCode());
-        static::assertEquals('Limit must be bigger than 1, 0 given.', $exception->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(SnippetException::SNIPPET_INVALID_LIMIT_QUERY, $exception->getErrorCode());
+        static::assertSame('Limit must be bigger than 1, 0 given.', $exception->getMessage());
     }
 }

--- a/tests/unit/Core/System/SystemConfig/Command/ConfigGetCommandTest.php
+++ b/tests/unit/Core/System/SystemConfig/Command/ConfigGetCommandTest.php
@@ -44,7 +44,7 @@ class ConfigGetCommandTest extends TestCase
     public function testConfigGetScalar(string $key, string $output): void
     {
         $commandOutput = $this->executeCommand($key, 'scalar');
-        static::assertEquals($commandOutput, $output);
+        static::assertSame($commandOutput, $output);
     }
 
     public static function configFormatScalarProvider(): \Generator
@@ -60,7 +60,7 @@ class ConfigGetCommandTest extends TestCase
     public function testConfigGetDefault(string $key, string $output): void
     {
         $commandOutput = $this->executeCommand($key);
-        static::assertEquals($commandOutput, $output);
+        static::assertSame($commandOutput, $output);
     }
 
     public static function configFormatDefaultProvider(): \Generator

--- a/tests/unit/Core/System/SystemConfig/Service/ConfigurationServiceTest.php
+++ b/tests/unit/Core/System/SystemConfig/Service/ConfigurationServiceTest.php
@@ -106,7 +106,7 @@ class ConfigurationServiceTest extends TestCase
 
         $expectedConfigWithoutValues = $this->getConfigWithoutValues();
 
-        static::assertEquals($expectedConfigWithoutValues, $actualConfig);
+        static::assertSame($expectedConfigWithoutValues, $actualConfig);
         static::assertSame($expectedConfigWithoutValues[0]['elements'][0], $actualConfig[0]['elements'][0]);
         static::assertSame($expectedConfigWithoutValues[0]['elements'][2], $actualConfig[0]['elements'][2]);
     }

--- a/tests/unit/Core/System/SystemConfig/SymfonySystemConfigServiceTest.php
+++ b/tests/unit/Core/System/SystemConfig/SymfonySystemConfigServiceTest.php
@@ -25,8 +25,8 @@ class SymfonySystemConfigServiceTest extends TestCase
 
         $service = new SymfonySystemConfigService($config);
 
-        static::assertEquals($config['default'], $service->getConfig());
-        static::assertEquals($config['salesChannelId'], $service->getConfig('salesChannelId'));
+        static::assertSame($config['default'], $service->getConfig());
+        static::assertSame($config['salesChannelId'], $service->getConfig('salesChannelId'));
     }
 
     public function testGet(): void
@@ -42,8 +42,8 @@ class SymfonySystemConfigServiceTest extends TestCase
 
         $service = new SymfonySystemConfigService($config);
 
-        static::assertEquals('value', $service->get('key'));
-        static::assertEquals('value2', $service->get('key', 'salesChannelId'));
+        static::assertSame('value', $service->get('key'));
+        static::assertSame('value2', $service->get('key', 'salesChannelId'));
         static::assertTrue($service->has('key'));
         static::assertFalse($service->has('nonExistentKey'));
         static::assertNull($service->get('nonExistentKey'));
@@ -85,9 +85,9 @@ class SymfonySystemConfigServiceTest extends TestCase
             'key' => null,
         ];
 
-        static::assertEquals(['key' => 'value', 'onlyDefault' => 'value'], $service->override($merged, null, inherit: false, nesting: false));
-        static::assertEquals(['key' => 'value2'], $service->override($merged, 'salesChannelId', inherit: false, nesting: false));
-        static::assertEquals(['key' => 'value2', 'onlyDefault' => 'value'], $service->override($merged, 'salesChannelId', nesting: false));
+        static::assertSame(['key' => 'value', 'onlyDefault' => 'value'], $service->override($merged, null, inherit: false, nesting: false));
+        static::assertSame(['key' => 'value2'], $service->override($merged, 'salesChannelId', inherit: false, nesting: false));
+        static::assertSame(['key' => 'value2', 'onlyDefault' => 'value'], $service->override($merged, 'salesChannelId', nesting: false));
     }
 
     public function testOverrideNested(): void
@@ -114,8 +114,8 @@ class SymfonySystemConfigServiceTest extends TestCase
             ],
         ];
 
-        static::assertEquals(['key' => 'value', 'nested' => ['key' => 'value'], 'first' => ['key' => 'test']], $service->override($merged, null, inherit: false));
-        static::assertEquals(['key' => 'value2', 'nested' => ['key' => 'value2'], 'second' => ['key' => 'test']], $service->override($merged, 'salesChannelId', inherit: false));
-        static::assertEquals(['key' => 'value2', 'nested' => ['key' => 'value2'], 'first' => ['key' => 'test'], 'second' => ['key' => 'test']], $service->override($merged, 'salesChannelId'));
+        static::assertSame(['key' => 'value', 'nested' => ['key' => 'value'], 'first' => ['key' => 'test']], $service->override($merged, null, inherit: false));
+        static::assertSame(['key' => 'value2', 'nested' => ['key' => 'value2'], 'second' => ['key' => 'test']], $service->override($merged, 'salesChannelId', inherit: false));
+        static::assertSame(['key' => 'value2', 'nested' => ['key' => 'value2'], 'first' => ['key' => 'test'], 'second' => ['key' => 'test']], $service->override($merged, 'salesChannelId'));
     }
 }

--- a/tests/unit/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
+++ b/tests/unit/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
@@ -115,7 +115,7 @@ class SystemConfigValidatorTest extends TestCase
 
         $result = $refMethod->invoke($systemConfigValidation, 'dummy domain', $contextMock);
 
-        static::assertEquals([], $result);
+        static::assertSame([], $result);
     }
 
     public function testGetSystemConfigByDomainWithException(): void
@@ -134,7 +134,7 @@ class SystemConfigValidatorTest extends TestCase
 
         $result = $refMethod->invoke($systemConfigValidation, 'dummy domain', $contextMock);
 
-        static::assertEquals($result, []);
+        static::assertSame($result, []);
     }
 
     /**

--- a/tests/unit/Core/System/SystemTest.php
+++ b/tests/unit/Core/System/SystemTest.php
@@ -16,6 +16,6 @@ class SystemTest extends TestCase
     {
         $system = new System();
 
-        static::assertEquals(-1, $system->getTemplatePriority());
+        static::assertSame(-1, $system->getTemplatePriority());
     }
 }

--- a/tests/unit/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollectionTest.php
+++ b/tests/unit/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollectionTest.php
@@ -35,7 +35,7 @@ class TaxRuleCollectionTest extends TestCase
             $rule3,
         ]);
 
-        static::assertEquals(
+        static::assertSame(
             $rule2,
             $collection->latestActivationDate()
         );
@@ -56,7 +56,7 @@ class TaxRuleCollectionTest extends TestCase
             $rule2,
         ]);
 
-        static::assertEquals(
+        static::assertSame(
             $rule2,
             $collection->highestTypePosition()
         );
@@ -82,7 +82,7 @@ class TaxRuleCollectionTest extends TestCase
             $rule3,
         ]);
 
-        static::assertEquals(
+        static::assertSame(
             ['rule1', 'rule3'],
             \array_values($collection->filterByTypePosition(2)->getIds())
         );

--- a/tests/unit/Core/System/UsageData/Api/ConsentControllerTest.php
+++ b/tests/unit/Core/System/UsageData/Api/ConsentControllerTest.php
@@ -42,7 +42,7 @@ class ConsentControllerTest extends TestCase
 
         $context = Context::createDefaultContext(new AdminApiSource('018a93bbe90570eda0d89c600de7dd19'));
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'isConsentGiven' => true,
                 'isBannerHidden' => true,

--- a/tests/unit/Core/System/UsageData/Consent/ConsentReporterTest.php
+++ b/tests/unit/Core/System/UsageData/Consent/ConsentReporterTest.php
@@ -26,7 +26,7 @@ class ConsentReporterTest extends TestCase
 {
     public function testSubscribedEvents(): void
     {
-        static::assertEquals([
+        static::assertSame([
             ConsentStateChangedEvent::class => 'reportConsent',
         ], ConsentReporter::getSubscribedEvents());
     }

--- a/tests/unit/Core/System/UsageData/Consent/ConsentServiceTest.php
+++ b/tests/unit/Core/System/UsageData/Consent/ConsentServiceTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\System\UsageData\Consent;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
@@ -280,7 +281,10 @@ class ConsentServiceTest extends TestCase
             new MockClock(),
         );
 
-        static::assertEquals($updatedAt, $consentService->getLastConsentIsAcceptedDate());
+        static::assertSame(
+            $updatedAt->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            $consentService->getLastConsentIsAcceptedDate()?->format(Defaults::STORAGE_DATE_TIME_FORMAT)
+        );
     }
 
     private function assertConsentEventFired(CollectingEventDispatcher $dispatcher, ConsentState $state): void
@@ -290,6 +294,6 @@ class ConsentServiceTest extends TestCase
 
         $consentChangedEvent = $events[0];
         static::assertInstanceOf(ConsentStateChangedEvent::class, $consentChangedEvent);
-        static::assertEquals($state, $consentChangedEvent->getState());
+        static::assertSame($state, $consentChangedEvent->getState());
     }
 }

--- a/tests/unit/Core/System/UsageData/EntitySync/DispatchEntitiesQueryBuilderTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/DispatchEntitiesQueryBuilderTest.php
@@ -211,7 +211,7 @@ class DispatchEntitiesQueryBuilderTest extends TestCase
         $parameters = $this->queryHelper->getQueryBuilder()->getParameters();
         static::assertCount(1, $parameters);
         static::assertArrayHasKey('lastApprovalDate', $parameters);
-        static::assertEquals($runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT), $parameters['lastApprovalDate']);
+        static::assertSame($runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT), $parameters['lastApprovalDate']);
     }
 
     public function testWithRunDateConstraintUpdatedOperation(): void
@@ -235,7 +235,7 @@ class DispatchEntitiesQueryBuilderTest extends TestCase
         $parameters = $this->queryHelper->getQueryBuilder()->getParameters();
         static::assertCount(1, $parameters);
         static::assertArrayHasKey('lastApprovalDate', $parameters);
-        static::assertEquals($runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT), $parameters['lastApprovalDate']);
+        static::assertSame($runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT), $parameters['lastApprovalDate']);
     }
 }
 

--- a/tests/unit/Core/System/UsageData/EntitySync/DispatchEntityMessageHandlerTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/DispatchEntityMessageHandlerTest.php
@@ -655,16 +655,18 @@ class DispatchEntityMessageHandlerTest extends TestCase
         static::assertSame(1337, $serialized['int']);
 
         static::assertArrayHasKey('createdAt', $serialized);
-        static::assertEquals(new \DateTimeImmutable('2023-07-31'), $serialized['createdAt']);
+        $createdAt = $serialized['createdAt'];
+        static::assertInstanceOf(\DateTimeInterface::class, $createdAt);
+        static::assertSame((new \DateTimeImmutable('2023-07-31'))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $createdAt->format(Defaults::STORAGE_DATE_TIME_FORMAT));
 
         static::assertArrayHasKey('updatedAt', $serialized);
         static::assertNull($serialized['updatedAt']);
 
         static::assertArrayHasKey('association_name', $serialized);
-        static::assertEquals('decoded_value', $serialized['association_name']);
+        static::assertSame('decoded_value', $serialized['association_name']);
 
         static::assertArrayHasKey('blob', $serialized);
-        static::assertEquals('blob', base64_decode($serialized['blob'], true));
+        static::assertSame('blob', base64_decode($serialized['blob'], true));
 
         static::assertArrayNotHasKey('one_to_one', $serialized);
     }

--- a/tests/unit/Core/System/UsageData/EntitySync/DispatchEntityMessageTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/DispatchEntityMessageTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\System\UsageData\EntitySync;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\UsageData\EntitySync\DispatchEntityMessage;
 use Shopware\Core\System\UsageData\EntitySync\Operation;
@@ -26,7 +27,7 @@ class DispatchEntityMessageTest extends TestCase
             []
         );
 
-        static::assertEquals($runDate, $message->runDate);
+        static::assertSame($runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT), $message->runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT));
     }
 
     /**

--- a/tests/unit/Core/System/UsageData/EntitySync/IterateEntitiesQueryBuilderTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/IterateEntitiesQueryBuilderTest.php
@@ -96,7 +96,7 @@ class IterateEntitiesQueryBuilderTest extends TestCase
             'FROM ' . EntityDefinitionQueryHelper::escape(IterableTestEntityDefinition::ENTITY_NAME),
             $queryBuilder->getSQL()
         );
-        static::assertEquals(12, $queryBuilder->getMaxResults());
+        static::assertSame(12, $queryBuilder->getMaxResults());
     }
 
     public function testCreateAddsLastRunConditionIfGiven(): void
@@ -119,12 +119,12 @@ class IterateEntitiesQueryBuilderTest extends TestCase
             'FROM ' . EntityDefinitionQueryHelper::escape(IterableTestEntityDefinition::ENTITY_NAME),
             $queryBuilder->getSQL()
         );
-        static::assertEquals(12, $queryBuilder->getMaxResults());
+        static::assertSame(12, $queryBuilder->getMaxResults());
         static::assertStringContainsString(
             '(created_at > :lastRun) AND (created_at <= :currentRun) AND ((updated_at IS NULL) OR (updated_at <= :currentRun))',
             $queryBuilder->getSQL()
         );
-        static::assertEquals('2023-08-11 00:00:00.000', $queryBuilder->getParameter('lastRun'));
+        static::assertSame('2023-08-11 00:00:00.000', $queryBuilder->getParameter('lastRun'));
     }
 
     public function testCreateThrowsForUpdatesIfLastRunIsNotSet(): void
@@ -142,13 +142,13 @@ class IterateEntitiesQueryBuilderTest extends TestCase
             'FROM ' . EntityDefinitionQueryHelper::escape(IterableTestEntityDefinition::ENTITY_NAME),
             $queryBuilder->getSQL()
         );
-        static::assertEquals(12, $queryBuilder->getMaxResults());
+        static::assertSame(12, $queryBuilder->getMaxResults());
 
         static::assertStringContainsString(
             '(created_at <= :lastRun) AND (updated_at > :lastRun) AND (updated_at <= :currentRun)',
             $queryBuilder->getSQL()
         );
-        static::assertEquals('2023-08-11 00:00:00.000', $queryBuilder->getParameter('lastRun'));
+        static::assertSame('2023-08-11 00:00:00.000', $queryBuilder->getParameter('lastRun'));
     }
 
     public function testCreateThrowsExceptionForDeletionsIfLastRunIsNotSet(): void
@@ -171,12 +171,12 @@ class IterateEntitiesQueryBuilderTest extends TestCase
             'FROM ' . EntityDefinitionQueryHelper::escape('usage_data_entity_deletion'),
             $queryBuilder->getSQL()
         );
-        static::assertEquals(12, $queryBuilder->getMaxResults());
+        static::assertSame(12, $queryBuilder->getMaxResults());
         static::assertStringContainsString(
             '(`entity_name` = :entityName) AND (`deleted_at` <= :currentRunDate)',
             $queryBuilder->getSQL(),
         );
-        static::assertEquals(IterableTestEntityDefinition::ENTITY_NAME, $queryBuilder->getParameter('entityName'));
+        static::assertSame(IterableTestEntityDefinition::ENTITY_NAME, $queryBuilder->getParameter('entityName'));
     }
 
     /**
@@ -210,7 +210,7 @@ class IterateEntitiesQueryBuilderTest extends TestCase
             $queryBuilder->getSQL()
         );
 
-        static::assertEquals(Uuid::fromHexToBytes(Defaults::LIVE_VERSION), $queryBuilder->getParameter('versionId'));
+        static::assertSame(Uuid::fromHexToBytes(Defaults::LIVE_VERSION), $queryBuilder->getParameter('versionId'));
     }
 }
 

--- a/tests/unit/Core/System/UsageData/EntitySync/IterateEntityMessageHandlerTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/IterateEntityMessageHandlerTest.php
@@ -139,8 +139,8 @@ class IterateEntityMessageHandlerTest extends TestCase
 
         static::assertInstanceOf(DispatchEntityMessage::class, $entitySyncMessage);
 
-        static::assertEquals('test-entity', $entitySyncMessage->entityName);
-        static::assertEquals([
+        static::assertSame('test-entity', $entitySyncMessage->entityName);
+        static::assertSame([
             ['id' => 'first-id'],
             ['id' => 'second-id'],
         ], $entitySyncMessage->primaryKeys);

--- a/tests/unit/Core/System/UsageData/EntitySync/IterateEntityMessageTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/IterateEntityMessageTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\System\UsageData\EntitySync;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\UsageData\EntitySync\IterateEntityMessage;
 use Shopware\Core\System\UsageData\EntitySync\Operation;
@@ -26,8 +27,8 @@ class IterateEntityMessageTest extends TestCase
             $dateTime,
         );
 
-        static::assertEquals($dateTime, $message->runDate);
-        static::assertEquals($dateTime, $message->lastRun);
+        static::assertSame($dateTime->format(Defaults::STORAGE_DATE_TIME_FORMAT), $message->runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame($dateTime->format(Defaults::STORAGE_DATE_TIME_FORMAT), $message->lastRun?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
     }
 
     /**

--- a/tests/unit/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskTest.php
+++ b/tests/unit/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskTest.php
@@ -16,11 +16,11 @@ class CollectEntityDataTaskTest extends TestCase
 {
     public function testItHandlesCorrectTask(): void
     {
-        static::assertEquals('usage_data.entity_data.collect', CollectEntityDataTask::getTaskName());
+        static::assertSame('usage_data.entity_data.collect', CollectEntityDataTask::getTaskName());
     }
 
     public function testItIsRescheduledEvery24Hours(): void
     {
-        static::assertEquals(60 * 60 * 24, CollectEntityDataTask::getDefaultInterval());
+        static::assertSame(60 * 60 * 24, CollectEntityDataTask::getDefaultInterval());
     }
 }

--- a/tests/unit/Core/System/UsageData/Services/EntityDeletedEventHelperTest.php
+++ b/tests/unit/Core/System/UsageData/Services/EntityDeletedEventHelperTest.php
@@ -102,7 +102,7 @@ class EntityDeletedEventHelperTest extends TestCase
             ->prepare();
         $entityIds = $eventHelper->getEntityIds();
         static::assertArrayHasKey(EntityWithSinglePrimaryKey::ENTITY_NAME, $entityIds);
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     'id' => $idsCollection->get('first-product'),

--- a/tests/unit/Core/System/UsageData/Services/EntityDispatchServiceTest.php
+++ b/tests/unit/Core/System/UsageData/Services/EntityDispatchServiceTest.php
@@ -60,7 +60,7 @@ class EntityDispatchServiceTest extends TestCase
 
     public function testItReturnsCorrectAppConfigKey(): void
     {
-        static::assertEquals(
+        static::assertSame(
             'usageData-entitySync-lastRun-sales_channel',
             EntityDispatchService::getLastRunKeyForEntity('sales_channel')
         );
@@ -157,7 +157,7 @@ class EntityDispatchServiceTest extends TestCase
         /* The message->getRunDate is not 100% equal to the one stored in the storage because
          * the last 3 decimals are lost in the formatting.
          */
-        static::assertEquals(
+        static::assertSame(
             $now->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             $appConfig->get('usageData-entitySync-lastRun-product'),
         );
@@ -165,9 +165,9 @@ class EntityDispatchServiceTest extends TestCase
         $salesChannelMessage = $messages[1]->getMessage();
         static::assertInstanceOf(IterateEntityMessage::class, $salesChannelMessage);
 
-        static::assertEquals(
-            $now->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        static::assertSame(
             $appConfig->get('usageData-entitySync-lastRun-sales_channel'),
+            $now->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         );
     }
 
@@ -197,7 +197,7 @@ class EntityDispatchServiceTest extends TestCase
 
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
 
-        static::assertEquals(
+        static::assertSame(
             $expectedLastRunDate?->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             $systemConfigService->get('core.usageData.lastEntitySyncRunDate'),
         );
@@ -232,7 +232,7 @@ class EntityDispatchServiceTest extends TestCase
 
         $messages = $messageBus->getMessages();
         $messageCountFirstRun = \count($messages);
-        static::assertEquals(2, $messageCountFirstRun);
+        static::assertSame(2, $messageCountFirstRun);
 
         // second run --> should not start another run as the time has not changed
         $entityDispatchService->dispatchIterateEntityMessages(new CollectEntityDataMessage('current-shop-id'));
@@ -323,16 +323,16 @@ class EntityDispatchServiceTest extends TestCase
         $productMessage = $messages[0]->getMessage();
         static::assertInstanceOf(IterateEntityMessage::class, $productMessage);
 
-        static::assertEquals('product', $productMessage->entityName);
+        static::assertSame('product', $productMessage->entityName);
         static::assertNull($productMessage->lastRun);
-        static::assertEquals($now, $productMessage->runDate);
+        static::assertSame($now->format(Defaults::STORAGE_DATE_TIME_FORMAT), $productMessage->runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT));
 
         $salesChannelMessage = $messages[1]->getMessage();
         static::assertInstanceOf(IterateEntityMessage::class, $salesChannelMessage);
 
-        static::assertEquals('sales_channel', $salesChannelMessage->entityName);
+        static::assertSame('sales_channel', $salesChannelMessage->entityName);
         static::assertNull($salesChannelMessage->lastRun);
-        static::assertEquals($now, $salesChannelMessage->runDate);
+        static::assertSame($now->format(Defaults::STORAGE_DATE_TIME_FORMAT), $salesChannelMessage->runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT));
     }
 
     public function testItAddsLastRunDateIfExists(): void
@@ -369,16 +369,16 @@ class EntityDispatchServiceTest extends TestCase
         $productMessage = $messages[0]->getMessage();
         static::assertInstanceOf(IterateEntityMessage::class, $productMessage);
 
-        static::assertEquals('product', $productMessage->entityName);
+        static::assertSame('product', $productMessage->entityName);
         static::assertNull($productMessage->lastRun);
-        static::assertEquals($now, $productMessage->runDate);
+        static::assertSame($now->format(Defaults::STORAGE_DATE_TIME_FORMAT), $productMessage->runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT));
 
         $salesChannelMessage = $messages[1]->getMessage();
         static::assertInstanceOf(IterateEntityMessage::class, $salesChannelMessage);
 
-        static::assertEquals('sales_channel', $salesChannelMessage->entityName);
-        static::assertEquals($storedScLastRunDatetime, $salesChannelMessage->lastRun);
-        static::assertEquals($now, $salesChannelMessage->runDate);
+        static::assertSame('sales_channel', $salesChannelMessage->entityName);
+        static::assertSame($storedScLastRunDatetime->format(Defaults::STORAGE_DATE_TIME_FORMAT), $salesChannelMessage->lastRun?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame($now->format(Defaults::STORAGE_DATE_TIME_FORMAT), $salesChannelMessage->runDate->format(Defaults::STORAGE_DATE_TIME_FORMAT));
     }
 
     public function testReturnsEarlyIfGatewayDoesNotAllowPush(): void
@@ -505,7 +505,7 @@ class EntityDispatchServiceTest extends TestCase
             $message = $envelope->getMessage();
             static::assertInstanceOf(IterateEntityMessage::class, $message);
             static::assertNull($message->lastRun);
-            static::assertEquals(Operation::CREATE, $message->operation);
+            static::assertSame(Operation::CREATE, $message->operation);
         }
     }
 
@@ -617,7 +617,7 @@ class EntityDispatchServiceTest extends TestCase
             ++$foundMessages[$message->entityName][$message->operation->value];
         }
 
-        static::assertEquals($expectedMessages, $foundMessages);
+        static::assertSame($expectedMessages, $foundMessages);
     }
 
     public function testResetLastRunDateForAllEntities(): void

--- a/tests/unit/Core/System/UsageData/Services/ManyToManyAssociationServiceTest.php
+++ b/tests/unit/Core/System/UsageData/Services/ManyToManyAssociationServiceTest.php
@@ -102,7 +102,7 @@ class ManyToManyAssociationServiceTest extends TestCase
             'primaryKeyName'
         );
 
-        static::assertEquals([
+        static::assertSame([
             'propertyName' => [
                 Uuid::fromHexToBytes($ids->get('1')) => [
                     $ids->get('referenceColumn-1'),

--- a/tests/unit/Core/System/UsageData/Subscriber/EntityDeleteSubscriberTest.php
+++ b/tests/unit/Core/System/UsageData/Subscriber/EntityDeleteSubscriberTest.php
@@ -69,7 +69,7 @@ class EntityDeleteSubscriberTest extends TestCase
 
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals([
+        static::assertSame([
             EntityDeleteEvent::class => 'handleEntityDeleteEvent',
         ], EntityDeleteSubscriber::getSubscribedEvents());
     }
@@ -94,12 +94,12 @@ class EntityDeleteSubscriberTest extends TestCase
             ->withAnyParameters()
             ->willReturnCallback(function ($key, $value) use ($productId): void {
                 if ($key === ':entity_name') {
-                    static::assertEquals(EntityWithSinglePrimaryKey::ENTITY_NAME, $value);
+                    static::assertSame(EntityWithSinglePrimaryKey::ENTITY_NAME, $value);
                     $this->requiredParameter[':entity_name'] = true;
                 }
 
                 if ($key === ':entity_ids') {
-                    static::assertEquals(json_encode(['id' => Uuid::fromBytesToHex($productId)]), $value);
+                    static::assertSame(json_encode(['id' => Uuid::fromBytesToHex($productId)]), $value);
                     $this->requiredParameter[':entity_ids'] = true;
                 }
             });
@@ -179,12 +179,12 @@ class EntityDeleteSubscriberTest extends TestCase
             ->withAnyParameters()
             ->willReturnCallback(function ($key, $value) use ($productId): void {
                 if ($key === ':entity_name') {
-                    static::assertEquals(EntityWithSinglePrimaryKey::ENTITY_NAME, $value);
+                    static::assertSame(EntityWithSinglePrimaryKey::ENTITY_NAME, $value);
                     $this->requiredParameter[':entity_name'] = true;
                 }
 
                 if ($key === ':entity_ids') {
-                    static::assertEquals(json_encode(['id' => Uuid::fromBytesToHex($productId)]), $value);
+                    static::assertSame(json_encode(['id' => Uuid::fromBytesToHex($productId)]), $value);
                     $this->requiredParameter[':entity_ids'] = true;
                 }
             });

--- a/tests/unit/Core/System/UsageData/Subscriber/ShopIdChangedSubscriberTest.php
+++ b/tests/unit/Core/System/UsageData/Subscriber/ShopIdChangedSubscriberTest.php
@@ -24,7 +24,7 @@ class ShopIdChangedSubscriberTest extends TestCase
 {
     public function testSubscribedEvents(): void
     {
-        static::assertEquals([
+        static::assertSame([
             ShopIdDeletedEvent::class => 'handleShopIdDeleted',
             ShopIdChangedEvent::class => 'handleShopIdChanged',
         ], ShopIdChangedSubscriber::getSubscribedEvents());

--- a/tests/unit/Core/System/UsageData/UsageDataExceptionTest.php
+++ b/tests/unit/Core/System/UsageData/UsageDataExceptionTest.php
@@ -130,35 +130,35 @@ class UsageDataExceptionTest extends TestCase
     {
         $exception = UsageDataException::unexpectedOperationInInitialRun(Operation::DELETE);
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        static::assertEquals('SYSTEM__USAGE_DATA_UNEXPECTED_OPERATION_IN_INITIAL_RUN', $exception->getErrorCode());
-        static::assertEquals('Operation "delete" was not expected to be dispatched in initial run', $exception->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('SYSTEM__USAGE_DATA_UNEXPECTED_OPERATION_IN_INITIAL_RUN', $exception->getErrorCode());
+        static::assertSame('Operation "delete" was not expected to be dispatched in initial run', $exception->getMessage());
     }
 
     public function testEntityNotAllowed(): void
     {
         $exception = UsageDataException::entityNotAllowed('product');
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        static::assertEquals('SYSTEM__USAGE_DATA_ENTITY_NOT_TAGGED', $exception->getErrorCode());
-        static::assertEquals('Entity "product" is not allowed to be used for usage data', $exception->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('SYSTEM__USAGE_DATA_ENTITY_NOT_TAGGED', $exception->getErrorCode());
+        static::assertSame('Entity "product" is not allowed to be used for usage data', $exception->getMessage());
     }
 
     public function testFailedToCompressEntityDispatchPayload(): void
     {
         $exception = UsageDataException::failedToCompressEntityDispatchPayload();
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        static::assertEquals('SYSTEM__USAGE_DATA_FAILED_TO_COMPRESS_ENTITY_DISPATCH_PAYLOAD', $exception->getErrorCode());
-        static::assertEquals('Failed to compress entity dispatch payload', $exception->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('SYSTEM__USAGE_DATA_FAILED_TO_COMPRESS_ENTITY_DISPATCH_PAYLOAD', $exception->getErrorCode());
+        static::assertSame('Failed to compress entity dispatch payload', $exception->getMessage());
     }
 
     public function testFailedToLoadDefaultAllowList(): void
     {
         $exception = UsageDataException::failedToLoadDefaultAllowList();
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        static::assertEquals('SYSTEM__USAGE_DATA_FAILED_TO_LOAD_DEFAULT_ALLOW_LIST', $exception->getErrorCode());
-        static::assertEquals('Failed to load default allow list', $exception->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('SYSTEM__USAGE_DATA_FAILED_TO_LOAD_DEFAULT_ALLOW_LIST', $exception->getErrorCode());
+        static::assertSame('Failed to load default allow list', $exception->getMessage());
     }
 }

--- a/tests/unit/Core/System/User/Recovery/UserRecoveryRequestEventTest.php
+++ b/tests/unit/Core/System/User/Recovery/UserRecoveryRequestEventTest.php
@@ -34,6 +34,6 @@ class UserRecoveryRequestEventTest extends TestCase
         $storer->restore($flow);
 
         static::assertArrayHasKey('resetUrl', $flow->data());
-        static::assertEquals('my-reset-url', $flow->data()['resetUrl']);
+        static::assertSame('my-reset-url', $flow->data()['resetUrl']);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/9317

### 2. What does this change do, exactly?

Replace `assertEquals` with `assertSame`