### PR TITLE
chore: Replace assertEquals with assertSame in framework unit tests

### DIFF
--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
@@ -242,13 +242,13 @@ class CacheResponseSubscriberTest extends TestCase
 
                 foreach (self::$hashes as $name => $value) {
                     if ($hashName === $name) {
-                        static::assertEquals(
+                        static::assertSame(
                             $value,
                             $cookie->getValue(),
                             \sprintf('Hashes for state "%s" did not match, got "%s", but expected "%s"', $hashName, $cookie->getValue(), $value)
                         );
                     } else {
-                        static::assertNotEquals(
+                        static::assertNotSame(
                             $value,
                             $cookie->getValue(),
                             \sprintf('Hashes for state "%s" and state "%s" should not match, but did match.', $hashName, $name)
@@ -719,7 +719,7 @@ class CacheResponseSubscriberTest extends TestCase
             $response->headers->getCookies(),
             $assertCountErrorMessage
         );
-        static::assertEquals(
+        static::assertSame(
             $cookieName,
             $response->headers->getCookies()[$cookiesAmount - 1]->getName(),
             $assertEqualsErrorMessage

--- a/tests/unit/Core/Framework/Adapter/Cache/ReverseProxy/VarnishReverseProxyGatewayTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/ReverseProxy/VarnishReverseProxyGatewayTest.php
@@ -67,9 +67,9 @@ class VarnishReverseProxyGatewayTest extends TestCase
         $request = $this->mockHandler->getLastRequest();
         static::assertNotNull($request);
 
-        static::assertEquals('PURGE', $request->getMethod());
-        static::assertEquals('http://localhost', $request->getUri()->__toString());
-        static::assertEquals('tag-1 tag-2', $request->getHeader('xkey')[0]);
+        static::assertSame('PURGE', $request->getMethod());
+        static::assertSame('http://localhost', $request->getUri()->__toString());
+        static::assertSame('tag-1 tag-2', $request->getHeader('xkey')[0]);
     }
 
     #[DataProvider('providerExceptions')]
@@ -102,8 +102,8 @@ class VarnishReverseProxyGatewayTest extends TestCase
 
         static::assertNotNull($request);
 
-        static::assertEquals('PURGE', $request->getMethod());
-        static::assertEquals('http://localhost/', $request->getUri()->__toString());
+        static::assertSame('PURGE', $request->getMethod());
+        static::assertSame('http://localhost/', $request->getUri()->__toString());
     }
 
     public function testBanAll(): void
@@ -118,8 +118,8 @@ class VarnishReverseProxyGatewayTest extends TestCase
 
         static::assertNotNull($request);
 
-        static::assertEquals('BAN', $request->getMethod());
-        static::assertEquals('http://localhost', $request->getUri()->__toString());
+        static::assertSame('BAN', $request->getMethod());
+        static::assertSame('http://localhost', $request->getUri()->__toString());
     }
 
     #[DataProvider('providerExceptions')]

--- a/tests/unit/Core/Framework/Adapter/Cache/StoreApiRouteCacheKeyEventTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/StoreApiRouteCacheKeyEventTest.php
@@ -52,30 +52,30 @@ class StoreApiRouteCacheKeyEventTest extends TestCase
             Uuid::randomHex(),
         ];
         $event = new StoreApiRouteCacheKeyEvent($parts, $this->request, $this->context, null);
-        static::assertEquals($parts, $event->getParts());
+        static::assertSame($parts, $event->getParts());
     }
 
     public function testSetPartsWillGetPartsReturnSetterValue(): void
     {
-        static::assertEquals([], $this->defaultEvent->getParts());
+        static::assertSame([], $this->defaultEvent->getParts());
         $parts = [
             Uuid::randomHex(),
             Uuid::randomHex(),
         ];
         $this->defaultEvent->setParts($parts);
-        static::assertEquals($parts, $this->defaultEvent->getParts());
+        static::assertSame($parts, $this->defaultEvent->getParts());
     }
 
     public function testGetRequestWillReturnCorrectRequest(): void
     {
-        static::assertEquals($this->request, $this->defaultEvent->getRequest());
+        static::assertSame($this->request, $this->defaultEvent->getRequest());
     }
 
     public function testGetCriteriaWithCriteriaWillReturnCriteria(): void
     {
         $criteria = new Criteria();
         $event = new StoreApiRouteCacheKeyEvent([], $this->request, $this->context, $criteria);
-        static::assertEquals($criteria, $event->getCriteria());
+        static::assertSame($criteria, $event->getCriteria());
     }
 
     public function testGetCriteriaWithNullInCriteriaWillReturnNull(): void
@@ -85,7 +85,7 @@ class StoreApiRouteCacheKeyEventTest extends TestCase
 
     public function testGetSalesChannelIdWillReturnChannelIdFromGivenContext(): void
     {
-        static::assertEquals($this->salesChannelEntity->getId(), $this->defaultEvent->getSalesChannelId());
+        static::assertSame($this->salesChannelEntity->getId(), $this->defaultEvent->getSalesChannelId());
     }
 
     public function testDisableCachingWillDisableCache(): void

--- a/tests/unit/Core/Framework/Adapter/EntityTemplateLoaderTest.php
+++ b/tests/unit/Core/Framework/Adapter/EntityTemplateLoaderTest.php
@@ -30,7 +30,7 @@ class EntityTemplateLoaderTest extends TestCase
     {
         $subscribedEvents = EntityTemplateLoader::getSubscribedEvents();
 
-        static::assertEquals(['app_template.written' => 'reset'], $subscribedEvents);
+        static::assertSame(['app_template.written' => 'reset'], $subscribedEvents);
     }
 
     public function testDevMode(): void

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
@@ -17,7 +17,7 @@ class AwsS3v3FactoryTest extends TestCase
 {
     public function testGetType(): void
     {
-        static::assertEquals('amazon-s3', (new AwsS3v3Factory())->getType());
+        static::assertSame('amazon-s3', (new AwsS3v3Factory())->getType());
     }
 
     public function testCreate(): void

--- a/tests/unit/Core/Framework/Adapter/Storage/MySQLKeyValueStorageTest.php
+++ b/tests/unit/Core/Framework/Adapter/Storage/MySQLKeyValueStorageTest.php
@@ -46,10 +46,10 @@ class MySQLKeyValueStorageTest extends TestCase
             'key-2' => null,
         ]);
 
-        static::assertEquals('value-1', $this->keyValueStorage->get('key-1', 'default'));
+        static::assertSame('value-1', $this->keyValueStorage->get('key-1', 'default'));
         static::assertNull($this->keyValueStorage->get('key-2'));
-        static::assertEquals('default', $this->keyValueStorage->get('key-2', 'default'));
-        static::assertEquals('default', $this->keyValueStorage->get('key-3', 'default'));
+        static::assertSame('default', $this->keyValueStorage->get('key-2', 'default'));
+        static::assertSame('default', $this->keyValueStorage->get('key-3', 'default'));
     }
 
     public function testRemove(): void
@@ -85,7 +85,7 @@ class MySQLKeyValueStorageTest extends TestCase
 
         $this->keyValueStorage->remove('key-1');
 
-        static::assertEquals('default', $this->keyValueStorage->get('key-1', 'default'));
+        static::assertSame('default', $this->keyValueStorage->get('key-1', 'default'));
     }
 
     public function testGetAfterSet(): void
@@ -101,7 +101,7 @@ class MySQLKeyValueStorageTest extends TestCase
         ]);
 
         static::assertTrue($this->keyValueStorage->has('key-1'));
-        static::assertEquals('value-1', $this->keyValueStorage->get('key-1'));
+        static::assertSame('value-1', $this->keyValueStorage->get('key-1'));
 
         $this->keyValueStorage->set('key-1', null);
 

--- a/tests/unit/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
@@ -50,7 +50,7 @@ TWIG;
         $renderer = new StringTemplateRenderer($environment, sys_get_temp_dir());
         $result = $renderer->render($template, ['item' => $item], $context);
 
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public static function labelRenderingDataProvider(): \Generator

--- a/tests/unit/Core/Framework/Adapter/Twig/SwTwigFunctionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/SwTwigFunctionTest.php
@@ -17,7 +17,7 @@ use Twig\Template;
 /**
  * @internal
  */
-#[CoversClass('Shopware\Core\Framework\Adapter\Twig\SwTwigFunction')]
+#[CoversClass(SwTwigFunction::class)]
 class SwTwigFunctionTest extends TestCase
 {
     private MockObject&Environment $environmentMock;
@@ -34,7 +34,7 @@ class SwTwigFunctionTest extends TestCase
         $object = new ArrayStruct(['test' => null]);
         $result = SwTwigFunction::getAttribute($this->environmentMock, new Source('', 'empty'), $object, 'test');
 
-        static::assertEquals('', $result);
+        static::assertNull($result);
     }
 
     public function testSwGetAttributeValueBool(): void
@@ -55,7 +55,7 @@ class SwTwigFunctionTest extends TestCase
         $object = new ArrayStruct(['test' => 'value']);
         $result = SwTwigFunction::getAttribute($this->environmentMock, new Source('', 'empty'), $object, 'test');
 
-        static::assertEquals('value', $result);
+        static::assertSame('value', $result);
     }
 
     public function testSwGetAttributeGetterMethods(): void
@@ -71,11 +71,11 @@ class SwTwigFunctionTest extends TestCase
 
         $result = SwTwigFunction::getAttribute($this->environmentMock, new Source('', 'empty'), $object, 'value');
 
-        static::assertEquals('valueValue', $result);
+        static::assertSame('valueValue', $result);
 
         $result = SwTwigFunction::getAttribute($this->environmentMock, new Source('', 'empty'), $object, 'getValue');
 
-        static::assertEquals('valueValue', $result);
+        static::assertSame('valueValue', $result);
 
         $result = SwTwigFunction::getAttribute($this->environmentMock, new Source('', 'empty'), $object, 'visible');
 
@@ -103,7 +103,7 @@ class SwTwigFunctionTest extends TestCase
         $env->method('getRuntime')->willReturn(new EscaperRuntime($env));
         $result = SwTwigFunction::escapeFilter($env, null, 'html', 'UTF-8');
 
-        static::assertEquals('', $result);
+        static::assertSame('', $result);
     }
 
     public function testEscapeFilterWithIntegerInput(): void
@@ -112,7 +112,7 @@ class SwTwigFunctionTest extends TestCase
         $env->method('getRuntime')->willReturn(new EscaperRuntime($env));
         $result = SwTwigFunction::escapeFilter($env, 123, 'html', 'UTF-8');
 
-        static::assertEquals('123', $result);
+        static::assertSame('123', $result);
     }
 
     public function testEscapeFilterWithStringInput(): void
@@ -121,7 +121,7 @@ class SwTwigFunctionTest extends TestCase
         $env->method('getRuntime')->willReturn(new EscaperRuntime($env));
         $result = SwTwigFunction::escapeFilter($env, 'test', 'html', 'UTF-8');
 
-        static::assertEquals('test', $result);
+        static::assertSame('test', $result);
     }
 
     public function testEscapeFilterReallyEscapeString(): void
@@ -130,7 +130,7 @@ class SwTwigFunctionTest extends TestCase
         $env->method('getRuntime')->willReturn(new EscaperRuntime($env));
         $result = SwTwigFunction::escapeFilter($env, '<script>alert("test")</script>', 'html', 'UTF-8');
 
-        static::assertEquals('&lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;', $result);
+        static::assertSame('&lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;', $result);
     }
 
     public function testEscapeFilterWithCachedStringInput(): void
@@ -144,7 +144,7 @@ class SwTwigFunctionTest extends TestCase
         // Second call to get the cached result
         $result = SwTwigFunction::escapeFilter($env, 'cached_string', 'html', 'UTF-8');
 
-        static::assertEquals('cached_string', $result);
+        static::assertSame('cached_string', $result);
     }
 }
 

--- a/tests/unit/Core/Framework/Adapter/Twig/TemplateFinderTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TemplateFinderTest.php
@@ -49,7 +49,7 @@ class TemplateFinderTest extends TestCase
     #[DataProvider('templateNameProvider')]
     public function testGetTemplateName(string $input, string $expectation): void
     {
-        static::assertEquals($expectation, $this->finder->getTemplateName($input));
+        static::assertSame($expectation, $this->finder->getTemplateName($input));
     }
 
     /**
@@ -77,7 +77,7 @@ class TemplateFinderTest extends TestCase
 
         $foundTemplate = $this->finder->find($template, $ignoreMissing, $source);
 
-        static::assertEquals($expectedTemplate, $foundTemplate);
+        static::assertSame($expectedTemplate, $foundTemplate);
     }
 
     public function testFindModifiesCache(): void
@@ -88,7 +88,7 @@ class TemplateFinderTest extends TestCase
             $cache->setTemplateScopes(['foo']);
 
             // template scope has been set
-            static::assertEquals($hash, $cache->generateKey('foo', 'bar'));
+            static::assertSame($hash, $cache->generateKey('foo', 'bar'));
 
             // config hash had been set as well
             $cache->setConfigHash('');

--- a/tests/unit/Core/Framework/Adapter/Twig/TwigVariableParserTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TwigVariableParserTest.php
@@ -51,7 +51,7 @@ TWIG;
         sort($expected);
         sort($variables);
 
-        static::assertEquals($expected, $variables);
+        static::assertSame($expected, $variables);
     }
 
     public function testParserHandlesAssociationsInLoops(): void
@@ -88,6 +88,6 @@ TWIG;
         sort($expected);
         sort($variables);
 
-        static::assertEquals($expected, $variables);
+        static::assertSame($expected, $variables);
     }
 }

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilderTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilderTest.php
@@ -68,30 +68,30 @@ class OpenApiDefinitionSchemaBuilderTest extends TestCase
         $properties = json_decode($schema['Simple']->toJson(), true, \JSON_THROW_ON_ERROR, \JSON_THROW_ON_ERROR)['properties'];
         static::assertArrayHasKey('id', $properties);
         static::assertArrayHasKey('type', $properties['id']);
-        static::assertEquals('string', $properties['id']['type']);
+        static::assertSame('string', $properties['id']['type']);
         static::assertArrayHasKey('pattern', $properties['id']);
-        static::assertEquals('^[0-9a-f]{32}$', $properties['id']['pattern']);
+        static::assertSame('^[0-9a-f]{32}$', $properties['id']['pattern']);
         static::assertArrayHasKey('stringField', $properties);
         static::assertArrayHasKey('type', $properties['stringField']);
-        static::assertEquals('string', $properties['stringField']['type']);
+        static::assertSame('string', $properties['stringField']['type']);
         static::assertArrayHasKey('intField', $properties);
         static::assertArrayHasKey('type', $properties['intField']);
-        static::assertEquals('integer', $properties['intField']['type']);
+        static::assertSame('integer', $properties['intField']['type']);
         static::assertArrayHasKey('format', $properties['intField']);
-        static::assertEquals('int64', $properties['intField']['format']);
+        static::assertSame('int64', $properties['intField']['format']);
         static::assertArrayHasKey('floatField', $properties);
         static::assertArrayHasKey('type', $properties['floatField']);
-        static::assertEquals('number', $properties['floatField']['type']);
+        static::assertSame('number', $properties['floatField']['type']);
         static::assertArrayHasKey('format', $properties['floatField']);
-        static::assertEquals('float', $properties['floatField']['format']);
+        static::assertSame('float', $properties['floatField']['format']);
         static::assertArrayHasKey('boolField', $properties);
         static::assertArrayHasKey('type', $properties['boolField']);
-        static::assertEquals('boolean', $properties['boolField']['type']);
+        static::assertSame('boolean', $properties['boolField']['type']);
         static::assertArrayHasKey('childCount', $properties);
         static::assertArrayHasKey('type', $properties['childCount']);
-        static::assertEquals('integer', $properties['childCount']['type']);
+        static::assertSame('integer', $properties['childCount']['type']);
         static::assertArrayHasKey('format', $properties['childCount']);
-        static::assertEquals('int64', $properties['childCount']['format']);
+        static::assertSame('int64', $properties['childCount']['format']);
     }
 
     public function testFlagConversion(): void
@@ -108,7 +108,7 @@ class OpenApiDefinitionSchemaBuilderTest extends TestCase
         static::assertArrayHasKey('readOnly', $properties['readOnlyField']);
         static::assertTrue($properties['readOnlyField']['readOnly']);
         static::assertArrayHasKey('runtimeField', $properties);
-        static::assertEquals('Runtime field, cannot be used as part of the criteria.', $properties['runtimeField']['description']);
+        static::assertSame('Runtime field, cannot be used as part of the criteria.', $properties['runtimeField']['description']);
     }
 
     public function testExtensionConversion(): void

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApi3GeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApi3GeneratorTest.php
@@ -130,6 +130,6 @@ class OpenApi3GeneratorTest extends TestCase
         $entities = $schema['components']['schemas'];
         static::assertArrayHasKey('Presentation', $entities);
         static::assertArrayHasKey('infoConfigResponse', $entities);
-        static::assertEquals('Experimental', $schema['tags'][0]['name'] ?? null);
+        static::assertSame('Experimental', $schema['tags'][0]['name'] ?? null);
     }
 }

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
@@ -99,7 +99,7 @@ class StoreApiGeneratorTest extends TestCase
         $entities = $schema['components']['schemas'];
         static::assertArrayHasKey('Presentation', $entities);
         static::assertArrayHasKey('infoConfigResponse', $entities);
-        static::assertEquals('Experimental', $schema['tags'][0]['name'] ?? null);
+        static::assertSame('Experimental', $schema['tags'][0]['name'] ?? null);
     }
 
     public function testSchemaContainsCustomPathsOnly(): void

--- a/tests/unit/Core/Framework/Api/ApiExceptionTest.php
+++ b/tests/unit/Core/Framework/Api/ApiExceptionTest.php
@@ -33,32 +33,32 @@ class ApiExceptionTest extends TestCase
     {
         $exception = ApiException::invalidSyncCriteriaException('operationKey');
 
-        static::assertEquals(ApiException::API_INVALID_SYNC_CRITERIA_EXCEPTION, $exception->getErrorCode());
-        static::assertEquals('Sync operation operationKey, with action "delete", requires a criteria with at least one filter and can only be applied for mapping entities', $exception->getMessage());
+        static::assertSame(ApiException::API_INVALID_SYNC_CRITERIA_EXCEPTION, $exception->getErrorCode());
+        static::assertSame('Sync operation operationKey, with action "delete", requires a criteria with at least one filter and can only be applied for mapping entities', $exception->getMessage());
     }
 
     public function testInvalidSyncOperationException(): void
     {
         $exception = ApiException::invalidSyncOperationException('message');
 
-        static::assertEquals(ApiException::API_INVALID_SYNC_OPERATION_EXCEPTION, $exception->getErrorCode());
-        static::assertEquals('message', $exception->getMessage());
+        static::assertSame(ApiException::API_INVALID_SYNC_OPERATION_EXCEPTION, $exception->getErrorCode());
+        static::assertSame('message', $exception->getMessage());
     }
 
     public function testResolverNotFoundException(): void
     {
         $exception = ApiException::resolverNotFoundException('name');
 
-        static::assertEquals(ApiException::API_RESOLVER_NOT_FOUND_EXCEPTION, $exception->getErrorCode());
-        static::assertEquals('Foreign key resolver for key name not found', $exception->getMessage());
+        static::assertSame(ApiException::API_RESOLVER_NOT_FOUND_EXCEPTION, $exception->getErrorCode());
+        static::assertSame('Foreign key resolver for key name not found', $exception->getMessage());
     }
 
     public function testUnsupportedAssociation(): void
     {
         $exception = ApiException::unsupportedAssociation('name');
 
-        static::assertEquals(ApiException::API_UNSUPPORTED_ASSOCIATION_FIELD, $exception->getErrorCode());
-        static::assertEquals('Unsupported association for field name', $exception->getMessage());
+        static::assertSame(ApiException::API_UNSUPPORTED_ASSOCIATION_FIELD, $exception->getErrorCode());
+        static::assertSame('Unsupported association for field name', $exception->getMessage());
     }
 
     public function testMissingPrivileges(): void
@@ -87,8 +87,8 @@ class ApiExceptionTest extends TestCase
     {
         $exception = ApiException::notExistingRelation('demo');
 
-        static::assertEquals(ApiException::API_NOT_EXISTING_RELATION_EXCEPTION, $exception->getErrorCode());
-        static::assertEquals('Resource at path "demo" is not an existing relation.', $exception->getMessage());
+        static::assertSame(ApiException::API_NOT_EXISTING_RELATION_EXCEPTION, $exception->getErrorCode());
+        static::assertSame('Resource at path "demo" is not an existing relation.', $exception->getMessage());
     }
 
     public function testBadRequest(): void
@@ -96,7 +96,7 @@ class ApiExceptionTest extends TestCase
         $exception = ApiException::badRequest('Bad request');
 
         static::assertInstanceOf(BadRequestHttpException::class, $exception);
-        static::assertEquals('Bad request', $exception->getMessage());
+        static::assertSame('Bad request', $exception->getMessage());
     }
 
     public function testMethodNotAllowed(): void
@@ -104,7 +104,7 @@ class ApiExceptionTest extends TestCase
         $exception = ApiException::methodNotAllowed(['GET'], 'Get only');
 
         static::assertInstanceOf(MethodNotAllowedHttpException::class, $exception);
-        static::assertEquals('Get only', $exception->getMessage());
+        static::assertSame('Get only', $exception->getMessage());
     }
 
     public function testUnauthorized(): void
@@ -112,7 +112,7 @@ class ApiExceptionTest extends TestCase
         $exception = ApiException::unauthorized('challenge', 'Message');
 
         static::assertInstanceOf(UnauthorizedHttpException::class, $exception);
-        static::assertEquals('Message', $exception->getMessage());
+        static::assertSame('Message', $exception->getMessage());
     }
 
     public function testNoEntityCloned(): void
@@ -120,7 +120,7 @@ class ApiExceptionTest extends TestCase
         $exception = ApiException::noEntityCloned('order', '1234');
 
         static::assertInstanceOf(NoEntityClonedException::class, $exception);
-        static::assertEquals('Could not clone entity order with id 1234.', $exception->getMessage());
+        static::assertSame('Could not clone entity order with id 1234.', $exception->getMessage());
     }
 
     public function testExpectationFailed(): void
@@ -128,7 +128,7 @@ class ApiExceptionTest extends TestCase
         $exception = ApiException::expectationFailed([]);
 
         static::assertInstanceOf(ExpectationFailedException::class, $exception);
-        static::assertEquals('API Expectations failed', $exception->getMessage());
+        static::assertSame('API Expectations failed', $exception->getMessage());
     }
 
     public function testInvalidSyncOperation(): void
@@ -136,7 +136,7 @@ class ApiExceptionTest extends TestCase
         $exception = ApiException::invalidSyncOperation('Message');
 
         static::assertInstanceOf(InvalidSyncOperationException::class, $exception);
-        static::assertEquals('Message', $exception->getMessage());
+        static::assertSame('Message', $exception->getMessage());
     }
 
     public function testInvalidSalesChannelId(): void
@@ -144,7 +144,7 @@ class ApiExceptionTest extends TestCase
         $exception = ApiException::invalidSalesChannelId('123');
 
         static::assertInstanceOf(InvalidSalesChannelIdException::class, $exception);
-        static::assertEquals('The provided salesChannelId "123" is invalid.', $exception->getMessage());
+        static::assertSame('The provided salesChannelId "123" is invalid.', $exception->getMessage());
     }
 
     public function testInvalidVersionName(): void
@@ -179,107 +179,107 @@ class ApiExceptionTest extends TestCase
     {
         $exception = ApiException::unsupportedOperation('invalid_operation');
 
-        static::assertEquals(ApiException::API_UNSUPPORTED_OPERATION_EXCEPTION, $exception->getErrorCode());
-        static::assertEquals('Unsupported invalid_operation operation.', $exception->getMessage());
+        static::assertSame(ApiException::API_UNSUPPORTED_OPERATION_EXCEPTION, $exception->getErrorCode());
+        static::assertSame('Unsupported invalid_operation operation.', $exception->getMessage());
     }
 
     public function testInvalidVersionId(): void
     {
         $exception = ApiException::invalidVersionId('invalid_version_id');
 
-        static::assertEquals(ApiException::API_INVALID_VERSION_ID, $exception->getErrorCode());
-        static::assertEquals('versionId invalid_version_id is not a valid uuid.', $exception->getMessage());
+        static::assertSame(ApiException::API_INVALID_VERSION_ID, $exception->getErrorCode());
+        static::assertSame('versionId invalid_version_id is not a valid uuid.', $exception->getMessage());
     }
 
     public function testInvalidApiType(): void
     {
         $exception = ApiException::invalidApiType('invalid_type');
 
-        static::assertEquals(ApiException::API_TYPE_PARAMETER_INVALID, $exception->getErrorCode());
-        static::assertEquals('Parameter type invalid_type is invalid.', $exception->getMessage());
+        static::assertSame(ApiException::API_TYPE_PARAMETER_INVALID, $exception->getErrorCode());
+        static::assertSame('Parameter type invalid_type is invalid.', $exception->getMessage());
     }
 
     public function testAppIdParameterIsMissing(): void
     {
         $exception = ApiException::appIdParameterIsMissing();
 
-        static::assertEquals(ApiException::API_APP_ID_PARAMETER_IS_MISSING, $exception->getErrorCode());
-        static::assertEquals('Parameter "id" is missing.', $exception->getMessage());
+        static::assertSame(ApiException::API_APP_ID_PARAMETER_IS_MISSING, $exception->getErrorCode());
+        static::assertSame('Parameter "id" is missing.', $exception->getMessage());
     }
 
     public function testSalesChannelIdParameterIsMissing(): void
     {
         $exception = ApiException::salesChannelIdParameterIsMissing();
 
-        static::assertEquals(ApiException::API_SALES_CHANNEL_ID_PARAMETER_IS_MISSING, $exception->getErrorCode());
-        static::assertEquals('Parameter "salesChannelId" is missing.', $exception->getMessage());
+        static::assertSame(ApiException::API_SALES_CHANNEL_ID_PARAMETER_IS_MISSING, $exception->getErrorCode());
+        static::assertSame('Parameter "salesChannelId" is missing.', $exception->getMessage());
     }
 
     public function testCustomerIdParameterIsMissing(): void
     {
         $exception = ApiException::customerIdParameterIsMissing();
 
-        static::assertEquals(ApiException::API_CUSTOMER_ID_PARAMETER_IS_MISSING, $exception->getErrorCode());
-        static::assertEquals('Parameter "customerId" is missing.', $exception->getMessage());
+        static::assertSame(ApiException::API_CUSTOMER_ID_PARAMETER_IS_MISSING, $exception->getErrorCode());
+        static::assertSame('Parameter "customerId" is missing.', $exception->getMessage());
     }
 
     public function testShippingCostsParameterIsMissing(): void
     {
         $exception = ApiException::shippingCostsParameterIsMissing();
 
-        static::assertEquals(ApiException::API_SHIPPING_COSTS_PARAMETER_IS_MISSING, $exception->getErrorCode());
-        static::assertEquals('Parameter "shippingCosts" is missing.', $exception->getMessage());
+        static::assertSame(ApiException::API_SHIPPING_COSTS_PARAMETER_IS_MISSING, $exception->getErrorCode());
+        static::assertSame('Parameter "shippingCosts" is missing.', $exception->getMessage());
     }
 
     public function testUnableGenerateBundle(): void
     {
         $exception = ApiException::unableGenerateBundle('bundleName');
 
-        static::assertEquals(ApiException::API_UNABLE_GENERATE_BUNDLE, $exception->getErrorCode());
-        static::assertEquals('Unable to generate bundle directory for bundle "bundleName".', $exception->getMessage());
+        static::assertSame(ApiException::API_UNABLE_GENERATE_BUNDLE, $exception->getErrorCode());
+        static::assertSame('Unable to generate bundle directory for bundle "bundleName".', $exception->getMessage());
     }
 
     public function testInvalidSchemaDefinitions(): void
     {
         $exception = ApiException::invalidSchemaDefinitions('file', new \JsonException());
 
-        static::assertEquals(ApiException::API_INVALID_SCHEMA_DEFINITION_EXCEPTION, $exception->getErrorCode());
+        static::assertSame(ApiException::API_INVALID_SCHEMA_DEFINITION_EXCEPTION, $exception->getErrorCode());
     }
 
     public function testInvalidAccessKey(): void
     {
         $exception = ApiException::invalidAccessKey();
 
-        static::assertEquals(ApiException::API_INVALID_ACCESS_KEY_EXCEPTION, $exception->getErrorCode());
+        static::assertSame(ApiException::API_INVALID_ACCESS_KEY_EXCEPTION, $exception->getErrorCode());
     }
 
     public function testInvalidAccessKeyIdentifier(): void
     {
         $exception = ApiException::invalidAccessKeyIdentifier();
 
-        static::assertEquals(ApiException::API_INVALID_ACCESS_KEY_IDENTIFIER_EXCEPTION, $exception->getErrorCode());
+        static::assertSame(ApiException::API_INVALID_ACCESS_KEY_IDENTIFIER_EXCEPTION, $exception->getErrorCode());
     }
 
     public function testSalesChannelInMaintenanceMode(): void
     {
         $exception = ApiException::salesChannelInMaintenanceMode();
 
-        static::assertEquals(ApiException::API_SALES_CHANNEL_MAINTENANCE_MODE, $exception->getErrorCode());
+        static::assertSame(ApiException::API_SALES_CHANNEL_MAINTENANCE_MODE, $exception->getErrorCode());
     }
 
     public function testAdminApiSourceExpected(): void
     {
         $exception = ApiException::invalidAdminSource('fooSource');
 
-        static::assertEquals(InvalidContextSourceException::class, $exception::class);
-        static::assertEquals(ApiException::API_INVALID_CONTEXT_SOURCE, $exception->getErrorCode());
+        static::assertSame(InvalidContextSourceException::class, $exception::class);
+        static::assertSame(ApiException::API_INVALID_CONTEXT_SOURCE, $exception->getErrorCode());
     }
 
     public function testUserNotLoggedIn(): void
     {
         $exception = ApiException::userNotLoggedIn();
 
-        static::assertEquals(ApiException::class, $exception::class);
-        static::assertEquals(ApiException::API_EXPECTED_USER, $exception->getErrorCode());
+        static::assertSame(ApiException::class, $exception::class);
+        static::assertSame(ApiException::API_EXPECTED_USER, $exception->getErrorCode());
     }
 }

--- a/tests/unit/Core/Framework/Api/Controller/CustomSnippetFormatControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/CustomSnippetFormatControllerTest.php
@@ -127,6 +127,6 @@ class CustomSnippetFormatControllerTest extends TestCase
         static::assertNotFalse($content);
         $content = \json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
         static::assertArrayHasKey('rendered', $content);
-        static::assertEquals('Rendered html', $content['rendered']);
+        static::assertSame('Rendered html', $content['rendered']);
     }
 }

--- a/tests/unit/Core/Framework/Api/Controller/SyncControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/SyncControllerTest.php
@@ -55,7 +55,7 @@ class SyncControllerTest extends TestCase
                 static::assertSame('delete-mapping', $operation->getKey());
                 static::assertSame('product', $operation->getEntity());
                 static::assertSame('delete', $operation->getAction());
-                static::assertEquals($criteria, $operation->getCriteria());
+                static::assertSame($criteria, $operation->getCriteria());
 
                 return new SyncResult([]);
             });
@@ -87,7 +87,7 @@ class SyncControllerTest extends TestCase
         $controller = new SyncController($service, $serializer);
 
         $response = $controller->sync($request, Context::createDefaultContext());
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
     }
 
     public function testSyncWithInvalidJson(): void

--- a/tests/unit/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
+++ b/tests/unit/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
@@ -91,8 +91,8 @@ class ErrorResponseFactoryTest extends TestCase
         $response = $errorResponseFactory->getResponseFromException(new \Exception($exceptionDetail, 5));
         $responseBody = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(500, $response->getStatusCode());
-        static::assertEquals([
+        static::assertSame(500, $response->getStatusCode());
+        static::assertSame([
             'errors' => [
                 [
                     'code' => '5',
@@ -113,8 +113,8 @@ class ErrorResponseFactoryTest extends TestCase
 
         $responseBody = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(418, $response->getStatusCode());
-        static::assertEquals([
+        static::assertSame(418, $response->getStatusCode());
+        static::assertSame([
             'errors' => [
                 [
                     'code' => '0',
@@ -139,7 +139,7 @@ class ErrorResponseFactoryTest extends TestCase
         unset($meta['previous'][0]['meta']);
 
         static::assertNotNull($meta);
-        static::assertEquals([
+        static::assertSame([
             [
                 'code' => '0',
                 'status' => '500',
@@ -149,8 +149,8 @@ class ErrorResponseFactoryTest extends TestCase
         ], $meta['previous']);
 
         unset($responseBody['errors'][0]['meta']);
-        static::assertEquals(418, $response->getStatusCode());
-        static::assertEquals([
+        static::assertSame(418, $response->getStatusCode());
+        static::assertSame([
             [
                 'code' => '0',
                 'status' => '418',
@@ -172,7 +172,7 @@ class ErrorResponseFactoryTest extends TestCase
         $response = $errorResponseFactory->getResponseFromException($simpleHttpException);
         $responseBody = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(418, $response->getStatusCode());
+        static::assertSame(418, $response->getStatusCode());
         static::assertEquals([
             'errors' => [
                 [
@@ -196,7 +196,7 @@ class ErrorResponseFactoryTest extends TestCase
         $errorFromWrite = $errorResponseFactory->getResponseFromException((new WriteException())->add($normalException));
         $errorRaw = $errorResponseFactory->getResponseFromException($normalException);
 
-        static::assertEquals($errorFromWrite->getContent(), $errorRaw->getContent());
+        static::assertSame($errorFromWrite->getContent(), $errorRaw->getContent());
     }
 
     public function testWriteExceptionConvertsHttpExceptionCorrectly(): void
@@ -207,7 +207,7 @@ class ErrorResponseFactoryTest extends TestCase
         $errorFromWrite = $errorResponseFactory->getResponseFromException((new WriteException())->add($httpException));
         $errorRaw = $errorResponseFactory->getResponseFromException($httpException);
 
-        static::assertEquals($errorFromWrite->getContent(), $errorRaw->getContent());
+        static::assertSame($errorFromWrite->getContent(), $errorRaw->getContent());
     }
 
     public function testWriteExceptionConvertsShopwareHttpExceptionCorrectly(): void
@@ -218,7 +218,7 @@ class ErrorResponseFactoryTest extends TestCase
         $errorFromWrite = $errorResponseFactory->getResponseFromException((new WriteException())->add($shopwareHttpException));
         $errorRaw = $errorResponseFactory->getResponseFromException($shopwareHttpException);
 
-        static::assertEquals($errorFromWrite->getContent(), $errorRaw->getContent());
+        static::assertSame($errorFromWrite->getContent(), $errorRaw->getContent());
     }
 
     public function testYieldDoesNotOverrideErrors(): void
@@ -242,7 +242,7 @@ class ErrorResponseFactoryTest extends TestCase
         $responseBody = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertCount(4, $responseBody['errors']);
-        static::assertEquals([
+        static::assertSame([
             $convertedShopwareHttpException,
             $convertedShopwareHttpException,
             $convertedShopwareHttpException,

--- a/tests/unit/Core/Framework/Api/OAuth/AccessTokenTest.php
+++ b/tests/unit/Core/Framework/Api/OAuth/AccessTokenTest.php
@@ -25,8 +25,8 @@ class AccessTokenTest extends TestCase
             'test'
         );
 
-        static::assertEquals('test', $token->getUserIdentifier());
-        static::assertEquals('administration', $token->getClient()->getIdentifier());
+        static::assertSame('test', $token->getUserIdentifier());
+        static::assertSame('administration', $token->getClient()->getIdentifier());
         static::assertCount(0, $token->getScopes());
 
         $config = JWTConfigurationFactory::createJWTConfiguration();
@@ -34,7 +34,7 @@ class AccessTokenTest extends TestCase
         $token->setClient($client);
         $token->setPrivateKey(new FakeCryptKey($config));
         $token->setIdentifier('administration');
-        static::assertEquals('administration', $token->getIdentifier());
+        static::assertSame('administration', $token->getIdentifier());
         static::assertSame($client, $token->getClient());
         $token->setExpiryDateTime(new \DateTimeImmutable());
 

--- a/tests/unit/Core/Framework/Api/OAuth/FakeCryptKeyTest.php
+++ b/tests/unit/Core/Framework/Api/OAuth/FakeCryptKeyTest.php
@@ -19,9 +19,9 @@ class FakeCryptKeyTest extends TestCase
     {
         $configuration = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText('test'));
         $fakeCryptKey = new FakeCryptKey($configuration);
-        static::assertEquals('', $fakeCryptKey->getKeyContents());
-        static::assertEquals('', $fakeCryptKey->getKeyPath());
-        static::assertEquals('', $fakeCryptKey->getPassPhrase());
+        static::assertSame('', $fakeCryptKey->getKeyContents());
+        static::assertSame('', $fakeCryptKey->getKeyPath());
+        static::assertSame('', $fakeCryptKey->getPassPhrase());
         static::assertSame($configuration, $fakeCryptKey->configuration);
     }
 }

--- a/tests/unit/Core/Framework/Api/OAuth/SymfonyBearerTokenValidatorTest.php
+++ b/tests/unit/Core/Framework/Api/OAuth/SymfonyBearerTokenValidatorTest.php
@@ -78,10 +78,10 @@ class SymfonyBearerTokenValidatorTest extends TestCase
 
         $validator->validateAuthorization($request);
 
-        static::assertEquals(self::TOKEN_USER_ID, $request->attributes->get('oauth_user_id'));
-        static::assertEquals(self::TOKEN_USER_ID, $request->attributes->get('oauth_access_token_id'));
-        static::assertEquals('test', $request->attributes->get('oauth_client_id'));
-        static::assertEquals([], $request->attributes->get('oauth_scopes'));
+        static::assertSame(self::TOKEN_USER_ID, $request->attributes->get('oauth_user_id'));
+        static::assertSame(self::TOKEN_USER_ID, $request->attributes->get('oauth_access_token_id'));
+        static::assertSame('test', $request->attributes->get('oauth_client_id'));
+        static::assertSame([], $request->attributes->get('oauth_scopes'));
     }
 
     public function testUserDeleted(): void

--- a/tests/unit/Core/Framework/Api/Serializer/JsonApiEncoderTest.php
+++ b/tests/unit/Core/Framework/Api/Serializer/JsonApiEncoderTest.php
@@ -54,7 +54,7 @@ class JsonApiEncoderTest extends TestCase
             static::assertIsArray($relationship['data']);
 
             if ($key === 'customer') {
-                static::assertEquals([
+                static::assertSame([
                     'type' => 'customer',
                     'id' => 'customer-id',
                 ], $relationship['data']);
@@ -62,7 +62,7 @@ class JsonApiEncoderTest extends TestCase
 
             if ($key === 'products') {
                 static::assertCount(1, $relationship['data']);
-                static::assertEquals([
+                static::assertSame([
                     'type' => 'product',
                     'id' => 'product-id',
                 ], $relationship['data'][0]);

--- a/tests/unit/Core/Framework/Api/Serializer/RecordTest.php
+++ b/tests/unit/Core/Framework/Api/Serializer/RecordTest.php
@@ -126,7 +126,7 @@ class RecordTest extends TestCase
         ]);
         $record->merge($entity);
 
-        static::assertEquals([
+        static::assertSame([
             'products' => [
                 'tmp' => [
                     'definition' => $productDefinition,

--- a/tests/unit/Core/Framework/Api/Sync/SyncFkResolverTest.php
+++ b/tests/unit/Core/Framework/Api/Sync/SyncFkResolverTest.php
@@ -72,7 +72,7 @@ class SyncFkResolverTest extends TestCase
         ];
 
         static::assertCount(1, $resolved);
-        static::assertEquals($expected, $resolved[0]);
+        static::assertSame($expected, $resolved[0]);
     }
 
     /**
@@ -214,7 +214,7 @@ class SyncFkResolverTest extends TestCase
 
         $resolved = $resolver->resolve('ops-1', 'product', [$payload]);
 
-        static::assertEquals([['taxId' => null]], $resolved);
+        static::assertSame([['taxId' => null]], $resolved);
     }
 }
 

--- a/tests/unit/Core/Framework/App/ActiveAppsLoaderTest.php
+++ b/tests/unit/Core/Framework/App/ActiveAppsLoaderTest.php
@@ -46,14 +46,14 @@ class ActiveAppsLoaderTest extends TestCase
         ];
 
         // call twice to test it gets cached
-        static::assertEquals($expected, $activeAppsLoader->getActiveApps());
-        static::assertEquals($expected, $activeAppsLoader->getActiveApps());
+        static::assertSame($expected, $activeAppsLoader->getActiveApps());
+        static::assertSame($expected, $activeAppsLoader->getActiveApps());
 
         // reset cache
 
         $activeAppsLoader->reset();
 
-        static::assertEquals($expected, $activeAppsLoader->getActiveApps());
+        static::assertSame($expected, $activeAppsLoader->getActiveApps());
     }
 
     public function testLoadAppsFromLocal(): void
@@ -89,6 +89,6 @@ class ActiveAppsLoaderTest extends TestCase
             ],
         ];
 
-        static::assertEquals($expected, $activeAppsLoader->getActiveApps());
+        static::assertSame($expected, $activeAppsLoader->getActiveApps());
     }
 }

--- a/tests/unit/Core/Framework/App/AppDownloaderTest.php
+++ b/tests/unit/Core/Framework/App/AppDownloaderTest.php
@@ -73,10 +73,10 @@ class AppDownloaderTest extends TestCase
             ->method('appendToFile')
             ->willReturnOnConsecutiveCalls()
             ->willReturnCallback(function (string $file, $content) use ($matcher): void {
-                $this->assertEquals('/path/to/file.zip', $file);
+                $this->assertSame('/path/to/file.zip', $file);
                 match ($matcher->numberOfInvocations()) {
-                    1 => $this->assertEquals('chunk1content', $content),
-                    2 => $this->assertEquals('chunk2content', $content),
+                    1 => $this->assertSame('chunk1content', $content),
+                    2 => $this->assertSame('chunk2content', $content),
                     default => null,
                 };
             });
@@ -92,8 +92,8 @@ class AppDownloaderTest extends TestCase
         $this->filesystem->expects($this->once())
             ->method('dumpFile')
             ->willReturnCallback(function (string $path, $contentResource): void {
-                static::assertEquals('/path/to/file.zip', $path);
-                static::assertEquals('content', stream_get_contents($contentResource));
+                static::assertSame('/path/to/file.zip', $path);
+                static::assertSame('content', stream_get_contents($contentResource));
             });
 
         $this->appDownloader->downloadFromFilesystem($fs, '/some/file.zip', '/path/to/file.zip');

--- a/tests/unit/Core/Framework/App/AppUrlChangeResolver/ResolverTest.php
+++ b/tests/unit/Core/Framework/App/AppUrlChangeResolver/ResolverTest.php
@@ -72,7 +72,7 @@ class ResolverTest extends TestCase
             ->method('getDescription')
             ->willReturn('second description');
 
-        static::assertEquals([
+        static::assertSame([
             'FirstStrategy' => 'first description',
             'SecondStrategy' => 'second description',
         ], $this->appUrlChangedResolverStrategy->getAvailableStrategies());

--- a/tests/unit/Core/Framework/App/Command/CreateAppCommandTest.php
+++ b/tests/unit/Core/Framework/App/Command/CreateAppCommandTest.php
@@ -46,7 +46,7 @@ class CreateAppCommandTest extends TestCase
         );
 
         static::assertFileExists($this->appDir . '/TestApp/manifest.xml');
-        static::assertEquals(
+        static::assertSame(
             <<<EOL
             <?xml version="1.0" encoding="UTF-8"?>
             <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -80,7 +80,7 @@ class CreateAppCommandTest extends TestCase
 
         static::assertFileExists($this->appDir . '/TestApp/manifest.xml');
         static::assertFileExists($this->appDir . '/TestApp/Resources/theme.json');
-        static::assertEquals(
+        static::assertSame(
             <<<EOL
             <?xml version="1.0" encoding="UTF-8"?>
             <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -100,7 +100,7 @@ class CreateAppCommandTest extends TestCase
             file_get_contents($this->appDir . '/TestApp/manifest.xml')
         );
 
-        static::assertEquals(
+        static::assertSame(
             <<<EOL
             {
               "name": "TestApp",
@@ -142,7 +142,7 @@ class CreateAppCommandTest extends TestCase
 
         static::assertFileExists($this->appDir . '/TestApp/manifest.xml');
 
-        static::assertEquals(
+        static::assertSame(
             <<<EOL
             <?xml version="1.0" encoding="UTF-8"?>
             <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -183,7 +183,7 @@ class CreateAppCommandTest extends TestCase
 
         static::assertFileExists($this->appDir . '/TestApp/manifest.xml');
 
-        static::assertEquals(
+        static::assertSame(
             <<<EOL
             <?xml version="1.0" encoding="UTF-8"?>
             <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/tests/unit/Core/Framework/App/Event/AppActivatedEventTest.php
+++ b/tests/unit/Core/Framework/App/Event/AppActivatedEventTest.php
@@ -25,8 +25,8 @@ class AppActivatedEventTest extends TestCase
             $context
         );
 
-        static::assertEquals($app, $event->getApp());
-        static::assertEquals($context, $event->getContext());
+        static::assertSame($app, $event->getApp());
+        static::assertSame($context, $event->getContext());
         static::assertSame(AppActivatedEvent::NAME, $event->getName());
         static::assertSame([], $event->getWebhookPayload());
     }

--- a/tests/unit/Core/Framework/App/Event/AppDeactivatedEventTest.php
+++ b/tests/unit/Core/Framework/App/Event/AppDeactivatedEventTest.php
@@ -25,8 +25,8 @@ class AppDeactivatedEventTest extends TestCase
             $context
         );
 
-        static::assertEquals($app, $event->getApp());
-        static::assertEquals($context, $event->getContext());
+        static::assertSame($app, $event->getApp());
+        static::assertSame($context, $event->getContext());
         static::assertSame(AppDeactivatedEvent::NAME, $event->getName());
         static::assertSame([], $event->getWebhookPayload());
     }

--- a/tests/unit/Core/Framework/App/Event/AppDeletedEventTest.php
+++ b/tests/unit/Core/Framework/App/Event/AppDeletedEventTest.php
@@ -24,8 +24,8 @@ class AppDeletedEventTest extends TestCase
             $context
         );
 
-        static::assertEquals($appId, $event->getAppId());
-        static::assertEquals($context, $event->getContext());
+        static::assertSame($appId, $event->getAppId());
+        static::assertSame($context, $event->getContext());
         static::assertSame(AppDeletedEvent::NAME, $event->getName());
         static::assertSame(['keepUserData' => false], $event->getWebhookPayload());
     }

--- a/tests/unit/Core/Framework/App/Event/AppFlowActionEventTest.php
+++ b/tests/unit/Core/Framework/App/Event/AppFlowActionEventTest.php
@@ -26,8 +26,8 @@ class AppFlowActionEventTest extends TestCase
         $event = new AppFlowActionEvent($eventName, $headers, $payload);
 
         static::assertSame($eventName, $event->getName());
-        static::assertEquals($headers, $event->getWebhookHeaders());
-        static::assertEquals($payload, $event->getWebhookPayload());
+        static::assertSame($headers, $event->getWebhookHeaders());
+        static::assertSame($payload, $event->getWebhookPayload());
         static::assertTrue($event->isAllowed('11111', new AclPrivilegeCollection([])));
     }
 }

--- a/tests/unit/Core/Framework/App/Event/AppInstalledEventTest.php
+++ b/tests/unit/Core/Framework/App/Event/AppInstalledEventTest.php
@@ -27,8 +27,8 @@ class AppInstalledEventTest extends TestCase
             $context
         );
 
-        static::assertEquals($app, $event->getApp());
-        static::assertEquals($context, $event->getContext());
+        static::assertSame($app, $event->getApp());
+        static::assertSame($context, $event->getContext());
         static::assertSame(AppInstalledEvent::NAME, $event->getName());
         static::assertSame([
             'appVersion' => '1.0.0',

--- a/tests/unit/Core/Framework/App/Event/AppUpdatedEventTest.php
+++ b/tests/unit/Core/Framework/App/Event/AppUpdatedEventTest.php
@@ -27,8 +27,8 @@ class AppUpdatedEventTest extends TestCase
             $context
         );
 
-        static::assertEquals($app, $event->getApp());
-        static::assertEquals($context, $event->getContext());
+        static::assertSame($app, $event->getApp());
+        static::assertSame($context, $event->getContext());
         static::assertSame(AppUpdatedEvent::NAME, $event->getName());
         static::assertSame([
             'appVersion' => '1.0.0',

--- a/tests/unit/Core/Framework/App/Exception/AppArchiveValidationFailureTest.php
+++ b/tests/unit/Core/Framework/App/Exception/AppArchiveValidationFailureTest.php
@@ -17,53 +17,53 @@ class AppArchiveValidationFailureTest extends TestCase
     {
         $e = AppArchiveValidationFailure::appEmpty();
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(AppArchiveValidationFailure::APP_EMPTY, $e->getErrorCode());
-        static::assertEquals('App does not contain any files', $e->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(AppArchiveValidationFailure::APP_EMPTY, $e->getErrorCode());
+        static::assertSame('App does not contain any files', $e->getMessage());
     }
 
     public function testNoTopLevelFolder(): void
     {
         $e = AppArchiveValidationFailure::noTopLevelFolder();
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(AppArchiveValidationFailure::APP_NO_TOP_LEVEL_FOLDER, $e->getErrorCode());
-        static::assertEquals('App zip does not contain any top level folder', $e->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(AppArchiveValidationFailure::APP_NO_TOP_LEVEL_FOLDER, $e->getErrorCode());
+        static::assertSame('App zip does not contain any top level folder', $e->getMessage());
     }
 
     public function testAppNameMismatch(): void
     {
         $e = AppArchiveValidationFailure::appNameMismatch('AppName', 'WrongAppName');
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(AppArchiveValidationFailure::APP_NAME_MISMATCH, $e->getErrorCode());
-        static::assertEquals('App name does not match expected. Expected: "AppName". Got: "WrongAppName"', $e->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(AppArchiveValidationFailure::APP_NAME_MISMATCH, $e->getErrorCode());
+        static::assertSame('App name does not match expected. Expected: "AppName". Got: "WrongAppName"', $e->getMessage());
     }
 
     public function testMissingManifest(): void
     {
         $e = AppArchiveValidationFailure::missingManifest();
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(AppArchiveValidationFailure::APP_MISSING_MANIFEST, $e->getErrorCode());
-        static::assertEquals('App archive does not contain a manifest.xml file', $e->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(AppArchiveValidationFailure::APP_MISSING_MANIFEST, $e->getErrorCode());
+        static::assertSame('App archive does not contain a manifest.xml file', $e->getMessage());
     }
 
     public function testDirectoryTraversal(): void
     {
         $e = AppArchiveValidationFailure::directoryTraversal();
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(AppArchiveValidationFailure::APP_DIRECTORY_TRAVERSAL, $e->getErrorCode());
-        static::assertEquals('Directory traversal detected', $e->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(AppArchiveValidationFailure::APP_DIRECTORY_TRAVERSAL, $e->getErrorCode());
+        static::assertSame('Directory traversal detected', $e->getMessage());
     }
 
     public function testInvalidPrefix(): void
     {
         $e = AppArchiveValidationFailure::invalidPrefix('somefile.xml', 'AppName');
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(AppArchiveValidationFailure::APP_INVALID_PREFIX, $e->getErrorCode());
-        static::assertEquals('Detected invalid file/directory "somefile.xml" in the app zip. Expected the directory: "AppName"', $e->getMessage());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(AppArchiveValidationFailure::APP_INVALID_PREFIX, $e->getErrorCode());
+        static::assertSame('Detected invalid file/directory "somefile.xml" in the app zip. Expected the directory: "AppName"', $e->getMessage());
     }
 }

--- a/tests/unit/Core/Framework/App/Flow/Action/AppFlowActionLoadedSubscriberTest.php
+++ b/tests/unit/Core/Framework/App/Flow/Action/AppFlowActionLoadedSubscriberTest.php
@@ -19,7 +19,7 @@ class AppFlowActionLoadedSubscriberTest extends TestCase
 {
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals([
+        static::assertSame([
             'app_flow_action.loaded' => 'unserialize',
         ], AppFlowActionLoadedSubscriber::getSubscribedEvents());
     }
@@ -45,7 +45,7 @@ class AppFlowActionLoadedSubscriberTest extends TestCase
         $subscriber->unserialize($event);
         static::assertNotFalse($fileIcon);
 
-        static::assertEquals(
+        static::assertSame(
             base64_encode($fileIcon),
             $appFlowAction->getIcon()
         );

--- a/tests/unit/Core/Framework/App/Flow/Action/AppFlowActionProviderTest.php
+++ b/tests/unit/Core/Framework/App/Flow/Action/AppFlowActionProviderTest.php
@@ -91,7 +91,7 @@ class AppFlowActionProviderTest extends TestCase
 
         $webhookData = $appFlowActionProvider->getWebhookPayloadAndHeaders($flow, $ids->get('appFlowActionId'));
 
-        static::assertEquals(['param1' => 'Text 1', 'param2' => 'Text 2 and Text 3'], $webhookData['payload']);
-        static::assertEquals(['content-type' => 'application/json'], $webhookData['headers']);
+        static::assertSame(['param1' => 'Text 1', 'param2' => 'Text 2 and Text 3'], $webhookData['payload']);
+        static::assertSame(['content-type' => 'application/json'], $webhookData['headers']);
     }
 }

--- a/tests/unit/Core/Framework/App/Flow/Event/Xml/CustomEventTest.php
+++ b/tests/unit/Core/Framework/App/Flow/Event/Xml/CustomEventTest.php
@@ -30,7 +30,7 @@ class CustomEventTest extends TestCase
         foreach ($events->getElementsByTagName('flow-event') as $event) {
             $result = CustomEvent::fromXml($event);
             $result = $result->toArray('en-GB');
-            static::assertEquals($expected, $result);
+            static::assertSame($expected, $result);
         }
     }
 }

--- a/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -339,7 +339,7 @@ class AppLifecycleTest extends TestCase
 
         static::assertCount(1, $appRepository->upserts[0]);
 
-        static::assertEquals([['id' => $appId, 'configurable' => false, 'allowDisable' => true]], $appRepository->upserts[1]);
+        static::assertSame([['id' => $appId, 'configurable' => false, 'allowDisable' => true]], $appRepository->upserts[1]);
 
         $this->io->rename(__DIR__ . '/../_fixtures/Resources/noconfighere', __DIR__ . '/../_fixtures/Resources/config');
     }

--- a/tests/unit/Core/Framework/App/Lifecycle/AppLoaderTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppLoaderTest.php
@@ -63,8 +63,8 @@ class AppLoaderTest extends TestCase
 
         static::assertTrue($app->isManagedByComposer());
 
-        static::assertEquals('test', $app->getMetadata()->getName());
-        static::assertEquals('1.0.0', $app->getMetadata()->getVersion());
+        static::assertSame('test', $app->getMetadata()->getName());
+        static::assertSame('1.0.0', $app->getMetadata()->getVersion());
 
         $this->expectException(AppException::class);
         $this->expectExceptionMessage('App test is managed by Composer and cannot be deleted');

--- a/tests/unit/Core/Framework/App/Lifecycle/ScriptFileReaderTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/ScriptFileReaderTest.php
@@ -26,7 +26,7 @@ class ScriptFileReaderTest extends TestCase
         $scripts = $scriptReader->getScriptPathsForApp($app);
         \sort($scripts);
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'app-activated/activate-script.twig',
                 'app-deactivated/deactivate-script.twig',

--- a/tests/unit/Core/Framework/App/Manifest/ManifestFactoryTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/ManifestFactoryTest.php
@@ -18,6 +18,6 @@ class ManifestFactoryTest extends TestCase
 
         $manifest = $factory->createFromXmlFile(__DIR__ . '/_fixtures/test/manifest.xml');
 
-        static::assertEquals(__DIR__ . '/_fixtures/test', $manifest->getPath());
+        static::assertSame(__DIR__ . '/_fixtures/test', $manifest->getPath());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/ManifestTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/ManifestTest.php
@@ -18,14 +18,14 @@ class ManifestTest extends TestCase
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/test/manifest.xml');
 
-        static::assertEquals(__DIR__ . '/_fixtures/test', $manifest->getPath());
+        static::assertSame(__DIR__ . '/_fixtures/test', $manifest->getPath());
     }
 
     public function testCreateFromXml(): void
     {
         $manifest = Manifest::createFromXml((string) file_get_contents(__DIR__ . '/_fixtures/test/manifest.xml'));
 
-        static::assertEquals('test', $manifest->getMetadata()->getName());
+        static::assertSame('test', $manifest->getMetadata()->getName());
     }
 
     public function testSetPath(): void
@@ -33,7 +33,7 @@ class ManifestTest extends TestCase
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/test/manifest.xml');
 
         $manifest->setPath('test');
-        static::assertEquals('test', $manifest->getPath());
+        static::assertSame('test', $manifest->getPath());
     }
 
     public function testCreateFromXmlFileThrowsXmlParsingExceptionIfInvalidWebhookEventNames(): void
@@ -68,7 +68,7 @@ class ManifestTest extends TestCase
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/test/manifest.xml');
 
-        static::assertEquals([
+        static::assertSame([
             'my.app.com',
             'test.com',
             'base-url.com',
@@ -84,14 +84,14 @@ class ManifestTest extends TestCase
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/test/manifest.xml');
 
-        static::assertEquals('>=6.4.0', $manifest->getMetadata()->getCompatibility()->getPrettyString());
+        static::assertSame('>=6.4.0', $manifest->getMetadata()->getCompatibility()->getPrettyString());
     }
 
     public function testFilledConstraint(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/compatibility/manifest.xml');
 
-        static::assertEquals('~6.5.0', $manifest->getMetadata()->getCompatibility()->getPrettyString());
+        static::assertSame('~6.5.0', $manifest->getMetadata()->getCompatibility()->getPrettyString());
     }
 
     public function testGetShippingMethods(): void
@@ -134,7 +134,7 @@ class ManifestTest extends TestCase
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/test/manifest.xml');
         $manifest->setSourceType('test');
 
-        static::assertEquals('test', $manifest->getSourceType());
+        static::assertSame('test', $manifest->getSourceType());
     }
 
     public function testSourceConfig(): void
@@ -142,6 +142,6 @@ class ManifestTest extends TestCase
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/test/manifest.xml');
         $manifest->setSourceConfig(['test' => 'test']);
 
-        static::assertEquals(['test' => 'test'], $manifest->getSourceConfig());
+        static::assertSame(['test' => 'test'], $manifest->getSourceConfig());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Administration/AdminTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Administration/AdminTest.php
@@ -24,49 +24,49 @@ class AdminTest extends TestCase
         static::assertCount(2, $admin->getModules());
 
         $firstActionButton = $admin->getActionButtons()[0];
-        static::assertEquals('viewOrder', $firstActionButton->getAction());
-        static::assertEquals('order', $firstActionButton->getEntity());
-        static::assertEquals('detail', $firstActionButton->getView());
-        static::assertEquals('https://swag-test.com/your-order', $firstActionButton->getUrl());
-        static::assertEquals([
+        static::assertSame('viewOrder', $firstActionButton->getAction());
+        static::assertSame('order', $firstActionButton->getEntity());
+        static::assertSame('detail', $firstActionButton->getView());
+        static::assertSame('https://swag-test.com/your-order', $firstActionButton->getUrl());
+        static::assertSame([
             'en-GB' => 'View Order',
             'de-DE' => 'Zeige Bestellung',
         ], $firstActionButton->getLabel());
 
         $secondActionButton = $admin->getActionButtons()[1];
-        static::assertEquals('doStuffWithProducts', $secondActionButton->getAction());
-        static::assertEquals('product', $secondActionButton->getEntity());
-        static::assertEquals('list', $secondActionButton->getView());
-        static::assertEquals('https://swag-test.com/do-stuff', $secondActionButton->getUrl());
-        static::assertEquals([
+        static::assertSame('doStuffWithProducts', $secondActionButton->getAction());
+        static::assertSame('product', $secondActionButton->getEntity());
+        static::assertSame('list', $secondActionButton->getView());
+        static::assertSame('https://swag-test.com/do-stuff', $secondActionButton->getUrl());
+        static::assertSame([
             'en-GB' => 'Do Stuff',
             'de-DE' => 'Mache Dinge',
         ], $secondActionButton->getLabel());
 
         $firstModule = $admin->getModules()[0];
-        static::assertEquals('https://test.com', $firstModule->getSource());
-        static::assertEquals('first-module', $firstModule->getName());
-        static::assertEquals([
+        static::assertSame('https://test.com', $firstModule->getSource());
+        static::assertSame('first-module', $firstModule->getName());
+        static::assertSame([
             'en-GB' => 'My first own module',
             'de-DE' => 'Mein erstes eigenes Modul',
         ], $firstModule->getLabel());
-        static::assertEquals('sw-test-structure-module', $firstModule->getParent());
-        static::assertEquals(10, $firstModule->getPosition());
+        static::assertSame('sw-test-structure-module', $firstModule->getParent());
+        static::assertSame(10, $firstModule->getPosition());
 
         $secondModule = $admin->getModules()[1];
         static::assertNull($secondModule->getSource());
-        static::assertEquals('structure-module', $secondModule->getName());
-        static::assertEquals([
+        static::assertSame('structure-module', $secondModule->getName());
+        static::assertSame([
             'en-GB' => 'My menu entry for modules',
             'de-DE' => 'Mein Menüeintrag für Module',
         ], $secondModule->getLabel());
-        static::assertEquals('sw-catalogue', $secondModule->getParent());
-        static::assertEquals(50, $secondModule->getPosition());
+        static::assertSame('sw-catalogue', $secondModule->getParent());
+        static::assertSame(50, $secondModule->getPosition());
 
         $mainModule = $admin->getMainModule();
 
         static::assertNotNull($mainModule);
-        static::assertEquals('https://main-module', $mainModule->getSource());
+        static::assertSame('https://main-module', $mainModule->getSource());
     }
 
     public function testModulesWithStructureElements(): void
@@ -79,8 +79,8 @@ class AdminTest extends TestCase
         $moduleWithStructureElement = $admin->getModules()[0];
 
         static::assertNull($moduleWithStructureElement->getSource());
-        static::assertEquals('sw-catalogue', $moduleWithStructureElement->getParent());
-        static::assertEquals(50, $moduleWithStructureElement->getPosition());
+        static::assertSame('sw-catalogue', $moduleWithStructureElement->getParent());
+        static::assertSame(50, $moduleWithStructureElement->getPosition());
     }
 
     public function testMainModuleIsOptional(): void

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/BoolFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/BoolFieldTest.php
@@ -26,12 +26,12 @@ class BoolFieldTest extends TestCase
 
         $boolField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(BoolField::class, $boolField);
-        static::assertEquals('test_bool_field', $boolField->getName());
-        static::assertEquals([
+        static::assertSame('test_bool_field', $boolField->getName());
+        static::assertSame([
             'en-GB' => 'Test bool field',
         ], $boolField->getLabel());
-        static::assertEquals([], $boolField->getHelpText());
-        static::assertEquals(1, $boolField->getPosition());
+        static::assertSame([], $boolField->getHelpText());
+        static::assertSame(1, $boolField->getPosition());
         static::assertFalse($boolField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/ColorPickerFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/ColorPickerFieldTest.php
@@ -26,12 +26,12 @@ class ColorPickerFieldTest extends TestCase
 
         $colorPickerField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(ColorPickerField::class, $colorPickerField);
-        static::assertEquals('test_color_picker_field', $colorPickerField->getName());
-        static::assertEquals([
+        static::assertSame('test_color_picker_field', $colorPickerField->getName());
+        static::assertSame([
             'en-GB' => 'Test color-picker field',
         ], $colorPickerField->getLabel());
-        static::assertEquals([], $colorPickerField->getHelpText());
-        static::assertEquals(1, $colorPickerField->getPosition());
+        static::assertSame([], $colorPickerField->getHelpText());
+        static::assertSame(1, $colorPickerField->getPosition());
         static::assertFalse($colorPickerField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/CustomFieldTypeFactoryTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/CustomFieldTypeFactoryTest.php
@@ -33,12 +33,12 @@ class CustomFieldTypeFactoryTest extends TestCase
         static::assertCount(1, $customFieldSet->getFields());
 
         $field = $customFieldSet->getFields()[0];
-        static::assertEquals('bool_field', $field->getName());
-        static::assertEquals([
+        static::assertSame('bool_field', $field->getName());
+        static::assertSame([
             'en-GB' => 'Test bool field',
             'de-DE' => 'Test bool field',
         ], $field->getLabel());
-        static::assertEquals([
+        static::assertSame([
             'en-GB' => 'Help text',
             'de-DE' => 'Help text',
         ], $field->getHelpText());

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/DateTimeFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/DateTimeFieldTest.php
@@ -26,12 +26,12 @@ class DateTimeFieldTest extends TestCase
 
         $dateTimeField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(DateTimeField::class, $dateTimeField);
-        static::assertEquals('test_datetime_field', $dateTimeField->getName());
-        static::assertEquals([
+        static::assertSame('test_datetime_field', $dateTimeField->getName());
+        static::assertSame([
             'en-GB' => 'Test datetime field',
         ], $dateTimeField->getLabel());
-        static::assertEquals([], $dateTimeField->getHelpText());
-        static::assertEquals(1, $dateTimeField->getPosition());
+        static::assertSame([], $dateTimeField->getHelpText());
+        static::assertSame(1, $dateTimeField->getPosition());
         static::assertFalse($dateTimeField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/FloatFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/FloatFieldTest.php
@@ -26,17 +26,17 @@ class FloatFieldTest extends TestCase
 
         $floatField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(FloatField::class, $floatField);
-        static::assertEquals('test_float_field', $floatField->getName());
-        static::assertEquals([
+        static::assertSame('test_float_field', $floatField->getName());
+        static::assertSame([
             'en-GB' => 'Test float field',
             'de-DE' => 'Test Kommazahlenfeld',
         ], $floatField->getLabel());
-        static::assertEquals(['en-GB' => 'This is a float field.'], $floatField->getHelpText());
-        static::assertEquals(2, $floatField->getPosition());
-        static::assertEquals(2.2, $floatField->getSteps());
-        static::assertEquals(0.5, $floatField->getMin());
-        static::assertEquals(1.6, $floatField->getMax());
-        static::assertEquals(['en-GB' => 'Enter a float...'], $floatField->getPlaceholder());
+        static::assertSame(['en-GB' => 'This is a float field.'], $floatField->getHelpText());
+        static::assertSame(2, $floatField->getPosition());
+        static::assertSame(2.2, $floatField->getSteps());
+        static::assertSame(0.5, $floatField->getMin());
+        static::assertSame(1.6, $floatField->getMax());
+        static::assertSame(['en-GB' => 'Enter a float...'], $floatField->getPlaceholder());
         static::assertFalse($floatField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/IntFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/IntFieldTest.php
@@ -26,17 +26,17 @@ class IntFieldTest extends TestCase
 
         $intField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(IntField::class, $intField);
-        static::assertEquals('test_int_field', $intField->getName());
-        static::assertEquals([
+        static::assertSame('test_int_field', $intField->getName());
+        static::assertSame([
             'en-GB' => 'Test int field',
             'de-DE' => 'Test Ganzzahlenfeld',
         ], $intField->getLabel());
-        static::assertEquals(['en-GB' => 'This is an int field.'], $intField->getHelpText());
-        static::assertEquals(1, $intField->getPosition());
-        static::assertEquals(2, $intField->getSteps());
-        static::assertEquals(0, $intField->getMin());
-        static::assertEquals(1, $intField->getMax());
-        static::assertEquals(['en-GB' => 'Enter an int...'], $intField->getPlaceholder());
+        static::assertSame(['en-GB' => 'This is an int field.'], $intField->getHelpText());
+        static::assertSame(1, $intField->getPosition());
+        static::assertSame(2, $intField->getSteps());
+        static::assertSame(0, $intField->getMin());
+        static::assertSame(1, $intField->getMax());
+        static::assertSame(['en-GB' => 'Enter an int...'], $intField->getPlaceholder());
         static::assertTrue($intField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/MediaSelectionFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/MediaSelectionFieldTest.php
@@ -26,12 +26,12 @@ class MediaSelectionFieldTest extends TestCase
 
         $mediaSelectionField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(MediaSelectionField::class, $mediaSelectionField);
-        static::assertEquals('test_media_selection_field', $mediaSelectionField->getName());
-        static::assertEquals([
+        static::assertSame('test_media_selection_field', $mediaSelectionField->getName());
+        static::assertSame([
             'en-GB' => 'Test media-selection field',
         ], $mediaSelectionField->getLabel());
-        static::assertEquals([], $mediaSelectionField->getHelpText());
-        static::assertEquals(1, $mediaSelectionField->getPosition());
+        static::assertSame([], $mediaSelectionField->getHelpText());
+        static::assertSame(1, $mediaSelectionField->getPosition());
         static::assertFalse($mediaSelectionField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/MultiEntitySelectFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/MultiEntitySelectFieldTest.php
@@ -26,14 +26,14 @@ class MultiEntitySelectFieldTest extends TestCase
 
         $multiEntitySelectField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(MultiEntitySelectField::class, $multiEntitySelectField);
-        static::assertEquals('test_multi_entity_select_field', $multiEntitySelectField->getName());
-        static::assertEquals([
+        static::assertSame('test_multi_entity_select_field', $multiEntitySelectField->getName());
+        static::assertSame([
             'en-GB' => 'Test multi-entity-select field',
         ], $multiEntitySelectField->getLabel());
-        static::assertEquals([], $multiEntitySelectField->getHelpText());
-        static::assertEquals(1, $multiEntitySelectField->getPosition());
-        static::assertEquals(['en-GB' => 'Choose an entity...'], $multiEntitySelectField->getPlaceholder());
+        static::assertSame([], $multiEntitySelectField->getHelpText());
+        static::assertSame(1, $multiEntitySelectField->getPosition());
+        static::assertSame(['en-GB' => 'Choose an entity...'], $multiEntitySelectField->getPlaceholder());
         static::assertFalse($multiEntitySelectField->getRequired());
-        static::assertEquals('product', $multiEntitySelectField->getEntity());
+        static::assertSame('product', $multiEntitySelectField->getEntity());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/MultiSelectFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/MultiSelectFieldTest.php
@@ -26,15 +26,15 @@ class MultiSelectFieldTest extends TestCase
 
         $multiSelectField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(MultiSelectField::class, $multiSelectField);
-        static::assertEquals('test_multi_select_field', $multiSelectField->getName());
-        static::assertEquals([
+        static::assertSame('test_multi_select_field', $multiSelectField->getName());
+        static::assertSame([
             'en-GB' => 'Test multi-select field',
         ], $multiSelectField->getLabel());
-        static::assertEquals([], $multiSelectField->getHelpText());
-        static::assertEquals(1, $multiSelectField->getPosition());
-        static::assertEquals(['en-GB' => 'Choose your options...'], $multiSelectField->getPlaceholder());
+        static::assertSame([], $multiSelectField->getHelpText());
+        static::assertSame(1, $multiSelectField->getPosition());
+        static::assertSame(['en-GB' => 'Choose your options...'], $multiSelectField->getPlaceholder());
         static::assertFalse($multiSelectField->getRequired());
-        static::assertEquals([
+        static::assertSame([
             'first' => [
                 'en-GB' => 'First',
                 'de-DE' => 'Erster',

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/PriceFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/PriceFieldTest.php
@@ -26,12 +26,12 @@ class PriceFieldTest extends TestCase
 
         $priceField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(PriceField::class, $priceField);
-        static::assertEquals('test_price_field', $priceField->getName());
-        static::assertEquals([
+        static::assertSame('test_price_field', $priceField->getName());
+        static::assertSame([
             'en-GB' => 'Test price field',
         ], $priceField->getLabel());
-        static::assertEquals([], $priceField->getHelpText());
-        static::assertEquals(1, $priceField->getPosition());
+        static::assertSame([], $priceField->getHelpText());
+        static::assertSame(1, $priceField->getPosition());
         static::assertFalse($priceField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/SingleEntitySelectFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/SingleEntitySelectFieldTest.php
@@ -26,14 +26,14 @@ class SingleEntitySelectFieldTest extends TestCase
 
         $singleEntitySelectField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(SingleEntitySelectField::class, $singleEntitySelectField);
-        static::assertEquals('test_single_entity_select_field', $singleEntitySelectField->getName());
-        static::assertEquals([
+        static::assertSame('test_single_entity_select_field', $singleEntitySelectField->getName());
+        static::assertSame([
             'en-GB' => 'Test single-entity-select field',
         ], $singleEntitySelectField->getLabel());
-        static::assertEquals([], $singleEntitySelectField->getHelpText());
-        static::assertEquals(1, $singleEntitySelectField->getPosition());
-        static::assertEquals(['en-GB' => 'Choose an entity...'], $singleEntitySelectField->getPlaceholder());
+        static::assertSame([], $singleEntitySelectField->getHelpText());
+        static::assertSame(1, $singleEntitySelectField->getPosition());
+        static::assertSame(['en-GB' => 'Choose an entity...'], $singleEntitySelectField->getPlaceholder());
         static::assertFalse($singleEntitySelectField->getRequired());
-        static::assertEquals('product', $singleEntitySelectField->getEntity());
+        static::assertSame('product', $singleEntitySelectField->getEntity());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/SingleSelectFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/SingleSelectFieldTest.php
@@ -26,15 +26,15 @@ class SingleSelectFieldTest extends TestCase
 
         $singleSelectField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(SingleSelectField::class, $singleSelectField);
-        static::assertEquals('test_single_select_field', $singleSelectField->getName());
-        static::assertEquals([
+        static::assertSame('test_single_select_field', $singleSelectField->getName());
+        static::assertSame([
             'en-GB' => 'Test single-select field',
         ], $singleSelectField->getLabel());
-        static::assertEquals([], $singleSelectField->getHelpText());
-        static::assertEquals(1, $singleSelectField->getPosition());
-        static::assertEquals(['en-GB' => 'Choose an option...'], $singleSelectField->getPlaceholder());
+        static::assertSame([], $singleSelectField->getHelpText());
+        static::assertSame(1, $singleSelectField->getPosition());
+        static::assertSame(['en-GB' => 'Choose an option...'], $singleSelectField->getPlaceholder());
         static::assertFalse($singleSelectField->getRequired());
-        static::assertEquals([
+        static::assertSame([
             'first' => [
                 'en-GB' => 'First',
                 'de-DE' => 'Erster',

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/TextAreaFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/TextAreaFieldTest.php
@@ -27,13 +27,13 @@ class TextAreaFieldTest extends TestCase
         $textAreaField = $customFieldSet->getFields()[0];
 
         static::assertInstanceOf(TextAreaField::class, $textAreaField);
-        static::assertEquals('test_text_area_field', $textAreaField->getName());
-        static::assertEquals([
+        static::assertSame('test_text_area_field', $textAreaField->getName());
+        static::assertSame([
             'en-GB' => 'Test text-area field',
         ], $textAreaField->getLabel());
-        static::assertEquals([], $textAreaField->getHelpText());
-        static::assertEquals(['en-GB' => 'Enter a text...'], $textAreaField->getPlaceholder());
-        static::assertEquals(1, $textAreaField->getPosition());
+        static::assertSame([], $textAreaField->getHelpText());
+        static::assertSame(['en-GB' => 'Enter a text...'], $textAreaField->getPlaceholder());
+        static::assertSame(1, $textAreaField->getPosition());
         static::assertFalse($textAreaField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/TextFieldTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/TextFieldTest.php
@@ -26,13 +26,13 @@ class TextFieldTest extends TestCase
 
         $textField = $customFieldSet->getFields()[0];
         static::assertInstanceOf(TextField::class, $textField);
-        static::assertEquals('test_text_field', $textField->getName());
-        static::assertEquals([
+        static::assertSame('test_text_field', $textField->getName());
+        static::assertSame([
             'en-GB' => 'Test text field',
         ], $textField->getLabel());
-        static::assertEquals([], $textField->getHelpText());
-        static::assertEquals(1, $textField->getPosition());
-        static::assertEquals(['en-GB' => 'Enter a text...'], $textField->getPlaceholder());
+        static::assertSame([], $textField->getHelpText());
+        static::assertSame(1, $textField->getPosition());
+        static::assertSame(['en-GB' => 'Enter a text...'], $textField->getPlaceholder());
         static::assertFalse($textField->getRequired());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldsTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldsTest.php
@@ -21,12 +21,12 @@ class CustomFieldsTest extends TestCase
         static::assertCount(1, $manifest->getCustomFields()->getCustomFieldSets());
 
         $customFieldSet = $manifest->getCustomFields()->getCustomFieldSets()[0];
-        static::assertEquals('custom_field_test', $customFieldSet->getName());
-        static::assertEquals([
+        static::assertSame('custom_field_test', $customFieldSet->getName());
+        static::assertSame([
             'en-GB' => 'Custom field test',
             'de-DE' => 'Zusatzfeld Test',
         ], $customFieldSet->getLabel());
-        static::assertEquals(['product', 'customer'], $customFieldSet->getRelatedEntities());
+        static::assertSame(['product', 'customer'], $customFieldSet->getRelatedEntities());
         static::assertTrue($customFieldSet->getGlobal());
 
         static::assertCount(2, $customFieldSet->getFields());

--- a/tests/unit/Core/Framework/App/Manifest/Xml/MetadataTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/MetadataTest.php
@@ -24,23 +24,23 @@ class MetadataTest extends TestCase
     public function testFromXml(): void
     {
         $metaData = $this->manifest->getMetadata();
-        static::assertEquals('test', $metaData->getName());
-        static::assertEquals('shopware AG', $metaData->getAuthor());
-        static::assertEquals('(c) by shopware AG', $metaData->getCopyright());
-        static::assertEquals('MIT', $metaData->getLicense());
-        static::assertEquals('https://test.com/privacy', $metaData->getPrivacy());
-        static::assertEquals('1.0.0', $metaData->getVersion());
-        static::assertEquals('icon.png', $metaData->getIcon());
+        static::assertSame('test', $metaData->getName());
+        static::assertSame('shopware AG', $metaData->getAuthor());
+        static::assertSame('(c) by shopware AG', $metaData->getCopyright());
+        static::assertSame('MIT', $metaData->getLicense());
+        static::assertSame('https://test.com/privacy', $metaData->getPrivacy());
+        static::assertSame('1.0.0', $metaData->getVersion());
+        static::assertSame('icon.png', $metaData->getIcon());
 
-        static::assertEquals([
+        static::assertSame([
             'en-GB' => 'Swag App Test',
             'de-DE' => 'Swag App Test',
         ], $metaData->getLabel());
-        static::assertEquals([
+        static::assertSame([
             'en-GB' => 'Test for App System',
             'de-DE' => 'Test für das App System',
         ], $metaData->getDescription());
-        static::assertEquals([
+        static::assertSame([
             'en-GB' => 'Following personal information will be processed on shopware AG\'s servers:
 
 - Name
@@ -60,14 +60,14 @@ class MetadataTest extends TestCase
 
         $metaData = $manifest->getMetadata();
 
-        static::assertEquals([
+        static::assertSame([
             'en-GB' => 'Swag App Test',
             'de-DE' => 'Swag App Test',
         ], $metaData->getLabel());
-        static::assertEquals([], $metaData->getDescription());
+        static::assertSame([], $metaData->getDescription());
 
         $array = $metaData->toArray('en-GB');
-        static::assertEquals([], $array['description']);
+        static::assertSame([], $array['description']);
     }
 
     public function testValidateTranslationsReturnsMissingTranslationErrorIfTranslationIsMissing(): void
@@ -76,7 +76,7 @@ class MetadataTest extends TestCase
         $error = $manifest->getMetadata()->validateTranslations();
 
         static::assertInstanceOf(MissingTranslationError::class, $error);
-        static::assertEquals('Missing translations for "Metadata":
+        static::assertSame('Missing translations for "Metadata":
 - label: de-DE, fr-FR', $error->getMessage());
     }
 

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Permission/PermissionsTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Permission/PermissionsTest.php
@@ -19,7 +19,7 @@ class PermissionsTest extends TestCase
 
         static::assertNotNull($manifest->getPermissions());
         static::assertCount(7, $manifest->getPermissions()->getPermissions());
-        static::assertEquals([
+        static::assertSame([
             'product' => ['create', 'update', 'delete'],
             'category' => ['delete'],
             'product_manufacturer' => ['create', 'delete'],
@@ -29,7 +29,7 @@ class PermissionsTest extends TestCase
             'order' => ['read'],
         ], $manifest->getPermissions()->getPermissions());
 
-        static::assertEquals(['user_change_me'], $manifest->getPermissions()->getAdditionalPrivileges());
+        static::assertSame(['user_change_me'], $manifest->getPermissions()->getAdditionalPrivileges());
     }
 
     public function testAsParsedPrivileges(): void
@@ -38,7 +38,7 @@ class PermissionsTest extends TestCase
 
         static::assertNotNull($manifest->getPermissions());
         static::assertCount(16, $manifest->getPermissions()->asParsedPrivileges());
-        static::assertEquals([
+        static::assertSame([
             'product:create',
             'product:read',
             'product:update',

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Webhook/WebhookTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Webhook/WebhookTest.php
@@ -21,21 +21,21 @@ class WebhookTest extends TestCase
         static::assertCount(3, $manifest->getWebhooks()->getWebhooks());
 
         $firstWebhook = $manifest->getWebhooks()->getWebhooks()[0];
-        static::assertEquals('hook1', $firstWebhook->getName());
-        static::assertEquals('https://test.com/hook', $firstWebhook->getUrl());
-        static::assertEquals('checkout.customer.before.login', $firstWebhook->getEvent());
+        static::assertSame('hook1', $firstWebhook->getName());
+        static::assertSame('https://test.com/hook', $firstWebhook->getUrl());
+        static::assertSame('checkout.customer.before.login', $firstWebhook->getEvent());
         static::assertFalse($firstWebhook->getOnlyLiveVersion());
 
         $secondWebhook = $manifest->getWebhooks()->getWebhooks()[1];
-        static::assertEquals('hook2', $secondWebhook->getName());
-        static::assertEquals('https://test.com/hook2', $secondWebhook->getUrl());
-        static::assertEquals('product.written', $secondWebhook->getEvent());
+        static::assertSame('hook2', $secondWebhook->getName());
+        static::assertSame('https://test.com/hook2', $secondWebhook->getUrl());
+        static::assertSame('product.written', $secondWebhook->getEvent());
         static::assertTrue($secondWebhook->getOnlyLiveVersion());
 
         $thirdWebhook = $manifest->getWebhooks()->getWebhooks()[2];
-        static::assertEquals('hook3', $thirdWebhook->getName());
-        static::assertEquals('https://test.com/hook3', $thirdWebhook->getUrl());
-        static::assertEquals('product.written', $thirdWebhook->getEvent());
+        static::assertSame('hook3', $thirdWebhook->getName());
+        static::assertSame('https://test.com/hook3', $thirdWebhook->getUrl());
+        static::assertSame('product.written', $thirdWebhook->getEvent());
         static::assertFalse($thirdWebhook->getOnlyLiveVersion());
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/XmlParserUtilsTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/XmlParserUtilsTest.php
@@ -18,7 +18,7 @@ class XmlParserUtilsTest extends TestCase
 
         $result = XmlParserUtils::parseAttributes($element);
 
-        static::assertEquals(['attr1' => 'value1', 'attr2' => 'value2'], $result);
+        static::assertSame(['attr1' => 'value1', 'attr2' => 'value2'], $result);
     }
 
     public function testParseChildren(): void
@@ -29,7 +29,7 @@ class XmlParserUtilsTest extends TestCase
 
         $result = XmlParserUtils::parseChildren($element);
 
-        static::assertEquals(['child1' => 'value1', 'child2' => 'value2'], $result);
+        static::assertSame(['child1' => 'value1', 'child2' => 'value2'], $result);
     }
 
     public function testParseChildrenWithTransformer(): void
@@ -40,7 +40,7 @@ class XmlParserUtilsTest extends TestCase
 
         $result = XmlParserUtils::parseChildren($element, fn (\DOMElement $e) => strtoupper($e->nodeValue ?? ''));
 
-        static::assertEquals(['child1' => 'VALUE1', 'child2' => 'VALUE2'], $result);
+        static::assertSame(['child1' => 'VALUE1', 'child2' => 'VALUE2'], $result);
     }
 
     public function testParseChildrenIgnoresNonDomElements(): void
@@ -61,7 +61,7 @@ class XmlParserUtilsTest extends TestCase
 
         $result = XmlParserUtils::parseChildrenAsList($element);
 
-        static::assertEquals(['value1', 'value2'], $result);
+        static::assertSame(['value1', 'value2'], $result);
     }
 
     public function testParseChildrenAsListWithTransformer(): void
@@ -72,7 +72,7 @@ class XmlParserUtilsTest extends TestCase
 
         $result = XmlParserUtils::parseChildrenAsList($element, fn (\DOMElement $e) => strtoupper($e->nodeValue ?? ''));
 
-        static::assertEquals(['VALUE1', 'VALUE2'], $result);
+        static::assertSame(['VALUE1', 'VALUE2'], $result);
     }
 
     public function testParseChildrenAsListIgnoresNonDomElements(): void
@@ -124,7 +124,7 @@ class XmlParserUtilsTest extends TestCase
             'version' => '1.5',
         ];
 
-        static::assertEquals($expectedResult, $result);
+        static::assertSame($expectedResult, $result);
     }
 
     public function testMapTranslatedTag(): void
@@ -141,7 +141,7 @@ class XmlParserUtilsTest extends TestCase
 
         $result = XmlParserUtils::mapTranslatedTag($en, []);
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'name' => [
                     'en-GB' => 'EnglishName',
@@ -156,7 +156,7 @@ class XmlParserUtilsTest extends TestCase
             ],
         ]);
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'name' => [
                     'en-GB' => 'EnglishName',
@@ -169,8 +169,8 @@ class XmlParserUtilsTest extends TestCase
 
     public function testKebabCaseToCamelCase(): void
     {
-        static::assertEquals('someValue', XmlParserUtils::kebabCaseToCamelCase('some-value'));
-        static::assertEquals('someValue', XmlParserUtils::kebabCaseToCamelCase('some_value'));
+        static::assertSame('someValue', XmlParserUtils::kebabCaseToCamelCase('some-value'));
+        static::assertSame('someValue', XmlParserUtils::kebabCaseToCamelCase('some_value'));
     }
 
     /**

--- a/tests/unit/Core/Framework/App/Source/LocalTest.php
+++ b/tests/unit/Core/Framework/App/Source/LocalTest.php
@@ -22,7 +22,7 @@ class LocalTest extends TestCase
     public function testName(): void
     {
         $source = new Local('/');
-        static::assertEquals('local', $source->name());
+        static::assertSame('local', $source->name());
     }
 
     public function testSupportsExistingAppWithLocalType(): void

--- a/tests/unit/Core/Framework/App/Source/RemoteZipTest.php
+++ b/tests/unit/Core/Framework/App/Source/RemoteZipTest.php
@@ -32,7 +32,7 @@ class RemoteZipTest extends TestCase
             $this->createMock(AppDownloader::class),
             $this->createMock(AppExtractor::class),
         );
-        static::assertEquals('remote-zip', $source->name());
+        static::assertSame('remote-zip', $source->name());
     }
 
     public function testSupportsExistingAppWithRemoteZipType(): void
@@ -108,7 +108,7 @@ class RemoteZipTest extends TestCase
 
         $filesystem = $source->filesystem($app);
 
-        static::assertEquals($dirFactory->path() . '/TestApp', $filesystem->location);
+        static::assertSame($dirFactory->path() . '/TestApp', $filesystem->location);
     }
 
     public static function appProvider(): \Generator
@@ -186,7 +186,7 @@ class RemoteZipTest extends TestCase
 
         $filesystem = $source->filesystem($app);
 
-        static::assertEquals($dirFactory->path() . '/TestApp', $filesystem->location);
+        static::assertSame($dirFactory->path() . '/TestApp', $filesystem->location);
     }
 
     public function testExceptionIsThrowIfDownloadingOrExtractingFails(): void

--- a/tests/unit/Core/Framework/App/Template/TemplateLoaderTest.php
+++ b/tests/unit/Core/Framework/App/Template/TemplateLoaderTest.php
@@ -33,7 +33,7 @@ class TemplateLoaderTest extends TestCase
         $templates = $templateLoader->getTemplatePathsForApp($this->manifest);
         \sort($templates);
 
-        static::assertEquals(
+        static::assertSame(
             ['storefront/layout/header/header.html.twig', 'storefront/layout/header/logo.html.twig', 'storefront/page/sitemap/sitemap.xml.twig'],
             $templates
         );

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
@@ -97,7 +97,7 @@ class EntityCacheKeyGeneratorTest extends TestCase
     {
         $generator = new EntityCacheKeyGenerator();
 
-        static::assertNotEquals(
+        static::assertNotSame(
             $generator->getSalesChannelContextHash(new DummyContext(), ['test']),
             $generator->getSalesChannelContextHash($compared, ['test'])
         );

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Command/CreateMigrationCommandTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Command/CreateMigrationCommandTest.php
@@ -68,8 +68,8 @@ class CreateMigrationCommandTest extends TestCase
             ->expects($fileRendererInvocation)
             ->method('render')
             ->willReturnCallback(function (string $namespace, string $className) use ($expectedNamespaces, $expectedClassNames, $fileRendererInvocation) {
-                static::assertEquals($expectedNamespaces[$fileRendererInvocation->numberOfInvocations() - 1], $namespace);
-                static::assertEquals($expectedClassNames[$fileRendererInvocation->numberOfInvocations() - 1], $className);
+                static::assertSame($expectedNamespaces[$fileRendererInvocation->numberOfInvocations() - 1], $namespace);
+                static::assertSame($expectedClassNames[$fileRendererInvocation->numberOfInvocations() - 1], $className);
 
                 return 'Migration file content';
             });
@@ -80,7 +80,7 @@ class CreateMigrationCommandTest extends TestCase
             ->expects($filesystemInvocation)
             ->method('dumpFile')
             ->willReturnCallback(function (string $path) use ($filesystemInvocation, $expectedPaths): void {
-                static::assertEquals($expectedPaths[$filesystemInvocation->numberOfInvocations() - 1], $path);
+                static::assertSame($expectedPaths[$filesystemInvocation->numberOfInvocations() - 1], $path);
             });
 
         $input = [

--- a/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
@@ -78,10 +78,10 @@ class DataAbstractionLayerExceptionTest extends TestCase
         $e = DataAbstractionLayerException::invalidFilterQuery('foo', 'baz');
 
         static::assertInstanceOf(InvalidFilterQueryException::class, $e);
-        static::assertEquals('foo', $e->getMessage());
-        static::assertEquals('baz', $e->getParameters()['path']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(DataAbstractionLayerException::INVALID_FILTER_QUERY, $e->getErrorCode());
+        static::assertSame('foo', $e->getMessage());
+        static::assertSame('baz', $e->getParameters()['path']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::INVALID_FILTER_QUERY, $e->getErrorCode());
     }
 
     public function testInvalidSortQuery(): void
@@ -89,48 +89,48 @@ class DataAbstractionLayerExceptionTest extends TestCase
         $e = DataAbstractionLayerException::invalidSortQuery('foo', 'baz');
 
         static::assertInstanceOf(InvalidSortQueryException::class, $e);
-        static::assertEquals('foo', $e->getMessage());
-        static::assertEquals('baz', $e->getParameters()['path']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(DataAbstractionLayerException::INVALID_SORT_QUERY, $e->getErrorCode());
+        static::assertSame('foo', $e->getMessage());
+        static::assertSame('baz', $e->getParameters()['path']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::INVALID_SORT_QUERY, $e->getErrorCode());
     }
 
     public function testCannotCreateNewVersion(): void
     {
         $e = DataAbstractionLayerException::cannotCreateNewVersion('product', 'product-id');
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('Cannot create new version. product by id product-id not found.', $e->getMessage());
-        static::assertEquals(DataAbstractionLayerException::CANNOT_CREATE_NEW_VERSION, $e->getErrorCode());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('Cannot create new version. product by id product-id not found.', $e->getMessage());
+        static::assertSame(DataAbstractionLayerException::CANNOT_CREATE_NEW_VERSION, $e->getErrorCode());
     }
 
     public function testVersionMergeAlreadyLocked(): void
     {
         $e = DataAbstractionLayerException::versionMergeAlreadyLocked('version-id');
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(DataAbstractionLayerException::VERSION_MERGE_ALREADY_LOCKED, $e->getErrorCode());
-        static::assertEquals('Merging of version version-id is locked, as the merge is already running by another process.', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::VERSION_MERGE_ALREADY_LOCKED, $e->getErrorCode());
+        static::assertSame('Merging of version version-id is locked, as the merge is already running by another process.', $e->getMessage());
     }
 
     public function testExpectedArray(): void
     {
         $e = DataAbstractionLayerException::expectedArray('some/path/0');
 
-        static::assertEquals('Expected data at some/path/0 to be an array.', $e->getMessage());
-        static::assertEquals('some/path/0', $e->getParameters()['path']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('FRAMEWORK__WRITE_MALFORMED_INPUT', $e->getErrorCode());
+        static::assertSame('Expected data at some/path/0 to be an array.', $e->getMessage());
+        static::assertSame('some/path/0', $e->getParameters()['path']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('FRAMEWORK__WRITE_MALFORMED_INPUT', $e->getErrorCode());
     }
 
     public function testExpectedAssociativeArray(): void
     {
         $e = DataAbstractionLayerException::expectedAssociativeArray('some/path/0');
 
-        static::assertEquals('Expected data at some/path/0 to be an associative array.', $e->getMessage());
-        static::assertEquals('some/path/0', $e->getParameters()['path']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('FRAMEWORK__INVALID_WRITE_INPUT', $e->getErrorCode());
+        static::assertSame('Expected data at some/path/0 to be an associative array.', $e->getMessage());
+        static::assertSame('some/path/0', $e->getParameters()['path']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('FRAMEWORK__INVALID_WRITE_INPUT', $e->getErrorCode());
     }
 
     public function testDecodeHandledByHydrator(): void
@@ -145,50 +145,50 @@ class DataAbstractionLayerExceptionTest extends TestCase
 
         $e = DataAbstractionLayerException::decodeHandledByHydrator($field);
 
-        static::assertEquals(
+        static::assertSame(
             \sprintf('Decoding of %s is handled by the entity hydrator.', ManyToManyAssociationField::class),
             $e->getMessage()
         );
-        static::assertEquals(ManyToManyAssociationField::class, $e->getParameters()['fieldClass']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals(DataAbstractionLayerException::DECODE_HANDLED_BY_HYDRATOR, $e->getErrorCode());
+        static::assertSame(ManyToManyAssociationField::class, $e->getParameters()['fieldClass']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::DECODE_HANDLED_BY_HYDRATOR, $e->getErrorCode());
     }
 
     public function testFkFieldByStorageNameNotFound(): void
     {
         $e = DataAbstractionLayerException::fkFieldByStorageNameNotFound(ProductDefinition::class, 'taxId');
 
-        static::assertEquals(
+        static::assertSame(
             'Can not detect FK field with storage name taxId in definition Shopware\Core\Content\Product\ProductDefinition',
             $e->getMessage()
         );
 
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(DataAbstractionLayerException::REFERENCE_FIELD_BY_STORAGE_NAME_NOT_FOUND, $e->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::REFERENCE_FIELD_BY_STORAGE_NAME_NOT_FOUND, $e->getErrorCode());
     }
 
     public function testLanguageFieldByStorageNameNotFound(): void
     {
         $e = DataAbstractionLayerException::languageFieldByStorageNameNotFound(ProductDefinition::class, 'taxId');
 
-        static::assertEquals(
+        static::assertSame(
             'Can not detect language field with storage name taxId in definition Shopware\Core\Content\Product\ProductDefinition',
             $e->getMessage()
         );
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(DataAbstractionLayerException::REFERENCE_FIELD_BY_STORAGE_NAME_NOT_FOUND, $e->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::REFERENCE_FIELD_BY_STORAGE_NAME_NOT_FOUND, $e->getErrorCode());
     }
 
     public function testDefinitionFieldDoesNotExist(): void
     {
         $e = DataAbstractionLayerException::definitionFieldDoesNotExist(ProductDefinition::class, 'taxId');
 
-        static::assertEquals(
+        static::assertSame(
             'Can not detect reference field with storage name taxId in definition Shopware\Core\Content\Product\ProductDefinition',
             $e->getMessage()
         );
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
-        static::assertEquals(DataAbstractionLayerException::REFERENCE_FIELD_BY_STORAGE_NAME_NOT_FOUND, $e->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::REFERENCE_FIELD_BY_STORAGE_NAME_NOT_FOUND, $e->getErrorCode());
     }
 
     public function testExpectedArrayWithType(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/CriteriaFieldsResolverTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/CriteriaFieldsResolverTest.php
@@ -50,7 +50,7 @@ class CriteriaFieldsResolverTest extends TestCase
 
         $result = $resolver->resolve($criteria, $this->registry->get(TestDefinition::class));
 
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public static function resolveFieldsProvider(): \Generator

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelperTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelperTest.php
@@ -30,7 +30,7 @@ class EntityDefinitionQueryHelperTest extends TestCase
     {
         $definition = $this->getRegistry()->getByEntityName('product');
 
-        static::assertEquals(
+        static::assertSame(
             $expectedRoot,
             EntityDefinitionQueryHelper::getRoot($accessor, $definition)
         );
@@ -41,7 +41,7 @@ class EntityDefinitionQueryHelperTest extends TestCase
     {
         $definition = $this->getRegistry()->getByEntityName('product');
 
-        static::assertEquals(
+        static::assertSame(
             $expectedEntity,
             EntityDefinitionQueryHelper::getAssociatedDefinition($definition, $accessor)->getEntityName()
         );

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityHydratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityHydratorTest.php
@@ -132,8 +132,6 @@ class EntityHydratorTest extends TestCase
         $structs = $hydrator->hydrate(new EntityCollection(), $definition->getEntityClass(), $definition, $rows, 'test', Context::createDefaultContext());
         static::assertCount(1, $structs);
 
-        static::assertEquals(1, $structs->count());
-
         $first = $structs->first();
         static::assertNotNull($first);
         static::assertSame('0', $first->get('name'));
@@ -157,7 +155,6 @@ class EntityHydratorTest extends TestCase
         $structs = $this->hydrator->hydrate(new EntityCollection(), $definition->getEntityClass(), $definition, $rows, 'test', Context::createDefaultContext());
         static::assertCount(1, $structs);
 
-        static::assertEquals(1, $structs->count());
         $first = $structs->first();
         static::assertNotNull($first);
         $customFields = $first->get('customFields');
@@ -386,7 +383,7 @@ class EntityHydratorTest extends TestCase
         static::assertNotNull($first);
         $country = $first->get('zipcode')->get('country');
         static::assertInstanceOf(ArrayEntity::class, $country);
-        static::assertEquals(Uuid::fromBytesToHex($countryId), $country->get('id'));
+        static::assertSame(Uuid::fromBytesToHex($countryId), $country->get('id'));
         static::assertArrayHasKey('zipcode', $first->get('warehouse')->all());
         static::assertNull($first->get('warehouse')->all()['zipcode']);
 
@@ -413,7 +410,7 @@ class EntityHydratorTest extends TestCase
         $structsWithoutToManyHydration = $this->hydrator->hydrate(new EntityCollection(), $definition->getEntityClass(), $definition, [$rowWithoutToManyHydration], 'test', $context);
         $first = $structsWithoutToManyHydration->first();
         static::assertNotNull($first);
-        static::assertEquals(Uuid::fromBytesToHex($id), $first->getId());
+        static::assertSame(Uuid::fromBytesToHex($id), $first->getId());
         static::assertArrayHasKey('toMany', $first->all());
         static::assertNull($first->all()['toMany']);
     }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/SchemaBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/SchemaBuilderTest.php
@@ -130,133 +130,133 @@ class SchemaBuilderTest extends TestCase
         static::assertSame('id', $table->getPrimaryKey()?->getColumns()[0]);
 
         static::assertTrue($table->hasColumn('id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('id')->getType()));
 
         static::assertTrue($table->hasColumn('version_id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('version_id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('version_id')->getType()));
 
         static::assertTrue($table->hasColumn('created_by_id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('created_by_id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('created_by_id')->getType()));
 
         static::assertTrue($table->hasColumn('updated_by_id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('updated_by_id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('updated_by_id')->getType()));
 
         static::assertTrue($table->hasColumn('state_id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('state_id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('state_id')->getType()));
 
         static::assertTrue($table->hasColumn('created_at'));
-        static::assertEquals(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('created_at')->getType()));
+        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('created_at')->getType()));
 
         static::assertTrue($table->hasColumn('updated_at'));
-        static::assertEquals(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('updated_at')->getType()));
+        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('updated_at')->getType()));
 
         static::assertTrue($table->hasColumn('datetime'));
-        static::assertEquals(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('datetime')->getType()));
+        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('datetime')->getType()));
 
         static::assertTrue($table->hasColumn('date'));
-        static::assertEquals(Types::DATE_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('date')->getType()));
+        static::assertSame(Types::DATE_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('date')->getType()));
 
         static::assertTrue($table->hasColumn('cart_price'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('cart_price')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('cart_price')->getType()));
 
         static::assertTrue($table->hasColumn('calculated_price'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('calculated_price')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('calculated_price')->getType()));
 
         static::assertTrue($table->hasColumn('price'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('price')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('price')->getType()));
 
         static::assertTrue($table->hasColumn('price_definition'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('price_definition')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('price_definition')->getType()));
 
         static::assertTrue($table->hasColumn('json'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('json')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('json')->getType()));
 
         static::assertTrue($table->hasColumn('list'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('list')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('list')->getType()));
 
         static::assertTrue($table->hasColumn('config_json'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('config_json')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('config_json')->getType()));
 
         static::assertTrue($table->hasColumn('custom_fields'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('custom_fields')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('custom_fields')->getType()));
 
         static::assertTrue($table->hasColumn('breadcrumb'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('breadcrumb')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('breadcrumb')->getType()));
 
         static::assertTrue($table->hasColumn('cash_rounding_config'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('cash_rounding_config')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('cash_rounding_config')->getType()));
 
         static::assertTrue($table->hasColumn('object'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('object')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('object')->getType()));
 
         static::assertTrue($table->hasColumn('tax_free_config'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('tax_free_config')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('tax_free_config')->getType()));
 
         static::assertTrue($table->hasColumn('tree_breadcrumb'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('tree_breadcrumb')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('tree_breadcrumb')->getType()));
 
         static::assertTrue($table->hasColumn('variant_listing_config'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('variant_listing_config')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('variant_listing_config')->getType()));
 
         static::assertTrue($table->hasColumn('version_data_payload'));
-        static::assertEquals(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('version_data_payload')->getType()));
+        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('version_data_payload')->getType()));
 
         static::assertTrue($table->hasColumn('child_count'));
-        static::assertEquals(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('child_count')->getType()));
+        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('child_count')->getType()));
 
         static::assertTrue($table->hasColumn('auto_increment'));
-        static::assertEquals(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('auto_increment')->getType()));
+        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('auto_increment')->getType()));
 
         static::assertTrue($table->hasColumn('int'));
-        static::assertEquals(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('int')->getType()));
+        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('int')->getType()));
 
         static::assertTrue($table->hasColumn('auto_increment'));
-        static::assertEquals(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('auto_increment')->getType()));
+        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('auto_increment')->getType()));
 
         static::assertTrue($table->hasColumn('tree_level'));
-        static::assertEquals(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('tree_level')->getType()));
+        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('tree_level')->getType()));
 
         static::assertTrue($table->hasColumn('bool'));
-        static::assertEquals(Types::BOOLEAN, Type::getTypeRegistry()->lookupName($table->getColumn('bool')->getType()));
+        static::assertSame(Types::BOOLEAN, Type::getTypeRegistry()->lookupName($table->getColumn('bool')->getType()));
 
         static::assertTrue($table->hasColumn('locked'));
-        static::assertEquals(Types::BOOLEAN, Type::getTypeRegistry()->lookupName($table->getColumn('locked')->getType()));
+        static::assertSame(Types::BOOLEAN, Type::getTypeRegistry()->lookupName($table->getColumn('locked')->getType()));
 
         static::assertTrue($table->hasColumn('password'));
-        static::assertEquals(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('password')->getType()));
+        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('password')->getType()));
 
         static::assertTrue($table->hasColumn('string'));
-        static::assertEquals(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('string')->getType()));
+        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('string')->getType()));
 
         static::assertTrue($table->hasColumn('timezone'));
-        static::assertEquals(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('timezone')->getType()));
+        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('timezone')->getType()));
 
         static::assertTrue($table->hasColumn('cron_interval'));
-        static::assertEquals(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('cron_interval')->getType()));
+        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('cron_interval')->getType()));
 
         static::assertTrue($table->hasColumn('date_interval'));
-        static::assertEquals(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('date_interval')->getType()));
+        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('date_interval')->getType()));
 
         static::assertTrue($table->hasColumn('email'));
-        static::assertEquals(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('email')->getType()));
+        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('email')->getType()));
 
         static::assertTrue($table->hasColumn('remote_address'));
-        static::assertEquals(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('remote_address')->getType()));
+        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('remote_address')->getType()));
 
         static::assertTrue($table->hasColumn('number_range'));
-        static::assertEquals(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('number_range')->getType()));
+        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('number_range')->getType()));
 
         static::assertTrue($table->hasColumn('blob'));
-        static::assertEquals(Types::BLOB, Type::getTypeRegistry()->lookupName($table->getColumn('blob')->getType()));
+        static::assertSame(Types::BLOB, Type::getTypeRegistry()->lookupName($table->getColumn('blob')->getType()));
 
         static::assertTrue($table->hasColumn('float'));
-        static::assertEquals(Types::DECIMAL, Type::getTypeRegistry()->lookupName($table->getColumn('float')->getType()));
+        static::assertSame(Types::DECIMAL, Type::getTypeRegistry()->lookupName($table->getColumn('float')->getType()));
 
         static::assertTrue($table->hasColumn('tree_path'));
-        static::assertEquals(Types::TEXT, Type::getTypeRegistry()->lookupName($table->getColumn('tree_path')->getType()));
+        static::assertSame(Types::TEXT, Type::getTypeRegistry()->lookupName($table->getColumn('tree_path')->getType()));
 
         static::assertTrue($table->hasColumn('long_text'));
-        static::assertEquals(Types::TEXT, Type::getTypeRegistry()->lookupName($table->getColumn('long_text')->getType()));
+        static::assertSame(Types::TEXT, Type::getTypeRegistry()->lookupName($table->getColumn('long_text')->getType()));
     }
 
     public function testForeignKeys(): void
@@ -270,31 +270,31 @@ class SchemaBuilderTest extends TestCase
         static::assertSame('id', $table->getPrimaryKey()?->getColumns()[0]);
 
         static::assertTrue($table->hasColumn('id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('id')->getType()));
 
         static::assertTrue($table->hasColumn('version_id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('version_id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('version_id')->getType()));
 
         static::assertTrue($table->hasColumn('parent_id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('parent_id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('parent_id')->getType()));
 
         static::assertTrue($table->hasColumn('parent_version_id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('parent_version_id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('parent_version_id')->getType()));
 
         static::assertTrue($table->hasColumn('created_at'));
-        static::assertEquals(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('created_at')->getType()));
+        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('created_at')->getType()));
 
         static::assertTrue($table->hasColumn('updated_at'));
-        static::assertEquals(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('updated_at')->getType()));
+        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('updated_at')->getType()));
 
         static::assertTrue($table->hasColumn('association_id'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id')->getType()));
 
         static::assertTrue($table->hasColumn('association_id2'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id2')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id2')->getType()));
 
         static::assertTrue($table->hasColumn('association_id3'));
-        static::assertEquals(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id3')->getType()));
+        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id3')->getType()));
 
         static::assertTrue($table->hasForeignKey('fk.test_entity_with_foreign_keys.association_id'));
         static::assertTrue($table->hasForeignKey('fk.test_entity_with_foreign_keys.association_id2'));
@@ -306,9 +306,9 @@ class SchemaBuilderTest extends TestCase
         static::assertSame('test_association', $associationFk->getForeignTableName());
         static::assertSame('id', $associationFk->getForeignColumns()[0]);
         static::assertArrayHasKey('onUpdate', $associationFk->getOptions());
-        static::assertEquals('CASCADE', $associationFk->getOptions()['onUpdate']);
+        static::assertSame('CASCADE', $associationFk->getOptions()['onUpdate']);
         static::assertArrayHasKey('onDelete', $associationFk->getOptions());
-        static::assertEquals('SET NULL', $associationFk->getOptions()['onDelete']);
+        static::assertSame('SET NULL', $associationFk->getOptions()['onDelete']);
 
         $associationFk2 = $table->getForeignKey('fk.test_entity_with_foreign_keys.association_id2');
 
@@ -316,9 +316,9 @@ class SchemaBuilderTest extends TestCase
         static::assertSame('test_association', $associationFk2->getForeignTableName());
         static::assertSame('id', $associationFk2->getForeignColumns()[0]);
         static::assertArrayHasKey('onUpdate', $associationFk2->getOptions());
-        static::assertEquals('CASCADE', $associationFk2->getOptions()['onUpdate']);
+        static::assertSame('CASCADE', $associationFk2->getOptions()['onUpdate']);
         static::assertArrayHasKey('onDelete', $associationFk2->getOptions());
-        static::assertEquals('CASCADE', $associationFk2->getOptions()['onDelete']);
+        static::assertSame('CASCADE', $associationFk2->getOptions()['onDelete']);
 
         $associationFk3 = $table->getForeignKey('fk.test_entity_with_foreign_keys.association_id3');
 
@@ -326,9 +326,9 @@ class SchemaBuilderTest extends TestCase
         static::assertSame('test_association', $associationFk3->getForeignTableName());
         static::assertSame('id', $associationFk3->getForeignColumns()[0]);
         static::assertArrayHasKey('onUpdate', $associationFk3->getOptions());
-        static::assertEquals('CASCADE', $associationFk3->getOptions()['onUpdate']);
+        static::assertSame('CASCADE', $associationFk3->getOptions()['onUpdate']);
         static::assertArrayHasKey('onDelete', $associationFk3->getOptions());
-        static::assertEquals('RESTRICT', $associationFk3->getOptions()['onDelete']);
+        static::assertSame('RESTRICT', $associationFk3->getOptions()['onDelete']);
     }
 
     public function testDefinitionMissingReferenceVersionField(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/EntityCollectionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/EntityCollectionTest.php
@@ -28,7 +28,7 @@ class EntityCollectionTest extends TestCase
             'not-exists' => ['foo' => 5],
         ]);
 
-        static::assertEquals([
+        static::assertSame([
             'element-1' => ['foo' => 3, 'bar' => 3, 'baz' => 3],
             'element-2' => ['foo' => 4, 'bar' => 4],
         ], $collection->getCustomFieldsValues());
@@ -56,7 +56,7 @@ class EntityCollectionTest extends TestCase
             new MyCollectionEntity('element-2', ['foo' => 2]),
         ]);
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'element-1' => 1,
                 'element-2' => 2,
@@ -64,7 +64,7 @@ class EntityCollectionTest extends TestCase
             $collection->getCustomFieldsValue('foo')
         );
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'element-1' => 1,
                 'element-2' => null,
@@ -90,32 +90,32 @@ class EntityCollectionTest extends TestCase
             new MyCollectionEntity('element-2', ['foo' => 2, 'bar' => 2, 'baz' => 2]),
         ]);
 
-        static::assertEquals([
+        static::assertSame([
             'element-1' => ['foo' => 1, 'bar' => 1],
             'element-2' => ['foo' => 2, 'bar' => 2, 'baz' => 2],
         ], $collection->getCustomFieldsValues());
 
-        static::assertEquals([
+        static::assertSame([
             'element-1' => ['foo' => 1],
             'element-2' => ['foo' => 2],
         ], $collection->getCustomFieldsValues('foo'));
 
-        static::assertEquals([
+        static::assertSame([
             'element-1' => ['foo' => 1, 'bar' => 1],
             'element-2' => ['foo' => 2, 'bar' => 2],
         ], $collection->getCustomFieldsValues('foo', 'bar'));
 
-        static::assertEquals([
+        static::assertSame([
             'element-1' => ['foo' => 1],
             'element-2' => ['foo' => 2, 'baz' => 2],
         ], $collection->getCustomFieldsValues('foo', 'baz'));
 
-        static::assertEquals([
+        static::assertSame([
             'element-1' => [],
             'element-2' => [],
         ], $collection->getCustomFieldsValues('not-exists'));
 
-        static::assertEquals([
+        static::assertSame([
             'element-1' => [],
             'element-2' => [],
         ], $collection->getCustomFieldsValues('not-exists', 'both'));

--- a/tests/unit/Core/Framework/DataAbstractionLayer/EntityCustomFieldsTraitTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/EntityCustomFieldsTraitTest.php
@@ -21,7 +21,7 @@ class EntityCustomFieldsTraitTest extends TestCase
 
         static::assertSame(['foo' => 'bar'], $entity->getCustomFieldsValues('foo'));
 
-        static::assertEquals([], $entity->getCustomFieldsValues('not-exists'));
+        static::assertSame([], $entity->getCustomFieldsValues('not-exists'));
 
         static::assertSame(['foo' => 'bar', 'bar' => 'foo'], $entity->getCustomFieldsValues('foo', 'bar'));
     }
@@ -54,14 +54,14 @@ class EntityCustomFieldsTraitTest extends TestCase
         ]);
 
         $entity->changeCustomFields(['foo' => 'baz']);
-        static::assertEquals('baz', $entity->getCustomFieldsValue('foo'));
-        static::assertEquals(['foo' => 'bar'], $entity->getCustomFieldsValue('bar'));
+        static::assertSame('baz', $entity->getCustomFieldsValue('foo'));
+        static::assertSame(['foo' => 'bar'], $entity->getCustomFieldsValue('bar'));
 
         $entity->changeCustomFields(['bar' => ['foo' => 'baz']]);
-        static::assertEquals(['foo' => 'baz'], $entity->getCustomFieldsValue('bar'));
+        static::assertSame(['foo' => 'baz'], $entity->getCustomFieldsValue('bar'));
 
         $entity->changeCustomFields(['foo' => 'baz', 'bar' => ['foo' => 'foo'], 'baz' => 'baz']);
-        static::assertEquals(['foo' => 'baz', 'bar' => ['foo' => 'foo'], 'baz' => 'baz'], $entity->getCustomFields());
+        static::assertSame(['foo' => 'baz', 'bar' => ['foo' => 'foo'], 'baz' => 'baz'], $entity->getCustomFields());
     }
 }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Event/EntityDeleteEventTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Event/EntityDeleteEventTest.php
@@ -139,9 +139,9 @@ class EntityDeleteEventTest extends TestCase
 
         $event->success();
 
-        static::assertEquals(2, $callback1->counter);
+        static::assertSame(2, $callback1->counter);
 
         $event->error();
-        static::assertEquals(1, $callback2->counter);
+        static::assertSame(1, $callback2->counter);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Event/EntityWriteEventTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Event/EntityWriteEventTest.php
@@ -113,9 +113,9 @@ class EntityWriteEventTest extends TestCase
 
         $event->success();
 
-        static::assertEquals(2, $callback1->counter);
+        static::assertSame(2, $callback1->counter);
 
         $event->error();
-        static::assertEquals(1, $callback2->counter);
+        static::assertSame(1, $callback2->counter);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Exception/EntityRepositoryNotFoundExceptionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Exception/EntityRepositoryNotFoundExceptionTest.php
@@ -19,7 +19,7 @@ class EntityRepositoryNotFoundExceptionTest extends TestCase
     {
         $exception = new EntityRepositoryNotFoundException(TestEntity::class);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
     }
 
     public function testGetErrorCodeWillReturnStringWithNotFoundText(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/RemoteAddressFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/RemoteAddressFieldTest.php
@@ -18,6 +18,6 @@ class RemoteAddressFieldTest extends TestCase
     {
         $field = new RemoteAddressField('remote_address', 'remoteAddress');
 
-        static::assertEquals('remote_address', $field->getStorageName());
+        static::assertSame('remote_address', $field->getStorageName());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CronIntervalFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CronIntervalFieldSerializerTest.php
@@ -62,7 +62,7 @@ class CronIntervalFieldSerializerTest extends TestCase
         )->current();
 
         static::assertIsString($cronExpression);
-        static::assertEquals(self::COMPLEX_CRON, $cronExpression);
+        static::assertSame(self::COMPLEX_CRON, $cronExpression);
     }
 
     public function testEncodeMethodWithIncorrectFieldParameterTypeWillThrowInvalidSerializerException(): void
@@ -131,7 +131,7 @@ class CronIntervalFieldSerializerTest extends TestCase
         )->current();
 
         static::assertIsString($cronExpression);
-        static::assertEquals(self::COMPLEX_CRON, $cronExpression);
+        static::assertSame(self::COMPLEX_CRON, $cronExpression);
     }
 
     public function testEncodeMethodWithIncorrectStringWillThrowInvalidCronIntervalFormatException(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/DateIntervalFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/DateIntervalFieldSerializerTest.php
@@ -66,7 +66,7 @@ class DateIntervalFieldSerializerTest extends TestCase
 
         static::assertIsString($dateIntervalString);
         static::assertMatchesRegularExpression(self::REGEX_DATE_INTERVAL_VALIDATION, $dateIntervalString);
-        static::assertEquals('P2Y0M5DT0H0M0S', $dateIntervalString);
+        static::assertSame('P2Y0M5DT0H0M0S', $dateIntervalString);
     }
 
     public function testEncodeMethodWithIncorrectFieldParameterTypeWillThrowInvalidSerializerException(): void
@@ -132,7 +132,7 @@ class DateIntervalFieldSerializerTest extends TestCase
 
         static::assertIsString($dateIntervalString);
         static::assertMatchesRegularExpression(self::REGEX_DATE_INTERVAL_VALIDATION, $dateIntervalString);
-        static::assertEquals('P2Y0M5DT0H0M2S', $dateIntervalString);
+        static::assertSame('P2Y0M5DT0H0M2S', $dateIntervalString);
     }
 
     public function testEncodeMethodWithIncorrectStringWillThrowInvalidDateIntervalFormatException(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/ListFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/ListFieldSerializerTest.php
@@ -29,7 +29,7 @@ class ListFieldSerializerTest extends TestCase
         );
 
         $actual = $serializer->decode($field, $input);
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     /**

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/ManyToOneAssociationFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/ManyToOneAssociationFieldSerializerTest.php
@@ -162,7 +162,7 @@ class ManyToOneAssociationFieldSerializerTest extends TestCase
             $params
         );
 
-        static::assertEquals([], iterator_to_array($result));
+        static::assertSame([], iterator_to_array($result));
     }
 }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/PasswordFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/PasswordFieldSerializerTest.php
@@ -106,7 +106,7 @@ class PasswordFieldSerializerTest extends TestCase
             $inputPasswordHashed = !empty(password_get_info($inputPassword)['algo']);
 
             if ($inputPasswordHashed) {
-                static::assertEquals($inputPassword, $result);
+                static::assertSame($inputPassword, $result);
             } else {
                 static::assertTrue(password_verify($inputPassword, $result));
             }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/MigrationFileRendererTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/MigrationFileRendererTest.php
@@ -41,6 +41,6 @@ class MigrationFileRendererTest extends TestCase
 
         $result = MigrationFileRenderer::createMigrationClassName($timestamp, $entity);
 
-        static::assertEquals('Migration20231117120000TestEntity', $result);
+        static::assertSame('Migration20231117120000TestEntity', $result);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/BucketAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/BucketAggregationTest.php
@@ -30,8 +30,8 @@ class BucketAggregationTest extends TestCase
         $aggregation = new BucketAggregation('test', 'test', null);
         $clone = clone $aggregation;
 
-        static::assertEquals($aggregation->getField(), $clone->getField());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($aggregation->getField(), $clone->getField());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
         static::assertNotSame($aggregation, $clone);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/DateHistogramAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/DateHistogramAggregationTest.php
@@ -48,6 +48,6 @@ class DateHistogramAggregationTest extends TestCase
 
         $clone = clone $aggregation;
 
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/FilterAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/FilterAggregationTest.php
@@ -57,7 +57,7 @@ class FilterAggregationTest extends TestCase
     {
         $aggregation = new FilterAggregation('foo', new TermsAggregation('foo', 'name'), [new EqualsFilter('name', 'test')]);
         $clone = clone $aggregation;
-        static::assertEquals($aggregation->getName(), $clone->getName());
+        static::assertSame($aggregation->getName(), $clone->getName());
         static::assertEquals($aggregation->getAggregation(), $clone->getAggregation());
         static::assertEquals($aggregation->getFilter(), $clone->getFilter());
         static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/TermsAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/TermsAggregationTest.php
@@ -30,8 +30,8 @@ class TermsAggregationTest extends TestCase
     {
         $aggregation = new TermsAggregation('foo', 'name');
         $clone = clone $aggregation;
-        static::assertEquals($aggregation->getName(), $clone->getName());
-        static::assertEquals($aggregation->getFields(), $clone->getFields());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($aggregation->getName(), $clone->getName());
+        static::assertSame($aggregation->getFields(), $clone->getFields());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/AvgAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/AvgAggregationTest.php
@@ -29,8 +29,8 @@ class AvgAggregationTest extends TestCase
         $aggregation = new AvgAggregation('foo', 'bar');
         $clone = clone $aggregation;
 
-        static::assertEquals('foo', $clone->getName());
-        static::assertEquals('bar', $clone->getField());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame('foo', $clone->getName());
+        static::assertSame('bar', $clone->getField());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/CountAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/CountAggregationTest.php
@@ -29,8 +29,8 @@ class CountAggregationTest extends TestCase
         $aggregation = new CountAggregation('foo', 'bar');
         $clone = clone $aggregation;
 
-        static::assertEquals('foo', $clone->getName());
-        static::assertEquals('bar', $clone->getField());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame('foo', $clone->getName());
+        static::assertSame('bar', $clone->getField());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/EntityAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/EntityAggregationTest.php
@@ -30,8 +30,8 @@ class EntityAggregationTest extends TestCase
         $aggregation = new EntityAggregation('foo', 'bar', 'product');
         $clone = clone $aggregation;
 
-        static::assertEquals('foo', $clone->getName());
-        static::assertEquals('bar', $clone->getField());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame('foo', $clone->getName());
+        static::assertSame('bar', $clone->getField());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/MaxAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/MaxAggregationTest.php
@@ -29,8 +29,8 @@ class MaxAggregationTest extends TestCase
         $aggregation = new MaxAggregation('foo', 'bar');
         $clone = clone $aggregation;
 
-        static::assertEquals('foo', $clone->getName());
-        static::assertEquals('bar', $clone->getField());
+        static::assertSame('foo', $clone->getName());
+        static::assertSame('bar', $clone->getField());
         static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/MinAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/MinAggregationTest.php
@@ -29,8 +29,8 @@ class MinAggregationTest extends TestCase
         $aggregation = new MinAggregation('foo', 'bar');
         $clone = clone $aggregation;
 
-        static::assertEquals('foo', $clone->getName());
-        static::assertEquals('bar', $clone->getField());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame('foo', $clone->getName());
+        static::assertSame('bar', $clone->getField());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
@@ -36,8 +36,8 @@ class RangeAggregationTest extends TestCase
         $aggregation = new RangeAggregation('foo', 'bar', [['to' => 100]]);
         $clone = clone $aggregation;
 
-        static::assertEquals('foo', $clone->getName());
-        static::assertEquals('bar', $clone->getField());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame('foo', $clone->getName());
+        static::assertSame('bar', $clone->getField());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/StatsAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/StatsAggregationTest.php
@@ -33,8 +33,8 @@ class StatsAggregationTest extends TestCase
         $aggregation = new StatsAggregation('foo', 'bar');
         $clone = clone $aggregation;
 
-        static::assertEquals('foo', $clone->getName());
-        static::assertEquals('bar', $clone->getField());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame('foo', $clone->getName());
+        static::assertSame('bar', $clone->getField());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/SumAggregationTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/SumAggregationTest.php
@@ -29,8 +29,8 @@ class SumAggregationTest extends TestCase
         $aggregation = new SumAggregation('foo', 'bar');
         $clone = clone $aggregation;
 
-        static::assertEquals('foo', $clone->getName());
-        static::assertEquals('bar', $clone->getField());
-        static::assertEquals($aggregation->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame('foo', $clone->getName());
+        static::assertSame('bar', $clone->getField());
+        static::assertSame($aggregation->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/CriteriaTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/CriteriaTest.php
@@ -134,11 +134,11 @@ class CriteriaTest extends TestCase
     public function testValidIdFormats(array $ids): void
     {
         $criteria = new Criteria($ids);
-        static::assertEquals($ids, $criteria->getIds());
+        static::assertSame($ids, $criteria->getIds());
 
         $criteria = new Criteria();
         $criteria->setIds($ids);
-        static::assertEquals($ids, $criteria->getIds());
+        static::assertSame($ids, $criteria->getIds());
     }
 
     /**

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/ContainsFilterTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/ContainsFilterTest.php
@@ -34,10 +34,10 @@ class ContainsFilterTest extends TestCase
         $filter = new ContainsFilter('foo', 'bar');
         $clone = clone $filter;
 
-        static::assertEquals($filter->jsonSerialize(), $clone->jsonSerialize());
-        static::assertEquals($filter->getField(), $clone->getField());
-        static::assertEquals($filter->getFields(), $clone->getFields());
-        static::assertEquals($filter->getValue(), $clone->getValue());
+        static::assertSame($filter->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($filter->getField(), $clone->getField());
+        static::assertSame($filter->getFields(), $clone->getFields());
+        static::assertSame($filter->getValue(), $clone->getValue());
         static::assertNotSame($filter, $clone);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/EqualsAnyFilterTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/EqualsAnyFilterTest.php
@@ -34,10 +34,10 @@ class EqualsAnyFilterTest extends TestCase
         $filter = new EqualsAnyFilter('foo', ['bar']);
         $clone = clone $filter;
 
-        static::assertEquals($filter->jsonSerialize(), $clone->jsonSerialize());
-        static::assertEquals($filter->getField(), $clone->getField());
-        static::assertEquals($filter->getFields(), $clone->getFields());
-        static::assertEquals($filter->getValue(), $clone->getValue());
+        static::assertSame($filter->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($filter->getField(), $clone->getField());
+        static::assertSame($filter->getFields(), $clone->getFields());
+        static::assertSame($filter->getValue(), $clone->getValue());
         static::assertNotSame($filter, $clone);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/EqualsFilterTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/EqualsFilterTest.php
@@ -34,10 +34,10 @@ class EqualsFilterTest extends TestCase
         $filter = new EqualsFilter('foo', 'bar');
         $clone = clone $filter;
 
-        static::assertEquals($filter->jsonSerialize(), $clone->jsonSerialize());
-        static::assertEquals($filter->getField(), $clone->getField());
-        static::assertEquals($filter->getFields(), $clone->getFields());
-        static::assertEquals($filter->getValue(), $clone->getValue());
+        static::assertSame($filter->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($filter->getField(), $clone->getField());
+        static::assertSame($filter->getFields(), $clone->getFields());
+        static::assertSame($filter->getValue(), $clone->getValue());
         static::assertNotSame($filter, $clone);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/PrefixFilterTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/PrefixFilterTest.php
@@ -34,10 +34,10 @@ class PrefixFilterTest extends TestCase
         $filter = new PrefixFilter('foo', 'bar');
         $clone = clone $filter;
 
-        static::assertEquals($filter->jsonSerialize(), $clone->jsonSerialize());
-        static::assertEquals($filter->getField(), $clone->getField());
-        static::assertEquals($filter->getFields(), $clone->getFields());
-        static::assertEquals($filter->getValue(), $clone->getValue());
+        static::assertSame($filter->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($filter->getField(), $clone->getField());
+        static::assertSame($filter->getFields(), $clone->getFields());
+        static::assertSame($filter->getValue(), $clone->getValue());
         static::assertNotSame($filter, $clone);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/RangeFilterTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/RangeFilterTest.php
@@ -43,9 +43,9 @@ class RangeFilterTest extends TestCase
         ]);
         $clone = clone $filter;
 
-        static::assertEquals($filter->jsonSerialize(), $clone->jsonSerialize());
-        static::assertEquals($filter->getField(), $clone->getField());
-        static::assertEquals($filter->getFields(), $clone->getFields());
+        static::assertSame($filter->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($filter->getField(), $clone->getField());
+        static::assertSame($filter->getFields(), $clone->getFields());
         static::assertNotSame($filter, $clone);
     }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/SuffixFilterTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/SuffixFilterTest.php
@@ -34,10 +34,10 @@ class SuffixFilterTest extends TestCase
         $filter = new SuffixFilter('foo', 'bar');
         $clone = clone $filter;
 
-        static::assertEquals($filter->jsonSerialize(), $clone->jsonSerialize());
-        static::assertEquals($filter->getField(), $clone->getField());
-        static::assertEquals($filter->getFields(), $clone->getFields());
-        static::assertEquals($filter->getValue(), $clone->getValue());
+        static::assertSame($filter->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($filter->getField(), $clone->getField());
+        static::assertSame($filter->getFields(), $clone->getFields());
+        static::assertSame($filter->getValue(), $clone->getValue());
         static::assertNotSame($filter, $clone);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Grouping/FieldGroupingTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Grouping/FieldGroupingTest.php
@@ -32,7 +32,7 @@ class FieldGroupingTest extends TestCase
         $clone = clone $fieldGrouping;
 
         static::assertEquals($fieldGrouping, $clone);
-        static::assertEquals($fieldGrouping->getField(), $clone->getField());
-        static::assertEquals($fieldGrouping->jsonSerialize(), $clone->jsonSerialize());
+        static::assertSame($fieldGrouping->getField(), $clone->getField());
+        static::assertSame($fieldGrouping->jsonSerialize(), $clone->jsonSerialize());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
@@ -136,8 +136,8 @@ class RequestCriteriaBuilderTest extends TestCase
         try {
             $this->requestCriteriaBuilder->handleRequest($request, new Criteria(), $this->staticDefinitionRegistry->get(ProductDefinition::class), Context::createDefaultContext());
         } catch (DataAbstractionLayerException $e) {
-            static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-            static::assertEquals('FRAMEWORK__INVALID_API_CRITERIA_IDS', $e->getErrorCode());
+            static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+            static::assertSame('FRAMEWORK__INVALID_API_CRITERIA_IDS', $e->getErrorCode());
             $postExceptionThrown = true;
         }
 
@@ -149,8 +149,8 @@ class RequestCriteriaBuilderTest extends TestCase
         try {
             $this->requestCriteriaBuilder->handleRequest($request, new Criteria(), $this->staticDefinitionRegistry->get(ProductDefinition::class), Context::createDefaultContext());
         } catch (DataAbstractionLayerException $e) {
-            static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-            static::assertEquals('FRAMEWORK__INVALID_API_CRITERIA_IDS', $e->getErrorCode());
+            static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+            static::assertSame('FRAMEWORK__INVALID_API_CRITERIA_IDS', $e->getErrorCode());
             $getExceptionThrown = true;
         }
 
@@ -182,13 +182,13 @@ class RequestCriteriaBuilderTest extends TestCase
         $request->setMethod(Request::METHOD_POST);
 
         $criteria = $this->requestCriteriaBuilder->handleRequest($request, new Criteria(), $this->staticDefinitionRegistry->get(ProductDefinition::class), Context::createDefaultContext());
-        static::assertEquals($expectedIds, $criteria->getIds());
+        static::assertSame($expectedIds, $criteria->getIds());
 
         $request = new Request($body);
         $request->setMethod(Request::METHOD_GET);
 
         $criteria = $this->requestCriteriaBuilder->handleRequest($request, new Criteria(), $this->staticDefinitionRegistry->get(ProductDefinition::class), Context::createDefaultContext());
-        static::assertEquals($expectedIds, $criteria->getIds());
+        static::assertSame($expectedIds, $criteria->getIds());
     }
 
     public function testAssociationsAddedToCriteria(): void
@@ -316,9 +316,9 @@ class RequestCriteriaBuilderTest extends TestCase
         static::assertCount(\count($expectedParsedSortings), $sorting);
         foreach ($expectedParsedSortings as $index => $expectedParsedSorting) {
             static::assertInstanceOf($expectedParsedSorting::class, $sorting[$index]);
-            static::assertEquals($expectedParsedSorting->getField(), $sorting[$index]->getField());
-            static::assertEquals($expectedParsedSorting->getDirection(), $sorting[$index]->getDirection());
-            static::assertEquals($expectedParsedSorting->getNaturalSorting(), $sorting[$index]->getNaturalSorting());
+            static::assertSame($expectedParsedSorting->getField(), $sorting[$index]->getField());
+            static::assertSame($expectedParsedSorting->getDirection(), $sorting[$index]->getDirection());
+            static::assertSame($expectedParsedSorting->getNaturalSorting(), $sorting[$index]->getNaturalSorting());
         }
     }
 
@@ -460,10 +460,10 @@ class RequestCriteriaBuilderTest extends TestCase
             );
         } catch (SearchRequestException $e) {
             $sortException = $e->getErrors()->current();
-            static::assertEquals($expected->getErrorCode(), $sortException['code']);
-            static::assertEquals($expected->getMessage(), $sortException['detail']);
-            static::assertEquals($expected->getStatusCode(), $sortException['status']);
-            static::assertEquals($expected->getParameter('path'), $sortException['source']['pointer']);
+            static::assertSame($expected->getErrorCode(), $sortException['code']);
+            static::assertSame($expected->getMessage(), $sortException['detail']);
+            static::assertSame($expected->getStatusCode(), (int) $sortException['status']);
+            static::assertSame($expected->getParameter('path'), $sortException['source']['pointer']);
 
             $wasThrown = true;
         }
@@ -532,8 +532,8 @@ class RequestCriteriaBuilderTest extends TestCase
         static::assertTrue($criteria->hasAssociation('options'));
         static::assertTrue($criteria->hasAssociation('categories'));
 
-        static::assertEquals(100, $criteria->getLimit());
-        static::assertEquals(101, $criteria->getAssociation('options')->getLimit());
+        static::assertSame(100, $criteria->getLimit());
+        static::assertSame(101, $criteria->getAssociation('options')->getLimit());
         static::assertNull($criteria->getAssociation('prices')->getLimit());
         static::assertNull($criteria->getAssociation('categories')->getLimit());
     }
@@ -677,9 +677,9 @@ class RequestCriteriaBuilderTest extends TestCase
             $this->requestCriteriaBuilder->fromArray($pagingPayload, new Criteria(), $this->staticDefinitionRegistry->get(ProductDefinition::class), Context::createDefaultContext());
         } catch (SearchRequestException $e) {
             $sortException = $e->getErrors()->current();
-            static::assertEquals($expectedExceptionCode, $sortException['code']);
-            static::assertEquals(400, $sortException['status']);
-            static::assertEquals($path, $sortException['source']['pointer']);
+            static::assertSame($expectedExceptionCode, $sortException['code']);
+            static::assertSame('400', $sortException['status']);
+            static::assertSame($path, $sortException['source']['pointer']);
 
             $wasThrown = true;
         }
@@ -741,9 +741,9 @@ class RequestCriteriaBuilderTest extends TestCase
         } catch (SearchRequestException $e) {
             $error = $e->getErrors()->current();
 
-            static::assertEquals('FRAMEWORK__INVALID_FILTER_QUERY', $error['code']);
-            static::assertEquals('The value for filter "name" must be scalar.', $error['detail']);
-            static::assertEquals(400, $error['status']);
+            static::assertSame('FRAMEWORK__INVALID_FILTER_QUERY', $error['code']);
+            static::assertSame('The value for filter "name" must be scalar.', $error['detail']);
+            static::assertSame('400', $error['status']);
 
             throw $e;
         }
@@ -764,9 +764,9 @@ class RequestCriteriaBuilderTest extends TestCase
         } catch (SearchRequestException $e) {
             $error = $e->getErrors()->current();
 
-            static::assertEquals('FRAMEWORK__INVALID_FILTER_QUERY', $error['code']);
-            static::assertEquals('The filter parameter has to be an array.', $error['detail']);
-            static::assertEquals(400, $error['status']);
+            static::assertSame('FRAMEWORK__INVALID_FILTER_QUERY', $error['code']);
+            static::assertSame('The filter parameter has to be an array.', $error['detail']);
+            static::assertSame('400', $error['status']);
 
             throw $e;
         }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSetTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSetTest.php
@@ -56,7 +56,7 @@ final class ChangeSetTest extends TestCase
         $changeSet->merge(new ChangeSet(['bar' => 0], ['bar' => 1], false));
 
         static::assertCount(2, $changeSet->getAfter(null));
-        static::assertEquals(1, $changeSet->getAfter('foo'));
-        static::assertEquals(1, $changeSet->getAfter('bar'));
+        static::assertSame(1, $changeSet->getAfter('foo'));
+        static::assertSame(1, $changeSet->getAfter('bar'));
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Write/FieldException/ExpectedArrayExceptionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Write/FieldException/ExpectedArrayExceptionTest.php
@@ -17,9 +17,9 @@ class ExpectedArrayExceptionTest extends TestCase
     {
         $e = new ExpectedArrayException('some/path/0');
 
-        static::assertEquals('Expected data at some/path/0 to be an array.', $e->getMessage());
-        static::assertEquals('some/path/0', $e->getParameters()['path']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('FRAMEWORK__WRITE_MALFORMED_INPUT', $e->getErrorCode());
+        static::assertSame('Expected data at some/path/0 to be an array.', $e->getMessage());
+        static::assertSame('some/path/0', $e->getParameters()['path']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('FRAMEWORK__WRITE_MALFORMED_INPUT', $e->getErrorCode());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Write/Validation/PostWriteValidationEventTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Write/Validation/PostWriteValidationEventTest.php
@@ -57,7 +57,7 @@ class PostWriteValidationEventTest extends TestCase
         $event = new PostWriteValidationEvent($this->context, $commands);
 
         foreach ($assertions as $entity => $ids) {
-            static::assertEquals($ids, $event->getPrimaryKeys($entity), \sprintf('Primary keys for entity %s not match', $entity));
+            static::assertSame($ids, $event->getPrimaryKeys($entity), \sprintf('Primary keys for entity %s not match', $entity));
         }
     }
 
@@ -73,7 +73,7 @@ class PostWriteValidationEventTest extends TestCase
         $event = new PostWriteValidationEvent($this->context, $commands);
 
         foreach ($assertions as $entity => $ids) {
-            static::assertEquals($ids, $event->getPrimaryKeys($entity), \sprintf('Primary keys for entity %s not match', $entity));
+            static::assertSame($ids, $event->getPrimaryKeys($entity), \sprintf('Primary keys for entity %s not match', $entity));
         }
     }
 
@@ -89,7 +89,7 @@ class PostWriteValidationEventTest extends TestCase
         $event = new PostWriteValidationEvent($this->context, $commands);
 
         foreach ($assertions as $entity => $ids) {
-            static::assertEquals($ids, $event->getDeletedPrimaryKeys($entity), \sprintf('Deleted primary keys for entity %s not match', $entity));
+            static::assertSame($ids, $event->getDeletedPrimaryKeys($entity), \sprintf('Deleted primary keys for entity %s not match', $entity));
         }
     }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Write/Validation/PreWriteValidationEventTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Write/Validation/PreWriteValidationEventTest.php
@@ -57,7 +57,7 @@ class PreWriteValidationEventTest extends TestCase
         $event = new PreWriteValidationEvent($this->context, $commands);
 
         foreach ($assertions as $entity => $ids) {
-            static::assertEquals($ids, $event->getPrimaryKeys($entity), \sprintf('Primary keys for entity %s not match', $entity));
+            static::assertSame($ids, $event->getPrimaryKeys($entity), \sprintf('Primary keys for entity %s not match', $entity));
         }
     }
 
@@ -73,7 +73,7 @@ class PreWriteValidationEventTest extends TestCase
         $event = new PreWriteValidationEvent($this->context, $commands);
 
         foreach ($assertions as $entity => $ids) {
-            static::assertEquals($ids, $event->getPrimaryKeys($entity), \sprintf('Primary keys for entity %s not match', $entity));
+            static::assertSame($ids, $event->getPrimaryKeys($entity), \sprintf('Primary keys for entity %s not match', $entity));
         }
     }
 
@@ -89,7 +89,7 @@ class PreWriteValidationEventTest extends TestCase
         $event = new PreWriteValidationEvent($this->context, $commands);
 
         foreach ($assertions as $entity => $ids) {
-            static::assertEquals($ids, $event->getDeletedPrimaryKeys($entity), \sprintf('Deleted primary keys for entity %s not match', $entity));
+            static::assertSame($ids, $event->getDeletedPrimaryKeys($entity), \sprintf('Deleted primary keys for entity %s not match', $entity));
         }
     }
 

--- a/tests/unit/Core/Framework/Demodata/Event/DemodataRequestCreatedEventTest.php
+++ b/tests/unit/Core/Framework/Demodata/Event/DemodataRequestCreatedEventTest.php
@@ -27,8 +27,8 @@ class DemodataRequestCreatedEventTest extends TestCase
             $input
         );
 
-        static::assertEquals($request, $event->getRequest());
-        static::assertEquals($context, $event->getContext());
-        static::assertEquals($input, $event->getInput());
+        static::assertSame($request, $event->getRequest());
+        static::assertSame($context, $event->getContext());
+        static::assertSame($input, $event->getInput());
     }
 }

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/RateLimiterCompilerPassTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/RateLimiterCompilerPassTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @internal
@@ -48,14 +49,16 @@ class RateLimiterCompilerPassTest extends TestCase
 
     public function testSystemServiceConfigReference(): void
     {
-        static::assertEquals('registerLimiterFactory', $this->rateLimiterDef->getMethodCalls()[0][0]);
+        static::assertSame('registerLimiterFactory', $this->rateLimiterDef->getMethodCalls()[0][0]);
 
         $registerLimiterFactoryCall = $this->rateLimiterDef->getMethodCalls()[0][1];
-        static::assertEquals('cart_add_line_item', $registerLimiterFactoryCall[0]);
+        static::assertSame('cart_add_line_item', $registerLimiterFactoryCall[0]);
 
-        /** @var Definition $rateLimiterDef */
         $rateLimiterDef = $registerLimiterFactoryCall[1];
+        static::assertInstanceOf(Definition::class, $rateLimiterDef);
 
-        static::assertEquals(SystemConfigService::class, $rateLimiterDef->getArgument(2));
+        $reference = $rateLimiterDef->getArgument(2);
+        static::assertInstanceOf(Reference::class, $reference);
+        static::assertSame(SystemConfigService::class, $reference->__toString());
     }
 }

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/RedisPrefixCompilerPassTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/RedisPrefixCompilerPassTest.php
@@ -27,6 +27,6 @@ class RedisPrefixCompilerPassTest extends TestCase
         $pass = new RedisPrefixCompilerPass();
         $pass->process($container);
 
-        static::assertEquals('%shopware.cache.redis_prefix%foo', $definition->getArgument(1));
+        static::assertSame('%shopware.cache.redis_prefix%foo', $definition->getArgument(1));
     }
 }

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/RemoveEventListenerTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/RemoveEventListenerTest.php
@@ -47,7 +47,7 @@ class RemoveEventListenerTest extends TestCase
 
         $current = $definition->getTag('kernel.event_listener');
 
-        static::assertEquals($expected, $current, \print_r($current, true));
+        static::assertSame($expected, $current, \print_r($current, true));
     }
 
     public static function removeProvider(): \Generator

--- a/tests/unit/Core/Framework/Event/EventData/ArrayTypeTest.php
+++ b/tests/unit/Core/Framework/Event/EventData/ArrayTypeTest.php
@@ -22,7 +22,7 @@ class ArrayTypeTest extends TestCase
             ],
         ];
 
-        static::assertEquals(
+        static::assertSame(
             $expected,
             (new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)))
                 ->toArray()

--- a/tests/unit/Core/Framework/Event/EventData/EntityCollectionTypeTest.php
+++ b/tests/unit/Core/Framework/Event/EventData/EntityCollectionTypeTest.php
@@ -20,6 +20,6 @@ class EntityCollectionTypeTest extends TestCase
             'entityClass' => CustomerDefinition::class,
         ];
 
-        static::assertEquals($expected, (new EntityCollectionType(CustomerDefinition::class))->toArray());
+        static::assertSame($expected, (new EntityCollectionType(CustomerDefinition::class))->toArray());
     }
 }

--- a/tests/unit/Core/Framework/Event/EventData/EntityTypeTest.php
+++ b/tests/unit/Core/Framework/Event/EventData/EntityTypeTest.php
@@ -23,7 +23,7 @@ class EntityTypeTest extends TestCase
             'entityName' => 'customer',
         ];
 
-        static::assertEquals($expected, (new EntityType($definition))->toArray());
-        static::assertEquals($expected, (new EntityType(new CustomerDefinition()))->toArray());
+        static::assertSame($expected, (new EntityType($definition))->toArray());
+        static::assertSame($expected, (new EntityType(new CustomerDefinition()))->toArray());
     }
 }

--- a/tests/unit/Core/Framework/Event/EventData/EventDataCollectionTest.php
+++ b/tests/unit/Core/Framework/Event/EventData/EventDataCollectionTest.php
@@ -33,6 +33,6 @@ class EventDataCollectionTest extends TestCase
             ],
         ];
 
-        static::assertEquals($expected, $collection->toArray());
+        static::assertSame($expected, $collection->toArray());
     }
 }

--- a/tests/unit/Core/Framework/Event/EventData/ObjectTypeTest.php
+++ b/tests/unit/Core/Framework/Event/EventData/ObjectTypeTest.php
@@ -27,7 +27,7 @@ class ObjectTypeTest extends TestCase
             ],
         ];
 
-        static::assertEquals(
+        static::assertSame(
             $expected,
             (new ObjectType())
                 ->add('myBool', new ScalarValueType(ScalarValueType::TYPE_BOOL))

--- a/tests/unit/Core/Framework/Event/EventData/ScalarValueTypeTest.php
+++ b/tests/unit/Core/Framework/Event/EventData/ScalarValueTypeTest.php
@@ -18,7 +18,7 @@ class ScalarValueTypeTest extends TestCase
             'type' => 'float',
         ];
 
-        static::assertEquals($expected, (new ScalarValueType(ScalarValueType::TYPE_FLOAT))->toArray());
+        static::assertSame($expected, (new ScalarValueType(ScalarValueType::TYPE_FLOAT))->toArray());
     }
 
     public function testThrowExceptionOnInvalidType(): void

--- a/tests/unit/Core/Framework/Feature/Command/FeatureListCommandTest.php
+++ b/tests/unit/Core/Framework/Feature/Command/FeatureListCommandTest.php
@@ -31,7 +31,7 @@ class FeatureListCommandTest extends TestCase
         $exitCode = $commandTester->execute([]);
 
         static::assertStringContainsString('[INFO] No features are registered', $commandTester->getDisplay());
-        static::assertEquals(Command::SUCCESS, $exitCode);
+        static::assertSame(Command::SUCCESS, $exitCode);
     }
 
     public function testFeatureTable(): void
@@ -72,6 +72,6 @@ class FeatureListCommandTest extends TestCase
         static::assertMatchesRegularExpression('/FEATURE_TWO\s+Feature 2\s+This is another feature\s+Disabled\s+\n/', $display);
         static::assertMatchesRegularExpression('/FEATURE_THREE\s+Feature 3\s+\s+Enabled\s+\n/', $display);
 
-        static::assertEquals(Command::SUCCESS, $exitCode);
+        static::assertSame(Command::SUCCESS, $exitCode);
     }
 }

--- a/tests/unit/Core/Framework/Feature/FeatureFlagRegistryTest.php
+++ b/tests/unit/Core/Framework/Feature/FeatureFlagRegistryTest.php
@@ -515,7 +515,7 @@ class FeatureFlagRegistryTest extends TestCase
 
         $service->register();
 
-        static::assertEquals([
+        static::assertSame([
             'FEATURE_STORED' => [
                 'active' => true,
                 'major' => false,
@@ -546,7 +546,7 @@ class FeatureFlagRegistryTest extends TestCase
 
         $service->register();
 
-        static::assertEquals($expected, Feature::getRegisteredFeatures());
+        static::assertSame($expected, Feature::getRegisteredFeatures());
     }
 
     /**

--- a/tests/unit/Core/Framework/FrameworkTest.php
+++ b/tests/unit/Core/Framework/FrameworkTest.php
@@ -20,7 +20,7 @@ class FrameworkTest extends TestCase
     {
         $framework = new Framework();
 
-        static::assertEquals(-1, $framework->getTemplatePriority());
+        static::assertSame(-1, $framework->getTemplatePriority());
     }
 
     public function testFeatureFlagRegisteredOnBoot(): void

--- a/tests/unit/Core/Framework/Health/SystemCheckerTest.php
+++ b/tests/unit/Core/Framework/Health/SystemCheckerTest.php
@@ -62,7 +62,7 @@ class SystemCheckerTest extends TestCase
 
         $results = $checker->check($context);
         static::assertCount(2, $results);
-        static::assertSame($resultForRunningTest, $results[0]);
+        static::assertEquals($resultForRunningTest, $results[0]);
         static::assertEquals($skippedResult, $results[1]);
     }
 

--- a/tests/unit/Core/Framework/Increment/ArrayIncrementerTest.php
+++ b/tests/unit/Core/Framework/Increment/ArrayIncrementerTest.php
@@ -33,13 +33,13 @@ class ArrayIncrementerTest extends TestCase
         $list = $this->arrayIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertEquals(1, $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
 
         $this->arrayIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->arrayIncrementer->list('test-user-1');
 
-        static::assertEquals(2, $list['sw.product.index']['count']);
+        static::assertSame(2, $list['sw.product.index']['count']);
     }
 
     public function testDecrement(): void
@@ -50,13 +50,13 @@ class ArrayIncrementerTest extends TestCase
         $list = $this->arrayIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertEquals(2, $list['sw.product.index']['count']);
+        static::assertSame(2, $list['sw.product.index']['count']);
 
         $this->arrayIncrementer->decrement('test-user-1', 'sw.product.index');
 
         $list = $this->arrayIncrementer->list('test-user-1');
 
-        static::assertEquals(1, $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
     }
 
     public function testList(): void
@@ -67,9 +67,9 @@ class ArrayIncrementerTest extends TestCase
 
         $list = $this->arrayIncrementer->list('test-user-1');
 
-        static::assertEquals(2, array_values($list)[0]['count']);
-        static::assertEquals('sw.product.index', array_values($list)[0]['key']);
-        static::assertEquals(1, array_values($list)[1]['count']);
+        static::assertSame(2, array_values($list)[0]['count']);
+        static::assertSame('sw.product.index', array_values($list)[0]['key']);
+        static::assertSame(1, array_values($list)[1]['count']);
 
         // List will return in DESC order of record's count
         $this->arrayIncrementer->increment('test-user-1', 'sw.order.index');
@@ -77,9 +77,9 @@ class ArrayIncrementerTest extends TestCase
 
         $list = $this->arrayIncrementer->list('test-user-1');
 
-        static::assertEquals(3, array_values($list)[0]['count']);
-        static::assertEquals('sw.order.index', array_values($list)[0]['key']);
-        static::assertEquals(2, array_values($list)[1]['count']);
+        static::assertSame(3, array_values($list)[0]['count']);
+        static::assertSame('sw.order.index', array_values($list)[0]['key']);
+        static::assertSame(2, array_values($list)[1]['count']);
 
         static::assertEmpty($this->arrayIncrementer->list('test2'));
     }
@@ -97,21 +97,21 @@ class ArrayIncrementerTest extends TestCase
 
         $list = $this->arrayIncrementer->list('test-user-1');
 
-        static::assertEquals(0, $list['sw.product.index']['count']);
+        static::assertSame(0, $list['sw.product.index']['count']);
 
         $this->arrayIncrementer->increment('test-user-1', 'sw.order.index');
         $this->arrayIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->arrayIncrementer->list('test-user-1');
 
-        static::assertEquals(1, $list['sw.product.index']['count']);
-        static::assertEquals(1, $list['sw.order.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.order.index']['count']);
 
         $this->arrayIncrementer->reset('test-user-1', 'sw.order.index');
 
         $list = $this->arrayIncrementer->list('test-user-1');
 
-        static::assertEquals(1, $list['sw.product.index']['count']);
-        static::assertEquals(0, $list['sw.order.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
+        static::assertSame(0, $list['sw.order.index']['count']);
     }
 }

--- a/tests/unit/Core/Framework/Increment/IncrementerGatewayCompilerPassTest.php
+++ b/tests/unit/Core/Framework/Increment/IncrementerGatewayCompilerPassTest.php
@@ -48,20 +48,20 @@ class IncrementerGatewayCompilerPassTest extends TestCase
         // user_activity pool is registered
         static::assertTrue($container->hasDefinition('shopware.increment.user_activity.gateway.mysql'));
         $definition = $container->getDefinition('shopware.increment.user_activity.gateway.mysql');
-        static::assertEquals(MySQLIncrementer::class, $definition->getClass());
+        static::assertSame(MySQLIncrementer::class, $definition->getClass());
         static::assertTrue($definition->hasTag('shopware.increment.gateway'));
 
         // message_queue pool is registered
         static::assertTrue($container->hasDefinition('shopware.increment.message_queue.redis_adapter'));
         static::assertTrue($container->hasDefinition('shopware.increment.message_queue.gateway.redis'));
         $definition = $container->getDefinition('shopware.increment.message_queue.gateway.redis');
-        static::assertEquals(RedisIncrementer::class, $definition->getClass());
+        static::assertSame(RedisIncrementer::class, $definition->getClass());
         static::assertTrue($definition->hasTag('shopware.increment.gateway'));
 
         // another_pool is registered
         static::assertNotNull($container->hasDefinition('shopware.increment.message_queue.gateway.redis'));
         $definition = $container->getDefinition('shopware.increment.message_queue.gateway.redis');
-        static::assertEquals(RedisIncrementer::class, $definition->getClass());
+        static::assertSame(RedisIncrementer::class, $definition->getClass());
         static::assertTrue($definition->hasTag('shopware.increment.gateway'));
     }
 
@@ -105,7 +105,7 @@ class IncrementerGatewayCompilerPassTest extends TestCase
         // custom_pool pool is registered
         static::assertTrue($container->hasDefinition('shopware.increment.custom_pool.gateway.custom_type'));
         $definition = $container->getDefinition('shopware.increment.custom_pool.gateway.custom_type');
-        static::assertEquals($customGateway::class, $definition->getClass());
+        static::assertSame($customGateway::class, $definition->getClass());
         static::assertTrue($definition->hasTag('shopware.increment.gateway'));
     }
 
@@ -131,7 +131,7 @@ class IncrementerGatewayCompilerPassTest extends TestCase
         // custom_pool pool is registered
         static::assertTrue($container->hasDefinition('shopware.increment.custom_pool.gateway.custom_type'));
         $definition = $container->getDefinition('shopware.increment.custom_pool.gateway.custom_type');
-        static::assertEquals($customGateway::class, $definition->getClass());
+        static::assertSame($customGateway::class, $definition->getClass());
         static::assertTrue($definition->hasTag('shopware.increment.gateway'));
     }
 

--- a/tests/unit/Core/Framework/Log/Monolog/DoctrineSQLHandlerTest.php
+++ b/tests/unit/Core/Framework/Log/Monolog/DoctrineSQLHandlerTest.php
@@ -48,7 +48,7 @@ class DoctrineSQLHandlerTest extends TestCase
 
         $this->connection->expects($this->exactly(2))->method('insert')
             ->willReturnCallback(function (string $table, array $data = []) use (&$exceptionThrown, &$insertData): int {
-                static::assertEquals('log_entry', $table);
+                static::assertSame('log_entry', $table);
                 static::assertNotEmpty($data['id']);
                 static::assertNotEmpty($data['created_at']);
                 unset($data['id'], $data['created_at']);
@@ -60,7 +60,7 @@ class DoctrineSQLHandlerTest extends TestCase
                     throw $exceptionThrown;
                 }
 
-                static::assertEquals([
+                static::assertSame([
                     'message' => 'Some message',
                     'level' => 400,
                     'channel' => 'business events',

--- a/tests/unit/Core/Framework/Log/Monolog/ErrorCodeLogLevelHandlerTest.php
+++ b/tests/unit/Core/Framework/Log/Monolog/ErrorCodeLogLevelHandlerTest.php
@@ -31,7 +31,7 @@ class ErrorCodeLogLevelHandlerTest extends TestCase
         $innerHandler->expects($this->once())
             ->method('handle')
             ->willReturnCallback(static function (LogRecord $record) use ($expectedLogLevel): bool {
-                static::assertEquals($expectedLogLevel, $record->level);
+                static::assertSame($expectedLogLevel, $record->level);
 
                 return true;
             });

--- a/tests/unit/Core/Framework/MessageQueue/MessageHandlerCompilerPassTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/MessageHandlerCompilerPassTest.php
@@ -42,7 +42,7 @@ class MessageHandlerCompilerPassTest extends TestCase
 
         foreach ($expectedTagAttributes as $key => $value) {
             static::assertArrayHasKey($key, $tagAttributes);
-            static::assertEquals($value, $tagAttributes[$key]);
+            static::assertSame($value, $tagAttributes[$key]);
         }
     }
 

--- a/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistryTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistryTest.php
@@ -163,10 +163,10 @@ class TaskRegistryTest extends TestCase
             static::assertArrayHasKey('status', $scheduledTaskPayload);
             static::assertArrayHasKey('id', $queueTaskPayload);
             static::assertArrayHasKey('id', $scheduledTaskPayload);
-            static::assertEquals(ScheduledTaskDefinition::STATUS_SKIPPED, $queueTaskPayload['status']);
-            static::assertEquals('queuedTask', $queueTaskPayload['id']);
-            static::assertEquals(ScheduledTaskDefinition::STATUS_SKIPPED, $scheduledTaskPayload['status']);
-            static::assertEquals('scheduledTask', $scheduledTaskPayload['id']);
+            static::assertSame(ScheduledTaskDefinition::STATUS_SKIPPED, $queueTaskPayload['status']);
+            static::assertSame('queuedTask', $queueTaskPayload['id']);
+            static::assertSame(ScheduledTaskDefinition::STATUS_SKIPPED, $scheduledTaskPayload['status']);
+            static::assertSame('scheduledTask', $scheduledTaskPayload['id']);
 
             return new EntityWrittenContainerEvent($context, new NestedEventCollection(), []);
         });
@@ -225,10 +225,10 @@ class TaskRegistryTest extends TestCase
             static::assertArrayHasKey('status', $skippedTaskPayload);
             static::assertArrayHasKey('id', $queueTaskPayload);
             static::assertArrayHasKey('id', $skippedTaskPayload);
-            static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $queueTaskPayload['status']);
-            static::assertEquals('queuedTask', $queueTaskPayload['id']);
-            static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $skippedTaskPayload['status']);
-            static::assertEquals('skippedTask', $skippedTaskPayload['id']);
+            static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $queueTaskPayload['status']);
+            static::assertSame('queuedTask', $queueTaskPayload['id']);
+            static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $skippedTaskPayload['status']);
+            static::assertSame('skippedTask', $skippedTaskPayload['id']);
 
             return new EntityWrittenContainerEvent($context, new NestedEventCollection(), []);
         });
@@ -264,8 +264,8 @@ class TaskRegistryTest extends TestCase
 
             static::assertNotEmpty($data[0]);
 
-            static::assertEquals('cleanupTask', $data[0]['id']);
-            static::assertEquals(CleanupCartTask::getDefaultInterval(), $data[0]['defaultRunInterval']);
+            static::assertSame('cleanupTask', $data[0]['id']);
+            static::assertSame(CleanupCartTask::getDefaultInterval(), $data[0]['defaultRunInterval']);
             static::assertArrayNotHasKey('runInterval', $data[0]);
 
             return new EntityWrittenContainerEvent($context, new NestedEventCollection(), []);
@@ -302,9 +302,9 @@ class TaskRegistryTest extends TestCase
 
             static::assertNotEmpty($data[0]);
 
-            static::assertEquals('cleanupTask', $data[0]['id']);
-            static::assertEquals(CleanupCartTask::getDefaultInterval(), $data[0]['defaultRunInterval']);
-            static::assertEquals(CleanupCartTask::getDefaultInterval(), $data[0]['runInterval']);
+            static::assertSame('cleanupTask', $data[0]['id']);
+            static::assertSame(CleanupCartTask::getDefaultInterval(), $data[0]['defaultRunInterval']);
+            static::assertSame(CleanupCartTask::getDefaultInterval(), $data[0]['runInterval']);
 
             return new EntityWrittenContainerEvent($context, new NestedEventCollection(), []);
         });
@@ -327,6 +327,6 @@ class TaskRegistryTest extends TestCase
         $tasks = (new TaskRegistry([], $repository, new ParameterBag([])))->getAllTasks(Context::createDefaultContext());
 
         static::assertCount(1, $tasks);
-        static::assertEquals($taskEntity, $tasks->first());
+        static::assertSame($taskEntity, $tasks->first());
     }
 }

--- a/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
@@ -92,7 +92,7 @@ class TaskSchedulerTest extends TestCase
             new ParameterBag()
         );
 
-        static::assertEquals(
+        static::assertSame(
             $time,
             $scheduler->getMinRunInterval()
         );
@@ -162,8 +162,8 @@ class TaskSchedulerTest extends TestCase
             static::assertArrayHasKey('id', $data);
             static::assertArrayHasKey('nextExecutionTime', $data);
             static::assertArrayHasKey('status', $data);
-            static::assertEquals('1', $data['id']);
-            static::assertEquals(ScheduledTaskDefinition::STATUS_SKIPPED, $data['status']);
+            static::assertSame('1', $data['id']);
+            static::assertSame(ScheduledTaskDefinition::STATUS_SKIPPED, $data['status']);
 
             return new EntityWrittenContainerEvent($context, new NestedEventCollection(), []);
         });
@@ -207,8 +207,8 @@ class TaskSchedulerTest extends TestCase
                 static::assertArrayHasKey('status', $data);
                 static::assertArrayHasKey('id', $data);
                 $status = $data['status'];
-                static::assertEquals($shouldSchedule ? ScheduledTaskDefinition::STATUS_QUEUED : ScheduledTaskDefinition::STATUS_SKIPPED, $status);
-                static::assertEquals('1', $data['id']);
+                static::assertSame($shouldSchedule ? ScheduledTaskDefinition::STATUS_QUEUED : ScheduledTaskDefinition::STATUS_SKIPPED, $status);
+                static::assertSame('1', $data['id']);
 
                 return new EntityWrittenContainerEvent($context, new NestedEventCollection(), []);
             });

--- a/tests/unit/Core/Framework/MessageQueue/SendEmailMessageJsonSerializerTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/SendEmailMessageJsonSerializerTest.php
@@ -38,7 +38,7 @@ class SendEmailMessageJsonSerializerTest extends TestCase
         $our = $serializer->serialize($sendMail, 'json');
         $their = $withoutSerializer->serialize($sendMail, 'json');
 
-        static::assertNotEquals($our, $their);
+        static::assertNotSame($our, $their);
     }
 
     #[DoesNotPerformAssertions]

--- a/tests/unit/Core/Framework/MessageQueue/Subscriber/PluginLifecycleSubscriberTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Subscriber/PluginLifecycleSubscriberTest.php
@@ -26,11 +26,11 @@ class PluginLifecycleSubscriberTest extends TestCase
 
         static::assertCount(3, $events);
         static::assertArrayHasKey(PluginPostActivateEvent::class, $events);
-        static::assertEquals('afterPluginStateChange', $events[PluginPostActivateEvent::class]);
+        static::assertSame('afterPluginStateChange', $events[PluginPostActivateEvent::class]);
         static::assertArrayHasKey(PluginPostDeactivateEvent::class, $events);
-        static::assertEquals('afterPluginStateChange', $events[PluginPostDeactivateEvent::class]);
+        static::assertSame('afterPluginStateChange', $events[PluginPostDeactivateEvent::class]);
         static::assertArrayHasKey(PluginPostUpdateEvent::class, $events);
-        static::assertEquals('afterPluginStateChange', $events[PluginPostUpdateEvent::class]);
+        static::assertSame('afterPluginStateChange', $events[PluginPostUpdateEvent::class]);
     }
 
     public function testRegisterScheduledTasks(): void

--- a/tests/unit/Core/Framework/MessageQueue/Subscriber/UpdatePostFinishSubscriberTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Subscriber/UpdatePostFinishSubscriberTest.php
@@ -22,7 +22,7 @@ class UpdatePostFinishSubscriberTest extends TestCase
 
         static::assertCount(1, $events);
         static::assertArrayHasKey(UpdatePostFinishEvent::class, $events);
-        static::assertEquals('updatePostFinishEvent', $events[UpdatePostFinishEvent::class]);
+        static::assertSame('updatePostFinishEvent', $events[UpdatePostFinishEvent::class]);
     }
 
     public function testUpdatePostFinishEvent(): void

--- a/tests/unit/Core/Framework/Notification/NotificationServiceTest.php
+++ b/tests/unit/Core/Framework/Notification/NotificationServiceTest.php
@@ -114,7 +114,7 @@ class NotificationServiceTest extends TestCase
 
         $notifications = $this->notificationService->getNotifications($context, 0, '1718179529');
 
-        static::assertEquals([
+        static::assertSame([
             'notifications' => $notificationCollection,
             'timestamp' => '2024-06-13 00:00:00.000',
         ], $notifications);

--- a/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
@@ -52,7 +52,7 @@ class MakerCommandTest extends TestCase
         $tester->setInputs(['ExamplePlugin']);
         $res = $tester->execute([]);
 
-        static::assertEquals(Command::SUCCESS, $res);
+        static::assertSame(Command::SUCCESS, $res);
     }
 
     public function testExecuteWithNoNameErrors(): void
@@ -69,7 +69,7 @@ class MakerCommandTest extends TestCase
         $tester = new CommandTester($command);
         $res = $tester->execute([], ['interactive' => false]);
 
-        static::assertEquals(Command::FAILURE, $res);
+        static::assertSame(Command::FAILURE, $res);
         static::assertStringContainsString('Plugin name is required', $tester->getDisplay());
     }
 
@@ -92,7 +92,7 @@ class MakerCommandTest extends TestCase
         $tester->setInputs(['ExamplePlugin']);
         $res = $tester->execute([]);
 
-        static::assertEquals(Command::FAILURE, $res);
+        static::assertSame(Command::FAILURE, $res);
         static::assertStringContainsString('Plugin base path is null', $tester->getDisplay());
     }
 

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/AdminModuleGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/AdminModuleGeneratorTest.php
@@ -43,7 +43,7 @@ class AdminModuleGeneratorTest extends TestCase
         (new AdminModuleGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(AdminModuleGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(AdminModuleGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CommandGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CommandGeneratorTest.php
@@ -43,7 +43,7 @@ class CommandGeneratorTest extends TestCase
         (new CommandGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(CommandGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(CommandGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CustomFieldsetGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CustomFieldsetGeneratorTest.php
@@ -43,7 +43,7 @@ class CustomFieldsetGeneratorTest extends TestCase
         (new CustomFieldsetGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(CustomFieldsetGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(CustomFieldsetGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/EntityGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/EntityGeneratorTest.php
@@ -51,8 +51,8 @@ class EntityGeneratorTest extends TestCase
         (new EntityGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(EntityGenerator::OPTION_NAME));
-        static::assertEquals($expectedEntities, $configuration->getOption(EntityGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(EntityGenerator::OPTION_NAME));
+        static::assertSame($expectedEntities, $configuration->getOption(EntityGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/EventSubscriberGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/EventSubscriberGeneratorTest.php
@@ -43,7 +43,7 @@ class EventSubscriberGeneratorTest extends TestCase
         (new EventSubscriberGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(EventSubscriberGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(EventSubscriberGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/JavascriptPluginGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/JavascriptPluginGeneratorTest.php
@@ -43,7 +43,7 @@ class JavascriptPluginGeneratorTest extends TestCase
         (new JavascriptPluginGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(JavascriptPluginGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(JavascriptPluginGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/ScheduledTaskGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/ScheduledTaskGeneratorTest.php
@@ -43,7 +43,7 @@ class ScheduledTaskGeneratorTest extends TestCase
         (new ScheduledTaskGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(ScheduledTaskGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(ScheduledTaskGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGeneratorTest.php
@@ -43,7 +43,7 @@ class StoreApiRouteGeneratorTest extends TestCase
         (new StoreApiRouteGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(StoreApiRouteGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(StoreApiRouteGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGeneratorTest.php
@@ -43,7 +43,7 @@ class StorefrontControllerGeneratorTest extends TestCase
         (new StorefrontControllerGenerator())
             ->addScaffoldConfig($configuration, $input, $io);
 
-        static::assertEquals($expectedHasOption, $configuration->hasOption(StorefrontControllerGenerator::OPTION_NAME));
+        static::assertSame($expectedHasOption, $configuration->hasOption(StorefrontControllerGenerator::OPTION_NAME));
     }
 
     public static function addScaffoldConfigProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/PluginScaffoldConfigurationTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/PluginScaffoldConfigurationTest.php
@@ -23,8 +23,8 @@ class PluginScaffoldConfigurationTest extends TestCase
         static::assertTrue($config->hasOption('option1'));
         static::assertTrue($config->hasOption('option2'));
         static::assertFalse($config->hasOption('option3'));
-        static::assertEquals('value1', $config->getOption('option1'));
-        static::assertEquals('value2', $config->getOption('option2'));
+        static::assertSame('value1', $config->getOption('option1'));
+        static::assertSame('value2', $config->getOption('option2'));
         static::assertNull($config->getOption('option3'));
     }
 
@@ -44,7 +44,7 @@ class PluginScaffoldConfigurationTest extends TestCase
 
         $config->addOption('option1', 'value1');
 
-        static::assertEquals('value1', $config->getOption('option1'));
+        static::assertSame('value1', $config->getOption('option1'));
         static::assertNull($config->getOption('option2'));
     }
 }

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/StubCollectionTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/StubCollectionTest.php
@@ -23,8 +23,8 @@ class StubCollectionTest extends TestCase
         $collection = new StubCollection($stubs);
 
         static::assertCount(2, $collection);
-        static::assertEquals($stubs[0], $collection->get('/path/to/stub1'));
-        static::assertEquals($stubs[1], $collection->get('/path/to/stub2'));
+        static::assertSame($stubs[0], $collection->get('/path/to/stub1'));
+        static::assertSame($stubs[1], $collection->get('/path/to/stub2'));
     }
 
     public function testAdd(): void
@@ -36,7 +36,7 @@ class StubCollectionTest extends TestCase
         $collection->add($stub);
 
         static::assertCount(1, $collection);
-        static::assertEquals($stub, $collection->get('/path/to/stub'));
+        static::assertSame($stub, $collection->get('/path/to/stub'));
     }
 
     public function testAppendNewStub(): void
@@ -49,8 +49,8 @@ class StubCollectionTest extends TestCase
 
         static::assertCount(1, $collection);
         static::assertInstanceOf(Stub::class, $collection->get('/path/to/stub'));
-        static::assertEquals($path, $collection->get('/path/to/stub')->getPath());
-        static::assertEquals($content, $collection->get('/path/to/stub')->getContent());
+        static::assertSame($path, $collection->get('/path/to/stub')->getPath());
+        static::assertSame($content, $collection->get('/path/to/stub')->getContent());
     }
 
     public function testAppendExistingStub(): void
@@ -65,7 +65,7 @@ class StubCollectionTest extends TestCase
 
         static::assertCount(1, $collection);
         static::assertInstanceOf(Stub::class, $collection->get('/path/to/stub'));
-        static::assertEquals($path, $collection->get('/path/to/stub')->getPath());
-        static::assertEquals($initialContent . $appendedContent, $collection->get('/path/to/stub')->getContent());
+        static::assertSame($path, $collection->get('/path/to/stub')->getPath());
+        static::assertSame($initialContent . $appendedContent, $collection->get('/path/to/stub')->getContent());
     }
 }

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/StubTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/StubTest.php
@@ -20,8 +20,8 @@ class StubTest extends TestCase
 
         $stub = Stub::template($destinationPath, $sourcePath);
 
-        static::assertEquals($destinationPath, $stub->getPath());
-        static::assertEquals(file_get_contents(__DIR__ . '/test-with-params.stub'), $stub->getContent());
+        static::assertSame($destinationPath, $stub->getPath());
+        static::assertSame(file_get_contents(__DIR__ . '/test-with-params.stub'), $stub->getContent());
     }
 
     public function testRawConstructor(): void
@@ -31,8 +31,8 @@ class StubTest extends TestCase
 
         $stub = Stub::raw($destinationPath, $content);
 
-        static::assertEquals($destinationPath, $stub->getPath());
-        static::assertEquals($content, $stub->getContent());
+        static::assertSame($destinationPath, $stub->getPath());
+        static::assertSame($content, $stub->getContent());
     }
 
     /**
@@ -43,7 +43,7 @@ class StubTest extends TestCase
     {
         $stub = new Stub('/path/to/destination', $content, $type, $params);
 
-        static::assertEquals($expectedContent, $stub->getContent());
+        static::assertSame($expectedContent, $stub->getContent());
     }
 
     public static function contentProvider(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Event/PluginPostDeactivationFailedEventTest.php
+++ b/tests/unit/Core/Framework/Plugin/Event/PluginPostDeactivationFailedEventTest.php
@@ -23,7 +23,7 @@ class PluginPostDeactivationFailedEventTest extends TestCase
             $activateContext,
             $exception
         );
-        static::assertEquals($activateContext, $event->getContext());
-        static::assertEquals($exception, $event->getException());
+        static::assertSame($activateContext, $event->getContext());
+        static::assertSame($exception, $event->getException());
     }
 }

--- a/tests/unit/Core/Framework/Plugin/Exception/RequirementStackExceptionTest.php
+++ b/tests/unit/Core/Framework/Plugin/Exception/RequirementStackExceptionTest.php
@@ -39,9 +39,9 @@ class RequirementStackExceptionTest extends TestCase
 
         static::assertCount(2, $converted);
 
-        static::assertEquals('424', $converted[0]['status']);
-        static::assertEquals('FRAMEWORK__PLUGIN_REQUIREMENT_MISSING', $converted[0]['code']);
+        static::assertSame('424', $converted[0]['status']);
+        static::assertSame('FRAMEWORK__PLUGIN_REQUIREMENT_MISSING', $converted[0]['code']);
 
-        static::assertEquals($convertedVersionMismatch, $converted[1]);
+        static::assertSame($convertedVersionMismatch, $converted[1]);
     }
 }

--- a/tests/unit/Core/Framework/Plugin/PluginTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginTest.php
@@ -38,27 +38,27 @@ class PluginTest extends TestCase
     {
         $plugin = new SwagTestPlugin(true, self::$swagTestPluginPath);
 
-        static::assertEquals(self::$swagTestPluginPath . '/src', $plugin->getPath());
+        static::assertSame(self::$swagTestPluginPath . '/src', $plugin->getPath());
     }
 
     public function testGetPathWithSymlinkedPlugin(): void
     {
         $plugin = new SwagTestPlugin(true, self::$symlinkedSwagTestPluginPath);
 
-        static::assertEquals(self::$symlinkedSwagTestPluginPath . '/src', $plugin->getPath());
+        static::assertSame(self::$symlinkedSwagTestPluginPath . '/src', $plugin->getPath());
     }
 
     public function testGetBasePath(): void
     {
         $plugin = new SwagTestPlugin(true, self::$symlinkedSwagTestPluginPath);
 
-        static::assertEquals(self::$symlinkedSwagTestPluginPath, $plugin->getBasePath());
+        static::assertSame(self::$symlinkedSwagTestPluginPath, $plugin->getBasePath());
     }
 
     public function testGetBasePathIncludingSlash(): void
     {
         $plugin = new SwagTestPlugin(true, 'somePlugin', '/www/');
 
-        static::assertEquals('/www/somePlugin', $plugin->getBasePath());
+        static::assertSame('/www/somePlugin', $plugin->getBasePath());
     }
 }

--- a/tests/unit/Core/Framework/Plugin/PluginZipDetectorTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginZipDetectorTest.php
@@ -58,7 +58,7 @@ class PluginZipDetectorTest extends TestCase
     #[DataProvider('archiveProvider')]
     public function testDetect(string $archiveName, string $expectedType): void
     {
-        static::assertEquals(
+        static::assertSame(
             $expectedType,
             $this->zipDetector->detect($this->fixturePath . $archiveName),
         );

--- a/tests/unit/Core/Framework/Plugin/Util/PluginFinderTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/PluginFinderTest.php
@@ -60,9 +60,9 @@ class PluginFinderTest extends TestCase
         static::assertInstanceOf(PluginFromFileSystemStruct::class, $plugins['Swag\Test']);
         static::assertTrue($plugins['Swag\Test']->getManagedByComposer());
         // path is still local if it exists
-        static::assertEquals(__DIR__ . '/_fixture/LocallyInstalledPlugins/SwagTest', $plugins['Swag\Test']->getPath());
+        static::assertSame(__DIR__ . '/_fixture/LocallyInstalledPlugins/SwagTest', $plugins['Swag\Test']->getPath());
         // version info is still from local, as that might be more up to date
-        static::assertEquals('v1.0.2', $plugins['Swag\Test']->getComposerPackage()->getPrettyVersion());
+        static::assertSame('v1.0.2', $plugins['Swag\Test']->getComposerPackage()->getPrettyVersion());
     }
 
     public function testComposerPackageFromPluginIsUsedIfNoLocalInstalledVersionExists(): void
@@ -77,8 +77,8 @@ class PluginFinderTest extends TestCase
         static::assertInstanceOf(PluginFromFileSystemStruct::class, $plugins['Swag\Test2']);
         static::assertTrue($plugins['Swag\Test2']->getManagedByComposer());
         // path is still local if it exists
-        static::assertEquals(__DIR__ . '/_fixture/ComposerProject/vendor/swag/test2', $plugins['Swag\Test2']->getPath());
+        static::assertSame(__DIR__ . '/_fixture/ComposerProject/vendor/swag/test2', $plugins['Swag\Test2']->getPath());
         // version info is still from local, as that might be more up to date
-        static::assertEquals('v2.0.1', $plugins['Swag\Test2']->getComposerPackage()->getPrettyVersion());
+        static::assertSame('v2.0.1', $plugins['Swag\Test2']->getComposerPackage()->getPrettyVersion());
     }
 }

--- a/tests/unit/Core/Framework/Routing/CanonicalRedirectServiceTest.php
+++ b/tests/unit/Core/Framework/Routing/CanonicalRedirectServiceTest.php
@@ -36,11 +36,11 @@ class CanonicalRedirectServiceTest extends TestCase
                 RedirectResponse::class,
                 $actual
             );
-            static::assertEquals(
+            static::assertSame(
                 $request->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK),
                 $actual->getTargetUrl()
             );
-            static::assertEquals(
+            static::assertSame(
                 Response::HTTP_MOVED_PERMANENTLY,
                 $actual->getStatusCode()
             );

--- a/tests/unit/Core/Framework/Routing/Event/MaintenanceModeRequestEventTest.php
+++ b/tests/unit/Core/Framework/Routing/Event/MaintenanceModeRequestEventTest.php
@@ -40,7 +40,7 @@ class MaintenanceModeRequestEventTest extends TestCase
             true
         );
 
-        static::assertEquals(['192.168.0.1'], $event->getAllowedIps());
+        static::assertSame(['192.168.0.1'], $event->getAllowedIps());
     }
 
     public function testGetRequest(): void

--- a/tests/unit/Core/Framework/Rule/Container/DaysSinceRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/Container/DaysSinceRuleTest.php
@@ -46,12 +46,12 @@ class DaysSinceRuleTest extends TestCase
         $operators = RuleConfig::OPERATOR_SET_NUMBER;
         $operators[] = Rule::OPERATOR_EMPTY;
 
-        static::assertEquals([
+        static::assertSame([
             'operators' => $operators,
             'isMatchAny' => false,
         ], $config['operatorSet']);
 
-        static::assertEquals([
+        static::assertSame([
             'name' => 'daysPassed',
             'type' => 'float',
             'config' => [

--- a/tests/unit/Core/Framework/Rule/RuleConfigTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleConfigTest.php
@@ -32,8 +32,8 @@ class RuleConfigTest extends TestCase
         $field = $ruleConfig->getField('foo');
 
         static::assertNotNull($field);
-        static::assertEquals('foo', $field['name']);
-        static::assertEquals('int', $field['type']);
+        static::assertSame('foo', $field['name']);
+        static::assertSame('int', $field['type']);
     }
 
     public function testFieldIsOverwritten(): void
@@ -46,8 +46,8 @@ class RuleConfigTest extends TestCase
         $field = $ruleConfig->getField('foo');
 
         static::assertNotNull($field);
-        static::assertEquals('foo', $field['name']);
-        static::assertEquals('string', $field['type']);
+        static::assertSame('foo', $field['name']);
+        static::assertSame('string', $field['type']);
     }
 
     public function testNumberFieldDefaultDigits(): void
@@ -59,9 +59,9 @@ class RuleConfigTest extends TestCase
         $field = $ruleConfig->getField('foo');
 
         static::assertNotNull($field);
-        static::assertEquals('foo', $field['name']);
-        static::assertEquals('float', $field['type']);
-        static::assertEquals(RuleConfig::DEFAULT_DIGITS, $field['config']['digits']);
+        static::assertSame('foo', $field['name']);
+        static::assertSame('float', $field['type']);
+        static::assertSame(RuleConfig::DEFAULT_DIGITS, $field['config']['digits']);
     }
 
     public function testNotOverrideNumberFieldDigits(): void
@@ -75,9 +75,9 @@ class RuleConfigTest extends TestCase
         $field = $ruleConfig->getField('foo');
 
         static::assertNotNull($field);
-        static::assertEquals('foo', $field['name']);
-        static::assertEquals('float', $field['type']);
-        static::assertEquals(5, $field['config']['digits']);
+        static::assertSame('foo', $field['name']);
+        static::assertSame('float', $field['type']);
+        static::assertSame(5, $field['config']['digits']);
     }
 
     public function testDateFieldConfig(): void
@@ -91,9 +91,9 @@ class RuleConfigTest extends TestCase
         $field = $ruleConfig->getField('foo');
 
         static::assertNotNull($field);
-        static::assertEquals('foo', $field['name']);
-        static::assertEquals('date', $field['type']);
-        static::assertEquals('bar', $field['config']['someConfig']);
+        static::assertSame('foo', $field['name']);
+        static::assertSame('date', $field['type']);
+        static::assertSame('bar', $field['config']['someConfig']);
     }
 
     public function testDateTimeFieldConfig(): void
@@ -107,8 +107,8 @@ class RuleConfigTest extends TestCase
         $field = $ruleConfig->getField('foo');
 
         static::assertNotNull($field);
-        static::assertEquals('foo', $field['name']);
-        static::assertEquals('datetime', $field['type']);
-        static::assertEquals('bar', $field['config']['someConfig']);
+        static::assertSame('foo', $field['name']);
+        static::assertSame('datetime', $field['type']);
+        static::assertSame('bar', $field['config']['someConfig']);
     }
 }

--- a/tests/unit/Core/Framework/Script/Service/ArrayFacadeTest.php
+++ b/tests/unit/Core/Framework/Script/Service/ArrayFacadeTest.php
@@ -70,6 +70,6 @@ class ArrayFacadeTest extends TestCase
         $a = new ArrayFacade($aArray);
         $a->replace(['foo' => 'baz']);
 
-        static::assertEquals('baz', $a['foo']);
+        static::assertSame('baz', $a['foo']);
     }
 }

--- a/tests/unit/Core/Framework/Serializer/StructNormalizerTest.php
+++ b/tests/unit/Core/Framework/Serializer/StructNormalizerTest.php
@@ -44,7 +44,7 @@ class StructNormalizerTest extends TestCase
             'foo' => 'bar',
         ];
 
-        static::assertEquals(
+        static::assertSame(
             $expected,
             $this->normalizer->normalize($struct)
         );
@@ -61,7 +61,7 @@ class StructNormalizerTest extends TestCase
             ['extensions' => [], 'foo' => 'bar'],
         ];
 
-        static::assertEquals(
+        static::assertSame(
             $expected,
             $this->normalizer->normalize($collection)
         );
@@ -112,7 +112,7 @@ class StructNormalizerTest extends TestCase
     #[DataProvider('denormalizeShouldReturnNonArraysProvider')]
     public function testDenormalizeShouldReturnNonArrays(mixed $input): void
     {
-        static::assertEquals($input, $this->normalizer->denormalize($input));
+        static::assertSame($input, $this->normalizer->denormalize($input));
     }
 
     public function testDenormalizeShouldThrowIfNonStructGiven(): void

--- a/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
+++ b/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
@@ -140,7 +140,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $response = $controller->uploadExtensions($request, Context::createDefaultContext());
 
-        static::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
     }
 
     public function testUploadExtensionsShallThrowExceptionIfPathToFileIsEmpty(): void
@@ -178,7 +178,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $downloader->expects($this->once())->method('download');
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_NO_CONTENT,
             $controller->downloadExtension('test', Context::createDefaultContext())->getStatusCode()
         );
@@ -198,7 +198,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $lifecycle->expects($this->once())->method('install');
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_NO_CONTENT,
             $controller->installExtension('plugin', 'test', Context::createDefaultContext())->getStatusCode()
         );
@@ -218,7 +218,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $lifecycle->expects($this->once())->method('uninstall');
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_NO_CONTENT,
             $controller->uninstallExtension('plugin', 'test', new Request(), Context::createDefaultContext())->getStatusCode()
         );
@@ -238,7 +238,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $lifecycle->expects($this->once())->method('remove');
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_NO_CONTENT,
             $controller->removeExtension('plugin', 'test', new Request(), Context::createDefaultContext())->getStatusCode()
         );
@@ -258,7 +258,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $lifecycle->expects($this->once())->method('activate');
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_NO_CONTENT,
             $controller->activateExtension('plugin', 'test', Context::createDefaultContext())->getStatusCode()
         );
@@ -278,7 +278,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $lifecycle->expects($this->once())->method('deactivate');
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_NO_CONTENT,
             $controller->deactivateExtension('plugin', 'test', Context::createDefaultContext())->getStatusCode()
         );
@@ -300,7 +300,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $request = new Request([], ['allowNewPermissions' => true]);
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_NO_CONTENT,
             $controller->updateExtension($request, 'plugin', 'test', Context::createDefaultContext())->getStatusCode()
         );
@@ -322,7 +322,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         $request = new Request([], ['allowNewPermissions' => false]);
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_NO_CONTENT,
             $controller->updateExtension($request, 'plugin', 'test', Context::createDefaultContext())->getStatusCode()
         );
@@ -345,25 +345,25 @@ class ExtensionStoreActionsControllerTest extends TestCase
         try {
             $controller->deactivateExtension('plugin', 'test', $context);
         } catch (StoreException $e) {
-            static::assertEquals(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
+            static::assertSame(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
         }
 
         try {
             $controller->activateExtension('plugin', 'test', $context);
         } catch (StoreException $e) {
-            static::assertEquals(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
+            static::assertSame(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
         }
 
         try {
             $controller->removeExtension('plugin', 'test', new Request(), $context);
         } catch (StoreException $e) {
-            static::assertEquals(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
+            static::assertSame(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
         }
 
         try {
             $controller->installExtension('plugin', 'test', $context);
         } catch (StoreException $e) {
-            static::assertEquals(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
+            static::assertSame(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
         }
     }
 

--- a/tests/unit/Core/Framework/Store/Api/FirstRunWizardControllerTest.php
+++ b/tests/unit/Core/Framework/Store/Api/FirstRunWizardControllerTest.php
@@ -584,7 +584,7 @@ class FirstRunWizardControllerTest extends TestCase
 
         $response = $frwController->frwFinish(new QueryDataBag(['failed' => 'true']), $this->createContext());
 
-        static::assertEquals(SymfonyResponse::HTTP_OK, $response->getStatusCode());
+        static::assertSame(SymfonyResponse::HTTP_OK, $response->getStatusCode());
     }
 
     public function testFinishFrwWithoutFailedParam(): void
@@ -602,7 +602,7 @@ class FirstRunWizardControllerTest extends TestCase
 
         $response = $frwController->frwFinish(new QueryDataBag([]), $this->createContext());
 
-        static::assertEquals(SymfonyResponse::HTTP_OK, $response->getStatusCode());
+        static::assertSame(SymfonyResponse::HTTP_OK, $response->getStatusCode());
     }
 
     public function testFinishFrwButUpgradingAccessTokenFails(): void
@@ -622,7 +622,7 @@ class FirstRunWizardControllerTest extends TestCase
 
         $response = $frwController->frwFinish(new QueryDataBag(['failed' => 'false']), $this->createContext());
 
-        static::assertEquals(SymfonyResponse::HTTP_OK, $response->getStatusCode());
+        static::assertSame(SymfonyResponse::HTTP_OK, $response->getStatusCode());
     }
 
     private function decodeJsonResponse(JsonResponse $response): mixed

--- a/tests/unit/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
+++ b/tests/unit/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
@@ -55,7 +55,7 @@ class FrwRequestOptionsProviderTest extends TestCase
             $userConfigRepositoryMock
         );
 
-        static::assertEquals([
+        static::assertSame([
             'X-Shopware-Token' => 'frw-user-token',
         ], $frwRequestOptionsProvider->getAuthenticationHeader($context));
     }
@@ -89,7 +89,7 @@ class FrwRequestOptionsProviderTest extends TestCase
             $userConfigRepositoryMock
         );
 
-        static::assertEquals([], $frwRequestOptionsProvider->getAuthenticationHeader($context));
+        static::assertSame([], $frwRequestOptionsProvider->getAuthenticationHeader($context));
     }
 
     public function testGetAuthenticationHeaderReturnsEmptyArrayIfUserConfigCanNotBeFound(): void
@@ -117,7 +117,7 @@ class FrwRequestOptionsProviderTest extends TestCase
             $userConfigRepositoryMock
         );
 
-        static::assertEquals([], $frwRequestOptionsProvider->getAuthenticationHeader($context));
+        static::assertSame([], $frwRequestOptionsProvider->getAuthenticationHeader($context));
     }
 
     public function testGetAuthenticationHeaderThrowsIfContextIsNoAdminApiSource(): void
@@ -160,7 +160,7 @@ class FrwRequestOptionsProviderTest extends TestCase
 
         $queries = $frwRequestOptionsProvider->getDefaultQueryParameters($context);
 
-        static::assertEquals([
+        static::assertSame([
             'queries' => 'some-queries',
         ], $queries);
     }

--- a/tests/unit/Core/Framework/Store/Authentication/LocaleProviderTest.php
+++ b/tests/unit/Core/Framework/Store/Authentication/LocaleProviderTest.php
@@ -28,14 +28,14 @@ class LocaleProviderTest extends TestCase
     {
         $provider = new LocaleProvider(static::createMock(EntityRepository::class));
 
-        static::assertEquals('en-GB', $provider->getLocaleFromContext(Context::createDefaultContext()));
+        static::assertSame('en-GB', $provider->getLocaleFromContext(Context::createDefaultContext()));
     }
 
     public function testGetLocaleFromContextReturnsEnGbIfNoUserIsAssociated(): void
     {
         $provider = new LocaleProvider(static::createMock(EntityRepository::class));
 
-        static::assertEquals(
+        static::assertSame(
             'en-GB',
             $provider->getLocaleFromContext(Context::createDefaultContext(
                 new AdminApiSource(null, 'i-am-an-integration')
@@ -68,7 +68,7 @@ class LocaleProviderTest extends TestCase
 
         $provider = new LocaleProvider($userRepository);
 
-        static::assertEquals('user-locale', $provider->getLocaleFromContext($context));
+        static::assertSame('user-locale', $provider->getLocaleFromContext($context));
     }
 
     public function testGetLocaleFromContextThrowsIfAssociatedUserCanNotBeFound(): void

--- a/tests/unit/Core/Framework/Store/Authentication/StoreRequestOptionsProviderTest.php
+++ b/tests/unit/Core/Framework/Store/Authentication/StoreRequestOptionsProviderTest.php
@@ -51,7 +51,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         );
 
         static::assertArrayHasKey('X-Shopware-Shop-Secret', $authHeaders);
-        static::assertEquals('store-secret', $authHeaders['X-Shopware-Shop-Secret']);
+        static::assertSame('store-secret', $authHeaders['X-Shopware-Shop-Secret']);
     }
 
     public function testGetAuthenticationHeaderDoesNotContainsShopSecretIfNotExists(): void
@@ -96,7 +96,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         );
 
         static::assertArrayHasKey('X-Shopware-Platform-Token', $authHeaders);
-        static::assertEquals('sbp-token', $authHeaders['X-Shopware-Platform-Token']);
+        static::assertSame('sbp-token', $authHeaders['X-Shopware-Platform-Token']);
     }
 
     public function testGetAuthenticationHeaderThrowsIfUserIdIsMissingInAdminApiSource(): void
@@ -151,7 +151,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         );
 
         static::assertArrayHasKey('X-Shopware-Platform-Token', $authHeaders);
-        static::assertEquals('sbp-token', $authHeaders['X-Shopware-Platform-Token']);
+        static::assertSame('sbp-token', $authHeaders['X-Shopware-Platform-Token']);
     }
 
     public function testGetAuthenticationHeaderReturnsNullIfNoUserHasATokenSet(): void
@@ -203,10 +203,10 @@ class StoreRequestOptionsProviderTest extends TestCase
         $queries = $provider->getDefaultQueryParameters(Context::createDefaultContext());
 
         static::assertArrayHasKey('domain', $queries);
-        static::assertEquals('domain.shopware.store', $queries['domain']);
+        static::assertSame('domain.shopware.store', $queries['domain']);
 
         static::assertArrayHasKey('shopwareVersion', $queries);
-        static::assertEquals('sw-version', $queries['shopwareVersion']);
+        static::assertSame('sw-version', $queries['shopwareVersion']);
     }
 
     public function testGetDefaultQueryParametersDelegatesToLocaleProvider(): void
@@ -229,7 +229,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         $queries = $provider->getDefaultQueryParameters($context);
 
         static::assertArrayHasKey('language', $queries);
-        static::assertEquals('locale-from-provider', $queries['language']);
+        static::assertSame('locale-from-provider', $queries['language']);
     }
 
     private function configureUserRepositorySearchMock(

--- a/tests/unit/Core/Framework/Store/Search/ExtensionCriteriaTest.php
+++ b/tests/unit/Core/Framework/Store/Search/ExtensionCriteriaTest.php
@@ -21,16 +21,16 @@ class ExtensionCriteriaTest extends TestCase
             'page' => 1,
         ]);
 
-        static::assertEquals(25, $extensionCriteria->getLimit());
-        static::assertEquals(0, $extensionCriteria->getOffset());
+        static::assertSame(25, $extensionCriteria->getLimit());
+        static::assertSame(0, $extensionCriteria->getOffset());
 
         $extensionCriteria = ExtensionCriteria::fromArray([
             'limit' => 10,
             'page' => 5,
         ]);
 
-        static::assertEquals(10, $extensionCriteria->getLimit());
-        static::assertEquals(40, $extensionCriteria->getOffset());
+        static::assertSame(10, $extensionCriteria->getLimit());
+        static::assertSame(40, $extensionCriteria->getOffset());
     }
 
     public function testItIgnoresInvalidValuesForSortDirection(): void
@@ -39,7 +39,7 @@ class ExtensionCriteriaTest extends TestCase
 
         $extensionCriteria->setOrderSequence('random');
 
-        static::assertEquals(ExtensionCriteria::ORDER_SEQUENCE_ASC, $extensionCriteria->getOrderSequence());
+        static::assertSame(ExtensionCriteria::ORDER_SEQUENCE_ASC, $extensionCriteria->getOrderSequence());
     }
 
     public function testOrderSequenceDesc(): void
@@ -48,7 +48,7 @@ class ExtensionCriteriaTest extends TestCase
 
         $extensionCriteria->setOrderSequence('DesC');
 
-        static::assertEquals(ExtensionCriteria::ORDER_SEQUENCE_DESC, $extensionCriteria->getOrderSequence());
+        static::assertSame(ExtensionCriteria::ORDER_SEQUENCE_DESC, $extensionCriteria->getOrderSequence());
     }
 
     public function testGetQueryOptionsWithMandatory(): void
@@ -58,7 +58,7 @@ class ExtensionCriteriaTest extends TestCase
             'page' => 2,
         ]);
 
-        static::assertEquals([
+        static::assertSame([
             'limit' => 25,
             'offset' => 25,
         ], $criteria->getQueryParameter());
@@ -112,9 +112,9 @@ class ExtensionCriteriaTest extends TestCase
 
         $extensionCriteria->setOrderBy('rating');
 
-        static::assertEquals('rating', $extensionCriteria->getQueryParameter()['orderBy']);
-        static::assertEquals('rating', $extensionCriteria->getOrderBy());
-        static::assertEquals(
+        static::assertSame('rating', $extensionCriteria->getQueryParameter()['orderBy']);
+        static::assertSame('rating', $extensionCriteria->getOrderBy());
+        static::assertSame(
             ExtensionCriteria::ORDER_SEQUENCE_ASC,
             $extensionCriteria->getQueryParameter()['orderSequence']
         );
@@ -126,8 +126,8 @@ class ExtensionCriteriaTest extends TestCase
         static::assertArrayNotHasKey('search', $extensionCriteria->getQueryParameter());
 
         $extensionCriteria->setSearch('my search');
-        static::assertEquals('my search', $extensionCriteria->getQueryParameter()['search']);
-        static::assertEquals('my search', $extensionCriteria->getSearch());
+        static::assertSame('my search', $extensionCriteria->getQueryParameter()['search']);
+        static::assertSame('my search', $extensionCriteria->getSearch());
     }
 
     public function testItFlattensFilterInQuery(): void
@@ -149,7 +149,7 @@ class ExtensionCriteriaTest extends TestCase
             ],
         ]);
 
-        static::assertEquals('living', $extensionCriteria->getQueryParameter()['category']);
-        static::assertEquals('3', $extensionCriteria->getQueryParameter()['rating']);
+        static::assertSame('living', $extensionCriteria->getQueryParameter()['category']);
+        static::assertSame('3', $extensionCriteria->getQueryParameter()['rating']);
     }
 }

--- a/tests/unit/Core/Framework/Store/Search/FilterStructClassTest.php
+++ b/tests/unit/Core/Framework/Store/Search/FilterStructClassTest.php
@@ -40,20 +40,20 @@ class FilterStructClassTest extends TestCase
             ],
         ]);
 
-        static::assertEquals('multi', $filter->getType());
+        static::assertSame('multi', $filter->getType());
 
         static::assertInstanceOf(MultiFilterStruct::class, $filter);
         static::assertCount(2, $filter->getQueries());
 
         $ratings = $filter->getQueries()[0];
         static::assertInstanceOf(EqualsFilterStruct::class, $ratings);
-        static::assertEquals('ratings', $ratings->getField());
-        static::assertEquals('2', $ratings->getValue());
+        static::assertSame('ratings', $ratings->getField());
+        static::assertSame('2', $ratings->getValue());
 
         $category = $filter->getQueries()[1];
         static::assertInstanceOf(EqualsFilterStruct::class, $category);
-        static::assertEquals('category', $category->getField());
-        static::assertEquals('5', $category->getValue());
+        static::assertSame('category', $category->getField());
+        static::assertSame('5', $category->getValue());
     }
 
     public function testGetQueryParametersFromMultiFilter(): void
@@ -74,7 +74,7 @@ class FilterStructClassTest extends TestCase
             ],
         ]);
 
-        static::assertEquals([
+        static::assertSame([
             'ratings' => '2',
             'category' => '5',
         ], $filter->getQueryParameter());
@@ -86,7 +86,7 @@ class FilterStructClassTest extends TestCase
         $filter->setField('field');
         $filter->setValue('value');
 
-        static::assertEquals('field', $filter->getField());
-        static::assertEquals('value', $filter->getValue());
+        static::assertSame('field', $filter->getField());
+        static::assertSame('value', $filter->getValue());
     }
 }

--- a/tests/unit/Core/Framework/Store/Services/FirstRunWizardClientTest.php
+++ b/tests/unit/Core/Framework/Store/Services/FirstRunWizardClientTest.php
@@ -54,7 +54,7 @@ class FirstRunWizardClientTest extends TestCase
             $firstRunWizardUserToken
         );
 
-        static::assertEquals(
+        static::assertSame(
             $firstRunWizardUserToken,
             $frwClient->frwLogin('j.doe@shopware.com', 'p4ssw0rd', $this->context)
         );
@@ -142,7 +142,7 @@ class FirstRunWizardClientTest extends TestCase
             $shopUserToken
         );
 
-        static::assertEquals(
+        static::assertSame(
             $shopUserToken,
             $frwClient->upgradeAccessToken($this->context)
         );
@@ -168,7 +168,7 @@ class FirstRunWizardClientTest extends TestCase
             $regions
         );
 
-        static::assertEquals(
+        static::assertSame(
             $regions,
             $frwClient->getRecommendationRegions($this->context)
         );
@@ -205,7 +205,7 @@ class FirstRunWizardClientTest extends TestCase
             $recommendations
         );
 
-        static::assertEquals(
+        static::assertSame(
             $recommendations,
             $frwClient->getRecommendations('us-west', 'payment', $this->context)
         );
@@ -231,7 +231,7 @@ class FirstRunWizardClientTest extends TestCase
             $languagePlugins
         );
 
-        static::assertEquals(
+        static::assertSame(
             $languagePlugins,
             $frwClient->getLanguagePlugins($this->context)
         );
@@ -257,7 +257,7 @@ class FirstRunWizardClientTest extends TestCase
             $languagePlugins
         );
 
-        static::assertEquals(
+        static::assertSame(
             $languagePlugins,
             $frwClient->getDemoDataPlugins($this->context)
         );
@@ -284,7 +284,7 @@ class FirstRunWizardClientTest extends TestCase
             $licenseDomains
         );
 
-        static::assertEquals(
+        static::assertSame(
             $licenseDomains,
             $frwClient->getLicenseDomains($this->context)
         );
@@ -335,7 +335,7 @@ class FirstRunWizardClientTest extends TestCase
             $verificationInfo
         );
 
-        static::assertEquals(
+        static::assertSame(
             $verificationInfo,
             $frwClient->fetchVerificationInfo('shopware.swag', $this->context)
         );

--- a/tests/unit/Core/Framework/Store/Services/FirstRunWizardServiceTest.php
+++ b/tests/unit/Core/Framework/Store/Services/FirstRunWizardServiceTest.php
@@ -479,12 +479,12 @@ class FirstRunWizardServiceTest extends TestCase
 
         $currentLicenseDomain = $licenseDomains->first();
         static::assertInstanceOf(LicenseDomainStruct::class, $currentLicenseDomain);
-        static::assertEquals('täst.de', $currentLicenseDomain->getDomain());
+        static::assertSame('täst.de', $currentLicenseDomain->getDomain());
         static::assertTrue($currentLicenseDomain->isActive());
 
         $otherLicenseDomain = $licenseDomains->last();
         static::assertInstanceOf(LicenseDomainStruct::class, $otherLicenseDomain);
-        static::assertEquals('shopware.swag', $otherLicenseDomain->getDomain());
+        static::assertSame('shopware.swag', $otherLicenseDomain->getDomain());
         static::assertFalse($otherLicenseDomain->isActive());
     }
 

--- a/tests/unit/Core/Framework/Store/Services/InstanceServiceTest.php
+++ b/tests/unit/Core/Framework/Store/Services/InstanceServiceTest.php
@@ -32,7 +32,7 @@ class InstanceServiceTest extends TestCase
             'i-am-unique'
         );
 
-        static::assertEquals('i-am-unique', $instanceService->getInstanceId());
+        static::assertSame('i-am-unique', $instanceService->getInstanceId());
     }
 
     public function testItReturnsSpecificShopwareVersion(): void
@@ -42,7 +42,7 @@ class InstanceServiceTest extends TestCase
             null
         );
 
-        static::assertEquals('6.1.0.0', $instanceService->getShopwareVersion());
+        static::assertSame('6.1.0.0', $instanceService->getShopwareVersion());
     }
 
     public function testItReturnsShopwareVersionStringIfVersionIsDeveloperVersion(): void
@@ -52,6 +52,6 @@ class InstanceServiceTest extends TestCase
             null
         );
 
-        static::assertEquals('___VERSION___', $instanceService->getShopwareVersion());
+        static::assertSame('___VERSION___', $instanceService->getShopwareVersion());
     }
 }

--- a/tests/unit/Core/Framework/Store/Services/TrackingEventClientTest.php
+++ b/tests/unit/Core/Framework/Store/Services/TrackingEventClientTest.php
@@ -57,7 +57,7 @@ class TrackingEventClientTest extends TestCase
 
         $lastRequest = $mockHandler->getLastRequest();
         static::assertInstanceOf(RequestInterface::class, $lastRequest);
-        static::assertEquals('/swplatform/tracking/events', $lastRequest->getUri()->getPath());
+        static::assertSame('/swplatform/tracking/events', $lastRequest->getUri()->getPath());
         static::assertEquals(
             [
                 'instanceId' => 'test-instance-id',
@@ -88,7 +88,7 @@ class TrackingEventClientTest extends TestCase
 
         $lastRequest = $mockHandler->getLastRequest();
         static::assertInstanceOf(RequestInterface::class, $lastRequest);
-        static::assertEquals('/swplatform/tracking/events', $lastRequest->getUri()->getPath());
+        static::assertSame('/swplatform/tracking/events', $lastRequest->getUri()->getPath());
         static::assertEquals(
             [
                 'instanceId' => 'test-instance-id',

--- a/tests/unit/Core/Framework/Store/Struct/ExtensionStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/ExtensionStructTest.php
@@ -48,7 +48,7 @@ class ExtensionStructTest extends TestCase
         $categorizedPermissions = $serializedExtension['permissions'];
 
         static::assertCount(3, $categorizedPermissions);
-        static::assertEquals([
+        static::assertSame([
             'product',
             'promotion',
             'other',

--- a/tests/unit/Core/Framework/Store/Struct/PermissionCollectionTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/PermissionCollectionTest.php
@@ -40,7 +40,7 @@ class PermissionCollectionTest extends TestCase
         $categorizedCollection = $permissionCollection->getCategorizedPermissions();
 
         static::assertCount(3, $categorizedCollection);
-        static::assertEquals([
+        static::assertSame([
             'product',
             'promotion',
             'other',
@@ -61,7 +61,7 @@ class PermissionCollectionTest extends TestCase
             }
         }
 
-        static::assertEquals(4, $countReadPermissions);
+        static::assertSame(4, $countReadPermissions);
     }
 
     public function testItFiltersDuplicatePermissions(): void
@@ -81,10 +81,10 @@ class PermissionCollectionTest extends TestCase
 
         static::assertCount(2, $permissionCollection->getElements());
 
-        static::assertEquals('product', $permissionCollection->getElements()[0]->getEntity());
-        static::assertEquals('delete', $permissionCollection->getElements()[0]->getOperation());
+        static::assertSame('product', $permissionCollection->getElements()[0]->getEntity());
+        static::assertSame('delete', $permissionCollection->getElements()[0]->getOperation());
 
-        static::assertEquals('product', $permissionCollection->getElements()[1]->getEntity());
-        static::assertEquals('read', $permissionCollection->getElements()[1]->getOperation());
+        static::assertSame('product', $permissionCollection->getElements()[1]->getEntity());
+        static::assertSame('read', $permissionCollection->getElements()[1]->getOperation());
     }
 }

--- a/tests/unit/Core/Framework/Store/Struct/ReviewStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/ReviewStructTest.php
@@ -29,13 +29,13 @@ class ReviewStructTest extends TestCase
 
         $rating = ReviewStruct::fromRequest(1, $request);
 
-        static::assertEquals(1, $rating->getExtensionId());
-        static::assertEquals('Author', $rating->getAuthorName());
-        static::assertEquals('Headline', $rating->getHeadline());
-        static::assertEquals('Text', $rating->getText());
+        static::assertSame(1, $rating->getExtensionId());
+        static::assertSame('Author', $rating->getAuthorName());
+        static::assertSame('Headline', $rating->getHeadline());
+        static::assertSame('Text', $rating->getText());
         static::assertTrue($rating->isAcceptGuidelines());
-        static::assertEquals(3, $rating->getRating());
-        static::assertEquals('1.1.0', $rating->getVersion());
+        static::assertSame(3, $rating->getRating());
+        static::assertSame('1.1.0', $rating->getVersion());
     }
 
     public function testFromRequestThrowsIfAuthorNameIsInvalid(): void

--- a/tests/unit/Core/Framework/Struct/CollectionTest.php
+++ b/tests/unit/Core/Framework/Struct/CollectionTest.php
@@ -20,7 +20,7 @@ class CollectionTest extends TestCase
         $elements = ['a', 'b'];
         $collection = new TestCollection($elements);
 
-        static::assertEquals($elements, $collection->getElements());
+        static::assertSame($elements, $collection->getElements());
     }
 
     public function testConstructorKeepingKeys(): void
@@ -28,7 +28,7 @@ class CollectionTest extends TestCase
         $elements = ['z' => 'a', 'y' => 'b'];
         $collection = new TestCollection($elements);
 
-        static::assertEquals($elements, $collection->getElements());
+        static::assertSame($elements, $collection->getElements());
     }
 
     public function testClear(): void
@@ -44,21 +44,21 @@ class CollectionTest extends TestCase
     public function testCount(): void
     {
         $collection = new TestCollection();
-        static::assertEquals(0, $collection->count());
+        static::assertCount(0, $collection);
 
         $collection->add('a');
         $collection->add('b');
-        static::assertEquals(2, $collection->count());
+        static::assertCount(2, $collection);
     }
 
     public function testGetNumericKeys(): void
     {
         $collection = new TestCollection();
-        static::assertEquals([], $collection->getKeys());
+        static::assertSame([], $collection->getKeys());
 
         $collection->add('a');
         $collection->add('b');
-        static::assertEquals([0, 1], $collection->getKeys());
+        static::assertSame([0, 1], $collection->getKeys());
     }
 
     public function testHasWithNumericKey(): void
@@ -82,7 +82,7 @@ class CollectionTest extends TestCase
         $collection->add('a');
         $collection->add('b');
         $result = $collection->map(fn ($element) => $element . '_test');
-        static::assertEquals(['a_test', 'b_test'], $result);
+        static::assertSame(['a_test', 'b_test'], $result);
     }
 
     public function testFmap(): void
@@ -95,7 +95,7 @@ class CollectionTest extends TestCase
         $collection->add('a');
         $collection->add('b');
         $filtered = $collection->fmap(fn ($element) => $element === 'a' ? false : $element . '_test');
-        static::assertEquals([1 => 'b_test'], $filtered);
+        static::assertSame([1 => 'b_test'], $filtered);
     }
 
     public function testSort(): void
@@ -112,7 +112,7 @@ class CollectionTest extends TestCase
 
         $collection->sort(fn ($a, $b) => strcmp((string) $a, (string) $b));
 
-        static::assertEquals([2 => 'a', 0 => 'b', 1 => 'c'], $collection->getElements());
+        static::assertSame([2 => 'a', 0 => 'b', 1 => 'c'], $collection->getElements());
     }
 
     public function testFilterInstance(): void
@@ -120,14 +120,14 @@ class CollectionTest extends TestCase
         $productStruct = new ProductEntity();
         $categoryStruct = new CategoryEntity();
         $collection = new TestCollection();
-        static::assertEquals(0, $collection->filterInstance(ProductEntity::class)->count());
+        static::assertCount(0, $collection->filterInstance(ProductEntity::class));
 
         $collection->add('a');
         $collection->add($productStruct);
         $collection->add($categoryStruct);
 
         $filtered = $collection->filterInstance(Struct::class);
-        static::assertEquals([$productStruct, $categoryStruct], array_values($filtered->getElements()));
+        static::assertSame([$productStruct, $categoryStruct], array_values($filtered->getElements()));
     }
 
     public function testFilter(): void
@@ -142,7 +142,7 @@ class CollectionTest extends TestCase
         $collection->add('c');
 
         $filtered = $collection->filter(fn ($element) => $element !== 'b');
-        static::assertEquals(['a', 'c'], array_values($filtered->getElements()));
+        static::assertSame(['a', 'c'], array_values($filtered->getElements()));
     }
 
     public function testSlice(): void
@@ -154,27 +154,27 @@ class CollectionTest extends TestCase
         $collection->add('b');
         $collection->add('c');
 
-        static::assertEquals(['b', 'c'], array_values($collection->slice(1)->getElements()));
-        static::assertEquals(['b'], array_values($collection->slice(1, 1)->getElements()));
+        static::assertSame(['b', 'c'], array_values($collection->slice(1)->getElements()));
+        static::assertSame(['b'], array_values($collection->slice(1, 1)->getElements()));
     }
 
     public function testGetElements(): void
     {
         $elements = ['a', 'b'];
         $collection = new TestCollection();
-        static::assertEquals([], $collection->getElements());
+        static::assertSame([], $collection->getElements());
 
         $collection->add('a');
         $collection->add('b');
 
-        static::assertEquals($elements, $collection->getElements());
+        static::assertSame($elements, $collection->getElements());
     }
 
     public function testJsonSerialize(): void
     {
         $elements = ['a', 'b'];
         $collection = new TestCollection();
-        static::assertEquals(
+        static::assertSame(
             [],
             $collection->jsonSerialize()
         );
@@ -182,7 +182,7 @@ class CollectionTest extends TestCase
         $collection->add('a');
         $collection->add('b');
 
-        static::assertEquals(
+        static::assertSame(
             $elements,
             $collection->jsonSerialize()
         );
@@ -196,7 +196,7 @@ class CollectionTest extends TestCase
         $collection->add('a');
         $collection->add('b');
 
-        static::assertEquals('a', $collection->first());
+        static::assertSame('a', $collection->first());
     }
 
     public function testLast(): void
@@ -207,7 +207,7 @@ class CollectionTest extends TestCase
         $collection->add('a');
         $collection->add('b');
 
-        static::assertEquals('b', $collection->last());
+        static::assertSame('b', $collection->last());
     }
 
     public function testGetAt(): void
@@ -217,8 +217,8 @@ class CollectionTest extends TestCase
 
         $collection->add('a');
         $collection->add('b');
-        static::assertEquals('a', $collection->getAt(0));
-        static::assertEquals('b', $collection->getAt(1));
+        static::assertSame('a', $collection->getAt(0));
+        static::assertSame('b', $collection->getAt(1));
     }
 
     public function testFirstWhereWithEmptyCollectionWillReturnNull(): void
@@ -233,7 +233,7 @@ class CollectionTest extends TestCase
         $collection->add('a1');
         $collection->add('a2');
         $collection->add('a3');
-        static::assertEquals('a1', $collection->firstWhere(fn ($element) => str_starts_with($element, 'a')));
+        static::assertSame('a1', $collection->firstWhere(fn ($element) => str_starts_with($element, 'a')));
     }
 }
 

--- a/tests/unit/Core/Framework/Struct/StateAwareTraitTest.php
+++ b/tests/unit/Core/Framework/Struct/StateAwareTraitTest.php
@@ -23,7 +23,7 @@ class StateAwareTraitTest extends TestCase
         $struct->addState('bar');
 
         // contains foo and bar at this point
-        static::assertEquals(['foo', 'bar'], $struct->getStates(), 'States do not match');
+        static::assertSame(['foo', 'bar'], $struct->getStates(), 'States do not match');
 
         static::assertTrue($struct->hasState('foo'), 'foo should be set');
 
@@ -34,7 +34,7 @@ class StateAwareTraitTest extends TestCase
         $struct->removeState('foo');
 
         // contains only bar at this point
-        static::assertEquals(['bar'], $struct->getStates(), 'States do not match');
+        static::assertSame(['bar'], $struct->getStates(), 'States do not match');
 
         static::assertFalse($struct->hasState('foo'), 'foo should not be set');
 
@@ -53,7 +53,7 @@ class StateAwareTraitTest extends TestCase
 
         static::assertTrue($value, 'Baz was not added');
 
-        static::assertEquals(['bar'], $struct->getStates(), 'States do not match');
+        static::assertSame(['bar'], $struct->getStates(), 'States do not match');
 
         static::assertFalse($struct->hasState('baz'), 'baz should not be set outside');
 
@@ -67,7 +67,7 @@ class StateAwareTraitTest extends TestCase
 
         static::assertTrue($value, 'Baz or foo were not added');
 
-        static::assertEquals(['bar'], $struct->getStates(), 'States do not match');
+        static::assertSame(['bar'], $struct->getStates(), 'States do not match');
 
         $value = $struct->state(
             function (StateStruct $state) {
@@ -83,7 +83,7 @@ class StateAwareTraitTest extends TestCase
 
         static::assertTrue($value, 'Baz or foo were not added');
 
-        static::assertEquals(['bar'], $struct->getStates(), 'States do not match');
+        static::assertSame(['bar'], $struct->getStates(), 'States do not match');
     }
 }
 

--- a/tests/unit/Core/Framework/Test/Script/Execution/ScriptTwigLoaderTest.php
+++ b/tests/unit/Core/Framework/Test/Script/Execution/ScriptTwigLoaderTest.php
@@ -38,11 +38,11 @@ class ScriptTwigLoaderTest extends TestCase
     {
         $source = $this->scriptLoader->getSourceContext($this->script->getName());
 
-        static::assertEquals(
+        static::assertSame(
             $this->script->getName(),
             $source->getName()
         );
-        static::assertEquals(
+        static::assertSame(
             $this->script->getScript(),
             $source->getCode()
         );

--- a/tests/unit/Core/Framework/Test/TestCaseHelper/ReflectionHelperTest.php
+++ b/tests/unit/Core/Framework/Test/TestCaseHelper/ReflectionHelperTest.php
@@ -27,7 +27,7 @@ class ReflectionHelperTest extends TestCase
 
         $method = ReflectionHelper::getMethod(FakeClassForHelper::class, 'myPrivateMethod');
 
-        static::assertEquals(['one', 'none'], $method->invoke($class));
+        static::assertSame(['one', 'none'], $method->invoke($class));
     }
 
     public function testGetPropertyValueFromPrivateScope(): void

--- a/tests/unit/Core/Framework/Update/Subscriber/UpdateSubscriberTest.php
+++ b/tests/unit/Core/Framework/Update/Subscriber/UpdateSubscriberTest.php
@@ -18,7 +18,7 @@ class UpdateSubscriberTest extends TestCase
 {
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             [
                 UpdatePostFinishEvent::class => [
                     ['updateFinishedDone', -9999],
@@ -38,7 +38,7 @@ class UpdateSubscriberTest extends TestCase
             ->expects($this->once())
             ->method('createNotification')
             ->willReturnCallback(function ($data): void {
-                static::assertEquals('something to inform' . \PHP_EOL, $data['message']);
+                static::assertSame('something to inform' . \PHP_EOL, $data['message']);
             });
 
         $event = new UpdatePostFinishEvent($context, $version, $version);

--- a/tests/unit/Core/Framework/Util/AfterSortTest.php
+++ b/tests/unit/Core/Framework/Util/AfterSortTest.php
@@ -70,7 +70,7 @@ class AfterSortTest extends TestCase
 
         $actualNames = array_map(fn (TestEntity $entity) => $entity->getName(), $afterSortCollection->getElements());
 
-        static::assertEquals($expectedNames, \array_values($actualNames));
+        static::assertSame($expectedNames, \array_values($actualNames));
     }
 
     public function testSortingInconsistentDataWithHole(): void
@@ -106,7 +106,7 @@ class AfterSortTest extends TestCase
 
         $actualNames = array_map(fn (TestEntity $entity) => $entity->getName(), $entities->getElements());
 
-        static::assertEquals($expectedNames, \array_values($actualNames));
+        static::assertSame($expectedNames, \array_values($actualNames));
     }
 
     public function testSortingInconsistentData(): void
@@ -142,7 +142,7 @@ class AfterSortTest extends TestCase
 
         $actualNames = array_map(fn (TestEntity $entity) => $entity->getName(), $entities->getElements());
 
-        static::assertEquals($expectedNames, \array_values($actualNames));
+        static::assertSame($expectedNames, \array_values($actualNames));
     }
 
     public function testSortingByAfterIdWithMultipleNullValues(): void
@@ -178,7 +178,7 @@ class AfterSortTest extends TestCase
 
         $actualNames = array_map(fn (TestEntity $entity) => $entity->getName(), $afterSortCollection->getElements());
 
-        static::assertEquals($expectedNames, $actualNames);
+        static::assertSame($expectedNames, $actualNames);
     }
 }
 

--- a/tests/unit/Core/Framework/Util/ComparatorExceptionTest.php
+++ b/tests/unit/Core/Framework/Util/ComparatorExceptionTest.php
@@ -19,8 +19,8 @@ class ComparatorExceptionTest extends TestCase
     {
         $e = ComparatorException::operatorNotSupported('test');
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('CONTENT__OPERATOR_NOT_SUPPORTED', $e->getErrorCode());
-        static::assertEquals('Operator "test" is not supported.', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('CONTENT__OPERATOR_NOT_SUPPORTED', $e->getErrorCode());
+        static::assertSame('Operator "test" is not supported.', $e->getMessage());
     }
 }

--- a/tests/unit/Core/Framework/Util/JsonTest.php
+++ b/tests/unit/Core/Framework/Util/JsonTest.php
@@ -25,8 +25,8 @@ class JsonTest extends TestCase
             Json::decodeToList('["abc", "foo"');
             static::fail(UtilException::class . ' not thrown');
         } catch (UtilException $e) {
-            static::assertEquals(UtilException::INVALID_JSON, $e->getErrorCode());
-            static::assertEquals('JSON is invalid', $e->getMessage());
+            static::assertSame(UtilException::INVALID_JSON, $e->getErrorCode());
+            static::assertSame('JSON is invalid', $e->getMessage());
             static::assertInstanceOf(\JsonException::class, $e->getPrevious());
         }
     }
@@ -37,8 +37,8 @@ class JsonTest extends TestCase
             Json::decodeToList('{"abc": "foo"}');
             static::fail(UtilException::class . ' not thrown');
         } catch (UtilException $e) {
-            static::assertEquals(UtilException::INVALID_JSON_NOT_LIST, $e->getErrorCode());
-            static::assertEquals('JSON cannot be decoded to a list', $e->getMessage());
+            static::assertSame(UtilException::INVALID_JSON_NOT_LIST, $e->getErrorCode());
+            static::assertSame('JSON cannot be decoded to a list', $e->getMessage());
         }
     }
 
@@ -48,8 +48,8 @@ class JsonTest extends TestCase
             Json::decodeToList('{"0": "abc", "2": "foo"}');
             static::fail(UtilException::class . ' not thrown');
         } catch (UtilException $e) {
-            static::assertEquals(UtilException::INVALID_JSON_NOT_LIST, $e->getErrorCode());
-            static::assertEquals('JSON cannot be decoded to a list', $e->getMessage());
+            static::assertSame(UtilException::INVALID_JSON_NOT_LIST, $e->getErrorCode());
+            static::assertSame('JSON cannot be decoded to a list', $e->getMessage());
         }
     }
 
@@ -79,8 +79,8 @@ class JsonTest extends TestCase
             Json::decodeToList($input);
             static::fail(UtilException::class . ' not thrown');
         } catch (UtilException $e) {
-            static::assertEquals(UtilException::INVALID_JSON_NOT_LIST, $e->getErrorCode());
-            static::assertEquals('JSON cannot be decoded to a list', $e->getMessage());
+            static::assertSame(UtilException::INVALID_JSON_NOT_LIST, $e->getErrorCode());
+            static::assertSame('JSON cannot be decoded to a list', $e->getMessage());
         }
     }
 

--- a/tests/unit/Core/Framework/Util/MemorySizeCalculatorTest.php
+++ b/tests/unit/Core/Framework/Util/MemorySizeCalculatorTest.php
@@ -22,7 +22,7 @@ class MemorySizeCalculatorTest extends TestCase
     #[DataProvider('memorySizeDataProvider')]
     public function testBytesConversion(string $limit, int $bytes): void
     {
-        static::assertEquals($bytes, MemorySizeCalculator::convertToBytes($limit));
+        static::assertSame($bytes, MemorySizeCalculator::convertToBytes($limit));
     }
 
     /**
@@ -57,7 +57,7 @@ class MemorySizeCalculatorTest extends TestCase
     #[DataProvider('bytesProvider')]
     public function testFormatBytes(int $bytes, string $formatted): void
     {
-        static::assertEquals($formatted, MemorySizeCalculator::formatToBytes($bytes));
+        static::assertSame($formatted, MemorySizeCalculator::formatToBytes($bytes));
     }
 
     /**
@@ -91,7 +91,7 @@ class MemorySizeCalculatorTest extends TestCase
 
         $maxUploadSize = MemorySizeCalculator::getMaxUploadSize($maxSize);
 
-        static::assertEquals($expected, $maxUploadSize);
+        static::assertSame($expected, $maxUploadSize);
 
         IniMock::withIniMock([]);
     }

--- a/tests/unit/Core/Framework/Util/UtilExceptionTest.php
+++ b/tests/unit/Core/Framework/Util/UtilExceptionTest.php
@@ -19,36 +19,36 @@ class UtilExceptionTest extends TestCase
     {
         $e = UtilException::invalidJson($p = new \JsonException('invalid'));
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('UTIL_INVALID_JSON', $e->getErrorCode());
-        static::assertEquals('JSON is invalid', $e->getMessage());
-        static::assertEquals($p, $e->getPrevious());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('UTIL_INVALID_JSON', $e->getErrorCode());
+        static::assertSame('JSON is invalid', $e->getMessage());
+        static::assertSame($p, $e->getPrevious());
     }
 
     public function testInvalidJsonNotList(): void
     {
         $e = UtilException::invalidJsonNotList();
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('UTIL_INVALID_JSON_NOT_LIST', $e->getErrorCode());
-        static::assertEquals('JSON cannot be decoded to a list', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('UTIL_INVALID_JSON_NOT_LIST', $e->getErrorCode());
+        static::assertSame('JSON cannot be decoded to a list', $e->getMessage());
     }
 
     public function testCannotFindFileInFilesystem(): void
     {
         $e = UtilException::cannotFindFileInFilesystem('some/file', 'some/folder');
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('UTIL__FILESYSTEM_FILE_NOT_FOUND', $e->getErrorCode());
-        static::assertEquals('The file "some/file" does not exist in the given filesystem "some/folder"', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('UTIL__FILESYSTEM_FILE_NOT_FOUND', $e->getErrorCode());
+        static::assertSame('The file "some/file" does not exist in the given filesystem "some/folder"', $e->getMessage());
     }
 
     public function testOperatorNotSupported(): void
     {
         $e = UtilException::operatorNotSupported('$');
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('UTIL__OPERATOR_NOT_SUPPORTED', $e->getErrorCode());
-        static::assertEquals('Operator "$" is not supported.', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('UTIL__OPERATOR_NOT_SUPPORTED', $e->getErrorCode());
+        static::assertSame('Operator "$" is not supported.', $e->getMessage());
     }
 
     /**
@@ -59,8 +59,8 @@ class UtilExceptionTest extends TestCase
     {
         $e = UtilException::operatorNotSupported('$');
         static::assertInstanceOf(ComparatorException::class, $e);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
-        static::assertEquals('CONTENT__OPERATOR_NOT_SUPPORTED', $e->getErrorCode());
-        static::assertEquals('Operator "$" is not supported.', $e->getMessage());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('CONTENT__OPERATOR_NOT_SUPPORTED', $e->getErrorCode());
+        static::assertSame('Operator "$" is not supported.', $e->getMessage());
     }
 }

--- a/tests/unit/Core/Framework/Util/VersionParserTest.php
+++ b/tests/unit/Core/Framework/Util/VersionParserTest.php
@@ -19,8 +19,8 @@ class VersionParserTest extends TestCase
     {
         $version = VersionParser::parseShopwareVersion($unparsedVersion);
 
-        static::assertEquals($parsedVersion, $version['version']);
-        static::assertEquals($parsedRevision, $version['revision']);
+        static::assertSame($parsedVersion, $version['version']);
+        static::assertSame($parsedRevision, $version['revision']);
     }
 
     /**

--- a/tests/unit/Core/Framework/Uuid/UuidTest.php
+++ b/tests/unit/Core/Framework/Uuid/UuidTest.php
@@ -15,14 +15,14 @@ class UuidTest extends TestCase
 {
     public function testRandomHex(): void
     {
-        static::assertNotEquals(Uuid::randomHex(), Uuid::randomHex());
+        static::assertNotSame(Uuid::randomHex(), Uuid::randomHex());
         static::assertTrue(Uuid::isValid(Uuid::randomHex()));
         static::assertStringNotContainsString('-', Uuid::randomHex());
     }
 
     public function testRandomBytes(): void
     {
-        static::assertNotEquals(Uuid::randomBytes(), Uuid::randomBytes());
+        static::assertNotSame(Uuid::randomBytes(), Uuid::randomBytes());
         static::assertSame(16, mb_strlen(Uuid::randomBytes(), '8bit'));
     }
 

--- a/tests/unit/Core/Framework/Validation/DataBag/DataBagTest.php
+++ b/tests/unit/Core/Framework/Validation/DataBag/DataBagTest.php
@@ -22,27 +22,27 @@ class DataBagTest extends TestCase
             '4' => new DataBag(['a' => 'b']),
         ]);
 
-        static::assertEquals([
+        static::assertSame([
             '1' => 'a',
             '2' => 1,
             '3' => true,
             '4' => ['a' => 'b'],
         ], $bag->all());
 
-        static::assertEquals([
+        static::assertSame([
             '1' => 'a',
             '2' => 1,
             '3' => true,
             '4' => ['a' => 'b'],
         ], $bag->toRequestDataBag()->all());
 
-        static::assertEquals([
+        static::assertSame([
             '1' => 'a',
             '2' => 1,
             '3' => true,
         ], $bag->only('1', '2', '3'));
 
-        static::assertEquals(['a' => 'b'], $bag->all('4'));
+        static::assertSame(['a' => 'b'], $bag->all('4'));
     }
 
     public function testAddSetConvertsToDataBag(): void
@@ -110,7 +110,7 @@ class DataBagTest extends TestCase
             '2' => new DataBag(['a' => 'b']),
         ]);
 
-        static::assertEquals(['a' => 'b'], $bag->all('2'));
+        static::assertSame(['a' => 'b'], $bag->all('2'));
 
         $this->expectException(BadRequestException::class);
         $bag->all('1');

--- a/tests/unit/Core/Framework/Webhook/Hookable/HookableEntityWrittenEventTest.php
+++ b/tests/unit/Core/Framework/Webhook/Hookable/HookableEntityWrittenEventTest.php
@@ -27,8 +27,8 @@ class HookableEntityWrittenEventTest extends TestCase
         $entityId = Uuid::randomHex();
         $event = HookableEntityWrittenEvent::fromWrittenEvent($this->getEntityWrittenEvent($entityId));
 
-        static::assertEquals('product.written', $event->getName());
-        static::assertEquals([
+        static::assertSame('product.written', $event->getName());
+        static::assertSame([
             [
                 'entity' => 'product',
                 'operation' => 'delete',
@@ -46,8 +46,8 @@ class HookableEntityWrittenEventTest extends TestCase
             ['versionId' => Defaults::LIVE_VERSION]
         ));
 
-        static::assertEquals('product.written', $event->getName());
-        static::assertEquals([
+        static::assertSame('product.written', $event->getName());
+        static::assertSame([
             [
                 'entity' => 'product',
                 'operation' => 'delete',

--- a/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -124,12 +124,12 @@ class WebhookManagerTest extends TestCase
             ],
         ], $payload);
 
-        static::assertEquals($message->getLanguageId(), Defaults::LANGUAGE_SYSTEM);
-        static::assertEquals($message->getAppId(), $webhook->appId);
-        static::assertEquals($message->getSecret(), $webhook->appSecret);
-        static::assertEquals($message->getShopwareVersion(), '0.0.0');
-        static::assertEquals($message->getUrl(), 'https://foo.bar');
-        static::assertEquals($message->getWebhookId(), $webhook->id);
+        static::assertSame($message->getLanguageId(), Defaults::LANGUAGE_SYSTEM);
+        static::assertSame($message->getAppId(), $webhook->appId);
+        static::assertSame($message->getSecret(), $webhook->appSecret);
+        static::assertSame($message->getShopwareVersion(), '0.0.0');
+        static::assertSame($message->getUrl(), 'https://foo.bar');
+        static::assertSame($message->getWebhookId(), $webhook->id);
     }
 
     public function testWebhookSettingForLiveVersionOnlyIsIgnoredIfEventTypeDoesNotMatch(): void
@@ -337,7 +337,7 @@ class WebhookManagerTest extends TestCase
         $request = $this->clientMock->getLastRequest();
 
         static::assertInstanceOf(RequestInterface::class, $request);
-        static::assertEquals('foo.bar', $request->getUri()->getHost());
+        static::assertSame('foo.bar', $request->getUri()->getHost());
 
         $headers = $request->getHeaders();
         static::assertArrayHasKey(RequestSigner::SHOPWARE_SHOP_SIGNATURE, $headers);

--- a/tests/unit/Core/Framework/Webhook/WebhookCacheClearerTest.php
+++ b/tests/unit/Core/Framework/Webhook/WebhookCacheClearerTest.php
@@ -15,7 +15,7 @@ class WebhookCacheClearerTest extends TestCase
 {
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals([
+        static::assertSame([
             'acl_role.written' => 'clearPrivilegesCache',
         ], WebhookCacheClearer::getSubscribedEvents());
     }

--- a/tests/unit/Core/Framework/Webhook/WebhookExceptionTest.php
+++ b/tests/unit/Core/Framework/Webhook/WebhookExceptionTest.php
@@ -19,17 +19,17 @@ class WebhookExceptionTest extends TestCase
     public function testAppWebhookFailedException(): void
     {
         $e = WebhookException::appWebhookFailedException('webhookId', 'appId', new \Exception('error'));
-        static::assertEquals('Webhook "webhookId" from "appId" failed with error: error.', $e->getMessage());
-        static::assertEquals('FRAMEWORK__APP_WEBHOOK_FAILED', $e->getErrorCode());
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame('Webhook "webhookId" from "appId" failed with error: error.', $e->getMessage());
+        static::assertSame('FRAMEWORK__APP_WEBHOOK_FAILED', $e->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
     }
 
     public function testWebhookFailedException(): void
     {
         $e = WebhookException::webhookFailedException('webhookId', new \Exception('error'));
-        static::assertEquals('Webhook "webhookId" failed with error: error.', $e->getMessage());
-        static::assertEquals('FRAMEWORK__WEBHOOK_FAILED', $e->getErrorCode());
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame('Webhook "webhookId" failed with error: error.', $e->getMessage());
+        static::assertSame('FRAMEWORK__WEBHOOK_FAILED', $e->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
     }
 
     public function testInvalidDataMapping(): void
@@ -44,8 +44,8 @@ class WebhookExceptionTest extends TestCase
 
         static::assertInstanceOf(WebhookException::class, $exception);
         static::assertSame('Invalid available DataMapping, could not get property "propertyName" on instance of classString', $exception->getMessage());
-        static::assertEquals('FRAMEWORK__WEBHOOK_INVALID_DATA_MAPPING', $exception->getErrorCode());
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__WEBHOOK_INVALID_DATA_MAPPING', $exception->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
     }
 
     public function testUnknownEventDataType(): void
@@ -60,7 +60,7 @@ class WebhookExceptionTest extends TestCase
 
         static::assertInstanceOf(WebhookException::class, $exception);
         static::assertSame('Unknown EventDataType: invalidType', $exception->getMessage());
-        static::assertEquals('FRAMEWORK__WEBHOOK_UNKNOWN_DATA_TYPE', $exception->getErrorCode());
-        static::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__WEBHOOK_UNKNOWN_DATA_TYPE', $exception->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/9317

### 2. What does this change do, exactly?

Replace `assertEquals` with `assertSame`