### PR TITLE
chore: Replace assertEquals with assertSame in framework integration tests

### DIFF
--- a/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorageTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorageTest.php
@@ -114,7 +114,7 @@ class MySQLInvalidatorStorageTest extends TestCase
 
         $tags = $storage->loadAndDelete();
 
-        static::assertEquals(['tag1', 'tag2', 'tag3'], $tags);
+        static::assertSame(['tag1', 'tag2', 'tag3'], $tags);
 
         $result = $this->connection->fetchFirstColumn('SELECT tag FROM invalidation_tags');
 
@@ -153,7 +153,7 @@ class MySQLInvalidatorStorageTest extends TestCase
         // 2. load tags on original connection (which will trigger callable from above to simulate parallel request loading tags)
         $tags = $storage1->loadAndDelete();
 
-        static::assertEquals(['tag1', 'tag2', 'tag3'], $tags);
+        static::assertSame(['tag1', 'tag2', 'tag3'], $tags);
 
         $result = $this->connection->fetchFirstColumn('SELECT tag FROM invalidation_tags');
 

--- a/tests/integration/Core/Framework/Adapter/Cache/RedisConnectionFactoryTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/RedisConnectionFactoryTest.php
@@ -30,7 +30,7 @@ class RedisConnectionFactoryTest extends TestCase
         $a->set('foo', 'bar');
         $b->set('foo', 'foo');
 
-        static::assertEquals($equals, $a->get('foo') === $b->get('foo'));
+        static::assertSame($equals, $a->get('foo') === $b->get('foo'));
     }
 
     public static function prefixProvider(): \Generator

--- a/tests/integration/Core/Framework/Adapter/Cache/Script/ScriptCacheInvalidationSubscriberTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/Script/ScriptCacheInvalidationSubscriberTest.php
@@ -37,7 +37,7 @@ class ScriptCacheInvalidationSubscriberTest extends TestCase
 
         $closure(static::getContainer());
 
-        static::assertEquals(!$shouldBeInvalidated, $cache->hasItem($tagName));
+        static::assertSame(!$shouldBeInvalidated, $cache->hasItem($tagName));
     }
 
     public static function invalidationCasesProvider(): \Generator

--- a/tests/integration/Core/Framework/Adapter/Redis/RedisContainerWiringTest.php
+++ b/tests/integration/Core/Framework/Adapter/Redis/RedisContainerWiringTest.php
@@ -47,7 +47,7 @@ class RedisContainerWiringTest extends TestCase
 
         // Validate config is read correctly
         static::assertTrue($container->hasParameter('shopware.redis.connections.ephemeral.dsn'));
-        static::assertEquals($redisUrl, $container->getParameter('shopware.redis.connections.ephemeral.dsn'));
+        static::assertSame($redisUrl, $container->getParameter('shopware.redis.connections.ephemeral.dsn'));
 
         // Validate that connection provider is correctly set
         static::assertTrue($container->has(RedisConnectionProvider::class));
@@ -85,7 +85,7 @@ class RedisContainerWiringTest extends TestCase
         static::assertArrayHasKey('count', $list2['test']);
 
         // Compare the 'count' values
-        static::assertEquals($list1['test']['count'] + 1, $list2['test']['count']);
+        static::assertSame($list1['test']['count'] + 1, $list2['test']['count']);
     }
 
     public function testCacheInvalidatorAdapter(): void

--- a/tests/integration/Core/Framework/Adapter/Storage/MySQLKeyValueStorageTest.php
+++ b/tests/integration/Core/Framework/Adapter/Storage/MySQLKeyValueStorageTest.php
@@ -41,7 +41,7 @@ class MySQLKeyValueStorageTest extends TestCase
             'keys' => ArrayParameterType::STRING,
         ]);
 
-        static::assertEquals([
+        static::assertSame([
             'key-1' => 'value-1',
             'key-2' => '',
             'key-3' => json_encode(['a' => 'b']),
@@ -54,10 +54,10 @@ class MySQLKeyValueStorageTest extends TestCase
         $this->keyValueStorage->set('key-1', 'value-1');
         $this->keyValueStorage->set('key-2', null);
 
-        static::assertEquals('value-1', $this->keyValueStorage->get('key-1', 'default'));
-        static::assertEquals('', $this->keyValueStorage->get('key-2'));
-        static::assertEquals('', $this->keyValueStorage->get('key-2', 'default'));
-        static::assertEquals('default', $this->keyValueStorage->get('key-3', 'default'));
+        static::assertSame('value-1', $this->keyValueStorage->get('key-1', 'default'));
+        static::assertSame('', $this->keyValueStorage->get('key-2'));
+        static::assertSame('', $this->keyValueStorage->get('key-2', 'default'));
+        static::assertSame('default', $this->keyValueStorage->get('key-3', 'default'));
     }
 
     #[Depends('testSet')]

--- a/tests/integration/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php
@@ -51,7 +51,7 @@ class EntityTemplateLoaderTest extends TestCase
 
     public function testGetSubscribedEvents(): void
     {
-        static::assertEquals(
+        static::assertSame(
             ['app_template.written' => 'reset'],
             EntityTemplateLoader::getSubscribedEvents()
         );
@@ -68,8 +68,8 @@ class EntityTemplateLoaderTest extends TestCase
         $this->importTemplates();
         $source = $this->templateLoader->getSourceContext('@TestTheme/storefront/base.html.twig');
 
-        static::assertEquals(self::FIRST_TEMPLATE, $source->getCode());
-        static::assertEquals('@TestTheme/storefront/base.html.twig', $source->getName());
+        static::assertSame(self::FIRST_TEMPLATE, $source->getCode());
+        static::assertSame('@TestTheme/storefront/base.html.twig', $source->getName());
     }
 
     public function testGetSourceContextForDeactivatedApp(): void
@@ -82,7 +82,7 @@ class EntityTemplateLoaderTest extends TestCase
 
     public function testGetCacheKey(): void
     {
-        static::assertEquals(
+        static::assertSame(
             '@TestTheme/storefront/base.html.twig',
             $this->templateLoader->getCacheKey('@TestTheme/storefront/base.html.twig')
         );

--- a/tests/integration/Core/Framework/Adapter/Twig/Extension/MediaExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/Extension/MediaExtensionTest.php
@@ -32,7 +32,7 @@ class MediaExtensionTest extends TestCase
             'context' => Context::createDefaultContext(),
         ]);
 
-        static::assertEquals('testImage/', $result);
+        static::assertSame('testImage/', $result);
     }
 
     public function testMultiSearch(): void
@@ -52,7 +52,7 @@ class MediaExtensionTest extends TestCase
             'context' => Context::createDefaultContext(),
         ]);
 
-        static::assertEquals('image-1/image-2/', $result);
+        static::assertSame('image-1/image-2/', $result);
     }
 
     public function testEmptySearch(): void
@@ -62,7 +62,7 @@ class MediaExtensionTest extends TestCase
             'context' => Context::createDefaultContext(),
         ]);
 
-        static::assertEquals('', $result);
+        static::assertSame('', $result);
     }
 
     /**

--- a/tests/integration/Core/Framework/Adapter/Twig/Extension/PhpSyntaxExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/Extension/PhpSyntaxExtensionTest.php
@@ -64,6 +64,6 @@ class PhpSyntaxExtensionTest extends TestCase
             $expected .= '-jsonEncode' . $index;
         }
 
-        static::assertEquals($expected, $result, 'Failure in php syntax support in twig rendering');
+        static::assertSame($expected, $result, 'Failure in php syntax support in twig rendering');
     }
 }

--- a/tests/integration/Core/Framework/Adapter/Twig/Extension/SwSanitizeTwigFilterTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/Extension/SwSanitizeTwigFilterTest.php
@@ -25,6 +25,6 @@ class SwSanitizeTwigFilterTest extends TestCase
         $filters = $this->swSanitize->getFilters();
 
         static::assertCount(1, $filters);
-        static::assertEquals('sw_sanitize', $filters[0]->getName());
+        static::assertSame('sw_sanitize', $filters[0]->getName());
     }
 }

--- a/tests/integration/Core/Framework/Adapter/Twig/ReplaceRecursiveFilterTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/ReplaceRecursiveFilterTest.php
@@ -66,7 +66,7 @@ class ReplaceRecursiveFilterTest extends TestCase
 
         $result = $this->replaceRecursiveFilter->replaceRecursive($arrayOne, $arrayTwo);
 
-        static::assertEquals($expect, $result);
+        static::assertSame($expect, $result);
     }
 
     public function testReplaceRecursiveThreeObjects(): void
@@ -118,6 +118,6 @@ class ReplaceRecursiveFilterTest extends TestCase
 
         $result = $this->replaceRecursiveFilter->replaceRecursive($arrayOne, $arrayTwo, $arrayThree);
 
-        static::assertEquals($expect, $result);
+        static::assertSame($expect, $result);
     }
 }

--- a/tests/integration/Core/Framework/Adapter/Twig/ReturnNodeTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/ReturnNodeTest.php
@@ -29,7 +29,7 @@ class ReturnNodeTest extends TestCase
 
         $result = $renderer->render($content, $data, Context::createDefaultContext());
 
-        static::assertEquals($expected, trim($result), 'Failure by rendering template: ' . $template);
+        static::assertSame($expected, trim($result), 'Failure by rendering template: ' . $template);
     }
 
     public static function nodeProvider(): \Generator

--- a/tests/integration/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
@@ -27,7 +27,7 @@ class StringTemplateRendererTest extends TestCase
         $templateMock = '{{ foo }}';
         $dataMock = ['foo' => 'bar'];
         $rendered = $this->stringTemplateRenderer->render($templateMock, $dataMock, Context::createDefaultContext());
-        static::assertEquals('bar', $rendered);
+        static::assertSame('bar', $rendered);
     }
 
     public function testInitialization(): void
@@ -49,6 +49,6 @@ class StringTemplateRendererTest extends TestCase
 
         $renderedWithTimezone = $this->stringTemplateRenderer->render($templateMock, ['testDate' => $testDate], $context);
 
-        static::assertNotEquals($renderedTime, $renderedWithTimezone);
+        static::assertNotSame($renderedTime, $renderedWithTimezone);
     }
 }

--- a/tests/integration/Core/Framework/Adapter/Twig/TwigCacheTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/TwigCacheTest.php
@@ -49,7 +49,7 @@ class TwigCacheTest extends TestCase
         static::assertInstanceOf(CacheInterface::class, $cache);
         $secondCacheKey = $cache->generateKey($templateName, static::class);
 
-        static::assertNotEquals($firstCacheKey, $secondCacheKey);
+        static::assertNotSame($firstCacheKey, $secondCacheKey);
     }
 
     /**

--- a/tests/integration/Core/Framework/Api/ApiAwareTest.php
+++ b/tests/integration/Core/Framework/Api/ApiAwareTest.php
@@ -121,9 +121,9 @@ class ApiAwareTest extends TestCase
         This change must be carefully controlled to ensure that no sensitive data is given out via the Store API.';
 
         $diff = array_diff($mapping, $expected);
-        static::assertEquals([], $diff, $message);
+        static::assertSame([], $diff, $message);
 
         $diff = array_diff($expected, $mapping);
-        static::assertEquals([], $diff, $message);
+        static::assertSame([], $diff, $message);
     }
 }

--- a/tests/integration/Core/Framework/Api/Controller/AclControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/AclControllerTest.php
@@ -72,8 +72,8 @@ class AclControllerTest extends TestCase
             $content = $response->getContent();
 
             static::assertIsString($content);
-            static::assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode(), $content);
-            static::assertEquals(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, json_decode($content, true, 512, \JSON_THROW_ON_ERROR)['errors'][0]['code'], $content);
+            static::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), $content);
+            static::assertSame(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, json_decode($content, true, 512, \JSON_THROW_ON_ERROR)['errors'][0]['code'], $content);
         } finally {
             $this->resetBrowser();
         }

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerTest.php
@@ -121,7 +121,7 @@ EOF;
         static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode(), (string) $response->getContent());
 
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $this->getBrowser()->request('GET', '/api/product/' . $id);
         static::assertSame(Response::HTTP_OK, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
@@ -149,7 +149,7 @@ EOF;
         static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode(), (string) $response->getContent());
 
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $this->getBrowserAuthenticatedWithIntegration()->request('GET', '/api/product/' . $id);
         static::assertSame(Response::HTTP_OK, $this->getBrowserAuthenticatedWithIntegration()->getResponse()->getStatusCode(), (string) $this->getBrowserAuthenticatedWithIntegration()->getResponse()->getContent());
@@ -165,7 +165,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode(), (string) $response->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         $this->getBrowser()->request('GET', '/api/country/' . $id);
         $response = $this->getBrowser()->getResponse();
@@ -181,7 +181,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode(), (string) $response->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country-state/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country-state/' . $id, $response->headers->get('Location'));
 
         $this->getBrowser()->request('GET', '/api/country/' . $id . '/states/');
         $response = $this->getBrowser()->getResponse();
@@ -194,7 +194,7 @@ EOF;
 
         static::assertArrayHasKey('meta', $responseData);
         static::assertArrayHasKey('total', $responseData['meta']);
-        static::assertEquals(1, $responseData['meta']['total']);
+        static::assertSame(1, $responseData['meta']['total']);
 
         static::assertSame($data['name'], $responseData['data'][0]['attributes']['name']);
         static::assertSame($data['shortCode'], $responseData['data'][0]['attributes']['shortCode']);
@@ -216,7 +216,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($browser, 'country', $id);
 
@@ -245,7 +245,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         $browser = $this->getBrowser();
         $connection = $this->getBrowser()->getContainer()->get(Connection::class);
@@ -269,7 +269,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($browser, 'country', $id);
     }
@@ -312,7 +312,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         $browser = $this->getBrowser();
         $connection = $this->getBrowser()->getContainer()->get(Connection::class);
@@ -356,7 +356,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), 'Create product failed id:' . $id);
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $data = [
             'id' => $manufacturer,
@@ -368,7 +368,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), 'Create manufacturer over product failed id:' . $id . "\n" . $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product-manufacturer/' . $manufacturer, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product-manufacturer/' . $manufacturer, $response->headers->get('Location'));
 
         $this->getBrowser()->request('GET', '/api/product/' . $id . '/manufacturer');
         $responseData = json_decode((string) $this->getBrowser()->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -405,7 +405,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), 'Create product failed id:' . $id);
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $user->authorizeBrowser($browser);
 
@@ -450,7 +450,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $data = [
             'id' => $id,
@@ -461,7 +461,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/category/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/category/' . $id, $response->headers->get('Location'));
 
         $this->getBrowser()->request('GET', '/api/product/' . $id . '/categories/');
         $responseData = json_decode((string) $this->getBrowser()->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -504,7 +504,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $data = [
             'id' => $id,
@@ -545,7 +545,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($this->getBrowser(), 'product', $id);
 
@@ -574,7 +574,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($browser, 'product', $id);
 
@@ -684,7 +684,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($this->getBrowser(), 'country', $id);
         $this->assertEntityExists($this->getBrowser(), 'country-state', $stateId);
@@ -720,7 +720,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($browser, 'country', $id);
         $this->assertEntityExists($browser, 'country-state', $stateId);
@@ -749,7 +749,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/named/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/named/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($this->getBrowser(), 'named', $id);
         $this->assertEntityExists($this->getBrowser(), 'named-optional-group', $groupId);
@@ -783,7 +783,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($this->getBrowser(), 'product', $id);
         $this->assertEntityExists($this->getBrowser(), 'category', $category);
@@ -826,7 +826,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $this->assertEntityExists($browser, 'product', $id);
         $this->assertEntityExists($browser, 'category', $category);
@@ -857,14 +857,14 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/tax/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/tax/' . $id, $response->headers->get('Location'));
 
         // update without response
         $this->getBrowser()->request('PATCH', '/api/tax/' . $id, ['name' => 'foo']);
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/tax/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/tax/' . $id, $response->headers->get('Location'));
 
         // with response
         $this->getBrowser()->request('PATCH', '/api/tax/' . $id . '?_response=1', ['name' => 'foo']);
@@ -906,8 +906,8 @@ EOF;
         $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('meta', $content, print_r($content, true));
-        static::assertEquals(1, $content['meta']['total']);
-        static::assertEquals($id, $content['data'][0]['id']);
+        static::assertSame(1, $content['meta']['total']);
+        static::assertSame($id, $content['data'][0]['id']);
     }
 
     public function testAggregate(): void
@@ -943,7 +943,7 @@ EOF;
         // data is empty as we ónly do aggregations
         static::assertEmpty($content['data']);
         static::assertArrayHasKey('aggregations', $content);
-        static::assertEquals(1, $content['aggregations']['total']['count']);
+        static::assertSame(1, $content['aggregations']['total']['count']);
     }
 
     public function testSearchNonTokenizeTerm(): void
@@ -969,8 +969,8 @@ EOF;
         $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('meta', $content, print_r($content, true));
-        static::assertEquals(1, $content['meta']['total']);
-        static::assertEquals($ids->get('customer'), $content['data'][0]['id']);
+        static::assertSame(1, $content['meta']['total']);
+        static::assertSame($ids->get('customer'), $content['data'][0]['id']);
 
         $data['term'] = 'example.com';
 
@@ -979,7 +979,7 @@ EOF;
         $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('meta', $content, print_r($content, true));
-        static::assertEquals(2, $content['meta']['total']);
+        static::assertSame(2, $content['meta']['total']);
     }
 
     public function testSearch(): void
@@ -1000,7 +1000,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $data = [
             'page' => 1,
@@ -1058,11 +1058,11 @@ EOF;
         $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('meta', $content, print_r($content, true));
-        static::assertEquals(1, $content['meta']['total']);
-        static::assertEquals($id, $content['data'][0]['id']);
+        static::assertSame(1, $content['meta']['total']);
+        static::assertSame($id, $content['data'][0]['id']);
 
         $this->getBrowser()->request('DELETE', '/api/product/' . $id);
-        static::assertEquals(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode());
     }
 
     public function testSearchWithoutPermission(): void
@@ -1090,7 +1090,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $data = [
             'page' => 1,
@@ -1272,7 +1272,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         TestUser::createNewTestUser(
             $browser->getContainer()->get(Connection::class),
@@ -1319,7 +1319,7 @@ EOF;
         $response = $browser->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/country/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/country/' . $id, $response->headers->get('Location'));
 
         TestUser::createNewTestUser(
             $browser->getContainer()->get(Connection::class),
@@ -1514,7 +1514,7 @@ EOF;
         foreach ($responseData['data'] as $datum) {
             static::assertArrayHasKey('productId', $datum);
             static::assertArrayHasKey('categoryId', $datum);
-            static::assertEquals($datum['productId'], $id);
+            static::assertSame($datum['productId'], $id);
 
             if ($categoryA === $datum['categoryId']) {
                 ++$categoryAFound;
@@ -1525,8 +1525,8 @@ EOF;
             }
         }
 
-        static::assertEquals(1, $categoryAFound);
-        static::assertEquals(1, $categoryBFound);
+        static::assertSame(1, $categoryAFound);
+        static::assertSame(1, $categoryBFound);
     }
 
     public function testNestedSearchOnManyToManyWithoutPermissionOnParent(): void
@@ -1633,7 +1633,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/product/' . $id, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/product/' . $id, $response->headers->get('Location'));
 
         $data = [
             'filter' => [
@@ -1646,8 +1646,8 @@ EOF;
         $this->getBrowser()->request('GET', '/api/product', [], [], [], json_encode($data, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
         $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(1, $content['meta']['total']);
-        static::assertEquals($id, $content['data'][0]['id']);
+        static::assertSame(1, $content['meta']['total']);
+        static::assertSame($id, $content['data'][0]['id']);
     }
 
     public function testAggregation(): void
@@ -1665,7 +1665,7 @@ EOF;
             'stock' => 50,
         ];
         $this->getBrowser()->request('POST', '/api/product', [], [], [], json_encode($data, \JSON_THROW_ON_ERROR));
-        static::assertEquals(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode());
 
         $productB = Uuid::randomHex();
         $data = [
@@ -1678,7 +1678,7 @@ EOF;
             'stock' => 100,
         ];
         $this->getBrowser()->request('POST', '/api/product', [], [], [], json_encode($data, \JSON_THROW_ON_ERROR));
-        static::assertEquals(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode());
 
         $data = [
             'aggregations' => [
@@ -1705,7 +1705,7 @@ EOF;
 
         $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode(), print_r((string) $response->getContent(), true));
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode(), print_r((string) $response->getContent(), true));
         static::assertNotEmpty($content);
 
         static::assertArrayHasKey('aggregations', $content);
@@ -1713,14 +1713,14 @@ EOF;
 
         static::assertArrayHasKey('product_count', $aggregations, print_r($aggregations, true));
         $productCount = $aggregations['product_count'];
-        static::assertEquals(2, $productCount['count']);
+        static::assertSame(2, $productCount['count']);
 
         static::assertArrayHasKey('product_stats', $aggregations);
         $productStats = $aggregations['product_stats'];
-        static::assertEquals(75, $productStats['avg']);
-        static::assertEquals(150, $productStats['sum']);
-        static::assertEquals(50, $productStats['min']);
-        static::assertEquals(100, $productStats['max']);
+        static::assertSame(75, $productStats['avg']);
+        static::assertSame(150, $productStats['sum']);
+        static::assertSame('50', $productStats['min']);
+        static::assertSame('100', $productStats['max']);
     }
 
     public function testParentChildLocation(): void
@@ -1752,7 +1752,7 @@ EOF;
         $response = $this->getBrowser()->getResponse();
         static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
         static::assertNotEmpty($response->headers->get('Location'));
-        static::assertEquals('http://localhost/api/language/' . $childId, $response->headers->get('Location'));
+        static::assertSame('http://localhost/api/language/' . $childId, $response->headers->get('Location'));
     }
 
     public function testJsonApiResponseSingle(): void
@@ -1789,10 +1789,10 @@ EOF;
         static::assertArrayHasKey('translated', $catData['attributes']);
         static::assertArrayHasKey('name', $catData['attributes']['translated']);
 
-        static::assertEquals($id, $catData['id']);
-        static::assertEquals('category', $catData['type']);
-        static::assertEquals($insertData['name'], $catData['attributes']['name']);
-        static::assertEquals($insertData['name'], $catData['attributes']['translated']['name']);
+        static::assertSame($id, $catData['id']);
+        static::assertSame('category', $catData['type']);
+        static::assertSame($insertData['name'], $catData['attributes']['name']);
+        static::assertSame($insertData['name'], $catData['attributes']['translated']['name']);
     }
 
     public function testJsonApiResponseMulti(): void
@@ -1822,17 +1822,17 @@ EOF;
         static::assertCount(3, $respData['data']);
 
         $data = $respData['data'];
-        static::assertEquals('category', $data[0]['type']);
-        static::assertEquals('Home', $data[0]['attributes']['name']);
-        static::assertEquals('Home', $data[0]['attributes']['translated']['name']);
+        static::assertSame('category', $data[0]['type']);
+        static::assertSame('Home', $data[0]['attributes']['name']);
+        static::assertSame('Home', $data[0]['attributes']['translated']['name']);
 
-        static::assertEquals('category', $data[1]['type']);
-        static::assertEquals($insertData[0]['name'], $data[1]['attributes']['name']);
-        static::assertEquals($insertData[0]['name'], $data[1]['attributes']['translated']['name']);
+        static::assertSame('category', $data[1]['type']);
+        static::assertSame($insertData[0]['name'], $data[1]['attributes']['name']);
+        static::assertSame($insertData[0]['name'], $data[1]['attributes']['translated']['name']);
 
-        static::assertEquals('category', $data[2]['type']);
-        static::assertEquals($insertData[1]['name'], $data[2]['attributes']['name']);
-        static::assertEquals($insertData[1]['name'], $data[2]['attributes']['translated']['name']);
+        static::assertSame('category', $data[2]['type']);
+        static::assertSame($insertData[1]['name'], $data[2]['attributes']['name']);
+        static::assertSame($insertData[1]['name'], $data[2]['attributes']['translated']['name']);
     }
 
     public function testCreateNewVersion(): void
@@ -1858,8 +1858,8 @@ EOF;
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
         static::assertTrue(Uuid::isValid($content['versionId']));
         static::assertNull($content['versionName']);
-        static::assertEquals($id, $content['id']);
-        static::assertEquals('category', $content['entity']);
+        static::assertSame($id, $content['id']);
+        static::assertSame('category', $content['entity']);
     }
 
     public function testCloneEntity(): void
@@ -1881,7 +1881,7 @@ EOF;
 
         $tax = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertArrayHasKey('data', $tax);
-        static::assertEquals($id, $tax['data']['id']);
+        static::assertSame($id, $tax['data']['id']);
 
         $this->getBrowser()->request('POST', '/api/_action/clone/tax/' . $id, [], [], [], json_encode($data, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
@@ -1889,7 +1889,7 @@ EOF;
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertArrayHasKey('id', $data);
-        static::assertNotEquals($id, $data['id']);
+        static::assertNotSame($id, $data['id']);
 
         $newId = $data['id'];
         $this->getBrowser()->request('GET', '/api/tax/' . $newId);
@@ -1897,7 +1897,7 @@ EOF;
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(15, $data['data']['attributes']['taxRate']);
+        static::assertSame(15.0, $data['data']['attributes']['taxRate']);
     }
 
     public function testWriteExtensionWithExtensionKey(): void
@@ -1955,12 +1955,12 @@ EOF;
         usort($included, fn ($a, $b) => $a['type'] <=> $b['type']);
 
         $extension = $included[0];
-        static::assertEquals('extension', $extension['type']);
+        static::assertSame('extension', $extension['type']);
         static::assertArrayHasKey('testSeoUrls', $extension['relationships']);
 
         $seoUrl = $included[1];
-        static::assertEquals('seo_url', $seoUrl['type']);
-        static::assertEquals('test', $seoUrl['attributes']['routeName']);
+        static::assertSame('seo_url', $seoUrl['type']);
+        static::assertSame('test', $seoUrl['attributes']['routeName']);
 
         $this->getBrowser()->request('GET', '/api/sales-channel/' . $salesChannelId . '/extensions/seo-urls');
         $response = $this->getBrowser()->getResponse();
@@ -1970,8 +1970,8 @@ EOF;
         static::assertCount(1, $data);
 
         $seoUrl = $data[0];
-        static::assertEquals('seo_url', $seoUrl['type']);
-        static::assertEquals('test', $seoUrl['attributes']['routeName']);
+        static::assertSame('seo_url', $seoUrl['type']);
+        static::assertSame('test', $seoUrl['attributes']['routeName']);
     }
 
     public function testCanWriteExtensionWithoutExtensionKey(): void
@@ -2027,12 +2027,12 @@ EOF;
         usort($included, fn ($a, $b) => $a['type'] <=> $b['type']);
 
         $extension = $included[0];
-        static::assertEquals('extension', $extension['type']);
+        static::assertSame('extension', $extension['type']);
         static::assertArrayHasKey('testSeoUrls', $extension['relationships']);
 
         $seoUrls = $included[1];
-        static::assertEquals('seo_url', $seoUrls['type']);
-        static::assertEquals('test', $seoUrls['attributes']['routeName']);
+        static::assertSame('seo_url', $seoUrls['type']);
+        static::assertSame('test', $seoUrls['attributes']['routeName']);
 
         $this->getBrowser()->request('GET', '/api/sales-channel/' . $salesChannelId . '/extensions/seo-urls');
         $response = $this->getBrowser()->getResponse();
@@ -2042,8 +2042,8 @@ EOF;
         static::assertCount(1, $data);
 
         $seoUrl = $data[0];
-        static::assertEquals('seo_url', $seoUrl['type']);
-        static::assertEquals('test', $seoUrl['attributes']['routeName']);
+        static::assertSame('seo_url', $seoUrl['type']);
+        static::assertSame('test', $seoUrl['attributes']['routeName']);
     }
 
     public function testCloneEntityWithoutPermission(): void
@@ -2072,7 +2072,7 @@ EOF;
 
         $tax = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertArrayHasKey('data', $tax);
-        static::assertEquals($id, $tax['data']['id']);
+        static::assertSame($id, $tax['data']['id']);
 
         $browser->request('POST', '/api/_action/clone/tax/' . $id, [], [], [], json_encode($data, \JSON_THROW_ON_ERROR));
         $response = $browser->getResponse();
@@ -2107,7 +2107,7 @@ EOF;
 
         $tax = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertArrayHasKey('data', $tax);
-        static::assertEquals('test tax', $tax['data']['attributes']['name']);
+        static::assertSame('test tax', $tax['data']['attributes']['name']);
     }
 
     public function testAggregationWorksForAdminStartPage(): void
@@ -2159,7 +2159,7 @@ EOF;
         $response = json_decode((string) $this->getBrowser()->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertArrayHasKey('data', $response);
         static::assertCount(1, $response['data']);
-        static::assertEquals($ids->get('address'), $response['data'][0]['id']);
+        static::assertSame($ids->get('address'), $response['data'][0]['id']);
     }
 
     public function testAccessDeniedAfterChangingUserPassword(): void
@@ -2188,7 +2188,7 @@ EOF;
 
         static::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), (string) $response->getContent());
         $jsonResponse = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals('Access token is expired', $jsonResponse['errors'][0]['detail']);
+        static::assertSame('Access token is expired', $jsonResponse['errors'][0]['detail']);
     }
 
     public function testPreventCreationOfSalesChannelWithoutDefaultSalesChannelLanguage(): void
@@ -2249,7 +2249,7 @@ EOF;
         $this->getBrowser()->request('POST', '/api/product-category', [], [], [], json_encode($mapping, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
         $repo = static::getContainer()->get(ProductDefinition::ENTITY_NAME . '.repository');
         $criteria = new Criteria([$productId]);
@@ -2257,7 +2257,7 @@ EOF;
         /** @var ProductEntity $product */
         $product = $repo->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
-        static::assertEquals([
+        static::assertSame([
             $categoryId,
         ], $product->getCategoryIds());
     }
@@ -2286,7 +2286,7 @@ EOF;
         $this->getBrowser()->request('POST', '/api/product-category?_response=1', [], [], [], json_encode($mapping, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
         $repo = static::getContainer()->get(ProductDefinition::ENTITY_NAME . '.repository');
         $criteria = new Criteria([$productId]);
@@ -2294,7 +2294,7 @@ EOF;
         /** @var ProductEntity $product */
         $product = $repo->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
-        static::assertEquals([
+        static::assertSame([
             $categoryId,
         ], $product->getCategoryIds());
     }
@@ -2341,8 +2341,8 @@ EOF;
         $response = json_decode($response, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $response['errors'][0]['status']);
-        static::assertEquals('Invalid payload. Should be associative array', $response['errors'][0]['detail']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, (int) $response['errors'][0]['status']);
+        static::assertSame('Invalid payload. Should be associative array', $response['errors'][0]['detail']);
     }
 
     public function testInvalidWriteInputExceptionIsConvertedToBadRequestOnUpdate(): void
@@ -2369,8 +2369,8 @@ EOF;
         $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $content['errors'][0]['status']);
-        static::assertEquals('Invalid payload. Should be associative array', $content['errors'][0]['detail']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, (int) $content['errors'][0]['status']);
+        static::assertSame('Invalid payload. Should be associative array', $content['errors'][0]['detail']);
     }
 
     #[DataProvider('provideEntityName')]

--- a/tests/integration/Core/Framework/Api/Controller/AuthControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/AuthControllerTest.php
@@ -39,19 +39,19 @@ class AuthControllerTest extends TestCase
         $client->request('GET', '/api/tax');
         static::assertNotFalse($client->getResponse()->getContent());
 
-        static::assertEquals(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
 
         static::assertNotFalse($client->getResponse()->getContent());
         $response = \json_decode($client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals(Response::HTTP_UNAUTHORIZED, $response['errors'][0]['status']);
-        static::assertEquals(
+        static::assertSame(Response::HTTP_UNAUTHORIZED, (int) $response['errors'][0]['status']);
+        static::assertSame(
             'The resource owner or authorization server denied the request.',
             $response['errors'][0]['title']
         );
-        static::assertEquals('Missing token in "Authorization" header', $response['errors'][0]['detail']);
+        static::assertSame('Missing token in "Authorization" header', $response['errors'][0]['detail']);
     }
 
     public function testCreateTokenWithInvalidCredentials(): void
@@ -66,16 +66,16 @@ class AuthControllerTest extends TestCase
         $client = $this->getBrowser();
         $client->request('POST', '/api/oauth/token', $authPayload, [], [], json_encode($authPayload, \JSON_THROW_ON_ERROR));
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
 
         static::assertNotFalse($client->getResponse()->getContent());
         $response = \json_decode($client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $response['errors'][0]['status']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, (int) $response['errors'][0]['status']);
 
-        static::assertEquals(OAuthServerException::invalidCredentials()->getMessage(), $response['errors'][0]['title']);
+        static::assertSame(OAuthServerException::invalidCredentials()->getMessage(), $response['errors'][0]['title']);
     }
 
     public function testAccessWithInvalidToken(): void
@@ -86,19 +86,19 @@ class AuthControllerTest extends TestCase
         ]);
         $client->request('GET', '/api/tax');
 
-        static::assertEquals(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
 
         static::assertNotFalse($client->getResponse()->getContent());
         $response = \json_decode($client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals(Response::HTTP_UNAUTHORIZED, $response['errors'][0]['status']);
-        static::assertEquals(
+        static::assertSame(Response::HTTP_UNAUTHORIZED, (int) $response['errors'][0]['status']);
+        static::assertSame(
             'The resource owner or authorization server denied the request.',
             $response['errors'][0]['title']
         );
-        static::assertEquals('The JWT string must have two dots', $response['errors'][0]['detail']);
+        static::assertSame('The JWT string must have two dots', $response['errors'][0]['detail']);
     }
 
     public function testAccessWithExpiredToken(): void
@@ -110,14 +110,14 @@ class AuthControllerTest extends TestCase
         );
         $client->request('GET', '/api/tax');
 
-        static::assertEquals(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
         static::assertNotFalse($client->getResponse()->getContent());
 
         $response = \json_decode($client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals(Response::HTTP_UNAUTHORIZED, $response['errors'][0]['status']);
+        static::assertSame(Response::HTTP_UNAUTHORIZED, (int) $response['errors'][0]['status']);
     }
 
     public function testAccessProtectedResourceWithToken(): void
@@ -125,7 +125,7 @@ class AuthControllerTest extends TestCase
         $this->getBrowser()->request('GET', '/api/tax');
         static::assertNotFalse($this->getBrowser()->getResponse()->getContent());
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_OK,
             $this->getBrowser()->getResponse()->getStatusCode(),
             $this->getBrowser()->getResponse()->getContent()
@@ -152,16 +152,16 @@ class AuthControllerTest extends TestCase
 
         $response = \json_decode($client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_BAD_REQUEST,
             $client->getResponse()->getStatusCode(),
             print_r($client->getResponse()->getContent(), true)
         );
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $response['errors'][0]['status']);
-        static::assertEquals('The refresh token is invalid.', $response['errors'][0]['title']);
-        static::assertEquals('Cannot decrypt the refresh token', $response['errors'][0]['detail']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, (int) $response['errors'][0]['status']);
+        static::assertSame('The refresh token is invalid.', $response['errors'][0]['title']);
+        static::assertSame('Cannot decrypt the refresh token', $response['errors'][0]['detail']);
     }
 
     public function testRevokedRefreshToken(): void
@@ -196,7 +196,7 @@ class AuthControllerTest extends TestCase
 
         $response = \json_decode($client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_BAD_REQUEST,
             $client->getResponse()->getStatusCode(),
             print_r($client->getResponse()->getContent(), true)
@@ -204,9 +204,9 @@ class AuthControllerTest extends TestCase
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $response['errors'][0]['status']);
-        static::assertEquals('The refresh token is invalid.', $response['errors'][0]['title']);
-        static::assertEquals('Token has been revoked', $response['errors'][0]['detail']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, (int) $response['errors'][0]['status']);
+        static::assertSame('The refresh token is invalid.', $response['errors'][0]['title']);
+        static::assertSame('Token has been revoked', $response['errors'][0]['detail']);
     }
 
     public function testRefreshToken(): void
@@ -291,7 +291,7 @@ class AuthControllerTest extends TestCase
 
         static::assertNotFalse($this->getBrowser()->getResponse()->getContent());
 
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_OK,
             $this->getBrowser()->getResponse()->getStatusCode(),
             $this->getBrowser()->getResponse()->getContent()
@@ -387,7 +387,7 @@ class AuthControllerTest extends TestCase
         static::assertInstanceOf(UnencryptedToken::class, $parsedAccessToken);
         $scopes = $parsedAccessToken->claims()->get('scopes');
 
-        static::assertEquals(['admin'], $scopes);
+        static::assertSame(['admin'], $scopes);
     }
 
     public function testSuperAdminScopeRemovedOnRefreshToken(): void
@@ -512,7 +512,7 @@ class AuthControllerTest extends TestCase
         $client->setServerParameter('HTTP_Authorization', \sprintf('Bearer %s', $accessToken));
         $client->request('GET', '/api/tax');
 
-        static::assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
     }
 
     public function testIntegrationAuthInvalid(): void
@@ -659,7 +659,7 @@ class AuthControllerTest extends TestCase
         ];
 
         $browser->request('POST', '/api/oauth/token', $authPayload, [], [], json_encode($authPayload, \JSON_THROW_ON_ERROR));
-        static::assertEquals(Response::HTTP_UNAUTHORIZED, $browser->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $browser->getResponse()->getStatusCode());
     }
 
     public function testUnauthorizedWithPasswordGrantTypeWhenTokenExpired(): void
@@ -679,7 +679,7 @@ class AuthControllerTest extends TestCase
         $browser->request('POST', '/api/oauth/token', $authPayload, [], [], json_encode($authPayload, \JSON_THROW_ON_ERROR));
         static::assertNotFalse($browser->getResponse()->getContent());
 
-        static::assertEquals(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
         $token = \json_decode($browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertIsString($accessToken = $token['access_token']);

--- a/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
@@ -158,9 +158,9 @@ class CacheControllerTest extends TestCase
 
             $response = $this->getBrowser()->getResponse();
 
-            static::assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode(), (string) $response->getContent());
+            static::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), (string) $response->getContent());
             $decode = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-            static::assertEquals(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, $decode['errors'][0]['code'], (string) $response->getContent());
+            static::assertSame(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, $decode['errors'][0]['code'], (string) $response->getContent());
         } finally {
             $this->resetBrowser();
         }

--- a/tests/integration/Core/Framework/Api/Controller/CustomSnippetFormatControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CustomSnippetFormatControllerTest.php
@@ -106,7 +106,7 @@ class CustomSnippetFormatControllerTest extends TestCase
         $content = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('rendered', $content);
-        static::assertEquals($expectedHtml, $content['rendered']);
+        static::assertSame($expectedHtml, $content['rendered']);
     }
 
     /**

--- a/tests/integration/Core/Framework/Api/Controller/IndexingControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/IndexingControllerTest.php
@@ -64,7 +64,7 @@ class IndexingControllerTest extends TestCase
             static::assertTrue($response['finish']);
         } else {
             static::assertFalse($response['finish']);
-            static::assertEquals(['offset' => $offset + 50], $response['offset']);
+            static::assertSame(['offset' => $offset + 50], $response['offset']);
         }
     }
 

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -494,19 +494,19 @@ class InfoControllerTest extends TestCase
         static::assertCount(3, $config['bundles']);
 
         static::assertArrayHasKey('AdminExtensionApiPlugin', $config['bundles']);
-        static::assertEquals('https://extension-api.test', $config['bundles']['AdminExtensionApiPlugin']['baseUrl']);
-        static::assertEquals('plugin', $config['bundles']['AdminExtensionApiPlugin']['type']);
+        static::assertSame('https://extension-api.test', $config['bundles']['AdminExtensionApiPlugin']['baseUrl']);
+        static::assertSame('plugin', $config['bundles']['AdminExtensionApiPlugin']['type']);
 
         static::assertArrayHasKey('AdminExtensionApiPluginWithLocalEntryPoint', $config['bundles']);
         static::assertStringContainsString(
             '/admin/adminextensionapipluginwithlocalentrypoint/index.html',
             $config['bundles']['AdminExtensionApiPluginWithLocalEntryPoint']['baseUrl'],
         );
-        static::assertEquals('plugin', $config['bundles']['AdminExtensionApiPluginWithLocalEntryPoint']['type']);
+        static::assertSame('plugin', $config['bundles']['AdminExtensionApiPluginWithLocalEntryPoint']['type']);
 
         static::assertArrayHasKey('AdminExtensionApiApp', $config['bundles']);
-        static::assertEquals('https://app-admin.test', $config['bundles']['AdminExtensionApiApp']['baseUrl']);
-        static::assertEquals('app', $config['bundles']['AdminExtensionApiApp']['type']);
+        static::assertSame('https://app-admin.test', $config['bundles']['AdminExtensionApiApp']['baseUrl']);
+        static::assertSame('app', $config['bundles']['AdminExtensionApiApp']['type']);
     }
 
     public function testFlowActionsRoute(): void

--- a/tests/integration/Core/Framework/Api/Controller/IntegrationControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/IntegrationControllerTest.php
@@ -102,7 +102,7 @@ class IntegrationControllerTest extends TestCase
             ->search(new Criteria([$ids->get('integration')]), $context);
 
         static::assertNotNull($assigned);
-        static::assertEquals(1, $assigned->count());
+        static::assertCount(1, $assigned);
         static::assertNotNull($assigned->first());
         static::assertTrue($assigned->first()->getAdmin());
     }
@@ -219,7 +219,7 @@ class IntegrationControllerTest extends TestCase
         $expectedIds = $ids->getList(['role-1', 'role-2']);
         sort($expectedIds);
 
-        static::assertEquals($expectedIds, $aclRoleIds);
+        static::assertSame($expectedIds, $aclRoleIds);
     }
 
     public function testPreventUpdateIntegrationWithAdministratorRoleAsNonAdmin(): void
@@ -261,7 +261,7 @@ class IntegrationControllerTest extends TestCase
         $assigned = static::getContainer()->get('integration.repository')
             ->search(new Criteria([$ids->get('integration')]), $context);
 
-        static::assertEquals(1, $assigned->count());
+        static::assertCount(1, $assigned);
         static::assertNotNull($assigned->first());
         static::assertFalse($assigned->first()->getAdmin());
     }

--- a/tests/integration/Core/Framework/Api/Controller/PromotionControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/PromotionControllerTest.php
@@ -73,8 +73,8 @@ class PromotionControllerTest extends TestCase
         $promotion = $this->getPromotionFromDB($promotionId);
 
         static::assertNotNull($promotion);
-        static::assertEquals($promotionId, $promotion->getId());
-        static::assertEquals('Super Sale', $promotion->getName());
+        static::assertSame($promotionId, $promotion->getId());
+        static::assertSame('Super Sale', $promotion->getName());
     }
 
     /**
@@ -101,9 +101,9 @@ class PromotionControllerTest extends TestCase
 
         $json = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals($promotionId, $json['data']['id']);
-        static::assertEquals('promotion', $json['data']['type']);
-        static::assertEquals('Super Sale', $json['data']['attributes']['name']);
+        static::assertSame($promotionId, $json['data']['id']);
+        static::assertSame('promotion', $json['data']['type']);
+        static::assertSame('Super Sale', $json['data']['attributes']['name']);
         static::assertTrue($json['data']['attributes']['active']);
     }
 
@@ -132,11 +132,11 @@ class PromotionControllerTest extends TestCase
         $json = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         // verify that we have 1 total found promotion
-        static::assertEquals(1, $json['meta']['total']);
+        static::assertSame(1, $json['meta']['total']);
 
         // assert values of first promotion
-        static::assertEquals($promotionId, $json['data'][0]['id']);
-        static::assertEquals('Super Sale', $json['data'][0]['attributes']['name']);
+        static::assertSame($promotionId, $json['data'][0]['id']);
+        static::assertSame('Super Sale', $json['data'][0]['attributes']['name']);
     }
 
     /**
@@ -163,12 +163,12 @@ class PromotionControllerTest extends TestCase
         $content = $response->getContent();
 
         static::assertIsString($content);
-        static::assertEquals(204, $response->getStatusCode(), $content);
+        static::assertSame(204, $response->getStatusCode(), $content);
 
         $promotion = $this->getPromotionFromDB($promotionId);
 
         static::assertNotNull($promotion);
-        static::assertEquals('Super Better Sale', $promotion->getName());
+        static::assertSame('Super Better Sale', $promotion->getName());
     }
 
     /**
@@ -193,7 +193,7 @@ class PromotionControllerTest extends TestCase
         $content = $response->getContent();
 
         static::assertIsString($content);
-        static::assertEquals(204, $response->getStatusCode(), $content);
+        static::assertSame(204, $response->getStatusCode(), $content);
 
         $promotion = $this->getPromotionFromDB($promotionId);
         static::assertNotNull($promotion);
@@ -230,8 +230,8 @@ class PromotionControllerTest extends TestCase
         /** @var PromotionDiscountEntity $discount */
         $discount = $promotion->getDiscounts()->get($discountId);
 
-        static::assertEquals('percentage', $discount->getType());
-        static::assertEquals(12.5, $discount->getValue());
+        static::assertSame('percentage', $discount->getType());
+        static::assertSame(12.5, $discount->getValue());
     }
 
     /**
@@ -256,7 +256,7 @@ class PromotionControllerTest extends TestCase
         $content = $response->getContent();
 
         static::assertIsString($content);
-        static::assertEquals(204, $response->getStatusCode(), $content);
+        static::assertSame(204, $response->getStatusCode(), $content);
 
         $promotions = $this->getPromotionFromDB($promotionId);
 

--- a/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
@@ -90,7 +90,7 @@ class SalesChannelProxyControllerTest extends TestCase
         $response = json_decode($response ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
-        static::assertEquals('FRAMEWORK__INVALID_SALES_CHANNEL', $response['errors'][0]['code'] ?? null);
+        static::assertSame('FRAMEWORK__INVALID_SALES_CHANNEL', $response['errors'][0]['code'] ?? null);
     }
 
     public function testProxyCallToSalesChannelApi(): void
@@ -122,12 +122,12 @@ class SalesChannelProxyControllerTest extends TestCase
             ]
         );
 
-        static::assertEquals($uuid, $this->getBrowser()->getRequest()->headers->get('sw-context-token'));
-        static::assertEquals($uuid, $this->getBrowser()->getRequest()->headers->get('sw-language-id'));
-        static::assertEquals($uuid, $this->getBrowser()->getRequest()->headers->get('sw-version-id'));
-        static::assertEquals($uuid, $this->getBrowser()->getResponse()->headers->get('sw-context-token'));
-        static::assertEquals($uuid, $this->getBrowser()->getResponse()->headers->get('sw-language-id'));
-        static::assertEquals($uuid, $this->getBrowser()->getResponse()->headers->get('sw-version-id'));
+        static::assertSame($uuid, $this->getBrowser()->getRequest()->headers->get('sw-context-token'));
+        static::assertSame($uuid, $this->getBrowser()->getRequest()->headers->get('sw-language-id'));
+        static::assertSame($uuid, $this->getBrowser()->getRequest()->headers->get('sw-version-id'));
+        static::assertSame($uuid, $this->getBrowser()->getResponse()->headers->get('sw-context-token'));
+        static::assertSame($uuid, $this->getBrowser()->getResponse()->headers->get('sw-language-id'));
+        static::assertSame($uuid, $this->getBrowser()->getResponse()->headers->get('sw-version-id'));
     }
 
     public function testOnlyDefinedHeadersAreCopied(): void
@@ -144,7 +144,7 @@ class SalesChannelProxyControllerTest extends TestCase
             ]
         );
 
-        static::assertEquals('foo', $this->getBrowser()->getRequest()->headers->get('sw-custom-header'));
+        static::assertSame('foo', $this->getBrowser()->getRequest()->headers->get('sw-custom-header'));
         static::assertArrayNotHasKey('sw-custom-header', $this->getBrowser()->getResponse()->headers->all());
     }
 
@@ -233,7 +233,7 @@ class SalesChannelProxyControllerTest extends TestCase
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals('FRAMEWORK__API_SALES_CHANNEL_ID_PARAMETER_IS_MISSING', $response['errors'][0]['code'] ?? null);
+        static::assertSame('FRAMEWORK__API_SALES_CHANNEL_ID_PARAMETER_IS_MISSING', $response['errors'][0]['code'] ?? null);
     }
 
     public function testSwitchCustomerWithInvalidChannelId(): void
@@ -252,7 +252,7 @@ class SalesChannelProxyControllerTest extends TestCase
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals('FRAMEWORK__INVALID_SALES_CHANNEL', $response['errors'][0]['code'] ?? null);
+        static::assertSame('FRAMEWORK__INVALID_SALES_CHANNEL', $response['errors'][0]['code'] ?? null);
     }
 
     public function testSwitchCustomerWithoutCustomerId(): void
@@ -267,7 +267,7 @@ class SalesChannelProxyControllerTest extends TestCase
         $response = json_decode($response ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
-        static::assertEquals('FRAMEWORK__API_SALES_CHANNEL_ID_PARAMETER_IS_MISSING', $response['errors'][0]['code'] ?? null);
+        static::assertSame('FRAMEWORK__API_SALES_CHANNEL_ID_PARAMETER_IS_MISSING', $response['errors'][0]['code'] ?? null);
     }
 
     public function testSwitchCustomerWithInvalidCustomerId(): void
@@ -306,13 +306,13 @@ class SalesChannelProxyControllerTest extends TestCase
 
         $contextTokenHeaderName = $this->getContextTokenHeaderName();
         static::assertTrue($response->headers->has(PlatformRequest::HEADER_CONTEXT_TOKEN));
-        static::assertEquals($browser->getServerParameter($contextTokenHeaderName), $response->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+        static::assertSame($browser->getServerParameter($contextTokenHeaderName), $response->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
 
         static::assertIsString($salesChannel['id']);
         // assert customer is updated in database
         $payload = $this->contextPersister->load($response->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN, ''), $salesChannel['id']);
         static::assertArrayHasKey('customerId', $payload);
-        static::assertEquals($customerId, $payload['customerId']);
+        static::assertSame($customerId, $payload['customerId']);
         static::assertArrayHasKey('permissions', $payload);
         static::assertArrayHasKey('allowProductPriceOverwrites', $payload['permissions']);
         static::assertTrue($payload['permissions']['allowProductPriceOverwrites']);
@@ -368,7 +368,7 @@ class SalesChannelProxyControllerTest extends TestCase
         $response = json_decode($response ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
-        static::assertEquals('FRAMEWORK__API_SALES_CHANNEL_ID_PARAMETER_IS_MISSING', $response['errors'][0]['code'] ?? null);
+        static::assertSame('FRAMEWORK__API_SALES_CHANNEL_ID_PARAMETER_IS_MISSING', $response['errors'][0]['code'] ?? null);
     }
 
     public function testModifyShippingCostsWithoutShippingCosts(): void
@@ -446,10 +446,10 @@ class SalesChannelProxyControllerTest extends TestCase
 
         // assert shipping costs in cart
         static::assertArrayHasKey('unitPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(20, $cart['deliveries'][0]['shippingCosts']['unitPrice']);
+        static::assertSame(20, $cart['deliveries'][0]['shippingCosts']['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(20, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
+        static::assertSame(20, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
 
         // create a new shipping method and request to change
         $shippingMethodId = $this->createShippingMethod();
@@ -474,13 +474,13 @@ class SalesChannelProxyControllerTest extends TestCase
 
         // assert shipping method in cart is changed but shipping costs in cart is not changed
         static::assertArrayHasKey('name', $cart['deliveries'][0]['shippingMethod']);
-        static::assertEquals('Test shipping method', $cart['deliveries'][0]['shippingMethod']['name']);
+        static::assertSame('Test shipping method', $cart['deliveries'][0]['shippingMethod']['name']);
 
         static::assertArrayHasKey('unitPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(20, $cart['deliveries'][0]['shippingCosts']['unitPrice']);
+        static::assertSame(20, $cart['deliveries'][0]['shippingCosts']['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(20, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
+        static::assertSame(20, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
     }
 
     public function testModifyShippingWith0Costs(): void
@@ -532,13 +532,13 @@ class SalesChannelProxyControllerTest extends TestCase
 
         // assert shipping method in cart is changed but shipping costs in cart is not changed
         static::assertArrayHasKey('name', $cart['deliveries'][0]['shippingMethod']);
-        static::assertEquals('Example shipping', $cart['deliveries'][0]['shippingMethod']['name']);
+        static::assertSame('Example shipping', $cart['deliveries'][0]['shippingMethod']['name']);
 
         static::assertArrayHasKey('unitPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(5, $cart['deliveries'][0]['shippingCosts']['unitPrice']);
+        static::assertSame(5, $cart['deliveries'][0]['shippingCosts']['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(5, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
+        static::assertSame(5, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
 
         $browser->request(
             'PATCH',
@@ -565,10 +565,10 @@ class SalesChannelProxyControllerTest extends TestCase
 
         // assert shipping costs in cart
         static::assertArrayHasKey('unitPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(0, $cart['deliveries'][0]['shippingCosts']['unitPrice']);
+        static::assertSame(0, $cart['deliveries'][0]['shippingCosts']['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(0, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
+        static::assertSame(0, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
     }
 
     public function testModifyShippingCostsManuallyInCaseCartIsEmpty(): void
@@ -626,14 +626,14 @@ class SalesChannelProxyControllerTest extends TestCase
 
         // shipping costs are now based on manual value, tax rate will be mixed
         static::assertArrayHasKey('unitPrice', $shippingCosts);
-        static::assertEquals(20, $shippingCosts['unitPrice']);
+        static::assertSame(20, $shippingCosts['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $shippingCosts);
-        static::assertEquals(20, $shippingCosts['totalPrice']);
+        static::assertSame(20, $shippingCosts['totalPrice']);
 
         static::assertCount(2, $shippingCosts['calculatedTaxes']);
-        static::assertEquals(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);
-        static::assertEquals(10, $shippingCosts['calculatedTaxes'][1]['taxRate']);
+        static::assertSame(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);
+        static::assertSame(10, $shippingCosts['calculatedTaxes'][1]['taxRate']);
 
         // using store-api through proxy to remove all items in cart
         $this->storeAPIRemoveLineItems($browser, [$firstProductId, $secondProductId], $salesChannelContext->getToken());
@@ -664,13 +664,13 @@ class SalesChannelProxyControllerTest extends TestCase
         $shippingCosts = $cart['deliveries'][0]['shippingCosts'];
 
         static::assertArrayHasKey('unitPrice', $shippingCosts);
-        static::assertEquals(20, $shippingCosts['unitPrice']);
+        static::assertSame(20, $shippingCosts['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $shippingCosts);
-        static::assertEquals(20, $shippingCosts['totalPrice']);
+        static::assertSame(20, $shippingCosts['totalPrice']);
 
         static::assertCount(1, $shippingCosts['calculatedTaxes']);
-        static::assertEquals(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);
+        static::assertSame(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);
     }
 
     public function testModifyShippingCostsManuallyInCaseCartIsNotEmpty(): void
@@ -724,13 +724,13 @@ class SalesChannelProxyControllerTest extends TestCase
 
         // shipping costs are now based on manual value, there is one tax rate
         static::assertArrayHasKey('unitPrice', $shippingCosts);
-        static::assertEquals(20, $shippingCosts['unitPrice']);
+        static::assertSame(20, $shippingCosts['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $shippingCosts);
-        static::assertEquals(20, $shippingCosts['totalPrice']);
+        static::assertSame(20, $shippingCosts['totalPrice']);
 
         static::assertCount(1, $shippingCosts['calculatedTaxes']);
-        static::assertEquals(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);
+        static::assertSame(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);
 
         // using store-api through proxy to remove Product item in cart, keep Credit item.
         $this->storeAPIRemoveLineItems($browser, [$firstProductId], $salesChannelContext->getToken());
@@ -757,13 +757,13 @@ class SalesChannelProxyControllerTest extends TestCase
         // shipping costs is still based on manual value
         $shippingCosts = $cart['deliveries'][0]['shippingCosts'];
         static::assertArrayHasKey('unitPrice', $shippingCosts);
-        static::assertEquals(20, $shippingCosts['unitPrice']);
+        static::assertSame(20, $shippingCosts['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $shippingCosts);
-        static::assertEquals(20, $shippingCosts['totalPrice']);
+        static::assertSame(20, $shippingCosts['totalPrice']);
 
         static::assertCount(1, $shippingCosts['calculatedTaxes']);
-        static::assertEquals(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);
+        static::assertSame(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);
     }
 
     public function testSwitchDeliveryMethodAndPriceWillBeCalculated(): void
@@ -778,7 +778,7 @@ class SalesChannelProxyControllerTest extends TestCase
 
         // assert shipping cost in cart is default from sales channel
         static::assertArrayHasKey('totalPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(0, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
+        static::assertSame(0, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
 
         // create a new shipping method and request to change
         $shippingMethodId = $this->createShippingMethod();
@@ -795,10 +795,10 @@ class SalesChannelProxyControllerTest extends TestCase
 
         // assert shipping method and cost are changed
         static::assertArrayHasKey('name', $cart['deliveries'][0]['shippingMethod']);
-        static::assertEquals('Test shipping method', $cart['deliveries'][0]['shippingMethod']['name']);
+        static::assertSame('Test shipping method', $cart['deliveries'][0]['shippingMethod']['name']);
 
         static::assertArrayHasKey('totalPrice', $cart['deliveries'][0]['shippingCosts']);
-        static::assertEquals(30, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
+        static::assertSame(30, $cart['deliveries'][0]['shippingCosts']['totalPrice']);
     }
 
     public function testCreditItemProcessorTakeCustomItemIntoAccount(): void
@@ -908,7 +908,7 @@ class SalesChannelProxyControllerTest extends TestCase
             $this->getRootProxyUrl('/disable-automatic-promotions'),
             ['salesChannelId' => $salesChannelContext->getSalesChannelId()]
         );
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
 
         // There is 1 line item in cart. It is product
         $cart = $this->getCart($browser, TestDefaults::SALES_CHANNEL);
@@ -947,7 +947,7 @@ class SalesChannelProxyControllerTest extends TestCase
             ['salesChannelId' => $salesChannelContext->getSalesChannelId()]
         );
 
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
 
         // Check automatic promotion code is disabled and exist the promotion code in cart
         $cart = $this->getCart($browser, TestDefaults::SALES_CHANNEL);
@@ -979,7 +979,7 @@ class SalesChannelProxyControllerTest extends TestCase
             ['salesChannelId' => $salesChannelContext->getSalesChannelId()]
         );
 
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
 
         // Check automatic promotion is disabled
         $cart = $this->getCart($browser, TestDefaults::SALES_CHANNEL);
@@ -993,7 +993,7 @@ class SalesChannelProxyControllerTest extends TestCase
             ['salesChannelId' => $salesChannelContext->getSalesChannelId()]
         );
 
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
 
         // Check automatic promotion is enabled
         $cart = $this->getCart($browser, TestDefaults::SALES_CHANNEL);
@@ -1010,7 +1010,7 @@ class SalesChannelProxyControllerTest extends TestCase
         $response = json_decode($response ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
-        static::assertEquals('FRAMEWORK__INVALID_SALES_CHANNEL', $response['errors'][0]['code'] ?? null);
+        static::assertSame('FRAMEWORK__INVALID_SALES_CHANNEL', $response['errors'][0]['code'] ?? null);
     }
 
     public function testProxyCreateOrderPrivileges(): void
@@ -1088,7 +1088,7 @@ class SalesChannelProxyControllerTest extends TestCase
                 $response = json_decode($response ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
                 static::assertArrayHasKey('errors', $response, print_r($response, true));
-                static::assertEquals('FRAMEWORK__MISSING_PRIVILEGE_ERROR', $response['errors'][0]['code'] ?? null);
+                static::assertSame('FRAMEWORK__MISSING_PRIVILEGE_ERROR', $response['errors'][0]['code'] ?? null);
                 static::assertStringContainsString(
                     $testOrderOnly ? CreditOrderLineItemListener::ACL_ORDER_CREATE_DISCOUNT_PRIVILEGE : 'order_line_item:create',
                     $response['errors'][0]['detail'] ?? ''
@@ -1126,12 +1126,12 @@ class SalesChannelProxyControllerTest extends TestCase
             ]
         );
 
-        static::assertEquals($uuid, $this->getBrowser()->getRequest()->headers->get('sw-context-token'));
-        static::assertEquals($uuid, $this->getBrowser()->getRequest()->headers->get('sw-language-id'));
-        static::assertEquals($uuid, $this->getBrowser()->getRequest()->headers->get('sw-version-id'));
-        static::assertEquals($uuid, $this->getBrowser()->getResponse()->headers->get('sw-context-token'));
-        static::assertEquals($uuid, $this->getBrowser()->getResponse()->headers->get('sw-language-id'));
-        static::assertEquals($uuid, $this->getBrowser()->getResponse()->headers->get('sw-version-id'));
+        static::assertSame($uuid, $this->getBrowser()->getRequest()->headers->get('sw-context-token'));
+        static::assertSame($uuid, $this->getBrowser()->getRequest()->headers->get('sw-language-id'));
+        static::assertSame($uuid, $this->getBrowser()->getRequest()->headers->get('sw-version-id'));
+        static::assertSame($uuid, $this->getBrowser()->getResponse()->headers->get('sw-context-token'));
+        static::assertSame($uuid, $this->getBrowser()->getResponse()->headers->get('sw-language-id'));
+        static::assertSame($uuid, $this->getBrowser()->getResponse()->headers->get('sw-version-id'));
     }
 
     private function getLangHeaderName(): string
@@ -1160,7 +1160,7 @@ class SalesChannelProxyControllerTest extends TestCase
         $this->getBrowser()->request('POST', $baseResource, [], [], [], json_encode($categoryData, \JSON_THROW_ON_ERROR) ?: '');
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
 
         $this->assertEntityExists($this->getBrowser(), 'category', $categoryData['id']);
 
@@ -1177,10 +1177,10 @@ class SalesChannelProxyControllerTest extends TestCase
 
         foreach ($expectedTranslations as $key => $expectedTranslation) {
             if (!\is_array($expectedTranslations[$key])) {
-                static::assertEquals($expectedTranslations[$key], $responseData[$key]);
+                static::assertSame($expectedTranslations[$key], $responseData[$key]);
             } else {
                 foreach ($expectedTranslations[$key] as $key2 => $expectedTranslation2) {
-                    static::assertEquals($expectedTranslation[$key2], $responseData[$key][$key2]);
+                    static::assertSame($expectedTranslation[$key2], $responseData[$key][$key2]);
                 }
             }
         }
@@ -1204,7 +1204,7 @@ class SalesChannelProxyControllerTest extends TestCase
                 'translationCodeId' => $fallbackLocaleId,
             ];
             $this->getBrowser()->request('POST', $baseUrl . '/language', [], [], [], json_encode($parentLanguageData, \JSON_THROW_ON_ERROR) ?: '');
-            static::assertEquals(204, $this->getBrowser()->getResponse()->getStatusCode());
+            static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
         }
 
         $localeId = Uuid::randomHex();
@@ -1225,7 +1225,7 @@ class SalesChannelProxyControllerTest extends TestCase
         ];
 
         $this->getBrowser()->request('POST', $baseUrl . '/language', [], [], [], json_encode($languageData, \JSON_THROW_ON_ERROR) ?: '');
-        static::assertEquals(204, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
 
         $this->getBrowser()->request('GET', $baseUrl . '/language/' . $langId);
     }
@@ -1312,7 +1312,7 @@ class SalesChannelProxyControllerTest extends TestCase
 
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $browser = clone $this->getBrowser();
         $browser->setServerParameter('HTTP_SW_CONTEXT_TOKEN', $response->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN) ?: '');

--- a/tests/integration/Core/Framework/Api/Controller/SyncControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/SyncControllerTest.php
@@ -403,7 +403,7 @@ class SyncControllerTest extends TestCase
         $messages = $this->gateway->list('message_queue_stats');
 
         static::assertNotEmpty($messages);
-        static::assertEquals(1, $messages[ProductIndexingMessage::class]['count']);
+        static::assertSame(1, $messages[ProductIndexingMessage::class]['count']);
     }
 
     public function testDirectIndexing(): void
@@ -569,7 +569,7 @@ class SyncControllerTest extends TestCase
         $response = json_decode($response, true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $response['errors'][0]['status']);
-        static::assertEquals($message, $response['errors'][0]['detail']);
+        static::assertSame(Response::HTTP_BAD_REQUEST, (int) $response['errors'][0]['status']);
+        static::assertSame($message, $response['errors'][0]['detail']);
     }
 }

--- a/tests/integration/Core/Framework/Api/Controller/UserControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/UserControllerTest.php
@@ -64,7 +64,7 @@ class UserControllerTest extends TestCase
 
         $content = json_decode((string) $response->getContent(), true);
         static::assertArrayHasKey('errors', $content);
-        static::assertEquals('This access token does not have the scope "user-verified" to process this Request', $content['errors'][0]['detail']);
+        static::assertSame('This access token does not have the scope "user-verified" to process this Request', $content['errors'][0]['detail']);
 
         static::getContainer()->get(Connection::class)
             ->executeStatement('DELETE FROM user WHERE email = \'admin@example.com\'');
@@ -112,7 +112,7 @@ class UserControllerTest extends TestCase
             );
 
         $assigned = array_column($assigned, 'id');
-        static::assertEquals(array_values($ids->getList(['role-2'])), $assigned);
+        static::assertSame(array_values($ids->getList(['role-2'])), $assigned);
     }
 
     public function testAddRoleAssignment(): void
@@ -158,7 +158,7 @@ class UserControllerTest extends TestCase
         $assigned = array_column($assigned, 'id');
         $expectedIds = $ids->getList(['role-1', 'role-2']);
         sort($expectedIds);
-        static::assertEquals($expectedIds, $assigned);
+        static::assertSame($expectedIds, $assigned);
     }
 
     public function testDeleteUser(): void
@@ -185,7 +185,7 @@ class UserControllerTest extends TestCase
 
         $content = json_decode((string) $response->getContent(), true);
         static::assertArrayHasKey('errors', $content);
-        static::assertEquals('This access token does not have the scope "user-verified" to process this Request', $content['errors'][0]['detail']);
+        static::assertSame('This access token does not have the scope "user-verified" to process this Request', $content['errors'][0]['detail']);
 
         static::getContainer()->get(Connection::class)
             ->executeStatement('DELETE FROM user WHERE email = \'admin@example.com\'');
@@ -205,13 +205,13 @@ class UserControllerTest extends TestCase
         $this->getBrowser()->request('PATCH', '/api/_info/me', ['firstName' => 'newName']);
         $responsePatch = $this->getBrowser()->getResponse();
 
-        static::assertEquals(Response::HTTP_NO_CONTENT, $responsePatch->getStatusCode(), (string) $responsePatch->getContent());
+        static::assertSame(Response::HTTP_NO_CONTENT, $responsePatch->getStatusCode(), (string) $responsePatch->getContent());
 
         $this->getBrowser()->request('GET', '/api/_info/me');
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
-        static::assertEquals('newName', json_decode((string) $response->getContent(), true)['data']['attributes']['firstName']);
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame('newName', json_decode((string) $response->getContent(), true)['data']['attributes']['firstName']);
     }
 
     public function testSetOwnProfileNoPermission(): void
@@ -222,9 +222,9 @@ class UserControllerTest extends TestCase
 
         $content = (string) $response->getContent();
 
-        static::assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode(), $content);
-        static::assertEquals(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, json_decode($content, true)['errors'][0]['code'], $content);
-        static::assertEquals(['user_change_me'], json_decode(json_decode($content, true)['errors'][0]['detail'], true)['missingPrivileges'], $content);
+        static::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), $content);
+        static::assertSame(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, json_decode($content, true)['errors'][0]['code'], $content);
+        static::assertSame(['user_change_me'], json_decode(json_decode($content, true)['errors'][0]['detail'], true)['missingPrivileges'], $content);
     }
 
     public function testSetOwnProfilePermissionButNotAllowedField(): void
@@ -235,9 +235,9 @@ class UserControllerTest extends TestCase
 
         $content = (string) $response->getContent();
 
-        static::assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode(), $content);
-        static::assertEquals(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, json_decode($content, true)['errors'][0]['code'], $content);
-        static::assertEquals(['user:update'], json_decode(json_decode($content, true)['errors'][0]['detail'], true)['missingPrivileges'], $content);
+        static::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), $content);
+        static::assertSame(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, json_decode($content, true)['errors'][0]['code'], $content);
+        static::assertSame(['user:update'], json_decode(json_decode($content, true)['errors'][0]['detail'], true)['missingPrivileges'], $content);
     }
 
     public function testPreventChangeOfUSerWithoutPermission(): void

--- a/tests/integration/Core/Framework/Api/OAuth/ClientRepositoryTest.php
+++ b/tests/integration/Core/Framework/Api/OAuth/ClientRepositoryTest.php
@@ -46,14 +46,14 @@ class ClientRepositoryTest extends TestCase
         ];
 
         $browser->request('POST', '/api/oauth/token', $authPayload, [], [], json_encode($authPayload, \JSON_THROW_ON_ERROR));
-        static::assertEquals(Response::HTTP_UNAUTHORIZED, $browser->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $browser->getResponse()->getStatusCode());
     }
 
     public function testDoesntAffectLoggedInUser(): void
     {
         $this->getBrowser()->request('GET', '/api/product');
 
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
     }
 
     private function fetchApp(string $appName): ?AppEntity

--- a/tests/integration/Core/Framework/Api/ResponseTypeRegistryTest.php
+++ b/tests/integration/Core/Framework/Api/ResponseTypeRegistryTest.php
@@ -48,11 +48,11 @@ class ResponseTypeRegistryTest extends TestCase
         $context = $this->getAdminContext();
         $response = $this->getDetailResponse($context, $id, '/api/category/' . $id, $accept, false);
 
-        static::assertEquals($accept, $response->headers->get('content-type'));
+        static::assertSame($accept, $response->headers->get('content-type'));
         $content = $response->getContent();
         static::assertIsString($content);
         $content = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals($id, $content['data']['name']);
+        static::assertSame($id, $content['data']['name']);
     }
 
     public function testAdminJsonApi(): void
@@ -63,15 +63,15 @@ class ResponseTypeRegistryTest extends TestCase
         $context = $this->getAdminContext();
         $response = $this->getDetailResponse($context, $id, $self, $accept, false);
 
-        static::assertEquals($accept, $response->headers->get('content-type'));
+        static::assertSame($accept, $response->headers->get('content-type'));
         $content = $response->getContent();
         static::assertIsString($content);
         $content = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         $this->assertDetailJsonApiStructure($content);
-        static::assertEquals($id, $content['data']['attributes']['name']);
-        static::assertEquals($self, $content['links']['self']);
-        static::assertEquals($self, $content['data']['links']['self']);
+        static::assertSame($id, $content['data']['attributes']['name']);
+        static::assertSame($self, $content['links']['self']);
+        static::assertSame($self, $content['data']['links']['self']);
     }
 
     public function testAdminJsonApiDefault(): void
@@ -82,15 +82,15 @@ class ResponseTypeRegistryTest extends TestCase
         $context = $this->getAdminContext();
         $response = $this->getDetailResponse($context, $id, $self, $accept, false);
 
-        static::assertEquals('application/vnd.api+json', $response->headers->get('content-type'));
+        static::assertSame('application/vnd.api+json', $response->headers->get('content-type'));
         $content = $response->getContent();
         static::assertIsString($content);
         $content = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         $this->assertDetailJsonApiStructure($content);
-        static::assertEquals($id, $content['data']['attributes']['name']);
-        static::assertEquals($self, $content['links']['self']);
-        static::assertEquals($self, $content['data']['links']['self']);
+        static::assertSame($id, $content['data']['attributes']['name']);
+        static::assertSame($self, $content['links']['self']);
+        static::assertSame($self, $content['data']['links']['self']);
     }
 
     public function testAdminApiUnsupportedContentType(): void
@@ -111,16 +111,16 @@ class ResponseTypeRegistryTest extends TestCase
         $context = $this->getAdminContext();
         $response = $this->getListResponse($context, $id, $self, $accept);
 
-        static::assertEquals($accept, $response->headers->get('content-type'));
+        static::assertSame($accept, $response->headers->get('content-type'));
         $content = $response->getContent();
         static::assertIsString($content);
         $content = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
         $this->assertDetailJsonApiStructure($content);
         static::assertNotEmpty($content['data']);
-        static::assertEquals($id, $content['data'][0]['attributes']['name']);
-        static::assertEquals($self, $content['links']['self']);
-        static::assertEquals($self . '/' . $id, $content['data'][0]['links']['self']);
+        static::assertSame($id, $content['data'][0]['attributes']['name']);
+        static::assertSame($self, $content['links']['self']);
+        static::assertSame($self . '/' . $id, $content['data'][0]['links']['self']);
     }
 
     /**

--- a/tests/integration/Core/Framework/Api/Serializer/JsonApiDecoderTest.php
+++ b/tests/integration/Core/Framework/Api/Serializer/JsonApiDecoderTest.php
@@ -231,7 +231,7 @@ class JsonApiDecoderTest extends TestCase
             ],
         ];
 
-        static::assertEquals($expected, $this->decoder->decode(json_encode($json, \JSON_THROW_ON_ERROR), 'jsonapi'));
+        static::assertSame($expected, $this->decoder->decode(json_encode($json, \JSON_THROW_ON_ERROR), 'jsonapi'));
     }
 
     public function testDecodeStructWithRelationships(): void
@@ -294,7 +294,7 @@ class JsonApiDecoderTest extends TestCase
             ],
         ];
 
-        static::assertEquals($expected, $this->decoder->decode(json_encode($json, \JSON_THROW_ON_ERROR), 'jsonapi'));
+        static::assertSame($expected, $this->decoder->decode(json_encode($json, \JSON_THROW_ON_ERROR), 'jsonapi'));
     }
 
     public function testDecodeStructWithToManyRelationships(): void

--- a/tests/integration/Core/Framework/Api/Serializer/JsonApiEncoderTest.php
+++ b/tests/integration/Core/Framework/Api/Serializer/JsonApiEncoderTest.php
@@ -246,7 +246,7 @@ class JsonApiEncoderTest extends TestCase
                 continue;
             }
             static::assertNotEmpty($included['relationships']['toOne']['data'], 'The relationship data to the loaded extension association is missing');
-            static::assertEquals('extended_product', $included['relationships']['toOne']['data']['type']);
+            static::assertSame('extended_product', $included['relationships']['toOne']['data']['type']);
             static::assertNotEmpty($included['relationships']['toOne']['data']['id']);
         }
     }
@@ -295,7 +295,7 @@ class JsonApiEncoderTest extends TestCase
             }
             static::assertNotEmpty($included['relationships']['oneToMany']['data'], 'The relationship data to the loaded extension association is missing');
             static::assertCount(2, $included['relationships']['oneToMany']['data']);
-            static::assertEquals('extended_product', $included['relationships']['oneToMany']['data'][0]['type']);
+            static::assertSame('extended_product', $included['relationships']['oneToMany']['data'][0]['type']);
             static::assertNotEmpty($included['relationships']['oneToMany']['data'][0]['id']);
         }
     }
@@ -319,7 +319,7 @@ class JsonApiEncoderTest extends TestCase
 
         $actual = json_decode((string) $encoder->encode(new Criteria(), $definition, $struct, SerializationFixture::API_BASE_URL), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals($output, $actual['data']['attributes']['customFields']);
+        static::assertSame($output, $actual['data']['attributes']['customFields']);
     }
 
     public static function customFieldsProvider(): \Generator
@@ -395,7 +395,7 @@ class JsonApiEncoderTest extends TestCase
             if (\is_array($value)) {
                 $this->assertValues($value, $actual[$key]);
             } else {
-                static::assertEquals($value, $actual[$key], 'Key: ' . $key);
+                static::assertSame($value, $actual[$key], 'Key: ' . $key);
             }
         }
     }

--- a/tests/integration/Core/Framework/Api/Serializer/JsonEntityEncoderTest.php
+++ b/tests/integration/Core/Framework/Api/Serializer/JsonEntityEncoderTest.php
@@ -155,7 +155,7 @@ class JsonEntityEncoderTest extends TestCase
 
         $actual = $encoder->encode(new Criteria(), $definition, $struct, SerializationFixture::API_BASE_URL);
 
-        static::assertEquals($output, array_intersect_key($output, $actual));
+        static::assertSame($output, array_intersect_key($output, $actual));
     }
 
     /**

--- a/tests/integration/Core/Framework/Api/Sync/SyncServiceTest.php
+++ b/tests/integration/Core/Framework/Api/Sync/SyncServiceTest.php
@@ -87,11 +87,11 @@ class SyncServiceTest extends TestCase
 
         $result = $this->service->sync($operations, Context::createDefaultContext(), new SyncBehavior());
 
-        static::assertEquals([], $result->getDeleted());
+        static::assertSame([], $result->getDeleted());
 
         $expected = ['product_price' => [$ids->get('not-existing-price')]];
 
-        static::assertEquals($expected, $result->getNotFound());
+        static::assertSame($expected, $result->getNotFound());
     }
 
     public function testDeleteProductMediaAndUpdateProduct(): void
@@ -444,6 +444,6 @@ class SyncServiceTest extends TestCase
         static::assertIsString($productPrice);
         $productPrice = json_decode($productPrice, true);
         $productPrice = array_shift($productPrice);
-        static::assertEquals(300, $productPrice['gross']);
+        static::assertSame(300.0, $productPrice['gross']);
     }
 }

--- a/tests/integration/Core/Framework/Api/TranslationTest.php
+++ b/tests/integration/Core/Framework/Api/TranslationTest.php
@@ -142,10 +142,10 @@ class TranslationTest extends TestCase
 
         $this->getBrowser()->request('GET', $baseResource, [], [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(412, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(412, $response->getStatusCode(), (string) $response->getContent());
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
+        static::assertSame(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
     }
 
     public function testInvalidUuidLanguageIdError(): void
@@ -156,18 +156,18 @@ class TranslationTest extends TestCase
 
         $this->getBrowser()->request('GET', $baseResource, [], [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(412, $response->getStatusCode());
+        static::assertSame(412, $response->getStatusCode());
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
+        static::assertSame(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
 
         $langId = \sprintf('id=%s', 'foobar');
         $this->getBrowser()->request('GET', $baseResource, [], [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(412, $response->getStatusCode());
+        static::assertSame(412, $response->getStatusCode());
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
+        static::assertSame(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
     }
 
     public function testNonExistingLanguageIdError(): void
@@ -178,18 +178,18 @@ class TranslationTest extends TestCase
 
         $this->getBrowser()->request('GET', $baseResource, [], [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(412, $response->getStatusCode());
+        static::assertSame(412, $response->getStatusCode());
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
+        static::assertSame(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
 
         $langId = \sprintf('id=%s', Uuid::randomHex());
         $this->getBrowser()->request('GET', $baseResource, [], [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(412, $response->getStatusCode());
+        static::assertSame(412, $response->getStatusCode());
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
+        static::assertSame(RoutingException::LANGUAGE_NOT_FOUND, $data['errors'][0]['code']);
     }
 
     public function testOverride(): void
@@ -332,7 +332,7 @@ class TranslationTest extends TestCase
 
         $this->getBrowser()->request('POST', $baseResource, $notTranslated);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
 
         $this->assertEntityExists($this->getBrowser(), 'locale', $id);
 
@@ -343,16 +343,16 @@ class TranslationTest extends TestCase
 
         $this->getBrowser()->request('PATCH', $baseResource . '/' . $id, $translated, [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
 
         $this->getBrowser()->request('GET', $baseResource . '/' . $id, [], [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
         $responseData = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals($translated['name'], $responseData['data']['attributes']['name']);
+        static::assertSame($translated['name'], $responseData['data']['attributes']['name']);
         static::assertNull($responseData['data']['attributes']['territory']);
 
-        static::assertEquals($notTranslated['territory'], $responseData['data']['attributes']['translated']['territory']);
+        static::assertSame($notTranslated['territory'], $responseData['data']['attributes']['translated']['territory']);
     }
 
     public function testDelete(): void
@@ -376,7 +376,7 @@ class TranslationTest extends TestCase
 
         $this->getBrowser()->request('POST', $baseResource, $categoryData);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
         $this->assertEntityExists($this->getBrowser(), 'category', $id);
 
         $headerName = $this->getLangHeaderName();
@@ -384,16 +384,16 @@ class TranslationTest extends TestCase
         $this->getBrowser()->request('GET', $baseResource . '/' . $id, [], [], [$headerName => Defaults::LANGUAGE_SYSTEM]);
         $response = $this->getBrowser()->getResponse();
         $responseData = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals($name, $responseData['data']['attributes']['name']);
+        static::assertSame($name, $responseData['data']['attributes']['name']);
 
         $this->getBrowser()->request('GET', $baseResource . '/' . $id, [], [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
         $responseData = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals($translatedName, $responseData['data']['attributes']['name']);
+        static::assertSame($translatedName, $responseData['data']['attributes']['name']);
 
         $this->getBrowser()->request('DELETE', $baseResource . '/' . $id . '/translations/' . $langId);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
 
         $this->getBrowser()->request('GET', $baseResource . '/' . $id, [], [], [$headerName => $langId]);
         $response = $this->getBrowser()->getResponse();
@@ -415,16 +415,16 @@ class TranslationTest extends TestCase
         $this->getBrowser()->request('POST', $baseResource, $categoryData);
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
         $this->assertEntityExists($this->getBrowser(), 'category', $id);
 
         $this->getBrowser()->request('DELETE', $baseResource . '/' . $id . '/translations/' . Defaults::LANGUAGE_SYSTEM);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(400, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(400, $response->getStatusCode(), (string) $response->getContent());
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(TranslationValidator::VIOLATION_DELETE_SYSTEM_TRANSLATION, $data['errors'][0]['code']);
-        static::assertEquals('/' . $id . '/translations/' . Defaults::LANGUAGE_SYSTEM, $data['errors'][0]['source']['pointer']);
+        static::assertSame(TranslationValidator::VIOLATION_DELETE_SYSTEM_TRANSLATION, $data['errors'][0]['code']);
+        static::assertSame('/' . $id . '/translations/' . Defaults::LANGUAGE_SYSTEM, $data['errors'][0]['source']['pointer']);
     }
 
     public function testDeleteEntityWithOneRootTranslation(): void
@@ -449,12 +449,12 @@ class TranslationTest extends TestCase
         $this->getBrowser()->request('POST', $baseResource, [], [], [], json_encode($categoryData, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
         $this->assertEntityExists($this->getBrowser(), 'category', $id);
 
         $this->getBrowser()->request('DELETE', $baseResource . '/' . $id);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testDeleteNonSystemRootTranslations(): void
@@ -474,12 +474,12 @@ class TranslationTest extends TestCase
         $this->getBrowser()->request('POST', $baseResource, [], [], [], json_encode($categoryData, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
         $this->assertEntityExists($this->getBrowser(), 'category', $id);
 
         $this->getBrowser()->request('DELETE', $baseResource . '/' . $id . '/translations/' . $rootDelete);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testDeleteChildLanguageTranslation(): void
@@ -502,12 +502,12 @@ class TranslationTest extends TestCase
         $this->getBrowser()->request('POST', $baseResource, [], [], [], json_encode($categoryData, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
         $this->assertEntityExists($this->getBrowser(), 'category', $id);
 
         $this->getBrowser()->request('DELETE', $baseResource . '/' . $id . '/translations/' . $childId);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(204, $response->getStatusCode());
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testMixedTranslationStatus(): void
@@ -554,17 +554,17 @@ class TranslationTest extends TestCase
         ];
         $this->getBrowser()->request('GET', $baseResource . '?sort=name', [], [], $headers);
         $response = $this->getBrowser()->getResponse();
-        static::assertEquals(200, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
         $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR)['data'];
 
         static::assertNull($data[0]['name']);
         static::assertNull($data[1]['name']);
-        static::assertEquals('3. child', $data[2]['name']);
+        static::assertSame('3. child', $data[2]['name']);
 
-        static::assertEquals('1. system', $data[0]['translated']['name']);
-        static::assertEquals('2. root', $data[1]['translated']['name']);
-        static::assertEquals('3. child', $data[2]['translated']['name']);
+        static::assertSame('1. system', $data[0]['translated']['name']);
+        static::assertSame('2. root', $data[1]['translated']['name']);
+        static::assertSame('3. child', $data[2]['translated']['name']);
     }
 
     private function getLangHeaderName(): string
@@ -588,7 +588,7 @@ class TranslationTest extends TestCase
         $this->getBrowser()->request('POST', $baseResource, [], [], [], json_encode($categoryData, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(400, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(400, $response->getStatusCode(), (string) $response->getContent());
 
         $responseData = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertCount(\count($errors), $responseData['errors']);
@@ -605,7 +605,7 @@ class TranslationTest extends TestCase
             return $e;
         }, $responseData['errors']);
 
-        static::assertEquals($errors, $actualErrors);
+        static::assertSame($errors, $actualErrors);
     }
 
     /**
@@ -624,7 +624,7 @@ class TranslationTest extends TestCase
         $this->getBrowser()->request('POST', $baseResource, [], [], [], json_encode($requestData, \JSON_THROW_ON_ERROR));
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(204, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
 
         $this->assertEntityExists($this->getBrowser(), $entity, $requestData['id']);
 
@@ -642,10 +642,10 @@ class TranslationTest extends TestCase
         static::assertArrayHasKey('data', $responseData, (string) $response->getContent());
         foreach ($expectedTranslations as $key => $expectedTranslation) {
             if (!\is_array($expectedTranslation)) {
-                static::assertEquals($expectedTranslation, $responseData['data'][$key]);
+                static::assertSame($expectedTranslation, $responseData['data'][$key]);
             } else {
                 foreach ($expectedTranslation as $key2 => $expectedTranslation2) {
-                    static::assertEquals($expectedTranslation2, $responseData['data'][$key][$key2]);
+                    static::assertSame($expectedTranslation2, $responseData['data'][$key][$key2]);
                 }
             }
         }
@@ -669,7 +669,7 @@ class TranslationTest extends TestCase
                 'translationCodeId' => $fallbackLocaleId,
             ];
             $this->getBrowser()->request('POST', $baseUrl . '/language', [], [], [], json_encode($parentLanguageData, \JSON_THROW_ON_ERROR));
-            static::assertEquals(204, $this->getBrowser()->getResponse()->getStatusCode());
+            static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
         }
 
         $localeId = Uuid::randomHex();
@@ -687,7 +687,7 @@ class TranslationTest extends TestCase
         ];
 
         $this->getBrowser()->request('POST', $baseUrl . '/language', [], [], [], json_encode($languageData, \JSON_THROW_ON_ERROR));
-        static::assertEquals(204, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
+        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
 
         $this->getBrowser()->request('GET', $baseUrl . '/language/' . $langId);
     }

--- a/tests/integration/Core/Framework/Api/VersionTest.php
+++ b/tests/integration/Core/Framework/Api/VersionTest.php
@@ -44,7 +44,7 @@ class VersionTest extends TestCase
     public function testAuthShouldNotBeProtected(): void
     {
         $this->unauthorizedClient->request('POST', '/api/oauth/token');
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_BAD_REQUEST,
             $this->unauthorizedClient->getResponse()->getStatusCode(),
             'Route should be protected. (URL: /api/oauth/token)'
@@ -53,16 +53,16 @@ class VersionTest extends TestCase
         $content = (string) $this->unauthorizedClient->getResponse()->getContent();
         $response = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertNotEquals('false', $content);
-        static::assertEquals('The authorization grant type is not supported by the authorization server.', $response['errors'][0]['title']);
-        static::assertEquals('Check that all required parameters have been provided', $response['errors'][0]['detail']);
+        static::assertNotSame('false', $content);
+        static::assertSame('The authorization grant type is not supported by the authorization server.', $response['errors'][0]['title']);
+        static::assertSame('Check that all required parameters have been provided', $response['errors'][0]['detail']);
     }
 
     #[DataProvider('protectedRoutesDataProvider')]
     public function testRoutesAreProtected(string $method, string $url): void
     {
         $this->unauthorizedClient->request($method, $url);
-        static::assertEquals(
+        static::assertSame(
             Response::HTTP_UNAUTHORIZED,
             $this->unauthorizedClient->getResponse()->getStatusCode(),
             'Route should be protected. (URL: ' . $url . ')'

--- a/tests/integration/Core/Framework/App/ActionButton/ActionButtonLoaderTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/ActionButtonLoaderTest.php
@@ -53,7 +53,7 @@ class ActionButtonLoaderTest extends TestCase
 
         usort($loadedActionButtons, fn (array $a, array $b): int => $a['app'] <=> $b['app']);
 
-        static::assertEquals([
+        static::assertSame([
             [
                 'app' => 'App1',
                 'id' => $this->app1OrderDetailButtonId,

--- a/tests/integration/Core/Framework/App/ActionButton/AppActionLoaderTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/AppActionLoaderTest.php
@@ -62,6 +62,6 @@ class AppActionLoaderTest extends TestCase
         ];
 
         static::assertEquals($expected, $result->asPayload());
-        static::assertEquals($action->getUrl(), $result->getTargetUrl());
+        static::assertSame($action->getUrl(), $result->getTargetUrl());
     }
 }

--- a/tests/integration/Core/Framework/App/Api/AppCmsControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppCmsControllerTest.php
@@ -37,10 +37,7 @@ class AppCmsControllerTest extends TestCase
         $actual['blocks'][0]['template'] = $this->stripWhitespace($actual['blocks'][0]['template']);
         $actual['blocks'][1]['template'] = $this->stripWhitespace($actual['blocks'][1]['template']);
 
-        static::assertEquals(
-            $expected,
-            $actual
-        );
+        static::assertEquals($expected, $actual);
     }
 
     private function stripWhitespace(string $text): string

--- a/tests/integration/Core/Framework/App/Api/AppUrlChangeControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppUrlChangeControllerTest.php
@@ -32,7 +32,7 @@ class AppUrlChangeControllerTest extends TestCase
         static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
 
         $appUrlChangeResolver = static::getContainer()->get(Resolver::class);
-        static::assertEquals($appUrlChangeResolver->getAvailableStrategies(), $response);
+        static::assertSame($appUrlChangeResolver->getAvailableStrategies(), $response);
     }
 
     public function testResolveWithExistingStrategy(): void
@@ -120,7 +120,7 @@ class AppUrlChangeControllerTest extends TestCase
         $response = \json_decode($this->getBrowser()->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
-        static::assertEquals(['oldUrl' => $oldUrl, 'newUrl' => $_SERVER['APP_URL']], $response);
+        static::assertSame(['oldUrl' => $oldUrl, 'newUrl' => $_SERVER['APP_URL']], $response);
     }
 
     public function testGetUrlDiffWithoutApps(): void

--- a/tests/integration/Core/Framework/App/AppServiceTest.php
+++ b/tests/integration/Core/Framework/App/AppServiceTest.php
@@ -102,7 +102,7 @@ class AppServiceTest extends TestCase
         static::assertInstanceOf(AppEntity::class, $first);
         static::assertSame('test', $first->getName());
         static::assertSame('1.0.0', $first->getVersion());
-        static::assertNotEquals('test', $first->getTranslation('label'));
+        static::assertNotSame('test', $first->getTranslation('label'));
 
         $this->assertDefaultActionButtons();
     }

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
@@ -84,7 +84,7 @@ class MoveShopPermanentlyStrategyTest extends TestCase
         static::assertNotNull($app->getIntegration());
         static::assertNotNull($updatedApp->getIntegration());
 
-        static::assertNotEquals(
+        static::assertNotSame(
             $app->getIntegration()->getSecretAccessKey(),
             $updatedApp->getIntegration()->getSecretAccessKey()
         );

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
@@ -85,14 +85,14 @@ class ReinstallAppsStrategyTest extends TestCase
 
         $reinstallAppsResolver->resolve($this->context);
 
-        static::assertNotEquals($shopId, $this->shopIdProvider->getShopId());
+        static::assertNotSame($shopId, $this->shopIdProvider->getShopId());
 
         // assert secret access key changed
         $updatedApp = $this->getInstalledApp($this->context);
         static::assertNotNull($app->getIntegration());
         static::assertNotNull($updatedApp->getIntegration());
 
-        static::assertNotEquals(
+        static::assertNotSame(
             $app->getIntegration()->getSecretAccessKey(),
             $updatedApp->getIntegration()->getSecretAccessKey()
         );
@@ -123,7 +123,7 @@ class ReinstallAppsStrategyTest extends TestCase
 
         $reinstallAppsResolver->resolve($this->context);
 
-        static::assertNotEquals($shopId, $this->shopIdProvider->getShopId());
+        static::assertNotSame($shopId, $this->shopIdProvider->getShopId());
     }
 
     private function changeAppUrl(): string

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
@@ -75,7 +75,7 @@ class UninstallAppsStrategyTest extends TestCase
 
         $uninstallAppsResolver->resolve($this->context);
 
-        static::assertNotEquals($shopId, $this->shopIdProvider->getShopId());
+        static::assertNotSame($shopId, $this->shopIdProvider->getShopId());
 
         static::assertNull($this->getInstalledApp($this->context));
     }

--- a/tests/integration/Core/Framework/App/Cms/Xml/BlockTest.php
+++ b/tests/integration/Core/Framework/App/Cms/Xml/BlockTest.php
@@ -23,7 +23,7 @@ class BlockTest extends TestCase
         static::assertSame('text-image', $firstBlock->getCategory());
         static::assertCount(3, $firstBlock->getSlots());
         static::assertCount(6, $firstBlock->getDefaultConfig()->toArray('en-GB'));
-        static::assertEquals(
+        static::assertSame(
             [
                 'en-GB' => 'First block from app',
                 'de-DE' => 'Erster Block einer App',
@@ -42,7 +42,7 @@ class BlockTest extends TestCase
         $slots = $firstBlock->getSlots();
         $defaultConfig = $firstBlock->getDefaultConfig();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'name' => 'first-block-name',
                 'category' => 'text-image',
@@ -60,7 +60,7 @@ class BlockTest extends TestCase
         $slots = $secondBlock->getSlots();
         $defaultConfig = $secondBlock->getDefaultConfig();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'name' => 'second-block-name',
                 'category' => 'text',

--- a/tests/integration/Core/Framework/App/Cms/Xml/BlocksTest.php
+++ b/tests/integration/Core/Framework/App/Cms/Xml/BlocksTest.php
@@ -20,7 +20,7 @@ class BlocksTest extends TestCase
         $firstBlock = $cmsExtensions->getBlocks()->getBlocks()[0];
         static::assertSame('first-block-name', $firstBlock->getName());
         static::assertSame('text-image', $firstBlock->getCategory());
-        static::assertEquals(
+        static::assertSame(
             [
                 'en-GB' => 'First block from app',
                 'de-DE' => 'Erster Block einer App',

--- a/tests/integration/Core/Framework/App/Cms/Xml/ConfigTest.php
+++ b/tests/integration/Core/Framework/App/Cms/Xml/ConfigTest.php
@@ -17,7 +17,7 @@ class ConfigTest extends TestCase
 
         $config = $cmsExtensions->getBlocks()->getBlocks()[0]->getSlots()[1]->getConfig();
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'displayMode' => [
                     'source' => 'static',

--- a/tests/integration/Core/Framework/App/Delta/DomainsDeltaProviderTest.php
+++ b/tests/integration/Core/Framework/App/Delta/DomainsDeltaProviderTest.php
@@ -47,7 +47,7 @@ class DomainsDeltaProviderTest extends TestCase
         $delta = (new DomainsDeltaProvider())->getReport($manifest, $app);
 
         static::assertCount(8, $delta);
-        static::assertEquals([
+        static::assertSame([
             'my.app.com',
             'test.com',
             'base-url.com',

--- a/tests/integration/Core/Framework/App/Flow/FlowAction/Xml/InputFieldTest.php
+++ b/tests/integration/Core/Framework/App/Flow/FlowAction/Xml/InputFieldTest.php
@@ -23,15 +23,15 @@ class InputFieldTest extends TestCase
 
         static::assertSame('textField', $firstInputField->getName());
         static::assertSame('text', $firstInputField->getType());
-        static::assertEquals([
+        static::assertSame([
             'en-GB' => 'To',
             'de-DE' => 'To DE',
         ], $firstInputField->getLabel());
-        static::assertEquals([
+        static::assertSame([
             'en-GB' => 'Enter to...',
             'de-DE' => 'Enter to DE...',
         ], $firstInputField->getPlaceHolder());
-        static::assertEquals([
+        static::assertSame([
             'en-GB' => 'Help text',
             'de-DE' => 'Help text DE',
         ], $firstInputField->getHelpText());

--- a/tests/integration/Core/Framework/App/Flow/FlowAction/Xml/MetadataTest.php
+++ b/tests/integration/Core/Framework/App/Flow/FlowAction/Xml/MetadataTest.php
@@ -26,21 +26,21 @@ class MetadataTest extends TestCase
         static::assertSame('https://example.xyz', $meta->getUrl());
         static::assertSame('sw-pencil', $meta->getSwIcon());
         static::assertSame('resource/pencil', $meta->getIcon());
-        static::assertEquals(
+        static::assertSame(
             [
                 'en-GB' => 'First action app',
                 'de-DE' => 'First action app DE',
             ],
             $firstAction->getMeta()->getLabel()
         );
-        static::assertEquals(
+        static::assertSame(
             [
                 'en-GB' => 'First action app description',
                 'de-DE' => 'First action app description DE',
             ],
             $firstAction->getMeta()->getDescription()
         );
-        static::assertEquals(
+        static::assertSame(
             [
                 'en-GB' => 'Headline for action',
                 'de-DE' => 'Überschrift für Aktion',

--- a/tests/integration/Core/Framework/App/Flow/FlowEvent/Xml/CustomEventTest.php
+++ b/tests/integration/Core/Framework/App/Flow/FlowEvent/Xml/CustomEventTest.php
@@ -21,6 +21,6 @@ class CustomEventTest extends TestCase
         static::assertSame('checkout.order.place.custom', $firstEvent->getName());
 
         static::assertSame('checkout.order.place.custom', $firstEvent->getName());
-        static::assertEquals(['orderAware', 'customerAware'], $firstEvent->getAware());
+        static::assertSame(['orderAware', 'customerAware'], $firstEvent->getAware());
     }
 }

--- a/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -515,7 +515,7 @@ class AppLifecycleTest extends TestCase
             $appEntity->getIcon()
         );
         static::assertSame('1.0.0', $appEntity->getVersion());
-        static::assertNotEquals('test', $appEntity->getTranslation('label'));
+        static::assertNotSame('test', $appEntity->getTranslation('label'));
         static::assertTrue($appEntity->getAllowDisable());
 
         $this->assertDefaultActionButtons();
@@ -710,7 +710,7 @@ class AppLifecycleTest extends TestCase
         );
         static::assertSame('1.0.0', $appEntity->getVersion());
         static::assertSame('https://base-url.com', $appEntity->getBaseAppUrl());
-        static::assertNotEquals('test', $appEntity->getTranslation('label'));
+        static::assertNotSame('test', $appEntity->getTranslation('label'));
         static::assertTrue($appEntity->getAllowDisable());
 
         $this->assertDefaultActionButtons();
@@ -1794,7 +1794,7 @@ class AppLifecycleTest extends TestCase
     {
         static::assertCount(2, $app->getModules());
 
-        static::assertEquals([
+        static::assertSame([
             [
                 'name' => 'first-module',
                 'label' => [
@@ -1876,7 +1876,7 @@ class AppLifecycleTest extends TestCase
         static::assertContains('product', $relatedEntities);
         static::assertContains('customer', $relatedEntities);
 
-        static::assertEquals([
+        static::assertSame([
             'label' => [
                 'de-DE' => 'Zusatzfeld Test',
                 'en-GB' => 'Custom field test',
@@ -2288,7 +2288,7 @@ class AppLifecycleTest extends TestCase
         static::assertSame($appFlowAction['sw_icon'], 'default-communication-speech-bubbles');
         $parameters = json_decode((string) $appFlowAction['parameters'], true, 512, \JSON_THROW_ON_ERROR);
         static::assertNotFalse($parameters);
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     'name' => 'message',
@@ -2302,7 +2302,7 @@ class AppLifecycleTest extends TestCase
 
         $config = json_decode((string) $appFlowAction['config'], true, 512, \JSON_THROW_ON_ERROR);
         static::assertNotFalse($config);
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     'name' => 'text',
@@ -2330,7 +2330,7 @@ class AppLifecycleTest extends TestCase
 
         $headers = json_decode((string) $appFlowAction['headers'], true, 512, \JSON_THROW_ON_ERROR);
         static::assertNotFalse($headers);
-        static::assertEquals(
+        static::assertSame(
             [
                 [
                     'name' => 'content-type',
@@ -2344,7 +2344,7 @@ class AppLifecycleTest extends TestCase
 
         $requirements = json_decode((string) $appFlowAction['requirements'], true, 512, \JSON_THROW_ON_ERROR);
         static::assertNotFalse($requirements);
-        static::assertEquals(
+        static::assertSame(
             [
                 'orderAware',
                 'customerAware',

--- a/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/BoolFieldTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/BoolFieldTest.php
@@ -21,7 +21,7 @@ class BoolFieldTest extends TestCase
         static::assertSame('test_bool_field', $boolField->getName());
         static::assertSame('bool', $boolField->getType());
         static::assertTrue($boolField->isActive());
-        static::assertEquals([
+        static::assertSame([
             'type' => 'checkbox',
             'label' => [
                 'en-GB' => 'Test bool field',

--- a/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/ColorPickerFieldTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/ColorPickerFieldTest.php
@@ -21,7 +21,7 @@ class ColorPickerFieldTest extends TestCase
         static::assertSame('test_color_picker_field', $colorPickerField->getName());
         static::assertSame('text', $colorPickerField->getType());
         static::assertTrue($colorPickerField->isActive());
-        static::assertEquals([
+        static::assertSame([
             'type' => 'colorpicker',
             'label' => [
                 'en-GB' => 'Test color-picker field',

--- a/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MediaSelectionFieldTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MediaSelectionFieldTest.php
@@ -21,7 +21,7 @@ class MediaSelectionFieldTest extends TestCase
         static::assertSame('test_media_selection_field', $mediaSelectionField->getName());
         static::assertSame('text', $mediaSelectionField->getType());
         static::assertTrue($mediaSelectionField->isActive());
-        static::assertEquals([
+        static::assertSame([
             'label' => [
                 'en-GB' => 'Test media-selection field',
             ],

--- a/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/PriceFieldTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/PriceFieldTest.php
@@ -21,7 +21,7 @@ class PriceFieldTest extends TestCase
         static::assertSame('test_price_field', $priceField->getName());
         static::assertSame('price', $priceField->getType());
         static::assertTrue($priceField->isActive());
-        static::assertEquals([
+        static::assertSame([
             'type' => 'price',
             'label' => [
                 'en-GB' => 'Test price field',

--- a/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/TextAreaFieldTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/TextAreaFieldTest.php
@@ -21,7 +21,7 @@ class TextAreaFieldTest extends TestCase
         static::assertSame('test_text_area_field', $textAreaField->getName());
         static::assertSame('html', $textAreaField->getType());
         static::assertTrue($textAreaField->isActive());
-        static::assertEquals([
+        static::assertSame([
             'label' => [
                 'en-GB' => 'Test text-area field',
             ],

--- a/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/TextFieldTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/Xml/CustomFieldTypes/TextFieldTest.php
@@ -21,7 +21,7 @@ class TextFieldTest extends TestCase
         static::assertSame('test_text_field', $textField->getName());
         static::assertSame('text', $textField->getType());
         static::assertTrue($textField->isActive());
-        static::assertEquals([
+        static::assertSame([
             'type' => 'text',
             'label' => [
                 'en-GB' => 'Test text field',

--- a/tests/integration/Core/Framework/CustomField/Api/CustomFieldSetActionControllerTest.php
+++ b/tests/integration/Core/Framework/CustomField/Api/CustomFieldSetActionControllerTest.php
@@ -20,8 +20,8 @@ class CustomFieldSetActionControllerTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertEquals(200, $response->getStatusCode());
-        static::assertEquals('application/json', $response->headers->get('Content-Type'));
+        static::assertSame(200, $response->getStatusCode());
+        static::assertSame('application/json', $response->headers->get('Content-Type'));
 
         $availableRelations = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertNotEmpty($availableRelations);

--- a/tests/integration/Core/Framework/CustomField/CustomFieldRepositoryTest.php
+++ b/tests/integration/Core/Framework/CustomField/CustomFieldRepositoryTest.php
@@ -44,9 +44,9 @@ class CustomFieldRepositoryTest extends TestCase
         $payloads = $events->getPayloads();
         static::assertNotEmpty($payloads);
 
-        static::assertEquals($attribute['id'], $payloads[0]['id']);
-        static::assertEquals($attribute['name'], $payloads[0]['name']);
-        static::assertEquals($attribute['type'], $payloads[0]['type']);
+        static::assertSame($attribute['id'], $payloads[0]['id']);
+        static::assertSame($attribute['name'], $payloads[0]['name']);
+        static::assertSame($attribute['type'], $payloads[0]['type']);
     }
 
     public function testSearchId(): void
@@ -72,10 +72,10 @@ class CustomFieldRepositoryTest extends TestCase
         $attribute = $result->first();
         static::assertNotNull($attribute);
 
-        static::assertEquals($sizeId, $attribute->getId());
-        static::assertEquals($attributes[0]['name'], $attribute->getName());
-        static::assertEquals($attributes[0]['type'], $attribute->getType());
-        static::assertEquals($attributes[0]['config'], $attribute->getConfig());
+        static::assertSame($sizeId, $attribute->getId());
+        static::assertSame($attributes[0]['name'], $attribute->getName());
+        static::assertSame($attributes[0]['type'], $attribute->getType());
+        static::assertSame($attributes[0]['config'], $attribute->getConfig());
     }
 
     public function testDelete(): void
@@ -101,7 +101,7 @@ class CustomFieldRepositoryTest extends TestCase
 
         static::assertNotNull($event);
         static::assertCount(1, $event->getIds());
-        static::assertEquals($sizeId, $event->getIds()[0]);
+        static::assertSame($sizeId, $event->getIds()[0]);
     }
 
     public function testUpdate(): void

--- a/tests/integration/Core/Framework/CustomField/CustomFieldSetRepositoryTest.php
+++ b/tests/integration/Core/Framework/CustomField/CustomFieldSetRepositoryTest.php
@@ -134,8 +134,8 @@ class CustomFieldSetRepositoryTest extends TestCase
         $attributeSet = $result->first();
         static::assertNotNull($attributeSet);
 
-        static::assertEquals($id2, $attributeSet->getId());
-        static::assertEquals($attributeSets[1]['config'], $attributeSet->getConfig());
+        static::assertSame($id2, $attributeSet->getId());
+        static::assertSame($attributeSets[1]['config'], $attributeSet->getConfig());
     }
 
     public function testDelete(): void
@@ -180,7 +180,7 @@ class CustomFieldSetRepositoryTest extends TestCase
         $event = $result->getEventByEntityName(CustomFieldSetDefinition::ENTITY_NAME);
         static::assertNotNull($event);
         static::assertCount(1, $event->getIds());
-        static::assertEquals($id, $event->getIds()[0]);
+        static::assertSame($id, $event->getIds()[0]);
 
         $event = $result->getEventByEntityName(CustomFieldDefinition::ENTITY_NAME);
         static::assertNotNull($event);
@@ -237,7 +237,7 @@ class CustomFieldSetRepositoryTest extends TestCase
         $result = $this->repo->search(new Criteria([$id]), Context::createDefaultContext())->getEntities();
         $set = $result->first();
         static::assertNotNull($set);
-        static::assertEquals($update['config'], $set->getConfig());
+        static::assertSame($update['config'], $set->getConfig());
     }
 
     public function testSearchWithAssociations(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -267,9 +267,9 @@ class AttributeEntityIntegrationTest extends TestCase
         static::assertSame(1, $record->int);
         static::assertSame(1.1, $record->float);
         static::assertTrue($record->bool);
-        static::assertEquals(new \DateTimeImmutable('2020-01-01 15:15:15'), $record->datetime);
-        static::assertEquals(new \DateTimeImmutable('2020-01-01 00:00:00'), $record->date);
-        static::assertEquals(new DateInterval('P1D'), $record->dateInterval);
+        static::assertSame((new \DateTimeImmutable('2020-01-01 15:15:15'))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $record->datetime?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame((new \DateTimeImmutable('2020-01-01 00:00:00'))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $record->date?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame((new DateInterval('P1D'))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $record->dateInterval?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
         static::assertSame('Europe/Berlin', $record->timeZone);
         static::assertSame(StringEnum::B, $record->enum);
         static::assertSame(['key' => 'value'], $record->json);
@@ -287,9 +287,9 @@ class AttributeEntityIntegrationTest extends TestCase
         static::assertSame(1, $record->transInt);
         static::assertSame(1.1, $record->transFloat);
         static::assertTrue($record->transBool);
-        static::assertEquals(new \DateTimeImmutable('2020-01-01 15:15:15'), $record->transDatetime);
-        static::assertEquals(new \DateTimeImmutable('2020-01-01 00:00:00'), $record->transDate);
-        static::assertEquals(new DateInterval('P1D'), $record->transDateInterval);
+        static::assertSame((new \DateTimeImmutable('2020-01-01 15:15:15'))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $record->transDatetime?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame((new \DateTimeImmutable('2020-01-01 00:00:00'))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $record->transDate?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame((new DateInterval('P1D'))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $record->transDateInterval?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
         static::assertSame('Europe/Berlin', $record->transTimeZone);
         static::assertSame(['key' => 'value'], $record->transJson);
         static::assertSame('string', $record->differentName);
@@ -309,11 +309,11 @@ class AttributeEntityIntegrationTest extends TestCase
             'int' => 1,
             'float' => 1.1,
             'bool' => true,
-            'datetime' => $record->datetime?->format(\DateTimeInterface::RFC3339_EXTENDED),
+            'datetime' => $record->datetime->format(\DateTimeInterface::RFC3339_EXTENDED),
             'autoIncrement' => 1,
             'enum' => StringEnum::B,
             'json' => ['key' => 'value'],
-            'date' => $record->date?->format(\DateTimeInterface::RFC3339_EXTENDED),
+            'date' => $record->date->format(\DateTimeInterface::RFC3339_EXTENDED),
             'dateInterval' => new DateInterval('P1D'),
             'timeZone' => 'Europe/Berlin',
             'serialized' => new PriceCollection([new Price(Defaults::CURRENCY, 1, 1, true)]),
@@ -323,9 +323,9 @@ class AttributeEntityIntegrationTest extends TestCase
             'transInt' => 1,
             'transFloat' => 1.1,
             'transBool' => true,
-            'transDatetime' => $record->transDatetime?->format(\DateTimeInterface::RFC3339_EXTENDED),
+            'transDatetime' => $record->transDatetime->format(\DateTimeInterface::RFC3339_EXTENDED),
             'transJson' => ['key' => 'value'],
-            'transDate' => $record->transDate?->format(\DateTimeInterface::RFC3339_EXTENDED),
+            'transDate' => $record->transDate->format(\DateTimeInterface::RFC3339_EXTENDED),
             'transDateInterval' => new DateInterval('P1D'),
             'transTimeZone' => 'Europe/Berlin',
             'differentName' => 'string',
@@ -809,10 +809,7 @@ class AttributeEntityIntegrationTest extends TestCase
 
         $record = $search->get($ids->get('first-key'));
         static::assertInstanceOf(AttributeEntity::class, $record);
-        static::assertEquals([
-            'foo' => 'bar',
-            'bar' => 'baz',
-        ], $record->getCustomFields());
+        static::assertSame(['bar' => 'baz', 'foo' => 'bar'], $record->getCustomFields());
         static::assertSame('bar', $record->getCustomFieldsValue('foo'));
         static::assertSame('baz', $record->getCustomFieldsValue('bar'));
     }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ChildCountIndexerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ChildCountIndexerTest.php
@@ -62,10 +62,10 @@ class ChildCountIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryC));
         static::assertNotNull($categories->get($categoryD));
 
-        static::assertEquals(2, $categories->get($categoryA)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryB)->getChildCount());
-        static::assertEquals(1, $categories->get($categoryC)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryD)->getChildCount());
+        static::assertSame(2, $categories->get($categoryA)->getChildCount());
+        static::assertSame(0, $categories->get($categoryB)->getChildCount());
+        static::assertSame(1, $categories->get($categoryC)->getChildCount());
+        static::assertSame(0, $categories->get($categoryD)->getChildCount());
 
         $this->categoryRepository->update([[
             'id' => $categoryD,
@@ -85,10 +85,10 @@ class ChildCountIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryC));
         static::assertNotNull($categories->get($categoryD));
 
-        static::assertEquals(3, $categories->get($categoryA)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryB)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryC)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryD)->getChildCount());
+        static::assertSame(3, $categories->get($categoryA)->getChildCount());
+        static::assertSame(0, $categories->get($categoryB)->getChildCount());
+        static::assertSame(0, $categories->get($categoryC)->getChildCount());
+        static::assertSame(0, $categories->get($categoryD)->getChildCount());
     }
 
     public function testChildCountCategoryMovingMultipleCategories(): void
@@ -118,11 +118,11 @@ class ChildCountIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryD));
         static::assertNotNull($categories->get($categoryE));
 
-        static::assertEquals(2, $categories->get($categoryA)->getChildCount());
-        static::assertEquals(1, $categories->get($categoryB)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryC)->getChildCount());
-        static::assertEquals(1, $categories->get($categoryD)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryE)->getChildCount());
+        static::assertSame(2, $categories->get($categoryA)->getChildCount());
+        static::assertSame(1, $categories->get($categoryB)->getChildCount());
+        static::assertSame(0, $categories->get($categoryC)->getChildCount());
+        static::assertSame(1, $categories->get($categoryD)->getChildCount());
+        static::assertSame(0, $categories->get($categoryE)->getChildCount());
 
         $this->categoryRepository->update([
             [
@@ -157,11 +157,11 @@ class ChildCountIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryD));
         static::assertNotNull($categories->get($categoryE));
 
-        static::assertEquals(2, $categories->get($categoryA)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryB)->getChildCount());
-        static::assertEquals(2, $categories->get($categoryC)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryD)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryE)->getChildCount());
+        static::assertSame(2, $categories->get($categoryA)->getChildCount());
+        static::assertSame(0, $categories->get($categoryB)->getChildCount());
+        static::assertSame(2, $categories->get($categoryC)->getChildCount());
+        static::assertSame(0, $categories->get($categoryD)->getChildCount());
+        static::assertSame(0, $categories->get($categoryE)->getChildCount());
     }
 
     public function testChildCountIndexer(): void
@@ -195,7 +195,7 @@ class ChildCountIndexerTest extends TestCase
         $categories = $this->categoryRepository->search(new Criteria([$categoryA, $categoryB, $categoryC, $categoryD]), $this->context)->getEntities();
 
         foreach ($categories as $category) {
-            static::assertEquals(0, $category->getChildCount());
+            static::assertSame(0, $category->getChildCount());
         }
 
         $this->childCountIndexer->update(CategoryDefinition::ENTITY_NAME, [$categoryA, $categoryB, $categoryC, $categoryD], $this->context);
@@ -207,10 +207,10 @@ class ChildCountIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryC));
         static::assertNotNull($categories->get($categoryD));
 
-        static::assertEquals(2, $categories->get($categoryA)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryB)->getChildCount());
-        static::assertEquals(1, $categories->get($categoryC)->getChildCount());
-        static::assertEquals(0, $categories->get($categoryD)->getChildCount());
+        static::assertSame(2, $categories->get($categoryA)->getChildCount());
+        static::assertSame(0, $categories->get($categoryB)->getChildCount());
+        static::assertSame(1, $categories->get($categoryC)->getChildCount());
+        static::assertSame(0, $categories->get($categoryD)->getChildCount());
     }
 
     public function testDeleteProductWithRecalculatedChildCount(): void
@@ -227,16 +227,16 @@ class ChildCountIndexerTest extends TestCase
 
         static::getContainer()->get('product.repository')->create($products, Context::createDefaultContext());
 
-        $count = $this->connection->fetchOne('SELECT child_count FROM product WHERE id = :id', ['id' => $ids->getBytes('parent')]);
-        static::assertEquals(2, $count);
+        $count = (int) $this->connection->fetchOne('SELECT child_count FROM product WHERE id = :id', ['id' => $ids->getBytes('parent')]);
+        static::assertSame(2, $count);
 
         static::getContainer()->get('product.repository')->delete([['id' => $ids->get('variant-1')]], Context::createDefaultContext());
-        $count = $this->connection->fetchOne('SELECT child_count FROM product WHERE id = :id', ['id' => $ids->getBytes('parent')]);
-        static::assertEquals(1, $count);
+        $count = (int) $this->connection->fetchOne('SELECT child_count FROM product WHERE id = :id', ['id' => $ids->getBytes('parent')]);
+        static::assertSame(1, $count);
 
         static::getContainer()->get('product.repository')->delete([['id' => $ids->get('variant-2')]], Context::createDefaultContext());
-        $count = $this->connection->fetchOne('SELECT child_count FROM product WHERE id = :id', ['id' => $ids->getBytes('parent')]);
-        static::assertEquals(0, $count);
+        $count = (int) $this->connection->fetchOne('SELECT child_count FROM product WHERE id = :id', ['id' => $ids->getBytes('parent')]);
+        static::assertSame(0, $count);
     }
 
     private function createCategory(?string $parentId = null): string

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
@@ -105,7 +105,7 @@ class CriteriaQueryHelperTest extends TestCase
         $builder = static::getContainer()->get(CriteriaQueryBuilder::class);
         $builder->build($queryBuilder, $productDefinition, $criteria, Context::createDefaultContext());
 
-        static::assertEquals($queryBuilder->getOrderByParts(), [
+        static::assertSame($queryBuilder->getOrderByParts(), [
             'MIN(`product`.`created_at`) ASC',
             '_score DESC',
         ]);
@@ -123,7 +123,7 @@ class CriteriaQueryHelperTest extends TestCase
         $builder = static::getContainer()->get(CriteriaQueryBuilder::class);
         $builder->build($queryBuilder, $productDefinition, $criteria, Context::createDefaultContext());
 
-        static::assertEquals($queryBuilder->getOrderByParts(), [
+        static::assertSame($queryBuilder->getOrderByParts(), [
             'MIN(`product`.`created_at`) ASC',
             '_score ASC',
         ]);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
@@ -91,7 +91,7 @@ class EntityForeignKeyResolverTest extends TestCase
         $deletedCategories = $deletedEvent->getDeletedPrimaryKeys('category');
         $deletedCategoriesRo = $deletedEvent->getPrimaryKeys('product_category_tree');
 
-        static::assertEquals($productId, $deletedProduct[0]);
+        static::assertSame($productId, $deletedProduct[0]);
         static::assertEmpty($deletedCategories, print_r($deletedCategories, true));
         static::assertCount(3, $deletedCategoriesRo);
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityReaderTest.php
@@ -79,7 +79,7 @@ class EntityReaderTest extends TestCase
         static::assertNotNull($translations);
         static::assertCount(2, $translations);
         $deDeTranslation = $translations->filterByLanguageId($this->getDeDeLanguageId())->first();
-        static::assertEquals('Deutscher Name', $deDeTranslation?->get('name'));
+        static::assertSame('Deutscher Name', $deDeTranslation?->get('name'));
     }
 
     public function testReadLoadsTranslationsAssociationsWithCriteriaFields(): void
@@ -105,7 +105,7 @@ class EntityReaderTest extends TestCase
         $deDeTranslation = $translations
             ->filter(fn (Entity $entity) => $entity->get('languageId') === $this->getDeDeLanguageId())
             ->first();
-        static::assertEquals('Deutscher Name', $deDeTranslation?->get('name'));
+        static::assertSame('Deutscher Name', $deDeTranslation?->get('name'));
     }
 
     public function testReadLoadsTranslatedFieldsInCorrectLanguage(): void
@@ -126,7 +126,7 @@ class EntityReaderTest extends TestCase
 
         static::assertInstanceOf(ProductCollection::class, $products);
         $translatedFields = $products->get($productId)?->get('translated');
-        static::assertEquals('Deutscher Name', $translatedFields['name']);
+        static::assertSame('Deutscher Name', $translatedFields['name']);
     }
 
     public function testReadLoadsTranslatedFieldsInCorrectLanguageWithCriteriaFields(): void
@@ -152,7 +152,7 @@ class EntityReaderTest extends TestCase
         $translatedFields = $products->get($productId)?->get('translated');
         static::assertNotNull($translatedFields);
         static::assertCount(1, $translatedFields);
-        static::assertEquals('Deutscher Name', $translatedFields['name']);
+        static::assertSame('Deutscher Name', $translatedFields['name']);
     }
 
     public function testReadLoadsTranslatedFieldsByApplyingLanguageOverrides(): void
@@ -178,7 +178,7 @@ class EntityReaderTest extends TestCase
         $translatedFields = $products->get($productId)?->get('translated');
         static::assertNotNull($translatedFields);
         static::assertCount(1, $translatedFields);
-        static::assertEquals('Fallback name', $translatedFields['name']);
+        static::assertSame('Fallback name', $translatedFields['name']);
     }
 
     public function testReadLoadsTranslatedFieldsByApplyingInheritanceAndLanguageOverridesPreferringOwnTranslation(): void
@@ -216,7 +216,7 @@ class EntityReaderTest extends TestCase
         $translatedFields = $products->get($productId)?->get('translated');
         static::assertNotNull($translatedFields);
         static::assertCount(1, $translatedFields);
-        static::assertEquals('Deutscher Name', $translatedFields['name']);
+        static::assertSame('Deutscher Name', $translatedFields['name']);
     }
 
     public function testReadLoadsTranslatedFieldsByApplyingInheritanceAndLanguageOverridesUsingParentTranslationAsFallback(): void
@@ -254,7 +254,7 @@ class EntityReaderTest extends TestCase
         $translatedFields = $products->get($productId)?->get('translated');
         static::assertNotNull($translatedFields);
         static::assertCount(1, $translatedFields);
-        static::assertEquals('Parent: Deutscher Name', $translatedFields['name']);
+        static::assertSame('Parent: Deutscher Name', $translatedFields['name']);
     }
 
     public function testAssociationWithOrderBy(): void
@@ -290,7 +290,7 @@ class EntityReaderTest extends TestCase
 
         $result = $entityRepository->search($criteria, $context);
 
-        static::assertEquals($ids->get('test'), $result->getEntities()->first()?->getId());
+        static::assertSame($ids->get('test'), $result->getEntities()->first()?->getId());
     }
 
     private function createProduct(

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcherTest.php
@@ -90,7 +90,7 @@ class EntitySearcherTest extends TestCase
             ]),
         );
 
-        static::assertEquals([$productId1], $productIds->getIds());
+        static::assertSame([$productId1], $productIds->getIds());
     }
 
     public function testSearchFiltersByTranslatedFieldsInAssociationsByApplyingLanguageOverrides(): void
@@ -132,7 +132,7 @@ class EntitySearcherTest extends TestCase
             ]),
         );
 
-        static::assertEquals([$productId1], $productIds->getIds());
+        static::assertSame([$productId1], $productIds->getIds());
     }
 
     public function testSearchFiltersByTranslatedFieldsByApplyingInheritanceAndLanguageOverridesPreferringOwnTranslation(): void
@@ -171,7 +171,7 @@ class EntitySearcherTest extends TestCase
             ]),
         );
 
-        static::assertEquals(
+        static::assertSame(
             [
                 $productId1,
                 $productId2,
@@ -205,7 +205,7 @@ class EntitySearcherTest extends TestCase
             ]),
         );
 
-        static::assertEquals([$productId1], $productIds->getIds());
+        static::assertSame([$productId1], $productIds->getIds());
     }
 
     public function testSearchAppliesTermToTranslatedFieldsByApplyingLanguageOverrides(): void
@@ -233,7 +233,7 @@ class EntitySearcherTest extends TestCase
             ]),
         );
 
-        static::assertEquals([$productId1], $productIds->getIds());
+        static::assertSame([$productId1], $productIds->getIds());
     }
 
     public function testSearchAppliesQueryToTranslatedFields(): void
@@ -261,7 +261,7 @@ class EntitySearcherTest extends TestCase
             ]),
         );
 
-        static::assertEquals([$productId1], $productIds->getIds());
+        static::assertSame([$productId1], $productIds->getIds());
     }
 
     public function testSearchAppliesQueryToTranslatedFieldsByApplyingLanguageOverrides(): void
@@ -289,7 +289,7 @@ class EntitySearcherTest extends TestCase
             ]),
         );
 
-        static::assertEquals([$productId1], $productIds->getIds());
+        static::assertSame([$productId1], $productIds->getIds());
     }
 
     public function testSearchFiltersByAndAppliesQueryToTranslatedFields(): void
@@ -328,7 +328,7 @@ class EntitySearcherTest extends TestCase
             ]),
         );
 
-        static::assertEquals([$productId1], $productIds->getIds());
+        static::assertSame([$productId1], $productIds->getIds());
     }
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGatewayTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGatewayTest.php
@@ -79,8 +79,8 @@ class EntityWriteGatewayTest extends TestCase
         $changeSet = $this->getChangeSet(ProductDefinition::ENTITY_NAME, $result);
 
         static::assertTrue($changeSet->hasChanged('stock'));
-        static::assertEquals(1, $changeSet->getBefore('stock'));
-        static::assertEquals(100, $changeSet->getAfter('stock'));
+        static::assertSame('1', $changeSet->getBefore('stock'));
+        static::assertSame(100, $changeSet->getAfter('stock'));
     }
 
     public function testUpdateWithSameValue(): void
@@ -104,7 +104,7 @@ class EntityWriteGatewayTest extends TestCase
         $changeSet = $this->getChangeSet(ProductDefinition::ENTITY_NAME, $result);
 
         static::assertFalse($changeSet->hasChanged('stock'));
-        static::assertEquals('1', $changeSet->getBefore('stock'));
+        static::assertSame('1', $changeSet->getBefore('stock'));
         static::assertNull($changeSet->getAfter('stock'));
     }
 
@@ -136,7 +136,7 @@ class EntityWriteGatewayTest extends TestCase
         $changeSet = $this->getChangeSet(ProductCategoryDefinition::ENTITY_NAME, $result);
 
         static::assertTrue($changeSet->hasChanged('product_id'));
-        static::assertEquals(Uuid::fromHexToBytes($id), $changeSet->getBefore('product_id'));
+        static::assertSame(Uuid::fromHexToBytes($id), $changeSet->getBefore('product_id'));
         static::assertNull($changeSet->getAfter('product_id'));
     }
 
@@ -161,8 +161,8 @@ class EntityWriteGatewayTest extends TestCase
         $changeSet = $this->getChangeSet(ProductTranslationDefinition::ENTITY_NAME, $result);
 
         static::assertTrue($changeSet->hasChanged('name'));
-        static::assertEquals('test', $changeSet->getBefore('name'));
-        static::assertEquals('updated', $changeSet->getAfter('name'));
+        static::assertSame('test', $changeSet->getBefore('name'));
+        static::assertSame('updated', $changeSet->getAfter('name'));
     }
 
     public function testChangeSetWithOneToMany(): void
@@ -191,8 +191,8 @@ class EntityWriteGatewayTest extends TestCase
         $changeSet = $this->getChangeSet(ProductVisibilityDefinition::ENTITY_NAME, $result);
 
         static::assertTrue($changeSet->hasChanged('visibility'));
-        static::assertEquals(ProductVisibilityDefinition::VISIBILITY_ALL, $changeSet->getBefore('visibility'));
-        static::assertEquals(ProductVisibilityDefinition::VISIBILITY_LINK, $changeSet->getAfter('visibility'));
+        static::assertSame(ProductVisibilityDefinition::VISIBILITY_ALL, (int) $changeSet->getBefore('visibility'));
+        static::assertSame(ProductVisibilityDefinition::VISIBILITY_LINK, (int) $changeSet->getAfter('visibility'));
     }
 
     public function testChangeSetWithManyToOne(): void
@@ -223,8 +223,8 @@ class EntityWriteGatewayTest extends TestCase
         $changeSet = $this->getChangeSet(ProductDefinition::ENTITY_NAME, $result);
 
         static::assertTrue($changeSet->hasChanged('product_manufacturer_id'));
-        static::assertEquals($id, Uuid::fromBytesToHex($changeSet->getBefore('product_manufacturer_id')));
-        static::assertEquals($newId, Uuid::fromBytesToHex($changeSet->getAfter('product_manufacturer_id')));
+        static::assertSame($id, Uuid::fromBytesToHex($changeSet->getBefore('product_manufacturer_id')));
+        static::assertSame($newId, Uuid::fromBytesToHex($changeSet->getAfter('product_manufacturer_id')));
     }
 
     public function testChangeSetWithMultipleCommandsForSameEntityType(): void
@@ -259,13 +259,13 @@ class EntityWriteGatewayTest extends TestCase
 
         static::assertNotNull($changeSetForProduct1);
         static::assertTrue($changeSetForProduct1->hasChanged('stock'));
-        static::assertEquals(1, $changeSetForProduct1->getBefore('stock'));
-        static::assertEquals(100, $changeSetForProduct1->getAfter('stock'));
+        static::assertSame('1', $changeSetForProduct1->getBefore('stock'));
+        static::assertSame(100, $changeSetForProduct1->getAfter('stock'));
 
         static::assertNotNull($changeSetForProduct2);
         static::assertTrue($changeSetForProduct2->hasChanged('stock'));
-        static::assertEquals(1, $changeSetForProduct2->getBefore('stock'));
-        static::assertEquals(50, $changeSetForProduct2->getAfter('stock'));
+        static::assertSame('1', $changeSetForProduct2->getBefore('stock'));
+        static::assertSame(50, $changeSetForProduct2->getAfter('stock'));
     }
 
     public function testCustomFieldsMergeWithIntegers(): void
@@ -353,7 +353,7 @@ class EntityWriteGatewayTest extends TestCase
         $event = $spy->event;
         static::assertInstanceOf(EntityDeleteEvent::class, $event);
         static::assertTrue($event->filled());
-        static::assertEquals([$id1, $id2], $event->getIds('product'));
+        static::assertSame([$id1, $id2], $event->getIds('product'));
     }
 
     public function testEntityDeleteEventSuccessCallbacksCalled(): void
@@ -464,7 +464,7 @@ class EntityWriteGatewayTest extends TestCase
         }
 
         static::assertInstanceOf(Exception::class, $exceptionThrown);
-        static::assertEquals('test', $exceptionThrown->getMessage());
+        static::assertSame('test', $exceptionThrown->getMessage());
 
         static::assertTrue($errorSpy->called);
         static::assertFalse($successSpy->called);
@@ -502,7 +502,7 @@ class EntityWriteGatewayTest extends TestCase
         };
 
         static::assertInstanceOf(EntityWriteEvent::class, $spy->event);
-        static::assertEquals([$id1, $id2], $spy->event->getIds('product'));
+        static::assertSame([$id1, $id2], $spy->event->getIds('product'));
     }
 
     /**
@@ -626,7 +626,7 @@ class EntityWriteGatewayTest extends TestCase
         }
 
         static::assertInstanceOf(Exception::class, $exceptionThrown);
-        static::assertEquals('test', $exceptionThrown->getMessage());
+        static::assertSame('test', $exceptionThrown->getMessage());
 
         static::assertTrue($errorSpy->called);
         static::assertFalse($successSpy->called);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
@@ -246,12 +246,12 @@ class ManyToOneAssociationFieldResolverTest extends TestCase
         );
 
         static::assertCount(1, $documents);
-        static::assertEquals(1, $documents->getTotal());
+        static::assertSame(1, $documents->getTotal());
 
         $document = $documents->getEntities()->first();
         static::assertInstanceOf(DocumentEntity::class, $document);
         static::assertNotNull($document->getOrder());
-        static::assertEquals('00000000000000000000000000000000', $document->getOrder()->getVersionId());
+        static::assertSame('00000000000000000000000000000000', $document->getOrder()->getVersionId());
     }
 
     public function testManyToOneInheritedWorks(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
@@ -129,7 +129,7 @@ class ManyToManyAssociationFieldTest extends TestCase
         $product = $this->productRepository->search($criteria, Context::createDefaultContext())->first();
 
         static::assertInstanceOf(PartialEntity::class, $product);
-        static::assertEquals('test', $product->get('name'));
+        static::assertSame('test', $product->get('name'));
         static::assertNull($product->get('properties'));
     }
 
@@ -191,18 +191,18 @@ class ManyToManyAssociationFieldTest extends TestCase
         $media = $cover->get('media');
         static::assertInstanceOf(PartialEntity::class, $media);
 
-        static::assertEquals($id, $product->get('productNumber'));
+        static::assertSame($id, $product->get('productNumber'));
         static::assertFalse($product->has('name'));
         static::assertFalse($product->has('customFields'));
 
-        static::assertEquals($propertyId, $property->getId());
-        static::assertEquals('Propertyname', $property->get('name'));
+        static::assertSame($propertyId, $property->getId());
+        static::assertSame('Propertyname', $property->get('name'));
         static::assertFalse($property->has('customFields'));
 
-        static::assertEquals($groupId, $group->getId());
+        static::assertSame($groupId, $group->getId());
         static::assertFalse($group->has('name'));
-        static::assertEquals('value', $group->get('customFields')['key']);
+        static::assertSame('value', $group->get('customFields')['key']);
 
-        static::assertEquals('myFile', $media->get('fileName'));
+        static::assertSame('myFile', $media->get('fileName'));
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/RepositoryIteratorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/RepositoryIteratorTest.php
@@ -44,7 +44,7 @@ class RepositoryIteratorTest extends TestCase
                 $criteria->getFilters()
             );
             static::assertCount(0, $criteria->getPostFilters());
-            static::assertEquals($offset, $criteria->getOffset());
+            static::assertSame($offset, $criteria->getOffset());
             ++$offset;
         }
     }
@@ -94,6 +94,6 @@ class RepositoryIteratorTest extends TestCase
         while ($iterator->fetchIds()) {
             ++$totalFetchedIds;
         }
-        static::assertEquals($totalFetchedIds, 3);
+        static::assertSame($totalFetchedIds, 3);
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/TreeIndexerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/TreeIndexerTest.php
@@ -65,14 +65,14 @@ class TreeIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryD));
 
         static::assertNull($categories->get($categoryA)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryB)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryC)->getPath());
-        static::assertEquals("|{$categoryA}|{$categoryC}|", $categories->get($categoryD)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryB)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryC)->getPath());
+        static::assertSame("|{$categoryA}|{$categoryC}|", $categories->get($categoryD)->getPath());
 
-        static::assertEquals(1, $categories->get($categoryA)->getLevel());
-        static::assertEquals(2, $categories->get($categoryB)->getLevel());
-        static::assertEquals(2, $categories->get($categoryC)->getLevel());
-        static::assertEquals(3, $categories->get($categoryD)->getLevel());
+        static::assertSame(1, $categories->get($categoryA)->getLevel());
+        static::assertSame(2, $categories->get($categoryB)->getLevel());
+        static::assertSame(2, $categories->get($categoryC)->getLevel());
+        static::assertSame(3, $categories->get($categoryD)->getLevel());
 
         $this->categoryRepository->update([[
             'id' => $categoryD,
@@ -97,14 +97,14 @@ class TreeIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryD));
 
         static::assertNull($categories->get($categoryA)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryB)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryC)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryD)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryB)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryC)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryD)->getPath());
 
-        static::assertEquals(1, $categories->get($categoryA)->getLevel());
-        static::assertEquals(2, $categories->get($categoryB)->getLevel());
-        static::assertEquals(2, $categories->get($categoryC)->getLevel());
-        static::assertEquals(2, $categories->get($categoryD)->getLevel());
+        static::assertSame(1, $categories->get($categoryA)->getLevel());
+        static::assertSame(2, $categories->get($categoryB)->getLevel());
+        static::assertSame(2, $categories->get($categoryC)->getLevel());
+        static::assertSame(2, $categories->get($categoryD)->getLevel());
     }
 
     public function testRefreshTreeMovingMultipleCategories(): void
@@ -134,16 +134,16 @@ class TreeIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryE));
 
         static::assertNull($categories->get($categoryA)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryB)->getPath());
-        static::assertEquals("|{$categoryA}|{$categoryB}|", $categories->get($categoryC)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryD)->getPath());
-        static::assertEquals("|{$categoryA}|{$categoryD}|", $categories->get($categoryE)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryB)->getPath());
+        static::assertSame("|{$categoryA}|{$categoryB}|", $categories->get($categoryC)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryD)->getPath());
+        static::assertSame("|{$categoryA}|{$categoryD}|", $categories->get($categoryE)->getPath());
 
-        static::assertEquals(1, $categories->get($categoryA)->getLevel());
-        static::assertEquals(2, $categories->get($categoryB)->getLevel());
-        static::assertEquals(3, $categories->get($categoryC)->getLevel());
-        static::assertEquals(2, $categories->get($categoryD)->getLevel());
-        static::assertEquals(3, $categories->get($categoryE)->getLevel());
+        static::assertSame(1, $categories->get($categoryA)->getLevel());
+        static::assertSame(2, $categories->get($categoryB)->getLevel());
+        static::assertSame(3, $categories->get($categoryC)->getLevel());
+        static::assertSame(2, $categories->get($categoryD)->getLevel());
+        static::assertSame(3, $categories->get($categoryE)->getLevel());
 
         $this->categoryRepository->update([
             [
@@ -179,16 +179,16 @@ class TreeIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryE));
 
         static::assertNull($categories->get($categoryA)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryB)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryC)->getPath());
-        static::assertEquals("|{$categoryA}|{$categoryC}|", $categories->get($categoryD)->getPath());
-        static::assertEquals("|{$categoryA}|{$categoryC}|", $categories->get($categoryE)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryB)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryC)->getPath());
+        static::assertSame("|{$categoryA}|{$categoryC}|", $categories->get($categoryD)->getPath());
+        static::assertSame("|{$categoryA}|{$categoryC}|", $categories->get($categoryE)->getPath());
 
-        static::assertEquals(1, $categories->get($categoryA)->getLevel());
-        static::assertEquals(2, $categories->get($categoryB)->getLevel());
-        static::assertEquals(2, $categories->get($categoryC)->getLevel());
-        static::assertEquals(3, $categories->get($categoryD)->getLevel());
-        static::assertEquals(3, $categories->get($categoryE)->getLevel());
+        static::assertSame(1, $categories->get($categoryA)->getLevel());
+        static::assertSame(2, $categories->get($categoryB)->getLevel());
+        static::assertSame(2, $categories->get($categoryC)->getLevel());
+        static::assertSame(3, $categories->get($categoryD)->getLevel());
+        static::assertSame(3, $categories->get($categoryE)->getLevel());
     }
 
     public function testRefreshTreeWithDifferentVersion(): void
@@ -217,14 +217,14 @@ class TreeIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryD));
 
         static::assertNull($categories->get($categoryA)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryB)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryC)->getPath());
-        static::assertEquals("|{$categoryA}|{$categoryC}|", $categories->get($categoryD)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryB)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryC)->getPath());
+        static::assertSame("|{$categoryA}|{$categoryC}|", $categories->get($categoryD)->getPath());
 
-        static::assertEquals(1, $categories->get($categoryA)->getLevel());
-        static::assertEquals(2, $categories->get($categoryB)->getLevel());
-        static::assertEquals(2, $categories->get($categoryC)->getLevel());
-        static::assertEquals(3, $categories->get($categoryD)->getLevel());
+        static::assertSame(1, $categories->get($categoryA)->getLevel());
+        static::assertSame(2, $categories->get($categoryB)->getLevel());
+        static::assertSame(2, $categories->get($categoryC)->getLevel());
+        static::assertSame(3, $categories->get($categoryD)->getLevel());
 
         $versionId = $this->categoryRepository->createVersion($categoryD, $this->context);
         $versionContext = $this->context->createWithVersionId($versionId);
@@ -234,7 +234,7 @@ class TreeIndexerTest extends TestCase
             ->getEntities()
             ->first();
         static::assertInstanceOf(CategoryEntity::class, $category);
-        static::assertEquals('|' . $categoryA . '|' . $categoryC . '|', $category->getPath());
+        static::assertSame('|' . $categoryA . '|' . $categoryC . '|', $category->getPath());
 
         // update parent of last category in version scope
         $updated = ['id' => $categoryD, 'parentId' => $categoryA];
@@ -246,13 +246,13 @@ class TreeIndexerTest extends TestCase
             ->getEntities()
             ->first();
         static::assertInstanceOf(CategoryEntity::class, $category);
-        static::assertEquals('|' . $categoryA . '|', $category->getPath());
+        static::assertSame('|' . $categoryA . '|', $category->getPath());
 
         $category = $this->categoryRepository->search(new Criteria([$categoryD]), $this->context)
             ->getEntities()
             ->first();
         static::assertInstanceOf(CategoryEntity::class, $category);
-        static::assertEquals('|' . $categoryA . '|' . $categoryC . '|', $category->getPath());
+        static::assertSame('|' . $categoryA . '|' . $categoryC . '|', $category->getPath());
 
         $this->categoryRepository->merge($versionId, $this->context);
 
@@ -261,7 +261,7 @@ class TreeIndexerTest extends TestCase
             ->getEntities()
             ->first();
         static::assertInstanceOf(CategoryEntity::class, $category);
-        static::assertEquals('|' . $categoryA . '|', $category->getPath());
+        static::assertSame('|' . $categoryA . '|', $category->getPath());
     }
 
     public function testIndexTree(): void
@@ -297,7 +297,7 @@ class TreeIndexerTest extends TestCase
         )->getEntities();
 
         foreach ($categories as $category) {
-            static::assertEquals(0, $category->getLevel());
+            static::assertSame(0, $category->getLevel());
             static::assertNull($category->getPath());
         }
 
@@ -316,14 +316,14 @@ class TreeIndexerTest extends TestCase
         static::assertNotNull($categories->get($categoryD));
 
         static::assertNull($categories->get($categoryA)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryB)->getPath());
-        static::assertEquals("|{$categoryA}|", $categories->get($categoryC)->getPath());
-        static::assertEquals("|{$categoryA}|{$categoryC}|", $categories->get($categoryD)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryB)->getPath());
+        static::assertSame("|{$categoryA}|", $categories->get($categoryC)->getPath());
+        static::assertSame("|{$categoryA}|{$categoryC}|", $categories->get($categoryD)->getPath());
 
-        static::assertEquals(1, $categories->get($categoryA)->getLevel());
-        static::assertEquals(2, $categories->get($categoryB)->getLevel());
-        static::assertEquals(2, $categories->get($categoryC)->getLevel());
-        static::assertEquals(3, $categories->get($categoryD)->getLevel());
+        static::assertSame(1, $categories->get($categoryA)->getLevel());
+        static::assertSame(2, $categories->get($categoryB)->getLevel());
+        static::assertSame(2, $categories->get($categoryC)->getLevel());
+        static::assertSame(3, $categories->get($categoryD)->getLevel());
     }
 
     private function createCategory(?string $parentId = null): string

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtectionValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtectionValidatorTest.php
@@ -49,7 +49,7 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertSame(403, $response->getStatusCode(), $response->getContent());
     }
 
     /**
@@ -83,7 +83,7 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertNotEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertNotSame(403, $response->getStatusCode(), $response->getContent());
 
         $this->getBrowser()
             ->request(
@@ -94,7 +94,7 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertNotEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertNotSame(403, $response->getStatusCode(), $response->getContent());
 
         $this->getBrowser()
             ->request(
@@ -105,7 +105,7 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertSame(403, $response->getStatusCode(), $response->getContent());
     }
 
     public function testItBlocksReadsOnForbiddenAssociations(): void
@@ -124,7 +124,7 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertSame(403, $response->getStatusCode(), $response->getContent());
 
         $this->getBrowser()
             ->request(
@@ -140,7 +140,7 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertNotEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertNotSame(403, $response->getStatusCode(), $response->getContent());
     }
 
     public function testItBlocksReadsOnForbiddenNestedAssociations(): void
@@ -163,7 +163,7 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertSame(403, $response->getStatusCode(), $response->getContent());
 
         $this->getBrowser()
             ->request(
@@ -183,7 +183,7 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertNotEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertNotSame(403, $response->getStatusCode(), $response->getContent());
     }
 
     public function testItDoesNotValidateCascadeDeletes(): void
@@ -202,9 +202,9 @@ class EntityProtectionValidatorTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertEquals(204, $response->getStatusCode(), $response->getContent());
+        static::assertSame(204, $response->getStatusCode(), $response->getContent());
 
-        static::assertEquals(
+        static::assertSame(
             $countBefore - 1,
             $salesChannelRepository->search(new Criteria(), Context::createDefaultContext())->getTotal()
         );

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
@@ -90,7 +90,7 @@ class EntityRepositoryTest extends TestCase
 
         $result = $repository->search($criteria, Context::createDefaultContext());
 
-        static::assertEquals(0, $result->count());
+        static::assertCount(0, $result);
     }
 
     /**
@@ -310,7 +310,7 @@ class EntityRepositoryTest extends TestCase
 
         $found = !empty($found->getIds());
 
-        static::assertEquals($match, $found);
+        static::assertSame($match, $found);
     }
 
     public static function orderTransactionsProvider(): \Generator
@@ -516,7 +516,7 @@ class EntityRepositoryTest extends TestCase
         $criteria = new Criteria([$id]);
         $locale = $repository->search($criteria, $context);
 
-        static::assertEquals([$id], $criteria->getIds());
+        static::assertSame([$id], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -556,7 +556,7 @@ class EntityRepositoryTest extends TestCase
 
         $criteria = new Criteria([$id]);
         $locale = $repository->search($criteria, $context);
-        static::assertEquals([$id], $criteria->getIds());
+        static::assertSame([$id], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -621,7 +621,7 @@ class EntityRepositoryTest extends TestCase
 
         $products = $repository->search($criteria, $context);
 
-        static::assertEquals([$id, $id2], $criteria->getIds());
+        static::assertSame([$id, $id2], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -756,7 +756,7 @@ class EntityRepositoryTest extends TestCase
         $criteria->addAssociation('manufacturer');
 
         $products = $repository->search($criteria, $context);
-        static::assertEquals([$id, $id2], $criteria->getIds());
+        static::assertSame([$id, $id2], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -816,7 +816,7 @@ class EntityRepositoryTest extends TestCase
 
         $criteria = new Criteria([$id, $newId]);
         $entities = $repository->search($criteria, $context);
-        static::assertEquals([$id, $newId], $criteria->getIds());
+        static::assertSame([$id, $newId], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -878,7 +878,7 @@ class EntityRepositoryTest extends TestCase
         $criteria = new Criteria([$id, $newId]);
         $entities = $this->categoryRepository->search($criteria, $context)->getEntities();
 
-        static::assertEquals([$id, $newId], $criteria->getIds());
+        static::assertSame([$id, $newId], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -902,7 +902,7 @@ class EntityRepositoryTest extends TestCase
         static::assertEquals($preCloneEntity->getUpdatedAt(), $postClone->getUpdatedAt());
 
         // Assert that createdAt changed
-        static::assertNotEquals($postClone->getCreatedAt(), $cloned->getCreatedAt());
+        static::assertNotSame($postClone->getCreatedAt(), $cloned->getCreatedAt());
         static::assertNull($cloned->getUpdatedAt());
     }
 
@@ -930,12 +930,12 @@ class EntityRepositoryTest extends TestCase
         static::assertCount(3, $written->getIds());
         $newId = $written->getIds();
         $newId = array_shift($newId);
-        static::assertNotEquals($id, $newId);
+        static::assertNotSame($id, $newId);
 
         $criteria = new Criteria([$id, $newId]);
         $criteria->addAssociation('children');
         $entities = $this->categoryRepository->search($criteria, $context)->getEntities();
-        static::assertEquals([$id, $newId], $criteria->getIds());
+        static::assertSame([$id, $newId], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -1026,7 +1026,7 @@ class EntityRepositoryTest extends TestCase
         $criteria->addAssociation('addresses');
 
         $entities = $repository->search($criteria, $context);
-        static::assertEquals([$recordA, $newId], $criteria->getIds());
+        static::assertSame([$recordA, $newId], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -1105,7 +1105,7 @@ class EntityRepositoryTest extends TestCase
         $category = $repo->search($criteria, $context)
             ->getEntities()
             ->get($newId);
-        static::assertEquals([$newId], $criteria->getIds());
+        static::assertSame([$newId], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -1439,7 +1439,7 @@ class EntityRepositoryTest extends TestCase
         $folder = $repository->search($criteria, $context)
             ->getEntities()
             ->get($id);
-        static::assertEquals([$id], $criteria->getIds());
+        static::assertSame([$id], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -1454,8 +1454,8 @@ class EntityRepositoryTest extends TestCase
         static::assertEmpty($childrenCriteria->getPostFilters());
         static::assertEmpty($childrenCriteria->getAggregations());
         static::assertEmpty($childrenCriteria->getAssociations());
-        static::assertEquals(2, $childrenCriteria->getLimit());
-        static::assertEquals(0, $childrenCriteria->getOffset());
+        static::assertSame(2, $childrenCriteria->getLimit());
+        static::assertSame(0, $childrenCriteria->getOffset());
 
         static::assertInstanceOf(MediaFolderEntity::class, $folder);
         static::assertInstanceOf(MediaFolderCollection::class, $folder->getChildren());
@@ -1469,7 +1469,7 @@ class EntityRepositoryTest extends TestCase
         $folder = $repository->search($criteria, $context)
             ->getEntities()
             ->get($id);
-        static::assertEquals([$id], $criteria->getIds());
+        static::assertSame([$id], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertEmpty($criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -1484,8 +1484,8 @@ class EntityRepositoryTest extends TestCase
         static::assertEmpty($childrenCriteria->getPostFilters());
         static::assertEmpty($childrenCriteria->getAggregations());
         static::assertEmpty($childrenCriteria->getAssociations());
-        static::assertEquals(3, $childrenCriteria->getLimit());
-        static::assertEquals(2, $childrenCriteria->getOffset());
+        static::assertSame(3, $childrenCriteria->getLimit());
+        static::assertSame(2, $childrenCriteria->getOffset());
 
         static::assertInstanceOf(MediaFolderEntity::class, $folder);
         static::assertInstanceOf(MediaFolderCollection::class, $folder->getChildren());
@@ -1527,7 +1527,7 @@ class EntityRepositoryTest extends TestCase
             new EqualsFilter('name', 'Child2'),
         ]));
         $this->categoryRepository->search($criteria, $context);
-        static::assertEquals([], $criteria->getIds());
+        static::assertSame([], $criteria->getIds());
         static::assertEmpty($criteria->getSorting());
         static::assertCount(1, $criteria->getFilters());
         static::assertEmpty($criteria->getPostFilters());
@@ -1537,7 +1537,7 @@ class EntityRepositoryTest extends TestCase
         static::assertNull($criteria->getOffset());
         $multiFilter = $criteria->getFilters()[0];
         static::assertInstanceOf(MultiFilter::class, $multiFilter);
-        static::assertEquals(MultiFilter::CONNECTION_OR, $multiFilter->getOperator());
+        static::assertSame(MultiFilter::CONNECTION_OR, $multiFilter->getOperator());
         static::assertCount(2, $multiFilter->getQueries());
     }
 
@@ -1560,10 +1560,7 @@ class EntityRepositoryTest extends TestCase
         $result = $repository->search(new Criteria(), Context::createDefaultContext());
         $currencyCount = (int) static::getContainer()->get(Connection::class)->fetchOne('SELECT COUNT(`id`) FROM `currency`');
 
-        static::assertEquals(
-            $currencyCount,
-            $result->getEntities()->count()
-        );
+        static::assertCount($currencyCount, $result->getEntities());
     }
 
     public function testSnippetWriteWithoutValueFieldThrowsWriteValidationError(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactoryTest.php
@@ -70,7 +70,7 @@ class EntityLoadedEventFactoryTest extends TestCase
         $createdEvents = $events->getEvents()->map(fn (EntityLoadedEvent $event): string => $event->getName());
         sort($createdEvents);
 
-        static::assertEquals([
+        static::assertSame([
             'category.loaded',
             'language.loaded',
             'product.loaded',
@@ -88,7 +88,7 @@ class EntityLoadedEventFactoryTest extends TestCase
         $createdEvents = $events->getEvents()->map(fn (EntityLoadedEvent $event): string => $event->getName());
         sort($createdEvents);
 
-        static::assertEquals([
+        static::assertSame([
             'tax.loaded',
         ], $createdEvents);
     }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/ConfigJsonFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/ConfigJsonFieldTest.php
@@ -93,14 +93,14 @@ EOF;
         $result = $searcher->search($this->configJsonDefinition, $criteria, $context);
 
         static::assertCount(1, $result->getIds());
-        static::assertEquals([$stringId], $result->getIds());
+        static::assertSame([$stringId], $result->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('data.foo', 'bar'));
         $result = $searcher->search($this->configJsonDefinition, $criteria, $context);
 
         static::assertCount(1, $result->getIds());
-        static::assertEquals([$objectId], $result->getIds());
+        static::assertSame([$objectId], $result->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('data', 'not found'));

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreateAtAndUpdatedAtFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreateAtAndUpdatedAtFieldTest.php
@@ -115,7 +115,7 @@ EOF;
         static::assertNotNull($entity->get('createdAt'));
         static::assertInstanceOf(\DateTimeInterface::class, $entity->get('createdAt'));
 
-        static::assertEquals(
+        static::assertSame(
             $date->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             $entity->get('createdAt')->format(Defaults::STORAGE_DATE_TIME_FORMAT)
         );
@@ -235,7 +235,7 @@ EOF;
         static::assertInstanceOf(ArrayEntity::class, $entity);
         static::assertInstanceOf(\DateTimeInterface::class, $entity->get('updatedAt'));
 
-        static::assertNotEquals(
+        static::assertNotSame(
             $date->format('Y-m-d'),
             $entity->get('updatedAt')->format('Y-m-d')
         );

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
@@ -94,7 +94,7 @@ class CreatedByFieldTest extends TestCase
         )->getEntities()->first();
 
         static::assertNotNull($result);
-        static::assertEquals($userId, $result->getCreatedById());
+        static::assertSame($userId, $result->getCreatedById());
     }
 
     private function getAdminContext(string $userId): Context

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
@@ -109,26 +109,26 @@ class CustomFieldTest extends TestCase
         static::assertCount(2, $events->getPayloads());
 
         $expected = [$barId, $bazId];
-        static::assertEquals($expected, $events->getIds());
+        static::assertSame($expected, $events->getIds());
 
         $actual = $repo->search(new Criteria([$barId]), Context::createDefaultContext())->first();
         static::assertNotNull($actual);
-        static::assertEquals($barId, $actual->get('id'));
-        static::assertEquals($entities[0]['custom'], $actual->get('custom'));
+        static::assertSame($barId, $actual->get('id'));
+        static::assertSame($entities[0]['custom'], $actual->get('custom'));
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('custom.foo', 'bar'));
         $result = $repo->search($criteria, Context::createDefaultContext());
         $expected = [$barId];
 
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('custom.foo', 'baz'));
         $result = $repo->search($criteria, Context::createDefaultContext());
         $expected = [$bazId];
 
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
     }
 
     public function testPatchJson(): void
@@ -150,7 +150,7 @@ class CustomFieldTest extends TestCase
 
         $actual = $repo->search(new Criteria([$entity['id']]), Context::createDefaultContext())->first();
         static::assertNotNull($actual);
-        static::assertEquals($entity['custom'], $actual->get('custom'));
+        static::assertSame($entity['custom'], $actual->get('custom'));
 
         $patch = [
             'id' => $entity['id'],
@@ -180,7 +180,7 @@ class CustomFieldTest extends TestCase
 
         $actual = $repo->search(new Criteria([$entity['id']]), Context::createDefaultContext())->first();
         static::assertNotNull($actual);
-        static::assertEquals($override['custom'], $actual->get('custom'));
+        static::assertSame($override['custom'], $actual->get('custom'));
     }
 
     public function testPatchObject(): void
@@ -200,7 +200,7 @@ class CustomFieldTest extends TestCase
 
         $actual = $repo->search(new Criteria([$entity['id']]), Context::createDefaultContext())->first();
         static::assertNotNull($actual);
-        static::assertEquals($entity['custom'], $actual->get('custom'));
+        static::assertSame($entity['custom'], $actual->get('custom'));
 
         $patch = [
             'id' => $entity['id'],
@@ -214,7 +214,7 @@ class CustomFieldTest extends TestCase
 
         $actual = $repo->search(new Criteria([$entity['id']]), Context::createDefaultContext())->first();
         static::assertNotNull($actual);
-        static::assertEquals($patch['custom'], $actual->get('custom'));
+        static::assertSame($patch['custom'], $actual->get('custom'));
     }
 
     public function testPatchEntityAndCustomFields(): void
@@ -234,7 +234,7 @@ class CustomFieldTest extends TestCase
 
         $actual = $repo->search(new Criteria([$entity['id']]), Context::createDefaultContext())->first();
         static::assertNotNull($actual);
-        static::assertEquals($entity['custom'], $actual->get('custom'));
+        static::assertSame($entity['custom'], $actual->get('custom'));
 
         $patch = [
             'id' => $entity['id'],
@@ -255,8 +255,8 @@ class CustomFieldTest extends TestCase
 
         $actual = $repo->search(new Criteria([$entity['id']]), Context::createDefaultContext())->first();
         static::assertNotNull($actual);
-        static::assertEquals($patch['name'], $actual->get('name'));
-        static::assertEquals($patch['custom'], $actual->get('custom'));
+        static::assertSame($patch['name'], $actual->get('name'));
+        static::assertSame($patch['custom'], $actual->get('custom'));
     }
 
     public function testSortingInt(): void
@@ -294,8 +294,8 @@ class CustomFieldTest extends TestCase
         $last = $result->last();
         static::assertNotNull($first);
         static::assertNotNull($last);
-        static::assertEquals(10, $first->get('custom')['int']);
-        static::assertEquals(2, $last->get('custom')['int']);
+        static::assertSame(10, $first->get('custom')['int']);
+        static::assertSame(2, $last->get('custom')['int']);
 
         $criteria = new Criteria();
         $criteria->addSorting(new FieldSorting('custom.int', FieldSorting::ASCENDING));
@@ -306,8 +306,8 @@ class CustomFieldTest extends TestCase
         $last = $result->last();
         static::assertNotNull($first);
         static::assertNotNull($last);
-        static::assertEquals(2, $first->get('custom')['int']);
-        static::assertEquals(10, $last->get('custom')['int']);
+        static::assertSame(2, $first->get('custom')['int']);
+        static::assertSame(10, $last->get('custom')['int']);
     }
 
     public function testSortingFloat(): void
@@ -347,8 +347,8 @@ class CustomFieldTest extends TestCase
         $last = $result->last();
         static::assertNotNull($first);
         static::assertNotNull($last);
-        static::assertEquals(10.0, $first->get('custom')['float']);
-        static::assertEquals(2.0, $last->get('custom')['float']);
+        static::assertSame(10.0, $first->get('custom')['float']);
+        static::assertSame(2.0, $last->get('custom')['float']);
 
         $criteria = new Criteria();
         $criteria->addSorting(new FieldSorting('custom.float', FieldSorting::ASCENDING));
@@ -360,8 +360,8 @@ class CustomFieldTest extends TestCase
         $last = $result->last();
         static::assertNotNull($first);
         static::assertNotNull($last);
-        static::assertEquals(2.0, $first->get('custom')['float']);
-        static::assertEquals(10.0, $last->get('custom')['float']);
+        static::assertSame(2.0, $first->get('custom')['float']);
+        static::assertSame(10.0, $last->get('custom')['float']);
     }
 
     public function testSortingDate(): void
@@ -405,8 +405,8 @@ class CustomFieldTest extends TestCase
 
         static::assertNotNull($first);
         static::assertNotNull($last);
-        static::assertEquals($laterDate->format(\DateTime::ATOM), $first->get('custom')['datetime']);
-        static::assertEquals($earlierDate->format(\DateTime::ATOM), $last->get('custom')['datetime']);
+        static::assertSame($laterDate->format(\DateTime::ATOM), $first->get('custom')['datetime']);
+        static::assertSame($earlierDate->format(\DateTime::ATOM), $last->get('custom')['datetime']);
 
         $criteria = new Criteria();
         $criteria->addSorting(new FieldSorting('custom.datetime', FieldSorting::ASCENDING));
@@ -418,8 +418,8 @@ class CustomFieldTest extends TestCase
         $last = $result->last();
         static::assertNotNull($first);
         static::assertNotNull($last);
-        static::assertEquals($earlierDate->format(\DateTime::ATOM), $first->get('custom')['datetime']);
-        static::assertEquals($laterDate->format(\DateTime::ATOM), $last->get('custom')['datetime']);
+        static::assertSame($earlierDate->format(\DateTime::ATOM), $first->get('custom')['datetime']);
+        static::assertSame($laterDate->format(\DateTime::ATOM), $last->get('custom')['datetime']);
     }
 
     public function testSortingDateTime(): void
@@ -455,10 +455,10 @@ class CustomFieldTest extends TestCase
 
         static::assertCount(4, $result);
 
-        static::assertEquals($dateTimes[3]->format(\DateTime::ATOM), $result[0]->get('custom')['datetime']);
-        static::assertEquals($dateTimes[2]->format(\DateTime::ATOM), $result[1]->get('custom')['datetime']);
-        static::assertEquals($dateTimes[1]->format(\DateTime::ATOM), $result[2]->get('custom')['datetime']);
-        static::assertEquals($dateTimes[0]->format(\DateTime::ATOM), $result[3]->get('custom')['datetime']);
+        static::assertSame($dateTimes[3]->format(\DateTime::ATOM), $result[0]->get('custom')['datetime']);
+        static::assertSame($dateTimes[2]->format(\DateTime::ATOM), $result[1]->get('custom')['datetime']);
+        static::assertSame($dateTimes[1]->format(\DateTime::ATOM), $result[2]->get('custom')['datetime']);
+        static::assertSame($dateTimes[0]->format(\DateTime::ATOM), $result[3]->get('custom')['datetime']);
 
         $criteria = new Criteria();
         $criteria->addSorting(new FieldSorting('custom.datetime', FieldSorting::ASCENDING));
@@ -466,10 +466,10 @@ class CustomFieldTest extends TestCase
 
         static::assertCount(4, $result);
 
-        static::assertEquals($dateTimes[0]->format(\DateTime::ATOM), $result[0]->get('custom')['datetime']);
-        static::assertEquals($dateTimes[1]->format(\DateTime::ATOM), $result[1]->get('custom')['datetime']);
-        static::assertEquals($dateTimes[2]->format(\DateTime::ATOM), $result[2]->get('custom')['datetime']);
-        static::assertEquals($dateTimes[3]->format(\DateTime::ATOM), $result[3]->get('custom')['datetime']);
+        static::assertSame($dateTimes[0]->format(\DateTime::ATOM), $result[0]->get('custom')['datetime']);
+        static::assertSame($dateTimes[1]->format(\DateTime::ATOM), $result[1]->get('custom')['datetime']);
+        static::assertSame($dateTimes[2]->format(\DateTime::ATOM), $result[2]->get('custom')['datetime']);
+        static::assertSame($dateTimes[3]->format(\DateTime::ATOM), $result[3]->get('custom')['datetime']);
     }
 
     public function testSortingString(): void
@@ -507,8 +507,8 @@ class CustomFieldTest extends TestCase
         $last = $result->last();
         static::assertNotNull($first);
         static::assertNotNull($last);
-        static::assertEquals('ab', $first->get('custom')['foo']);
-        static::assertEquals('a', $last->get('custom')['foo']);
+        static::assertSame('ab', $first->get('custom')['foo']);
+        static::assertSame('a', $last->get('custom')['foo']);
 
         $criteria = new Criteria();
         $criteria->addSorting(new FieldSorting('custom.foo', FieldSorting::ASCENDING));
@@ -519,8 +519,8 @@ class CustomFieldTest extends TestCase
         $last = $result->last();
         static::assertNotNull($first);
         static::assertNotNull($last);
-        static::assertEquals('a', $first->get('custom')['foo']);
-        static::assertEquals('ab', $last->get('custom')['foo']);
+        static::assertSame('a', $first->get('custom')['foo']);
+        static::assertSame('ab', $last->get('custom')['foo']);
     }
 
     public function testStringEqualsCriteria(): void
@@ -545,13 +545,13 @@ class CustomFieldTest extends TestCase
         $criteriaFalse->addFilter(new EqualsFilter('custom.string', 'a'));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = [$aId, $upperAId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteriaFalse = new Criteria();
         $criteriaFalse->addFilter(new EqualsFilter('custom.string', 'A'));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = [$aId, $upperAId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
     }
 
     public function testBooleanEqualsCriteria(): void
@@ -577,13 +577,13 @@ class CustomFieldTest extends TestCase
         $criteriaFalse->addFilter(new EqualsFilter('custom.bool', false));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = [$falseId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteriaTrue = new Criteria();
         $criteriaTrue->addFilter(new EqualsFilter('custom.bool', true));
         $result = $repo->search($criteriaTrue, Context::createDefaultContext());
         $expected = [$trueId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteriaTrue = new Criteria();
         $criteriaTrue->addFilter(new EqualsFilter('custom.bool', null));
@@ -615,19 +615,19 @@ class CustomFieldTest extends TestCase
         $criteriaFalse->addFilter(new EqualsFilter('custom.int', 10));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = [$intId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteriaFalse = new Criteria();
         $criteriaFalse->addFilter(new EqualsFilter('custom.int', 10.0));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = [$intId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteriaFalse = new Criteria();
         $criteriaFalse->addFilter(new EqualsFilter('custom.int', 0));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = [$zeroIntId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
     }
 
     public function testFloatEqualsCriteria(): void
@@ -653,13 +653,13 @@ class CustomFieldTest extends TestCase
         $criteriaFalse->addFilter(new EqualsFilter('custom.float', 0.1));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = [$dotOneId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteriaFalse = new Criteria();
         $criteriaFalse->addFilter(new EqualsFilter('custom.float', 0.099999999999999));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = [$almostDotOneId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
     }
 
     public function testDateTimeEqualsCriteria(): void
@@ -688,19 +688,19 @@ class CustomFieldTest extends TestCase
         $criteriaFalse->addFilter(new EqualsFilter('custom.datetime', '1990-01-01'));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = $ids;
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteriaFalse = new Criteria();
         $criteriaFalse->addFilter(new EqualsFilter('custom.datetime', '1990-01-01T00:00:00.000000'));
         $result = $repo->search($criteriaFalse, Context::createDefaultContext());
         $expected = $ids;
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteriaNow = new Criteria();
         $criteriaNow->addFilter(new EqualsFilter('custom.datetime', $now));
         $result = $repo->search($criteriaNow, Context::createDefaultContext());
         $expected = [$nowId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
     }
 
     public function testSetCustomFieldsOnNullColumn(): void
@@ -726,11 +726,11 @@ class CustomFieldTest extends TestCase
         $payload = $event->getPayloads()[0];
         unset($payload['updatedAt']);
 
-        static::assertEquals($expected, $payload);
+        static::assertSame($expected, $payload);
 
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
         static::assertNotNull($first);
-        static::assertEquals($update['custom'], $first->get('custom'));
+        static::assertSame($update['custom'], $first->get('custom'));
     }
 
     public function testSetCustomFieldsOnEmptyArray(): void
@@ -756,11 +756,11 @@ class CustomFieldTest extends TestCase
         $payload = $event->getPayloads()[0];
         unset($payload['updatedAt']);
 
-        static::assertEquals($expected, $payload);
+        static::assertSame($expected, $payload);
 
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
         static::assertNotNull($first);
-        static::assertEquals($update['custom'], $first->get('custom'));
+        static::assertSame($update['custom'], $first->get('custom'));
     }
 
     public function testSetCustomFieldsToNull(): void
@@ -807,7 +807,7 @@ class CustomFieldTest extends TestCase
 
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
         static::assertNotNull($first);
-        static::assertEquals([], $first->get('custom'));
+        static::assertSame([], $first->get('custom'));
     }
 
     public function testInheritance(): void
@@ -829,13 +829,13 @@ class CustomFieldTest extends TestCase
         $parent = $repo->search(new Criteria([$parentId]), $context)->first();
         static::assertInstanceOf(ArrayEntity::class, $parent);
 
-        static::assertEquals('parent', $parent->get('name'));
-        static::assertEquals(['foo' => 'bar'], $parent->get('custom'));
+        static::assertSame('parent', $parent->get('name'));
+        static::assertSame(['foo' => 'bar'], $parent->get('custom'));
 
         $child = $repo->search(new Criteria([$childId]), $context)->first();
         static::assertInstanceOf(ArrayEntity::class, $child);
 
-        static::assertEquals('child', $child->get('name'));
+        static::assertSame('child', $child->get('name'));
         static::assertNull($child->get('custom'));
 
         $criteria = new Criteria();
@@ -843,13 +843,13 @@ class CustomFieldTest extends TestCase
 
         $results = $repo->search($criteria, $context);
         $expected = [$parentId];
-        static::assertEquals(array_combine($expected, $expected), $results->getIds());
+        static::assertSame(array_combine($expected, $expected), $results->getIds());
 
         $parent = $repo->search(new Criteria([$parentId]), $context)->first();
         static::assertInstanceOf(ArrayEntity::class, $parent);
 
-        static::assertEquals('parent', $parent->get('name'));
-        static::assertEquals(['foo' => 'bar'], $parent->get('custom'));
+        static::assertSame('parent', $parent->get('name'));
+        static::assertSame(['foo' => 'bar'], $parent->get('custom'));
 
         $criteria = new Criteria([$childId]);
 
@@ -857,15 +857,15 @@ class CustomFieldTest extends TestCase
         $child = $repo->search($criteria, $context)->first();
         static::assertNotNull($child);
 
-        static::assertEquals('child', $child->get('name'));
-        static::assertEquals(['foo' => 'bar'], $child->get('custom'));
+        static::assertSame('child', $child->get('name'));
+        static::assertSame(['foo' => 'bar'], $child->get('custom'));
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('custom.foo', 'bar'));
 
         $results = $repo->search($criteria, $context);
         $expected = [$parentId, $childId];
-        static::assertEquals(array_combine($expected, $expected), $results->getIds());
+        static::assertSame(array_combine($expected, $expected), $results->getIds());
     }
 
     public function testInheritanceCustomFieldsAreMerged(): void
@@ -887,40 +887,40 @@ class CustomFieldTest extends TestCase
         $parent = $repo->search(new Criteria([$parentId]), $context)->first();
         static::assertInstanceOf(ArrayEntity::class, $parent);
 
-        static::assertEquals('parent', $parent->get('name'));
-        static::assertEquals(['foo' => 'bar'], $parent->get('custom'));
-        static::assertEquals('parent', $parent->get('name'));
-        static::assertEquals(['foo' => 'bar'], $parent->get('custom'));
+        static::assertSame('parent', $parent->get('name'));
+        static::assertSame(['foo' => 'bar'], $parent->get('custom'));
+        static::assertSame('parent', $parent->get('name'));
+        static::assertSame(['foo' => 'bar'], $parent->get('custom'));
 
         $criteria = new Criteria([$childId]);
         $context->setConsiderInheritance(true);
         $child = $repo->search($criteria, $context)->first();
 
         static::assertNotNull($child);
-        static::assertEquals('child', $child->get('name'));
-        static::assertEquals('child', $child->get('name'));
-        static::assertEquals(['foo' => 'bar'], $child->get('custom'));
+        static::assertSame('child', $child->get('name'));
+        static::assertSame('child', $child->get('name'));
+        static::assertSame(['foo' => 'bar'], $child->get('custom'));
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('custom.foo', 'bar'));
         $results = $repo->search($criteria, $context);
         $expected = [$parentId, $childId];
-        static::assertEquals(array_combine($expected, $expected), $results->getIds());
+        static::assertSame(array_combine($expected, $expected), $results->getIds());
 
         $context->setConsiderInheritance(false);
         $child = $repo->search(new Criteria([$childId]), $context)->first();
         static::assertNotNull($child);
 
-        static::assertEquals('child', $child->get('name'));
+        static::assertSame('child', $child->get('name'));
         static::assertNull($child->get('custom'));
-        static::assertEquals('child', $child->get('name'));
+        static::assertSame('child', $child->get('name'));
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('custom.foo', 'bar'));
 
         $results = $repo->search($criteria, $context);
         $expected = [$parentId];
-        static::assertEquals(array_combine($expected, $expected), $results->getIds());
+        static::assertSame(array_combine($expected, $expected), $results->getIds());
     }
 
     public function testCustomFieldAssoc(): void
@@ -937,7 +937,7 @@ class CustomFieldTest extends TestCase
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
 
         static::assertNotEmpty($first);
-        static::assertEquals(['assoc' => ['foo' => 'bar']], $first->get('custom'));
+        static::assertSame(['assoc' => ['foo' => 'bar']], $first->get('custom'));
 
         $patch = [
             'id' => $id,
@@ -948,7 +948,7 @@ class CustomFieldTest extends TestCase
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
 
         static::assertNotEmpty($first);
-        static::assertEquals(['assoc' => ['foo' => 'baz']], $first->get('custom'));
+        static::assertSame(['assoc' => ['foo' => 'baz']], $first->get('custom'));
     }
 
     public function testCustomFieldPrice(): void
@@ -1013,7 +1013,7 @@ class CustomFieldTest extends TestCase
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
 
         static::assertNotEmpty($first);
-        static::assertEquals(['array' => ['foo', 'bar']], $first->get('custom'));
+        static::assertSame(['array' => ['foo', 'bar']], $first->get('custom'));
 
         $patch = [
             'id' => $id,
@@ -1024,7 +1024,7 @@ class CustomFieldTest extends TestCase
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
 
         static::assertNotEmpty($first);
-        static::assertEquals(['array' => ['bar', 'baz']], $first->get('custom'));
+        static::assertSame(['array' => ['bar', 'baz']], $first->get('custom'));
     }
 
     public function testUpdateDecodedCorrectly(): void
@@ -1095,7 +1095,7 @@ class CustomFieldTest extends TestCase
 
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
         $encoded = json_decode(json_encode($first, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals($dateTime->format(\DateTime::ATOM), $encoded['custom']['date']);
+        static::assertSame($dateTime->format(\DateTime::ATOM), $encoded['custom']['date']);
     }
 
     public function testJsonEncodeNestedDateTime(): void
@@ -1115,7 +1115,7 @@ class CustomFieldTest extends TestCase
 
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
         $encoded = json_decode(json_encode($first, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals($dateTime->format(\DateTime::ATOM), $encoded['custom']['json']['date']);
+        static::assertSame($dateTime->format(\DateTime::ATOM), $encoded['custom']['json']['date']);
     }
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTranslationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTranslationTest.php
@@ -177,10 +177,10 @@ class CustomFieldTranslationTest extends TestCase
         $result = $repo->search(new Criteria([$id]), $context)->first();
         static::assertInstanceOf(Entity::class, $result);
         $expected = ['code' => 'en-GB', 'system' => 'system'];
-        static::assertEquals($expected, $result->getTranslated()['customTranslated']);
+        static::assertSame($expected, $result->getTranslated()['customTranslated']);
 
         $expectedViewData = $expected;
-        static::assertEquals($expectedViewData, $result->getTranslated()['customTranslated']);
+        static::assertSame($expectedViewData, $result->getTranslated()['customTranslated']);
 
         $chain = [$this->getDeDeLanguageId(), Defaults::LANGUAGE_SYSTEM];
         $context = new Context(new SystemSource(), [], Defaults::CURRENCY, $chain);
@@ -188,10 +188,10 @@ class CustomFieldTranslationTest extends TestCase
         static::assertInstanceOf(Entity::class, $result);
 
         $expected = ['de' => 'de', 'code' => 'de-DE'];
-        static::assertEquals($expected, $result->get('customTranslated'));
+        static::assertSame($expected, $result->get('customTranslated'));
 
         $expectedViewData = ['code' => 'de-DE', 'system' => 'system', 'de' => 'de'];
-        static::assertEquals($expectedViewData, $result->getTranslated()['customTranslated']);
+        static::assertSame($expectedViewData, $result->getTranslated()['customTranslated']);
 
         $chain = [$rootLanguageId, Defaults::LANGUAGE_SYSTEM];
         $context = new Context(new SystemSource(), [], Defaults::CURRENCY, $chain);
@@ -200,9 +200,9 @@ class CustomFieldTranslationTest extends TestCase
         static::assertInstanceOf(Entity::class, $result);
 
         $expected = ['code' => 'root', 'root' => 'root'];
-        static::assertEquals($expected, $result->get('customTranslated'));
+        static::assertSame($expected, $result->get('customTranslated'));
         $expectedViewData = ['code' => 'root', 'system' => 'system', 'root' => 'root'];
-        static::assertEquals($expectedViewData, $result->getTranslated()['customTranslated']);
+        static::assertSame($expectedViewData, $result->getTranslated()['customTranslated']);
 
         $chain = [$childLanguageId, $rootLanguageId, Defaults::LANGUAGE_SYSTEM];
         $context = new Context(new SystemSource(), [], Defaults::CURRENCY, $chain);
@@ -211,9 +211,9 @@ class CustomFieldTranslationTest extends TestCase
         static::assertInstanceOf(Entity::class, $result);
 
         $expected = ['code' => 'child', 'child' => 'child'];
-        static::assertEquals($expected, $result->get('customTranslated'));
+        static::assertSame($expected, $result->get('customTranslated'));
         $expectedViewData = ['code' => 'child', 'system' => 'system', 'root' => 'root', 'child' => 'child'];
-        static::assertEquals($expectedViewData, $result->getTranslated()['customTranslated']);
+        static::assertSame($expectedViewData, $result->getTranslated()['customTranslated']);
     }
 
     public function testTranslationChainOnFilter(): void
@@ -267,7 +267,7 @@ class CustomFieldTranslationTest extends TestCase
         $criteria->addFilter(new EqualsFilter('customTranslated.systemFloat', 1.0));
         $result = $repo->search($criteria, $context);
         $expected = [$id];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $first = $result->first();
         static::assertInstanceOf(Entity::class, $first);
@@ -287,13 +287,13 @@ class CustomFieldTranslationTest extends TestCase
         $context->setConsiderInheritance(true);
         $result = $repo->search($criteria, $context);
         $expected = [];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('customTranslated.child', $now));
         $result = $repo->search($criteria, $context);
         $expected = [];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         // root -> system
         $context = new Context(new SystemSource(), [], Defaults::CURRENCY, [$rootId, Defaults::LANGUAGE_SYSTEM]);
@@ -302,13 +302,13 @@ class CustomFieldTranslationTest extends TestCase
         $criteria->addFilter(new EqualsFilter('customTranslated.systemFloat', 1.0));
         $result = $repo->search($criteria, $context);
         $expected = [$id];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('customTranslated.root', true));
         $result = $repo->search($criteria, $context);
         $expected = [$id];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $first = $result->first();
         static::assertInstanceOf(Entity::class, $first);
@@ -327,7 +327,7 @@ class CustomFieldTranslationTest extends TestCase
         $criteria->addFilter(new EqualsFilter('customTranslated.child', $now));
         $result = $repo->search($criteria, $context);
         $expected = [];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         // child -> root -> system
         $context = new Context(new SystemSource(), [], Defaults::CURRENCY, [$childId, $rootId, Defaults::LANGUAGE_SYSTEM]);
@@ -336,20 +336,20 @@ class CustomFieldTranslationTest extends TestCase
         $criteria->addFilter(new EqualsFilter('customTranslated.systemFloat', 1.0));
         $result = $repo->search($criteria, $context);
         $expected = [$id];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('customTranslated.root', true));
         $result = $repo->search($criteria, $context);
         $expected = [$id];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('customTranslated.child', $now));
 
         $result = $repo->search($criteria, $context);
         $expected = [$id];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $first = $result->first();
         static::assertInstanceOf(Entity::class, $first);
@@ -434,7 +434,7 @@ class CustomFieldTranslationTest extends TestCase
         $criteria->addFilter(new EqualsFilter('customTranslated.systemFloat', 1.0));
         $result = $repo->search($criteria, $context);
         $expected = [$childId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $first = $result->first();
         static::assertInstanceOf(Entity::class, $first);
@@ -455,13 +455,13 @@ class CustomFieldTranslationTest extends TestCase
         $context->setConsiderInheritance(false);
         $result = $repo->search($criteria, $context);
         $expected = [];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('customTranslated.sub', $now));
         $result = $repo->search($criteria, $context);
         $expected = [];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         // root -> system
         $context = new Context(new SystemSource(), [], Defaults::CURRENCY, [$rootId, Defaults::LANGUAGE_SYSTEM]);
@@ -485,7 +485,7 @@ class CustomFieldTranslationTest extends TestCase
         $context->setConsiderInheritance(true);
         $result = $repo->search($criteria, $context);
         $expected = [$childId];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         $first = $result->first();
         static::assertInstanceOf(Entity::class, $first);
@@ -506,7 +506,7 @@ class CustomFieldTranslationTest extends TestCase
         $context->setConsiderInheritance(false);
         $result = $repo->search($criteria, $context);
         $expected = [];
-        static::assertEquals(array_combine($expected, $expected), $result->getIds());
+        static::assertSame(array_combine($expected, $expected), $result->getIds());
 
         // child -> root -> system
         $context = new Context(new SystemSource(), [], Defaults::CURRENCY, [$childId, $rootId, Defaults::LANGUAGE_SYSTEM]);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/DateFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/DateFieldTest.php
@@ -71,7 +71,7 @@ EOF;
         $data = $this->connection->fetchAllAssociative('SELECT * FROM `_date_field_test`');
 
         static::assertCount(1, $data);
-        static::assertEquals(Uuid::fromHexToBytes($id), $data[0]['id']);
+        static::assertSame(Uuid::fromHexToBytes($id), $data[0]['id']);
         static::assertNull($data[0]['date_nullable']);
         static::assertSame($date->format(Defaults::STORAGE_DATE_FORMAT), $data[0]['date']);
     }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/Flag/WriteProtectedFlagTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/Flag/WriteProtectedFlagTest.php
@@ -115,12 +115,11 @@ EOF;
 
         static::assertInstanceOf(WriteException::class, $ex);
         static::assertCount(1, $ex->getExceptions());
-        static::assertEquals('This field is write-protected.', $this->getValidationExceptionMessage($ex));
+        static::assertSame('This field is write-protected.', $this->getValidationExceptionMessage($ex));
 
         $fieldException = $ex->getExceptions()[0];
-        static::assertEquals(WriteConstraintViolationException::class, $fieldException::class);
         static::assertInstanceOf(WriteConstraintViolationException::class, $fieldException);
-        static::assertEquals('/0/protected', $fieldException->getPath());
+        static::assertSame('/0/protected', $fieldException->getPath());
     }
 
     public function testWriteWithoutProtectedField(): void
@@ -139,7 +138,7 @@ EOF;
         $data = $this->connection->fetchAllAssociative('SELECT * FROM `_test_nullable`');
 
         static::assertCount(1, $data);
-        static::assertEquals(Uuid::fromHexToBytes($id), $data[0]['id']);
+        static::assertSame(Uuid::fromHexToBytes($id), $data[0]['id']);
         static::assertEmpty($data[0]['protected']);
     }
 
@@ -160,8 +159,8 @@ EOF;
         $data = $this->connection->fetchAllAssociative('SELECT * FROM `_test_nullable`');
 
         static::assertCount(1, $data);
-        static::assertEquals(Uuid::fromHexToBytes($id), $data[0]['id']);
-        static::assertEquals('foobar', $data[0]['system_protected']);
+        static::assertSame(Uuid::fromHexToBytes($id), $data[0]['id']);
+        static::assertSame('foobar', $data[0]['system_protected']);
     }
 
     public function testWriteManyToOneWithoutPermission(): void
@@ -187,12 +186,11 @@ EOF;
 
         static::assertInstanceOf(WriteException::class, $ex);
         static::assertCount(1, $ex->getExceptions());
-        static::assertEquals('This field is write-protected.', $this->getValidationExceptionMessage($ex, 'relation'));
+        static::assertSame('This field is write-protected.', $this->getValidationExceptionMessage($ex, 'relation'));
 
         $fieldException = $ex->getExceptions()[0];
-        static::assertEquals(WriteConstraintViolationException::class, $fieldException::class);
         static::assertInstanceOf(WriteConstraintViolationException::class, $fieldException);
-        static::assertEquals('/0/relation', $fieldException->getPath());
+        static::assertSame('/0/relation', $fieldException->getPath());
     }
 
     public function testWriteManyToOneWithPermission(): void
@@ -214,8 +212,8 @@ EOF;
         $data = $this->connection->fetchAllAssociative('SELECT * FROM `_test_nullable`');
 
         static::assertCount(1, $data);
-        static::assertEquals(Uuid::fromHexToBytes($id), $data[0]['id']);
-        static::assertEquals(Uuid::fromHexToBytes($id), $data[0]['system_relation_id']);
+        static::assertSame(Uuid::fromHexToBytes($id), $data[0]['id']);
+        static::assertSame(Uuid::fromHexToBytes($id), $data[0]['system_relation_id']);
     }
 
     public function testWriteOneToManyWithoutPermission(): void
@@ -243,12 +241,11 @@ EOF;
 
         static::assertInstanceOf(WriteException::class, $ex);
         static::assertCount(1, $ex->getExceptions());
-        static::assertEquals('This field is write-protected.', $this->getValidationExceptionMessage($ex, 'wp'));
+        static::assertSame('This field is write-protected.', $this->getValidationExceptionMessage($ex, 'wp'));
 
         $fieldException = $ex->getExceptions()[0];
-        static::assertEquals(WriteConstraintViolationException::class, $fieldException::class);
         static::assertInstanceOf(WriteConstraintViolationException::class, $fieldException);
-        static::assertEquals('/0/wp', $fieldException->getPath());
+        static::assertSame('/0/wp', $fieldException->getPath());
     }
 
     public function testWriteOneToManyWithPermission(): void
@@ -300,12 +297,11 @@ EOF;
 
         static::assertInstanceOf(WriteException::class, $ex);
         static::assertCount(1, $ex->getExceptions());
-        static::assertEquals('This field is write-protected.', $this->getValidationExceptionMessage($ex, 'relations'));
+        static::assertSame('This field is write-protected.', $this->getValidationExceptionMessage($ex, 'relations'));
 
         $fieldException = $ex->getExceptions()[0];
-        static::assertEquals(WriteConstraintViolationException::class, $fieldException::class);
         static::assertInstanceOf(WriteConstraintViolationException::class, $fieldException);
-        static::assertEquals('/0/relations', $fieldException->getPath());
+        static::assertSame('/0/relations', $fieldException->getPath());
     }
 
     public function testWriteManyToManyWithPermission(): void
@@ -330,8 +326,8 @@ EOF;
         $data = $this->connection->fetchAllAssociative('SELECT * FROM `_test_nullable_reference`');
 
         static::assertCount(1, $data);
-        static::assertEquals(Uuid::fromHexToBytes($id), $data[0]['wp_id']);
-        static::assertEquals(Uuid::fromHexToBytes($id2), $data[0]['relation_id']);
+        static::assertSame(Uuid::fromHexToBytes($id), $data[0]['wp_id']);
+        static::assertSame(Uuid::fromHexToBytes($id2), $data[0]['relation_id']);
     }
 
     public function testWriteTranslationWithoutPermission(): void
@@ -355,12 +351,11 @@ EOF;
 
         static::assertInstanceOf(WriteException::class, $ex);
         static::assertCount(1, $ex->getExceptions());
-        static::assertEquals('This field is write-protected.', $this->getValidationExceptionMessage($ex));
+        static::assertSame('This field is write-protected.', $this->getValidationExceptionMessage($ex));
 
         $fieldException = $ex->getExceptions()[0];
-        static::assertEquals(WriteConstraintViolationException::class, $fieldException::class);
         static::assertInstanceOf(WriteConstraintViolationException::class, $fieldException);
-        static::assertEquals('/0/protected', $fieldException->getPath());
+        static::assertSame('/0/protected', $fieldException->getPath());
     }
 
     public function testWriteTranslationWithPermission(): void
@@ -380,8 +375,8 @@ EOF;
         $data = $this->connection->fetchAllAssociative('SELECT * FROM `_test_nullable_translation`');
 
         static::assertCount(1, $data);
-        static::assertEquals(Uuid::fromHexToBytes($id), $data[0]['_test_nullable_id']);
-        static::assertEquals('foobar', $data[0]['system_protected']);
+        static::assertSame(Uuid::fromHexToBytes($id), $data[0]['_test_nullable_id']);
+        static::assertSame('foobar', $data[0]['system_protected']);
     }
 
     protected function createWriteContext(): WriteContext

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/JsonFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/JsonFieldTest.php
@@ -419,8 +419,8 @@ EOF;
         static::assertArrayHasKey('child', $decoded);
         static::assertArrayHasKey('childDateTime', $decoded['child']);
 
-        static::assertEquals($insertTime->format(Defaults::STORAGE_DATE_TIME_FORMAT), $decoded['child']['childDateTime']);
-        static::assertEquals($insertTime->format(Defaults::STORAGE_DATE_FORMAT), $decoded['child']['childDate']);
+        static::assertSame($insertTime->format(Defaults::STORAGE_DATE_TIME_FORMAT), $decoded['child']['childDateTime']);
+        static::assertSame($insertTime->format(Defaults::STORAGE_DATE_FORMAT), $decoded['child']['childDate']);
     }
 
     public function testNestedJsonFilter(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/OneToOneAssociationFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/OneToOneAssociationFieldTest.php
@@ -336,7 +336,7 @@ SET FOREIGN_KEY_CHECKS = 1;
 
         static::assertInstanceOf(SumResult::class, $sum);
 
-        static::assertEquals(11, $sum->getSum());
+        static::assertSame(11.0, $sum->getSum());
     }
 
     public function testCreateVersioning(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/PasswordFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/PasswordFieldTest.php
@@ -31,7 +31,7 @@ class PasswordFieldTest extends TestCase
     public function testGetStorage(): void
     {
         $field = new PasswordField('password', 'password');
-        static::assertEquals('password', $field->getStorageName());
+        static::assertSame('password', $field->getStorageName());
     }
 
     public function testNullableField(): void
@@ -54,7 +54,7 @@ class PasswordFieldTest extends TestCase
         ));
 
         $payload = iterator_to_array($payload);
-        static::assertEquals($kvPair->getValue(), $payload['password']);
+        static::assertSame($kvPair->getValue(), $payload['password']);
     }
 
     public function testEncoding(): void
@@ -77,7 +77,7 @@ class PasswordFieldTest extends TestCase
         ));
 
         $payload = iterator_to_array($payload);
-        static::assertNotEquals($kvPair->getValue(), $payload['password']);
+        static::assertNotSame($kvPair->getValue(), $payload['password']);
         static::assertTrue(password_verify((string) $kvPair->getValue(), (string) $payload['password']));
     }
 
@@ -163,6 +163,6 @@ class PasswordFieldTest extends TestCase
         ));
 
         $payload = iterator_to_array($payload);
-        static::assertEquals($kvPair->getValue(), $payload['password']);
+        static::assertSame($kvPair->getValue(), $payload['password']);
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/PriceFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/PriceFieldTest.php
@@ -108,7 +108,7 @@ EOF;
         static::assertInstanceOf(Price::class, $price);
 
         static::assertInstanceOf(Price::class, $price->getListPrice());
-        static::assertEquals(2, $price->getListPrice()->getNet());
+        static::assertSame(2.0, $price->getListPrice()->getNet());
     }
 
     public function testListPriceInCriteriaParts(): void
@@ -183,7 +183,7 @@ EOF;
             ->get(EntitySearcherInterface::class)
             ->search($definition, $criteria, Context::createDefaultContext());
 
-        static::assertEquals(
+        static::assertSame(
             [
                 $ids->get('was-2'),
                 $ids->get('was'),
@@ -295,7 +295,7 @@ EOF;
             ->get(EntitySearcherInterface::class)
             ->search($definition, $criteria, $context);
 
-        static::assertEquals($expected, array_values($result->getIds()));
+        static::assertSame($expected, array_values($result->getIds()));
 
         // test descending sorting
         $criteria = new Criteria();
@@ -305,7 +305,7 @@ EOF;
             ->get(EntitySearcherInterface::class)
             ->search($definition, $criteria, $context);
 
-        static::assertEquals(array_reverse($expected), array_values($result->getIds()));
+        static::assertSame(array_reverse($expected), array_values($result->getIds()));
     }
 
     /**
@@ -530,7 +530,7 @@ EOF;
             ->get(EntitySearcherInterface::class)
             ->search($definition, $criteria, $context);
 
-        static::assertEquals(\count($expected), $result->getTotal(), print_r($result->getData(), true));
+        static::assertSame(\count($expected), $result->getTotal(), print_r($result->getData(), true));
         foreach ($expected as $id) {
             static::assertTrue($result->has($id));
         }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
@@ -113,7 +113,7 @@ class UpdatedByFieldTest extends TestCase
         )->getEntities()->first();
 
         static::assertNotNull($result);
-        static::assertEquals($userId, $result->getUpdatedById());
+        static::assertSame($userId, $result->getUpdatedById());
     }
 
     private function getAdminContext(string $userId): Context

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/ConfigJsonFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/ConfigJsonFieldSerializerTest.php
@@ -90,6 +90,6 @@ class ConfigJsonFieldSerializerTest extends TestCase
         $encoded = $this->serializer->encode($this->field, $this->existence, $kvPair, $this->parameters)->current();
         $decoded = $this->serializer->decode($this->field, $encoded);
 
-        static::assertEquals($input, $decoded, 'Output should be equal to the input');
+        static::assertSame($input, $decoded, 'Output should be equal to the input');
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/DateTimeFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/DateTimeFieldSerializerTest.php
@@ -114,7 +114,7 @@ class DateTimeFieldSerializerTest extends TestCase
         $decoded = $this->serializer->decode($this->field, $encoded);
         static::assertNotNull($decoded);
 
-        static::assertEquals($expected, $decoded->format('c'), 'Output should be ' . $expected);
+        static::assertSame($expected, $decoded->format('c'), 'Output should be ' . $expected);
     }
 
     public function testSerializerValidatesRequiredField(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/EmailFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/EmailFieldSerializerTest.php
@@ -72,7 +72,7 @@ class EmailFieldSerializerTest extends TestCase
         }
 
         static::assertInstanceOf(WriteConstraintViolationException::class, $exception, 'This value should not be blank.');
-        static::assertEquals('/email', $exception->getViolations()->get(0)->getPropertyPath());
+        static::assertSame('/email', $exception->getViolations()->get(0)->getPropertyPath());
     }
 
     #[DataProvider('getEmailListProvider')]

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializerTest.php
@@ -85,7 +85,7 @@ class JsonFieldSerializerTest extends TestCase
         $kvPair = new KeyValuePair('password', $input, true);
         $actual = $this->serializer->encode($field, $this->existence, $kvPair, $this->parameters)->current();
 
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     /**
@@ -119,7 +119,7 @@ class JsonFieldSerializerTest extends TestCase
     {
         $field->compile(static::getContainer()->get(DefinitionInstanceRegistry::class));
         $actual = $this->serializer->decode($field, $input);
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 
     public function testEmptyValueForRequiredField(): void
@@ -131,7 +131,7 @@ class JsonFieldSerializerTest extends TestCase
 
         $result = $this->serializer->encode($field, $this->existence, $kvPair, $this->parameters)->current();
 
-        static::assertEquals('[]', $result);
+        static::assertSame('[]', $result);
     }
 
     public function testRequiredValidationThrowsError(): void
@@ -150,7 +150,7 @@ class JsonFieldSerializerTest extends TestCase
         }
 
         static::assertInstanceOf(WriteConstraintViolationException::class, $exception, 'JsonFieldSerializer does not throw violation exception for empty required field.');
-        static::assertEquals('/data', $exception->getViolations()->get(0)->getPropertyPath());
+        static::assertSame('/data', $exception->getViolations()->get(0)->getPropertyPath());
     }
 
     public function testNullValueForNotRequiredField(): void
@@ -169,6 +169,6 @@ class JsonFieldSerializerTest extends TestCase
     {
         $result = Json::encode("something\x82 another");
 
-        static::assertEquals('"something another"', $result);
+        static::assertSame('"something another"', $result);
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/ReferenceVersionFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/ReferenceVersionFieldSerializerTest.php
@@ -32,7 +32,7 @@ class ReferenceVersionFieldSerializerTest extends TestCase
         $connection = static::getContainer()->get(Connection::class);
 
         $value = $connection->fetchOne('SELECT LOWER(HEX(product_manufacturer_version_id)) FROM product WHERE id = :id', ['id' => $ids->getBytes('p1')]);
-        static::assertEquals(Defaults::LIVE_VERSION, $value);
+        static::assertSame(Defaults::LIVE_VERSION, $value);
 
         $connection->executeStatement('UPDATE product SET product_manufacturer_version_id = NULL WHERE id = :id', ['id' => $ids->getBytes('p1')]);
 
@@ -48,6 +48,6 @@ class ReferenceVersionFieldSerializerTest extends TestCase
             ->update([$update], Context::createDefaultContext());
 
         $value = $connection->fetchOne('SELECT LOWER(HEX(product_manufacturer_version_id)) FROM product WHERE id = :id', ['id' => $ids->getBytes('p1')]);
-        static::assertEquals(Defaults::LIVE_VERSION, $value);
+        static::assertSame(Defaults::LIVE_VERSION, $value);
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/StringFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/StringFieldSerializerTest.php
@@ -88,12 +88,12 @@ class StringFieldSerializerTest extends TestCase
         // error cases
         if ($expectError) {
             static::assertInstanceOf(WriteConstraintViolationException::class, $exception, 'This value should not be blank.');
-            static::assertEquals('/' . $field->getPropertyName(), $exception->getViolations()->get(0)->getPropertyPath());
+            static::assertSame('/' . $field->getPropertyName(), $exception->getViolations()->get(0)->getPropertyPath());
 
             return;
         }
 
         static::assertNull($exception);
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/TranslatedFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/TranslatedFieldSerializerTest.php
@@ -35,7 +35,7 @@ class TranslatedFieldSerializerTest extends TestCase
     {
         $data = $this->normalize(['description' => null]);
 
-        static::assertEquals([
+        static::assertSame([
             'description' => null,
             'translations' => [
                 $this->writeContext->getContext()->getLanguageId() => [
@@ -49,7 +49,7 @@ class TranslatedFieldSerializerTest extends TestCase
     {
         $data = $this->normalize(['description' => 'abc']);
 
-        static::assertEquals([
+        static::assertSame([
             'description' => 'abc',
             'translations' => [
                 $this->writeContext->getContext()->getLanguageId() => [
@@ -69,7 +69,7 @@ class TranslatedFieldSerializerTest extends TestCase
             ],
         ]);
 
-        static::assertEquals([
+        static::assertSame([
             'description' => [
                 $languageId => 'abc',
             ],

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -462,7 +462,7 @@ class EntityReaderTest extends TestCase
 
         static::assertInstanceOf(ProductEntity::class, $product);
         static::assertNull($product->getName());
-        static::assertEquals('test', $product->getDescription());
+        static::assertSame('test', $product->getDescription());
     }
 
     public function testInheritedTranslationsInViewData(): void
@@ -510,8 +510,8 @@ class EntityReaderTest extends TestCase
             ->first();
 
         static::assertInstanceOf(ProductEntity::class, $product);
-        static::assertEquals('EN', $product->getTranslated()['name']);
-        static::assertEquals('test', $product->getTranslated()['description']);
+        static::assertSame('EN', $product->getTranslated()['name']);
+        static::assertSame('test', $product->getTranslated()['description']);
     }
 
     public function testParentInheritanceInViewData(): void
@@ -565,7 +565,7 @@ class EntityReaderTest extends TestCase
         static::assertInstanceOf(ProductEntity::class, $parent);
         static::assertInstanceOf(TaxEntity::class, $parent->getTax());
         static::assertInstanceOf(Price::class, $parent->getCurrencyPrice(Defaults::CURRENCY));
-        static::assertEquals(50, $parent->getCurrencyPrice(Defaults::CURRENCY)->getGross());
+        static::assertSame(50.0, $parent->getCurrencyPrice(Defaults::CURRENCY)->getGross());
 
         $red = $products->get($redId);
 
@@ -581,9 +581,9 @@ class EntityReaderTest extends TestCase
 
         static::assertInstanceOf(ProductEntity::class, $green);
         static::assertInstanceOf(TaxEntity::class, $green->getTax());
-        static::assertEquals($greenTax, $green->getTaxId());
+        static::assertSame($greenTax, $green->getTaxId());
         static::assertInstanceOf(Price::class, $green->getCurrencyPrice(Defaults::CURRENCY));
-        static::assertEquals(100, $green->getCurrencyPrice(Defaults::CURRENCY)->getGross());
+        static::assertSame(100.0, $green->getCurrencyPrice(Defaults::CURRENCY)->getGross());
 
         $criteria = new Criteria([$parentId, $greenId, $redId]);
         $criteria->addAssociation('tax');
@@ -597,7 +597,7 @@ class EntityReaderTest extends TestCase
         static::assertInstanceOf(ProductEntity::class, $parent);
         static::assertInstanceOf(TaxEntity::class, $parent->getTax());
         static::assertInstanceOf(Price::class, $parent->getCurrencyPrice(Defaults::CURRENCY));
-        static::assertEquals(50, $parent->getCurrencyPrice(Defaults::CURRENCY)->getGross());
+        static::assertSame(50.0, $parent->getCurrencyPrice(Defaults::CURRENCY)->getGross());
 
         $red = $products->get($redId);
 
@@ -606,16 +606,16 @@ class EntityReaderTest extends TestCase
 
         // price and tax are inherited by parent
         static::assertInstanceOf(TaxEntity::class, $red->getTax());
-        static::assertEquals($parentTax, $red->getTaxId());
+        static::assertSame($parentTax, $red->getTaxId());
         static::assertInstanceOf(Price::class, $red->getCurrencyPrice(Defaults::CURRENCY));
-        static::assertEquals(50, $red->getCurrencyPrice(Defaults::CURRENCY)->getGross());
+        static::assertSame(50.0, $red->getCurrencyPrice(Defaults::CURRENCY)->getGross());
 
         $green = $products->get($greenId);
         static::assertInstanceOf(ProductEntity::class, $green);
         static::assertInstanceOf(TaxEntity::class, $green->getTax());
-        static::assertEquals($greenTax, $green->getTaxId());
+        static::assertSame($greenTax, $green->getTaxId());
         static::assertInstanceOf(Price::class, $green->getCurrencyPrice(Defaults::CURRENCY));
-        static::assertEquals(100, $green->getCurrencyPrice(Defaults::CURRENCY)->getGross());
+        static::assertSame(100.0, $green->getCurrencyPrice(Defaults::CURRENCY)->getGross());
     }
 
     public function testInheritanceWithOneToMany(): void
@@ -1128,8 +1128,8 @@ class EntityReaderTest extends TestCase
 
         $this->customerRepository->upsert([$customer], $context);
 
-        $addresses = $this->connection->fetchOne('SELECT COUNT(id) FROM customer_address WHERE customer_id = :id', ['id' => Uuid::fromHexToBytes($id)]);
-        static::assertEquals(5, $addresses);
+        $addresses = (int) $this->connection->fetchOne('SELECT COUNT(id) FROM customer_address WHERE customer_id = :id', ['id' => Uuid::fromHexToBytes($id)]);
+        static::assertSame(5, $addresses);
 
         $criteria = new Criteria([$id]);
         $criteria->addAssociation('addresses');
@@ -1328,7 +1328,7 @@ class EntityReaderTest extends TestCase
 
         static::assertInstanceOf(CustomerAddressCollection::class, $customer1->getAddresses());
         static::assertCount(3, $customer1->getAddresses());
-        static::assertEquals(
+        static::assertSame(
             [$addressId2, $addressId1, $addressId3],
             array_values($customer1->getAddresses()->getIds())
         );
@@ -1336,7 +1336,7 @@ class EntityReaderTest extends TestCase
         $customerAddressCollection = $customer2->getAddresses();
         static::assertNotNull($customerAddressCollection);
         static::assertCount(3, $customerAddressCollection);
-        static::assertEquals(
+        static::assertSame(
             [$addressId6, $addressId5, $addressId4],
             array_values($customerAddressCollection->getIds())
         );
@@ -1357,14 +1357,14 @@ class EntityReaderTest extends TestCase
 
         $customer1Addresses = $customer1->getAddresses();
         static::assertNotNull($customer1Addresses);
-        static::assertEquals(
+        static::assertSame(
             [$addressId3, $addressId1, $addressId2],
             array_values($customer1Addresses->getIds())
         );
 
         $customer2Addresses = $customer2->getAddresses();
         static::assertNotNull($customer2Addresses);
-        static::assertEquals(
+        static::assertSame(
             [$addressId4, $addressId5, $addressId6],
             array_values($customer2Addresses->getIds())
         );
@@ -1423,7 +1423,7 @@ class EntityReaderTest extends TestCase
         static::assertCount(3, $customer->getAddresses());
 
         $streets = $customer->getAddresses()->map(fn (CustomerAddressEntity $e) => $e->getStreet());
-        static::assertEquals(['A', 'B', 'D'], array_values($streets));
+        static::assertSame(['A', 'B', 'D'], array_values($streets));
 
         $criteria = new Criteria([$id]);
         $criteria->getAssociation('addresses')->setLimit(3);
@@ -1438,7 +1438,7 @@ class EntityReaderTest extends TestCase
         static::assertCount(3, $customer->getAddresses());
 
         $streets = $customer->getAddresses()->map(fn (CustomerAddressEntity $e) => $e->getStreet());
-        static::assertEquals(['X', 'E', 'D'], array_values($streets));
+        static::assertSame(['X', 'E', 'D'], array_values($streets));
     }
 
     public function testLoadOneToManySupportsPagination(): void
@@ -1614,12 +1614,12 @@ class EntityReaderTest extends TestCase
         $products = $manufacturer->getProducts();
         static::assertNotNull($products);
 
-        static::assertEquals(1, $products->count());
+        static::assertCount(1, $products);
         static::assertInstanceOf(ProductEntity::class, $products->first());
 
         $categories = $products->first()->getCategories();
         static::assertNotNull($categories);
-        static::assertEquals(1, $categories->count());
+        static::assertCount(1, $categories);
         static::assertInstanceOf(CategoryEntity::class, $categories->first());
     }
 
@@ -1843,7 +1843,7 @@ class EntityReaderTest extends TestCase
         static::assertInstanceOf(ProductCollection::class, $category1->getProducts());
         static::assertCount(2, $category1->getProducts());
 
-        static::assertEquals(
+        static::assertSame(
             [$id1, $id3],
             array_values($category1->getProducts()->getIds())
         );
@@ -1852,7 +1852,7 @@ class EntityReaderTest extends TestCase
         static::assertInstanceOf(ProductCollection::class, $category2->getProducts());
         static::assertCount(2, $category2->getProducts());
 
-        static::assertEquals(
+        static::assertSame(
             [$id2, $id3],
             array_values($category2->getProducts()->getIds())
         );
@@ -1871,7 +1871,7 @@ class EntityReaderTest extends TestCase
         static::assertInstanceOf(CategoryEntity::class, $category1);
         $category1Products = $category1->getProducts();
         static::assertNotNull($category1Products);
-        static::assertEquals(
+        static::assertSame(
             [$id3, $id1],
             array_values($category1Products->getIds())
         );
@@ -1879,7 +1879,7 @@ class EntityReaderTest extends TestCase
         static::assertInstanceOf(CategoryEntity::class, $category2);
         $category2Products = $category2->getProducts();
         static::assertNotNull($category2Products);
-        static::assertEquals(
+        static::assertSame(
             [$id3, $id2],
             array_values($category2Products->getIds())
         );
@@ -2077,11 +2077,11 @@ class EntityReaderTest extends TestCase
 
         $transDe = $catTranslations->filterByLanguageId($this->deLanguageId)->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $transDe);
-        static::assertEquals('deutsch', $transDe->getName());
+        static::assertSame('deutsch', $transDe->getName());
 
         $transSystem = $catTranslations->filterByLanguageId(Defaults::LANGUAGE_SYSTEM)->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $transSystem);
-        static::assertEquals('system', $transSystem->getName());
+        static::assertSame('system', $transSystem->getName());
     }
 
     public function testPricesAreConvertedWithCurrencyFactor(): void
@@ -2237,8 +2237,8 @@ class EntityReaderTest extends TestCase
 
         $result = $repository->search(new Criteria(), Context::createDefaultContext());
 
-        static::assertEquals(3, $result->getTotal());
-        static::assertEquals(3, $result->count());
+        static::assertSame(3, $result->getTotal());
+        static::assertCount(3, $result);
 
         $foundIds = [];
         foreach ($result as $entity) {
@@ -2276,8 +2276,8 @@ class EntityReaderTest extends TestCase
 
         $result = $repository->search(new Criteria([['testField' => $id1]]), Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertEquals(1, $result->count());
+        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result);
     }
 
     public function testDirectlyReadFromTranslationEntity(): void
@@ -2303,14 +2303,14 @@ class EntityReaderTest extends TestCase
 
         $result = static::getContainer()->get('category_translation.repository')->search($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertEquals(1, $result->count());
+        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result);
 
         $translation = $result->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $translation);
-        static::assertEquals('system', $translation->getName());
-        static::assertEquals(Defaults::LANGUAGE_SYSTEM, $translation->getLanguageId());
-        static::assertEquals($id, $translation->getCategoryId());
+        static::assertSame('system', $translation->getName());
+        static::assertSame(Defaults::LANGUAGE_SYSTEM, $translation->getLanguageId());
+        static::assertSame($id, $translation->getCategoryId());
     }
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
@@ -50,7 +50,7 @@ class RangeAggregationTest extends TestCase
 
         $aggregation = new RangeAggregation('test', 'test', []);
 
-        static::assertEquals($expectedKey, $method->invoke($aggregation, $from, $to));
+        static::assertSame($expectedKey, $method->invoke($aggregation, $from, $to));
     }
 
     /**
@@ -129,7 +129,7 @@ class RangeAggregationTest extends TestCase
         static::assertCount(\count($rangesDefinition), $rangesResult);
         foreach ($rangesResult as $key => $count) {
             static::assertArrayHasKey($key, $rangesExpectedResult);
-            static::assertEquals($rangesExpectedResult[$key], $count);
+            static::assertSame($rangesExpectedResult[$key], $count);
         }
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntityAggregatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntityAggregatorTest.php
@@ -169,22 +169,22 @@ class EntityAggregatorTest extends TestCase
 
         $bucket = $categoryAgg->get('');
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(1, $bucket->getCount());
+        static::assertSame(1, $bucket->getCount());
         static::assertNull($bucket->getResult());
 
         $bucket = $categoryAgg->get($this->ids->get('c-1'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(3, $bucket->getCount());
+        static::assertSame(3, $bucket->getCount());
         static::assertNull($bucket->getResult());
 
         $bucket = $categoryAgg->get($this->ids->get('c-2'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(1, $bucket->getCount());
+        static::assertSame(1, $bucket->getCount());
         static::assertNull($bucket->getResult());
 
         $bucket = $categoryAgg->get($this->ids->get('c-3'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(2, $bucket->getCount());
+        static::assertSame(2, $bucket->getCount());
         static::assertNull($bucket->getResult());
     }
 
@@ -222,7 +222,7 @@ class EntityAggregatorTest extends TestCase
         // validation of not assigned category
         $bucket = $categoryAgg->get('');
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(1, $bucket->getCount());
+        static::assertSame(1, $bucket->getCount());
 
         $manufacturerAgg = $bucket->getResult();
         static::assertInstanceOf(TermsResult::class, $manufacturerAgg);
@@ -231,12 +231,12 @@ class EntityAggregatorTest extends TestCase
         static::assertTrue($manufacturerAgg->has($this->ids->get('m-3')));
         $bucket = $manufacturerAgg->get($this->ids->get('m-3'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(1, $bucket->getCount());
+        static::assertSame(1, $bucket->getCount());
 
         // validation of category 1
         $bucket = $categoryAgg->get($this->ids->get('c-1'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(3, $bucket->getCount());
+        static::assertSame(3, $bucket->getCount());
 
         $manufacturerAgg = $bucket->getResult();
         static::assertInstanceOf(TermsResult::class, $manufacturerAgg);
@@ -246,15 +246,15 @@ class EntityAggregatorTest extends TestCase
 
         $bucket = $manufacturerAgg->get($this->ids->get('m-1'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(1, $bucket->getCount());
+        static::assertSame(1, $bucket->getCount());
         $bucket = $manufacturerAgg->get($this->ids->get('m-2'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(2, $bucket->getCount());
+        static::assertSame(2, $bucket->getCount());
 
         // validation of category 2
         $bucket = $categoryAgg->get($this->ids->get('c-2'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(1, $bucket->getCount());
+        static::assertSame(1, $bucket->getCount());
 
         $manufacturerAgg = $bucket->getResult();
         static::assertInstanceOf(TermsResult::class, $manufacturerAgg);
@@ -263,12 +263,12 @@ class EntityAggregatorTest extends TestCase
 
         $bucket = $manufacturerAgg->get($this->ids->get('m-1'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(1, $bucket->getCount());
+        static::assertSame(1, $bucket->getCount());
 
         // validation of category 3
         $bucket = $categoryAgg->get($this->ids->get('c-3'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(2, $bucket->getCount());
+        static::assertSame(2, $bucket->getCount());
 
         $manufacturerAgg = $bucket->getResult();
         static::assertInstanceOf(TermsResult::class, $manufacturerAgg);
@@ -277,7 +277,7 @@ class EntityAggregatorTest extends TestCase
 
         $bucket = $manufacturerAgg->get($this->ids->get('m-2'));
         static::assertInstanceOf(Bucket::class, $bucket);
-        static::assertEquals(2, $bucket->getCount());
+        static::assertSame(2, $bucket->getCount());
     }
 
     public function testTermsAggregationWithSorting(): void
@@ -574,7 +574,7 @@ class EntityAggregatorTest extends TestCase
         $max = $result->get('max-price');
         static::assertInstanceOf(MaxResult::class, $max);
 
-        static::assertEquals(250, $max->getMax());
+        static::assertSame('250.0000', $max->getMax());
     }
 
     public function testMaxAggregationWithTermsAggregation(): void
@@ -611,21 +611,21 @@ class EntityAggregatorTest extends TestCase
         static::assertInstanceOf(MaxResult::class, $bucket->getResult());
         static::assertSame(1, $bucket->getCount());
         $max = $bucket->getResult();
-        static::assertEquals(50, $max->getMax());
+        static::assertSame('50.0000', $max->getMax());
 
         $bucket = $manufacturers->get($this->ids->get('m-2'));
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(MaxResult::class, $bucket->getResult());
         static::assertSame(3, $bucket->getCount());
         $max = $bucket->getResult();
-        static::assertEquals(200, $max->getMax());
+        static::assertSame('200.0000', $max->getMax());
 
         $bucket = $manufacturers->get($this->ids->get('m-3'));
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(MaxResult::class, $bucket->getResult());
         static::assertSame(1, $bucket->getCount());
         $max = $bucket->getResult();
-        static::assertEquals(250, $max->getMax());
+        static::assertSame('250.0000', $max->getMax());
     }
 
     public function testMinAggregation(): void
@@ -647,7 +647,7 @@ class EntityAggregatorTest extends TestCase
         $min = $result->get('min-price');
         static::assertInstanceOf(MinResult::class, $min);
 
-        static::assertEquals(50, $min->getMin());
+        static::assertSame('50.0000', $min->getMin());
     }
 
     public function testMinAggregationWithTermsAggregation(): void
@@ -684,21 +684,21 @@ class EntityAggregatorTest extends TestCase
         static::assertInstanceOf(MinResult::class, $bucket->getResult());
         static::assertSame(1, $bucket->getCount());
         $min = $bucket->getResult();
-        static::assertEquals(50, $min->getMin());
+        static::assertSame('50.0000', $min->getMin());
 
         $bucket = $manufacturers->get($this->ids->get('m-2'));
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(MinResult::class, $bucket->getResult());
         static::assertSame(3, $bucket->getCount());
         $min = $bucket->getResult();
-        static::assertEquals(100, $min->getMin());
+        static::assertSame('100.0000', $min->getMin());
 
         $bucket = $manufacturers->get($this->ids->get('m-3'));
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(MinResult::class, $bucket->getResult());
         static::assertSame(1, $bucket->getCount());
         $min = $bucket->getResult();
-        static::assertEquals(250, $min->getMin());
+        static::assertSame('250.0000', $min->getMin());
     }
 
     public function testCountAggregation(): void
@@ -720,7 +720,7 @@ class EntityAggregatorTest extends TestCase
         $count = $result->get('count-manufacturer');
         static::assertInstanceOf(CountResult::class, $count);
 
-        static::assertEquals(3, $count->getCount());
+        static::assertSame(3, $count->getCount());
     }
 
     public function testCountAggregationWithTermsAggregation(): void
@@ -758,21 +758,21 @@ class EntityAggregatorTest extends TestCase
         static::assertInstanceOf(CountResult::class, $bucket->getResult());
         static::assertSame(3, $bucket->getCount());
         $count = $bucket->getResult();
-        static::assertEquals(2, $count->getCount());
+        static::assertSame(2, $count->getCount());
 
         $bucket = $categories->get($this->ids->get('c-2'));
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(CountResult::class, $bucket->getResult());
         static::assertSame(1, $bucket->getCount());
         $count = $bucket->getResult();
-        static::assertEquals(1, $count->getCount());
+        static::assertSame(1, $count->getCount());
 
         $bucket = $categories->get($this->ids->get('c-3'));
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(CountResult::class, $bucket->getResult());
         static::assertSame(2, $bucket->getCount());
         $count = $bucket->getResult();
-        static::assertEquals(1, $count->getCount());
+        static::assertSame(1, $count->getCount());
     }
 
     public function testCountAggregationWithScoreQuery(): void
@@ -795,7 +795,7 @@ class EntityAggregatorTest extends TestCase
         $count = $result->get('count-manufacturer');
         static::assertInstanceOf(CountResult::class, $count);
 
-        static::assertEquals(1, $count->getCount());
+        static::assertSame(1, $count->getCount());
     }
 
     public function testCountAggregationWithScoreQueryAndAssociation(): void
@@ -819,7 +819,7 @@ class EntityAggregatorTest extends TestCase
         $count = $result->get('count-manufacturer');
         static::assertInstanceOf(CountResult::class, $count);
 
-        static::assertEquals(1, $count->getCount());
+        static::assertSame(1, $count->getCount());
     }
 
     public function testCountAggregationWithScoreCombinedWithFilter(): void
@@ -848,12 +848,12 @@ class EntityAggregatorTest extends TestCase
         $count = $result->get('count-manufacturer');
         static::assertInstanceOf(CountResult::class, $count);
 
-        static::assertEquals(1, $count->getCount());
+        static::assertSame(1, $count->getCount());
 
         $count = $result->get('count-manufacturer2');
         static::assertInstanceOf(CountResult::class, $count);
 
-        static::assertEquals(1, $count->getCount());
+        static::assertSame(1, $count->getCount());
     }
 
     public function testStatsAggregation(): void
@@ -875,10 +875,10 @@ class EntityAggregatorTest extends TestCase
         $stats = $result->get('stats-price');
         static::assertInstanceOf(StatsResult::class, $stats);
 
-        static::assertEquals(50, $stats->getMin());
-        static::assertEquals(250, $stats->getMax());
-        static::assertEquals(150, $stats->getAvg());
-        static::assertEquals(750, $stats->getSum());
+        static::assertSame('50.0000', $stats->getMin());
+        static::assertSame('250.0000', $stats->getMax());
+        static::assertSame(150.0, $stats->getAvg());
+        static::assertSame(750.0, $stats->getSum());
     }
 
     public function testStatsAggregationWithScoreQuery(): void
@@ -901,10 +901,10 @@ class EntityAggregatorTest extends TestCase
         $stats = $result->get('stats-price');
         static::assertInstanceOf(StatsResult::class, $stats);
 
-        static::assertEquals(50, $stats->getMin());
-        static::assertEquals(50, $stats->getMax());
-        static::assertEquals(50, $stats->getAvg());
-        static::assertEquals(50, $stats->getSum());
+        static::assertSame('50.0000', $stats->getMin());
+        static::assertSame('50.0000', $stats->getMax());
+        static::assertSame(50.0, $stats->getAvg());
+        static::assertSame(50.0, $stats->getSum());
     }
 
     public function testStatsAggregationWithTermsAggregation(): void
@@ -941,30 +941,30 @@ class EntityAggregatorTest extends TestCase
         static::assertInstanceOf(StatsResult::class, $bucket->getResult());
         static::assertSame(1, $bucket->getCount());
         $stats = $bucket->getResult();
-        static::assertEquals(50, $stats->getMin());
-        static::assertEquals(50, $stats->getMax());
-        static::assertEquals(50, $stats->getAvg());
-        static::assertEquals(50, $stats->getSum());
+        static::assertSame('50.0000', $stats->getMin());
+        static::assertSame('50.0000', $stats->getMax());
+        static::assertSame(50.0, $stats->getAvg());
+        static::assertSame(50.0, $stats->getSum());
 
         $bucket = $manufacturers->get($this->ids->get('m-2'));
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(StatsResult::class, $bucket->getResult());
         static::assertSame(3, $bucket->getCount());
         $stats = $bucket->getResult();
-        static::assertEquals(100, $stats->getMin());
-        static::assertEquals(200, $stats->getMax());
-        static::assertEquals(150, $stats->getAvg());
-        static::assertEquals(450, $stats->getSum());
+        static::assertSame('100.0000', $stats->getMin());
+        static::assertSame('200.0000', $stats->getMax());
+        static::assertSame(150.0, $stats->getAvg());
+        static::assertSame(450.0, $stats->getSum());
 
         $bucket = $manufacturers->get($this->ids->get('m-3'));
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(StatsResult::class, $bucket->getResult());
         static::assertSame(1, $bucket->getCount());
         $stats = $bucket->getResult();
-        static::assertEquals(250, $stats->getMin());
-        static::assertEquals(250, $stats->getMax());
-        static::assertEquals(250, $stats->getAvg());
-        static::assertEquals(250, $stats->getSum());
+        static::assertSame('250.0000', $stats->getMin());
+        static::assertSame('250.0000', $stats->getMax());
+        static::assertSame(250.0, $stats->getAvg());
+        static::assertSame(250.0, $stats->getSum());
     }
 
     public function testEntityAggregation(): void
@@ -1106,7 +1106,7 @@ class EntityAggregatorTest extends TestCase
         $price = $result->get('avg-price');
         static::assertInstanceOf(AvgResult::class, $price);
 
-        static::assertEquals(75, $price->getAvg());
+        static::assertSame(75.0, $price->getAvg());
     }
 
     #[DataProvider('dateHistogramProvider')]
@@ -1294,25 +1294,25 @@ class EntityAggregatorTest extends TestCase
         static::assertInstanceOf(AvgResult::class, $bucket->getResult());
 
         $avg = $bucket->getResult();
-        static::assertEquals(75, $avg->getAvg());
+        static::assertSame(75.0, $avg->getAvg());
 
         $bucket = $histogram->get('2019-06-01 00:00:00');
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(AvgResult::class, $bucket->getResult());
         $avg = $bucket->getResult();
-        static::assertEquals(150, $avg->getAvg());
+        static::assertSame(150.0, $avg->getAvg());
 
         $bucket = $histogram->get('2020-09-01 00:00:00');
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(AvgResult::class, $bucket->getResult());
         $avg = $bucket->getResult();
-        static::assertEquals(200, $avg->getAvg());
+        static::assertSame(200.0, $avg->getAvg());
 
         $bucket = $histogram->get('2021-12-01 00:00:00');
         static::assertInstanceOf(Bucket::class, $bucket);
         static::assertInstanceOf(AvgResult::class, $bucket->getResult());
         $avg = $bucket->getResult();
-        static::assertEquals(250, $avg->getAvg());
+        static::assertSame(250.0, $avg->getAvg());
     }
 
     public function testAggregateNonExistingShouldFail(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntitySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntitySearcherTest.php
@@ -79,9 +79,9 @@ class EntitySearcherTest extends TestCase
 
         $result = static::getContainer()->get('product.repository')->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(100, $result->getScore($ids->get('john')));
-        static::assertEquals(200, $result->getScore($ids->get('john.doe')));
-        static::assertEquals(100, $result->getScore($ids->get('doe')));
+        static::assertSame(100.0, $result->getScore($ids->get('john')));
+        static::assertSame(200.0, $result->getScore($ids->get('john.doe')));
+        static::assertSame(100.0, $result->getScore($ids->get('doe')));
     }
 
     public function testIdSearchResultHelpers(): void
@@ -113,7 +113,7 @@ class EntitySearcherTest extends TestCase
         }
         static::assertInstanceOf(\RuntimeException::class, $exception);
 
-        static::assertEquals([], $result->getDataOfId('not-exists'));
+        static::assertSame([], $result->getDataOfId('not-exists'));
         static::assertSame($context, $result->getContext());
         static::assertEquals($criteria, $result->getCriteria());
     }
@@ -150,8 +150,8 @@ class EntitySearcherTest extends TestCase
         static::assertArrayHasKey($ids->get('p2'), $data);
         static::assertArrayHasKey('productNumber', $data[$ids->get('p2')]);
         static::assertArrayHasKey('autoIncrement', $data[$ids->get('p2')]);
-        static::assertEquals($increments[$ids->get('p1')], $data[$ids->get('p1')]['autoIncrement']);
-        static::assertEquals($increments[$ids->get('p2')], $data[$ids->get('p2')]['autoIncrement']);
+        static::assertSame((int) $increments[$ids->get('p1')], $data[$ids->get('p1')]['autoIncrement']);
+        static::assertSame((int) $increments[$ids->get('p2')], $data[$ids->get('p2')]['autoIncrement']);
     }
 
     public function testTotalCountWithSearchTerm(): void
@@ -480,7 +480,7 @@ class EntitySearcherTest extends TestCase
 
         $result = $searcher->search(static::getContainer()->get(TaxDefinition::class), $criteria, Context::createDefaultContext());
 
-        static::assertEquals($expected, $result->getIds());
+        static::assertSame($expected, $result->getIds());
     }
 
     public function testSortingWithToMany(): void
@@ -524,7 +524,7 @@ class EntitySearcherTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(
+        static::assertSame(
             [$ids->get('product-2'), $ids->get('product-1')],
             $result->getIds()
         );
@@ -614,6 +614,6 @@ class EntitySearcherTest extends TestCase
             Context::createDefaultContext()
         );
 
-        static::assertEquals(0, $result->getTotal());
+        static::assertSame(0, $result->getTotal());
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/FkFieldPrimarySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/FkFieldPrimarySearcherTest.php
@@ -89,7 +89,7 @@ class FkFieldPrimarySearcherTest extends TestCase
         $fkFieldPrimaryTupel = $fkFieldPrimaryRepository->search($criteria, Context::createDefaultContext())->getElements();
         static::assertArrayHasKey($this->productId, $fkFieldPrimaryTupel);
         static::assertTrue($fkFieldPrimaryTupel[$this->productId]->has('name'));
-        static::assertEquals('TestPrimary', $fkFieldPrimaryTupel[$this->productId]->get('name'));
+        static::assertSame('TestPrimary', $fkFieldPrimaryTupel[$this->productId]->get('name'));
     }
 
     public function testSearchByMultiPrimaryFkKey(): void
@@ -115,7 +115,7 @@ class FkFieldPrimarySearcherTest extends TestCase
         $multiFkFieldPrimaryTupel = $multiPrimaryRepository->search($criteria, Context::createDefaultContext());
         $key = $firstId . '-' . $secondId;
         static::assertArrayHasKey($key, $multiFkFieldPrimaryTupel->getElements());
-        static::assertEquals($firstId, $multiFkFieldPrimaryTupel->getElements()[$key]->get('firstId'));
+        static::assertSame($firstId, $multiFkFieldPrimaryTupel->getElements()[$key]->get('firstId'));
     }
 
     public function testSearchForTranslation(): void
@@ -145,7 +145,7 @@ class FkFieldPrimarySearcherTest extends TestCase
 
         $key = $this->productId . '-' . Defaults::LANGUAGE_SYSTEM;
         static::assertArrayHasKey($key, $productTranslation->getElements());
-        static::assertEquals('Test', $productTranslation->getElements()[$key]->getName());
+        static::assertSame('Test', $productTranslation->getElements()[$key]->getName());
     }
 
     private function addPrimaryFkField(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
@@ -121,7 +121,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds(new Criteria($ids->prefixed('product-')), Context::createDefaultContext());
 
-        static::assertEquals(\count($products), $result->getTotal());
+        static::assertSame(\count($products), $result->getTotal());
 
         return $ids;
     }
@@ -250,7 +250,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('category-1')));
         static::assertTrue($result->has($ids->get('category-2')));
         static::assertFalse($result->has($ids->get('category-3')));
@@ -270,7 +270,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -289,7 +289,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertFalse($result->has($ids->get('product-2')));
     }
@@ -310,7 +310,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertFalse($result->has($ids->get('product-2')));
     }
@@ -331,7 +331,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertFalse($result->has($ids->get('product-2')));
     }
@@ -348,7 +348,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('category-1')));
         static::assertTrue($result->has($ids->get('category-2')));
         static::assertFalse($result->has($ids->get('category-3')));
@@ -366,7 +366,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('category-1')));
         static::assertFalse($result->has($ids->get('category-2')));
         static::assertTrue($result->has($ids->get('category-3')));
@@ -386,7 +386,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -405,7 +405,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
 
@@ -420,7 +420,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -439,7 +439,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -459,7 +459,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('category-1')));
         static::assertTrue($result->has($ids->get('category-2')));
         static::assertFalse($result->has($ids->get('category-3')));
@@ -479,7 +479,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -498,7 +498,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -518,7 +518,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product_manufacturer.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertTrue($result->has($ids->get('manufacturer-1')));
         static::assertFalse($result->has($ids->get('manufacturer-2')));
 
@@ -534,7 +534,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product_manufacturer.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('manufacturer-1')));
         static::assertTrue($result->has($ids->get('manufacturer-2')));
     }
@@ -553,7 +553,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
 
@@ -568,7 +568,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -587,7 +587,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertFalse($result->has($ids->get('product-2')));
     }
@@ -606,7 +606,7 @@ class JoinFilterTest extends TestCase
         $result = Context::createDefaultContext()->enableInheritance(fn (Context $context) => static::getContainer()->get('product.repository')
             ->searchIds($criteria, $context));
 
-        static::assertEquals(3, $result->getTotal());
+        static::assertSame(3, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertTrue($result->has($ids->get('product-1-variant')));
@@ -625,7 +625,7 @@ class JoinFilterTest extends TestCase
         $result = Context::createDefaultContext()->enableInheritance(fn (Context $context) => static::getContainer()->get('product.repository')
             ->searchIds($criteria, $context));
 
-        static::assertEquals(3, $result->getTotal());
+        static::assertSame(3, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertTrue($result->has($ids->get('product-1-variant')));
@@ -646,7 +646,7 @@ class JoinFilterTest extends TestCase
         $result = Context::createDefaultContext()->enableInheritance(fn (Context $context) => static::getContainer()->get('product.repository')
             ->searchIds($criteria, $context));
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertTrue($result->has($ids->get('product-1-variant')));
@@ -665,7 +665,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -683,7 +683,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
     }
@@ -701,7 +701,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertFalse($result->has($ids->get('product-3')));
@@ -718,7 +718,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-3')));
         static::assertTrue($result->has($ids->get('product-1-variant')));
         static::assertFalse($result->has($ids->get('product-1')));
@@ -736,7 +736,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-3')));
         static::assertTrue($result->has($ids->get('product-1-variant')));
         static::assertFalse($result->has($ids->get('product-2')));
@@ -754,7 +754,7 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertFalse($result->has($ids->get('product-1')));
         static::assertTrue($result->has($ids->get('product-3')));

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/NaturalSortingTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/NaturalSortingTest.php
@@ -72,7 +72,7 @@ class NaturalSortingTest extends TestCase
         // extract names to compare them
         $actual = $options->map(static fn (PropertyGroupOptionEntity $option) => $option->getName());
 
-        static::assertEquals($rawOrder, array_values($actual));
+        static::assertSame($rawOrder, array_values($actual));
 
         // check natural sorting
         $criteria = new Criteria();
@@ -82,7 +82,7 @@ class NaturalSortingTest extends TestCase
         $options = $this->optionRepository->search($criteria, $context);
         $actual = $options->map(static fn (PropertyGroupOptionEntity $option) => $option->getName());
 
-        static::assertEquals($naturalOrder, array_values($actual));
+        static::assertSame($naturalOrder, array_values($actual));
     }
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParserTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParserTest.php
@@ -75,13 +75,13 @@ class AggregationParserTest extends TestCase
 
         $maxAggregation = $criteria->getAggregation('max_agg');
         static::assertInstanceOf(MaxAggregation::class, $maxAggregation);
-        static::assertEquals('max_agg', $maxAggregation->getName());
-        static::assertEquals('product.tax.taxRate', $maxAggregation->getField());
+        static::assertSame('max_agg', $maxAggregation->getName());
+        static::assertSame('product.tax.taxRate', $maxAggregation->getField());
 
         $avgAggregation = $criteria->getAggregation('avg_agg');
         static::assertInstanceOf(AvgAggregation::class, $avgAggregation);
-        static::assertEquals('avg_agg', $avgAggregation->getName());
-        static::assertEquals('product.stock', $avgAggregation->getField());
+        static::assertSame('avg_agg', $avgAggregation->getName());
+        static::assertSame('product.stock', $avgAggregation->getField());
     }
 
     public function testBuildAggregationsWithSameName(): void
@@ -112,13 +112,13 @@ class AggregationParserTest extends TestCase
 
         $maxAggregation = $criteria->getAggregation('max');
         static::assertInstanceOf(MaxAggregation::class, $maxAggregation);
-        static::assertEquals('max', $maxAggregation->getName());
-        static::assertEquals('product.tax.taxRate', $maxAggregation->getField());
+        static::assertSame('max', $maxAggregation->getName());
+        static::assertSame('product.tax.taxRate', $maxAggregation->getField());
 
         $avgAggregation = $criteria->getAggregation('avg');
         static::assertInstanceOf(AvgAggregation::class, $avgAggregation);
-        static::assertEquals('avg', $avgAggregation->getName());
-        static::assertEquals('product.stock', $avgAggregation->getField());
+        static::assertSame('avg', $avgAggregation->getName());
+        static::assertSame('product.stock', $avgAggregation->getField());
     }
 
     public function testICanCreateNestedAggregations(): void
@@ -249,8 +249,8 @@ class AggregationParserTest extends TestCase
 
         $entity = $criteria->getAggregation('entity_test');
         static::assertInstanceOf(EntityAggregation::class, $entity);
-        static::assertEquals('product.manufacturerId', $entity->getField());
-        static::assertEquals(ProductManufacturerDefinition::ENTITY_NAME, $entity->getEntity());
+        static::assertSame('product.manufacturerId', $entity->getField());
+        static::assertSame(ProductManufacturerDefinition::ENTITY_NAME, $entity->getEntity());
     }
 
     public function testThrowExceptionByEntityAggregationWithoutDefinition(): void
@@ -308,8 +308,8 @@ class AggregationParserTest extends TestCase
         static::assertInstanceOf(RangeAggregation::class, $agg);
         $computedRanges = $agg->getRanges();
 
-        static::assertEquals($expectedRanges[0] + ['key' => '1-2'], $computedRanges[0]);
-        static::assertEquals($expectedRanges[1] + ['key' => '2-3'], $computedRanges[1]);
+        static::assertSame($expectedRanges[0] + ['key' => '1-2'], $computedRanges[0]);
+        static::assertSame($expectedRanges[1] + ['key' => '2-3'], $computedRanges[1]);
     }
 
     public function testQuestionMarkNotAllowedInAggregationName(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -70,7 +70,7 @@ class SqlQueryParserTest extends TestCase
             $this->ids->get('product2-without-category'),
         ];
 
-        static::assertEquals($productsWithoutCategory, $result->getIds());
+        static::assertSame($productsWithoutCategory, $result->getIds());
     }
 
     public function testFindProductsWithCategory(): void
@@ -84,7 +84,7 @@ class SqlQueryParserTest extends TestCase
             $this->ids->get('product1-with-category'),
         ];
 
-        static::assertEquals($productsWithoutCategory, $result->getIds());
+        static::assertSame($productsWithoutCategory, $result->getIds());
     }
 
     #[DataProvider('whenToUseNullSafeOperatorProvider')]
@@ -101,7 +101,7 @@ class SqlQueryParserTest extends TestCase
             $has = $has || str_contains((string) $where, '<=>');
         }
 
-        static::assertEquals($expected, $has);
+        static::assertSame($expected, $has);
     }
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Term/EntityScoreBuilderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Term/EntityScoreBuilderTest.php
@@ -76,7 +76,7 @@ class EntityScoreBuilderTest extends TestCase
 
         $queries = $builder->buildScoreQueries($pattern, $this->onlyDateFieldDefinition, 'test', $this->context);
 
-        static::assertNotEquals(
+        static::assertNotSame(
             [
                 new ScoreQuery(new EqualsFilter('test.dateTime', $dateTerm), 100),
                 new ScoreQuery(new ContainsFilter('test.dateTime', $dateTerm), 50),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilterTest.php
@@ -41,7 +41,7 @@ class TokenFilterTest extends TestCase
 
         sort($expected);
         sort($keywords);
-        static::assertEquals($expected, $keywords);
+        static::assertSame($expected, $keywords);
     }
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
@@ -104,7 +104,7 @@ class VersionManagerTest extends TestCase
         $extension = $product->getExtension('manyToOne');
 
         static::assertInstanceOf(ArrayEntity::class, $extension);
-        static::assertEquals($extendableId, $extension->get('id'));
+        static::assertSame($extendableId, $extension->get('id'));
 
         $criteria = (new Criteria())->addFilter(new EqualsFilter('manyToOne.id', $extendableId));
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/EntityWriterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/EntityWriterTest.php
@@ -482,13 +482,13 @@ class EntityWriterTest extends TestCase
 
         static::assertSame('ABC', $product['ean']);
 
-        static::assertNotEquals('0000-00-00 00:00:00', $product['updated_at']);
-        static::assertNotEquals('2011-01-01 15:03:01', $product['updated_at']);
+        static::assertNotSame('0000-00-00 00:00:00', $product['updated_at']);
+        static::assertNotSame('2011-01-01 15:03:01', $product['updated_at']);
 
-        static::assertNotEquals('0000-00-00 00:00:00', $product['created_at']);
-        static::assertNotEquals('2011-01-01 15:03:01', $product['created_at']);
-        static::assertNotEquals('0000-00-00 00:00:00', $newProduct['created_at']);
-        static::assertNotEquals('2011-01-01 15:03:01', $newProduct['created_at']);
+        static::assertNotSame('0000-00-00 00:00:00', $product['created_at']);
+        static::assertNotSame('2011-01-01 15:03:01', $product['created_at']);
+        static::assertNotSame('0000-00-00 00:00:00', $newProduct['created_at']);
+        static::assertNotSame('2011-01-01 15:03:01', $newProduct['created_at']);
     }
 
     public function testInsertIgnoresRuntimeFields(): void
@@ -700,7 +700,7 @@ class EntityWriterTest extends TestCase
 
         static::assertNotNull($manufacturer);
         static::assertInstanceOf(ProductManufacturerEntity::class, $manufacturer);
-        static::assertEquals($mediaId, $manufacturer->getMediaId());
+        static::assertSame($mediaId, $manufacturer->getMediaId());
     }
 
     public function testWriteTranslatedEntityWithoutRequiredFieldsNotInSystemLanguage(): void
@@ -722,10 +722,7 @@ class EntityWriterTest extends TestCase
             ],
         ], $context);
 
-        static::assertEquals(
-            1,
-            $mediaRepo->search(new Criteria([$mediaId]), $context)->getEntities()->count()
-        );
+        static::assertCount(1, $mediaRepo->search(new Criteria([$mediaId]), $context)->getEntities());
     }
 
     public function testWriteWithEmptyDataIsValid(): void
@@ -928,7 +925,7 @@ class EntityWriterTest extends TestCase
 
         static::assertIsArray($translations);
         static::assertNull($translations['name']);
-        static::assertEquals('update', $translations['description']);
+        static::assertSame('update', $translations['description']);
     }
 
     protected function createWriteContext(): WriteContext

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/ParentChildTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/ParentChildTest.php
@@ -55,7 +55,7 @@ class ParentChildTest extends TestCase
         $first = $e->getExceptions()[0];
 
         static::assertInstanceOf(ExpectedArrayException::class, $first);
-        static::assertEquals('/0/children', $first->getPath());
+        static::assertSame('/0/children', $first->getPath());
     }
 
     public function testICanWriteChildren(): void
@@ -125,7 +125,7 @@ class ParentChildTest extends TestCase
             )
         );
 
-        static::assertEquals(
+        static::assertSame(
             Uuid::fromHexToBytes($parent),
             $this->connection->fetchOne(
                 'SELECT parent_id FROM category WHERE id = :id',
@@ -133,7 +133,7 @@ class ParentChildTest extends TestCase
             )
         );
 
-        static::assertEquals(
+        static::assertSame(
             Uuid::fromHexToBytes($child1),
             $this->connection->fetchOne(
                 'SELECT parent_id FROM category WHERE id = :id',
@@ -141,7 +141,7 @@ class ParentChildTest extends TestCase
             )
         );
 
-        static::assertEquals(
+        static::assertSame(
             Uuid::fromHexToBytes($child2),
             $this->connection->fetchOne(
                 'SELECT parent_id FROM category WHERE id = :id',
@@ -174,7 +174,7 @@ class ParentChildTest extends TestCase
                 ['id' => Uuid::fromHexToBytes($parent)]
             )
         );
-        static::assertEquals(
+        static::assertSame(
             Uuid::fromHexToBytes($parent),
             $this->connection->fetchOne(
                 'SELECT parent_id FROM category WHERE id = :id',
@@ -212,14 +212,14 @@ class ParentChildTest extends TestCase
                 ['id' => Uuid::fromHexToBytes($parent)]
             )
         );
-        static::assertEquals(
+        static::assertSame(
             Uuid::fromHexToBytes($parent),
             $this->connection->fetchOne(
                 'SELECT parent_id FROM category WHERE id = :id',
                 ['id' => Uuid::fromHexToBytes($child1)]
             )
         );
-        static::assertEquals(
+        static::assertSame(
             Uuid::fromHexToBytes($child1),
             $this->connection->fetchOne(
                 'SELECT parent_id FROM category WHERE id = :id',

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/SetNullOnDeleteTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/SetNullOnDeleteTest.php
@@ -170,7 +170,7 @@ class SetNullOnDeleteTest extends TestCase
         static::assertArrayHasKey(SetNullOnDeleteParentDefinition::ENTITY_NAME, $deleted);
 
         static::assertCount(1, $deleted[SetNullOnDeleteParentDefinition::ENTITY_NAME]);
-        static::assertEquals($ids->get('parent'), $deleted[SetNullOnDeleteParentDefinition::ENTITY_NAME][0]->getPrimaryKey());
+        static::assertSame($ids->get('parent'), $deleted[SetNullOnDeleteParentDefinition::ENTITY_NAME][0]->getPrimaryKey());
 
         $updated = $result->getWritten();
         static::assertCount(1, $updated);
@@ -179,8 +179,8 @@ class SetNullOnDeleteTest extends TestCase
         static::assertCount(1, $updated[SetNullOnDeleteChildDefinition::ENTITY_NAME]);
         /** @var EntityWriteResult $updateResult */
         $updateResult = $updated[SetNullOnDeleteChildDefinition::ENTITY_NAME][0];
-        static::assertEquals($ids->get('child'), $updateResult->getPrimaryKey());
-        static::assertEquals([
+        static::assertSame($ids->get('child'), $updateResult->getPrimaryKey());
+        static::assertSame([
             'id' => $ids->get('child'),
             'setNullOnDeleteParentId' => null,
             'setNullOnDeleteParentVersionId' => null,
@@ -238,7 +238,7 @@ class SetNullOnDeleteTest extends TestCase
         static::assertArrayHasKey(SetNullOnDeleteManyToOneDefinition::ENTITY_NAME, $deleted);
 
         static::assertCount(1, $deleted[SetNullOnDeleteManyToOneDefinition::ENTITY_NAME]);
-        static::assertEquals($childId, $deleted[SetNullOnDeleteManyToOneDefinition::ENTITY_NAME][0]->getPrimaryKey());
+        static::assertSame($childId, $deleted[SetNullOnDeleteManyToOneDefinition::ENTITY_NAME][0]->getPrimaryKey());
 
         $updated = $result->getWritten();
         static::assertCount(1, $updated);
@@ -247,7 +247,7 @@ class SetNullOnDeleteTest extends TestCase
         static::assertCount(1, $updated[SetNullOnDeleteParentDefinition::ENTITY_NAME]);
         /** @var EntityWriteResult $updateResult */
         $updateResult = $updated[SetNullOnDeleteParentDefinition::ENTITY_NAME][0];
-        static::assertEquals($id, $updateResult->getPrimaryKey());
+        static::assertSame($id, $updateResult->getPrimaryKey());
         static::assertEquals([
             'id' => $id,
             'versionId' => Defaults::LIVE_VERSION,
@@ -289,7 +289,7 @@ class SetNullOnDeleteTest extends TestCase
             SetNullOnDeleteChildDefinition::ENTITY_NAME . '.written',
             static function (EntityWrittenEvent $event) use ($childId, &$eventWasThrown): void {
                 static::assertCount(1, $event->getPayloads());
-                static::assertEquals(
+                static::assertSame(
                     [
                         'id' => $childId,
                         'setNullOnDeleteParentId' => null,

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/TranslationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/TranslationTest.php
@@ -572,8 +572,8 @@ class TranslationTest extends TestCase
             ->first();
 
         static::assertInstanceOf(CategoryEntity::class, $catSystem);
-        static::assertEquals('system', $catSystem->getName());
-        static::assertEquals('system', $catSystem->getTranslated()['name']);
+        static::assertSame('system', $catSystem->getName());
+        static::assertSame('system', $catSystem->getTranslated()['name']);
 
         $deDeContext = new Context(new SystemSource(), [], Defaults::CURRENCY, [$this->deLanguageId, Defaults::LANGUAGE_SYSTEM]);
         $catDeDe = $this->categoryRepository
@@ -584,7 +584,7 @@ class TranslationTest extends TestCase
         static::assertNotNull($catDeDe);
         static::assertInstanceOf(CategoryEntity::class, $catDeDe);
         static::assertNull($catDeDe->getName());
-        static::assertEquals('system', $catDeDe->getTranslated()['name']);
+        static::assertSame('system', $catDeDe->getTranslated()['name']);
     }
 
     public function testUpsert(): void
@@ -755,7 +755,7 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $slot = $searchResult->getEntities()->get($page['sections'][0]['blocks'][0]['slots'][0]['id']);
         static::assertInstanceOf(CmsSlotEntity::class, $slot);
-        static::assertEquals([], $slot->getConfig());
+        static::assertSame([], $slot->getConfig());
 
         $slot = $searchResult->getEntities()->get($page['sections'][0]['blocks'][0]['slots'][1]['id']);
         static::assertInstanceOf(CmsSlotEntity::class, $slot);
@@ -823,7 +823,7 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $slot = $searchResult->getEntities()->get($page['sections'][0]['blocks'][0]['slots'][0]['id']);
         static::assertInstanceOf(CmsSlotEntity::class, $slot);
-        static::assertEquals([], $slot->getConfig());
+        static::assertSame([], $slot->getConfig());
 
         $slot = $searchResult->getEntities()->get($page['sections'][0]['blocks'][0]['slots'][1]['id']);
         static::assertInstanceOf(CmsSlotEntity::class, $slot);
@@ -840,7 +840,7 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $slot = $searchResult->getEntities()->get($page['sections'][0]['blocks'][0]['slots'][0]['id']);
         static::assertInstanceOf(CmsSlotEntity::class, $slot);
-        static::assertEquals([], $slot->getConfig());
+        static::assertSame([], $slot->getConfig());
 
         $slot = $searchResult->getEntities()->get($page['sections'][0]['blocks'][0]['slots'][1]['id']);
         static::assertInstanceOf(CmsSlotEntity::class, $slot);
@@ -884,11 +884,11 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $enTranslation = $category->getTranslations()->filterByLanguageId(Defaults::LANGUAGE_SYSTEM)->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $enTranslation);
-        static::assertEquals('en translation', $enTranslation->getName());
+        static::assertSame('en translation', $enTranslation->getName());
 
         $deTranslation = $category->getTranslations()->filterByLanguageId($this->getDeDeLanguageId())->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $deTranslation);
-        static::assertEquals('de übersetzung', $deTranslation->getName());
+        static::assertSame('de übersetzung', $deTranslation->getName());
     }
 
     public function testTranslationValuesHavePriorityOverDefaultValueWithIds(): void
@@ -924,11 +924,11 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $enTranslation = $category->getTranslations()->filterByLanguageId(Defaults::LANGUAGE_SYSTEM)->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $enTranslation);
-        static::assertEquals('en translation', $enTranslation->getName());
+        static::assertSame('en translation', $enTranslation->getName());
 
         $deTranslation = $category->getTranslations()->filterByLanguageId($this->getDeDeLanguageId())->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $deTranslation);
-        static::assertEquals('de übersetzung', $deTranslation->getName());
+        static::assertSame('de übersetzung', $deTranslation->getName());
     }
 
     public function testTranslationValuesHavePriorityOverDefaultValuesWithIds(): void
@@ -966,11 +966,11 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $enTranslation = $category->getTranslations()->filterByLanguageId(Defaults::LANGUAGE_SYSTEM)->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $enTranslation);
-        static::assertEquals('en translation', $enTranslation->getName());
+        static::assertSame('en translation', $enTranslation->getName());
 
         $deTranslation = $category->getTranslations()->filterByLanguageId($this->getDeDeLanguageId())->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $deTranslation);
-        static::assertEquals('de übersetzung', $deTranslation->getName());
+        static::assertSame('de übersetzung', $deTranslation->getName());
     }
 
     public function testDefaultValueWithLocaleHasPriorityOverTranslationValueWithId(): void
@@ -1008,11 +1008,11 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $enTranslation = $category->getTranslations()->filterByLanguageId(Defaults::LANGUAGE_SYSTEM)->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $enTranslation);
-        static::assertEquals('default', $enTranslation->getName());
+        static::assertSame('default', $enTranslation->getName());
 
         $deTranslation = $category->getTranslations()->filterByLanguageId($this->getDeDeLanguageId())->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $deTranslation);
-        static::assertEquals('de übersetzung', $deTranslation->getName());
+        static::assertSame('de übersetzung', $deTranslation->getName());
     }
 
     public function testWriteWithInheritedTranslationCode(): void
@@ -1064,11 +1064,11 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $enTranslation = $translations->filterByLanguageId(Defaults::LANGUAGE_SYSTEM)->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $enTranslation);
-        static::assertEquals('default', $enTranslation->getName());
+        static::assertSame('default', $enTranslation->getName());
 
         $childTranslation = $translations->filterByLanguageId($this->ids->get('language-parent'))->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $childTranslation);
-        static::assertEquals('parent language', $childTranslation->getName());
+        static::assertSame('parent language', $childTranslation->getName());
 
         $childTranslation = $translations->filterByLanguageId($this->ids->get('language-child'))->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $childTranslation);
@@ -1125,14 +1125,14 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
 
         $enTranslation = $translations->filterByLanguageId(Defaults::LANGUAGE_SYSTEM)->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $enTranslation);
-        static::assertEquals('default', $enTranslation->getName());
+        static::assertSame('default', $enTranslation->getName());
 
         $childTranslation = $translations->filterByLanguageId($this->ids->get('language-parent'))->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $childTranslation);
-        static::assertEquals('parent language', $childTranslation->getName());
+        static::assertSame('parent language', $childTranslation->getName());
 
         $childTranslation = $translations->filterByLanguageId($this->ids->get('language-child'))->first();
         static::assertInstanceOf(CategoryTranslationEntity::class, $childTranslation);
-        static::assertEquals('child language', $childTranslation->getName());
+        static::assertSame('child language', $childTranslation->getName());
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/Validation/LockValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/Validation/LockValidatorTest.php
@@ -114,7 +114,7 @@ EOF;
 
         $description = $this->connection->fetchOne('SELECT `description` FROM `_test_lock` WHERE `id` = :id', ['id' => Uuid::fromHexToBytes($data['id'])]);
 
-        static::assertEquals('bar', $description);
+        static::assertSame('bar', $description);
     }
 
     public function testUpdateTranslationOnUnlockedShouldPass(): void
@@ -130,8 +130,8 @@ EOF;
         $description = $this->connection->fetchOne('SELECT `description` FROM `_test_lock` WHERE `id` = :id', ['id' => Uuid::fromHexToBytes($data['id'])]);
         $name = $this->connection->fetchOne('SELECT `name` FROM `_test_lock_translation` WHERE `_test_lock_id` = :id', ['id' => Uuid::fromHexToBytes($data['id'])]);
 
-        static::assertEquals('bar', $description);
-        static::assertEquals('ware', $name);
+        static::assertSame('bar', $description);
+        static::assertSame('ware', $name);
     }
 
     public function testUpdateOnLockedShouldBePrevented(): void
@@ -207,6 +207,6 @@ EOF;
         $violation = $violationException->getViolations()->findByCodes(LockValidator::VIOLATION_LOCKED);
 
         static::assertNotNull($violation);
-        static::assertEquals(LockValidator::VIOLATION_LOCKED, $violation->get(0)->getCode());
+        static::assertSame(LockValidator::VIOLATION_LOCKED, $violation->get(0)->getCode());
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/WriterExtensionTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/WriterExtensionTest.php
@@ -112,10 +112,10 @@ class WriterExtensionTest extends TestCase
         static::assertCount(2, $productExtensions);
         $first = $productExtensions->first();
         static::assertInstanceOf(ArrayEntity::class, $first);
-        static::assertEquals('test 1', $first->get('name'));
+        static::assertSame('test 1', $first->get('name'));
         $last = $productExtensions->last();
         static::assertInstanceOf(ArrayEntity::class, $last);
-        static::assertEquals('test 2', $last->get('name'));
+        static::assertSame('test 2', $last->get('name'));
     }
 
     public function testCanWriteExtensionWithoutExtensionKey(): void
@@ -150,10 +150,10 @@ class WriterExtensionTest extends TestCase
         static::assertCount(2, $productExtensions);
         $first = $productExtensions->first();
         static::assertInstanceOf(ArrayEntity::class, $first);
-        static::assertEquals('test 1', $first->get('name'));
+        static::assertSame('test 1', $first->get('name'));
         $last = $productExtensions->last();
         static::assertInstanceOf(ArrayEntity::class, $last);
-        static::assertEquals('test 2', $last->get('name'));
+        static::assertSame('test 2', $last->get('name'));
     }
 
     private function createProduct(string $productId): void

--- a/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
@@ -125,13 +125,13 @@ class FeatureTest extends TestCase
         $currentConfig = array_keys(Feature::getAll(false));
         $featureFlags = array_keys(self::$features);
 
-        static::assertEquals(\array_map(Feature::normalizeName(...), $featureFlags), \array_map(Feature::normalizeName(...), $currentConfig));
+        static::assertSame(\array_map(Feature::normalizeName(...), $featureFlags), \array_map(Feature::normalizeName(...), $currentConfig));
 
         $this->setUpFixtures();
         $featureFlags = array_merge($featureFlags, $this->fixtureFlags);
 
         $configAfterRegistration = array_keys(Feature::getAll(false));
-        static::assertEquals(\array_map(Feature::normalizeName(...), $featureFlags), \array_map(Feature::normalizeName(...), $configAfterRegistration));
+        static::assertSame(\array_map(Feature::normalizeName(...), $featureFlags), \array_map(Feature::normalizeName(...), $configAfterRegistration));
     }
 
     public function testTwigFeatureFlag(): void
@@ -208,13 +208,13 @@ class FeatureTest extends TestCase
         Feature::registerFeatures($registeredFeatures);
 
         $actualFeatures = Feature::getRegisteredFeatures();
-        static::assertEquals($features['FEATURE_NEXT_101'], $actualFeatures['FEATURE_NEXT_101']);
+        static::assertSame($features['FEATURE_NEXT_101'], $actualFeatures['FEATURE_NEXT_101']);
 
         $expectedFeatureFlags = [
             'FEATURE_NEXT_101' => true,
             'FEATURE_NEXT_102' => false,
         ];
-        static::assertEquals($expectedFeatureFlags, Feature::getAll(false));
+        static::assertSame($expectedFeatureFlags, Feature::getAll(false));
     }
 
     /**

--- a/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
+++ b/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
@@ -60,9 +60,9 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertIsArray($entries);
         static::assertArrayHasKey('foo', $entries);
-        static::assertEquals(2, $entries['foo']['count']);
+        static::assertSame(2, $entries['foo']['count']);
         static::assertArrayHasKey('bar', $entries);
-        static::assertEquals(1, $entries['bar']['count']);
+        static::assertSame(1, $entries['bar']['count']);
     }
 
     public function testEndpointWithoutCluster(): void
@@ -75,7 +75,7 @@ class IncrementApiControllerTest extends TestCase
 
         $errors = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR)['errors'];
 
-        static::assertEquals('Parameter "cluster" is missing.', $errors[0]['detail']);
+        static::assertSame('Parameter "cluster" is missing.', $errors[0]['detail']);
     }
 
     public function testIncrementEndpointWithInvalidPool(): void
@@ -92,7 +92,7 @@ class IncrementApiControllerTest extends TestCase
 
         $errors = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR)['errors'];
 
-        static::assertEquals('Increment gateway for pool "unknown-pool" was not found.', $errors[0]['detail']);
+        static::assertSame('Increment gateway for pool "unknown-pool" was not found.', $errors[0]['detail']);
     }
 
     public function testIncrementEndpoint(): void
@@ -114,7 +114,7 @@ class IncrementApiControllerTest extends TestCase
         $entries = $this->gateway->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
-        static::assertEquals(1, $entries['foo']['count']);
+        static::assertSame(1, $entries['foo']['count']);
     }
 
     public function testDecrementEndpoint(): void
@@ -124,7 +124,7 @@ class IncrementApiControllerTest extends TestCase
         $entries = $this->gateway->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
-        static::assertEquals(1, $entries['foo']['count']);
+        static::assertSame(1, $entries['foo']['count']);
 
         $url = '/api/_action/decrement/user_activity';
 
@@ -143,7 +143,7 @@ class IncrementApiControllerTest extends TestCase
         $entries = $this->gateway->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
-        static::assertEquals(0, $entries['foo']['count']);
+        static::assertSame(0, $entries['foo']['count']);
     }
 
     public function testResetEndpoint(): void
@@ -156,8 +156,8 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertArrayHasKey('foo', $entries);
         static::assertArrayHasKey('bar', $entries);
-        static::assertEquals(2, $entries['foo']['count']);
-        static::assertEquals(1, $entries['bar']['count']);
+        static::assertSame(2, $entries['foo']['count']);
+        static::assertSame(1, $entries['bar']['count']);
 
         $url = '/api/_action/reset-increment/user_activity';
 
@@ -176,8 +176,8 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertArrayHasKey('foo', $entries);
         static::assertArrayHasKey('bar', $entries);
-        static::assertEquals(0, $entries['foo']['count']);
-        static::assertEquals(0, $entries['bar']['count']);
+        static::assertSame(0, $entries['foo']['count']);
+        static::assertSame(0, $entries['bar']['count']);
     }
 
     public function testIncrementEndpointWithCustomCluster(): void
@@ -202,7 +202,7 @@ class IncrementApiControllerTest extends TestCase
         $entries = $this->gateway->list($clusterName);
 
         static::assertArrayHasKey('foo', $entries);
-        static::assertEquals(1, $entries['foo']['count']);
+        static::assertSame(1, $entries['foo']['count']);
 
         $url = '/api/_action/increment/user_activity?cluster=' . $clusterName;
 
@@ -213,6 +213,6 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
         static::assertArrayHasKey('foo', $entries);
-        static::assertEquals(1, $entries['foo']['count']);
+        static::assertSame(1, $entries['foo']['count']);
     }
 }

--- a/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
+++ b/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
@@ -29,13 +29,13 @@ class MySQLIncrementerTest extends TestCase
         $list = $this->mysqlIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertEquals(1, $list['sw.product.index']['count']);
+        static::assertSame('1', $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertEquals(2, $list['sw.product.index']['count']);
+        static::assertSame('2', $list['sw.product.index']['count']);
     }
 
     public function testDecrement(): void
@@ -46,13 +46,13 @@ class MySQLIncrementerTest extends TestCase
         $list = $this->mysqlIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertEquals(2, $list['sw.product.index']['count']);
+        static::assertSame('2', $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->decrement('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertEquals(1, $list['sw.product.index']['count']);
+        static::assertSame('1', $list['sw.product.index']['count']);
     }
 
     public function testList(): void
@@ -63,9 +63,9 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertEquals(2, array_values($list)[0]['count']);
-        static::assertEquals('sw.product.index', array_values($list)[0]['key']);
-        static::assertEquals(1, array_values($list)[1]['count']);
+        static::assertSame('2', array_values($list)[0]['count']);
+        static::assertSame('sw.product.index', array_values($list)[0]['key']);
+        static::assertSame('1', array_values($list)[1]['count']);
 
         // List will return in DESC order of record's count
         $this->mysqlIncrementer->increment('test-user-1', 'sw.order.index');
@@ -73,9 +73,9 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertEquals(3, array_values($list)[0]['count']);
-        static::assertEquals('sw.order.index', array_values($list)[0]['key']);
-        static::assertEquals(2, array_values($list)[1]['count']);
+        static::assertSame('3', array_values($list)[0]['count']);
+        static::assertSame('sw.order.index', array_values($list)[0]['key']);
+        static::assertSame('2', array_values($list)[1]['count']);
     }
 
     public function testReset(): void
@@ -91,21 +91,21 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertEquals(0, $list['sw.product.index']['count']);
+        static::assertSame('0', $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->increment('test-user-1', 'sw.order.index');
         $this->mysqlIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertEquals(1, $list['sw.product.index']['count']);
-        static::assertEquals(1, $list['sw.order.index']['count']);
+        static::assertSame('1', $list['sw.product.index']['count']);
+        static::assertSame('1', $list['sw.order.index']['count']);
 
         $this->mysqlIncrementer->reset('test-user-1', 'sw.order.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertEquals(1, $list['sw.product.index']['count']);
-        static::assertEquals(0, $list['sw.order.index']['count']);
+        static::assertSame('1', $list['sw.product.index']['count']);
+        static::assertSame('0', $list['sw.order.index']['count']);
     }
 }

--- a/tests/integration/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
@@ -64,7 +64,7 @@ class ConsumeMessagesControllerTest extends TestCase
         static::assertSame(200, $client->getResponse()->getStatusCode(), \print_r($response, true));
         static::assertArrayHasKey('handledMessages', $response);
         static::assertIsInt($response['handledMessages']);
-        static::assertEquals(1, $response['handledMessages']);
+        static::assertSame(1, $response['handledMessages']);
     }
 
     public function testMessageStatsDecrement(): void
@@ -86,6 +86,6 @@ class ConsumeMessagesControllerTest extends TestCase
         $entries = $this->incrementer->list('message_queue_stats');
 
         static::assertArrayHasKey(ProductIndexingMessage::class, $entries);
-        static::assertEquals(0, $entries[ProductIndexingMessage::class]['count']);
+        static::assertSame(0, $entries[ProductIndexingMessage::class]['count']);
     }
 }

--- a/tests/integration/Core/Framework/MessageQueue/Api/MessageQueueEndpointTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Api/MessageQueueEndpointTest.php
@@ -46,8 +46,8 @@ class MessageQueueEndpointTest extends TestCase
         }
 
         static::assertArrayHasKey('foo', $mapped);
-        static::assertEquals(1, $mapped['foo']);
+        static::assertSame(1, $mapped['foo']);
         static::assertArrayHasKey('bar', $mapped);
-        static::assertEquals(2, $mapped['bar']);
+        static::assertSame(2, $mapped['bar']);
     }
 }

--- a/tests/integration/Core/Framework/MessageQueue/Api/ScheduledTaskControllerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Api/ScheduledTaskControllerTest.php
@@ -52,7 +52,7 @@ class ScheduledTaskControllerTest extends TestCase
 
         /** @var ScheduledTaskEntity $task */
         $task = $repo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
-        static::assertEquals(ScheduledTaskDefinition::STATUS_QUEUED, $task->getStatus());
+        static::assertSame(ScheduledTaskDefinition::STATUS_QUEUED, $task->getStatus());
     }
 
     public function testRunSkippedTasks(): void
@@ -83,7 +83,7 @@ class ScheduledTaskControllerTest extends TestCase
 
         /** @var ScheduledTaskEntity $task */
         $task = $repo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
-        static::assertEquals(ScheduledTaskDefinition::STATUS_QUEUED, $task->getStatus());
+        static::assertSame(ScheduledTaskDefinition::STATUS_QUEUED, $task->getStatus());
     }
 
     public function testGetMinRunInterval(): void

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
@@ -79,9 +79,9 @@ class ScheduledTaskHandlerTest extends TestCase
         $newOriginalNextExecutionString = $newOriginalNextExecution->format(Defaults::STORAGE_DATE_TIME_FORMAT);
         $nextExecutionTimeString = $task->getNextExecutionTime()->format(Defaults::STORAGE_DATE_TIME_FORMAT);
 
-        static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
-        static::assertEquals($newOriginalNextExecutionString, $nextExecutionTimeString);
-        static::assertNotEquals($originalNextExecution->format(\DATE_ATOM), $task->getNextExecutionTime()->format(\DATE_ATOM));
+        static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
+        static::assertSame($newOriginalNextExecutionString, $nextExecutionTimeString);
+        static::assertNotSame($originalNextExecution->format(\DATE_ATOM), $task->getNextExecutionTime()->format(\DATE_ATOM));
     }
 
     /**
@@ -128,12 +128,12 @@ class ScheduledTaskHandlerTest extends TestCase
         /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
 
-        static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
+        static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
         static::assertGreaterThan(
             $task->getNextExecutionTime()->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             $nowTime->format(Defaults::STORAGE_DATE_TIME_FORMAT)
         );
-        static::assertNotEquals($originalNextExecution->format(\DATE_ATOM), $task->getNextExecutionTime()->format(\DATE_ATOM));
+        static::assertNotSame($originalNextExecution->format(\DATE_ATOM), $task->getNextExecutionTime()->format(\DATE_ATOM));
     }
 
     public function testHandleOnException(): void
@@ -167,13 +167,13 @@ class ScheduledTaskHandlerTest extends TestCase
         }
 
         static::assertInstanceOf(\RuntimeException::class, $exception);
-        static::assertEquals('This Exception should be thrown', $exception->getMessage());
+        static::assertSame('This Exception should be thrown', $exception->getMessage());
 
         static::assertTrue($handler->wasCalled());
 
         /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
-        static::assertEquals(ScheduledTaskDefinition::STATUS_FAILED, $task->getStatus());
+        static::assertSame(ScheduledTaskDefinition::STATUS_FAILED, $task->getStatus());
     }
 
     public function testHandleOnExceptionWithRescheduleOnFailure(): void
@@ -212,7 +212,7 @@ class ScheduledTaskHandlerTest extends TestCase
 
         /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
-        static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
+        static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
     }
 
     public function testHandleIgnoresIfTaskIsNotFound(): void
@@ -257,7 +257,7 @@ class ScheduledTaskHandlerTest extends TestCase
 
         /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
-        static::assertEquals($status, $task->getStatus());
+        static::assertSame($status, $task->getStatus());
     }
 
     /**

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
@@ -68,7 +68,7 @@ class TaskSchedulerTest extends TestCase
         $this->messageBus->expects($this->once())
             ->method('dispatch')
             ->with(static::callback(function (TestTask $task) use ($taskId) {
-                static::assertEquals($taskId, $task->getTaskId());
+                static::assertSame($taskId, $task->getTaskId());
 
                 return true;
             }))
@@ -78,7 +78,7 @@ class TaskSchedulerTest extends TestCase
 
         /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
-        static::assertEquals(ScheduledTaskDefinition::STATUS_QUEUED, $task->getStatus());
+        static::assertSame(ScheduledTaskDefinition::STATUS_QUEUED, $task->getStatus());
     }
 
     public function testScheduleTasksDoesntScheduleFutureTask(): void
@@ -105,7 +105,7 @@ class TaskSchedulerTest extends TestCase
 
         /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
-        static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
+        static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
     }
 
     #[DataProvider('nonScheduledStatus')]
@@ -133,7 +133,7 @@ class TaskSchedulerTest extends TestCase
 
         /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
-        static::assertEquals($status, $task->getStatus());
+        static::assertSame($status, $task->getStatus());
     }
 
     /**
@@ -196,7 +196,7 @@ class TaskSchedulerTest extends TestCase
         } catch (\Exception $exception) {
             /** @var ScheduledTaskEntity $task2Entity */
             $task2Entity = $this->scheduledTaskRepo->search(new Criteria([$taskId2]), $context)->get($taskId2);
-            static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $task2Entity->getStatus());
+            static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task2Entity->getStatus());
 
             throw $exception;
         }
@@ -232,7 +232,7 @@ class TaskSchedulerTest extends TestCase
         $result = $this->scheduler->getNextExecutionTime();
         static::assertInstanceOf(\DateTime::class, $result);
         // when saving the Date to the DB the microseconds aren't saved, so we can't simply compare the datetime objects
-        static::assertEquals(
+        static::assertSame(
             $nextExecutionTime->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             $result->format(Defaults::STORAGE_DATE_TIME_FORMAT)
         );
@@ -286,7 +286,7 @@ class TaskSchedulerTest extends TestCase
         $this->messageBus->expects($this->never())
             ->method('dispatch');
 
-        static::assertEquals(5, $this->scheduler->getMinRunInterval());
+        static::assertSame(5, $this->scheduler->getMinRunInterval());
     }
 
     public function testGetMinRunIntervalWhenEmpty(): void

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/TaskRegistryTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/TaskRegistryTest.php
@@ -52,10 +52,10 @@ class TaskRegistryTest extends TestCase
         /** @var ScheduledTaskEntity $task */
         $task = $tasks->first();
         static::assertInstanceOf(ScheduledTaskEntity::class, $task);
-        static::assertEquals(TestTask::class, $task->getScheduledTaskClass());
-        static::assertEquals(TestTask::getDefaultInterval(), $task->getRunInterval());
-        static::assertEquals(TestTask::getTaskName(), $task->getName());
-        static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
+        static::assertSame(TestTask::class, $task->getScheduledTaskClass());
+        static::assertSame(TestTask::getDefaultInterval(), $task->getRunInterval());
+        static::assertSame(TestTask::getTaskName(), $task->getName());
+        static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
     }
 
     public function testUpdatesRunIntervalOnAlreadyRegisteredTaskWhenRunIntervalMatchesDefault(): void
@@ -81,11 +81,11 @@ class TaskRegistryTest extends TestCase
         /** @var ScheduledTaskEntity $task */
         $task = $tasks->first();
         static::assertInstanceOf(ScheduledTaskEntity::class, $task);
-        static::assertEquals(TestTask::class, $task->getScheduledTaskClass());
-        static::assertEquals(1, $task->getRunInterval());
-        static::assertEquals(1, $task->getDefaultRunInterval());
-        static::assertEquals('test', $task->getName());
-        static::assertEquals(ScheduledTaskDefinition::STATUS_FAILED, $task->getStatus());
+        static::assertSame(TestTask::class, $task->getScheduledTaskClass());
+        static::assertSame(1, $task->getRunInterval());
+        static::assertSame(1, $task->getDefaultRunInterval());
+        static::assertSame('test', $task->getName());
+        static::assertSame(ScheduledTaskDefinition::STATUS_FAILED, $task->getStatus());
     }
 
     public function testDoesNotUpdateRunIntervalOnAlreadyRegisteredTaskWhenRunIntervalWasChanged(): void
@@ -111,11 +111,11 @@ class TaskRegistryTest extends TestCase
         /** @var ScheduledTaskEntity $task */
         $task = $tasks->first();
         static::assertInstanceOf(ScheduledTaskEntity::class, $task);
-        static::assertEquals(TestTask::class, $task->getScheduledTaskClass());
-        static::assertEquals(5, $task->getRunInterval());
-        static::assertEquals(1, $task->getDefaultRunInterval());
-        static::assertEquals('test', $task->getName());
-        static::assertEquals(ScheduledTaskDefinition::STATUS_FAILED, $task->getStatus());
+        static::assertSame(TestTask::class, $task->getScheduledTaskClass());
+        static::assertSame(5, $task->getRunInterval());
+        static::assertSame(1, $task->getDefaultRunInterval());
+        static::assertSame('test', $task->getName());
+        static::assertSame(ScheduledTaskDefinition::STATUS_FAILED, $task->getStatus());
     }
 
     public function testWithWrongClass(): void

--- a/tests/integration/Core/Framework/MessageQueue/Subscriber/MessageQueueStatsSubscriberTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Subscriber/MessageQueueStatsSubscriberTest.php
@@ -38,22 +38,22 @@ class MessageQueueStatsSubscriberTest extends TestCase
         $bus->dispatch(new BarMessage());
 
         $stats = $pool->list('message_queue_stats');
-        static::assertEquals(1, $stats[FooMessage::class]['count']);
-        static::assertEquals(3, $stats[BarMessage::class]['count']);
+        static::assertSame(1, $stats[FooMessage::class]['count']);
+        static::assertSame(3, $stats[BarMessage::class]['count']);
 
         $this->runWorker();
 
         $stats = $pool->list('message_queue_stats');
-        static::assertEquals(0, $stats[FooMessage::class]['count']);
-        static::assertEquals(0, $stats[BarMessage::class]['count']);
+        static::assertSame(0, $stats[FooMessage::class]['count']);
+        static::assertSame(0, $stats[BarMessage::class]['count']);
 
         $bus->dispatch(new NoHandlerMessage());
 
         $stats = $pool->list('message_queue_stats');
-        static::assertEquals(1, $stats[NoHandlerMessage::class]['count']);
+        static::assertSame(1, $stats[NoHandlerMessage::class]['count']);
 
         $this->runWorker();
         $stats = $pool->list('message_queue_stats');
-        static::assertEquals(0, $stats[NoHandlerMessage::class]['count']);
+        static::assertSame(0, $stats[NoHandlerMessage::class]['count']);
     }
 }

--- a/tests/integration/Core/Framework/Plugin/BundleConfigGeneratorTest.php
+++ b/tests/integration/Core/Framework/Plugin/BundleConfigGeneratorTest.php
@@ -49,19 +49,19 @@ class BundleConfigGeneratorTest extends TestCase
         static::assertArrayHasKey('SwagApp', $configs);
 
         $appConfig = $configs['SwagApp'];
-        static::assertEquals(
+        static::assertSame(
             $appPath,
             $appConfig['basePath']
         );
-        static::assertEquals(['Resources/views'], $appConfig['views']);
-        static::assertEquals('swag-app', $appConfig['technicalName']);
+        static::assertSame(['Resources/views'], $appConfig['views']);
+        static::assertSame('swag-app', $appConfig['technicalName']);
         static::assertArrayNotHasKey('administration', $appConfig);
 
         static::assertArrayHasKey('storefront', $appConfig);
         $storefrontConfig = $appConfig['storefront'];
 
-        static::assertEquals('Resources/app/storefront/src', $storefrontConfig['path']);
-        static::assertEquals('Resources/app/storefront/src/main.js', $storefrontConfig['entryFilePath']);
+        static::assertSame('Resources/app/storefront/src', $storefrontConfig['path']);
+        static::assertSame('Resources/app/storefront/src/main.js', $storefrontConfig['entryFilePath']);
         static::assertNull($storefrontConfig['webpack']);
 
         // Style files can and need only be imported if storefront is installed
@@ -71,7 +71,7 @@ class BundleConfigGeneratorTest extends TestCase
                 $appPath . 'Resources/app/storefront/src/scss/base.scss',
                 $appPath . 'Resources/app/storefront/src/scss/overrides.scss',
             ];
-            static::assertEquals([], array_diff($expectedStyles, $storefrontConfig['styleFiles']));
+            static::assertSame([], array_diff($expectedStyles, $storefrontConfig['styleFiles']));
         }
     }
 
@@ -86,19 +86,19 @@ class BundleConfigGeneratorTest extends TestCase
         static::assertArrayHasKey('SwagApp', $configs);
 
         $appConfig = $configs['SwagApp'];
-        static::assertEquals(
+        static::assertSame(
             realpath($appPath),
             realpath($projectDir . '/' . $appConfig['basePath'])
         );
-        static::assertEquals(['Resources/views'], $appConfig['views']);
-        static::assertEquals('swag-app', $appConfig['technicalName']);
+        static::assertSame(['Resources/views'], $appConfig['views']);
+        static::assertSame('swag-app', $appConfig['technicalName']);
         static::assertArrayNotHasKey('administration', $appConfig);
 
         static::assertArrayHasKey('storefront', $appConfig);
         $storefrontConfig = $appConfig['storefront'];
 
-        static::assertEquals('Resources/app/storefront/src', $storefrontConfig['path']);
-        static::assertEquals('Resources/app/storefront/src/main.js', $storefrontConfig['entryFilePath']);
+        static::assertSame('Resources/app/storefront/src', $storefrontConfig['path']);
+        static::assertSame('Resources/app/storefront/src/main.js', $storefrontConfig['entryFilePath']);
         static::assertNull($storefrontConfig['webpack']);
 
         // Style files can and need only be imported if storefront is installed
@@ -113,7 +113,7 @@ class BundleConfigGeneratorTest extends TestCase
                 $appPath . '/Resources/app/storefront/src/scss/base.scss',
             ];
 
-            static::assertEquals($expectedStyles, $storefrontConfig['styleFiles']);
+            static::assertSame($expectedStyles, $storefrontConfig['styleFiles']);
         }
     }
 
@@ -137,20 +137,20 @@ class BundleConfigGeneratorTest extends TestCase
         static::assertArrayHasKey('SwagTest', $configs);
 
         $appConfig = $configs['SwagTest'];
-        static::assertEquals(
+        static::assertSame(
             $appPath,
             static::getContainer()->getParameter('kernel.project_dir') . '/' . $appConfig['basePath']
         );
-        static::assertEquals(['Resources/views'], $appConfig['views']);
-        static::assertEquals('swag-test', $appConfig['technicalName']);
+        static::assertSame(['Resources/views'], $appConfig['views']);
+        static::assertSame('swag-test', $appConfig['technicalName']);
         static::assertArrayNotHasKey('administration', $appConfig);
 
         static::assertArrayHasKey('storefront', $appConfig);
         $storefrontConfig = $appConfig['storefront'];
 
-        static::assertEquals('Resources/app/storefront/src', $storefrontConfig['path']);
+        static::assertSame('Resources/app/storefront/src', $storefrontConfig['path']);
         static::assertNull($storefrontConfig['entryFilePath']);
-        static::assertEquals('Resources/app/storefront/build/webpack.config.js', $storefrontConfig['webpack']);
-        static::assertEquals([], $storefrontConfig['styleFiles']);
+        static::assertSame('Resources/app/storefront/build/webpack.config.js', $storefrontConfig['webpack']);
+        static::assertSame([], $storefrontConfig['styleFiles']);
     }
 }

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -402,14 +402,14 @@ class PluginLifecycleServiceTest extends TestCase
             $dependants = $params['dependants'];
             $dependantNames = $params['dependantNames'];
 
-            static::assertEquals(self::PLUGIN_NAME, $dependencyName);
+            static::assertSame(self::PLUGIN_NAME, $dependencyName);
             static::assertCount(1, $dependants);
-            static::assertEquals(\sprintf('"%s"', self::DEPENDENT_PLUGIN_NAME), $dependantNames);
+            static::assertSame(\sprintf('"%s"', self::DEPENDENT_PLUGIN_NAME), $dependantNames);
 
             $dependant = array_pop($dependants);
 
             static::assertInstanceOf(PluginEntity::class, $dependant);
-            static::assertEquals(self::DEPENDENT_PLUGIN_NAME, $dependant->getName());
+            static::assertSame(self::DEPENDENT_PLUGIN_NAME, $dependant->getName());
 
             throw $exception;
         }

--- a/tests/integration/Core/Framework/RateLimiter/Policy/TimeBackoffLimiterTest.php
+++ b/tests/integration/Core/Framework/RateLimiter/Policy/TimeBackoffLimiterTest.php
@@ -113,19 +113,19 @@ class TimeBackoffLimiterTest extends TestCase
     {
         $backoff = new TimeBackoff($this->id, $this->config['limits']);
 
-        static::assertEquals(0, $backoff->getAttempts());
-        static::assertEquals($this->config['limits'][0]['limit'], $backoff->getAvailableAttempts(time()));
+        static::assertSame(0, $backoff->getAttempts());
+        static::assertSame($this->config['limits'][0]['limit'], $backoff->getAvailableAttempts(time()));
 
         $backoff->setTimer(time());
         $backoff->setAttempts(3);
 
-        static::assertEquals(3, $backoff->getAttempts());
+        static::assertSame(3, $backoff->getAttempts());
 
         foreach ($this->config['limits'] as $limit) {
             for ($i = 0; $i < 2; ++$i) {
                 // request should be thorttled for new request
                 static::assertTrue($backoff->shouldThrottle($backoff->getAttempts() + 1, time()));
-                static::assertEquals(0, $backoff->getAvailableAttempts(time()));
+                static::assertSame(0, $backoff->getAvailableAttempts(time()));
 
                 // after wait time, request could be send again
                 static::assertFalse($backoff->shouldThrottle($backoff->getAttempts() + 1, time() + $this->intervalToSeconds($limit['interval'])));
@@ -136,12 +136,12 @@ class TimeBackoffLimiterTest extends TestCase
 
                 // request should be thorttled again
                 static::assertTrue($backoff->shouldThrottle($backoff->getAttempts(), time()));
-                static::assertEquals(0, $backoff->getAvailableAttempts(time()));
+                static::assertSame(0, $backoff->getAvailableAttempts(time()));
 
                 // after wait time, request could be send again
                 $time = time() + $this->intervalToSeconds($limit['interval']);
                 static::assertFalse($backoff->shouldThrottle($backoff->getAttempts(), $time));
-                static::assertEquals(1, $backoff->getAvailableAttempts($time));
+                static::assertSame(1, $backoff->getAvailableAttempts($time));
             }
         }
     }

--- a/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
+++ b/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
@@ -113,11 +113,11 @@ class RateLimiterTest extends TestCase
             static::assertArrayHasKey('errors', $response);
 
             if ($i >= 10) {
-                static::assertEquals(429, $response['errors'][0]['status']);
-                static::assertEquals('CHECKOUT__CUSTOMER_AUTH_THROTTLED', $response['errors'][0]['code']);
+                static::assertSame(429, (int) $response['errors'][0]['status']);
+                static::assertSame('CHECKOUT__CUSTOMER_AUTH_THROTTLED', $response['errors'][0]['code']);
             } else {
-                static::assertEquals(401, $response['errors'][0]['status']);
-                static::assertEquals('Unauthorized', $response['errors'][0]['title']);
+                static::assertSame(401, (int) $response['errors'][0]['status']);
+                static::assertSame('Unauthorized', $response['errors'][0]['title']);
             }
         }
     }
@@ -166,11 +166,11 @@ class RateLimiterTest extends TestCase
             static::assertArrayHasKey('errors', $response);
 
             if ($i >= 10) {
-                static::assertEquals(429, $response['errors'][0]['status']);
-                static::assertEquals('FRAMEWORK__AUTH_THROTTLED', $response['errors'][0]['code']);
+                static::assertSame(429, (int) $response['errors'][0]['status']);
+                static::assertSame('FRAMEWORK__AUTH_THROTTLED', $response['errors'][0]['code']);
             } else {
-                static::assertEquals(400, $response['errors'][0]['status']);
-                static::assertEquals(6, $response['errors'][0]['code']);
+                static::assertSame(400, (int) $response['errors'][0]['status']);
+                static::assertSame('6', $response['errors'][0]['code']);
             }
         }
     }
@@ -218,10 +218,10 @@ class RateLimiterTest extends TestCase
 
             if ($i >= 3) {
                 static::assertArrayHasKey('errors', $response, print_r($response, true));
-                static::assertEquals(429, $response['errors'][0]['status']);
-                static::assertEquals('FRAMEWORK__RATE_LIMIT_EXCEEDED', $response['errors'][0]['code']);
+                static::assertSame(429, (int) $response['errors'][0]['status']);
+                static::assertSame('FRAMEWORK__RATE_LIMIT_EXCEEDED', $response['errors'][0]['code']);
             } else {
-                static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
+                static::assertSame(200, $this->browser->getResponse()->getStatusCode());
             }
         }
     }
@@ -245,10 +245,10 @@ class RateLimiterTest extends TestCase
                 $response = json_decode((string) $response, true, 512, \JSON_THROW_ON_ERROR);
                 static::assertIsArray($response);
                 static::assertArrayHasKey('errors', $response);
-                static::assertEquals(429, $response['errors'][0]['status']);
-                static::assertEquals('FRAMEWORK__RATE_LIMIT_EXCEEDED', $response['errors'][0]['code']);
+                static::assertSame(429, (int) $response['errors'][0]['status']);
+                static::assertSame('FRAMEWORK__RATE_LIMIT_EXCEEDED', $response['errors'][0]['code']);
             } else {
-                static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
+                static::assertSame(200, $this->browser->getResponse()->getStatusCode());
             }
         }
     }
@@ -327,10 +327,10 @@ class RateLimiterTest extends TestCase
                 $response = json_decode((string) $response, true, 512, \JSON_THROW_ON_ERROR);
 
                 static::assertArrayHasKey('errors', $response);
-                static::assertEquals(429, $response['errors'][0]['status']);
-                static::assertEquals(NewsletterException::NEWSLETTER_RECIPIENT_THROTTLED, $response['errors'][0]['code']);
+                static::assertSame(429, (int) $response['errors'][0]['status']);
+                static::assertSame(NewsletterException::NEWSLETTER_RECIPIENT_THROTTLED, $response['errors'][0]['code']);
             } else {
-                static::assertEquals(204, $this->browser->getResponse()->getStatusCode());
+                static::assertSame(204, $this->browser->getResponse()->getStatusCode());
             }
         }
     }

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverAppTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverAppTest.php
@@ -40,7 +40,7 @@ class ApiRequestContextResolverAppTest extends TestCase
         $response = $browser->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertEquals(200, $response->getStatusCode(), $response->getContent());
+        static::assertSame(200, $response->getStatusCode(), $response->getContent());
     }
 
     public function testCantReadWithoutPermission(): void
@@ -52,7 +52,7 @@ class ApiRequestContextResolverAppTest extends TestCase
 
         $browser->request('GET', '/api/media');
 
-        static::assertEquals(403, $browser->getResponse()->getStatusCode());
+        static::assertSame(403, $browser->getResponse()->getStatusCode());
     }
 
     public function testCantReadWithoutAnyPermission(): void
@@ -64,7 +64,7 @@ class ApiRequestContextResolverAppTest extends TestCase
 
         $browser->request('GET', '/api/product');
 
-        static::assertEquals(403, $browser->getResponse()->getStatusCode());
+        static::assertSame(403, $browser->getResponse()->getStatusCode());
     }
 
     public function testCanNotWriteWithoutPermissions(): void
@@ -88,9 +88,9 @@ class ApiRequestContextResolverAppTest extends TestCase
         $response = $browser->getResponse();
 
         static::assertIsString($response->getContent());
-        static::assertEquals(403, $response->getStatusCode(), $response->getContent());
+        static::assertSame(403, $response->getStatusCode(), $response->getContent());
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, $data['errors'][0]['code']);
+        static::assertSame(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, $data['errors'][0]['code']);
     }
 
     public function testCanWriteWithPermissionsSet(): void
@@ -114,7 +114,7 @@ class ApiRequestContextResolverAppTest extends TestCase
             json_encode($this->getProductData($productId, $context), \JSON_THROW_ON_ERROR)
         );
 
-        static::assertEquals(204, $browser->getResponse()->getStatusCode());
+        static::assertSame(204, $browser->getResponse()->getStatusCode());
 
         $product = $productRepository->search(new Criteria(), $context)->getEntities()->get($productId);
 
@@ -147,13 +147,13 @@ class ApiRequestContextResolverAppTest extends TestCase
             ], \JSON_THROW_ON_ERROR)
         );
 
-        static::assertEquals(204, $browser->getResponse()->getStatusCode());
+        static::assertSame(204, $browser->getResponse()->getStatusCode());
 
         /** @var ProductEntity $product */
         $product = $productRepository->search(new Criteria(), $context)->getEntities()->get($productId);
 
         static::assertNotNull($product);
-        static::assertEquals($newName, $product->getName());
+        static::assertSame($newName, $product->getName());
     }
 
     private function authorizeBrowserWithIntegrationByAppName(KernelBrowser $browser, string $appName): void

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
@@ -66,10 +66,10 @@ class ApiRequestContextResolverTest extends TestCase
 
         $source = $context->getSource();
 
-        static::assertEquals($isAdmin, $source->isAdmin());
+        static::assertSame($isAdmin, $source->isAdmin());
 
         foreach ($expected as $privilege => $allowed) {
-            static::assertEquals($allowed, $source->isAllowed($privilege), $privilege);
+            static::assertSame($allowed, $source->isAllowed($privilege), $privilege);
         }
     }
 
@@ -100,10 +100,10 @@ class ApiRequestContextResolverTest extends TestCase
 
         $source = $context->getSource();
 
-        static::assertEquals($isAdmin, $source->isAdmin());
+        static::assertSame($isAdmin, $source->isAdmin());
 
         foreach ($expected as $privilege => $allowed) {
-            static::assertEquals($allowed, $source->isAllowed($privilege), $privilege);
+            static::assertSame($allowed, $source->isAllowed($privilege), $privilege);
         }
     }
 
@@ -212,7 +212,7 @@ class ApiRequestContextResolverTest extends TestCase
         ]);
         $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(200, $browser->getResponse()->getStatusCode());
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
         static::assertArrayHasKey('data', $response);
     }
 
@@ -265,7 +265,7 @@ class ApiRequestContextResolverTest extends TestCase
         ]);
         $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), \json_encode($response, \JSON_THROW_ON_ERROR));
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), \json_encode($response, \JSON_THROW_ON_ERROR));
         static::assertArrayHasKey('errors', $response);
     }
 
@@ -331,7 +331,7 @@ class ApiRequestContextResolverTest extends TestCase
         ]);
         $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), \json_encode($response, \JSON_THROW_ON_ERROR));
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), \json_encode($response, \JSON_THROW_ON_ERROR));
         static::assertArrayHasKey('errors', $response);
 
         $errors = $response['errors'];
@@ -395,7 +395,7 @@ class ApiRequestContextResolverTest extends TestCase
         ]);
         $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(Response::HTTP_BAD_REQUEST, $browser->getResponse()->getStatusCode(), \json_encode($response, \JSON_THROW_ON_ERROR));
+        static::assertSame(Response::HTTP_BAD_REQUEST, $browser->getResponse()->getStatusCode(), \json_encode($response, \JSON_THROW_ON_ERROR));
         static::assertArrayHasKey('errors', $response);
 
         $errors = $response['errors'];
@@ -419,13 +419,13 @@ class ApiRequestContextResolverTest extends TestCase
             'limit' => 2,
         ]);
 
-        static::assertEquals(403, $browser->getResponse()->getStatusCode());
+        static::assertSame(403, $browser->getResponse()->getStatusCode());
 
         $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
         $errors = $response['errors'];
-        static::assertEquals('{"message":"Missing privilege","missingPrivileges":["currency:read"]}', $errors[0]['detail']);
+        static::assertSame('{"message":"Missing privilege","missingPrivileges":["currency:read"]}', $errors[0]['detail']);
     }
 
     public function testIntegrationWithPrivileges(): void
@@ -444,7 +444,7 @@ class ApiRequestContextResolverTest extends TestCase
         ]);
         $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(200, $browser->getResponse()->getStatusCode());
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
         static::assertArrayHasKey('data', $response);
     }
 

--- a/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
@@ -204,12 +204,12 @@ class SalesChannelRequestContextResolverTest extends TestCase
 
         $resolver->resolve($request);
 
-        static::assertEquals($imitatingUserId, $request->getSession()->get(PlatformRequest::ATTRIBUTE_IMITATING_USER_ID));
+        static::assertSame($imitatingUserId, $request->getSession()->get(PlatformRequest::ATTRIBUTE_IMITATING_USER_ID));
 
         $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
 
         static::assertInstanceOf(SalesChannelContext::class, $context);
-        static::assertEquals($imitatingUserId, $context->getImitatingUserId());
+        static::assertSame($imitatingUserId, $context->getImitatingUserId());
     }
 
     public function testImitatingUserIdClearWithoutCustomer(): void

--- a/tests/integration/Core/Framework/Rule/Api/RuleConfigControllerTest.php
+++ b/tests/integration/Core/Framework/Rule/Api/RuleConfigControllerTest.php
@@ -25,7 +25,7 @@ class RuleConfigControllerTest extends TestCase
         );
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
 
         $content = json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
@@ -35,13 +35,13 @@ class RuleConfigControllerTest extends TestCase
         $customerGroupRouleConfig = $content[$customerGroupRuleName];
 
         static::assertCount(2, $customerGroupRouleConfig['operatorSet']['operators']);
-        static::assertEquals(RuleConfig::OPERATOR_SET_STRING, $customerGroupRouleConfig['operatorSet']['operators']);
+        static::assertSame(RuleConfig::OPERATOR_SET_STRING, $customerGroupRouleConfig['operatorSet']['operators']);
         static::assertTrue($customerGroupRouleConfig['operatorSet']['isMatchAny']);
 
         static::assertCount(1, $customerGroupRouleConfig['fields']);
 
-        static::assertEquals('customerGroupIds', $customerGroupRouleConfig['fields']['customerGroupIds']['name']);
-        static::assertEquals('multi-entity-id-select', $customerGroupRouleConfig['fields']['customerGroupIds']['type']);
-        static::assertEquals(CustomerGroupDefinition::ENTITY_NAME, $customerGroupRouleConfig['fields']['customerGroupIds']['config']['entity']);
+        static::assertSame('customerGroupIds', $customerGroupRouleConfig['fields']['customerGroupIds']['name']);
+        static::assertSame('multi-entity-id-select', $customerGroupRouleConfig['fields']['customerGroupIds']['type']);
+        static::assertSame(CustomerGroupDefinition::ENTITY_NAME, $customerGroupRouleConfig['fields']['customerGroupIds']['config']['entity']);
     }
 }

--- a/tests/integration/Core/Framework/Rule/TimeRangeRuleTest.php
+++ b/tests/integration/Core/Framework/Rule/TimeRangeRuleTest.php
@@ -58,8 +58,8 @@ class TimeRangeRuleTest extends TestCase
         static::assertIsArray($value);
         static::assertArrayHasKey('toTime', $value);
         static::assertArrayHasKey('fromTime', $value);
-        static::assertEquals('12:00', $value['toTime']);
-        static::assertEquals('15:00', $value['fromTime']);
+        static::assertSame('12:00', $value['toTime']);
+        static::assertSame('15:00', $value['fromTime']);
 
         $ruleRepository->delete([['id' => $ruleId]], $context);
         $conditionRepository->delete([['id' => $id]], $context);

--- a/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
@@ -41,7 +41,7 @@ class ScriptApiRouteTest extends TestCase
         static::assertSame('some debug information', $traces['api-simple-script'][0]['output'][0]);
 
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
     }
 
     public function testApiEndpointWithSlashInHookName(): void
@@ -61,7 +61,7 @@ class ScriptApiRouteTest extends TestCase
         static::assertSame('some debug information', $traces['api-simple-script'][0]['output'][0]);
 
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
     }
 
     public function testAppNotAllowed(): void
@@ -74,19 +74,19 @@ class ScriptApiRouteTest extends TestCase
         static::assertNotFalse($browser->getResponse()->getContent());
         $response = \json_decode($browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode());
         static::assertArrayHasKey('errors', $response);
-        static::assertEquals('FRAMEWORK__PERMISSION_DENIED', $response['errors'][0]['code']);
+        static::assertSame('FRAMEWORK__PERMISSION_DENIED', $response['errors'][0]['code']);
 
         $this->kernelBrowser = null;
         $browser = $this->getBrowser(true, [], ['app.all']);
         $browser->request('POST', '/api/script/simple-script');
-        static::assertEquals(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
 
         $this->kernelBrowser = null;
         $browser = $this->getBrowser(true, [], ['app.api-endpoint-cases']);
         $browser->request('POST', '/api/script/simple-script');
-        static::assertEquals(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
     }
 
     public function testRepositoryCall(): void
@@ -146,14 +146,14 @@ class ScriptApiRouteTest extends TestCase
         $browser = $this->getBrowser();
         $browser->request('POST', '/api/script/insufficient-permissions');
 
-        static::assertEquals(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode());
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode());
         static::assertNotFalse($browser->getResponse()->getContent());
 
         $response = \json_decode($browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals('Forbidden', $response['errors'][0]['title']);
+        static::assertSame('Forbidden', $response['errors'][0]['title']);
         static::assertStringContainsString('api-insufficient-permissions', $response['errors'][0]['detail']);
         static::assertStringContainsString('Missing privilege', $response['errors'][0]['detail']);
     }
@@ -173,8 +173,8 @@ class ScriptApiRouteTest extends TestCase
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals('Forbidden', $response['errors'][0]['title']);
-        static::assertEquals('The user does not have the permission to do this action.', $response['errors'][0]['detail']);
+        static::assertSame('Forbidden', $response['errors'][0]['title']);
+        static::assertSame('The user does not have the permission to do this action.', $response['errors'][0]['detail']);
     }
 
     public function testAccessFromAppIntegrationIsAllowed(): void
@@ -246,6 +246,6 @@ class ScriptApiRouteTest extends TestCase
         $content = \json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertArrayHasKey('errors', $content);
         static::assertCount(1, $content['errors']);
-        static::assertEquals('FRAMEWORK__ACCESS_FROM_SCRIPT_EXECUTION_NOT_ALLOWED', $content['errors'][0]['code']);
+        static::assertSame('FRAMEWORK__ACCESS_FROM_SCRIPT_EXECUTION_NOT_ALLOWED', $content['errors'][0]['code']);
     }
 }

--- a/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
@@ -48,7 +48,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_simple_script_response', $response['apiAlias']);
     }
 
@@ -70,7 +70,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_simple_script_response', $response['apiAlias']);
     }
 
@@ -146,7 +146,7 @@ class ScriptStoreApiRouteTest extends TestCase
 
         static::assertArrayHasKey('errors', $response);
         static::assertCount(1, $response['errors']);
-        static::assertEquals('Forbidden', $response['errors'][0]['title']);
+        static::assertSame('Forbidden', $response['errors'][0]['title']);
         static::assertStringContainsString('store-api-insufficient-permissions', $response['errors'][0]['detail']);
         static::assertStringContainsString('Missing privilege', $response['errors'][0]['detail']);
     }
@@ -162,10 +162,10 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
 
         static::assertTrue($this->browser->getResponse()->headers->has('test'));
-        static::assertEquals('value', $this->browser->getResponse()->headers->get('test'));
+        static::assertSame('value', $this->browser->getResponse()->headers->get('test'));
     }
 
     public function testRedirectResponse(): void
@@ -208,7 +208,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
         static::assertFalse($this->browser->getResponse()->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
@@ -227,7 +227,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
         static::assertFalse($this->browser->getResponse()->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
@@ -246,7 +246,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
     }
 
@@ -268,7 +268,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
         $this->browser->request('GET', '/store-api/script/cache-script');
@@ -285,7 +285,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
         // invalidate the custom cache tag
@@ -306,7 +306,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
     }
 
@@ -328,7 +328,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
         $this->browser->request('GET', '/store-api/script/cache-script');
@@ -345,7 +345,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
         // Login to get the `logged-in` invalidation state
@@ -365,7 +365,7 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
         static::assertArrayHasKey('foo', $response);
-        static::assertEquals('bar', $response['foo']);
+        static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
     }
 

--- a/tests/integration/Core/Framework/Script/Execution/ScriptExecutorTest.php
+++ b/tests/integration/Core/Framework/Script/Execution/ScriptExecutorTest.php
@@ -64,7 +64,7 @@ class ScriptExecutorTest extends TestCase
 
                 continue;
             }
-            static::assertEquals($value, $object->get($key));
+            static::assertSame($value, $object->get($key));
         }
     }
 
@@ -139,7 +139,7 @@ class ScriptExecutorTest extends TestCase
         $context = Context::createDefaultContext();
         $this->executor->execute(new StoppableTestHook('stoppable-case', $context, ['object' => $object]));
 
-        static::assertEquals([
+        static::assertSame([
             'first-script' => 'called',
             'second-script' => 'called',
         ], $object->all());
@@ -155,12 +155,12 @@ class ScriptExecutorTest extends TestCase
         $this->executor->execute(new DeprecatedTestHook('simple-function-case', $context, ['object' => $object]));
 
         static::assertTrue($object->has('foo'));
-        static::assertEquals('bar', $object->get('foo'));
+        static::assertSame('bar', $object->get('foo'));
 
         $traces = $this->getScriptTraces();
         static::assertArrayHasKey('simple-function-case', $traces);
         static::assertCount(1, $traces['simple-function-case'][0]['deprecations']);
-        static::assertEquals([
+        static::assertSame([
             DeprecatedTestHook::getDeprecationNotice() => 1,
         ], $traces['simple-function-case'][0]['deprecations']);
     }
@@ -181,7 +181,7 @@ class ScriptExecutorTest extends TestCase
         $traces = $this->getScriptTraces();
         static::assertArrayHasKey('simple-service-script', $traces);
         static::assertArrayHasKey('The `repository` service is deprecated for testing purposes.', $traces['simple-service-script'][0]['deprecations']);
-        static::assertEquals(2, $traces['simple-service-script'][0]['deprecations']['The `repository` service is deprecated for testing purposes.']);
+        static::assertSame(2, $traces['simple-service-script'][0]['deprecations']['The `repository` service is deprecated for testing purposes.']);
     }
 
     public function testNotImplementingAFunctionThatWillBeRequiredTriggersException(): void
@@ -200,7 +200,7 @@ class ScriptExecutorTest extends TestCase
         $traces = $this->getScriptTraces();
         static::assertArrayHasKey('simple-function-case::test', $traces);
         static::assertCount(1, $traces['simple-function-case::test'][0]['deprecations']);
-        static::assertEquals([
+        static::assertSame([
             'Function "test" will be required from v6.5.0.0 onward, but is not implemented in script "simple-function-case/simple-function-case.twig", please make sure you add the block in your script.' => 1,
         ], $traces['simple-function-case::test'][0]['deprecations']);
     }

--- a/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
@@ -91,8 +91,8 @@ class SeoUrlRepositoryTest extends TestCase
             ->getEntities()
             ->first();
         static::assertInstanceOf(SeoUrlEntity::class, $first);
-        static::assertEquals($update['id'], $first->getId());
-        static::assertEquals($update['seoPathInfo'], $first->getSeoPathInfo());
+        static::assertSame($update['id'], $first->getId());
+        static::assertSame($update['seoPathInfo'], $first->getSeoPathInfo());
     }
 
     public function testDelete(): void
@@ -118,7 +118,7 @@ class SeoUrlRepositoryTest extends TestCase
         $result = $this->seoUrlRepository->delete([['id' => $id]], $context);
         $event = $result->getEventByEntityName(SeoUrlDefinition::ENTITY_NAME);
         static::assertNotNull($event);
-        static::assertEquals([$id], $event->getIds());
+        static::assertSame([$id], $event->getIds());
 
         $first = $this->seoUrlRepository->search(new Criteria([$id]), $context)->first();
         static::assertNull($first);

--- a/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
@@ -197,7 +197,7 @@ class SeoUrlPersisterTest extends TestCase
 
         $canonical = $canonicals->first();
         static::assertInstanceOf(SeoUrlEntity::class, $canonical);
-        static::assertEquals($fk1, $canonical->getForeignKey());
+        static::assertSame($fk1, $canonical->getForeignKey());
     }
 
     public function testSameSeoPathDifferentLanguage(): void
@@ -332,7 +332,7 @@ class SeoUrlPersisterTest extends TestCase
         static::assertNotNull($canon);
 
         static::assertTrue($canon->getIsModified());
-        static::assertNotEquals('no-effect', $canon->getSeoPathInfo());
+        static::assertNotSame('no-effect', $canon->getSeoPathInfo());
     }
 
     public function testUpdateSeoUrlsShouldMarkSeoUrlAsDeleted(): void

--- a/tests/integration/Core/Framework/ServiceDefinitionTest.php
+++ b/tests/integration/Core/Framework/ServiceDefinitionTest.php
@@ -95,7 +95,7 @@ class ServiceDefinitionTest extends TestCase
         $commandTester->execute([]);
         restore_error_handler();
 
-        static::assertEquals(
+        static::assertSame(
             0,
             $commandTester->getStatusCode(),
             "\"bin/console lint:container\" returned errors:\n" . $commandTester->getDisplay()

--- a/tests/integration/Core/Framework/Store/Api/ExtensionStoreLicensesControllerTest.php
+++ b/tests/integration/Core/Framework/Store/Api/ExtensionStoreLicensesControllerTest.php
@@ -29,7 +29,7 @@ class ExtensionStoreLicensesControllerTest extends TestCase
         );
 
         $response = $controller->cancelSubscription(1, Context::createDefaultContext());
-        static::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
     }
 
     public function testRateLicensedExtension(): void
@@ -49,6 +49,6 @@ class ExtensionStoreLicensesControllerTest extends TestCase
         ]);
 
         $response = $controller->rateLicensedExtension(1, $request, Context::createDefaultContext());
-        static::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
     }
 }

--- a/tests/integration/Core/Framework/Store/Api/FirstRunWizardControllerTest.php
+++ b/tests/integration/Core/Framework/Store/Api/FirstRunWizardControllerTest.php
@@ -61,8 +61,8 @@ class FirstRunWizardControllerTest extends TestCase
 
         $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
         static::assertInstanceOf(Request::class, $lastRequest);
-        static::assertEquals('POST', $lastRequest->getMethod());
-        static::assertEquals('/swplatform/tracking/events', $lastRequest->getUri()->getPath());
+        static::assertSame('POST', $lastRequest->getMethod());
+        static::assertSame('/swplatform/tracking/events', $lastRequest->getUri()->getPath());
     }
 
     public function testFrwLoginStoresFrwUserToken(): void
@@ -89,7 +89,7 @@ class FirstRunWizardControllerTest extends TestCase
             $context
         );
 
-        static::assertEquals(
+        static::assertSame(
             $frwUserToken,
             $this->fetchUserConfig(FirstRunWizardService::USER_CONFIG_KEY_FRW_USER_TOKEN, FirstRunWizardService::USER_CONFIG_VALUE_FRW_USER_TOKEN)
         );
@@ -139,11 +139,11 @@ class FirstRunWizardControllerTest extends TestCase
         static::assertNull(
             $this->fetchUserConfig(FirstRunWizardService::USER_CONFIG_KEY_FRW_USER_TOKEN, FirstRunWizardService::USER_CONFIG_VALUE_FRW_USER_TOKEN)
         );
-        static::assertEquals(
+        static::assertSame(
             $shopUserToken,
             $this->fetchStoreToken($context)
         );
-        static::assertEquals(
+        static::assertSame(
             $shopSecret,
             static::getContainer()->get(SystemConfigService::class)->getString(StoreRequestOptionsProvider::CONFIG_KEY_STORE_SHOP_SECRET)
         );
@@ -192,7 +192,7 @@ class FirstRunWizardControllerTest extends TestCase
             $context,
         );
 
-        static::assertEquals(
+        static::assertSame(
             'shopware.swag',
             static::getContainer()->get(SystemConfigService::class)->getString(StoreRequestOptionsProvider::CONFIG_KEY_STORE_LICENSE_DOMAIN)
         );

--- a/tests/integration/Core/Framework/Store/Api/StoreControllerTest.php
+++ b/tests/integration/Core/Framework/Store/Api/StoreControllerTest.php
@@ -147,7 +147,7 @@ class StoreControllerTest extends TestCase
         static::assertIsString($response);
 
         $response = json_decode($response, true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals($response['userInfo'], [
+        static::assertSame($response['userInfo'], [
             'name' => 'John Doe',
             'email' => 'john.doe@shopware.com',
         ]);
@@ -182,7 +182,7 @@ class StoreControllerTest extends TestCase
         static::assertIsString($response);
 
         $response = json_decode($response, true, 512, \JSON_THROW_ON_ERROR);
-        static::assertEquals($response['userInfo'], [
+        static::assertSame($response['userInfo'], [
             'name' => 'John Doe',
             'email' => 'john.doe@shopware.com',
         ]);

--- a/tests/integration/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
+++ b/tests/integration/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
@@ -55,7 +55,7 @@ class FrwRequestOptionsProviderTest extends TestCase
         $headers = $this->optionsProvider->getAuthenticationHeader($this->context);
 
         static::assertArrayHasKey('X-Shopware-Token', $headers);
-        static::assertEquals($frwUserToken, $headers['X-Shopware-Token']);
+        static::assertSame($frwUserToken, $headers['X-Shopware-Token']);
     }
 
     public function testRemovesEmptyAuthenticationHeaderIfFrwUserTokenIsNotSet(): void

--- a/tests/integration/Core/Framework/Store/Authentication/LocaleProviderTest.php
+++ b/tests/integration/Core/Framework/Store/Authentication/LocaleProviderTest.php
@@ -53,14 +53,14 @@ class LocaleProviderTest extends TestCase
 
         $locale = $this->localeProvider->getLocaleFromContext($context);
 
-        static::assertEquals($userLocale, $locale);
+        static::assertSame($userLocale, $locale);
     }
 
     public function testGetLocaleFromContextReturnsEnglishForSystemContext(): void
     {
         $locale = $this->localeProvider->getLocaleFromContext(Context::createDefaultContext());
 
-        static::assertEquals('en-GB', $locale);
+        static::assertSame('en-GB', $locale);
     }
 
     public function testGetLocaleFromContextReturnsEnglishForIntegrations(): void
@@ -69,6 +69,6 @@ class LocaleProviderTest extends TestCase
             Context::createDefaultContext(new AdminApiSource(null, Uuid::randomHex()))
         );
 
-        static::assertEquals('en-GB', $locale);
+        static::assertSame('en-GB', $locale);
     }
 }

--- a/tests/integration/Core/Framework/Store/Authentication/StoreRequestOptionsProviderTest.php
+++ b/tests/integration/Core/Framework/Store/Authentication/StoreRequestOptionsProviderTest.php
@@ -40,7 +40,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         $this->setShopSecret($shopSecret);
         $headers = $this->storeRequestOptionsProvider->getAuthenticationHeader($this->storeContext);
 
-        static::assertEquals([
+        static::assertSame([
             'X-Shopware-Platform-Token' => $this->getStoreTokenFromContext($this->storeContext),
             'X-Shopware-Shop-Secret' => $shopSecret,
         ], $headers);
@@ -53,7 +53,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         $this->setShopSecret($shopSecret);
         $headers = $this->storeRequestOptionsProvider->getAuthenticationHeader(Context::createDefaultContext());
 
-        static::assertEquals([
+        static::assertSame([
             'X-Shopware-Platform-Token' => $this->getStoreTokenFromContext($this->storeContext),
             'X-Shopware-Shop-Secret' => $shopSecret,
         ], $headers);
@@ -72,7 +72,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         $queries = $this->storeRequestOptionsProvider->getDefaultQueryParameters($this->storeContext);
 
         static::assertArrayHasKey('language', $queries);
-        static::assertEquals(
+        static::assertSame(
             $this->getLanguageFromContext($this->storeContext),
             $queries['language']
         );
@@ -83,7 +83,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         $queries = $this->storeRequestOptionsProvider->getDefaultQueryParameters($this->storeContext);
 
         static::assertArrayHasKey('shopwareVersion', $queries);
-        static::assertEquals($this->getShopwareVersion(), $queries['shopwareVersion']);
+        static::assertSame($this->getShopwareVersion(), $queries['shopwareVersion']);
     }
 
     public function testGetDefaultQueriesDoesHaveDomainSetEvenIfLicenseDomainIsNull(): void
@@ -93,7 +93,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         $queries = $this->storeRequestOptionsProvider->getDefaultQueryParameters($this->storeContext);
 
         static::assertArrayHasKey('domain', $queries);
-        static::assertEquals('', $queries['domain']);
+        static::assertSame('', $queries['domain']);
     }
 
     public function testGetDefaultQueriesDoesHaveDomainSetIfLicenseDomainIsSet(): void
@@ -103,7 +103,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         $queries = $this->storeRequestOptionsProvider->getDefaultQueryParameters($this->storeContext);
 
         static::assertArrayHasKey('domain', $queries);
-        static::assertEquals('shopware.swag', $queries['domain']);
+        static::assertSame('shopware.swag', $queries['domain']);
     }
 
     public function testGetDefaultQueriesWithLicenseDomain(): void
@@ -113,7 +113,7 @@ class StoreRequestOptionsProviderTest extends TestCase
         $queries = $this->storeRequestOptionsProvider->getDefaultQueryParameters($this->storeContext);
 
         static::assertArrayHasKey('domain', $queries);
-        static::assertEquals('new-license-domain', $queries['domain']);
+        static::assertSame('new-license-domain', $queries['domain']);
     }
 
     private function getLanguageFromContext(Context $context): string

--- a/tests/integration/Core/Framework/Store/Services/ExtensionLoaderTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionLoaderTest.php
@@ -92,8 +92,8 @@ class ExtensionLoaderTest extends TestCase
         static::assertNull($extension->getLocalId());
         static::assertNull($extension->getLicense());
         static::assertNull($extension->getVersion());
-        static::assertEquals($listingResponse['name'], $extension->getName());
-        static::assertEquals($listingResponse['label'], $extension->getLabel());
+        static::assertSame($listingResponse['name'], $extension->getName());
+        static::assertSame($listingResponse['label'], $extension->getLabel());
 
         static::assertInstanceOf(VariantCollection::class, $extension->getVariants());
         static::assertInstanceOf(ImageCollection::class, $extension->getImages());
@@ -126,7 +126,7 @@ class ExtensionLoaderTest extends TestCase
         $extension = $extensions->get('AppStoreTestPlugin');
 
         static::assertInstanceOf(ExtensionStruct::class, $extension);
-        static::assertEquals('AppStoreTestPlugin', $extension->getName());
+        static::assertSame('AppStoreTestPlugin', $extension->getName());
         static::assertTrue($extension->isAllowUpdate());
 
         $pluginId = $extension->getLocalId();
@@ -146,7 +146,7 @@ class ExtensionLoaderTest extends TestCase
         $extension = $extensions->get('AppStoreTestPlugin');
 
         static::assertInstanceOf(ExtensionStruct::class, $extension);
-        static::assertEquals('AppStoreTestPlugin', $extension->getName());
+        static::assertSame('AppStoreTestPlugin', $extension->getName());
         // update still allowed, as the plugin is not loaded from vendor folder
         // this is the case for all plugins that `executeComposerCommands` but are still installed in /custom/plugins
         static::assertTrue($extension->isAllowUpdate());
@@ -165,7 +165,7 @@ class ExtensionLoaderTest extends TestCase
         $extension = $extensions->get('AppStoreTestPlugin');
 
         static::assertInstanceOf(ExtensionStruct::class, $extension);
-        static::assertEquals('AppStoreTestPlugin', $extension->getName());
+        static::assertSame('AppStoreTestPlugin', $extension->getName());
         // update not allowed when it is installed over composer (and not just required by composer)
         static::assertFalse($extension->isAllowUpdate());
     }
@@ -209,20 +209,18 @@ class ExtensionLoaderTest extends TestCase
             new AppCollection([$installedApp])
         );
 
-        static::assertEquals([
-            'German',
-            'British English',
-        ], $extensions->first()?->getLanguages());
-
-        static::assertSame($installedApp->getUpdatedAt(), $extensions->first()?->getUpdatedAt());
+        $firstExtension = $extensions->first();
+        static::assertNotNull($firstExtension);
+        static::assertSame(['German', 'British English'], $firstExtension->getLanguages());
+        static::assertSame($installedApp->getUpdatedAt(), $firstExtension->getUpdatedAt());
         static::assertEquals(new PermissionCollection([
             PermissionStruct::fromArray(['entity' => 'product', 'operation' => 'create']),
             PermissionStruct::fromArray(['entity' => 'product', 'operation' => 'read']),
             PermissionStruct::fromArray(['entity' => 'additional_privileges', 'operation' => 'additional:privilege']),
-        ]), $extensions->first()?->getPermissions());
+        ]), $firstExtension->getPermissions());
 
         foreach ($extensions as $extension) {
-            static::assertEquals(ExtensionStruct::EXTENSION_TYPE_APP, $extension->getType());
+            static::assertSame(ExtensionStruct::EXTENSION_TYPE_APP, $extension->getType());
         }
     }
 

--- a/tests/integration/Core/Framework/Store/Services/ExtensionStoreLicensesServiceTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionStoreLicensesServiceTest.php
@@ -45,12 +45,12 @@ class ExtensionStoreLicensesServiceTest extends TestCase
 
         $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
         static::assertNotNull($lastRequest);
-        static::assertEquals(
+        static::assertSame(
             '/swplatform/pluginlicenses/1/cancel',
             $lastRequest->getUri()->getPath()
         );
 
-        static::assertEquals(
+        static::assertSame(
             [
                 'shopwareVersion' => '___VERSION___',
                 'language' => 'en-GB',

--- a/tests/integration/Core/Framework/Store/Services/StoreClientFactoryTest.php
+++ b/tests/integration/Core/Framework/Store/Services/StoreClientFactoryTest.php
@@ -49,10 +49,10 @@ class StoreClientFactoryTest extends TestCase
         static::assertEquals(self::TEST_STORE_URI, $config['base_uri']);
 
         static::assertArrayHasKey('Content-Type', $config['headers']);
-        static::assertEquals('application/json', $config['headers']['Content-Type']);
+        static::assertSame('application/json', $config['headers']['Content-Type']);
 
         static::assertArrayHasKey('Accept', $config['headers']);
-        static::assertEquals('application/vnd.api+json,application/json', $config['headers']['Accept']);
+        static::assertSame('application/vnd.api+json,application/json', $config['headers']['Accept']);
 
         /** @var HandlerStack $stack */
         $stack = $config['handler'];

--- a/tests/integration/Core/Framework/Store/Services/StoreClientTest.php
+++ b/tests/integration/Core/Framework/Store/Services/StoreClientTest.php
@@ -65,14 +65,14 @@ class StoreClientTest extends TestCase
     {
         $this->getStoreRequestHandler()->append(new Response(200, [], '{"signature": "signed"}'));
 
-        static::assertEquals('signed', $this->storeClient->signPayloadWithAppSecret('[this can be anything]', 'testApp'));
+        static::assertSame('signed', $this->storeClient->signPayloadWithAppSecret('[this can be anything]', 'testApp'));
 
         $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
         static::assertInstanceOf(RequestInterface::class, $lastRequest);
 
-        static::assertEquals('/swplatform/generatesignature', $lastRequest->getUri()->getPath());
+        static::assertSame('/swplatform/generatesignature', $lastRequest->getUri()->getPath());
 
-        static::assertEquals([
+        static::assertSame([
             'shopwareVersion' => $this->getShopwareVersion(),
             'language' => 'en-GB',
             'domain' => 'shopware-test',
@@ -98,7 +98,7 @@ class StoreClientTest extends TestCase
         $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
         static::assertInstanceOf(RequestInterface::class, $lastRequest);
 
-        static::assertEquals([
+        static::assertSame([
             'shopwareVersion' => $this->getShopwareVersion(),
             'language' => 'en-GB',
             'domain' => 'shopware-test',
@@ -107,20 +107,20 @@ class StoreClientTest extends TestCase
         $contextSource = $this->storeContext->getSource();
         static::assertInstanceOf(AdminApiSource::class, $contextSource);
 
-        static::assertEquals([
+        static::assertSame([
             'shopwareId' => 'shopwareId',
             'password' => 'password',
             'shopwareUserId' => $contextSource->getUserId(),
         ], \json_decode($lastRequest->getBody()->getContents(), true, flags: \JSON_THROW_ON_ERROR));
 
         // token from login.json
-        static::assertEquals(
+        static::assertSame(
             'updated-token',
             $this->getStoreTokenFromContext($this->storeContext)
         );
 
         // secret from login.json
-        static::assertEquals(
+        static::assertSame(
             'shop.secret',
             $this->configService->get('core.store.shopSecret')
         );
@@ -140,17 +140,17 @@ class StoreClientTest extends TestCase
 
         $updateList = $this->storeClient->getExtensionUpdateList($pluginList, $this->storeContext);
 
-        static::assertEquals([], $updateList);
+        static::assertSame([], $updateList);
 
         $cachedList = $this->cache->get(StoreClient::EXTENSION_LIST_CACHE, fn () => null);
 
         static::assertIsArray($cachedList);
-        static::assertEquals([], $cachedList);
+        static::assertSame([], $cachedList);
 
         $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
         static::assertInstanceOf(RequestInterface::class, $lastRequest);
 
-        static::assertEquals(
+        static::assertSame(
             $this->getStoreTokenFromContext($this->storeContext),
             $lastRequest->getHeader('X-Shopware-Platform-Token')[0],
         );
@@ -188,17 +188,17 @@ class StoreClientTest extends TestCase
         $updateList = $this->storeClient->getExtensionUpdateList($pluginList, $this->storeContext);
 
         static::assertCount(1, $updateList);
-        static::assertEquals('TestExtension', $updateList[0]->getName());
-        static::assertEquals('1.1.0', $updateList[0]->getVersion());
-        static::assertEquals('feature1,feature2', $updateList[0]->getInAppFeatures());
+        static::assertSame('TestExtension', $updateList[0]->getName());
+        static::assertSame('1.1.0', $updateList[0]->getVersion());
+        static::assertSame('feature1,feature2', $updateList[0]->getInAppFeatures());
 
         $cachedList = $this->cache->get(StoreClient::EXTENSION_LIST_CACHE, fn () => null);
 
         static::assertIsArray($cachedList);
         static::assertCount(1, $cachedList);
-        static::assertEquals('TestExtension', $cachedList[0]->getName());
-        static::assertEquals('1.1.0', $cachedList[0]->getVersion());
-        static::assertEquals('feature1,feature2', $cachedList[0]->getInAppFeatures());
+        static::assertSame('TestExtension', $cachedList[0]->getName());
+        static::assertSame('1.1.0', $cachedList[0]->getVersion());
+        static::assertSame('feature1,feature2', $cachedList[0]->getInAppFeatures());
 
         $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
         static::assertInstanceOf(RequestInterface::class, $lastRequest);
@@ -221,9 +221,9 @@ class StoreClientTest extends TestCase
         $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
         static::assertInstanceOf(RequestInterface::class, $lastRequest);
 
-        static::assertEquals('/swplatform/userinfo', $lastRequest->getUri()->getPath());
-        static::assertEquals('GET', $lastRequest->getMethod());
-        static::assertEquals($userInfo, $returnedUserInfo);
+        static::assertSame('/swplatform/userinfo', $lastRequest->getUri()->getPath());
+        static::assertSame('GET', $lastRequest->getMethod());
+        static::assertSame($userInfo, $returnedUserInfo);
     }
 
     public function testMissingConnectionBecauseYouAreInGermanCellularInternet(): void
@@ -259,8 +259,8 @@ class StoreClientTest extends TestCase
         $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
         static::assertInstanceOf(RequestInterface::class, $lastRequest);
 
-        static::assertEquals('/swplatform/pluginlicenses/123/cancel', $lastRequest->getUri()->getPath());
-        static::assertEquals('POST', $lastRequest->getMethod());
+        static::assertSame('/swplatform/pluginlicenses/123/cancel', $lastRequest->getUri()->getPath());
+        static::assertSame('POST', $lastRequest->getMethod());
     }
 
     public function testCancelSubscriptionAlreadyCancelled(): void

--- a/tests/integration/Core/Framework/Store/Services/StoreServiceTest.php
+++ b/tests/integration/Core/Framework/Store/Services/StoreServiceTest.php
@@ -53,6 +53,6 @@ class StoreServiceTest extends TestCase
 
         $updatedUser = $this->getUserRepository()->search($criteria, $adminStoreContext)->getEntities()->first();
 
-        static::assertEquals('updated-store-token', $updatedUser?->getStoreToken());
+        static::assertSame('updated-store-token', $updatedUser?->getStoreToken());
     }
 }

--- a/tests/integration/Core/Framework/Telemetry/EventTelemetryFlowTest.php
+++ b/tests/integration/Core/Framework/Telemetry/EventTelemetryFlowTest.php
@@ -55,7 +55,7 @@ class EventTelemetryFlowTest extends TestCase
             'enabled' => true,
         ]);
         static::assertNotEmpty($this->transport->getEmittedMetrics());
-        static::assertEquals(
+        static::assertSame(
             Metric::fromConfigured(new ConfiguredMetric('cache.invalidate.count', 1), $metricConfig),
             $this->transport->getEmittedMetrics()[0]
         );
@@ -86,7 +86,7 @@ class EventTelemetryFlowTest extends TestCase
         // search triggers EntitySearchedEvent, event is configured via attribute
         $userRepository->search($criteria, Context::createDefaultContext())->first();
         static::assertNotEmpty($this->transport->getEmittedMetrics());
-        static::assertEquals(
+        static::assertSame(
             Metric::fromConfigured(new ConfiguredMetric('dal.associations.count', 2), $metricConfig),
             $this->transport->getEmittedMetrics()[0]
         );

--- a/tests/integration/Core/Framework/TestCaseBase/DatabaseTransactionBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/DatabaseTransactionBehaviourTest.php
@@ -55,7 +55,7 @@ class DatabaseTransactionBehaviourTest extends TestCase
 
     public function testLastTestCaseIsSet(): void
     {
-        static::assertEquals($this->nameWithDataSet(), static::$lastTestCase);
+        static::assertSame($this->nameWithDataSet(), static::$lastTestCase);
     }
 
     public function testTransactionOpenWithoutClose(): void

--- a/tests/integration/Core/Framework/TestCaseBase/KernelTestBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/KernelTestBehaviourTest.php
@@ -29,7 +29,7 @@ class KernelTestBehaviourTest extends TestCase
 
     public function testTheKernelIsEqual(): void
     {
-        static::assertEquals($this->kernelId, spl_object_hash($this->getKernel()));
+        static::assertSame($this->kernelId, spl_object_hash($this->getKernel()));
     }
 
     public function testClientIsUsingTheSameKernel(): void

--- a/tests/integration/Core/Framework/Translation/TranslatorTest.php
+++ b/tests/integration/Core/Framework/Translation/TranslatorTest.php
@@ -71,7 +71,7 @@ class TranslatorTest extends TestCase
         $result = $this->translator->getCatalogue('en-GB')->get('frontend.note.item.NoteLinkZoom');
         $prop->setValue($stack, []);
 
-        static::assertEquals(
+        static::assertSame(
             'Enlarge',
             $result
         );
@@ -98,7 +98,7 @@ class TranslatorTest extends TestCase
         static::getContainer()->get(RequestStack::class)->push($request);
 
         // get overwritten string
-        static::assertEquals(
+        static::assertSame(
             $snippet['value'],
             $this->translator->getCatalogue('en-GB')->get('new.unit.test.key')
         );
@@ -113,46 +113,46 @@ class TranslatorTest extends TestCase
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('en');
         static::assertInstanceOf(MessageCatalogueInterface::class, $catalogue->getFallbackCatalogue());
-        static::assertEquals('en_GB', $catalogue->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_GB', $catalogue->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('en_GB');
         static::assertInstanceOf(MessageCatalogueInterface::class, $catalogue->getFallbackCatalogue());
-        static::assertEquals('en_001', $catalogue->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_001', $catalogue->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('en-GB');
         $fallback = $catalogue->getFallbackCatalogue();
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback);
-        static::assertEquals('en', $fallback->getLocale());
+        static::assertSame('en', $fallback->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue());
-        static::assertEquals('en_GB', $fallback->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_GB', $fallback->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('de');
         $fallback = $catalogue->getFallbackCatalogue();
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback);
-        static::assertEquals('en_GB', $fallback->getLocale());
+        static::assertSame('en_GB', $fallback->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue());
-        static::assertEquals('en', $fallback->getFallbackCatalogue()->getLocale());
+        static::assertSame('en', $fallback->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('de_DE');
         $fallback = $catalogue->getFallbackCatalogue();
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback);
-        static::assertEquals('de', $fallback->getLocale());
+        static::assertSame('de', $fallback->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue());
-        static::assertEquals('en_GB', $fallback->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_GB', $fallback->getFallbackCatalogue()->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue()->getFallbackCatalogue());
-        static::assertEquals('en', $fallback->getFallbackCatalogue()->getFallbackCatalogue()->getLocale());
+        static::assertSame('en', $fallback->getFallbackCatalogue()->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('de-DE');
         $fallback = $catalogue->getFallbackCatalogue();
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback);
-        static::assertEquals('en', $fallback->getLocale());
+        static::assertSame('en', $fallback->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue());
-        static::assertEquals('en_GB', $fallback->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_GB', $fallback->getFallbackCatalogue()->getLocale());
         $this->translator->reset();
     }
 
@@ -162,50 +162,50 @@ class TranslatorTest extends TestCase
 
         $catalogue = $this->translator->getCatalogue('en');
         static::assertInstanceOf(MessageCatalogueInterface::class, $catalogue->getFallbackCatalogue());
-        static::assertEquals('en_GB', $catalogue->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_GB', $catalogue->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('en_GB');
         static::assertInstanceOf(MessageCatalogueInterface::class, $catalogue->getFallbackCatalogue());
-        static::assertEquals('en_001', $catalogue->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_001', $catalogue->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('en-GB');
         $fallback = $catalogue->getFallbackCatalogue();
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback);
-        static::assertEquals('de', $fallback->getLocale());
+        static::assertSame('de', $fallback->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue());
-        static::assertEquals('en_GB', $fallback->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_GB', $fallback->getFallbackCatalogue()->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue()->getFallbackCatalogue());
-        static::assertEquals('en', $fallback->getFallbackCatalogue()->getFallbackCatalogue()->getLocale());
+        static::assertSame('en', $fallback->getFallbackCatalogue()->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('de');
         $fallback = $catalogue->getFallbackCatalogue();
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback);
-        static::assertEquals('en_GB', $fallback->getLocale());
+        static::assertSame('en_GB', $fallback->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue());
-        static::assertEquals('en', $fallback->getFallbackCatalogue()->getLocale());
+        static::assertSame('en', $fallback->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('de_DE');
         $fallback = $catalogue->getFallbackCatalogue();
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback);
-        static::assertEquals('de', $fallback->getLocale());
+        static::assertSame('de', $fallback->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue());
-        static::assertEquals('en_GB', $fallback->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_GB', $fallback->getFallbackCatalogue()->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue()->getFallbackCatalogue());
-        static::assertEquals('en', $fallback->getFallbackCatalogue()->getFallbackCatalogue()->getLocale());
+        static::assertSame('en', $fallback->getFallbackCatalogue()->getFallbackCatalogue()->getLocale());
 
         $this->translator->reset();
         $catalogue = $this->translator->getCatalogue('de-DE');
         $fallback = $catalogue->getFallbackCatalogue();
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback);
-        static::assertEquals('de', $fallback->getLocale());
+        static::assertSame('de', $fallback->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue());
-        static::assertEquals('en_GB', $fallback->getFallbackCatalogue()->getLocale());
+        static::assertSame('en_GB', $fallback->getFallbackCatalogue()->getLocale());
         static::assertInstanceOf(MessageCatalogueInterface::class, $fallback->getFallbackCatalogue()->getFallbackCatalogue());
-        static::assertEquals('en', $fallback->getFallbackCatalogue()->getFallbackCatalogue()->getLocale());
+        static::assertSame('en', $fallback->getFallbackCatalogue()->getFallbackCatalogue()->getLocale());
         $this->translator->reset();
     }
 
@@ -238,29 +238,29 @@ class TranslatorTest extends TestCase
         static::getContainer()->get(RequestStack::class)->push($request);
 
         // get overwritten string
-        static::assertEquals(
+        static::assertSame(
             $snippets[0]['value'],
             $this->translator->trans('new.unit.test.key', [], null, 'en-GB')
         );
-        static::assertEquals(
+        static::assertSame(
             $snippets[1]['value'],
             $this->translator->trans('new.unit.test.key', [], null, 'de-DE')
         );
-        static::assertEquals(
+        static::assertSame(
             $snippets[0]['value'],
             $this->translator->trans('new.unit.test.key', [], null, 'en')
         );
-        static::assertEquals(
+        static::assertSame(
             $snippets[1]['value'],
             $this->translator->trans('new.unit.test.key', [], null, 'de-DE')
         );
-        static::assertEquals(
+        static::assertSame(
             $snippets[0]['value'],
             $this->translator->trans('new.unit.test.key')
         );
 
         $this->translator->setLocale('de-DE');
-        static::assertEquals(
+        static::assertSame(
             $snippets[1]['value'],
             $this->translator->trans('new.unit.test.key')
         );
@@ -284,16 +284,16 @@ class TranslatorTest extends TestCase
 
         $created = $snippetRepository->create([$snippet], Context::createDefaultContext())->getEventByEntityName(SnippetDefinition::ENTITY_NAME);
         static::assertInstanceOf(EntityWrittenEvent::class, $created);
-        static::assertEquals([$snippet['id']], $created->getIds());
+        static::assertSame([$snippet['id']], $created->getIds());
 
         $deleted = $snippetRepository->delete([['id' => $snippet['id']]], Context::createDefaultContext())->getEventByEntityName(SnippetDefinition::ENTITY_NAME);
         static::assertInstanceOf(EntityWrittenEvent::class, $deleted);
-        static::assertEquals([$snippet['id']], $deleted->getIds());
+        static::assertSame([$snippet['id']], $deleted->getIds());
     }
 
     public function testItReplacesReservedCharacter(): void
     {
-        static::assertEquals('translator.<_r_strong>', Translator::buildName('</strong>'));
+        static::assertSame('translator.<_r_strong>', Translator::buildName('</strong>'));
     }
 
     public function testThemeSnippetsGetsMergedWithOverride(): void
@@ -331,7 +331,7 @@ class TranslatorTest extends TestCase
             $salesChannelContext->getContext()
         );
 
-        static::assertEquals('Service date equivalent to invoice date', $translator->trans('document.serviceDateNotice'));
+        static::assertSame('Service date equivalent to invoice date', $translator->trans('document.serviceDateNotice'));
         $translator->reset();
         $loader->reset();
 
@@ -351,13 +351,13 @@ class TranslatorTest extends TestCase
             $salesChannelContext->getContext()
         );
 
-        static::assertEquals('Swag Theme serviceDateNotice EN', $translator->trans('document.serviceDateNotice'));
+        static::assertSame('Swag Theme serviceDateNotice EN', $translator->trans('document.serviceDateNotice'));
 
         $translator->reset();
         $loader->reset();
 
         // In reset, we ignore all theme snippets and use the default ones
-        static::assertEquals('Service date equivalent to invoice date', $translator->trans('document.serviceDateNotice'));
+        static::assertSame('Service date equivalent to invoice date', $translator->trans('document.serviceDateNotice'));
 
         // Assign the Storefront theme again and assert that the original snippet is used again
         $criteria = new Criteria();
@@ -377,13 +377,13 @@ class TranslatorTest extends TestCase
             $salesChannelContext->getContext()
         );
 
-        static::assertEquals('Service date equivalent to invoice date', $translator->trans('document.serviceDateNotice'));
+        static::assertSame('Service date equivalent to invoice date', $translator->trans('document.serviceDateNotice'));
     }
 
     #[DataProvider('pluralTranslationProvider')]
     public function testPluralRules(string $expected, string $id, int $number, string $locale): void
     {
-        static::assertEquals($expected, $this->translator->trans($id, ['%count%' => (string) $number], null, $locale));
+        static::assertSame($expected, $this->translator->trans($id, ['%count%' => (string) $number], null, $locale));
     }
 
     /**

--- a/tests/integration/Core/Framework/Util/FilesystemTest.php
+++ b/tests/integration/Core/Framework/Util/FilesystemTest.php
@@ -69,7 +69,7 @@ class FilesystemTest extends TestCase
 
         $fs = new Filesystem($this->root);
 
-        static::assertEquals($this->root . '/file1.php', $fs->realpath('file1.php'));
+        static::assertSame($this->root . '/file1.php', $fs->realpath('file1.php'));
     }
 
     public function testRealPath(): void
@@ -79,7 +79,7 @@ class FilesystemTest extends TestCase
 
         $fs = new Filesystem($this->root);
 
-        static::assertEquals($this->root . '/folder/file1.php', $fs->realpath('folder/../folder/file1.php'));
+        static::assertSame($this->root . '/folder/file1.php', $fs->realpath('folder/../folder/file1.php'));
     }
 
     public function testPath(): void
@@ -90,9 +90,9 @@ class FilesystemTest extends TestCase
         $this->io->touch($this->root . '/folder/file2.php');
         $this->io->touch($this->root . '/file1.php');
 
-        static::assertEquals($this->root . '/file1.php', $fs->path('file1.php'));
-        static::assertEquals($this->root . '/folder/file2.php', $fs->path('folder', 'file2.php'));
-        static::assertEquals($this->root . '/folder/file3.php', $fs->path('folder', 'file3.php')); // file does not exist but still works
+        static::assertSame($this->root . '/file1.php', $fs->path('file1.php'));
+        static::assertSame($this->root . '/folder/file2.php', $fs->path('folder', 'file2.php'));
+        static::assertSame($this->root . '/folder/file3.php', $fs->path('folder', 'file3.php')); // file does not exist but still works
     }
 
     public function testReadThrowsAnExceptionWhenFileDoesNotExist(): void
@@ -110,7 +110,7 @@ class FilesystemTest extends TestCase
 
         $this->io->dumpFile($this->root . '/file.php', 'somecontent');
 
-        static::assertEquals('somecontent', $fs->read('file.php'));
+        static::assertSame('somecontent', $fs->read('file.php'));
     }
 
     public function testFindFiles(): void

--- a/tests/integration/Core/Framework/Util/HtmlSanitizerTest.php
+++ b/tests/integration/Core/Framework/Util/HtmlSanitizerTest.php
@@ -28,7 +28,7 @@ class HtmlSanitizerTest extends TestCase
     {
         $filteredString = $this->sanitizer->sanitize($this->unfilteredString);
 
-        static::assertEquals($this->unfilteredString, $filteredString);
+        static::assertSame($this->unfilteredString, $filteredString);
     }
 
     public function testOverrideHasNoEffectToFutureCalls(): void
@@ -37,7 +37,7 @@ class HtmlSanitizerTest extends TestCase
         $filteredString = $this->sanitizer->sanitize($this->unfilteredString);
 
         static::assertSame($filteredWithOverride, 'test');
-        static::assertEquals($this->unfilteredString, $filteredString);
+        static::assertSame($this->unfilteredString, $filteredString);
     }
 
     public function testForbiddenElementAllowedAttribute(): void
@@ -93,7 +93,7 @@ class HtmlSanitizerTest extends TestCase
         $config = $newPurifier->config;
         static::assertInstanceOf(\HTMLPurifier_Config::class, $config);
         static::assertNull($config->get('Cache.DefinitionImpl'));
-        static::assertEquals($cacheDir, $config->get('Cache.SerializerPath'));
+        static::assertSame($cacheDir, $config->get('Cache.SerializerPath'));
     }
 
     public function testSanitizeNotThrowingOnNull(): void

--- a/tests/integration/Core/Framework/Webhook/Handler/WebhookEventMessageHandlerTest.php
+++ b/tests/integration/Core/Framework/Webhook/Handler/WebhookEventMessageHandlerTest.php
@@ -92,15 +92,15 @@ class WebhookEventMessageHandlerTest extends TestCase
         $payload = $request->getBody()->getContents();
         $body = json_decode($payload, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals('POST', $request->getMethod());
-        static::assertEquals($body['body'], 'payload');
+        static::assertSame('POST', $request->getMethod());
+        static::assertSame($body['body'], 'payload');
         static::assertGreaterThanOrEqual($body['timestamp'], $timestamp);
         static::assertTrue($request->hasHeader('sw-version'));
-        static::assertEquals($request->getHeaderLine('sw-version'), '6.4');
-        static::assertEquals($request->getHeaderLine(AuthMiddleware::SHOPWARE_USER_LANGUAGE), 'en-GB');
-        static::assertEquals($request->getHeaderLine(AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE), Defaults::LANGUAGE_SYSTEM);
+        static::assertSame($request->getHeaderLine('sw-version'), '6.4');
+        static::assertSame($request->getHeaderLine(AuthMiddleware::SHOPWARE_USER_LANGUAGE), 'en-GB');
+        static::assertSame($request->getHeaderLine(AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE), Defaults::LANGUAGE_SYSTEM);
         static::assertTrue($request->hasHeader('shopware-shop-signature'));
-        static::assertEquals(
+        static::assertSame(
             hash_hmac('sha256', $payload, 's3cr3t'),
             $request->getHeaderLine('shopware-shop-signature')
         );
@@ -108,7 +108,7 @@ class WebhookEventMessageHandlerTest extends TestCase
         $webhookEventLog = $webhookEventLogRepository->search(new Criteria([$webhookEventId]), Context::createDefaultContext())->first();
 
         static::assertInstanceOf(WebhookEventLogEntity::class, $webhookEventLog);
-        static::assertEquals($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_SUCCESS);
+        static::assertSame($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_SUCCESS);
     }
 
     /**
@@ -174,15 +174,15 @@ class WebhookEventMessageHandlerTest extends TestCase
         $payload = $request->getBody()->getContents();
         $body = json_decode($payload, true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals('POST', $request->getMethod());
-        static::assertEquals($body['body'], 'payload');
+        static::assertSame('POST', $request->getMethod());
+        static::assertSame($body['body'], 'payload');
         static::assertGreaterThanOrEqual($body['timestamp'], $timestamp);
         static::assertTrue($request->hasHeader('sw-version'));
-        static::assertEquals($request->getHeaderLine('sw-version'), '6.4');
-        static::assertEquals($request->getHeaderLine(AuthMiddleware::SHOPWARE_USER_LANGUAGE), 'en-GB');
-        static::assertEquals($request->getHeaderLine(AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE), Defaults::LANGUAGE_SYSTEM);
+        static::assertSame($request->getHeaderLine('sw-version'), '6.4');
+        static::assertSame($request->getHeaderLine(AuthMiddleware::SHOPWARE_USER_LANGUAGE), 'en-GB');
+        static::assertSame($request->getHeaderLine(AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE), Defaults::LANGUAGE_SYSTEM);
         static::assertTrue($request->hasHeader('shopware-shop-signature'));
-        static::assertEquals(
+        static::assertSame(
             hash_hmac('sha256', $payload, 's3cr3t'),
             $request->getHeaderLine('shopware-shop-signature')
         );
@@ -190,7 +190,7 @@ class WebhookEventMessageHandlerTest extends TestCase
         $webhookEventLog = $webhookEventLogRepository->search(new Criteria([$webhookEventId]), Context::createDefaultContext())->first();
 
         static::assertInstanceOf(WebhookEventLogEntity::class, $webhookEventLog);
-        static::assertEquals($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_SUCCESS);
+        static::assertSame($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_SUCCESS);
     }
 
     public function testNonJsonErrorResponse(): void
@@ -248,7 +248,7 @@ class WebhookEventMessageHandlerTest extends TestCase
             ($this->webhookEventMessageHandler)($webhookEventMessage);
         } catch (WebhookException $e) {
             $wasThrown = true;
-            static::assertEquals(WebhookException::APP_WEBHOOK_FAILED, $e->getErrorCode());
+            static::assertSame(WebhookException::APP_WEBHOOK_FAILED, $e->getErrorCode());
         }
 
         static::assertTrue($wasThrown);
@@ -256,8 +256,8 @@ class WebhookEventMessageHandlerTest extends TestCase
         $webhookEventLog = $webhookEventLogRepository->search(new Criteria([$webhookEventId]), Context::createDefaultContext())->first();
 
         static::assertInstanceOf(WebhookEventLogEntity::class, $webhookEventLog);
-        static::assertEquals($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_QUEUED);
-        static::assertEquals($webhookEventLog->getResponseStatusCode(), 500);
+        static::assertSame($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_QUEUED);
+        static::assertSame($webhookEventLog->getResponseStatusCode(), 500);
         static::assertEquals($webhookEventLog->getResponseContent(), [
             'headers' => [],
             'body' => '<h1>not json</h1>',

--- a/tests/integration/Core/Framework/Webhook/Hookable/HookableBusinessEventTest.php
+++ b/tests/integration/Core/Framework/Webhook/Hookable/HookableBusinessEventTest.php
@@ -39,9 +39,9 @@ class HookableBusinessEventTest extends TestCase
             static::getContainer()->get(BusinessEventEncoder::class)
         );
 
-        static::assertEquals($scalarEvent->getName(), $event->getName());
+        static::assertSame($scalarEvent->getName(), $event->getName());
         $shopwareVersion = static::getContainer()->getParameter('kernel.shopware_version');
-        static::assertEquals($scalarEvent->getEncodeValues($shopwareVersion), $event->getWebhookPayload());
+        static::assertSame($scalarEvent->getEncodeValues($shopwareVersion), $event->getWebhookPayload());
     }
 
     #[DataProvider('getEventsWithoutPermissions')]

--- a/tests/integration/Core/Framework/Webhook/Hookable/HookableEventFactoryTest.php
+++ b/tests/integration/Core/Framework/Webhook/Hookable/HookableEventFactoryTest.php
@@ -70,14 +70,14 @@ class HookableEventFactoryTest extends TestCase
 
         static::assertCount(1, $hookables);
         $event = $hookables[0];
-        static::assertEquals('product.written', $event->getName());
+        static::assertSame('product.written', $event->getName());
 
         $payload = $event->getWebhookPayload();
         static::assertCount(1, $payload);
         $actualUpdatedFields = $payload[0]['updatedFields'];
         unset($payload[0]['updatedFields']);
 
-        static::assertEquals([[
+        static::assertSame([[
             'entity' => 'product',
             'operation' => 'insert',
             'primaryKey' => $id,
@@ -136,13 +136,13 @@ class HookableEventFactoryTest extends TestCase
 
         static::assertCount(1, $hookables);
         $event = $hookables[0];
-        static::assertEquals('product.written', $event->getName());
+        static::assertSame('product.written', $event->getName());
 
         $payload = $event->getWebhookPayload();
         $actualUpdatedFields = $payload[0]['updatedFields'];
         unset($payload[0]['updatedFields']);
 
-        static::assertEquals([[
+        static::assertSame([[
             'entity' => 'product',
             'operation' => 'update',
             'primaryKey' => $id,
@@ -176,8 +176,8 @@ class HookableEventFactoryTest extends TestCase
 
         static::assertCount(1, $hookables);
         $event = $hookables[0];
-        static::assertEquals('product.deleted', $event->getName());
-        static::assertEquals([[
+        static::assertSame('product.deleted', $event->getName());
+        static::assertSame([[
             'entity' => 'product',
             'operation' => 'delete',
             'primaryKey' => $id,
@@ -241,9 +241,9 @@ class HookableEventFactoryTest extends TestCase
 
         static::assertCount(1, $hookables);
         $event = $hookables[0];
-        static::assertEquals('product.written', $event->getName());
+        static::assertSame('product.written', $event->getName());
 
-        static::assertEquals([[
+        static::assertSame([[
             'entity' => 'product',
             'operation' => 'update',
             'primaryKey' => $id,
@@ -302,9 +302,9 @@ class HookableEventFactoryTest extends TestCase
 
         static::assertCount(2, $hookables);
         $event = $hookables[0];
-        static::assertEquals('product.written', $event->getName());
+        static::assertSame('product.written', $event->getName());
 
-        static::assertEquals([[
+        static::assertSame([[
             'entity' => 'product',
             'operation' => 'update',
             'primaryKey' => $id,
@@ -324,8 +324,8 @@ class HookableEventFactoryTest extends TestCase
         ]], $event->getWebhookPayload());
 
         $event = $hookables[1];
-        static::assertEquals('product_price.written', $event->getName());
-        static::assertEquals([[
+        static::assertSame('product_price.written', $event->getName());
+        static::assertSame([[
             'entity' => 'product_price',
             'operation' => 'insert',
             'primaryKey' => $productPriceId,
@@ -378,8 +378,8 @@ class HookableEventFactoryTest extends TestCase
         static::assertCount(1, $hookables);
 
         $event = $hookables[0];
-        static::assertEquals('product_price.written', $event->getName());
-        static::assertEquals([[
+        static::assertSame('product_price.written', $event->getName());
+        static::assertSame([[
             'entity' => 'product_price',
             'operation' => 'insert',
             'primaryKey' => $id,
@@ -409,14 +409,14 @@ class HookableEventFactoryTest extends TestCase
 
         static::assertCount(1, $hookables);
         $event = $hookables[0];
-        static::assertEquals('sales_channel_domain.written', $event->getName());
+        static::assertSame('sales_channel_domain.written', $event->getName());
 
         $payload = $event->getWebhookPayload();
         static::assertCount(1, $payload);
         $actualUpdatedFields = $payload[0]['updatedFields'];
         unset($payload[0]['updatedFields']);
 
-        static::assertEquals([[
+        static::assertSame([[
             'entity' => 'sales_channel_domain',
             'operation' => 'insert',
             'primaryKey' => $id,

--- a/tests/integration/Core/Framework/Webhook/Subscriber/RetryWebhookMessageFailedSubscriberTest.php
+++ b/tests/integration/Core/Framework/Webhook/Subscriber/RetryWebhookMessageFailedSubscriberTest.php
@@ -97,6 +97,6 @@ class RetryWebhookMessageFailedSubscriberTest extends TestCase
             ->getEntities()
             ->first();
         static::assertNotNull($webhookEventLog);
-        static::assertEquals($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_FAILED);
+        static::assertSame($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_FAILED);
     }
 }

--- a/tests/integration/Core/Framework/Webhook/WebhookApiTest.php
+++ b/tests/integration/Core/Framework/Webhook/WebhookApiTest.php
@@ -28,6 +28,6 @@ class WebhookApiTest extends TestCase
 
         $response = $this->getBrowser()->getResponse();
 
-        static::assertEquals(204, $response->getStatusCode(), \print_r($response->getContent(), true));
+        static::assertSame(204, $response->getStatusCode(), \print_r($response->getContent(), true));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/9317

### 2. What does this change do, exactly?

Replace `assertEquals` with `assertSame`