### PR TITLE
chore(ci): add workflow for automatically creating documentation tasks

### DIFF
--- a/.github/bin/js/package-lock.json
+++ b/.github/bin/js/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@shopware-ag/gh-project-automation": "^1.2.0"
+        "@shopware-ag/gh-project-automation": "^1.3.0"
       }
     },
     "node_modules/@actions/core": {
@@ -28,15 +28,18 @@
       }
     },
     "node_modules/@actions/github": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
-      "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
       "optional": true,
       "dependencies": {
         "@actions/http-client": "^2.2.0",
         "@octokit/core": "^5.0.1",
-        "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
+        "@octokit/plugin-paginate-rest": "^9.2.2",
+        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "undici": "^5.28.5"
       }
     },
     "node_modules/@actions/glob": {
@@ -233,9 +236,9 @@
       }
     },
     "node_modules/@shopware-ag/gh-project-automation": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.2.0.tgz",
-      "integrity": "sha512-zFAIXJaUFCOkT6jJrzWTIOlcvORSALJE4+SCB5QRC+wgckJXBdvhBhwX6Z4SnSe9wvta5Ken1CjUF+A5ZR64Tw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.3.1.tgz",
+      "integrity": "sha512-04eMwnPe1ebbX570QmedrgpwtTOFdQ8Z59KIvaLcE/RLhBTHgGzsYQjqkSnIqnbz/q7r5BTQWaeAmErT9FVgDw==",
       "optionalDependencies": {
         "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",
@@ -247,9 +250,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "22.15.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
+      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
       "optional": true,
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/.github/bin/js/package.json
+++ b/.github/bin/js/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@shopware-ag/gh-project-automation": "^1.2.0"
+    "@shopware-ag/gh-project-automation": "^1.3.0"
   }
 }

--- a/.github/workflows/doc-task.yml
+++ b/.github/workflows/doc-task.yml
@@ -1,12 +1,12 @@
 name: Manage documentation tasks for GitHub Epics
 
 on:
-  workflow_dispatch:
   schedule: # Every 15 minutes
     - cron: '*/15 * * * *'
 
 jobs:
   manage-docs:
+    if: github.repository == 'shopware/shopware' && github.ref == 'refs/heads/trunk'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write

--- a/.github/workflows/doc-task.yml
+++ b/.github/workflows/doc-task.yml
@@ -31,4 +31,4 @@ jobs:
           github-token: ${{ steps.sts.outputs.token }}
           script: |
             const { createDocumentationTasksForProjects } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
-            await createDocumentationTasksForProjects({github, core, context}, ${{ vars.DOC_TASK_PROJECTS }}, 'shopware')
+            await createDocumentationTasksForProjects({github, core, context, fetch}, ${{ secrets.DOC_TASK_PROJECTS }}, 'shopware', ${{ secrets.DOC_TASK_PROJECT_ID }}, '${{ secrets.DOC_TASK_DESCRIPTION }}')

--- a/.github/workflows/doc-task.yml
+++ b/.github/workflows/doc-task.yml
@@ -1,0 +1,34 @@
+name: Manage documentation tasks for GitHub Epics
+
+on:
+  workflow_dispatch:
+  schedule: # Every 15 minutes
+    - cron: '*/15 * * * *'
+
+jobs:
+  manage-docs:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      issues: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+      - id: sts
+        continue-on-error: true
+        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
+        with:
+          scope: shopware
+          identity: ManageProjects
+      - shell: bash
+        run: npm ci --prefix .github/bin/js/
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        env:
+          JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        with:
+          github-token: ${{ steps.sts.outputs.token }}
+          script: |
+            const { createDocumentationTasksForProjects } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
+            await createDocumentationTasksForProjects({github, core, context}, ${{ vars.DOC_TASK_PROJECTS }}, 'shopware')


### PR DESCRIPTION
Depends: shopware/gh-project-automation#12
Resolves: #8775

---

With this change, a scheduled workflow will run that attempts to correlate GitHub epics with Jira epics for the GitHub projects referenced in [DOC_TASK_PROJECTS](https://github.com/shopware/shopware/settings/secrets/actions/DOC_TASK_PROJECTS) (JSON Array of GitHub project numbers).

For each correlated epic in progress, a documentation task will be created in the Jira project [DOC_TASK_PROJECT_ID](https://github.com/shopware/shopware/settings/secrets/actions/DOC_TASK_PROJECT_ID) (Jira project number), the issue body will be prefixed with [DOC_TASK_DESCRIPTION](https://github.com/shopware/shopware/settings/secrets/actions/DOC_TASK_DESCRIPTION) (Plain text).

In order to successfully correlate epics and create documentation tasks in Jira, [JIRA_USERNAME](https://github.com/shopware/shopware/settings/secrets/actions/JIRA_USERNAME) and [JIRA_API_TOKEN](https://github.com/shopware/shopware/settings/secrets/actions/JIRA_API_TOKEN) need to be provided as well.