### PR TITLE
fix: replace depreacted tc call [6.7.0.0] 

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-error-summary/sw-error-summary.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-error-summary/sw-error-summary.html.twig
@@ -3,7 +3,7 @@
     v-if="errorCount > 0"
     class="sw-error-summary"
     variant="critical"
-    :title="$tc('sw-error-summary.title', errorCount)"
+    :title="$tc('sw-error-summary.title', {}, errorCount)"
     :show-icon="true"
 >
     <li

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/sw-property-search.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/sw-property-search.html.twig
@@ -92,7 +92,7 @@
                         class="sw-property-search__tree-selection__column-items-selected"
                         data-index="assignedOptions"
                     >
-                        <span v-if="item.optionCount > 0">{{ $tc('sw-property-search.selected', item.optionCount, { count: item.optionCount }) }}</span>
+                        <span v-if="item.optionCount > 0">{{ $tc('sw-property-search.selected', { count: item.optionCount }, item.optionCount) }}</span>
                     </sw-grid-column>
                     {% endblock %}
                 </template>

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-bulk-edit-modal/sw-bulk-edit-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-bulk-edit-modal/sw-bulk-edit-modal.html.twig
@@ -1,7 +1,7 @@
 {% block sw_bulk_edit_modal %}
 <sw-modal
     class="sw-bulk-edit-modal"
-    :title="$tc('global.sw-bulk-edit-modal.bulkEditModalTitle', itemCount, { count: itemCount })"
+    :title="$tc('global.sw-bulk-edit-modal.bulkEditModalTitle', { count: itemCount }, itemCount)"
     variant="full"
     @modal-close="$emit('modal-close')"
     @edit-items="$emit('edit-items')"

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.html.twig
@@ -69,7 +69,7 @@
             name="bulk-modal-delete-confirm-text"
             v-bind="{ selectionCount }"
         >
-            {{ $tc('global.entity-components.deleteMessage', selectionCount, { count: selectionCount }) }}
+            {{ $tc('global.entity-components.deleteMessage', { count: selectionCount }, selectionCount) }}
         </slot>
     </p>
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
@@ -83,7 +83,7 @@
             ref="resultsList"
             :options="results"
             :is-loading="isLoading"
-            :empty-message="$tc('global.sw-single-select.messageNoResults', searchTerm, { term: searchTerm })"
+            :empty-message="$tc('global.sw-single-select.messageNoResults', { term: searchTerm })"
             :focus-el="$refs.swSelectInput"
             @paginate="paginate"
             @item-select="setValue"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor.html.twig
@@ -99,7 +99,7 @@
                 justify="right"
             >
                 <span class="sw-text-editor__text-length">
-                    {{ $tc('global.sw-text-editor.labelTextLength', textLength, { count: textLength }) }}
+                    {{ $tc('global.sw-text-editor.labelTextLength', { count: textLength }, textLength) }}
                 </span>
             </sw-container>
         </div>

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-delete/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-delete/index.js
@@ -78,10 +78,10 @@ export default {
                     successOverall: 'global.sw-media-modal-delete.notification.successOverall.message.media',
                     errorOverall: this.$tc('global.sw-media-modal-delete.notification.errorOverall.message.media'),
                     modalTitle: this.$tc('global.default.warning'),
-                    deleteMessage: this.$tc('global.sw-media-modal-delete.deleteMessage.media', this.mediaItems.length, {
+                    deleteMessage: this.$tc('global.sw-media-modal-delete.deleteMessage.media', {
                         name: this.mediaNameFilter(this.mediaItems[0]),
                         count: this.mediaItems.length,
-                    }),
+                    }, this.mediaItems.length),
                 };
             }
 
@@ -89,10 +89,10 @@ export default {
                 successOverall: 'global.sw-media-modal-delete.notification.successOverall.message.folder',
                 errorOverall: this.$tc('global.sw-media-modal-delete.notification.errorOverall.message.folder'),
                 modalTitle: this.$tc('global.default.warning'),
-                deleteMessage: this.$tc('global.sw-media-modal-delete.deleteMessage.folder', this.folders.length, {
+                deleteMessage: this.$tc('global.sw-media-modal-delete.deleteMessage.folder', {
                     name: this.folders[0].name,
                     count: this.folders.length,
-                }),
+                }, this.folders.length),
             };
         },
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-dissolve/sw-media-modal-folder-dissolve.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-dissolve/sw-media-modal-folder-dissolve.html.twig
@@ -7,7 +7,7 @@
 >
 
     {% block sw_media_modal_folder_dissolve_body %}
-    {{ $tc('global.sw-media-modal-folder-dissolve.dissolveMessage', itemsToDissolve.length, { folderName: itemsToDissolve[0].name, count: itemsToDissolve.length }) }}
+    {{ $tc('global.sw-media-modal-folder-dissolve.dissolveMessage', { folderName: itemsToDissolve[0].name, count: itemsToDissolve.length }, itemsToDissolve.length) }}
     {% endblock %}
 
     {% block sw_media_modal_folder_dissolve_footer %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-move/sw-media-modal-move.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-move/sw-media-modal-move.html.twig
@@ -2,7 +2,7 @@
 <sw-modal
     variant="default"
     class="sw-media-modal-move"
-    :title="$tc('global.sw-media-modal-move.titleModal', itemsToMove.length, { mediaName: mediaNameFilter(itemsToMove[0]), count: itemsToMove.length }) "
+    :title="$tc('global.sw-media-modal-move.titleModal', { mediaName: mediaNameFilter(itemsToMove[0]), count: itemsToMove.length }, itemsToMove.length) "
     @modal-close="closeMoveModal"
 >
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-inheritance-warning/sw-inheritance-warning.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-inheritance-warning/sw-inheritance-warning.html.twig
@@ -9,7 +9,7 @@
 
     {% block sw_inheritance_warning_text %}
     <p>
-        {{ $tc('sw-inheritance-warning.infoTextInheritedField', name, { moduleName: name }) }}
+        {{ $tc('sw-inheritance-warning.infoTextInheritedField', { moduleName: name }) }}
     </p>
     {% endblock %}
 </div>

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-duplicated-media-v2/sw-duplicated-media-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-duplicated-media-v2/sw-duplicated-media-v2.html.twig
@@ -104,7 +104,7 @@
             v-if="!isLoading && hasAdditionalErrors"
             v-model:checked="shouldSaveSelection"
             class="sw-duplicated-media-v2__additional-error-count"
-            :label="$tc('global.sw-duplicated-media-v2.labelSaveSelection', additionalErrorCount)"
+            :label="$tc('global.sw-duplicated-media-v2.labelSaveSelection', { count: additionalErrorCount })"
         />
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/sw-license-violation.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/sw-license-violation.html.twig
@@ -101,7 +101,7 @@
     >
 
         <p class="sw-plugin-list__confirm-delete-text">
-            {{ $tc('sw-license-violation.messageDeleteConfirm', '', { pluginName: deletePluginItem.label }) }}
+            {{ $tc('sw-license-violation.messageDeleteConfirm', { pluginName: deletePluginItem.label }) }}
         </p>
 
         <template #modal-footer>

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-confirm/sw-bulk-edit-save-modal-confirm.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-confirm/sw-bulk-edit-save-modal-confirm.html.twig
@@ -1,7 +1,7 @@
 {% block sw_bulk_edit_save_modal_confirm %}
 <div class="sw-bulk-edit-save-modal-confirm">
     <p class="sw-bulk-edit-save-modal__help-text">
-        {{ $tc('sw-bulk-edit.modal.confirm.description', itemTotal, {itemCount: itemTotal}) }}
+        {{ $tc('sw-bulk-edit.modal.confirm.description', { itemCount: itemTotal }, itemTotal) }}
     </p>
 
     {% block sw_bulk_edit_save_modal_confirm_trigger_flows %}

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.html.twig
@@ -11,7 +11,7 @@
     {% block sw_bulk_edit_order_smart_bar_header %}
     <template #smart-bar-header>
 
-        <h2>{{ $tc('sw-bulk-edit.order.textTitle', selectedIds.length, { orderTotal: selectedIds.length }) }}</h2>
+        <h2>{{ $tc('sw-bulk-edit.order.textTitle', { orderTotal: selectedIds.length }, selectedIds.length) }}</h2>
 
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.html.twig
@@ -32,8 +32,8 @@
         {% block sw_bulk_edit_product_smart_bar_header_title %}
         <h2>
             {{ isChild
-            ? $tc('sw-bulk-edit.variant.textTitle', selectedIds.length, { variantTotal: selectedIds.length })
-            : $tc('sw-bulk-edit.product.textTitle', selectedIds.length, { productTotal: selectedIds.length })
+            ? $tc('sw-bulk-edit.variant.textTitle', { variantTotal: selectedIds.length }, selectedIds.length)
+            : $tc('sw-bulk-edit.product.textTitle', { productTotal: selectedIds.length }, selectedIds.length)
             }}
         </h2>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-overwrite-modal/sw-category-entry-point-overwrite-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-overwrite-modal/sw-category-entry-point-overwrite-modal.html.twig
@@ -7,7 +7,7 @@
 >
 
     <p class="sw-confirm-modal__text">
-        {{ $tc('sw-category.entry-point-overwrite-modal.textBefore', salesChannels.length) }}
+        {{ $tc('sw-category.entry-point-overwrite-modal.textBefore', {}, salesChannels.length) }}
     </p>
 
     <ul>
@@ -20,7 +20,7 @@
     </ul>
 
     <p class="sw-confirm-modal__text">
-        {{ $tc('sw-category.entry-point-overwrite-modal.textAfter', salesChannels.length) }}
+        {{ $tc('sw-category.entry-point-overwrite-modal.textAfter', {}, salesChannels.length) }}
     </p>
 </sw-confirm-modal>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -531,7 +531,7 @@
             </h3>
 
             <p class="sw-cms-sidebar__layout-set-as-default-info-text">
-                {{ $tc('sw-cms.components.setDefaultLayoutModal.infoText', page.type === 'product_detail') }}
+                {{ $tc('sw-cms.components.setDefaultLayoutModal.infoText', {}, page.type === 'product_detail') }}
             </p>
 
             <mt-button

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
@@ -330,7 +330,7 @@
                     v-if="showLayoutSetAsDefaultModal"
                     class="sw-cms-detail__confirm-set-as-default-modal"
                     :title="$tc('sw-cms.components.setDefaultLayoutModal.title')"
-                    :text="$tc('sw-cms.components.setDefaultLayoutModal.infoText', page.type === 'product_detail')"
+                    :text="$tc('sw-cms.components.setDefaultLayoutModal.infoText', {}, page.type === 'product_detail')"
                     @confirm="onConfirmLayoutSetAsDefault"
                     @cancel="onCloseLayoutSetAsDefault"
                     @close="onCloseLayoutSetAsDefault"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
@@ -426,7 +426,7 @@
                 v-if="showLayoutSetAsDefaultModal"
                 class="sw-cms-list__confirm-set-as-default-modal"
                 :title="$tc('sw-cms.components.setDefaultLayoutModal.title')"
-                :text="$tc('sw-cms.components.setDefaultLayoutModal.infoText', newDefaultLayout.type === 'product_detail')"
+                :text="$tc('sw-cms.components.setDefaultLayoutModal.infoText', {}, newDefaultLayout.type === 'product_detail')"
                 @confirm="onConfirmLayoutSetAsDefault"
                 @cancel="onCloseLayoutSetAsDefault"
                 @close="onCloseLayoutSetAsDefault"

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -76,7 +76,7 @@
                 v-if="!customerEditMode"
                 class="sw-customer-base__label-is-active"
             >
-                {{ $tc('sw-customer.baseInfo.contentActive', customer.active ? 1 : 2) }}
+                {{ $tc('sw-customer.baseInfo.contentActive', {}, customer.active ? 1 : 2) }}
             </dd>
             {% endblock %}
 
@@ -107,7 +107,7 @@
                 v-if="!customerEditMode"
                 class="sw-customer-base__label-is-confirmed"
             >
-                {{ $tc('sw-customer.baseInfo.contentConfirmed', customer.doubleOptInConfirmDate ? 1 : 2) }}
+                {{ $tc('sw-customer.baseInfo.contentConfirmed', {}, customer.doubleOptInConfirmDate ? 1 : 2) }}
             </dd>
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-ratings-summary/sw-extension-ratings-summary.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-ratings-summary/sw-extension-ratings-summary.html.twig
@@ -10,7 +10,7 @@
 
         {% block sw_extension_ratings_summary_grid_label %}
         <p>
-            {{ $tc('sw-extension-store.component.sw-extension-ratings.sw-extension-ratings-summary.labelRating', summary.numberOfRatings, { numberOfRatings: summary.numberOfRatings }) }}
+            {{ $tc('sw-extension-store.component.sw-extension-ratings.sw-extension-ratings-summary.labelRating', { numberOfRatings: summary.numberOfRatings }, summary.numberOfRatings) }}
         </p>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/index.js
@@ -248,7 +248,7 @@ export default {
 
         bulkDeleteWarningMessage(selectionCount) {
             return `${this.$tc('sw-flow.list.warningDeleteText')}
-            ${this.$tc('global.entity-components.deleteMessage', selectionCount, { count: selectionCount })}`;
+            ${this.$tc('global.entity-components.deleteMessage', { count: selectionCount }, selectionCount)}`;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-sidebar/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-sidebar/index.js
@@ -97,7 +97,7 @@ export default {
         },
 
         getSelectedFilesCount() {
-            return `${this.$tc('sw-media.sidebar.labelHeadlineMultiple', this.items.length, { count: this.items.length })}`;
+            return `${this.$tc('sw-media.sidebar.labelHeadlineMultiple', { count: this.items.length }, this.items.length)}`;
         },
 
         firstEntity() {

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-list/index.js
@@ -187,7 +187,7 @@ export default {
             }
 
             this.createNotificationError({
-                message: this.$tc('sw-product-stream.general.errorCategory', count, { name, count }),
+                message: this.$tc('sw-product-stream.general.errorCategory', { name, count }, count),
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/index.js
@@ -541,9 +541,9 @@ export default {
                     this.isDeletionOver = true;
 
                     this.createNotificationError({
-                        message: this.$tc('sw-product.list.notificationVariantDeleteErrorCanonicalUrl', amount, {
+                        message: this.$tc('sw-product.list.notificationVariantDeleteErrorCanonicalUrl', {
                             variantName,
-                        }),
+                        }, amount),
                     });
 
                     return;
@@ -553,10 +553,10 @@ export default {
                     .syncDeleted(variantIds)
                     .then(() => {
                         this.createNotificationSuccess({
-                            message: this.$tc('sw-product.list.notificationVariantDeleteSuccess', amount, {
+                            message: this.$tc('sw-product.list.notificationVariantDeleteSuccess', {
                                 variantName,
                                 amount,
-                            }),
+                            }, amount),
                         });
 
                         this.$refs.variantGrid.resetSelection();
@@ -565,10 +565,10 @@ export default {
                     })
                     .catch(() => {
                         this.createNotificationError({
-                            message: this.$tc('sw-product.list.notificationVariantDeleteError', amount, {
+                            message: this.$tc('sw-product.list.notificationVariantDeleteError', {
                                 variantName,
                                 amount,
-                            }),
+                            }, amount),
                         });
                     })
                     .finally(() => {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.html.twig
@@ -150,14 +150,14 @@
         {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxHeader') }}
         <div class="sw-product-modal-variant-generation__infoBoxContent">
             <span class="sw-product-modal-variant-generation__variant-amount">
-                {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxCount', variantGenerationQueue.createQueue.length, { count: variantGenerationQueue.createQueue.length }) }}
+                {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxCount', { count: variantGenerationQueue.createQueue.length }, variantGenerationQueue.createQueue.length) }}
             </span>
-            {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxCreateLabel', variantGenerationQueue.createQueue.length, { count: variantGenerationQueue.createQueue.length }) }}
+            {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxCreateLabel', { count: variantGenerationQueue.createQueue.length }, variantGenerationQueue.createQueue.length) }}
 
             <span class="sw-product-modal-variant-generation__variant-amount">
-                {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxCount', variantGenerationQueue.deleteQueue.length, { count: variantGenerationQueue.deleteQueue.length }) }}
+                {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxCount', { count: variantGenerationQueue.deleteQueue.length }, variantGenerationQueue.deleteQueue.length) }}
             </span>
-            {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxDeleteLabel', variantGenerationQueue.deleteQueue.length, { count: variantGenerationQueue.deleteQueue.length }) }}
+            {{ $tc('sw-product.variations.configuratorModal.uploadInfoBoxDeleteLabel', { count: variantGenerationQueue.deleteQueue.length }, variantGenerationQueue.deleteQueue.length) }}
         </div>
     </div>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/discount/sw-promotion-v2-settings-discount-type/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/discount/sw-promotion-v2-settings-discount-type/index.js
@@ -82,7 +82,7 @@ export default {
         },
 
         labelValue() {
-            return this.$tc('sw-promotion-v2.detail.discounts.settings.discountType.labelValue', !this.isPercentageType);
+            return this.$tc('sw-promotion-v2.detail.discounts.settings.discountType.labelValue', {}, !this.isPercentageType);
         },
 
         showAdvancedPricesLink() {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/index.js
@@ -60,9 +60,9 @@ export default {
                 return '';
             }
 
-            return this.$tc('sw-promotion-v2.detail.base.codes.individual.textDeleteConfirm', this.currentSelection.length, {
+            return this.$tc('sw-promotion-v2.detail.base.codes.individual.textDeleteConfirm', {
                 code: this.currentSelection[0].code || '',
-            });
+            }, this.currentSelection.length);
         },
 
         codeColumns() {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-modal/sw-sales-channel-products-assignment-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-modal/sw-sales-channel-products-assignment-modal.html.twig
@@ -104,7 +104,7 @@
             :is-loading="isAssignProductLoading || isProductLoading"
             @click="onAddProducts"
         >
-            {{ $tc('sw-sales-channel.detail.products.buttonAddProducts', productCount, { productCount: productCount }) }}
+            {{ $tc('sw-sales-channel.detail.products.buttonAddProducts', { productCount: productCount }, productCount) }}
         </mt-button>
         {% endblock %}
     </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.html.twig
@@ -40,7 +40,7 @@
                         variant="secondary"
                         @click="openAddProductsModal"
                     >
-                        {{ $tc('sw-sales-channel.detail.products.buttonAddProducts', 0) }}
+                        {{ $tc('sw-sales-channel.detail.products.buttonAddProducts', {}, 0) }}
                     </mt-button>
                     {% endblock %}
                 </sw-container>
@@ -203,7 +203,7 @@
                 variant="secondary"
                 @click="openAddProductsModal"
             >
-                {{ $tc('sw-sales-channel.detail.products.buttonAddProducts', 0) }}
+                {{ $tc('sw-sales-channel.detail.products.buttonAddProducts', {}, 0) }}
             </mt-button>
             {% endblock %}
         </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-custom-field-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-custom-field-list.html.twig
@@ -223,14 +223,14 @@
     {% block sw_custom_field_list_custom_field_delete %}
     <sw-modal
         v-if="deleteCustomField"
-        :title="$tc('sw-settings-custom-field.customField.list.titleDeleteAction', deleteCustomField.length)"
+        :title="$tc('sw-settings-custom-field.customField.list.titleDeleteAction', {}, deleteCustomField.length)"
         variant="small"
         @modal-close="onCancelDeleteCustomField"
     >
 
         {% block sw_custom_field_list_custom_field_delete_text %}
         <p class="sw-custom-field-delete__description">
-            {{ $tc('sw-settings-custom-field.customField.list.textDeleteActionConfirmation', deleteCustomField.length, { count: deleteCustomField.length }) }}
+            {{ $tc('sw-settings-custom-field.customField.list.textDeleteActionConfirmation', { count: deleteCustomField.length }, deleteCustomField.length) }}
         </p>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.html.twig
@@ -98,8 +98,8 @@
                                 v-model:value="customerGroup.displayGross"
                                 bordered
                                 :label="$tc('sw-settings-customer-group.detail.fieldDisplayGrossLabel')"
-                                :label-option-true="$tc('sw-settings-customer-group.detail.fieldDisplayGrossValues', 1)"
-                                :label-option-false="$tc('sw-settings-customer-group.detail.fieldDisplayGrossValues', 0)"
+                                :label-option-true="$tc('sw-settings-customer-group.detail.fieldDisplayGrossValues', {}, 1)"
+                                :label-option-false="$tc('sw-settings-customer-group.detail.fieldDisplayGrossValues', {}, 0)"
                                 :disabled="!acl.can('customer_groups.editor') || undefined"
                             />
                             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-list/sw-settings-customer-group-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-list/sw-settings-customer-group-list.html.twig
@@ -132,7 +132,7 @@
                         {% block sw_settings_customer_group_list_grid_column_display_gross %}
                         <template #column-displayGross="{ item }">
                             {% block sw_settings_customer_group_list_grid_column_display_gross_inner %}
-                            {{ $tc('sw-settings-customer-group.detail.fieldDisplayGrossValues', +item.displayGross) }}
+                            {{ $tc('sw-settings-customer-group.detail.fieldDisplayGrossValues', {}, +item.displayGross) }}
                                 {% endblock %}
                         </template>
                         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-assignments/sw-settings-rule-detail-assignments.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-assignments/sw-settings-rule-detail-assignments.html.twig
@@ -104,7 +104,7 @@
                 </template>
 
                 <template #bulk-modal-delete-confirm-text="{ selectionCount }">
-                    {{ $tc('sw-settings-rule.detail.textModalBulkDelete', selectionCount, { count: selectionCount }) }}
+                    {{ $tc('sw-settings-rule.detail.textModalBulkDelete', { count: selectionCount }, selectionCount) }}
                 </template>
 
                 <template #bulk-modal-delete-items="{ isBulkLoading, deleteItems }">

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/index.js
@@ -137,9 +137,7 @@ export default {
 
         confirmDeleteText() {
             const name = this.priceGroup.rule ? this.priceGroup.rule.name : '';
-            return this.$tc('sw-settings-shipping.priceMatrix.textDeleteConfirm', Number(!!this.priceGroup.rule), {
-                name: name,
-            });
+            return this.$tc('sw-settings-shipping.priceMatrix.textDeleteConfirm', { name }, Number(!!this.priceGroup.rule));
         },
 
         currencyColumns() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/index.js
@@ -60,9 +60,9 @@ export default {
     computed: {
         identifier() {
             return this.snippetSets
-                ? this.$tc('sw-settings-snippet.list.identifier', this.snippetSets.length, {
+                ? this.$tc('sw-settings-snippet.list.identifier', {
                       setName: this.metaName,
-                  })
+                  }, this.snippetSets.length)
                 : '';
         },
 
@@ -431,7 +431,7 @@ export default {
 
         inlineSaveSuccessMessage(key) {
             const titleSaveSuccess = this.$tc('global.default.success');
-            const messageSaveSuccess = this.$tc('sw-settings-snippet.list.messageSaveSuccess', this.queryIdCount, { key });
+            const messageSaveSuccess = this.$tc('sw-settings-snippet.list.messageSaveSuccess', { key }, this.queryIdCount);
 
             this.createNotificationSuccess({
                 title: titleSaveSuccess,
@@ -441,7 +441,7 @@ export default {
 
         inlineSaveErrorMessage(key) {
             const titleSaveError = this.$tc('global.default.error');
-            const messageSaveError = this.$tc('sw-settings-snippet.list.messageSaveError', this.queryIdCount, { key });
+            const messageSaveError = this.$tc('sw-settings-snippet.list.messageSaveError', { key }, this.queryIdCount);
 
             this.createNotificationError({
                 title: titleSaveError,
@@ -545,9 +545,9 @@ export default {
 
         createSuccessMessage(item) {
             const title = this.$tc('global.default.success');
-            const message = this.$tc('sw-settings-snippet.list.resetSuccessMessage', !item.isCustomSnippet, {
+            const message = this.$tc('sw-settings-snippet.list.resetSuccessMessage', {
                 key: item.value,
-            });
+            }, !item.isCustomSnippet);
 
             this.createNotificationSuccess({
                 title,
@@ -557,9 +557,9 @@ export default {
 
         createResetErrorNote(item) {
             const title = this.$tc('global.default.error');
-            const message = this.$tc('sw-settings-snippet.list.resetErrorMessage', item.isCustomSnippet ? 2 : 0, {
+            const message = this.$tc('sw-settings-snippet.list.resetErrorMessage', {
                 key: item.value,
-            });
+            }, item.isCustomSnippet ? 2 : 0);
 
             this.createNotificationError({
                 title,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/sw-settings-snippet-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/sw-settings-snippet-list.html.twig
@@ -23,7 +23,7 @@
         >
             {% block sw_settings_snippet_list_smart_bar_header_title_text %}
             <span class="sw-settings_snippet_list__smart-bar-title-text">
-                {{ $tc('sw-settings-snippet.list.textSnippetList', snippetSets.length, { setName: metaName }) }}
+                {{ $tc('sw-settings-snippet.list.textSnippetList', { setName: metaName }, snippetSets.length) }}
             </span>
             {% endblock %}
 
@@ -152,7 +152,7 @@
                         :disabled="!acl.can('snippet.deleter') || undefined"
                         @click="onReset(item)"
                     >
-                        {{ $tc('sw-settings-snippet.list.contextMenuDelete', item.isCustomSnippet) }}
+                        {{ $tc('sw-settings-snippet.list.contextMenuDelete', {}, item.isCustomSnippet) }}
                     </sw-context-menu-item>
                     {% endblock %}
                 </template>
@@ -176,7 +176,7 @@
                             v-if="!item.isCustomSnippet"
                             class="sw-settings-snippet-list__delete-modal-confirm-reset-text"
                         >
-                            {{ $tc('sw-settings-snippet.list.textResetConfirm', queryIdCount, { key: item[metaId].translationKey }) }}
+                            {{ $tc('sw-settings-snippet.list.textResetConfirm', { key: item[metaId].translationKey }, queryIdCount) }}
                         </span>
                         {% endblock %}
 
@@ -253,7 +253,7 @@
                                 size="small"
                                 @click="onConfirmReset(item)"
                             >
-                                {{ $tc('sw-settings-snippet.list.contextMenuDelete', item.isCustomSnippet) }}
+                                {{ $tc('sw-settings-snippet.list.contextMenuDelete', {}, item.isCustomSnippet) }}
                             </mt-button>
                             {% endblock %}
                         </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/index.js
@@ -258,7 +258,7 @@ export default {
 
         createInlineErrorNote(name) {
             this.createNotificationError({
-                message: this.$tc('sw-settings-snippet.setList.inlineEditErrorMessage', name !== null, { name }),
+                message: this.$tc('sw-settings-snippet.setList.inlineEditErrorMessage', { name }, name !== null),
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tag/component/sw-settings-tag-detail-assignments/sw-settings-tag-detail-assignments.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tag/component/sw-settings-tag-detail-assignments/sw-settings-tag-detail-assignments.html.twig
@@ -85,7 +85,7 @@
                                     class="associations-grid__count"
                                 >
                                     {{ getCount(item.assignment) }}
-                                    {{ $tc('sw-settings-tag.detail.assignments.assignments', getCount(item.assignment)) }}
+                                    {{ $tc('sw-settings-tag.detail.assignments.assignments', {}, getCount(item.assignment)) }}
                                 </span>
                             </mt-button>
                             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
@@ -181,7 +181,7 @@ export default {
         },
 
         createErrorNotification(errors) {
-            let message = `<div>${this.$tc('sw-config-form-renderer.configLoadErrorMessage', errors.length)}</div><ul>`;
+            let message = `<div>${this.$tc('sw-config-form-renderer.configLoadErrorMessage', {}, errors.length)}</div><ul>`;
 
             errors.forEach((error) => {
                 message = `${message}<li>${error.detail}</li>`;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- There are still some $tc calls left that use the deprecated and no longer working call signature 

### 2. What does this change do, exactly?
- Change all $tc calls to be valid again

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
