### PR TITLE
fix: double entries in select field of flow builder

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.spec.js
@@ -702,8 +702,8 @@ describe('src/module/sw-flow/component/sw-flow-sequence-action', () => {
 
         const actionItems = wrapper.findAll('.sw-select-result');
 
-        expect(actionItems).toHaveLength(8);
-        expect(actionItems.at(7).get('.sw-highlight-text').text()).toBe('Telegram send message');
+        expect(actionItems).toHaveLength(6);
+        expect(actionItems.at(5).get('.sw-highlight-text').text()).toBe('Telegram send message');
     });
 
     it('should disable the actions when inactive the app flow actions', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.spec.js
@@ -668,6 +668,52 @@ describe('src/module/sw-flow/component/sw-flow-sequence-action', () => {
         expect(actionItems.at(1).text()).toBe('sw-flow.actions.group.tag');
     });
 
+    it('should remove duplicates of available actions based on action type', async () => {
+        const triggerActions = [
+            {
+                name: 'action.add.customer.tag',
+                requirements: ['Shopware\\Core\\Framework\\Event\\CustomerAware'],
+            },
+            {
+                name: 'action.add.order.tag',
+                requirements: ['Shopware\\Core\\Framework\\Event\\OrderAware'],
+            },
+            {
+                name: 'action.remove.customer.tag',
+                requirements: ['Shopware\\Core\\Framework\\Event\\CustomerAware'],
+            },
+            {
+                name: 'action.remove.order.tag',
+                requirements: ['Shopware\\Core\\Framework\\Event\\CustomerAware'],
+            },
+        ];
+
+        Shopware.State.commit('swFlowState/setTriggerEvent', {
+            name: 'checkout.customer.login',
+            aware: [
+                'Shopware\\Core\\Framework\\Event\\CustomerAware',
+                'Shopware\\Core\\Framework\\Event\\OrderAware',
+            ],
+        });
+
+        Shopware.State.commit('swFlowState/setTriggerActions', triggerActions);
+
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        const actionSelect = wrapper.find('.sw-single-select__selection');
+        await actionSelect.trigger('click');
+        await flushPromises();
+
+        const actionItems = wrapper.findAll('.sw-select-result');
+        const labels = actionItems.map(item => item.text());
+
+        expect(labels).toEqual([
+            'sw-flow.actions.addTag',
+            'sw-flow.actions.removeTag',
+        ]);
+    });
+
     it('should has actions from app flow actions in actions list', async () => {
         const appFlowResponse = [
             {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.spec.js
@@ -670,33 +670,33 @@ describe('src/module/sw-flow/component/sw-flow-sequence-action', () => {
 
     it('should remove duplicates of available actions based on action type', async () => {
         const triggerActions = [
-            {
-                name: 'action.add.customer.tag',
-                requirements: ['Shopware\\Core\\Framework\\Event\\CustomerAware'],
-            },
-            {
-                name: 'action.add.order.tag',
-                requirements: ['Shopware\\Core\\Framework\\Event\\OrderAware'],
-            },
-            {
-                name: 'action.remove.customer.tag',
-                requirements: ['Shopware\\Core\\Framework\\Event\\CustomerAware'],
-            },
-            {
-                name: 'action.remove.order.tag',
-                requirements: ['Shopware\\Core\\Framework\\Event\\CustomerAware'],
-            },
+            { name: 'action.add.customer.tag', requirements: ['CustomerAware'] },
+            { name: 'action.add.order.tag', requirements: ['OrderAware'] },
+            { name: 'action.remove.customer.tag', requirements: ['CustomerAware'] },
+            { name: 'action.remove.order.tag', requirements: ['OrderAware'] },
         ];
 
-        Shopware.State.commit('swFlowState/setTriggerEvent', {
-            name: 'checkout.customer.login',
-            aware: [
-                'Shopware\\Core\\Framework\\Event\\CustomerAware',
-                'Shopware\\Core\\Framework\\Event\\OrderAware',
-            ],
-        });
+        const originalTriggerActions = Shopware.State.get('swFlowState').triggerActions;
+        const originalTriggerEvent = Shopware.State.get('swFlowState').triggerEvent;
 
         Shopware.State.commit('swFlowState/setTriggerActions', triggerActions);
+        Shopware.State.commit('swFlowState/setTriggerEvent', {
+            name: 'checkout.customer.login',
+            aware: ['CustomerAware', 'OrderAware'],
+        });
+
+        const originalService = Shopware.Service('flowBuilderService');
+        Shopware.Service().flowBuilderService = {
+            mapActionType: (actionName) => {
+                if (actionName.includes('add.customer.tag') || actionName.includes('add.order.tag')) {
+                    return 'add.tag';
+                }
+                if (actionName.includes('remove.customer.tag') || actionName.includes('remove.order.tag')) {
+                    return 'remove.tag';
+                }
+                return actionName;
+            }
+        };
 
         const wrapper = await createWrapper();
         await flushPromises();
@@ -705,13 +705,18 @@ describe('src/module/sw-flow/component/sw-flow-sequence-action', () => {
         await actionSelect.trigger('click');
         await flushPromises();
 
-        const actionItems = wrapper.findAll('.sw-select-result');
-        const labels = actionItems.map(item => item.text());
+        const actionItems = wrapper.findAll('.sw-select-result .sw-highlight-text');
+        const labels = actionItems.map(el => el.text());
 
-        expect(labels).toEqual([
+        expect(labels).toHaveLength(2);
+        expect(labels).toEqual(expect.arrayContaining([
             'sw-flow.actions.addTag',
             'sw-flow.actions.removeTag',
-        ]);
+        ]));
+
+        Shopware.State.commit('swFlowState/setTriggerActions', originalTriggerActions);
+        Shopware.State.commit('swFlowState/setTriggerEvent', originalTriggerEvent);
+        Shopware.Service().flowBuilderService = originalService;
     });
 
     it('should has actions from app flow actions in actions list', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/state/flow.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/state/flow.state.js
@@ -217,6 +217,18 @@ export default {
                     return;
                 }
 
+                const actionType = Shopware.Service('flowBuilderService').mapActionType(action.name);
+
+                if (actionType) {
+                    const hasDuplicate = availableActions.find((existingName) => {
+                        return Shopware.Service('flowBuilderService').mapActionType(existingName) === actionType;
+                    });
+
+                    if (hasDuplicate !== undefined) {
+                        return;
+                    }
+                }
+
                 availableActions.push(action.name);
             });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In some flows that use more than one Entity like `State enter / Order / State / Cancelled` or `Checkout / Order / Placed` (Order and Customer entity), the actions "add tag" and "remove tag" are displayed twice.

### 2. What does this change do, exactly?
Adds an duplicate check in the flow.state.js.

### 3. Describe each step to reproduce the issue or behaviour.

    Go to flow builder
    Create new flow or edit existing flow
    Create an action container and open the select action field
    Scroll down to the "Tags" section
    See double entries


### 4. Please link to the relevant issues (if any).

- closes #9167


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
