### PR TITLE
fix: Reduce height of product title link on wishlist [6.6.x]

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_product-wishlist.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_product-wishlist.scss
@@ -4,6 +4,16 @@ Product box for wishlist
 Styling for productbox component.
 */
 
+$box-standard-height-img: 200px;
+
+.product-box {
+    // Do not expand the Bootstrap `stretched-link` pseudo element over the entire product card.
+    // By giving it the image height, only the image itself is linked and the remaining content is still selectable.
+    &.box-wishlist .stretched-link::after {
+        height: calc(#{$box-standard-height-img} + var(--#{$prefix}card-spacer-y));
+    }
+}
+
 .product-wishlist {
     margin-top: 10px;
 

--- a/tests/acceptance/tests/Settings/Wishlist/WishlistRegisteredCustomerFunctionalities.spec.ts
+++ b/tests/acceptance/tests/Settings/Wishlist/WishlistRegisteredCustomerFunctionalities.spec.ts
@@ -1,7 +1,6 @@
 import { test } from '@fixtures/AcceptanceTest';
-import { satisfies } from 'compare-versions';
 
-test('Customers can add or remove products from their wishlist.',{ tag: '@Wishlist' }, async ({ 
+test('Customers can add or remove products from their wishlist.',{ tag: '@Wishlist' }, async ({
     TestDataService,
     ShopCustomer,
     StorefrontHome,
@@ -55,16 +54,12 @@ test('Customers can add or remove products from their wishlist.',{ tag: '@Wishli
         await ShopCustomer.expects(StorefrontHome.wishlistBasket).toContainText('1');
     });
 
-    // TO-DO: This step is skipped, please check the details from ticket : https://shopware.atlassian.net/browse/NEXT-40639
-    // eslint-disable-next-line playwright/no-conditional-in-test
-    if (!InstanceMeta.features['ACCESSIBILITY_TWEAKS'] && satisfies(InstanceMeta.version, '<6.7')) {
-        await test.step('Add product to cart from wishlist and verify it is added and wishlist icon is visible on offcanvas', async () => {       
-            await ShopCustomer.attemptsTo(AddProductToCartFromWishlist(product1));
-            const offcanvasItem = await StorefrontOffCanvasCart.getLineItemByProductNumber(product1.productNumber);
-            const expectedPrice = await product1Locators.productPrice.innerText();
-            const itemPrice = await offcanvasItem.productTotalPriceValue.innerText();
-            await ShopCustomer.expects(offcanvasItem.wishlistAddedButton).toBeVisible(); 
-            await ShopCustomer.expects(itemPrice).toBe(expectedPrice);       
+    await test.step('Add product to cart from wishlist and verify it is added and wishlist icon is visible on offcanvas', async () => {
+        await ShopCustomer.attemptsTo(AddProductToCartFromWishlist(product1));
+        const offcanvasItem = await StorefrontOffCanvasCart.getLineItemByProductNumber(product1.productNumber);
+        const expectedPrice = await product1Locators.productPrice.innerText();
+        const itemPrice = await offcanvasItem.productTotalPriceValue.innerText();
+        await ShopCustomer.expects(offcanvasItem.wishlistAddedButton).toBeVisible();
+        await ShopCustomer.expects(itemPrice).toBe(expectedPrice);
     });
-    }
 });


### PR DESCRIPTION
The :after pseudo-element covered the whole card. This shrinks the size to only overlap the title.

Fixes https://github.com/shopware/shopware/issues/8684

Backport of https://github.com/shopware/shopware/pull/7324