### PR TITLE
fix: Consider theme asset directory while deleting old theme directories

### DIFF
--- a/src/Storefront/Theme/ScheduledTask/DeleteThemeFilesTaskHandler.php
+++ b/src/Storefront/Theme/ScheduledTask/DeleteThemeFilesTaskHandler.php
@@ -76,7 +76,13 @@ final class DeleteThemeFilesTaskHandler extends ScheduledTaskHandler
         );
 
         $themePaths = [];
+        foreach (array_unique(array_column($salesChannelThemeMappings, 'themeId')) as $themeId) {
+            // Add path with themeId (for assets)
+            $themePaths[] = 'theme' . \DIRECTORY_SEPARATOR . $themeId;
+        }
+
         foreach ($salesChannelThemeMappings as $salesChannelThemeMapping) {
+            // Add path with themePrefix (for CSS and JS files)
             $themePaths[] = 'theme' . \DIRECTORY_SEPARATOR . $this->themePathBuilder->assemblePath($salesChannelThemeMapping['salesChannelId'], $salesChannelThemeMapping['themeId']);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The recently introduced `DeleteThemeFilesTaskHandler` didn't consider the theme asset directories and deletes it although it is still used. 

### 2. What does this change do, exactly?

Consider the directory with the assets which is named with the theme ID

### 3. Describe each step to reproduce the issue or behaviour.

See linked issue

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/9406

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
