### PR TITLE
fix: add missing start_period config for database container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -43,6 +43,7 @@ services:
         healthcheck:
             test: [ "CMD", "mariadb-admin" ,"ping", "-h", "localhost", "-proot" ]
             start_interval: 3s
+            start_period: 10s
             interval: 5s
             timeout: 1s
             retries: 10


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Newer Versions of Docker Compose fail with an error when a `start_interval` is configured without
a `start_period`, see: https://github.com/docker/compose/commit/0403f0d76d91f5ef673bfe8f18bc7bf831c48725

> healthcheck.start_interval requires healthcheck.start_period to be set

### 2. What does this change do, exactly?

Adds the missing `start_period` config to the database service in `compose.yaml`

### 3. Describe each step to reproduce the issue or behaviour.

Run `docker compose up -d` with latest Docker Compose version (tested with 2.36.0).

The database service will not start and an error occurs:

> healthcheck.start_interval requires healthcheck.start_period to be set

### 4. Please link to the relevant issues (if any).

- relates #8502 - introduced the healthcheck

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
