### PR TITLE
fix: Correct shipping costs for Google Analytics

### DIFF
--- a/changelog/_unreleased/2025-05-15-transmit-correct-shipping-costs-to-google-analytics.md
+++ b/changelog/_unreleased/2025-05-15-transmit-correct-shipping-costs-to-google-analytics.md
@@ -1,0 +1,8 @@
+---
+title: Transmit correct shipping costs to Google Analytics
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed `@Storefront/storefront/component/checkout/hidden-line-items-information.html.twig` template to use the correct shipping costs of the order, which is used to push the information to Google Analytics

--- a/src/Storefront/Resources/views/storefront/component/checkout/hidden-line-items-information.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/hidden-line-items-information.html.twig
@@ -1,7 +1,7 @@
 {% block component_hidden_line_items_information %}
     <div class="d-none hidden-line-items-information"
          data-currency="{{ context.currency.translated.shortName }}"
-         data-shipping="{{ cart.deliveries.shippingCosts.sum().totalPrice }}"
+         data-shipping="{{ cart.shippingCosts.totalPrice }}"
          data-value="{{ cart.price.totalPrice }}"
          data-tax="{{ cart.price.calculatedTaxes.amount }}"
     >


### PR DESCRIPTION
### 1. Why is this change necessary?
`cart.deliveries.shippingCosts.sum().totalPrice` does not exist, as `cart.deliveries` is an [`OrderDeliveryCollection`](https://github.com/shopware/shopware/blob/8169c7a99ad05eda2646907ae1238b216c91cddf/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryCollection.php)

### 2. What does this change do, exactly?
Use the correct variable.

### 3. Describe each step to reproduce the issue or behaviour.
Use the `LineItemHelper`

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
