### PR TITLE
fix: styling prio of sw-single-select

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.scss
@@ -1,6 +1,6 @@
 @import "~scss/variables";
 
-.sw-single-select {
+.sw-single-select.sw-select {
     .sw-single-select__selection-input {
         padding: 12px 0;
         min-height: 22px + 2 * 12px;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-select-v2/sw-order-state-select-v2.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-select-v2/sw-order-state-select-v2.scss
@@ -17,10 +17,6 @@
         input {
             border-radius: 15px;
         }
-
-        .sw-single-select__selection-text {
-            padding: 12px 8px;
-        }
     }
 
     .sw-order-state__neutral-select.sw-single-select {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The styling for the `sw-single-select` has the same prio as the styling of it's base component `sw-select-base`. In the loaded styling sheet, `sw-select-base` is constantly defined after `sw-single-select`, therefore the styling of sw-select-base is used. That shouldn't be the case.

### 2. What does this change do, exactly?
- Revert #8972
- Give the styling of sw-single-select more prio

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #8966
- potentially all styling issues in combination with `sw-single-select`, as long as no hotfix as applied

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
