### PR TITLE
fix: Set the context token from main request also to current request

### DIFF
--- a/changelog/_unreleased/2025-05-15-provide-context-token-to-current-request.md
+++ b/changelog/_unreleased/2025-05-15-provide-context-token-to-current-request.md
@@ -1,0 +1,15 @@
+---
+title: Provide context token to current request
+author: Michael Telgmann
+author_github: mitelg
+---
+# Storefront
+* Changed `\Shopware\Storefront\Framework\Routing\StorefrontSubscriber::startSession()` to provide the context token to the current request if it differs from the main request.
+___
+
+# Upgrade Information
+
+## StorefrontSubscriber now adds context token to the current request
+The `\Shopware\Storefront\Framework\Routing\StorefrontSubscriber::startSession()` method has been updated to provide the context token to the current request if it differs from the main request.
+This is especially necessary if a reverse proxy like Varnish or Fastly is used.
+Due to loading of the header and footer via ESI, it would otherwise cause the sub requests for those to have a different contexts than the main request.

--- a/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\Routing\KernelListenerPriorities;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
-use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
 use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
@@ -38,6 +37,8 @@ use Symfony\Component\Routing\RouterInterface;
 #[CoversClass(StorefrontSubscriber::class)]
 class StorefrontSubscriberTest extends TestCase
 {
+    private const TEST_CONTEXT_TOKEN = 'test-context-token';
+
     public function testHasEvents(): void
     {
         $expected = [
@@ -76,24 +77,22 @@ class StorefrontSubscriberTest extends TestCase
         $router = $this->createMock(RouterInterface::class);
         $router->method('generate')->willReturn('/maintenance');
 
-        $storefrontSubscriber = new StorefrontSubscriber(
-            new RequestStack(),
-            $router,
-            $maintenanceModeResolver,
-            new StaticSystemConfigService(),
-        );
-
         $event = new RequestEvent(
             $this->createMock(HttpKernelInterface::class),
             new Request(),
             HttpKernelInterface::MAIN_REQUEST
         );
 
-        $storefrontSubscriber->maintenanceResolver($event);
+        (new StorefrontSubscriber(
+            new RequestStack(),
+            $router,
+            $maintenanceModeResolver,
+            new StaticSystemConfigService(),
+        ))->maintenanceResolver($event);
 
-        static::assertTrue($event->hasResponse());
-        static::assertInstanceOf(RedirectResponse::class, $event->getResponse());
-        static::assertSame('/maintenance', $event->getResponse()->getTargetUrl());
+        $response = $event->getResponse();
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/maintenance', $response->getTargetUrl());
     }
 
     public function testRedirectLoginPageWhenCustomerNotLoggedInWithRoutingException(): void
@@ -104,38 +103,29 @@ class StorefrontSubscriberTest extends TestCase
             ->with('frontend.account.login.page')
             ->willReturn('/login');
 
-        $subscriber = new StorefrontSubscriber(
+        $event = new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(attributes: [SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true]),
+            HttpKernelInterface::MAIN_REQUEST,
+            new CustomerNotLoggedInRoutingException(
+                Response::HTTP_FORBIDDEN,
+                RoutingException::CUSTOMER_NOT_LOGGED_IN_CODE,
+                'Customer is not logged in.'
+            )
+        );
+
+        (new StorefrontSubscriber(
             $this->createMock(RequestStack::class),
             $router,
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
-        );
-
-        $exception = new CustomerNotLoggedInRoutingException(Response::HTTP_FORBIDDEN, RoutingException::CUSTOMER_NOT_LOGGED_IN_CODE, 'Customer is not logged in.');
-        $request = new Request();
-        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST, true);
-
-        $event = new ExceptionEvent(
-            $this->createMock(HttpKernelInterface::class),
-            $request,
-            HttpKernelInterface::MAIN_REQUEST,
-            $exception
-        );
-
-        $subscriber->customerNotLoggedInHandler($event);
+        ))->customerNotLoggedInHandler($event);
 
         static::assertInstanceOf(RedirectResponse::class, $event->getResponse());
     }
 
     public function testRedirectCustomerNonStorefrontRequest(): void
     {
-        $subscriber = new StorefrontSubscriber(
-            $this->createMock(RequestStack::class),
-            $this->createMock(RouterInterface::class),
-            $this->createMock(MaintenanceModeResolver::class),
-            new StaticSystemConfigService(),
-        );
-
         $event = new ExceptionEvent(
             $this->createMock(HttpKernelInterface::class),
             new Request(),
@@ -143,7 +133,12 @@ class StorefrontSubscriberTest extends TestCase
             new \RuntimeException('test')
         );
 
-        $subscriber->customerNotLoggedInHandler($event);
+        (new StorefrontSubscriber(
+            $this->createMock(RequestStack::class),
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            new StaticSystemConfigService(),
+        ))->customerNotLoggedInHandler($event);
 
         static::assertFalse($event->hasResponse());
     }
@@ -156,25 +151,23 @@ class StorefrontSubscriberTest extends TestCase
             ->with('frontend.account.login.page')
             ->willReturn('/login');
 
-        $subscriber = new StorefrontSubscriber(
+        $event = new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(attributes: [SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true]),
+            HttpKernelInterface::MAIN_REQUEST,
+            new CustomerNotLoggedInException(
+                Response::HTTP_FORBIDDEN,
+                RoutingException::CUSTOMER_NOT_LOGGED_IN_CODE,
+                'Foo test'
+            )
+        );
+
+        (new StorefrontSubscriber(
             $this->createMock(RequestStack::class),
             $router,
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
-        );
-
-        $exception = new CustomerNotLoggedInException(Response::HTTP_FORBIDDEN, RoutingException::CUSTOMER_NOT_LOGGED_IN_CODE, 'Foo test');
-        $request = new Request();
-        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST, true);
-
-        $event = new ExceptionEvent(
-            $this->createMock(HttpKernelInterface::class),
-            $request,
-            HttpKernelInterface::MAIN_REQUEST,
-            $exception
-        );
-
-        $subscriber->customerNotLoggedInHandler($event);
+        ))->customerNotLoggedInHandler($event);
 
         static::assertInstanceOf(RedirectResponse::class, $event->getResponse());
     }
@@ -187,37 +180,24 @@ class StorefrontSubscriberTest extends TestCase
             ->with('frontend.account.login.page')
             ->willReturn('/login');
 
-        $subscriber = new StorefrontSubscriber(
+        $event = new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(attributes: [SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true]),
+            HttpKernelInterface::MAIN_REQUEST,
+            new RoutingException(Response::HTTP_FORBIDDEN, 'foo', 'You have to be logged in to access this page')
+        );
+
+        (new StorefrontSubscriber(
             $this->createMock(RequestStack::class),
             $router,
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
-        );
-
-        $exception = new RoutingException(Response::HTTP_FORBIDDEN, 'foo', 'You have to be logged in to access this page');
-        $request = new Request();
-        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST, true);
-
-        $event = new ExceptionEvent(
-            $this->createMock(HttpKernelInterface::class),
-            $request,
-            HttpKernelInterface::MAIN_REQUEST,
-            $exception
-        );
-
-        $subscriber->customerNotLoggedInHandler($event);
+        ))->customerNotLoggedInHandler($event);
     }
 
     #[DataProvider('dataProviderXMLHttpRequest')]
     public function testNonXmlHttpRequestPassesThrough(Request $request, bool $expected): void
     {
-        $storefrontSubscriber = new StorefrontSubscriber(
-            new RequestStack(),
-            $this->createMock(RouterInterface::class),
-            $this->createMock(MaintenanceModeResolver::class),
-            new StaticSystemConfigService(),
-        );
-
         $event = new ControllerEvent(
             $this->createMock(HttpKernelInterface::class),
             function (): void {},
@@ -231,7 +211,12 @@ class StorefrontSubscriberTest extends TestCase
             static::assertTrue($event->isMainRequest());
         }
 
-        $storefrontSubscriber->preventPageLoadingFromXmlHttpRequest($event);
+        (new StorefrontSubscriber(
+            new RequestStack(),
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            new StaticSystemConfigService(),
+        ))->preventPageLoadingFromXmlHttpRequest($event);
     }
 
     public static function dataProviderXMLHttpRequest(): \Generator
@@ -242,38 +227,76 @@ class StorefrontSubscriberTest extends TestCase
         ];
 
         yield 'XMLHttpRequest, but not a storefront request' => [
-            'request' => new Request([], [], [], [], [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']),
+            'request' => new Request(server: ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']),
             'expected' => false,
         ];
 
         yield 'XMLHttpRequest, but a storefront request and not allowed' => [
-            'request' => new Request([], [], [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StorefrontRouteScope::ID]], [], [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']),
+            'request' => new Request(
+                attributes: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StorefrontRouteScope::ID]],
+                server: ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']
+            ),
             'expected' => true,
         ];
 
         yield 'XMLHttpRequest, but a storefront request and allowed' => [
-            'request' => new Request([], [], [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StorefrontRouteScope::ID], 'XmlHttpRequest' => true], [], [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']),
+            'request' => new Request(
+                attributes: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StorefrontRouteScope::ID], 'XmlHttpRequest' => true],
+                server: ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']
+            ),
             'expected' => false,
         ];
     }
 
     public function testStartSession(): void
     {
-        $request = new Request([], [], [SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true, PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT => Generator::generateSalesChannelContext()], [], [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        $request = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => 'test-sales-channel-id',
+            ],
+            server: ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']
+        );
         $request->setSession(new Session(new MockArraySessionStorage()));
         $requestStack = new RequestStack();
 
         $requestStack->push($request);
 
-        $subscriber = new StorefrontSubscriber(
+        (new StorefrontSubscriber(
             $requestStack,
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
-        );
-
-        $subscriber->startSession();
+        ))->startSession();
 
         static::assertTrue($request->getSession()->has('sessionId'));
+    }
+
+    public function testSubRequestShouldGetSameContextTokenAsMainRequest(): void
+    {
+        $mainRequest = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => 'test-sales-channel-id',
+            ]
+        );
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set(PlatformRequest::HEADER_CONTEXT_TOKEN, self::TEST_CONTEXT_TOKEN);
+        $mainRequest->setSession($session);
+
+        $subRequest = new Request();
+        $requestStack = new RequestStack([$mainRequest, $subRequest]);
+
+        (new StorefrontSubscriber(
+            $requestStack,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            new StaticSystemConfigService(),
+        ))->startSession();
+
+        $subRequestContextToken = $subRequest->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN);
+        static::assertSame(self::TEST_CONTEXT_TOKEN, $subRequestContextToken);
+        static::assertSame($mainRequest->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN), $subRequestContextToken);
     }
 }

--- a/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Routing\KernelListenerPriorities;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
+use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
 use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
@@ -253,7 +254,7 @@ class StorefrontSubscriberTest extends TestCase
         $request = new Request(
             attributes: [
                 SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
-                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => 'test-sales-channel-id',
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT => Generator::generateSalesChannelContext(),
             ],
             server: ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']
         );
@@ -298,5 +299,65 @@ class StorefrontSubscriberTest extends TestCase
         $subRequestContextToken = $subRequest->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN);
         static::assertSame(self::TEST_CONTEXT_TOKEN, $subRequestContextToken);
         static::assertSame($mainRequest->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN), $subRequestContextToken);
+    }
+
+    public function testUpdateSessionWithoutRequest(): void
+    {
+        $requestStack = new RequestStack();
+
+        (new StorefrontSubscriber(
+            $requestStack,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            new StaticSystemConfigService()
+        ))->updateSession(self::TEST_CONTEXT_TOKEN);
+
+        static::assertNull($requestStack->getCurrentRequest());
+    }
+
+    public function testUpdateSessionIsNoSalesChannelRequest(): void
+    {
+        $request = new Request();
+
+        (new StorefrontSubscriber(
+            new RequestStack([$request]),
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            new StaticSystemConfigService()
+        ))->updateSession(self::TEST_CONTEXT_TOKEN);
+
+        static::assertNull($request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+    }
+
+    public function testUpdateSessionWithoutSession(): void
+    {
+        $request = new Request(attributes: [SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true]);
+        $requestStack = new RequestStack([$request]);
+
+        (new StorefrontSubscriber(
+            $requestStack,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            new StaticSystemConfigService()
+        ))->updateSession(self::TEST_CONTEXT_TOKEN);
+
+        static::assertNull($request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+    }
+
+    public function testUpdateSession(): void
+    {
+        $request = new Request(attributes: [SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true]);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $requestStack = new RequestStack([$request]);
+
+        (new StorefrontSubscriber(
+            $requestStack,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            new StaticSystemConfigService()
+        ))->updateSession(self::TEST_CONTEXT_TOKEN);
+
+        static::assertSame(self::TEST_CONTEXT_TOKEN, $request->getSession()->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+        static::assertSame(self::TEST_CONTEXT_TOKEN, $request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

If a `reverse_proxy` for the `http_cache` is enabled, the header and footer are loaded as sub-requests of the main request that is loading the page. This caused a different context in those sub-requests, as the subscriber only handled the main request. Features in the header and footer do not work, if the context differs. Also this should not happen at all, as the context should be unique to the whole page and user. 

### 2. What does this change do, exactly?

Add a check in the subscriber if the current request is different to the main request. If so, set the context token also to the headers of the current request. Which would be the sub-request for the header or footer. 

### 3. Describe each step to reproduce the issue or behaviour.

enable this config:
```
shopware:
    http_cache:
        reverse_proxy:
            enabled: true
```
Dump the `context.token` in
`src/Storefront/Resources/views/storefront/base.html.twig`,
`src/Storefront/Resources/views/storefront/layout/header.html.twig` and
`src/Storefront/Resources/views/storefront/layout/footer.html.twig`.

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/9441

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
