### PR TITLE
fix: Pagination has additional spacing in Generate Variants modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/sw-property-search.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/sw-property-search.scss
@@ -73,6 +73,10 @@
 
         .sw-grid__pagination {
             background-color: $color-white;
+
+            .mt-icon {
+                margin: 0;
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- This rule removes the margin from elements with the class `mt-icon`  effect inside the `.sw-property-search__tree-selection__group_grid` container.

| 1 Page  | 2 Pages |
| ------------- | ------------- |
| ![CleanShot 2025-05-15 at 23 39 30@2x](https://github.com/user-attachments/assets/7b5dd0bc-721f-4680-872d-e6da1444569e) | ![75605](https://github.com/user-attachments/assets/b1ac58bd-c3bc-4297-9cd7-ec7a07113131)  |

### 2. What does this change do, exactly?
- Set the margin 0 to the mt-icon inside the Pagination element `sw-grid__pagination` of `tree-selection`

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a product
2. Under Variants tab, click the 'Generate Variants' option to open the modal

### 4. Please link to the relevant issues (if any).
 - closes the issue #9432 when the PR is merged
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
