### PR TITLE
feat: add skip-theme-recompile option for app:uninstall command

### DIFF
--- a/changelog/_unreleased/2025-05-16-add-skip-theme-compile-option-for-app-uninstall.md
+++ b/changelog/_unreleased/2025-05-16-add-skip-theme-compile-option-for-app-uninstall.md
@@ -1,0 +1,5 @@
+---
+title: Add `skip-theme-compile` option for app uninstall
+---
+# Core
+* Added `skip-theme-recompile` option to `app:uninstall` command to skip theme compilation during uninstall. This can be useful to speed up the build process when uninstall multiple apps and manually recompile the theme once.

--- a/changelog/_unreleased/2025-05-16-add-skip-theme-compile-option-for-app-uninstall.md
+++ b/changelog/_unreleased/2025-05-16-add-skip-theme-compile-option-for-app-uninstall.md
@@ -2,4 +2,4 @@
 title: Add `skip-theme-compile` option for app uninstall
 ---
 # Core
-* Added `skip-theme-recompile` option to `app:uninstall` command to skip theme compilation during uninstall. This can be useful to speed up the build process when uninstall multiple apps and manually recompile the theme once.
+* Added `skip-theme-compile` option to `app:uninstall` command to skip theme compilation during uninstall. This can be useful to speed up the build process when uninstall multiple apps and manually recompile the theme once.

--- a/src/Core/Framework/App/Command/UninstallAppCommand.php
+++ b/src/Core/Framework/App/Command/UninstallAppCommand.php
@@ -50,7 +50,7 @@ class UninstallAppCommand extends Command
         }
 
         $context = Context::createCLIContext();
-        if ($input->getOption('skip-theme-recompile')) {
+        if ($input->getOption('skip-theme-compile')) {
             $context->addState(ThemeLifecycleHandler::STATE_SKIP_THEME_COMPILATION);
         }
 
@@ -89,7 +89,7 @@ class UninstallAppCommand extends Command
             'Keep user data of the app'
         );
         $this->addOption(
-            'skip-theme-recompile',
+            'skip-theme-compile',
             null,
             InputOption::VALUE_NONE,
             'Use this option to skip recompiling of all themes'

--- a/src/Core/Framework/App/Command/UninstallAppCommand.php
+++ b/src/Core/Framework/App/Command/UninstallAppCommand.php
@@ -11,6 +11,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginLifecycleService;
+use Shopware\Storefront\Theme\ThemeLifecycleHandler;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -49,6 +51,10 @@ class UninstallAppCommand extends Command
         }
 
         $context = Context::createCLIContext();
+        if ($input->getOption('skip-theme-recompile')) {
+            $context->addState(ThemeLifecycleHandler::STATE_SKIP_THEME_COMPILATION);
+        }
+
         $app = $this->getAppByName($name, $context);
 
         if (!$app) {
@@ -78,6 +84,8 @@ class UninstallAppCommand extends Command
     {
         $this->addArgument('name', InputArgument::REQUIRED, 'The name of the app');
         $this->addOption('keep-user-data', null, InputOption::VALUE_NONE, 'Keep user data of the app');
+        $this->addOption('skip-theme-recompile', null, InputOption::VALUE_NONE, 'Use this option to skip recompiling of all themes'
+    );
     }
 
     private function getAppByName(string $name, Context $context): ?AppEntity

--- a/src/Core/Framework/App/Command/UninstallAppCommand.php
+++ b/src/Core/Framework/App/Command/UninstallAppCommand.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Storefront\Theme\ThemeLifecycleHandler;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -83,9 +82,18 @@ class UninstallAppCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('name', InputArgument::REQUIRED, 'The name of the app');
-        $this->addOption('keep-user-data', null, InputOption::VALUE_NONE, 'Keep user data of the app');
-        $this->addOption('skip-theme-recompile', null, InputOption::VALUE_NONE, 'Use this option to skip recompiling of all themes'
-    );
+        $this->addOption(
+            'keep-user-data',
+            null,
+            InputOption::VALUE_NONE,
+            'Keep user data of the app'
+        );
+        $this->addOption(
+            'skip-theme-recompile',
+            null,
+            InputOption::VALUE_NONE,
+            'Use this option to skip recompiling of all themes'
+        );
     }
 
     private function getAppByName(string $name, Context $context): ?AppEntity


### PR DESCRIPTION
With 6.7 cloud deployment we uninstall all the old premium theme apps, everytime we recompile all themes, this negatively affects downtime for the shops, in order to minimize the negative effect we should skip theme compile during app uninstallation as we will do it manually later anyway
