### PR TITLE
ci: refactor needs-triage

### DIFF
--- a/.github/workflows/01-needs-triage-labeler.yml
+++ b/.github/workflows/01-needs-triage-labeler.yml
@@ -2,14 +2,16 @@ name: Add or remove needs-triage label
 
 on:
   pull_request_target:
-    types: [opened, labeled, unlabeled]
+    types: [opened]
   issues:
-    types: [opened, labeled, unlabeled]
+    types: [opened]
 
 jobs:
   needs-triage:
     runs-on: ubuntu-24.04
     steps:
+      - name: Wait 5 minutes
+        run: sleep 5m
       - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
         with:
           script: |
@@ -19,6 +21,7 @@ jobs:
               console.debug("Issue or PR is closed. Skipping label management.");
               return;
             }
+            
             const issue_number = context.payload.number ?? context.payload.issue.number;
 
             // get labels via api
@@ -32,30 +35,11 @@ jobs:
               throw new Error(`Failed to fetch labels for issue #${issue_number}`);
             }
 
-            console.debug(labels);
-
             // Check if the issue has either a domain/ label or a service/ label
             const hasRequiredLabel = labels.data.some(label => label.name.startsWith('domain/') || label.name.startsWith('service/'));
             const hasNeedsTriageLabel = labels.data.some(label => label.name === 'needs-triage');
             
-            // remove needs-triage label if it has the required label
-            if (hasRequiredLabel && hasNeedsTriageLabel) {
-              console.debug('remove needs-triage label');
-              const removeResponse = await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number,
-                name: "needs-triage",
-              });
-
-              if (removeResponse.status !== 200) {
-                throw new Error(`Failed to remove label needs-triage from issue #${issue_number}`);
-              }
-
-              return;
-            }
-
-            // if neither, add needs-triage label
+            // if no required label and no needs-triage label, add needs-triage
             if (!hasRequiredLabel && !hasNeedsTriageLabel) {
               console.debug('add needs-triage label');
               const addResponse = await github.rest.issues.addLabels({


### PR DESCRIPTION
The needs-triage jobs often run into race conditions with manual labeling. To make this more robust we're changing how it works

- only run once on `opened` event and not also on `labeled`/`unlabeled`
- run the first job delayed by 5 minutes, so that most manual changes are already done

This should make sure that each issue gets the `needs-triage` label

To fix issues that have no `needs-triage` or `needs-triage` and `domain/service` label, we'll implement a cron that runs over all issues, instead of reacting to events. This should stabilize it and automatically fix them. This will be implemented in a different PR
