### PR TITLE
fix: Send email to customer toggle is misaligned

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-change-modal/sw-order-state-change-modal-attach-documents/sw-order-state-change-modal-attach-documents.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-change-modal/sw-order-state-change-modal-attach-documents/sw-order-state-change-modal-attach-documents.scss
@@ -2,6 +2,7 @@
     &__button-wrapper {
         display: flex;
         justify-content: flex-end;
+        align-items: center;
     }
 
     .sw-order-state-change-modal-attach-documents__button {
@@ -16,6 +17,5 @@
 
     .sw-order-state-change-modal-attach-documents__button {
         height: 32px;
-        margin-top: 8px;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
|  Send email to customer toggle is misaligned |
| ------------- |
|![CleanShot 2025-05-16 at 15 56 22](https://github.com/user-attachments/assets/f279531a-d873-496f-a614-28c17a6e1142)|

### 2. What does this change do, exactly?
 - Add alignment center and remove the margin top of the button in `sw-order-state-change-modal-attach-documents`. [Refer](https://github.com/shopware/shopware/pull/9499/files)
 
![CleanShot 2025-05-16 at 15 46 40](https://github.com/user-attachments/assets/2c3abfb9-6150-441c-9364-1605277878d7)

### 3. Describe each step to reproduce the issue or behaviour.
- Create an order. Update the status for payment, shipping or order dropdowns

### 4. Please link to the relevant issues (if any).

- Closes the issue #9489 when the PR is merged

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
