### PR TITLE
fix(admin): Remove superflous padding of property search toolbar

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-add-properties-modal/sw-product-add-properties-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-add-properties-modal/sw-product-add-properties-modal.scss
@@ -73,7 +73,6 @@ $background-color: $color-gray-100;
     }
 
     .sw-product-add-properties-modal__toolbar {
-        padding: 30px;
         border-bottom: 1px solid #d8dde6;
         background-color: $background-color;
         grid-template-columns: 1fr auto;


### PR DESCRIPTION
### 1. Why is this change necessary?
Look at the modal of the properties on the product configuration:
![image](https://github.com/user-attachments/assets/cc1d174c-edbd-4834-8934-a268f484f21b)

### 2. What does this change do, exactly?
![image](https://github.com/user-attachments/assets/76bc1bd2-b37d-4ea3-8ff2-9e3e304b8531)


### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
