### PR TITLE
fix: promotion advanced price style unset min-height

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.scss
@@ -32,4 +32,8 @@
         overflow: visible;
         text-overflow: initial;
     }
+
+    .mt-block-field__block {
+        min-height: unset;
+    }
 }


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/8801
unset min-height for price input field