### PR TITLE
fix: wrong size of chevron in menu breadcrumb navigation

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-index/sw-flow-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-index/sw-flow-index.html.twig
@@ -13,7 +13,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-flow.list.textHeadline') }}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.html.twig
@@ -8,7 +8,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-integration.general.headlineIntegrations') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-index/sw-mail-template-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-index/sw-mail-template-index.html.twig
@@ -17,7 +17,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-mail-template.list.textMailTemplateOverview') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig
@@ -17,7 +17,7 @@
         <h2>
             {% block sw_newsletter_recipientlist_list_smart_bar_header_title_text %}
             {{ $tc('global.sw-admin-menu.navigation.mainMenuItemMarketing') }}
-            <mt-icon name="regular-chevron-right-xs" />
+            <mt-icon name="regular-chevron-right-xs" size="12px" />
             {{ $tc('sw-newsletter-recipient.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
@@ -9,7 +9,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-cache.general.mainMenuItemGeneral') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cart/page/sw-settings-cart/sw-settings-cart.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cart/page/sw-settings-cart/sw-settings-cart.html.twig
@@ -15,7 +15,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-cart.general.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/page/sw-settings-country-list/sw-settings-country-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/page/sw-settings-country-list/sw-settings-country-list.html.twig
@@ -21,7 +21,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-country.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-list/sw-settings-currency-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-list/sw-settings-currency-list.html.twig
@@ -27,7 +27,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-currency.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-list/sw-settings-custom-field-set-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-list/sw-settings-custom-field-set-list.html.twig
@@ -17,7 +17,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-custom-field.set.list.textHeadline') }}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-list/sw-settings-customer-group-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-list/sw-settings-customer-group-list.html.twig
@@ -20,7 +20,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-customer-group.general.mainMenuItemGeneral') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/page/sw-settings-delivery-time-list/sw-settings-delivery-time-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/page/sw-settings-delivery-time-list/sw-settings-delivery-time-list.html.twig
@@ -9,7 +9,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-delivery-time.list.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-list/sw-settings-document-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-list/sw-settings-document-list.html.twig
@@ -20,7 +20,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-document.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig
@@ -23,7 +23,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-language.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing/sw-settings-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing/sw-settings-listing.html.twig
@@ -19,7 +19,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-listing.general.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig
@@ -20,7 +20,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-logging.list.title') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-login-registration/page/sw-settings-login-registration/sw-settings-login-registration.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-login-registration/page/sw-settings-login-registration/sw-settings-login-registration.html.twig
@@ -15,7 +15,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-login-registration.general.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig
@@ -9,7 +9,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-mailer.general.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.html.twig
@@ -6,7 +6,7 @@
         <h2>{{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-media.general.title') }} </h2>
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-newsletter/page/sw-settings-newsletter/sw-settings-newsletter.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-newsletter/page/sw-settings-newsletter/sw-settings-newsletter.html.twig
@@ -15,7 +15,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-newsletter.general.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/sw-settings-number-range-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/sw-settings-number-range-list.html.twig
@@ -21,7 +21,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-number-range.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-list/sw-settings-product-feature-sets-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-list/sw-settings-product-feature-sets-list.html.twig
@@ -21,7 +21,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-product-feature-sets.list.textHeadline') }}
             {% endblock %}
         </h2>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.html.twig
@@ -21,7 +21,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-rule.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-list/sw-settings-salutation-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-list/sw-settings-salutation-list.html.twig
@@ -20,7 +20,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-salutation.general.mainMenuItemGeneral') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/page/sw-settings-search/sw-settings-search.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/page/sw-settings-search/sw-settings-search.html.twig
@@ -7,7 +7,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-search.general.mainMenuItemGeneral') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/page/sw-settings-seo/sw-settings-seo.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/page/sw-settings-seo/sw-settings-seo.html.twig
@@ -9,7 +9,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-seo.general.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.html.twig
@@ -20,7 +20,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-shipping.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-index/sw-settings-shopware-updates-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-index/sw-settings-shopware-updates-index.html.twig
@@ -9,7 +9,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-shopware-updates.general.emptyTitle') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-sitemap/page/sw-settings-sitemap/sw-settings-sitemap.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-sitemap/page/sw-settings-sitemap/sw-settings-sitemap.html.twig
@@ -15,7 +15,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-sitemap.general.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.html.twig
@@ -19,7 +19,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-snippet.general.mainMenuItemGeneral') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-state-machine/page/sw-settings-state-machine-list/sw-settings-state-machine-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-state-machine/page/sw-settings-state-machine-list/sw-settings-state-machine-list.html.twig
@@ -8,7 +8,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-state-machine.general.mainMenuItemGeneral') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-store/page/sw-settings-store/sw-settings-store.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-store/page/sw-settings-store/sw-settings-store.html.twig
@@ -15,7 +15,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-store.general.textHeadline') }}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tag/page/sw-settings-tag-list/sw-settings-tag-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tag/page/sw-settings-tag-list/sw-settings-tag-list.html.twig
@@ -20,7 +20,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-tag.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-list/sw-settings-tax-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-list/sw-settings-tax-list.html.twig
@@ -20,7 +20,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             /> {{ $tc('sw-settings-tax.list.textHeadline') }}
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-units/page/sw-settings-units-list/sw-settings-units.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-units/page/sw-settings-units-list/sw-settings-units.html.twig
@@ -9,7 +9,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-units.general.mainMenuItemGeneral') }}
         </h2>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/page/sw-settings-usage-data/sw-settings-usage-data.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/page/sw-settings-usage-data/sw-settings-usage-data.html.twig
@@ -9,12 +9,12 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings.index.tabSystem') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-settings-usage-data.general.textHeadline') }}
         </h2>

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions/sw-users-permissions.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions/sw-users-permissions.html.twig
@@ -7,7 +7,7 @@
             {{ $tc('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
-                size="16px"
+                size="12px"
             />
             {{ $tc('sw-users-permissions.general.label') }}
             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/9224

### 2. What does this change do, exactly?

Fix the sizes, see:

<img width="548" alt="Bildschirmfoto 2025-05-16 um 13 31 23" src="https://github.com/user-attachments/assets/9a60f6cb-61d3-4ad7-9b19-0460125ce4ba" />
<img width="517" alt="Bildschirmfoto 2025-05-16 um 13 31 26" src="https://github.com/user-attachments/assets/f2a4acc3-39e0-4b5f-8acf-5a095b346ff9" />
<img width="658" alt="Bildschirmfoto 2025-05-16 um 13 31 35" src="https://github.com/user-attachments/assets/16b8eb82-ca00-4b92-bab8-1133749121b1" />
<img width="455" alt="Bildschirmfoto 2025-05-16 um 13 31 38" src="https://github.com/user-attachments/assets/eb6b5835-c49f-457a-a501-4a38a29ca5fe" />
