### PR TITLE
fix: add backward compatibility for old button variants

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/index.ts
@@ -23,11 +23,28 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         buttonProps(button: buttonProps) {
+            // eslint-disable-next-line max-len
+            type buttonVariantsWithFallback = 'ghost' | 'primary' | 'secondary' | 'critical' | 'action' | 'ghost-danger' | 'danger' | 'contrast' | 'context';
+
+            // Convert deprecated button variants to new ones
+            const variantMap: Record<string, buttonVariantsWithFallback> = {
+                ghost: 'secondary',
+                danger: 'critical',
+                'ghost-danger': 'critical',
+                contrast: 'secondary',
+                context: 'action',
+            };
+
+            const originalVariant = button.variant ?? 'primary';
+            const mappedVariant = variantMap[originalVariant] ?? originalVariant;
+            const isGhost = ['ghost', 'ghost-danger'].includes(originalVariant);
+
             return {
                 method: button.method ?? ((): undefined => undefined),
                 label: button.label ?? '',
-                size: button.size ?? '',
-                variant: button.variant ?? '',
+                size: button.size ?? 'small',
+                variant: mappedVariant,
+                ghost: isGhost,
                 square: button.square ?? false,
             };
         },


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/9483

### 2. What does this change do, exactly?

Convert old variant names to new variants. Also add a default size:
<img width="1137" alt="Bildschirmfoto 2025-05-16 um 15 27 35" src="https://github.com/user-attachments/assets/da5dd06a-927f-42ea-bc05-32488fd04e88" />

