### PR TITLE
feat: changed file_exists to suitable is_dir/is_file

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -9,7 +9,7 @@ $_SERVER['SCRIPT_FILENAME'] = __FILE__;
 
 require_once __DIR__ . '/../vendor/autoload_runtime.php';
 
-if (!file_exists(__DIR__ . '/../.env') && !file_exists(__DIR__ . '/../.env.dist') && !file_exists(__DIR__ . '/../.env.local.php')) {
+if (!is_file(__DIR__ . '/../.env') && !is_file(__DIR__ . '/../.env.dist') && !is_file(__DIR__ . '/../.env.local.php')) {
     $_SERVER['APP_RUNTIME_OPTIONS']['disable_dotenv'] = true;
 }
 
@@ -18,7 +18,7 @@ $_SERVER['APP_RUNTIME_OPTIONS']['prod_envs'] = ['prod', 'e2e'];
 return function (array $context) {
     $classLoader = require __DIR__ . '/../vendor/autoload.php';
 
-    if (!file_exists(dirname(__DIR__) . '/install.lock')) {
+    if (!is_file(dirname(__DIR__) . '/install.lock')) {
         $baseURL = str_replace(basename(__FILE__), '', $_SERVER['SCRIPT_NAME']);
         $baseURL = rtrim($baseURL, '/');
 
@@ -32,7 +32,7 @@ return function (array $context) {
         header('Content-type: text/html; charset=utf-8', true, 503);
         header('Status: 503 Service Temporarily Unavailable');
         header('Retry-After: 1200');
-        if (file_exists(__DIR__ . '/maintenance.html')) {
+        if (is_file(__DIR__ . '/maintenance.html')) {
             readfile(__DIR__ . '/maintenance.html');
         } else {
             readfile(__DIR__ . '/recovery/update/maintenance.html');
@@ -44,7 +44,7 @@ return function (array $context) {
     $appEnv = $context['APP_ENV'] ?? 'dev';
     $debug = (bool) ($context['APP_DEBUG'] ?? ($appEnv !== 'prod'));
 
-    if (!file_exists(dirname(__DIR__) . '/install.lock')) {
+    if (!is_file(dirname(__DIR__) . '/install.lock')) {
         return new InstallerKernel($appEnv, $debug);
     }
 

--- a/src/Administration/Command/DeleteExtensionLocalPublicFilesCommand.php
+++ b/src/Administration/Command/DeleteExtensionLocalPublicFilesCommand.php
@@ -44,11 +44,11 @@ class DeleteExtensionLocalPublicFilesCommand extends Command
                 continue;
             }
 
-            if (file_exists($bundlePath . '/Resources/public/administration/css')) {
+            if (\is_dir($bundlePath . '/Resources/public/administration/css')) {
                 touch($bundle->getPath() . '/Resources/.administration-css');
             }
 
-            if (file_exists($bundlePath . '/Resources/public/administration/js')) {
+            if (\is_dir($bundlePath . '/Resources/public/administration/js')) {
                 touch($bundle->getPath() . '/Resources/.administration-js');
             }
 

--- a/src/Administration/Framework/Twig/ViteFileAccessorDecorator.php
+++ b/src/Administration/Framework/Twig/ViteFileAccessorDecorator.php
@@ -43,7 +43,7 @@ class ViteFileAccessorDecorator extends FileAccessor
             return false;
         }
 
-        return $this->filesystem->exists($bundle->getPath() . $this->getRelativeFileLocation($fileType));
+        return \is_file($bundle->getPath() . $this->getRelativeFileLocation($fileType));
     }
 
     /**
@@ -97,7 +97,7 @@ class ViteFileAccessorDecorator extends FileAccessor
         if (!isset($this->content[$bundle->getName()][$fileType])) {
             $viteEntryPointsPath = $bundle->getPath() . $this->getRelativeFileLocation($fileType);
 
-            if (!$this->filesystem->exists($viteEntryPointsPath)) {
+            if (!\is_file($viteEntryPointsPath)) {
                 return $this->content[$bundle->getName()][$fileType] = [];
             }
 

--- a/src/Administration/Snippet/SnippetFinder.php
+++ b/src/Administration/Snippet/SnippetFinder.php
@@ -56,12 +56,12 @@ class SnippetFinder implements SnippetFinderInterface
 
         foreach ($activePlugins as $plugin) {
             $pluginPath = $plugin->getPath() . '/Resources/app/administration/src';
-            if (file_exists($pluginPath)) {
+            if (\is_dir($pluginPath)) {
                 $paths[] = $pluginPath;
             }
 
             $meteorPluginPath = $plugin->getPath() . '/Resources/app/meteor-app';
-            if (file_exists($meteorPluginPath)) {
+            if (\is_dir($meteorPluginPath)) {
                 $paths[] = $meteorPluginPath;
             }
         }
@@ -94,12 +94,12 @@ class SnippetFinder implements SnippetFinderInterface
             $meteorBundlePath = $bundle->getPath() . '/Resources/app/meteor-app';
 
             // Add the bundle path if it exists
-            if (file_exists($bundlePath)) {
+            if (\is_dir($bundlePath)) {
                 $paths[] = $bundlePath;
             }
 
             // Add the meteor bundle path if it exists
-            if (file_exists($meteorBundlePath)) {
+            if (\is_dir($meteorBundlePath)) {
                 $paths[] = $meteorBundlePath;
             }
         }

--- a/src/Core/Checkout/Document/Service/DocumentMerger.php
+++ b/src/Core/Checkout/Document/Service/DocumentMerger.php
@@ -249,7 +249,7 @@ final class DocumentMerger
         } catch (IOException $e) {
             throw DocumentException::cannotReadZipFile($tempFile, $e);
         } finally {
-            if ($this->filesystem->exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 $this->filesystem->remove($tempFile);
             }
         }

--- a/src/Core/DevOps/Docs/ArrayWriter.php
+++ b/src/Core/DevOps/Docs/ArrayWriter.php
@@ -14,7 +14,7 @@ class ArrayWriter
 
     public function __construct(private readonly string $path)
     {
-        if (file_exists($path)) {
+        if (\is_file($path)) {
             $this->data = (array) require $path;
         }
     }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/AclValidPermissionsHelper.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/AclValidPermissionsHelper.php
@@ -44,7 +44,7 @@ class AclValidPermissionsHelper
 
     public function __construct(string $schemaPath = self::SCHEMA_FILE)
     {
-        if (!file_exists($schemaPath)) {
+        if (!\is_file($schemaPath)) {
             return;
         }
 

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoFileExistsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoFileExistsRule.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @implements Rule<FuncCall>
+ *
+ * @internal
+ */
+#[Package('framework')]
+class NoFileExistsRule implements Rule
+{
+    public const FILE_EXISTS_INFORMATION = 'The method file_exists is inefficient. Additionally, it cannot distinguish between files and directories. Use is_dir or is_file instead.';
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    /**
+     * @return array<array-key, RuleError|string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof FuncCall || !$node->name instanceof Name) {
+            return [];
+        }
+
+        if ($node->name->toString() !== 'file_exists') {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(\sprintf('Avoid using file_exists. %s', self::FILE_EXISTS_INFORMATION))
+                ->identifier('shopware.fileExists')
+                ->build(),
+        ];
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoFilesystemExistsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoFilesystemExistsRule.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @implements Rule<MethodCall>
+ *
+ * @internal
+ */
+#[Package('framework')]
+class NoFilesystemExistsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @return array<array-key, RuleError|string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof MethodCall || !$node->name instanceof Identifier) {
+            return [];
+        }
+
+        if ($node->name->toString() !== 'exists') {
+            return [];
+        }
+
+        $calledOnType = $scope->getType($node->var);
+
+        if (!$calledOnType->isObject()->yes()) {
+            return [];
+        }
+
+        $classNames = $calledOnType->getObjectClassNames();
+        if (!\in_array(Filesystem::class, $classNames, true)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(\sprintf('Avoid using exists of %s which uses file_exists. %s', Filesystem::class, NoFileExistsRule::FILE_EXISTS_INFORMATION))
+                ->identifier('shopware.fileExists')
+                ->build(),
+        ];
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
@@ -8,6 +8,8 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoFlowEventAwareExtendsRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoFlowStoreFunctionRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoEnvironmentHelperInsideCompilerPassRule
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoFileExistsRule
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoFilesystemExistsRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoSuperGlobalsInsideCompilerPassRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoDALAutoload
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\DALFieldsMustBeRegisteredWithSchemaBuilder

--- a/src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
+++ b/src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
@@ -9,20 +9,20 @@ use Symfony\Component\Dotenv\Dotenv;
 
 if (!\defined('TEST_PROJECT_DIR')) {
     \define('TEST_PROJECT_DIR', (function (): string {
-        if (isset($_SERVER['PROJECT_ROOT']) && file_exists($_SERVER['PROJECT_ROOT'])) {
+        if (isset($_SERVER['PROJECT_ROOT']) && \is_dir($_SERVER['PROJECT_ROOT'])) {
             return $_SERVER['PROJECT_ROOT'];
         }
 
-        if (isset($_ENV['PROJECT_ROOT']) && file_exists($_ENV['PROJECT_ROOT'])) {
+        if (isset($_ENV['PROJECT_ROOT']) && \is_dir($_ENV['PROJECT_ROOT'])) {
             return $_ENV['PROJECT_ROOT'];
         }
 
-        if (file_exists('vendor') && (file_exists('.env') || file_exists('.env.dist'))) {
+        if (\is_dir('vendor') && (\is_file('.env') || \is_file('.env.dist'))) {
             return (string) getcwd();
         }
 
         $dir = $rootDir = __DIR__;
-        while (!file_exists($dir . '/vendor')) {
+        while (!\is_dir($dir . '/vendor')) {
             if ($dir === \dirname($dir)) {
                 return $rootDir;
             }
@@ -36,7 +36,7 @@ if (!\defined('TEST_PROJECT_DIR')) {
 $_ENV['PROJECT_ROOT'] = $_SERVER['PROJECT_ROOT'] = TEST_PROJECT_DIR;
 $classLoader = require TEST_PROJECT_DIR . '/vendor/autoload.php';
 
-if (class_exists(Dotenv::class) && (file_exists(TEST_PROJECT_DIR . '/.env.local.php') || file_exists(TEST_PROJECT_DIR . '/.env') || file_exists(TEST_PROJECT_DIR . '/.env.dist'))) {
+if (class_exists(Dotenv::class) && (\is_file(TEST_PROJECT_DIR . '/.env.local.php') || \is_file(TEST_PROJECT_DIR . '/.env') || \is_file(TEST_PROJECT_DIR . '/.env.dist'))) {
     (new Dotenv())->usePutenv()->bootEnv(TEST_PROJECT_DIR . '/.env');
 }
 

--- a/src/Core/DevOps/Test/Command/MakeCoverageTestCommand.php
+++ b/src/Core/DevOps/Test/Command/MakeCoverageTestCommand.php
@@ -82,7 +82,7 @@ class MakeCoverageTestCommand extends Command
             $folderPath = $testPath . '/' . implode('/', $namespaceParts);
             $testFileName = $folderPath . '/' . $reflection->getShortName() . 'Test.php';
 
-            if ($this->filesystem->exists($testFileName)) {
+            if (\is_file($testFileName)) {
                 $io->note(\sprintf('Test file %s already exists', $testFileName));
 
                 continue;
@@ -185,7 +185,7 @@ class MakeCoverageTestCommand extends Command
     {
         $class = str_replace('"', '', $rawClass);
 
-        if (str_ends_with($class, '.php') && $this->filesystem->exists($class)) {
+        if (str_ends_with($class, '.php') && \is_file($class)) {
             $content = (string) file_get_contents($class);
             preg_match('/namespace\s+([^;]+);/', $content, $matches);
             $namespace = $matches[1] ?? '';

--- a/src/Core/Framework/Adapter/Asset/AssetInstallCommand.php
+++ b/src/Core/Framework/Adapter/Asset/AssetInstallCommand.php
@@ -56,7 +56,7 @@ class AssetInstallCommand extends Command
 
         $publicDir = $this->kernel->getProjectDir() . '/public/';
 
-        if (!file_exists($publicDir . '/.htaccess') && file_exists($publicDir . '/.htaccess.dist')) {
+        if (!\is_file($publicDir . '/.htaccess') && \is_file($publicDir . '/.htaccess.dist')) {
             $io->writeln('Copying .htaccess.dist to .htaccess');
             copy($publicDir . '/.htaccess.dist', $publicDir . '/.htaccess');
         }

--- a/src/Core/Framework/Adapter/Kernel/KernelFactory.php
+++ b/src/Core/Framework/Adapter/Kernel/KernelFactory.php
@@ -85,7 +85,7 @@ class KernelFactory
         $dir = $r->getFileName();
 
         $dir = $rootDir = \dirname($dir);
-        while (!file_exists($dir . '/vendor')) {
+        while (!\is_dir($dir . '/vendor')) {
             if ($dir === \dirname($dir)) {
                 return $rootDir;
             }

--- a/src/Core/Framework/Adapter/Twig/NamespaceHierarchy/BundleHierarchyBuilder.php
+++ b/src/Core/Framework/Adapter/Twig/NamespaceHierarchy/BundleHierarchyBuilder.php
@@ -32,7 +32,7 @@ class BundleHierarchyBuilder implements TemplateNamespaceHierarchyBuilderInterfa
 
             $directory = $bundlePath . '/Resources/views';
 
-            if (!file_exists($directory)) {
+            if (!\is_dir($directory)) {
                 continue;
             }
 

--- a/src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+++ b/src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
@@ -271,7 +271,7 @@ class DumpClassSchemaCommand extends Command
 
     private function getFilePath(string $className): string
     {
-        if (!file_exists($this->schemaPath)) {
+        if (!\is_dir($this->schemaPath)) {
             if (!mkdir($concurrentDirectory = $this->schemaPath, 0777, true) && !is_dir($concurrentDirectory)) {
                 throw ApiException::directoryWasNotCreated($concurrentDirectory);
             }

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -29,7 +29,6 @@ use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -60,7 +59,6 @@ class InfoController extends AbstractController
         private readonly ApiRouteInfoResolver $apiRouteInfoResolver,
         private readonly InAppPurchase $inAppPurchase,
         private readonly ?ViteFileAccessorDecorator $viteFileAccessorDecorator,
-        private readonly Filesystem $filesystem,
         private readonly ShopIdProvider $shopIdProvider,
         private readonly StatsService $messageStatsService,
     ) {
@@ -304,7 +302,7 @@ class InfoController extends AbstractController
             return $bundle->getAdminBaseUrl();
         }
 
-        if (!$this->filesystem->exists($bundle->getPath() . '/Resources/public/meteor-app/index.html')) {
+        if (!\is_file($bundle->getPath() . '/Resources/public/meteor-app/index.html')) {
             return null;
         }
 

--- a/src/Core/Framework/App/Command/CreateAppCommand.php
+++ b/src/Core/Framework/App/Command/CreateAppCommand.php
@@ -299,7 +299,7 @@ class CreateAppCommand extends Command
      */
     private function createApp(string $appDirectory, array $details, bool $createThemeConfig): void
     {
-        if (file_exists($appDirectory)) {
+        if (\is_dir($appDirectory)) {
             throw AppException::directoryAlreadyExists($details['name']);
         }
 

--- a/src/Core/Framework/App/Command/ValidateAppCommand.php
+++ b/src/Core/Framework/App/Command/ValidateAppCommand.php
@@ -99,7 +99,7 @@ class ValidateAppCommand extends Command
      */
     private function getManifestsFromDir(string $dir): array
     {
-        if (!file_exists($dir)) {
+        if (!\is_dir($dir)) {
             throw new ManifestNotFoundException($dir);
         }
 

--- a/src/Core/Framework/App/Lifecycle/AppLoader.php
+++ b/src/Core/Framework/App/Lifecycle/AppLoader.php
@@ -55,7 +55,7 @@ class AppLoader
      */
     private function loadFromAppDir(): array
     {
-        if (!file_exists($this->appDir)) {
+        if (!\is_dir($this->appDir)) {
             return [];
         }
 

--- a/src/Core/Framework/App/Validation/ConfigValidator.php
+++ b/src/Core/Framework/App/Validation/ConfigValidator.php
@@ -59,7 +59,7 @@ class ConfigValidator extends AbstractManifestValidator
     {
         $configPath = \sprintf('%s/Resources/config/config.xml', $appFolder);
 
-        if (!file_exists($configPath)) {
+        if (!\is_file($configPath)) {
             return [];
         }
 

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -23,7 +23,6 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\Bundle as SymfonyBundle;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
@@ -67,7 +66,7 @@ abstract class Bundle extends SymfonyBundle
     {
         $confDir = $this->getPath() . '/Resources/config';
 
-        if (file_exists($confDir)) {
+        if (\is_dir($confDir)) {
             $routes->import($confDir . '/{routes}/*' . Kernel::CONFIG_EXTS, 'glob');
             $routes->import($confDir . '/{routes}/' . $environment . '/**/*' . Kernel::CONFIG_EXTS, 'glob');
             $routes->import($confDir . '/{routes}' . Kernel::CONFIG_EXTS, 'glob');
@@ -85,10 +84,9 @@ abstract class Bundle extends SymfonyBundle
 
     public function configureRouteOverwrites(RoutingConfigurator $routes, string $environment): void
     {
-        $fileSystem = new Filesystem();
         $confDir = $this->getPath() . '/Resources/config';
 
-        if ($fileSystem->exists($confDir)) {
+        if (\is_dir($confDir)) {
             $routes->import($confDir . '/{routes_overwrite}' . Kernel::CONFIG_EXTS, 'glob');
         }
     }
@@ -112,7 +110,7 @@ abstract class Bundle extends SymfonyBundle
     {
         $migrationPath = $this->getMigrationPath();
 
-        if (!is_dir($migrationPath)) {
+        if (!\is_dir($migrationPath)) {
             return;
         }
 

--- a/src/Core/Framework/Changelog/Command/ChangelogCheckCommand.php
+++ b/src/Core/Framework/Changelog/Command/ChangelogCheckCommand.php
@@ -40,7 +40,7 @@ class ChangelogCheckCommand extends Command
         $IOHelper->title('Check the validation of changelog files');
 
         $path = $input->getArgument('changelog') ?: '';
-        if (\is_string($path) && $path !== '' && !file_exists($path)) {
+        if (\is_string($path) && $path !== '' && !\is_file($path)) {
             $IOHelper->error('The given file NOT found');
 
             return self::FAILURE;

--- a/src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
@@ -138,7 +138,7 @@ class ChangelogProcessor
 
     protected function existedRelease(string $version): bool
     {
-        return $this->filesystem->exists($this->getTargetReleaseDir($version));
+        return \is_dir($this->getTargetReleaseDir($version));
     }
 
     protected function getTargetReleaseDir(string $version, bool $realPath = true): string

--- a/src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
@@ -167,7 +167,7 @@ class ChangelogReleaseCreator extends ChangelogProcessor
 
         $upgradeFile = $this->getTargetUpgradeFile($version);
         if (!$dryRun) {
-            if (!$this->filesystem->exists($upgradeFile)) {
+            if (!\is_file($upgradeFile)) {
                 $this->filesystem->touch($upgradeFile);
             }
 
@@ -223,7 +223,7 @@ class ChangelogReleaseCreator extends ChangelogProcessor
 
         $upgradeFile = $this->getTargetNextMajorUpgradeFile($version);
         if (!$dryRun) {
-            if (!$this->filesystem->exists($upgradeFile)) {
+            if (!\is_file($upgradeFile)) {
                 $this->filesystem->touch($upgradeFile);
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateEntitiesCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateEntitiesCommand.php
@@ -37,7 +37,7 @@ class CreateEntitiesCommand extends Command
         $io = new ShopwareStyle($input, $output);
         $io->title('DAL generate schema');
 
-        if (!file_exists($this->dir)) {
+        if (!\is_dir($this->dir)) {
             mkdir($this->dir);
         }
 
@@ -58,7 +58,7 @@ class CreateEntitiesCommand extends Command
                     continue;
                 }
 
-                if (!file_exists($this->dir . '/' . $domain)) {
+                if (!\is_dir($this->dir . '/' . $domain)) {
                     mkdir($this->dir . '/' . $domain);
                 }
 

--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php
@@ -74,7 +74,7 @@ class CreateHydratorCommand extends Command
         $io = new ShopwareStyle($input, $output);
         $io->title('DAL generate hydrators');
 
-        if (!file_exists($this->dir)) {
+        if (!\is_dir($this->dir)) {
             mkdir($this->dir);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateMigrationCommand.php
@@ -99,7 +99,7 @@ class CreateMigrationCommand extends Command
 
         $directory = $bundle->getMigrationPath();
 
-        if (!$this->filesystem->exists($directory)) {
+        if (!\is_dir($directory)) {
             $this->filesystem->mkdir($directory);
         }
 

--- a/src/Core/Framework/DependencyInjection/api.xml
+++ b/src/Core/Framework/DependencyInjection/api.xml
@@ -173,7 +173,6 @@
             <argument type="service" id="Shopware\Core\Framework\Api\Route\ApiRouteInfoResolver"/>
             <argument type="service" id="Shopware\Core\Framework\Store\InAppPurchase"/>
             <argument type="service" id="Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator" on-invalid="null"/>
-            <argument type="service" id="filesystem"/>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
             <argument type="service" id="Shopware\Core\Framework\MessageQueue\Stats\StatsService"/>
 

--- a/src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
@@ -30,7 +30,7 @@ class RefreshMigrationCommand extends Command
 
         $output->writeln('Updating timestamp of migration: ' . $filename);
 
-        if (!file_exists($path)) {
+        if (!\is_file($path)) {
             throw MigrationException::migrationFileDoesNotExist($path);
         }
 

--- a/src/Core/Framework/Plugin/BundleConfigGenerator.php
+++ b/src/Core/Framework/Plugin/BundleConfigGenerator.php
@@ -118,7 +118,7 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
 
     private function isTheme(string $path): bool
     {
-        return file_exists($path . '/Resources/theme.json');
+        return \is_file($path . '/Resources/theme.json');
     }
 
     private function getEntryFile(string $rootPath, string $componentPath): ?string
@@ -126,8 +126,13 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
         $path = trim($componentPath, '/');
         $absolutePath = $rootPath . '/' . $path;
 
-        return file_exists($absolutePath . '/main.ts') ? $path . '/main.ts'
-            : (file_exists($absolutePath . '/main.js') ? $path . '/main.js' : null);
+        foreach (['js', 'ts'] as $type) {
+            if (\is_file($absolutePath . '/main.' . $type)) {
+                return $path . '/main.' . $type;
+            }
+        }
+
+        return null;
     }
 
     private function getWebpackConfig(string $rootPath, string $componentPath): ?string
@@ -136,10 +141,10 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
         $absolutePath = $rootPath . '/' . $path;
 
         $configFileName = match (true) {
-            file_exists($absolutePath . '/build/webpack.config.ts') => 'webpack.config.ts',
-            file_exists($absolutePath . '/build/webpack.config.cts') => 'webpack.config.cts',
-            file_exists($absolutePath . '/build/webpack.config.js') => 'webpack.config.js',
-            file_exists($absolutePath . '/build/webpack.config.cjs') => 'webpack.config.cjs',
+            \is_file($absolutePath . '/build/webpack.config.ts') => 'webpack.config.ts',
+            \is_file($absolutePath . '/build/webpack.config.cts') => 'webpack.config.cts',
+            \is_file($absolutePath . '/build/webpack.config.js') => 'webpack.config.js',
+            \is_file($absolutePath . '/build/webpack.config.cjs') => 'webpack.config.cjs',
             default => null,
         };
 

--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -109,7 +109,7 @@ class PluginCreateCommand extends Command
         } catch (\Throwable $exception) {
             $io->error($exception->getMessage());
 
-            if (isset($directory) && $this->filesystem->exists($directory)) {
+            if (isset($directory) && \is_dir($directory)) {
                 $this->filesystem->remove($directory);
             }
 

--- a/src/Core/Framework/Plugin/PluginExtractor.php
+++ b/src/Core/Framework/Plugin/PluginExtractor.php
@@ -131,7 +131,7 @@ class PluginExtractor
     private function findOldFile(string $destination, string $pluginName): string
     {
         $dir = $destination . \DIRECTORY_SEPARATOR . $pluginName;
-        if ($this->filesystem->exists($dir)) {
+        if (\is_dir($dir)) {
             return $dir;
         }
 

--- a/src/Core/Framework/Plugin/Util/ZipUtils.php
+++ b/src/Core/Framework/Plugin/Util/ZipUtils.php
@@ -14,7 +14,7 @@ class ZipUtils
     {
         $stream = new \ZipArchive();
 
-        if (!file_exists($filename)) {
+        if (!\is_file($filename)) {
             throw PluginException::cannotExtractNoSuchFile($filename);
         }
 

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestShipsVendorDirectory/vendor/composer/ClassLoader.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestShipsVendorDirectory/vendor/composer/ClassLoader.php
@@ -503,7 +503,7 @@ class ClassLoader
                 if (isset($this->prefixDirsPsr4[$search])) {
                     $pathEnd = DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $lastPos + 1);
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {
-                        if (file_exists($file = $dir . $pathEnd)) {
+                        if (\is_file($file = $dir . $pathEnd)) {
                             return $file;
                         }
                     }
@@ -513,7 +513,7 @@ class ClassLoader
 
         // PSR-4 fallback dirs
         foreach ($this->fallbackDirsPsr4 as $dir) {
-            if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr4)) {
+            if (\is_file($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr4)) {
                 return $file;
             }
         }
@@ -532,7 +532,7 @@ class ClassLoader
             foreach ($this->prefixesPsr0[$first] as $prefix => $dirs) {
                 if (0 === strpos($class, $prefix)) {
                     foreach ($dirs as $dir) {
-                        if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
+                        if (\is_file($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
                             return $file;
                         }
                     }
@@ -542,7 +542,7 @@ class ClassLoader
 
         // PSR-0 fallback dirs
         foreach ($this->fallbackDirsPsr0 as $dir) {
-            if (file_exists($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
+            if (\is_file($file = $dir . DIRECTORY_SEPARATOR . $logicalPathPsr0)) {
                 return $file;
             }
         }

--- a/src/Core/Framework/Update/Services/UpdateHtaccess.php
+++ b/src/Core/Framework/Update/Services/UpdateHtaccess.php
@@ -38,7 +38,7 @@ class UpdateHtaccess implements EventSubscriberInterface
 
     public function update(): void
     {
-        if (!file_exists($this->htaccessPath) || !file_exists($this->htaccessPath . '.dist')) {
+        if (!\is_file($this->htaccessPath) || !\is_file($this->htaccessPath . '.dist')) {
             return;
         }
 

--- a/src/Core/Framework/Util/Filesystem.php
+++ b/src/Core/Framework/Util/Filesystem.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Util;
 
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem as Io;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
@@ -26,19 +27,29 @@ class Filesystem
 
     public function has(string ...$path): bool
     {
-        return $this->io->exists(Path::join($this->location, ...$path));
+        $path = $this->path(...$path);
+
+        return \is_dir($path) || \is_file($path);
     }
 
     public function hasFile(string ...$path): bool
     {
-        $path = Path::join($this->location, ...$path);
+        $path = $this->path(...$path);
 
-        return $this->io->exists($path) && !is_dir($path);
+        return \is_file($path);
     }
 
     public function path(string ...$path): string
     {
-        return Path::join($this->location, ...$path);
+        $maxPathLength = \PHP_MAXPATHLEN - 2;
+
+        $path = Path::join($this->location, ...$path);
+
+        if (\strlen($path) > $maxPathLength) {
+            throw new IOException(\sprintf('Could not check if file exist because path length exceeds %d characters.', $maxPathLength), 0, null, $path);
+        }
+
+        return $path;
     }
 
     public function realpath(string ...$path): string
@@ -47,7 +58,7 @@ class Filesystem
             throw UtilException::cannotFindFileInFilesystem(Path::join(...$path), $this->location);
         }
 
-        return (string) realpath(Path::join($this->location, ...$path));
+        return (string) realpath($this->path(...$path));
     }
 
     public function read(string ...$path): string
@@ -56,7 +67,7 @@ class Filesystem
             throw UtilException::cannotFindFileInFilesystem(Path::join(...$path), $this->location);
         }
 
-        return (string) file_get_contents(Path::join($this->location, ...$path));
+        return (string) file_get_contents($this->path(...$path));
     }
 
     /**
@@ -68,7 +79,7 @@ class Filesystem
     public function findFiles(string $name, string $in): array
     {
         $finder = new Finder();
-        $finder->in(Path::join($this->location, $in))
+        $finder->in($this->path($in))
             ->files()
             ->name($name);
 

--- a/src/Core/Installer/Configuration/EnvConfigWriter.php
+++ b/src/Core/Installer/Configuration/EnvConfigWriter.php
@@ -77,7 +77,7 @@ EOT;
         $secret = Key::createNewRandomKey()->saveToAsciiSafeString();
 
         // Copy flex default .env if missing
-        if (!file_exists($this->projectDir . '/.env')) {
+        if (!\is_file($this->projectDir . '/.env')) {
             $template = str_replace(
                 [
                     'SECRET_PLACEHOLDER',
@@ -124,7 +124,7 @@ EOT;
 
         $htaccessPath = $this->projectDir . '/public/.htaccess';
 
-        if (file_exists($htaccessPath . '.dist') && !file_exists($htaccessPath)) {
+        if (\is_file($htaccessPath . '.dist') && !\is_file($htaccessPath)) {
             $perms = fileperms($htaccessPath . '.dist');
             copy($htaccessPath . '.dist', $htaccessPath);
 

--- a/src/Core/Installer/Database/MigrationCollectionFactory.php
+++ b/src/Core/Installer/Database/MigrationCollectionFactory.php
@@ -48,15 +48,15 @@ class MigrationCollectionFactory
 
     private function createMigrationSource(string $version): MigrationSource
     {
-        if (file_exists($this->projectDir . '/platform/src/Core/schema.sql')) {
+        if (\is_file($this->projectDir . '/platform/src/Core/schema.sql')) {
             $coreBasePath = $this->projectDir . '/platform/src/Core';
             $storefrontBasePath = $this->projectDir . '/platform/src/Storefront';
             $adminBasePath = $this->projectDir . '/platform/src/Administration';
-        } elseif (file_exists($this->projectDir . '/src/Core/schema.sql')) {
+        } elseif (\is_file($this->projectDir . '/src/Core/schema.sql')) {
             $coreBasePath = $this->projectDir . '/src/Core';
             $storefrontBasePath = $this->projectDir . '/src/Storefront';
             $adminBasePath = $this->projectDir . '/src/Administration';
-        } elseif (file_exists($this->projectDir . '/vendor/shopware/platform/src/Core/schema.sql')) {
+        } elseif (\is_file($this->projectDir . '/vendor/shopware/platform/src/Core/schema.sql')) {
             $coreBasePath = $this->projectDir . '/vendor/shopware/platform/src/Core';
             $storefrontBasePath = $this->projectDir . '/vendor/shopware/platform/src/Storefront';
             $adminBasePath = $this->projectDir . '/vendor/shopware/platform/src/Administration';

--- a/src/Core/Installer/Finish/UniqueIdGenerator.php
+++ b/src/Core/Installer/Finish/UniqueIdGenerator.php
@@ -19,10 +19,8 @@ class UniqueIdGenerator
 
     public function getUniqueId(): string
     {
-        if (file_exists($this->cacheFilePath)) {
-            if ($id = file_get_contents($this->cacheFilePath)) {
-                return $id;
-            }
+        if (\is_file($this->cacheFilePath) && $id = file_get_contents($this->cacheFilePath)) {
+            return $id;
         }
 
         $uniqueId = $this->generateUniqueId();

--- a/src/Core/Installer/InstallerKernel.php
+++ b/src/Core/Installer/InstallerKernel.php
@@ -73,12 +73,12 @@ class InstallerKernel extends HttpKernel
 
         /** @var string $dir */
         $dir = $r->getFileName();
-        if (!file_exists($dir)) {
+        if (!\is_file($dir)) {
             throw new \LogicException(\sprintf('Cannot auto-detect project dir for kernel of class "%s".', $r->name));
         }
 
         $dir = $rootDir = \dirname($dir);
-        while (!file_exists($dir . '/vendor')) {
+        while (!\is_dir($dir . '/vendor')) {
             if ($dir === \dirname($dir)) {
                 return $rootDir;
             }

--- a/src/Core/Installer/Requirements/FilesystemRequirementsValidator.php
+++ b/src/Core/Installer/Requirements/FilesystemRequirementsValidator.php
@@ -13,7 +13,7 @@ use Shopware\Core\Installer\Requirements\Struct\RequirementsCheckCollection;
 #[Package('framework')]
 class FilesystemRequirementsValidator implements RequirementsValidatorInterface
 {
-    private const NEEDED_PATHS = [
+    private const NEEDED_DIRECTORY_PATHS = [
         '.',
         'var/log/',
         'var/cache/',
@@ -27,7 +27,7 @@ class FilesystemRequirementsValidator implements RequirementsValidatorInterface
 
     public function validateRequirements(RequirementsCheckCollection $checks): RequirementsCheckCollection
     {
-        foreach (self::NEEDED_PATHS as $path) {
+        foreach (self::NEEDED_DIRECTORY_PATHS as $path) {
             $absolutePath = $this->projectDir . '/' . $path;
 
             $checks->add(new PathCheck(
@@ -41,6 +41,6 @@ class FilesystemRequirementsValidator implements RequirementsValidatorInterface
 
     private function existsAndIsWritable(string $path): bool
     {
-        return file_exists($path) && is_readable($path) && is_writable($path);
+        return \is_dir($path) && \is_readable($path) && \is_writable($path);
     }
 }

--- a/src/Core/Maintenance/System/Command/SystemInstallCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemInstallCommand.php
@@ -61,7 +61,7 @@ class SystemInstallCommand extends Command
         $_ENV['BLUE_GREEN_DEPLOYMENT'] = $isBlueGreen;
         putenv('BLUE_GREEN_DEPLOYMENT=' . $isBlueGreen);
 
-        if (!$input->getOption('force') && file_exists($this->projectDir . '/install.lock')) {
+        if (!$input->getOption('force') && \is_file($this->projectDir . '/install.lock')) {
             $output->comment('install.lock already exists. Delete it or pass --force to do it anyway.');
 
             return self::FAILURE;
@@ -163,8 +163,8 @@ class SystemInstallCommand extends Command
 
         $result = $this->runCommands($commands, $output);
 
-        if (!file_exists($this->projectDir . '/public/.htaccess')
-            && file_exists($this->projectDir . '/public/.htaccess.dist')
+        if (!\is_file($this->projectDir . '/public/.htaccess')
+            && \is_file($this->projectDir . '/public/.htaccess.dist')
         ) {
             copy($this->projectDir . '/public/.htaccess.dist', $this->projectDir . '/public/.htaccess');
         }

--- a/src/Core/Maintenance/System/Command/SystemSetupCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemSetupCommand.php
@@ -113,14 +113,14 @@ class SystemSetupCommand extends Command
 
         $io = new SymfonyStyle($input, $output);
 
-        if (file_exists($this->projectDir . '/symfony.lock')) {
+        if (\is_file($this->projectDir . '/symfony.lock')) {
             $io->warning('It looks like you have installed Shopware with Symfony Flex. You should use a .env.local file instead of creating a complete new one');
         }
 
         $io->title('Shopware setup process');
         $io->text('This tool will setup your instance.');
 
-        if (!$input->getOption('force') && file_exists($this->projectDir . '/.env')) {
+        if (!$input->getOption('force') && \is_file($this->projectDir . '/.env')) {
             $io->comment('Instance has already been set-up. To start over, please delete your .env file.');
 
             return Command::SUCCESS;

--- a/src/Core/Service/ServiceSourceResolver.php
+++ b/src/Core/Service/ServiceSourceResolver.php
@@ -63,9 +63,11 @@ class ServiceSourceResolver implements Source
 
         $name = $app instanceof Manifest ? $app->getMetadata()->getName() : $app->getName();
 
+        $appPath = Path::join($temporaryDirectory, $name);
+
         // app is already on the filesystem, use that
-        if ($this->io->exists(Path::join($temporaryDirectory, $name))) {
-            return new Filesystem(Path::join($temporaryDirectory, $name));
+        if ($this->io->exists($appPath)) {
+            return new Filesystem($appPath);
         }
 
         /** @var ServiceSourceConfig $sourceConfig */

--- a/src/Core/System/CustomEntity/CustomEntityLifecycleService.php
+++ b/src/Core/System/CustomEntity/CustomEntityLifecycleService.php
@@ -65,7 +65,7 @@ class CustomEntityLifecycleService
     private function getXmlSchema(string $pathToCustomEntityFile): ?CustomEntityXmlSchema
     {
         $filePath = Path::join($pathToCustomEntityFile, CustomEntityXmlSchema::FILENAME);
-        if (!file_exists($filePath)) {
+        if (!\is_file($filePath)) {
             return null;
         }
 
@@ -79,7 +79,7 @@ class CustomEntityLifecycleService
     {
         $configPath = Path::join($pathToCustomEntityFile, 'config', AdminUiXmlSchema::FILENAME);
 
-        if (!file_exists($configPath)) {
+        if (!\is_file($configPath)) {
             return null;
         }
 

--- a/src/Storefront/Framework/Captcha/BasicCaptcha/BasicCaptchaGenerator.php
+++ b/src/Storefront/Framework/Captcha/BasicCaptcha/BasicCaptchaGenerator.php
@@ -4,7 +4,6 @@ namespace Shopware\Storefront\Framework\Captcha\BasicCaptcha;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
-use Symfony\Component\Filesystem\Filesystem;
 
 #[Package('framework')]
 class BasicCaptchaGenerator extends AbstractBasicCaptchaGenerator
@@ -20,9 +19,7 @@ class BasicCaptchaGenerator extends AbstractBasicCaptchaGenerator
     {
         $code = $this->createCaptchaCode($length);
 
-        $filesystem = new Filesystem();
-
-        if ($filesystem->exists($this->backgroundPath)) {
+        if (\is_file($this->backgroundPath)) {
             /** @var \GdImage $img */
             $img = imagecreatefrompng($this->backgroundPath);
         } else {
@@ -32,7 +29,7 @@ class BasicCaptchaGenerator extends AbstractBasicCaptchaGenerator
         }
 
         $codeColor = (int) imagecolorallocate($img, 0, 0, 0);
-        if ($filesystem->exists($this->fontPath)) {
+        if (\is_file($this->fontPath)) {
             imagettftext($img, 45, 0, 80, 55, $codeColor, $this->fontPath, $code);
         } else {
             imagestring($img, 5, 100, 20, $code, $codeColor);

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -64,7 +64,7 @@ class ThemeCreateCommand extends Command
 
         $directory = \sprintf('%s/custom/%splugins/%s', $this->projectDir, $staticPrefix, $pluginName);
 
-        if (file_exists($directory)) {
+        if (\is_dir($directory)) {
             $io->error(\sprintf('Plugin directory %s already exists', $directory));
 
             return self::FAILURE;

--- a/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+++ b/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
@@ -135,7 +135,7 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
 
         $scriptPath = $path . \sprintf('/Resources/app/storefront/dist/storefront/js/%s/%s.js', $assetName, $assetName);
 
-        if (file_exists($scriptPath)) {
+        if (\is_file($scriptPath)) {
             $config->setScriptFiles(FileCollection::createFromArray([$this->stripBasePath($scriptPath, $path . '/Resources')]));
 
             return $config;
@@ -148,7 +148,7 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
     {
         $pathname = $path . \DIRECTORY_SEPARATOR . 'Resources/theme.json';
 
-        if (!file_exists($pathname)) {
+        if (!\is_file($pathname)) {
             throw new InvalidThemeBundleException($name);
         }
 
@@ -191,11 +191,11 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
     {
         $path = rtrim($path, '/') . '/Resources/app/storefront/src';
 
-        if (file_exists($path . '/main.ts')) {
+        if (\is_file($path . '/main.ts')) {
             return 'app/storefront/src/main.ts';
         }
 
-        if (file_exists($path . '/main.js')) {
+        if (\is_file($path . '/main.js')) {
             return 'app/storefront/src/main.js';
         }
 

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -144,12 +144,12 @@ class ThemeCompiler implements ThemeCompilerInterface
                     $filename = basename($originalPath);
                     $extension = $this->getImportFileExtension(pathinfo($filename, \PATHINFO_EXTENSION));
                     $path = $dirname . \DIRECTORY_SEPARATOR . $filename . $extension;
-                    if (file_exists($path)) {
+                    if (\is_file($path)) {
                         return $path;
                     }
 
                     $path = $dirname . \DIRECTORY_SEPARATOR . '_' . $filename . $extension;
-                    if (file_exists($path)) {
+                    if (\is_file($path)) {
                         return $path;
                     }
                 }
@@ -193,8 +193,9 @@ class ThemeCompiler implements ThemeCompilerInterface
 
             $targetPath = $themePath . '/js/' . $folderName;
             foreach ($files as $file) {
-                if (file_exists($file->getRealPath())) {
-                    $copyFiles[] = new CopyBatchInput($file->getRealPath(), [$targetPath . '/' . $file->getFilename()], $this->themeFilesystemConfig['visibility'] ?? Visibility::PUBLIC);
+                $filePath = $file->getRealPath();
+                if ($filePath) {
+                    $copyFiles[] = new CopyBatchInput($filePath, [$targetPath . '/' . $file->getFilename()], $this->themeFilesystemConfig['visibility'] ?? Visibility::PUBLIC);
                 }
             }
         }

--- a/src/Storefront/Theme/ThemeFileResolver.php
+++ b/src/Storefront/Theme/ThemeFileResolver.php
@@ -115,7 +115,7 @@ class ThemeFileResolver
         foreach ($files as $file) {
             $filepath = $file->getFilepath();
             if (!$this->isInclude($filepath)) {
-                if (file_exists($filepath)) {
+                if (\is_file($filepath)) {
                     $resolvedFiles->add($file);
 
                     continue;

--- a/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php
@@ -376,6 +376,6 @@ class DocumentMergerTest extends TestCase
 
         $zip->close();
         $filesystem->remove($tempFile);
-        static::assertFalse($filesystem->exists($tempFile), 'temporary zip file should have been deleted');
+        static::assertFalse(\is_file($tempFile), 'temporary zip file should have been deleted');
     }
 }

--- a/tests/integration/Core/Content/ImportExport/AbstractImportExportTestCase.php
+++ b/tests/integration/Core/Content/ImportExport/AbstractImportExportTestCase.php
@@ -340,7 +340,7 @@ abstract class AbstractImportExportTestCase extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }

--- a/tests/integration/Core/Content/ImportExport/ImportExportTest.php
+++ b/tests/integration/Core/Content/ImportExport/ImportExportTest.php
@@ -814,8 +814,8 @@ SWTEST;1;' . $productName . ';9.35;10;0c17372fe6aa46059a97fc28b40f46c4;7;7%%;%s'
         $filesystem->dumpFile(__DIR__ . '/fixtures/' . $csvFileName, $csvContent);
 
         try {
-            static::assertTrue($filesystem->exists($this->projectDir . self::PUBLIC_MEDIA_PATH . '/' . $imageName));
-            static::assertTrue($filesystem->exists(__DIR__ . '/fixtures/' . $csvFileName));
+            static::assertTrue(\is_file($this->projectDir . self::PUBLIC_MEDIA_PATH . '/' . $imageName));
+            static::assertTrue(\is_file(__DIR__ . '/fixtures/' . $csvFileName));
 
             $progress = $this->import(
                 $context,

--- a/tests/integration/Core/Content/ImportExport/Service/MappingServiceTest.php
+++ b/tests/integration/Core/Content/ImportExport/Service/MappingServiceTest.php
@@ -161,7 +161,7 @@ class MappingServiceTest extends TestCase
             static::assertSame($key, $mapping->getKey(), $testCase);
         }
 
-        if (file_exists($filePath)) {
+        if (\is_file($filePath)) {
             unlink($filePath);
         }
     }

--- a/tests/integration/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/integration/Core/Content/Media/File/FileSaverTest.php
@@ -82,7 +82,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }
@@ -125,7 +125,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }
@@ -166,7 +166,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }
@@ -210,7 +210,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }
@@ -254,7 +254,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }
@@ -302,7 +302,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }
@@ -342,7 +342,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }
@@ -663,7 +663,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }
@@ -709,7 +709,7 @@ class FileSaverTest extends TestCase
                 $context
             );
         } finally {
-            if (file_exists($tempFile)) {
+            if (\is_file($tempFile)) {
                 unlink($tempFile);
             }
         }

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -414,7 +414,6 @@ class InfoControllerTest extends TestCase
                 $kernel,
                 new Filesystem(),
             ),
-            new Filesystem(),
             static::getContainer()->get(ShopIdProvider::class),
             $this->createMock(StatsService::class),
         );
@@ -486,7 +485,6 @@ class InfoControllerTest extends TestCase
                 $kernel,
                 new Filesystem(),
             ),
-            new Filesystem(),
             static::getContainer()->get(ShopIdProvider::class),
             $this->createMock(StatsService::class),
         );

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -85,9 +85,9 @@ class PluginManagementServiceTest extends TestCase
     {
         $this->getPluginManagementService()->extractPluginZip(self::PLUGIN_ZIP_FIXTURE_PATH);
 
-        $extractedPlugin = $this->filesystem->exists(self::PLUGIN_FASHION_THEME_PATH);
-        $extractedPluginBaseClass = $this->filesystem->exists(self::PLUGIN_FASHION_THEME_BASE_CLASS_PATH);
-        $pluginZipExists = $this->filesystem->exists(self::PLUGIN_ZIP_FIXTURE_PATH);
+        $extractedPlugin = \is_dir(self::PLUGIN_FASHION_THEME_PATH);
+        $extractedPluginBaseClass = \is_file(self::PLUGIN_FASHION_THEME_BASE_CLASS_PATH);
+        $pluginZipExists = \is_file(self::PLUGIN_ZIP_FIXTURE_PATH);
         static::assertTrue($extractedPlugin);
         static::assertTrue($extractedPluginBaseClass);
         static::assertFalse($pluginZipExists);
@@ -97,9 +97,9 @@ class PluginManagementServiceTest extends TestCase
     {
         $this->getPluginManagementService()->extractPluginZip(self::PLUGIN_ZIP_FIXTURE_PATH, false);
 
-        $extractedPlugin = $this->filesystem->exists(self::PLUGIN_FASHION_THEME_PATH);
-        $extractedPluginBaseClass = $this->filesystem->exists(self::PLUGIN_FASHION_THEME_BASE_CLASS_PATH);
-        $pluginZipExists = $this->filesystem->exists(self::PLUGIN_ZIP_FIXTURE_PATH);
+        $extractedPlugin = \is_dir(self::PLUGIN_FASHION_THEME_PATH);
+        $extractedPluginBaseClass = \is_file(self::PLUGIN_FASHION_THEME_BASE_CLASS_PATH);
+        $pluginZipExists = \is_file(self::PLUGIN_ZIP_FIXTURE_PATH);
         static::assertTrue($extractedPlugin);
         static::assertTrue($extractedPluginBaseClass);
         static::assertTrue($pluginZipExists);

--- a/tests/integration/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeCompilerTest.php
@@ -406,7 +406,7 @@ PHP_EOL;
         $projectDir = static::getContainer()->getParameter('kernel.project_dir');
         $testFolder = $projectDir . '/bla';
 
-        if (!file_exists($testFolder)) {
+        if (!\is_dir($testFolder)) {
             mkdir($testFolder);
         }
 

--- a/tests/unit/Core/Checkout/Document/Service/DocumentMergerTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentMergerTest.php
@@ -263,7 +263,6 @@ class DocumentMergerTest extends TestCase
         $fpdi->method('setSourceFile')->willThrowException(new FpdiException('PDF merge failed'));
 
         $filesystem = $this->createMock(Filesystem::class);
-        $filesystem->method('exists')->willReturn(true);
         $filesystem->method('readFile')->willReturn('zip file content');
         $filesystem->expects($this->once())->method('remove');
 
@@ -310,7 +309,6 @@ class DocumentMergerTest extends TestCase
         $filesystem->expects($this->once())
             ->method('readFile')
             ->willThrowException(new IOException('Failed to read file'));
-        $filesystem->expects($this->once())->method('exists')->willReturn(true);
         $filesystem->expects($this->once())->method('remove');
 
         $this->expectException(DocumentException::class);

--- a/tests/unit/Core/Content/Media/File/FileFetcherTest.php
+++ b/tests/unit/Core/Content/Media/File/FileFetcherTest.php
@@ -210,11 +210,11 @@ class FileFetcherTest extends TestCase
 
     private function deleteTemporyData(): void
     {
-        if (file_exists(self::TEMP_FILE)) {
+        if (\is_file(self::TEMP_FILE)) {
             unlink(self::TEMP_FILE);
         }
 
-        if (is_dir(self::TEMP_DIR)) {
+        if (\is_dir(self::TEMP_DIR)) {
             static::assertTrue(rmdir(self::TEMP_DIR));
         }
     }

--- a/tests/unit/Core/DevOps/Test/Command/MakeCoverageTestCommandTest.php
+++ b/tests/unit/Core/DevOps/Test/Command/MakeCoverageTestCommandTest.php
@@ -66,8 +66,8 @@ class MakeCoverageTestCommandTest extends TestCase
 
         static::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/Test/Command/not-a-classTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/NotAClassTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/DevOps/Test/Command/not-a-classTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/DevOps/NotAClassTest.php'));
     }
 
     public function testExecute(): void
@@ -105,27 +105,27 @@ class MakeCoverageTestCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $tester->getStatusCode());
-        static::assertTrue($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/System/Command/SystemDumpDatabaseCommandTest.php'));
-        static::assertTrue($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/DevOpsTest.php'));
-        static::assertTrue($fileSystem->exists($this->projectDir . '/tests/migration/Core/V6_5/Migration1670854818RemoveEventActionTableTest.php'));
+        static::assertTrue(\is_file($this->projectDir . '/tests/unit/Core/DevOps/System/Command/SystemDumpDatabaseCommandTest.php'));
+        static::assertTrue(\is_file($this->projectDir . '/tests/unit/Core/DevOps/DevOpsTest.php'));
+        static::assertTrue(\is_file($this->projectDir . '/tests/migration/Core/V6_5/Migration1670854818RemoveEventActionTableTest.php'));
         static::assertIsString($devOpsTest = file_get_contents($this->projectDir . '/tests/unit/Core/DevOps/DevOpsTest.php'));
         static::assertIsString($migrationTest = file_get_contents($this->projectDir . '/tests/migration/Core/V6_5/Migration1670854818RemoveEventActionTableTest.php'));
         static::assertSame($this->getDevOpsTestTemplate(), $devOpsTest);
         static::assertSame($this->getMigrationTestTemplate(), $migrationTest);
 
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/Test/Command/not-a-classTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Framework/ShopwareExceptionTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/NotAClassTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/System/Command/OpenApiValidationCommandTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Framework/ShopwareHttpExceptionTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Checkout/Cart/Event/CheckoutOrderPlacedEventTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Framework/Adapter/Twig/functionsTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Framework/Adapter/Twig/BundleFixtureTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Content/Product/ProductCollectionTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Content/Product/ProductDefinitionTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Content/Product/ProductEntityTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Checkout/Document/Struct/DocumentGenerateOperationTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/DevOps/Test/Command/not-a-classTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Framework/ShopwareExceptionTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/DevOps/NotAClassTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/DevOps/System/Command/OpenApiValidationCommandTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Framework/ShopwareHttpExceptionTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Checkout/Cart/Event/CheckoutOrderPlacedEventTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Framework/Adapter/Twig/functionsTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Framework/Adapter/Twig/BundleFixtureTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Content/Product/ProductCollectionTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Content/Product/ProductDefinitionTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Content/Product/ProductEntityTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Checkout/Document/Struct/DocumentGenerateOperationTest.php'));
 
         // execute again to test if the file is not rewrite
         $tester->execute([
@@ -144,16 +144,16 @@ class MakeCoverageTestCommandTest extends TestCase
 
         static::assertSame(Command::SUCCESS, $tester->getStatusCode());
 
-        static::assertTrue($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/System/Command/SystemDumpDatabaseCommandTest.php'));
-        static::assertTrue($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/DevOpsTest.php'));
-        static::assertTrue($fileSystem->exists($this->projectDir . '/tests/migration/Core/V6_5/Migration1670854818RemoveEventActionTableTest.php'));
+        static::assertTrue(\is_file($this->projectDir . '/tests/unit/Core/DevOps/System/Command/SystemDumpDatabaseCommandTest.php'));
+        static::assertTrue(\is_file($this->projectDir . '/tests/unit/Core/DevOps/DevOpsTest.php'));
+        static::assertTrue(\is_file($this->projectDir . '/tests/migration/Core/V6_5/Migration1670854818RemoveEventActionTableTest.php'));
 
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/Test/Command/not-a-classTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Framework/ShopwareExceptionTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/NotAClassTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/DevOps/System/Command/OpenApiValidationCommandTest.php'));
-        static::assertFalse($fileSystem->exists($this->projectDir . '/tests/unit/Core/Framework/ShopwareHttpExceptionTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/DevOps/Test/Command/not-a-classTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Framework/ShopwareExceptionTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/DevOps/NotAClassTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/DevOps/System/Command/OpenApiValidationCommandTest.php'));
+        static::assertFalse(\is_file($this->projectDir . '/tests/unit/Core/Framework/ShopwareHttpExceptionTest.php'));
     }
 
     private function getDevOpsTestTemplate(): string

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -224,7 +224,6 @@ class InfoControllerTest extends TestCase
                 $kernel,
                 new Filesystem(),
             ),
-            new Filesystem(),
             $this->shopIdProvider,
             $this->statsService,
         );

--- a/tests/unit/Core/Framework/App/Flow/Action/AppFlowActionLoadedSubscriberTest.php
+++ b/tests/unit/Core/Framework/App/Flow/Action/AppFlowActionLoadedSubscriberTest.php
@@ -33,7 +33,7 @@ class AppFlowActionLoadedSubscriberTest extends TestCase
         $iconPath = __DIR__ . '/../../Manifest/_fixtures/icon.png';
 
         $fileIcon = '';
-        if (file_exists($iconPath)) {
+        if (\is_file($iconPath)) {
             $fileIcon = \file_get_contents($iconPath);
         }
 

--- a/tests/unit/Core/Framework/App/Source/RemoteZipTest.php
+++ b/tests/unit/Core/Framework/App/Source/RemoteZipTest.php
@@ -176,7 +176,6 @@ class RemoteZipTest extends TestCase
         $fs->method('exists')
             ->with($dirFactory->path() . '/TestApp')
             ->willReturn(false);
-
         $source = new RemoteZip(
             $dirFactory,
             $downloader,

--- a/tests/unit/Core/Framework/Plugin/PluginTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginTest.php
@@ -29,7 +29,7 @@ class PluginTest extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        if (file_exists(self::$symlinkedSwagTestPluginPath) && is_link(self::$symlinkedSwagTestPluginPath)) {
+        if (\is_dir(self::$symlinkedSwagTestPluginPath) && \is_link(self::$symlinkedSwagTestPluginPath)) {
             unlink(self::$symlinkedSwagTestPluginPath);
         }
     }

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -54,8 +54,8 @@ class KernelTest extends TestCase
             'Container',
         );
 
-        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
-        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
+        static::assertTrue(\is_file($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
+        static::assertTrue(\is_file($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
     }
 
     public function testDumpContainerDoesNotDumpPreloadFileIfWarmupCacheDirIsGiven(): void
@@ -73,10 +73,10 @@ class KernelTest extends TestCase
             'Container',
         );
 
-        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
+        static::assertTrue(\is_file($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
 
         // Do not create the preload file in warmup cache
-        static::assertFalse($this->filesystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
+        static::assertFalse(\is_file($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
     }
 
     private function createKernel(): Kernel

--- a/tests/unit/Storefront/Framework/Twig/Extension/IconCacheTwigFilterTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Extension/IconCacheTwigFilterTest.php
@@ -113,7 +113,7 @@ class IconCacheTwigFilterTest extends TestCase
             $directory = $bundle->getPath() . '/Resources/views';
             $loader->addPath($directory);
             $loader->addPath($directory, $bundle->getName());
-            if (file_exists($directory . '/../app/storefront/dist')) {
+            if (\is_dir($directory . '/../app/storefront/dist')) {
                 $loader->addPath($directory . '/../app/storefront/dist', $bundle->getName());
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
#5913

### 2. What does this change do, exactly?
- Changed any usage of `file_exists` to `is_dir` or `is_file`
- Changed any usage of method `exists` of class `Symfony\Component\Filesystem\Filesystem` to `is_dir` or `is_file`
- Added new PHPStan rules to disallow function `file_exists` usage
- Added new PHPStan rules to disallow method `exists` usage of class `Symfony\Component\Filesystem\Filesystem`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
#5913

### 5. Checklist
- [ ] Co-authored by @M-arcus 


- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
