### PR TITLE
Make start-hot-reload.js more robust against unexpected requests

### DIFF
--- a/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
+++ b/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
@@ -83,7 +83,7 @@ const proxyOptions = {
                     return;
                 }
                 // we only replace things when the request is a document
-                const isDocumentRequest = req.headers['sec-fetch-dest'] === 'document' || req.headers.accept.indexOf('text/html') !== -1;
+                const isDocumentRequest = req.headers['sec-fetch-dest'] === 'document' || (req.headers.accept?.indexOf('text/html') ?? '') !== -1;
                 const isHtmlRequests = req.url.indexOf('widgets/menu/offcanvas') !== -1 || req.url.indexOf('checkout/offcanvas') !== -1;
 
                 if (isDocumentRequest || isHtmlRequests) {


### PR DESCRIPTION
Update the check for the "Accept" header, and allow it to be not preset, to prevent fatal errors from non-expected sources, like the chrome development tool.

### 1. Why is this change necessary?

With the latest version of Google Chrome, the dev server receives requests with a missing "Accept" header, once the Chrome web developer tool is open. These requests cause the webpack dev server to crash, as the current checks on the start-hot-reload.js assume the "Accept" header to be always present.


### 2. What does this change do, exactly?
This change allows for the "Accept" header to be NULL, without changing the underlying behavior of the webpack dev server.

### 3. Describe each step to reproduce the issue or behaviour.
Make sure, you have the lastest version of Google Chrome installed on your machine. Start the webpack dev sever via `. bin/watch-storefront.sh`. Try to navigate through the site.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
