### PR TITLE
fix: Link to first level nav items is not empty anymore

### DIFF
--- a/changelog/_unreleased/2025-05-19-fix-first-level-nav-bar-links.md
+++ b/changelog/_unreleased/2025-05-19-fix-first-level-nav-bar-links.md
@@ -1,0 +1,6 @@
+---
+title: Fix first level nav bar links
+issue: 9557
+---
+# Storefront
+* Changed `navbar.html.twig` to use `seoUrl` twig function instead of the `seoLink`prop that is not available on 6.7.0.0, thus the links to the navbar items should be generated correctly.

--- a/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
@@ -63,9 +63,9 @@
                                     {% else %}
                                         <li class="nav-item nav-item-{{ id }} {% if hasChildren %}dropdown position-static{% endif %}">
                                             <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2{% if hasChildren %} dropdown-toggle{% endif %}"
-                                               href="{{ category.seoLink }}"
+                                               href="{{ seoUrl('frontend.navigation.page', { navigationId: category.id }) }}"
                                                {% if hasChildren %}data-bs-toggle="dropdown"{% endif %}
-                                               {% if category.shouldOpenInNewTab %}target="_blank"{% endif %}
+                                               {% if category_linknewtab(category) %}target="_blank"{% endif %}
                                                itemprop="url"
                                                title="{{ name }}">
                                                 <span itemprop="name" class="main-navigation-link-text">{{ name }}</span>


### PR DESCRIPTION

The backport here: https://github.com/shopware/shopware/pull/9358 relied on props that are only available in trunk but not 6.7.0.0 (by design)

The PR that added those props to trunk is here: https://github.com/shopware/shopware/pull/8383