### PR TITLE
refactor: Simplify category loaded subscriber

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2749,9 +2749,3 @@ parameters:
 			message: "#^Expected domain exception class Shopware\\\\Core\\\\Framework\\\\Notification\\\\NotificationException, got Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiException$#"
 			count: 2
 			path: src/Core/Framework/Notification/Api/NotificationController.php
-
-		-
-			message: '#^Parameter \#1 \$event of method Shopware\\Core\\Content\\Category\\Subscriber\\CategorySubscriber\:\:categoryLoaded\(\) expects Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityLoadedEvent\<Shopware\\Core\\Content\\Category\\CategoryEntity\>, Shopware\\Core\\System\\SalesChannel\\Entity\\SalesChannelEntityLoadedEvent\<Shopware\\Core\\Content\\Category\\SalesChannel\\SalesChannelCategoryEntity\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/unit/Core/Content/Category/Subscriber/CategorySubscriberTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2749,3 +2749,9 @@ parameters:
 			message: "#^Expected domain exception class Shopware\\\\Core\\\\Framework\\\\Notification\\\\NotificationException, got Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiException$#"
 			count: 2
 			path: src/Core/Framework/Notification/Api/NotificationController.php
+
+		-
+			message: '#^Parameter \#1 \$event of method Shopware\\Core\\Content\\Category\\Subscriber\\CategorySubscriber\:\:categoryLoaded\(\) expects Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityLoadedEvent\<Shopware\\Core\\Content\\Category\\CategoryEntity\>, Shopware\\Core\\System\\SalesChannel\\Entity\\SalesChannelEntityLoadedEvent\<Shopware\\Core\\Content\\Category\\SalesChannel\\SalesChannelCategoryEntity\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/unit/Core/Content/Category/Subscriber/CategorySubscriberTest.php

--- a/src/Core/Content/Category/Subscriber/CategorySubscriber.php
+++ b/src/Core/Content/Category/Subscriber/CategorySubscriber.php
@@ -37,7 +37,7 @@ class CategorySubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param EntityLoadedEvent<CategoryEntity> $event
+     * @param EntityLoadedEvent<covariant CategoryEntity> $event
      */
     public function categoryLoaded(EntityLoadedEvent $event): void
     {

--- a/src/Core/Content/Category/Subscriber/CategorySubscriber.php
+++ b/src/Core/Content/Category/Subscriber/CategorySubscriber.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Category\Subscriber;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\CategoryEvents;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelCategoryEntity;
 use Shopware\Core\Content\Category\Service\AbstractCategoryUrlGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEvent;
 use Shopware\Core\Framework\Log\Package;
@@ -30,48 +31,52 @@ class CategorySubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CategoryEvents::CATEGORY_LOADED_EVENT => 'entityLoaded',
-            'sales_channel.' . CategoryEvents::CATEGORY_LOADED_EVENT => 'entityLoaded',
+            CategoryEvents::CATEGORY_LOADED_EVENT => 'categoryLoaded',
+            'sales_channel.' . CategoryEvents::CATEGORY_LOADED_EVENT => 'salesChannelCategoryLoaded',
         ];
     }
 
     /**
      * @param EntityLoadedEvent<CategoryEntity> $event
      */
-    public function entityLoaded(EntityLoadedEvent $event): void
+    public function categoryLoaded(EntityLoadedEvent $event): void
     {
-        $salesChannelId = $event instanceof SalesChannelEntityLoadedEvent ? $event->getSalesChannelContext()->getSalesChannelId() : null;
+        $systemDefaultLayout = $this->systemConfigService->getString(CategoryDefinition::CONFIG_KEY_DEFAULT_CMS_PAGE_CATEGORY);
 
         foreach ($event->getEntities() as $category) {
-            if ($event instanceof SalesChannelEntityLoadedEvent) {
-                $category->assign([
-                    'seoLink' => $this->categoryUrlGenerator->generate($category, $event->getSalesChannelContext()->getSalesChannel()),
-                ]);
+            if (!$category->getCmsPageId()) {
+                $category->setCmsPageId($systemDefaultLayout);
+                $category->setCmsPageIdSwitched(true);
             }
+        }
+    }
 
-            $categoryCmsPageId = $category->getCmsPageId();
+    /**
+     * @param SalesChannelEntityLoadedEvent<SalesChannelCategoryEntity> $event
+     */
+    public function salesChannelCategoryLoaded(SalesChannelEntityLoadedEvent $event): void
+    {
+        $salesChannel = $event->getSalesChannelContext()->getSalesChannel();
+        $salesChannelId = $salesChannel->getId();
 
-            // continue if cms page is given and was not set in the subscriber
-            if ($categoryCmsPageId !== null && !$category->getCmsPageIdSwitched()) {
+        $systemDefaultLayout = $this->systemConfigService->getString(CategoryDefinition::CONFIG_KEY_DEFAULT_CMS_PAGE_CATEGORY);
+        $salesChannelDefaultLayout = $this->systemConfigService->getString(CategoryDefinition::CONFIG_KEY_DEFAULT_CMS_PAGE_CATEGORY, $salesChannelId);
+
+        foreach ($event->getEntities() as $category) {
+            $category->assign([
+                'seoLink' => $this->categoryUrlGenerator->generate($category, $salesChannel),
+            ]);
+
+            if ($salesChannelDefaultLayout === '') {
                 continue;
             }
 
-            // continue if cms page is given and not the overall default
-            if ($categoryCmsPageId !== null && $categoryCmsPageId !== $this->systemConfigService->get(CategoryDefinition::CONFIG_KEY_DEFAULT_CMS_PAGE_CATEGORY)) {
+            // continue if layout is given and was not set in the `category.loaded` event and has not been modified in between
+            if ($category->getCmsPageId() !== null && (!$category->getCmsPageIdSwitched() || $category->getCmsPageId() !== $systemDefaultLayout)) {
                 continue;
             }
 
-            $userDefault = $this->systemConfigService->get(CategoryDefinition::CONFIG_KEY_DEFAULT_CMS_PAGE_CATEGORY, $salesChannelId);
-
-            // cms page is not given in system config
-            if ($userDefault === null) {
-                continue;
-            }
-
-            /** @var string $userDefault */
-            $category->setCmsPageId($userDefault);
-
-            // mark cms page as set in the subscriber
+            $category->setCmsPageId($salesChannelDefaultLayout);
             $category->setCmsPageIdSwitched(true);
         }
     }

--- a/src/Core/Content/Category/Subscriber/CategorySubscriber.php
+++ b/src/Core/Content/Category/Subscriber/CategorySubscriber.php
@@ -42,6 +42,9 @@ class CategorySubscriber implements EventSubscriberInterface
     public function categoryLoaded(EntityLoadedEvent $event): void
     {
         $systemDefaultLayout = $this->systemConfigService->getString(CategoryDefinition::CONFIG_KEY_DEFAULT_CMS_PAGE_CATEGORY);
+        if ($systemDefaultLayout === '') {
+            return;
+        }
 
         foreach ($event->getEntities() as $category) {
             if (!$category->getCmsPageId()) {

--- a/tests/unit/Core/Content/Category/Subscriber/CategorySubscriberTest.php
+++ b/tests/unit/Core/Content/Category/Subscriber/CategorySubscriberTest.php
@@ -29,8 +29,8 @@ class CategorySubscriberTest extends TestCase
     public function testHasEvents(): void
     {
         $expectedEvents = [
-            CategoryEvents::CATEGORY_LOADED_EVENT => 'entityLoaded',
-            'sales_channel.' . CategoryEvents::CATEGORY_LOADED_EVENT => 'entityLoaded',
+            CategoryEvents::CATEGORY_LOADED_EVENT => 'categoryLoaded',
+            'sales_channel.' . CategoryEvents::CATEGORY_LOADED_EVENT => 'salesChannelCategoryLoaded',
         ];
 
         static::assertSame($expectedEvents, CategorySubscriber::getSubscribedEvents());
@@ -46,14 +46,19 @@ class CategorySubscriberTest extends TestCase
     ): void {
         $categorySubscriber = new CategorySubscriber($systemConfigService, $this->createMock(CategoryUrlGenerator::class));
 
+        static::assertSame($cmsPageIdBeforeEvent, $categoryEntity->getCmsPageId());
+
         if ($salesChannelId) {
             $event = new SalesChannelEntityLoadedEvent(new CategoryDefinition(), [$categoryEntity], $this->getSalesChannelContext($salesChannelId));
+
+            $categorySubscriber->categoryLoaded($event);
+            $categorySubscriber->salesChannelCategoryLoaded($event);
         } else {
             $event = new EntityLoadedEvent(new CategoryDefinition(), [$categoryEntity], Context::createDefaultContext());
+
+            $categorySubscriber->categoryLoaded($event);
         }
 
-        static::assertSame($cmsPageIdBeforeEvent, $categoryEntity->getCmsPageId());
-        $categorySubscriber->entityLoaded($event);
         static::assertSame($cmsPageIdAfterEvent, $categoryEntity->getCmsPageId());
     }
 

--- a/tests/unit/Core/Content/Category/Subscriber/CategorySubscriberTest.php
+++ b/tests/unit/Core/Content/Category/Subscriber/CategorySubscriberTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\CategoryEvents;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelCategoryDefinition;
 use Shopware\Core\Content\Category\SalesChannel\SalesChannelCategoryEntity;
 use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
 use Shopware\Core\Content\Category\Subscriber\CategorySubscriber;
@@ -36,51 +37,57 @@ class CategorySubscriberTest extends TestCase
         static::assertSame($expectedEvents, CategorySubscriber::getSubscribedEvents());
     }
 
-    #[DataProvider('entityLoadedEventDataProvider')]
-    public function testEntityLoadedEvent(
+    #[DataProvider('categoryLoadedEventDataProvider')]
+    public function testCategoryLoadedEvent(
         SystemConfigService $systemConfigService,
         CategoryEntity $categoryEntity,
         ?string $cmsPageIdBeforeEvent,
-        ?string $cmsPageIdAfterEvent,
-        ?string $salesChannelId
+        ?string $cmsPageIdAfterEvent
     ): void {
         $categorySubscriber = new CategorySubscriber($systemConfigService, $this->createMock(CategoryUrlGenerator::class));
 
         static::assertSame($cmsPageIdBeforeEvent, $categoryEntity->getCmsPageId());
 
-        if ($salesChannelId) {
-            $event = new SalesChannelEntityLoadedEvent(new CategoryDefinition(), [$categoryEntity], $this->getSalesChannelContext($salesChannelId));
+        $event = new EntityLoadedEvent(new CategoryDefinition(), [$categoryEntity], Context::createDefaultContext());
+        $categorySubscriber->categoryLoaded($event);
 
-            $categorySubscriber->categoryLoaded($event);
-            $categorySubscriber->salesChannelCategoryLoaded($event);
-        } else {
-            $event = new EntityLoadedEvent(new CategoryDefinition(), [$categoryEntity], Context::createDefaultContext());
+        static::assertSame($cmsPageIdAfterEvent, $categoryEntity->getCmsPageId());
+    }
 
-            $categorySubscriber->categoryLoaded($event);
-        }
+    #[DataProvider('salesChannelCategoryLoadedEventDataProvider')]
+    public function testSalesChannelCategoryLoadedEvent(
+        SystemConfigService $systemConfigService,
+        SalesChannelCategoryEntity $categoryEntity,
+        ?string $cmsPageIdBeforeEvent,
+        ?string $cmsPageIdAfterEvent,
+        string $salesChannelId
+    ): void {
+        $categorySubscriber = new CategorySubscriber($systemConfigService, $this->createMock(CategoryUrlGenerator::class));
+
+        static::assertSame($cmsPageIdBeforeEvent, $categoryEntity->getCmsPageId());
+
+        $event = new SalesChannelEntityLoadedEvent(
+            new SalesChannelCategoryDefinition(),
+            [$categoryEntity],
+            $this->getSalesChannelContext($salesChannelId)
+        );
+
+        $categorySubscriber->categoryLoaded($event);
+        $categorySubscriber->salesChannelCategoryLoaded($event);
 
         static::assertSame($cmsPageIdAfterEvent, $categoryEntity->getCmsPageId());
     }
 
     /**
-     * @return array<string, array{SystemConfigService, CategoryEntity, string|null, string|null, string|null}>
+     * @return array<string, array{SystemConfigService, CategoryEntity, string|null, string|null}>
      */
-    public static function entityLoadedEventDataProvider(): iterable
+    public static function categoryLoadedEventDataProvider(): iterable
     {
         yield 'It does not set cms page id if already set by the user' => [
             self::getSystemConfigServiceMock(),
             self::getCategory('foobar', false),
             'foobar',
             'foobar',
-            null,
-        ];
-
-        yield 'It does not set cms page id if already set by the subscriber' => [
-            self::getSystemConfigServiceMock(null, 'cmsPageId'),
-            self::getCategory('differentCmsPageId', true, true),
-            'differentCmsPageId',
-            'differentCmsPageId',
-            'salesChannelId',
         ];
 
         yield 'It does not set if no default is given' => [
@@ -88,15 +95,35 @@ class CategorySubscriberTest extends TestCase
             self::getCategory(null, false),
             null,
             null,
-            null,
         ];
 
-        yield 'It uses overall default if no salesChannel is given' => [
+        yield 'It uses overall default' => [
             self::getSystemConfigServiceMock(null, 'cmsPageId'),
             self::getCategory(null, false),
             null,
             'cmsPageId',
-            null,
+        ];
+    }
+
+    /**
+     * @return array<string, array{SystemConfigService, CategoryEntity, string|null, string|null, string}>
+     */
+    public static function salesChannelCategoryLoadedEventDataProvider(): iterable
+    {
+        yield 'It does not set cms page id if already set by the user' => [
+            self::getSystemConfigServiceMock(),
+            self::getCategory('foobar', false, true),
+            'foobar',
+            'foobar',
+            'salesChannelId',
+        ];
+
+        yield 'It does not set cms page id if already set by the subscriber' => [
+            self::getSystemConfigServiceMock('salesChannelId', 'cmsPageId'),
+            self::getCategory('differentCmsPageId', true, true),
+            'differentCmsPageId',
+            'differentCmsPageId',
+            'salesChannelId',
         ];
 
         yield 'It uses salesChannel specific default' => [
@@ -105,6 +132,17 @@ class CategorySubscriberTest extends TestCase
             null,
             'salesChannelSpecificDefault',
             'salesChannelId',
+        ];
+
+        $systemConfigWithOnlyGlobalDefault = self::getSystemConfigServiceMock('nonExistentSalesChannel', 'foobar');
+        $systemConfigWithOnlyGlobalDefault->set(CategoryDefinition::CONFIG_KEY_DEFAULT_CMS_PAGE_CATEGORY, 'globalDefaultCmsPage');
+
+        yield 'It uses global default when no sales channel specific default is set' => [
+            $systemConfigWithOnlyGlobalDefault,
+            self::getCategory(null, false, true),
+            null,
+            'globalDefaultCmsPage',
+            'testSalesChannelId',
         ];
     }
 
@@ -127,6 +165,9 @@ class CategorySubscriberTest extends TestCase
         ]);
     }
 
+    /**
+     * @return ($salesChannelEntity is true ? SalesChannelCategoryEntity : CategoryEntity)
+     */
     private static function getCategory(?string $cmsPageId, bool $cmsPageIdSwitched, bool $salesChannelEntity = false): CategoryEntity
     {
         $category = new CategoryEntity();


### PR DESCRIPTION
### 1. Why is this change necessary?
The original subscriber has been historically grown, and was quite confusing regarding the layouts.

### 2. What does this change do, exactly?
Split the listeners up into two separate listeners and cleanup the implementation to make it more clear what is actually happening. Also do not load the configuration inside a loop.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
