### PR TITLE
fix: missing action buttons for extension warnings [6.7.0.0]

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.html.twig
@@ -3,6 +3,7 @@
     class="sw-extension-permissions-modal"
     :title="modalTitle"
     variant="small"
+    @modal-close="close"
 >
     {% block sw_extension_permissions_modal_content %}
     {% block sw_extension_permissions_modal_intro %}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
@@ -14,6 +14,13 @@
             variant="attention"
             :title="$tc('sw-app.component.sw-app-wrong-app-url-modal.title')"
         >
+            <div>
+                {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.explanation') }}
+            </div>
+
+            <div>
+                {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.textGetSupport') }}
+            </div>
 
             <mt-button
                 class="sw-app-wrong-app-url-modal__content-link-button"
@@ -30,13 +37,16 @@
             variant="attention"
             :title="$tc('sw-extension-store.component.sw-extension-my-extensions-listing.alertExtensionManagement.title')"
         >
-            <template #default>
-                <div>
-                    {{ $tc('sw-extension-store.component.sw-extension-my-extensions-listing.alertExtensionManagement.description') }}
-                </div>
-            </template>
+            <div>
+                {{ $tc('sw-extension-store.component.sw-extension-my-extensions-listing.alertExtensionManagement.description') }}
+            </div>
 
-            <!-- Slot "actions" was removed and has no replacement. -->
+            <mt-link
+                type="external"
+                href="https://developer.shopware.com/docs/guides/hosting/installation-updates/extension-managment.html"
+            >
+                {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.labelLearnMoreButton') }}
+            </mt-link>
         </mt-banner>
 
         {% block sw_extension_my_extensions_list_empty_state %}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.scss
@@ -28,6 +28,10 @@
         .sw-extension-my-extensions-listing__app-url-warning {
             max-width: 960px;
             margin-bottom: 32px;
+
+            .mt-button {
+                margin-top: 8px;
+            }
         }
 
         .sw-extension-my-extensions-listing__runtime-extension-warning {


### PR DESCRIPTION
Backport of #8065
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Action buttons/links got lost during the transition

### 2. What does this change do, exactly?

Add the actions back

### 3. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
fixes #8050
fixes #8983

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
