### PR TITLE
fix: Theme settings getting lost when navigating quickly

### DIFF
--- a/changelog/_unreleased/2025-05-20-added-reset-parameter-to-update-theme.md
+++ b/changelog/_unreleased/2025-05-20-added-reset-parameter-to-update-theme.md
@@ -1,0 +1,11 @@
+---
+title: Fix theme settings getting lost when navigating quickly
+issue: #9572
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: @amenk
+---
+
+# Storefront
+* Added new parameter `reset` to `\Shopware\Storefront\Theme\Controller\ThemeController::updateTheme()` which resets the theme.
+* Changed call in `sw-theme-manager-detail` to use the `reset` flag to run a reset and update in one step.

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
@@ -547,9 +547,7 @@ Component.register('sw-theme-manager-detail', {
             this.removeInheritedFromChangeset(allValues);
 
             // Theme has to be reset, because inherited fields needs to be removed from the set
-            return this.themeService.resetTheme(this.themeId).then(() => {
-                return this.themeService.updateTheme(this.themeId, { config: allValues });
-            });
+            return this.themeService.updateTheme(this.themeId, { config: allValues }, { reset: true });
         },
 
         saveFinish() {

--- a/src/Storefront/Theme/Controller/ThemeController.php
+++ b/src/Storefront/Theme/Controller/ThemeController.php
@@ -41,6 +41,10 @@ class ThemeController extends AbstractController
     {
         $config = $request->request->all('config');
 
+        if ($request->query->getBoolean('reset')) {
+            $this->themeService->resetTheme($themeId, $context);
+        }
+
         $this->themeService->updateTheme(
             $themeId,
             $config,


### PR DESCRIPTION
### 1. Why is this change necessary?

Theme settings can get lost when navigating away from the theme settings route to quickly 

### 2. What does this change do, exactly?

Before updating a theme, resetTheme was called. This now happens server side to make this more robust

### 3. Describe each step to reproduce the issue or behaviour.

1. throttle connection to 2G
2. save theme config
3. quickly navigate to sales channel config
4. updateTheme request fails, theme stays reset

### 4. Please link to the relevant issues (if any).
closes: #9572


### 5. Checklist

- [no, race condition too hard to reproduce] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [no, where?] I have written or adjusted the documentation according to my changes
- [it's obvious] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
