### PR TITLE
fix: type of promotionLineItem rule

### DIFF
--- a/changelog/_unreleased/2025-05-20-display-promotion-rule-as-line-item-rule.md
+++ b/changelog/_unreleased/2025-05-20-display-promotion-rule-as-line-item-rule.md
@@ -1,0 +1,8 @@
+---
+title: Display Promotion rule correctly as line item rule in Administration
+author: Max Stegmeyer
+author_email: m.stegmeyer@shopware.com
+author_github: @mstegmeyer
+---
+# Administration
+* Changed ConditionTypeDataProvider to correctly identify the rule `promotionLineItem` as a line item rule

--- a/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts
+++ b/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts
@@ -504,9 +504,9 @@ Application.addServiceProviderDecorator('ruleConditionDataProviderService', (rul
     });
 
     ruleConditionService.addCondition('promotionLineItem', {
-        component: 'sw-condition-generic',
+        component: 'sw-condition-generic-line-item',
         label: 'global.sw-condition.condition.promotionLineItemRule',
-        scopes: ['cart'],
+        scopes: ['lineItem'],
         group: 'promotion',
     });
 

--- a/src/Core/Checkout/Promotion/Rule/PromotionLineItemRule.php
+++ b/src/Core/Checkout/Promotion/Rule/PromotionLineItemRule.php
@@ -51,10 +51,6 @@ class PromotionLineItemRule extends Rule
         }
 
         foreach ($promotionLineItems as $lineItem) {
-            if ($lineItem->getPayloadValue('promotionId') === null) {
-                continue;
-            }
-
             if ($this->lineItemMatches($lineItem)) {
                 return true;
             }
@@ -88,11 +84,10 @@ class PromotionLineItemRule extends Rule
 
     private function lineItemMatches(LineItem $lineItem): bool
     {
-        if ($lineItem->getType() !== LineItem::PROMOTION_LINE_ITEM_TYPE) {
+        $promotionId = $lineItem->getPayloadValue('promotionId');
+        if ($lineItem->getType() !== LineItem::PROMOTION_LINE_ITEM_TYPE || $promotionId === null) {
             return $this->operator === self::OPERATOR_NEQ;
         }
-
-        $promotionId = $lineItem->getPayloadValue('promotionId');
 
         return RuleComparison::uuids([$promotionId], $this->identifiers, $this->operator);
     }

--- a/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
@@ -190,7 +190,7 @@ class PromotionLineItemRuleTest extends TestCase
             true,
         ];
 
-        yield 'one promotion does not matches' => [
+        yield 'one promotion does not match' => [
             ['matchedId', 'alsoMatchedId'],
             [
                 new LineItem('matchedId', LineItem::PRODUCT_LINE_ITEM_TYPE),


### PR DESCRIPTION
### 1. Why is this change necessary?
The negation of the operator of the rule `promotionLineItem` ("is none of") does not work as expected. For more details: #9450 

### 2. What does this change do, exactly?
For other line item rules, we have a "matches all line items" wrapper. This is not displayed for this. Therefore, I changed the type to show this "matches all"-selection.

### 3. Describe each step to reproduce the issue or behaviour.
- Create two promotions that are always active (ensure this maybe in the cart)
- Create a rule, that configures as "promotion" "is none of" "one of your promotions"
- Check the Symfony dev console, you can see that the rule does not match, because one of the promotion line items is not of the promotions
- After the change, we have the possibility to configure, whether "all" promotions may "not [be] one of" the selected promotions.

### 4. Please link to the relevant issues (if any).
fixes #9450

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
