### PR TITLE
fix: wrong margin when inline edit table

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -336,6 +336,10 @@
             .sw-data-grid__cell-content {
                 padding: 10px;
                 color: darken($color-gray-300, 10%);
+
+                .mt-field {
+                    margin-bottom: 0;
+                }
             }
 
             .sw-data-grid__cell-value {
@@ -482,6 +486,12 @@
         .sw-media-preview-v2 {
             width: 32px;
             height: 32px;
+        }
+
+        .is--inline-edit .sw-data-grid__cell-content {
+            .mt-block-field__block {
+                min-height: var(--scale-size-32);
+            }
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.scss
@@ -28,12 +28,4 @@ $sw-property-list-color-success: $color-emerald-500;
             }
         }
     }
-
-    .sw-data-grid__row {
-        &.is--inline-edit {
-            .mt-field {
-                margin-bottom: 0;
-            }
-        }
-    }
 }


### PR DESCRIPTION
### Description
Some place have wrong margin when inline edit table if we turn off compact mode.

Turn off compact mode in table here
![Screenshot 2025-05-20 at 16 36 31](https://github.com/user-attachments/assets/78390bc2-fec2-4025-922a-752f93a9d793)

Then have inline edit. Some place have issue 
![7e67506e-4b1a-403a-970e-9e23dd408453](https://github.com/user-attachments/assets/b3b82e4f-0ce8-4d1c-ab1a-c739e2c69f02)
![36ee71db-847e-4b6a-bb8b-52aebb5fbc63](https://github.com/user-attachments/assets/4951733b-4401-445a-a8cd-b1d7d6b5e4ef)
![47a288a9-128b-4b25-b68c-64dfc751efe0](https://github.com/user-attachments/assets/7d38e7e6-874d-4d63-9704-cce57116cefd)

