### PR TITLE
refactor: Replace breadcrumb separator by CSS only solution

### DIFF
--- a/changelog/_unreleased/2025-05-20-replace-breadcrumb-separator-by-css-only-solution.md
+++ b/changelog/_unreleased/2025-05-20-replace-breadcrumb-separator-by-css-only-solution.md
@@ -1,0 +1,9 @@
+---
+title: Replace breadcrumb separator by CSS only solution
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Deprecated twig block `layout_breadcrumb_placeholder` from the template `@Storefront/storefront/layout/breadcrumb.html.twig` and replaced breadcrumb separator by a CSS only solution
+* Changed the breadcrumb separator `.breadcrumb-placeholder` from a `div` to a list item, such that the breadcrumb list only contains `li` elements

--- a/changelog/_unreleased/2025-05-20-replace-breadcrumb-separator-by-css-only-solution.md
+++ b/changelog/_unreleased/2025-05-20-replace-breadcrumb-separator-by-css-only-solution.md
@@ -1,9 +1,0 @@
----
-title: Replace breadcrumb separator by CSS only solution
-author: Max
-author_email: max@swk-web.com
-author_github: @aragon999
----
-# Storefront
-* Deprecated twig block `layout_breadcrumb_placeholder` from the template `@Storefront/storefront/layout/breadcrumb.html.twig` and replaced breadcrumb separator by a CSS only solution
-* Changed the breadcrumb separator `.breadcrumb-placeholder` from a `div` to a list item, such that the breadcrumb list only contains `li` elements

--- a/changelog/_unreleased/2025-05-20-replace-breadcrumb-separator-by-the-bootstrap-default-solution.md
+++ b/changelog/_unreleased/2025-05-20-replace-breadcrumb-separator-by-the-bootstrap-default-solution.md
@@ -1,0 +1,24 @@
+---
+title: Replace breadcrumb separator by the bootstrap default solution
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Deprecated twig block `layout_breadcrumb_placeholder` from the template `@Storefront/storefront/layout/breadcrumb.html.twig` and replaced the breadcrumb separator by the bootstrap default implementation, adjust the `breadcrumbDivider` variable to use a custom separator
+* Deprecated the twig variable `breadcrumbKeys` as it is not needed anymore
+* Added the attribute `aria-hidden="true"` to the `.breadcrumb-placeholder` for accessibility
+___
+# Upgrade Information
+## Breadcrumb separator using Bootstrap default
+
+The breadcrumb separator is now using the bootstrap default, i.e. the CSS variable `--bs-breadcrumb-divider`, which is set on the corresponding breadcrumb `nav`-element: https://getbootstrap.com/docs/5.3/components/breadcrumb/#dividers
+
+Therefore the block `layout_breadcrumb_placeholder` has been deprecated and will be removed and the separator can be set using the twig variable `breadcrumbDivider`, i.e.
+```twig
+{% block layout_breadcrumb_container %}
+    {% with {breadcrumbDivider: 'url(data:image/svg+xml,' ~ source('@Storefront/assets/icon/my-custom-separator.svg')|url_encode ~ ')'} %}
+        {{ parent() }}
+    {% endwith %}
+{% endblock %}
+```

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_breadcrumb.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_breadcrumb.scss
@@ -7,14 +7,30 @@ https://getbootstrap.com/docs/5.2/components/breadcrumb
 */
 
 .breadcrumb {
-    .breadcrumb-placeholder {
-        margin: 0 $spacer-sm;
+    @if not feature('v6.8.0.0') {
+        .breadcrumb-placeholder {
+            margin: 0 $spacer-sm;
+        }
+
+        svg {
+            height: $font-size-base;
+            width: auto;
+            top: 3px;
+        }
     }
 
-    svg {
-        height: $font-size-base;
-        width: auto;
-        top: 3px;
+    .breadcrumb-item + .breadcrumb-item:before {
+        content: '';
+        display: inline-block;
+        float: none;
+        width: $spacer-sm;
+        height: $spacer-sm;
+        padding: 0;
+        margin-right: $spacer-sm;
+        vertical-align: middle;
+        border-right: 2px solid $body-color;
+        border-bottom: 2px solid $body-color;
+        transform: rotate(-45deg);
     }
 
     a {

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_breadcrumb.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_breadcrumb.scss
@@ -20,17 +20,8 @@ https://getbootstrap.com/docs/5.2/components/breadcrumb
     }
 
     .breadcrumb-item + .breadcrumb-item:before {
-        content: '';
-        display: inline-block;
-        float: none;
-        width: $spacer-sm;
-        height: $spacer-sm;
-        padding: 0;
-        margin-right: $spacer-sm;
-        vertical-align: middle;
-        border-right: 2px solid $body-color;
-        border-bottom: 2px solid $body-color;
-        transform: rotate(-45deg);
+        line-height: 24px;
+        padding-top: 3px;
     }
 
     a {

--- a/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
@@ -11,56 +11,62 @@
     {% endif %}
 
     {% if breadcrumbCategories|length > 0 %}
+        {# @deprecated tag:v6.8.0 - Variable `breadcrumbKeys` will be removed #}
         {% set breadcrumbKeys = breadcrumbCategories|keys %}
 
-        <nav aria-label="breadcrumb">
-            {% block layout_breadcrumb_list %}
-                <ol class="breadcrumb"
-                    itemscope
-                    itemtype="https://schema.org/BreadcrumbList">
-                    {% for breadcrumbCategory in breadcrumbCategories %}
-                        {% set key = breadcrumbCategory.id %}
-                        {% set name = breadcrumbCategory.translated.name %}
-                        {% set categoryUrl = breadcrumbCategory.seoUrl %}
+        {% set breadcrumDivider = 'url(data:image/svg+xml,' ~ source('@Storefront/assets/icon/solid/arrow-medium-right.svg')|url_encode ~ ')' %}
+        {# {% set breadcrumDivider = '' %} #}
 
-                        {% block layout_breadcrumb_list_item %}
-                            <li class="breadcrumb-item"
-                                {% if key is same as(categoryId) %}aria-current="page"{% endif %}
-                                itemprop="itemListElement"
-                                itemscope
-                                itemtype="https://schema.org/ListItem">
-                                {% if breadcrumbCategory.type == 'folder' %}
-                                    <div itemprop="item">
-                                        <div itemprop="name">{{ name }}</div>
-                                    </div>
-                                {% else %}
-                                    <a href="{{ categoryUrl }}"
-                                       class="breadcrumb-link {% if key is same as(categoryId) %} is-active{% endif %}"
-                                       title="{{ name }}"
-                                       {% if breadcrumbCategory.shouldOpenInNewTab %}target="_blank"{% endif %}
-                                       itemprop="item">
-                                        <link itemprop="url"
-                                              href="{{ categoryUrl }}">
-                                        <span class="breadcrumb-title" itemprop="name">{{ name }}</span>
-                                    </a>
-                                {% endif %}
-                                <meta itemprop="position" content="{{ loop.index }}">
-                            </li>
-                        {% endblock %}
+        {% block layout_breadcrumb_container %}
+            <nav aria-label="breadcrumb"{% if feature('v6.8.0.0') %} style="--bs-breadcrumb-divider: {{ breadcrumDivider }};"{% endif %}>
+                {% block layout_breadcrumb_list %}
+                    <ol class="breadcrumb"
+                        itemscope
+                        itemtype="https://schema.org/BreadcrumbList">
+                        {% for breadcrumbCategory in breadcrumbCategories %}
+                            {% set key = breadcrumbCategory.id %}
+                            {% set name = breadcrumbCategory.translated.name %}
+                            {% set categoryUrl = breadcrumbCategory.seoUrl %}
 
-                        {% if not feature('v6.8.0.0') %}
-                            {# @deprecated tag:v6.8.0 - Block will be removed, the separator has been moved to a CSS only solution - Extend the `layout_breadcrumb_list_item` block if needed #}
-                            {% block layout_breadcrumb_placeholder %}
-                                {% if key != breadcrumbKeys|last %}
-                                    <li class="breadcrumb-placeholder">
-                                        {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid' } %}
-                                    </li>
-                                {% endif %}
+                            {% block layout_breadcrumb_list_item %}
+                                <li class="breadcrumb-item"
+                                    {% if key is same as(categoryId) %}aria-current="page"{% endif %}
+                                    itemprop="itemListElement"
+                                    itemscope
+                                    itemtype="https://schema.org/ListItem">
+                                    {% if breadcrumbCategory.type == 'folder' %}
+                                        <div itemprop="item">
+                                            <div itemprop="name">{{ name }}</div>
+                                        </div>
+                                    {% else %}
+                                        <a href="{{ categoryUrl }}"
+                                           class="breadcrumb-link {% if key is same as(categoryId) %} is-active{% endif %}"
+                                           title="{{ name }}"
+                                           {% if breadcrumbCategory.shouldOpenInNewTab %}target="_blank"{% endif %}
+                                           itemprop="item">
+                                            <link itemprop="url"
+                                                  href="{{ categoryUrl }}">
+                                            <span class="breadcrumb-title" itemprop="name">{{ name }}</span>
+                                        </a>
+                                    {% endif %}
+                                    <meta itemprop="position" content="{{ loop.index }}">
+                                </li>
                             {% endblock %}
-                        {% endif %}
-                    {% endfor %}
-                </ol>
-            {% endblock %}
-        </nav>
+
+                            {% if not feature('v6.8.0.0') %}
+                                {# @deprecated tag:v6.8.0 - Block will be removed, the separator has been moved to a CSS only solution - Extend the `layout_breadcrumb_list_item` block if needed #}
+                                {% block layout_breadcrumb_placeholder %}
+                                    {% if key != breadcrumbKeys|last %}
+                                        <li class="breadcrumb-placeholder">
+                                            {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid' } %}
+                                        </li>
+                                    {% endif %}
+                                {% endblock %}
+                            {% endif %}
+                        {% endfor %}
+                    </ol>
+                {% endblock %}
+            </nav>
+        {% endblock %}
     {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
@@ -48,13 +48,16 @@
                             </li>
                         {% endblock %}
 
-                        {% block layout_breadcrumb_placeholder %}
-                            {% if key != breadcrumbKeys|last %}
-                                <div class="breadcrumb-placeholder">
-                                    {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid' } %}
-                                </div>
-                            {% endif %}
-                        {% endblock %}
+                        {% if not feature('v6.8.0.0') %}
+                            {# @deprecated tag:v6.8.0 - Block will be removed, the separator has been moved to a CSS only solution - Extend the `layout_breadcrumb_list_item` block if needed #}
+                            {% block layout_breadcrumb_placeholder %}
+                                {% if key != breadcrumbKeys|last %}
+                                    <li class="breadcrumb-placeholder">
+                                        {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid' } %}
+                                    </li>
+                                {% endif %}
+                            {% endblock %}
+                        {% endif %}
                     {% endfor %}
                 </ol>
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
@@ -14,11 +14,10 @@
         {# @deprecated tag:v6.8.0 - Variable `breadcrumbKeys` will be removed #}
         {% set breadcrumbKeys = breadcrumbCategories|keys %}
 
-        {% set breadcrumDivider = 'url(data:image/svg+xml,' ~ source('@Storefront/assets/icon/solid/arrow-medium-right.svg')|url_encode ~ ')' %}
-        {# {% set breadcrumDivider = '' %} #}
+        {% set breadcrumbDivider = 'url(data:image/svg+xml,' ~ source('@Storefront/assets/icon/solid/arrow-medium-right.svg')|url_encode ~ ')' %}
 
         {% block layout_breadcrumb_container %}
-            <nav aria-label="breadcrumb"{% if feature('v6.8.0.0') %} style="--bs-breadcrumb-divider: {{ breadcrumDivider }};"{% endif %}>
+            <nav aria-label="breadcrumb"{% if feature('v6.8.0.0') %} style="--bs-breadcrumb-divider: {{ breadcrumbDivider }};"{% endif %}>
                 {% block layout_breadcrumb_list %}
                     <ol class="breadcrumb"
                         itemscope
@@ -57,9 +56,9 @@
                                 {# @deprecated tag:v6.8.0 - Block will be removed, the separator has been moved to a CSS only solution - Extend the `layout_breadcrumb_list_item` block if needed #}
                                 {% block layout_breadcrumb_placeholder %}
                                     {% if key != breadcrumbKeys|last %}
-                                        <li class="breadcrumb-placeholder">
+                                        <div class="breadcrumb-placeholder" aria-hidden="true">
                                             {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid' } %}
-                                        </li>
+                                        </div>
                                     {% endif %}
                                 {% endblock %}
                             {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The main problem is, that currently inside a list there is a direct child item, which is not a list item:
![image](https://github.com/user-attachments/assets/2de601a0-5875-48ba-b77b-0e403c7a1085)

But in general the amount of HTML elements should probably be reduced and the separator can be replaced by a CSS only solution.

### 2. What does this change do, exactly?
Replace the `div` by a `li` and for 6.8 deprecate the HTML separator completely.

Left is before and right after:
![screenshot-20 05 2025-17 05 34](https://github.com/user-attachments/assets/e2588fdd-8aef-4e9e-825e-041a26541e24)

Note that the bootstrap default separator is a `/`. This could also be used. I choose not to use the separator with an SVG item, as I think this can be easier replaced by an element which only contains two borders. But that can of course also be changed, maybe also the bootstrap default `/` or the `>` can be used in the default implementation.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
