### PR TITLE
fix: license-violations race conditions

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-inactivity-login/page/index/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-inactivity-login/page/index/index.ts
@@ -140,10 +140,12 @@ export default Component.wrapComponentConfig({
 
             if (previousRoute?.fullPath) {
                 void this.$router.push(previousRoute.fullPath);
-                return;
+            } else {
+                void this.$router.push({ name: 'core' });
             }
 
-            void this.$router.push({ name: 'core' });
+            // Reload the page to ensure all non-login initializers are executed
+            window.location.reload();
         },
 
         onBackToLogin() {


### PR DESCRIPTION
### 1. Why is this change necessary?

Closes #9607

### 2. What does this change do, exactly?

The issue is happening in the following situation (reproducible):
1. User gets Inactivity Login
2. User directly is logging in
3. Several initializers aren't loaded yet

The fix did a automatic reload after login and changing the route. Before Vite this happened a bit later in the stack but due to the error beforehand and different timing of the services we won't get that far. So I moved the reloading part much more forward. This solves also some other issues happening after logging in with the inactivity-login modal.