### PR TITLE
fix: release date not aligned in product detail

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/index.js
@@ -3,6 +3,7 @@
  */
 
 import template from './sw-product-settings-form.html.twig';
+import './sw-product-settings-form.scss';
 
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.html.twig
@@ -8,6 +8,7 @@
         {% block sw_product_settings_form_release_date_field %}
         <sw-inherit-wrapper
             v-model:value="product.releaseDate"
+            class="sw-product-settings-form__release-date"
             :has-parent="!!parentProduct.id"
             :inherited-value="parentProduct.releaseDate"
             :label="$tc('sw-product.settingsForm.labelReleaseDate')"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.scss
@@ -1,0 +1,11 @@
+.sw-product-settings-form {
+    .sw-product-settings-form__release-date {
+        .wrapper {
+            row-gap: 0;
+        }
+
+        .mt-datepicker__hint {
+            margin-top: 6px;
+        }
+    }
+}


### PR DESCRIPTION
### Description 

The effect not aligned because we moved label property [here](https://github.com/shopware/shopware/pull/8753/files#diff-23604b8f8a85be4294622f25ea75aca1a383b919dc460a82e5c6ce24571c9007R13)

### Solution

| Before  | After |
|---------------------------|-------------------------|
|![image](https://github.com/user-attachments/assets/26a31873-f125-42e9-bacf-b2c1d68a7db8) | ![Screenshot 2025-05-21 at 18 07 45](https://github.com/user-attachments/assets/85e790c3-eccb-4f64-9cb5-900168e824c3)

