### PR TITLE
fix: Replace sw-button by mt-button and set correct button variants in the `sw-theme-manager-list` component

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.html.twig
@@ -295,18 +295,23 @@
                             {% block sw_theme_list_delete_modal_footer %}
                                 <template #modal-footer>
                                     {% block sw_theme_list_delete_modal_cancel %}
-                                        <sw-button @click="onCloseDeleteModal"
-                                                   size="small">
+                                        <mt-button
+                                            variant="secondary"
+                                            size="small"
+                                            @click="onCloseDeleteModal"
+                                        >
                                             {{ $t('global.default.cancel') }}
-                                        </sw-button>
+                                        </mt-button>
                                     {% endblock %}
 
                                     {% block sw_theme_list_delete_modal_confirm %}
-                                        <sw-button @click="onConfirmThemeDelete"
-                                                   variant="danger"
-                                                   size="small">
+                                        <mt-button
+                                            variant="critical"
+                                            size="small"
+                                            @click="onConfirmThemeDelete"
+                                        >
                                             {{ $t('global.default.delete') }}
-                                        </sw-button>
+                                        </mt-button>
                                     {% endblock %}
                                 </template>
                             {% endblock %}
@@ -336,19 +341,24 @@
                             {% block sw_theme_list_duplicate_modal_footer %}
                                 <template #modal-footer>
                                     {% block sw_theme_list_duplicate_modal_cancel %}
-                                        <sw-button @click="onCloseDuplicateModal"
-                                                   size="small">
+                                        <mt-button
+                                            variant="secondary"
+                                            size="small"
+                                            @click="onCloseDuplicateModal"
+                                        >
                                             {{ $t('global.default.cancel') }}
-                                        </sw-button>
+                                        </mt-button>
                                     {% endblock %}
 
                                     {% block sw_theme_list_duplicate_modal_confirm %}
-                                        <sw-button @click="onConfirmThemeDuplicate"
-                                                   variant="primary"
-                                                   :disabled="newThemeName.length < 3"
-                                                   size="small">
+                                        <mt-button
+                                            variant="primary"
+                                            :disabled="newThemeName.length < 3"
+                                            size="small"
+                                            @click="onConfirmThemeDuplicate"
+                                        >
                                             {{ $t('sw-theme-manager.modal.buttonDuplicateTheme') }}
-                                        </sw-button>
+                                        </mt-button>
                                     {% endblock %}
                                 </template>
                             {% endblock %}
@@ -378,19 +388,24 @@
                             {% block sw_theme_list_rename_modal_footer %}
                                 <template #modal-footer>
                                     {% block sw_theme_list_rename_modal_cancel %}
-                                        <sw-button @click="onCloseRenameModal"
-                                                   size="small">
+                                        <mt-button
+                                            variant="secondary"
+                                            size="small"
+                                            @click="onCloseRenameModal"
+                                        >
                                             {{ $t('global.default.cancel') }}
-                                        </sw-button>
+                                        </mt-button>
                                     {% endblock %}
 
                                     {% block sw_theme_list_rename_modal_confirm %}
-                                        <sw-button @click="onConfirmThemeRename"
-                                                   variant="primary"
-                                                   :disabled="newThemeName.length < 3"
-                                                   size="small">
-                                            {{ $t('sw-theme-manager.modal.buttonRenameTheme') }}
-                                        </sw-button>
+                                        <mt-button
+                                            variant="primary"
+                                            :disabled="newThemeName.length < 3"
+                                            size="small"
+                                            @click="onConfirmThemeRename"
+                                        >
+                                            {{ $t('global.default.save') }}
+                                        </mt-button>
                                     {% endblock %}
                                 </template>
                             {% endblock %}

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/de-DE.json
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/de-DE.json
@@ -130,7 +130,7 @@
       "textDuplicateInfo": "Wenn Du ein Duplikat erstellst, kannst Du das Theme mit einer anderen Farbkonfiguration für weitere Verkaufskanäle nutzen.",
       "buttonDuplicateTheme": "Duplikat anlegen",
       "modalTitleRename": "Umbenennen",
-      "textRenameInfo": "Geib einen neuen Namen für das Theme an.",
+      "textRenameInfo": "Gib einen neuen Namen für das Theme an.",
       "labelRenameThemeName": "Neuer Theme Name",
       "placeholderRenameThemeName": "Namen eintragen",
       "modalTextResetInfo": "Bist du sicher, dass du das Theme auf die Standardeinstellungen zurücksetzen möchtest?",


### PR DESCRIPTION
### 1. Why is this change necessary?
There are two issues, on the one hand, the `sw-button` has an old property (`danger` instead of `critical`) and furthermore there is a removed snippet used, when changing the name of a theme.

Edit: Just came upon another issue, the German snippet when renaming contains a typo :-)

### 2. What does this change do, exactly?
Replace the `sw-button`s by `mt-button`s, correct the attributes, and use a general snippet when changing the name.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Closes https://github.com/shopware/shopware/issues/8139

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
