### PR TITLE
feat: add query timeout support for MySQL and MariaDB

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
@@ -93,16 +93,10 @@ class EntitySearcher implements EntitySearcherInterface
 
         // Apply query timeout as SQL hint if set
         if ($criteria->getQueryTimeout() !== null) {
-            $timeout = $criteria->getQueryTimeout();
-            $platformName = $this->connection->getDatabasePlatform()::class;
-            
-            if (strpos($platformName, 'MySQL') !== false) {
-                // MySQL 8 syntax - hint for a single query
-                $query->setComment('+ MAX_EXECUTION_TIME(' . $timeout . ')');
-            } elseif (strpos($platformName, 'MariaDB') !== false) {
-                // MariaDB syntax - hint for a single query
-                $query->setComment('+ MAX_STATEMENT_TIME(' . ($timeout / 1000) . ')');
-            }
+            $query->setQueryTimeout(
+                $criteria->getQueryTimeout(),
+                $this->connection->getDatabasePlatform()
+            );
         }
 
         // Execute and fetch ids
@@ -188,14 +182,10 @@ class EntitySearcher implements EntitySearcherInterface
 
         // Apply query timeout to count query as well
         if ($criteria->getQueryTimeout() !== null) {
-            $timeout = $criteria->getQueryTimeout();
-            $platformName = $this->connection->getDatabasePlatform()::class;
-            
-            if (strpos($platformName, 'MySQL') !== false) {
-                $total->setComment('+ MAX_EXECUTION_TIME(' . $timeout . ')');
-            } elseif (strpos($platformName, 'MariaDB') !== false) {
-                $total->setComment('+ MAX_STATEMENT_TIME(' . ($timeout / 1000) . ')');
-            }
+            $total->setQueryTimeout(
+                $criteria->getQueryTimeout(),
+                $this->connection->getDatabasePlatform()
+            );
         }
 
         return (int) $total->executeQuery()->fetchOne();

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
@@ -93,10 +93,7 @@ class EntitySearcher implements EntitySearcherInterface
 
         // Apply query timeout as SQL hint if set
         if ($criteria->getQueryTimeout() !== null) {
-            $query->setQueryTimeout(
-                $criteria->getQueryTimeout(),
-                $this->connection->getDatabasePlatform()
-            );
+            $query->setQueryTimeout($criteria->getQueryTimeout());
         }
 
         // Execute and fetch ids
@@ -182,10 +179,7 @@ class EntitySearcher implements EntitySearcherInterface
 
         // Apply query timeout to count query as well
         if ($criteria->getQueryTimeout() !== null) {
-            $total->setQueryTimeout(
-                $criteria->getQueryTimeout(),
-                $this->connection->getDatabasePlatform()
-            );
+            $total->setQueryTimeout($criteria->getQueryTimeout());
         }
 
         return (int) $total->executeQuery()->fetchOne();

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
@@ -91,7 +91,21 @@ class EntitySearcher implements EntitySearcherInterface
             $query->setTitle($criteria->getTitle() . '::search-ids');
         }
 
-        // execute and fetch ids
+        // Apply query timeout as SQL hint if set
+        if ($criteria->getQueryTimeout() !== null) {
+            $timeout = $criteria->getQueryTimeout();
+            $platformName = $this->connection->getDatabasePlatform()::class;
+            
+            if (strpos($platformName, 'MySQL') !== false) {
+                // MySQL 8 syntax - hint for a single query
+                $query->setComment('+ MAX_EXECUTION_TIME(' . $timeout . ')');
+            } elseif (strpos($platformName, 'MariaDB') !== false) {
+                // MariaDB syntax - hint for a single query
+                $query->setComment('+ MAX_STATEMENT_TIME(' . ($timeout / 1000) . ')');
+            }
+        }
+
+        // Execute and fetch ids
         $rows = $query->executeQuery()->fetchAllAssociative();
 
         $total = $this->getTotalCount($criteria, $query, $rows);
@@ -171,6 +185,18 @@ class EntitySearcher implements EntitySearcherInterface
         $total->select('COUNT(*)')
             ->from(\sprintf('(%s) total', $query->getSQL()))
             ->setParameters($query->getParameters(), $query->getParameterTypes());
+
+        // Apply query timeout to count query as well
+        if ($criteria->getQueryTimeout() !== null) {
+            $timeout = $criteria->getQueryTimeout();
+            $platformName = $this->connection->getDatabasePlatform()::class;
+            
+            if (strpos($platformName, 'MySQL') !== false) {
+                $total->setComment('+ MAX_EXECUTION_TIME(' . $timeout . ')');
+            } elseif (strpos($platformName, 'MariaDB') !== false) {
+                $total->setComment('+ MAX_STATEMENT_TIME(' . ($timeout / 1000) . ')');
+            }
+        }
 
         return (int) $total->executeQuery()->fetchOne();
     }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
@@ -30,6 +30,11 @@ class QueryBuilder extends DBALQueryBuilder
 
     private ?string $title = null;
 
+    /**
+     * SQL comment to be added to the query
+     */
+    private ?string $comment = null;
+
     public function addState(string $state): void
     {
         $this->states[$state] = $state;
@@ -81,6 +86,25 @@ class QueryBuilder extends DBALQueryBuilder
         $this->title = $title;
     }
 
+    /**
+     * Sets an SQL comment to be prepended to the query.
+     * This can be used for optimizer hints like MAX_EXECUTION_TIME.
+     */
+    public function setComment(?string $comment): self
+    {
+        $this->comment = $comment;
+
+        return $this;
+    }
+
+    /**
+     * Gets the current SQL comment
+     */
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
     public function getSQL(): string
     {
         // Use a copy of this query builder to generate the SQL including the translation joins. This way calling this
@@ -98,6 +122,14 @@ class QueryBuilder extends DBALQueryBuilder
 
         if ($this->getTitle()) {
             $sql = '# ' . $this->title . \PHP_EOL . $sql;
+        }
+        
+        // Add SQL comment/hint if set
+        if ($this->getComment()) {
+            // For SELECT queries, add the comment right after the SELECT keyword
+            if (strpos($sql, 'SELECT ') === 0) {
+                $sql = 'SELECT /*' . $this->comment . '*/ ' . substr($sql, 7);
+            }
         }
 
         return $sql;

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\QueryBuilder as DBALQueryBuilder;
 use Shopware\Core\Framework\Log\Package;
 
@@ -123,16 +124,35 @@ class QueryBuilder extends DBALQueryBuilder
         if ($this->getTitle()) {
             $sql = '# ' . $this->title . \PHP_EOL . $sql;
         }
-        
+
         // Add SQL comment/hint if set
         if ($this->getComment()) {
             // For SELECT queries, add the comment right after the SELECT keyword
-            if (strpos($sql, 'SELECT ') === 0) {
+            if (str_starts_with($sql, 'SELECT ')) {
                 $sql = 'SELECT /*' . $this->comment . '*/ ' . substr($sql, 7);
             }
         }
 
         return $sql;
+    }
+
+    /**
+     * Sets a query timeout for the current query.
+     * This method will set the appropriate SQL comment/hint based on the database platform.
+     */
+    public function setQueryTimeout(int $timeout, AbstractPlatform $platform): self
+    {
+        $platformName = $platform::class;
+
+        if (str_contains($platformName, 'MySQL')) {
+            // MySQL 8 syntax - hint for a single query
+            $this->setComment('+ MAX_EXECUTION_TIME(' . $timeout . ')');
+        } elseif (str_contains($platformName, 'MariaDB')) {
+            // MariaDB syntax - hint for a single query
+            $this->setComment('+ MAX_STATEMENT_TIME(' . ($timeout / 1000) . ')');
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal;
 
-use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder as DBALQueryBuilder;
 use Shopware\Core\Framework\Log\Package;
 
@@ -35,6 +35,12 @@ class QueryBuilder extends DBALQueryBuilder
      * SQL comment to be added to the query
      */
     private ?string $comment = null;
+
+    public function __construct(
+        private readonly Connection $connection
+    ) {
+        parent::__construct($connection);
+    }
 
     public function addState(string $state): void
     {
@@ -121,16 +127,16 @@ class QueryBuilder extends DBALQueryBuilder
         }
         $sql = $query->getUnmodifiedSQL();
 
-        if ($this->getTitle()) {
-            $sql = '# ' . $this->title . \PHP_EOL . $sql;
-        }
-
         // Add SQL comment/hint if set
         if ($this->getComment()) {
             // For SELECT queries, add the comment right after the SELECT keyword
             if (str_starts_with($sql, 'SELECT ')) {
                 $sql = 'SELECT /*' . $this->comment . '*/ ' . substr($sql, 7);
             }
+        }
+
+        if ($this->getTitle()) {
+            $sql = '# ' . $this->title . \PHP_EOL . $sql;
         }
 
         return $sql;
@@ -140,8 +146,9 @@ class QueryBuilder extends DBALQueryBuilder
      * Sets a query timeout for the current query.
      * This method will set the appropriate SQL comment/hint based on the database platform.
      */
-    public function setQueryTimeout(int $timeout, AbstractPlatform $platform): self
+    public function setQueryTimeout(int $timeout): self
     {
+        $platform = $this->connection->getDatabasePlatform();
         $platformName = $platform::class;
 
         if (str_contains($platformName, 'MySQL')) {

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -106,6 +106,11 @@ class Criteria extends Struct implements \Stringable
     protected array $fields = [];
 
     /**
+     * Query timeout in milliseconds
+     */
+    protected ?int $queryTimeout = null;
+
+    /**
      * @param array<string>|array<array<string, string>>|null $ids
      */
     public function __construct(?array $ids = null, protected int $nestingLevel = 0)
@@ -612,6 +617,24 @@ class Criteria extends Struct implements \Stringable
     public function getNestingLevel(): int
     {
         return $this->nestingLevel;
+    }
+
+    /**
+     * Sets a timeout for the query in milliseconds
+     */
+    public function setQueryTimeout(?int $queryTimeout): self
+    {
+        $this->queryTimeout = $queryTimeout;
+
+        return $this;
+    }
+
+    /**
+     * Returns the query timeout in milliseconds
+     */
+    public function getQueryTimeout(): ?int
+    {
+        return $this->queryTimeout;
     }
 
     /**

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
@@ -135,12 +135,12 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
 
         if (!$criteria->getGroupFields()) {
             $array = $search->toArray();
-            
+
             // Use criteria timeout if set, otherwise use default timeout
-            $timeout = $criteria->getQueryTimeout() !== null 
-                ? $criteria->getQueryTimeout() . 'ms' 
+            $timeout = $criteria->getQueryTimeout() !== null
+                ? $criteria->getQueryTimeout() . 'ms'
                 : $this->timeout;
-                
+
             $array['timeout'] = $timeout;
 
             return $array;
@@ -154,12 +154,12 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
 
         $array = $search->toArray();
         $array['collapse'] = $this->parseGrouping($criteria->getGroupFields(), $definition, $context);
-        
+
         // Use criteria timeout if set, otherwise use default timeout
-        $timeout = $criteria->getQueryTimeout() !== null 
-            ? $criteria->getQueryTimeout() . 'ms' 
+        $timeout = $criteria->getQueryTimeout() !== null
+            ? $criteria->getQueryTimeout() . 'ms'
             : $this->timeout;
-            
+
         $array['timeout'] = $timeout;
 
         return $array;

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
@@ -135,7 +135,13 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
 
         if (!$criteria->getGroupFields()) {
             $array = $search->toArray();
-            $array['timeout'] = $this->timeout;
+            
+            // Use criteria timeout if set, otherwise use default timeout
+            $timeout = $criteria->getQueryTimeout() !== null 
+                ? $criteria->getQueryTimeout() . 'ms' 
+                : $this->timeout;
+                
+            $array['timeout'] = $timeout;
 
             return $array;
         }
@@ -148,7 +154,13 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
 
         $array = $search->toArray();
         $array['collapse'] = $this->parseGrouping($criteria->getGroupFields(), $definition, $context);
-        $array['timeout'] = $this->timeout;
+        
+        // Use criteria timeout if set, otherwise use default timeout
+        $timeout = $criteria->getQueryTimeout() !== null 
+            ? $criteria->getQueryTimeout() . 'ms' 
+            : $this->timeout;
+            
+        $array['timeout'] = $timeout;
 
         return $array;
     }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilderTest.php
@@ -1,0 +1,234 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Dbal;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
+
+/**
+ * @internal
+ */
+#[CoversClass(QueryBuilder::class)]
+class QueryBuilderTest extends TestCase
+{
+    private Connection&MockObject $connection;
+    private QueryBuilder $queryBuilder;
+
+    protected function setUp(): void
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+
+        $this->connection = $this->createMock(Connection::class);
+        $this->connection->method('getDatabasePlatform')->willReturn($platform);
+
+        $this->queryBuilder = new QueryBuilder($this->connection);
+    }
+
+    public function testSetAndGetComment(): void
+    {
+        // Initial value should be null
+        static::assertNull($this->queryBuilder->getComment());
+
+        // Test setting a comment
+        $this->queryBuilder->setComment('TEST_COMMENT');
+        static::assertSame('TEST_COMMENT', $this->queryBuilder->getComment());
+
+        // Test setting null
+        $this->queryBuilder->setComment(null);
+        static::assertNull($this->queryBuilder->getComment());
+    }
+
+    public function testGetSQLWithComment(): void
+    {
+        // We'll simulate what getSQL() does but in a controlled way
+        // First set up our QueryBuilder
+        $queryBuilder = new QueryBuilder($this->connection);
+        
+        // Set a comment
+        $queryBuilder->setComment('+ MAX_EXECUTION_TIME(1000)');
+        
+        // Create a reflection class to access private methods/properties
+        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
+        $commentProperty = $reflectionClass->getProperty('comment');
+        $commentProperty->setAccessible(true);
+        
+        // Verify the comment is stored correctly
+        static::assertEquals('+ MAX_EXECUTION_TIME(1000)', $commentProperty->getValue($queryBuilder));
+        
+        // Now manually apply the comment transformation to test it
+        $sql = 'SELECT * FROM test_table';
+        $commentValue = $commentProperty->getValue($queryBuilder);
+        $modifiedSql = 'SELECT /*' . $commentValue . '*/ ' . substr($sql, 7);
+        
+        // Verify the comment is applied correctly
+        static::assertStringContainsString('SELECT /*+ MAX_EXECUTION_TIME(1000)*/ ', $modifiedSql);
+    }
+
+    public function testGetSQLWithTitle(): void
+    {
+        // Set up our QueryBuilder
+        $queryBuilder = new QueryBuilder($this->connection);
+        
+        // Set a title
+        $queryBuilder->setTitle('Test Query');
+        
+        // Create a reflection class to access private methods/properties
+        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
+        $titleProperty = $reflectionClass->getProperty('title');
+        $titleProperty->setAccessible(true);
+        
+        // Verify the title is stored correctly
+        static::assertEquals('Test Query', $titleProperty->getValue($queryBuilder));
+        
+        // Now manually apply the title transformation to test it
+        $sql = 'SELECT * FROM test_table';
+        $titleValue = $titleProperty->getValue($queryBuilder);
+        $modifiedSql = '# ' . $titleValue . PHP_EOL . $sql;
+        
+        // Verify the title is applied correctly
+        static::assertStringContainsString('# Test Query', $modifiedSql);
+    }
+
+    public function testGetSQLWithCommentAndTitle(): void
+    {
+        // Set up our QueryBuilder
+        $queryBuilder = new QueryBuilder($this->connection);
+        
+        // Set both title and comment
+        $queryBuilder->setTitle('Test Query');
+        $queryBuilder->setComment('+ MAX_EXECUTION_TIME(1000)');
+        
+        // Create a reflection class to access private methods/properties
+        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
+        $titleProperty = $reflectionClass->getProperty('title');
+        $commentProperty = $reflectionClass->getProperty('comment');
+        $titleProperty->setAccessible(true);
+        $commentProperty->setAccessible(true);
+        
+        // Verify properties are stored correctly
+        static::assertEquals('Test Query', $titleProperty->getValue($queryBuilder));
+        static::assertEquals('+ MAX_EXECUTION_TIME(1000)', $commentProperty->getValue($queryBuilder));
+        
+        // Now manually apply the transformations to test them
+        $sql = 'SELECT * FROM test_table';
+        $titleValue = $titleProperty->getValue($queryBuilder);
+        $commentValue = $commentProperty->getValue($queryBuilder);
+        
+        // First add comment to SELECT
+        $modifiedSql = 'SELECT /*' . $commentValue . '*/ ' . substr($sql, 7);
+        // Then add title at the beginning
+        $modifiedSql = '# ' . $titleValue . PHP_EOL . $modifiedSql;
+        
+        // Verify both transformations are applied correctly
+        static::assertStringContainsString('# Test Query', $modifiedSql);
+        static::assertStringContainsString('SELECT /*+ MAX_EXECUTION_TIME(1000)*/ ', $modifiedSql);
+    }
+
+    public function testCommentOnlyAppliedToSelectStatements(): void
+    {
+        // Create a QueryBuilder with an UPDATE statement
+        $queryBuilder = new QueryBuilder($this->connection);
+        $queryBuilder->update('test_table')->set('column', 'value');
+        $queryBuilder->setComment('TEST_COMMENT');
+        
+        // Create a reflection class to access private properties
+        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
+        $commentProperty = $reflectionClass->getProperty('comment');
+        $commentProperty->setAccessible(true);
+        
+        // Verify the comment is stored
+        static::assertEquals('TEST_COMMENT', $commentProperty->getValue($queryBuilder));
+        
+        // Now manually verify that comment would NOT be added to non-SELECT statements
+        $sql = 'UPDATE test_table SET column = value';
+        static::assertStringNotContainsString('/*TEST_COMMENT*/', $sql);
+        
+        // For this test, we only want to verify that the getSQL method in QueryBuilder 
+        // would NOT add comments to non-SELECT statements, which is handled by the condition:
+        // if (strpos($sql, 'SELECT ') === 0) { ... }
+    }
+
+    public function testAddAndGetState(): void
+    {
+        // Initial state should be empty
+        static::assertEmpty($this->queryBuilder->getStates());
+
+        // Test adding a state
+        $this->queryBuilder->addState('test_state');
+        static::assertTrue($this->queryBuilder->hasState('test_state'));
+        static::assertSame(['test_state' => 'test_state'], $this->queryBuilder->getStates());
+
+        // Test removing a state
+        $this->queryBuilder->removeState('test_state');
+        static::assertFalse($this->queryBuilder->hasState('test_state'));
+        static::assertEmpty($this->queryBuilder->getStates());
+    }
+
+    public function testTranslationJoins(): void
+    {
+        // Create real QueryBuilder instances
+        $translationBuilder = new QueryBuilder($this->connection);
+        $translationBuilder->select('translation.*')
+            ->from('translation_table', 'translation');
+
+        $queryBuilder = new QueryBuilder($this->connection);
+        $queryBuilder->select('entity.*')
+            ->from('entity_table', 'entity');
+            
+        // Add the translation join
+        $queryBuilder->addTranslationJoin(
+            'entity',
+            'translation',
+            $translationBuilder,
+            'entity.id = translation.entity_id'
+        );
+
+        // Create a reflection class to access private properties
+        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
+        $translationJoinsProperty = $reflectionClass->getProperty('translationJoins');
+        $translationJoinsProperty->setAccessible(true);
+        
+        // Verify translation join is stored correctly
+        $translationJoins = $translationJoinsProperty->getValue($queryBuilder);
+        static::assertArrayHasKey('translation', $translationJoins);
+        static::assertSame($translationBuilder, $translationJoins['translation']['queryBuilder']);
+        static::assertEquals('entity.id = translation.entity_id', $translationJoins['translation']['joinCondition']);
+        
+        // Verify we can retrieve the translation builder
+        $returnedBuilder = $queryBuilder->getTranslationQueryBuilder('translation');
+        static::assertSame($translationBuilder, $returnedBuilder);
+    }
+
+    public function testGetNonExistentTranslationQueryBuilder(): void
+    {
+        // Test getting a non-existent translation query builder
+        $returnedBuilder = $this->queryBuilder->getTranslationQueryBuilder('non_existent');
+        static::assertNull($returnedBuilder);
+    }
+
+    public function testSelectPartsTracking(): void
+    {
+        // Test tracking of select parts
+        $this->queryBuilder->select('column1', 'column2');
+        static::assertEquals(['column1', 'column2'], $this->queryBuilder->getSelectParts());
+
+        // Test tracking of added select parts
+        $this->queryBuilder->addSelect('column3', 'column4');
+        static::assertEquals(['column1', 'column2', 'column3', 'column4'], $this->queryBuilder->getSelectParts());
+    }
+
+    public function testOrderByPartsTracking(): void
+    {
+        // Test tracking of order by parts
+        $this->queryBuilder->orderBy('column1', 'ASC');
+        static::assertEquals(['column1 ASC'], $this->queryBuilder->getOrderByParts());
+
+        // Test tracking of added order by parts
+        $this->queryBuilder->addOrderBy('column2', 'DESC');
+        static::assertEquals(['column1 ASC', 'column2 DESC'], $this->queryBuilder->getOrderByParts());
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilderTest.php
@@ -4,7 +4,11 @@ namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Dbal;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDB1060Platform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
@@ -16,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
 class QueryBuilderTest extends TestCase
 {
     private Connection&MockObject $connection;
+
     private QueryBuilder $queryBuilder;
 
     protected function setUp(): void
@@ -47,23 +52,23 @@ class QueryBuilderTest extends TestCase
         // We'll simulate what getSQL() does but in a controlled way
         // First set up our QueryBuilder
         $queryBuilder = new QueryBuilder($this->connection);
-        
+
         // Set a comment
         $queryBuilder->setComment('+ MAX_EXECUTION_TIME(1000)');
-        
+
         // Create a reflection class to access private methods/properties
         $reflectionClass = new \ReflectionClass(QueryBuilder::class);
         $commentProperty = $reflectionClass->getProperty('comment');
         $commentProperty->setAccessible(true);
-        
+
         // Verify the comment is stored correctly
         static::assertEquals('+ MAX_EXECUTION_TIME(1000)', $commentProperty->getValue($queryBuilder));
-        
+
         // Now manually apply the comment transformation to test it
         $sql = 'SELECT * FROM test_table';
         $commentValue = $commentProperty->getValue($queryBuilder);
         $modifiedSql = 'SELECT /*' . $commentValue . '*/ ' . substr($sql, 7);
-        
+
         // Verify the comment is applied correctly
         static::assertStringContainsString('SELECT /*+ MAX_EXECUTION_TIME(1000)*/ ', $modifiedSql);
     }
@@ -72,23 +77,23 @@ class QueryBuilderTest extends TestCase
     {
         // Set up our QueryBuilder
         $queryBuilder = new QueryBuilder($this->connection);
-        
+
         // Set a title
         $queryBuilder->setTitle('Test Query');
-        
+
         // Create a reflection class to access private methods/properties
         $reflectionClass = new \ReflectionClass(QueryBuilder::class);
         $titleProperty = $reflectionClass->getProperty('title');
         $titleProperty->setAccessible(true);
-        
+
         // Verify the title is stored correctly
         static::assertEquals('Test Query', $titleProperty->getValue($queryBuilder));
-        
+
         // Now manually apply the title transformation to test it
         $sql = 'SELECT * FROM test_table';
         $titleValue = $titleProperty->getValue($queryBuilder);
-        $modifiedSql = '# ' . $titleValue . PHP_EOL . $sql;
-        
+        $modifiedSql = '# ' . $titleValue . \PHP_EOL . $sql;
+
         // Verify the title is applied correctly
         static::assertStringContainsString('# Test Query', $modifiedSql);
     }
@@ -97,32 +102,32 @@ class QueryBuilderTest extends TestCase
     {
         // Set up our QueryBuilder
         $queryBuilder = new QueryBuilder($this->connection);
-        
+
         // Set both title and comment
         $queryBuilder->setTitle('Test Query');
         $queryBuilder->setComment('+ MAX_EXECUTION_TIME(1000)');
-        
+
         // Create a reflection class to access private methods/properties
         $reflectionClass = new \ReflectionClass(QueryBuilder::class);
         $titleProperty = $reflectionClass->getProperty('title');
         $commentProperty = $reflectionClass->getProperty('comment');
         $titleProperty->setAccessible(true);
         $commentProperty->setAccessible(true);
-        
+
         // Verify properties are stored correctly
         static::assertEquals('Test Query', $titleProperty->getValue($queryBuilder));
         static::assertEquals('+ MAX_EXECUTION_TIME(1000)', $commentProperty->getValue($queryBuilder));
-        
+
         // Now manually apply the transformations to test them
         $sql = 'SELECT * FROM test_table';
         $titleValue = $titleProperty->getValue($queryBuilder);
         $commentValue = $commentProperty->getValue($queryBuilder);
-        
+
         // First add comment to SELECT
         $modifiedSql = 'SELECT /*' . $commentValue . '*/ ' . substr($sql, 7);
         // Then add title at the beginning
-        $modifiedSql = '# ' . $titleValue . PHP_EOL . $modifiedSql;
-        
+        $modifiedSql = '# ' . $titleValue . \PHP_EOL . $modifiedSql;
+
         // Verify both transformations are applied correctly
         static::assertStringContainsString('# Test Query', $modifiedSql);
         static::assertStringContainsString('SELECT /*+ MAX_EXECUTION_TIME(1000)*/ ', $modifiedSql);
@@ -134,22 +139,56 @@ class QueryBuilderTest extends TestCase
         $queryBuilder = new QueryBuilder($this->connection);
         $queryBuilder->update('test_table')->set('column', 'value');
         $queryBuilder->setComment('TEST_COMMENT');
-        
+
         // Create a reflection class to access private properties
         $reflectionClass = new \ReflectionClass(QueryBuilder::class);
         $commentProperty = $reflectionClass->getProperty('comment');
         $commentProperty->setAccessible(true);
-        
+
         // Verify the comment is stored
         static::assertEquals('TEST_COMMENT', $commentProperty->getValue($queryBuilder));
-        
+
         // Now manually verify that comment would NOT be added to non-SELECT statements
         $sql = 'UPDATE test_table SET column = value';
         static::assertStringNotContainsString('/*TEST_COMMENT*/', $sql);
-        
-        // For this test, we only want to verify that the getSQL method in QueryBuilder 
+
+        // For this test, we only want to verify that the getSQL method in QueryBuilder
         // would NOT add comments to non-SELECT statements, which is handled by the condition:
         // if (strpos($sql, 'SELECT ') === 0) { ... }
+    }
+
+    #[DataProvider('queryTimeoutProvider')]
+    public function testSetQueryTimeout(AbstractPlatform $platform, int $timeout, ?string $expectedComment): void
+    {
+        $queryBuilder = new QueryBuilder($this->connection);
+
+        // Call the method to test
+        $result = $queryBuilder->setQueryTimeout($timeout, $platform);
+
+        // Verify the comment is set correctly
+        static::assertSame($expectedComment, $queryBuilder->getComment());
+
+        // Verify the method returns $this for method chaining
+        static::assertSame($queryBuilder, $result);
+    }
+
+    public static function queryTimeoutProvider(): \Generator
+    {
+        yield 'MySQL Platform' => [
+            new MySQLPlatform(),
+            1000,
+            '+ MAX_EXECUTION_TIME(1000)',
+        ];
+        yield 'MariaDB Platform' => [
+            new MariaDB1060Platform(),
+            1000,
+            '+ MAX_STATEMENT_TIME(1)',
+        ];
+        yield 'Other Platform' => [
+            new PostgreSQLPlatform(),
+            1000,
+            null, // No comment should be set for unsupported platforms
+        ];
     }
 
     public function testAddAndGetState(): void
@@ -178,7 +217,7 @@ class QueryBuilderTest extends TestCase
         $queryBuilder = new QueryBuilder($this->connection);
         $queryBuilder->select('entity.*')
             ->from('entity_table', 'entity');
-            
+
         // Add the translation join
         $queryBuilder->addTranslationJoin(
             'entity',
@@ -191,13 +230,13 @@ class QueryBuilderTest extends TestCase
         $reflectionClass = new \ReflectionClass(QueryBuilder::class);
         $translationJoinsProperty = $reflectionClass->getProperty('translationJoins');
         $translationJoinsProperty->setAccessible(true);
-        
+
         // Verify translation join is stored correctly
         $translationJoins = $translationJoinsProperty->getValue($queryBuilder);
         static::assertArrayHasKey('translation', $translationJoins);
         static::assertSame($translationBuilder, $translationJoins['translation']['queryBuilder']);
         static::assertEquals('entity.id = translation.entity_id', $translationJoins['translation']['joinCondition']);
-        
+
         // Verify we can retrieve the translation builder
         $returnedBuilder = $queryBuilder->getTranslationQueryBuilder('translation');
         static::assertSame($translationBuilder, $returnedBuilder);

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilderTest.php
@@ -25,10 +25,8 @@ class QueryBuilderTest extends TestCase
 
     protected function setUp(): void
     {
-        $platform = $this->createMock(AbstractPlatform::class);
-
         $this->connection = $this->createMock(Connection::class);
-        $this->connection->method('getDatabasePlatform')->willReturn($platform);
+        $this->connection->method('getDatabasePlatform')->willReturn(new MySQLPlatform());
 
         $this->queryBuilder = new QueryBuilder($this->connection);
     }
@@ -49,28 +47,18 @@ class QueryBuilderTest extends TestCase
 
     public function testGetSQLWithComment(): void
     {
-        // We'll simulate what getSQL() does but in a controlled way
-        // First set up our QueryBuilder
         $queryBuilder = new QueryBuilder($this->connection);
+        $queryBuilder->select('*')->from('test_table');
 
         // Set a comment
         $queryBuilder->setComment('+ MAX_EXECUTION_TIME(1000)');
 
-        // Create a reflection class to access private methods/properties
-        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
-        $commentProperty = $reflectionClass->getProperty('comment');
-        $commentProperty->setAccessible(true);
-
         // Verify the comment is stored correctly
-        static::assertEquals('+ MAX_EXECUTION_TIME(1000)', $commentProperty->getValue($queryBuilder));
+        static::assertSame('+ MAX_EXECUTION_TIME(1000)', $queryBuilder->getComment());
 
-        // Now manually apply the comment transformation to test it
-        $sql = 'SELECT * FROM test_table';
-        $commentValue = $commentProperty->getValue($queryBuilder);
-        $modifiedSql = 'SELECT /*' . $commentValue . '*/ ' . substr($sql, 7);
-
-        // Verify the comment is applied correctly
-        static::assertStringContainsString('SELECT /*+ MAX_EXECUTION_TIME(1000)*/ ', $modifiedSql);
+        // Get the SQL and verify the comment is applied correctly to SELECT
+        $sql = $queryBuilder->getSQL();
+        static::assertStringContainsString('SELECT /*+ MAX_EXECUTION_TIME(1000)*/ ', $sql);
     }
 
     public function testGetSQLWithTitle(): void
@@ -81,56 +69,35 @@ class QueryBuilderTest extends TestCase
         // Set a title
         $queryBuilder->setTitle('Test Query');
 
-        // Create a reflection class to access private methods/properties
-        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
-        $titleProperty = $reflectionClass->getProperty('title');
-        $titleProperty->setAccessible(true);
-
         // Verify the title is stored correctly
-        static::assertEquals('Test Query', $titleProperty->getValue($queryBuilder));
+        static::assertSame('Test Query', $queryBuilder->getTitle());
 
-        // Now manually apply the title transformation to test it
-        $sql = 'SELECT * FROM test_table';
-        $titleValue = $titleProperty->getValue($queryBuilder);
-        $modifiedSql = '# ' . $titleValue . \PHP_EOL . $sql;
+        // Create a SELECT statement and check that the title is in the SQL
+        $queryBuilder->select('*')->from('test_table');
+        $sql = $queryBuilder->getSQL();
 
         // Verify the title is applied correctly
-        static::assertStringContainsString('# Test Query', $modifiedSql);
+        static::assertStringContainsString('# Test Query', $sql);
     }
 
     public function testGetSQLWithCommentAndTitle(): void
     {
-        // Set up our QueryBuilder
         $queryBuilder = new QueryBuilder($this->connection);
+        // Setup the builder
+        $queryBuilder->select('*')->from('test_table');
 
         // Set both title and comment
         $queryBuilder->setTitle('Test Query');
         $queryBuilder->setComment('+ MAX_EXECUTION_TIME(1000)');
 
-        // Create a reflection class to access private methods/properties
-        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
-        $titleProperty = $reflectionClass->getProperty('title');
-        $commentProperty = $reflectionClass->getProperty('comment');
-        $titleProperty->setAccessible(true);
-        $commentProperty->setAccessible(true);
-
         // Verify properties are stored correctly
-        static::assertEquals('Test Query', $titleProperty->getValue($queryBuilder));
-        static::assertEquals('+ MAX_EXECUTION_TIME(1000)', $commentProperty->getValue($queryBuilder));
+        static::assertSame('Test Query', $queryBuilder->getTitle());
+        static::assertSame('+ MAX_EXECUTION_TIME(1000)', $queryBuilder->getComment());
 
-        // Now manually apply the transformations to test them
-        $sql = 'SELECT * FROM test_table';
-        $titleValue = $titleProperty->getValue($queryBuilder);
-        $commentValue = $commentProperty->getValue($queryBuilder);
-
-        // First add comment to SELECT
-        $modifiedSql = 'SELECT /*' . $commentValue . '*/ ' . substr($sql, 7);
-        // Then add title at the beginning
-        $modifiedSql = '# ' . $titleValue . \PHP_EOL . $modifiedSql;
-
-        // Verify both transformations are applied correctly
-        static::assertStringContainsString('# Test Query', $modifiedSql);
-        static::assertStringContainsString('SELECT /*+ MAX_EXECUTION_TIME(1000)*/ ', $modifiedSql);
+        // Get the SQL and verify both transformations are applied correctly
+        $sql = $queryBuilder->getSQL();
+        static::assertStringContainsString('# Test Query', $sql);
+        static::assertStringContainsString('SELECT /*+ MAX_EXECUTION_TIME(1000)*/ ', $sql);
     }
 
     public function testCommentOnlyAppliedToSelectStatements(): void
@@ -140,30 +107,26 @@ class QueryBuilderTest extends TestCase
         $queryBuilder->update('test_table')->set('column', 'value');
         $queryBuilder->setComment('TEST_COMMENT');
 
-        // Create a reflection class to access private properties
-        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
-        $commentProperty = $reflectionClass->getProperty('comment');
-        $commentProperty->setAccessible(true);
-
         // Verify the comment is stored
-        static::assertEquals('TEST_COMMENT', $commentProperty->getValue($queryBuilder));
+        static::assertSame('TEST_COMMENT', $queryBuilder->getComment());
 
-        // Now manually verify that comment would NOT be added to non-SELECT statements
-        $sql = 'UPDATE test_table SET column = value';
+        // Get the SQL for the UPDATE statement
+        $sql = $queryBuilder->getSQL();
+
+        // Verify that comment would NOT be added to non-SELECT statements
         static::assertStringNotContainsString('/*TEST_COMMENT*/', $sql);
-
-        // For this test, we only want to verify that the getSQL method in QueryBuilder
-        // would NOT add comments to non-SELECT statements, which is handled by the condition:
-        // if (strpos($sql, 'SELECT ') === 0) { ... }
     }
 
     #[DataProvider('queryTimeoutProvider')]
     public function testSetQueryTimeout(AbstractPlatform $platform, int $timeout, ?string $expectedComment): void
     {
-        $queryBuilder = new QueryBuilder($this->connection);
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn($platform);
+
+        $queryBuilder = new QueryBuilder($connection);
 
         // Call the method to test
-        $result = $queryBuilder->setQueryTimeout($timeout, $platform);
+        $result = $queryBuilder->setQueryTimeout($timeout);
 
         // Verify the comment is set correctly
         static::assertSame($expectedComment, $queryBuilder->getComment());
@@ -209,12 +172,17 @@ class QueryBuilderTest extends TestCase
 
     public function testTranslationJoins(): void
     {
-        // Create real QueryBuilder instances
-        $translationBuilder = new QueryBuilder($this->connection);
+        // Mock the connection behavior to handle getSQL call properly
+        $mockConnection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // Create real QueryBuilder instances with our mock connection
+        $translationBuilder = new QueryBuilder($mockConnection);
         $translationBuilder->select('translation.*')
             ->from('translation_table', 'translation');
 
-        $queryBuilder = new QueryBuilder($this->connection);
+        $queryBuilder = new QueryBuilder($mockConnection);
         $queryBuilder->select('entity.*')
             ->from('entity_table', 'entity');
 
@@ -225,17 +193,6 @@ class QueryBuilderTest extends TestCase
             $translationBuilder,
             'entity.id = translation.entity_id'
         );
-
-        // Create a reflection class to access private properties
-        $reflectionClass = new \ReflectionClass(QueryBuilder::class);
-        $translationJoinsProperty = $reflectionClass->getProperty('translationJoins');
-        $translationJoinsProperty->setAccessible(true);
-
-        // Verify translation join is stored correctly
-        $translationJoins = $translationJoinsProperty->getValue($queryBuilder);
-        static::assertArrayHasKey('translation', $translationJoins);
-        static::assertSame($translationBuilder, $translationJoins['translation']['queryBuilder']);
-        static::assertEquals('entity.id = translation.entity_id', $translationJoins['translation']['joinCondition']);
 
         // Verify we can retrieve the translation builder
         $returnedBuilder = $queryBuilder->getTranslationQueryBuilder('translation');
@@ -253,21 +210,21 @@ class QueryBuilderTest extends TestCase
     {
         // Test tracking of select parts
         $this->queryBuilder->select('column1', 'column2');
-        static::assertEquals(['column1', 'column2'], $this->queryBuilder->getSelectParts());
+        static::assertSame(['column1', 'column2'], $this->queryBuilder->getSelectParts());
 
         // Test tracking of added select parts
         $this->queryBuilder->addSelect('column3', 'column4');
-        static::assertEquals(['column1', 'column2', 'column3', 'column4'], $this->queryBuilder->getSelectParts());
+        static::assertSame(['column1', 'column2', 'column3', 'column4'], $this->queryBuilder->getSelectParts());
     }
 
     public function testOrderByPartsTracking(): void
     {
         // Test tracking of order by parts
         $this->queryBuilder->orderBy('column1', 'ASC');
-        static::assertEquals(['column1 ASC'], $this->queryBuilder->getOrderByParts());
+        static::assertSame(['column1 ASC'], $this->queryBuilder->getOrderByParts());
 
         // Test tracking of added order by parts
         $this->queryBuilder->addOrderBy('column2', 'DESC');
-        static::assertEquals(['column1 ASC', 'column2 DESC'], $this->queryBuilder->getOrderByParts());
+        static::assertSame(['column1 ASC', 'column2 DESC'], $this->queryBuilder->getOrderByParts());
     }
 }


### PR DESCRIPTION
## Description

This PR adds support for setting a SQL query timeout in the Criteria class, which can then be applied to both MySQL/MariaDB and Elasticsearch queries.

## Changes

- Added `queryTimeout` property to the `Criteria` class with getter/setter methods
- Added support for SQL comment hints in the `QueryBuilder` class
- Applied SQL query timeout for MySQL and MariaDB in the `EntitySearcher` class
- Applied timeout in the `ElasticsearchEntitySearcher` class for Elasticsearch queries
- Added unit tests for the new SQL comment functionality in `QueryBuilder`

## Implementation Details

### MySQL 8 and MariaDB Support
- For MySQL 8, we use the `MAX_EXECUTION_TIME` optimizer hint
- For MariaDB, we use the `MAX_STATEMENT_TIME` optimizer hint (with proper conversion from ms to seconds)
- The timeout is applied only to the specific query instead of modifying session variables

### Elasticsearch Support
- Added support to use the Criteria timeout in Elasticsearch queries
- Falls back to the default timeout if none is specified in the Criteria

## How to Use

```php
// Create criteria with a 1000ms (1 second) timeout
$criteria = new Criteria();
$criteria->setQueryTimeout(1000);

// The timeout will be automatically applied 
// when the criteria is used in repository methods
$products = $productRepository->search($criteria, $context);
```

## Testing
Added comprehensive unit tests for the `QueryBuilder` class to ensure proper SQL comment functionality with and without query timeouts.