### PR TITLE
fix: Replace sw-button by mt-button and set correct button variants in the `sw-theme-manager-detail` component

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -62,17 +62,18 @@
                     {% block sw_theme_manager_detail_smart_bar_actions_save_context_menu %}
                         <sw-context-button>
                             <template #button>
-                                <sw-button
+                                <mt-button
                                     class="sw_theme_manager_detail__button-context-menu"
                                     square
                                     variant="primary"
                                     :disabled="isLoading || !acl.can('theme.editor')"
+                                    size="default"
                                 >
-                                    <sw-icon
-                                            name="regular-chevron-down-xs"
-                                            size="16"
+                                    <mt-icon
+                                        name="regular-chevron-down-xs"
+                                        size="16"
                                     />
-                                </sw-button>
+                                </mt-button>
                             </template>
 
                             {% block sw_theme_manager_detail_smart_bar_actions_save_context_menu_actions %}
@@ -450,22 +451,23 @@
                     {% block sw_theme_manager_reset_modal_footer %}
                         <template #modal-footer>
                             {% block sw_theme_manager_reset_modal_cancel %}
-                                <sw-button
+                                <mt-button
                                     size="small"
+                                    variant="primary"
                                     @click="onCloseResetModal"
                                 >
                                     {{ $t('global.default.cancel') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
 
                             {% block sw_theme_manager_reset_modal_confirm %}
-                                <sw-button
+                                <mt-button
                                     size="small"
-                                    variant="danger"
+                                    variant="critical"
                                     @click="onConfirmThemeReset"
                                 >
                                     {{ $t('sw-theme-manager.actions.buttonReset') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
                      </template>
                     {% endblock %}
@@ -487,22 +489,23 @@
                     {% block sw_theme_manager_detail_delete_modal_footer %}
                         <template #modal-footer>
                             {% block sw_theme_manager_detail_delete_modal_cancel %}
-                                <sw-button
+                                <mt-button
+                                    variant="secondary"
                                     size="small"
                                     @click="onCloseDeleteModal"
                                 >
                                     {{ $t('global.default.cancel') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
 
                             {% block sw_theme_manager_detail_delete_modal_confirm %}
-                                <sw-button
-                                    variant="danger"
+                                <mt-button
+                                    variant="critical"
                                     size="small"
                                     @click="onConfirmThemeDelete"
                                 >
                                     {{ $t('global.default.delete') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
                         </template>
                     {% endblock %}
@@ -564,22 +567,23 @@
                     {% block sw_theme_manager_detail_save_modal_footer %}
                         <template #modal-footer>
                             {% block sw_theme_manager_detail_save_modal_cancel %}
-                                <sw-button
+                                <mt-button
+                                    variant="secondary"
                                     size="small"
                                     @click="onCloseSaveModal"
                                 >
                                     {{ $t('global.default.cancel') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
 
                             {% block sw_theme_manager_detail_save_modal_confirm %}
-                                <sw-button
+                                <mt-button
                                     variant="primary"
                                     size="small"
                                     @click="onConfirmThemeSave"
                                 >
                                     {{ $t('global.default.save') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
                         </template>
                     {% endblock %}
@@ -609,19 +613,24 @@
                     {% block sw_theme_manager_detail_duplicate_modal_footer %}
                         <template #modal-footer>
                             {% block sw_theme_manager_detail_duplicate_modal_cancel %}
-                                <sw-button @click="onCloseDuplicateModal"
-                                           size="small">
+                                <mt-button
+                                    variant="primary"
+                                    size="small"
+                                    @click="onCloseDuplicateModal"
+                                >
                                     {{ $t('global.default.cancel') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
 
                             {% block sw_theme_manager_detail_duplicate_modal_confirm %}
-                                <sw-button @click="onConfirmThemeDuplicate"
-                                           variant="primary"
-                                           :disabled="newThemeName.length < 3"
-                                           size="small">
+                                <mt-button
+                                    variant="primary"
+                                    :disabled="newThemeName.length < 3"
+                                    size="small"
+                                    @click="onConfirmThemeDuplicate"
+                                >
                                     {{ $t('sw-theme-manager.modal.buttonDuplicateTheme') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
                         </template>
                     {% endblock %}
@@ -651,19 +660,24 @@
                     {% block sw_theme_manager_detail_rename_modal_footer %}
                         <template #modal-footer>
                             {% block sw_theme_manager_detail_rename_modal_cancel %}
-                                <sw-button @click="onCloseRenameModal"
-                                           size="small">
+                                <mt-button
+                                    variant="secondary"
+                                    size="small"
+                                    @click="onCloseRenameModal"
+                                >
                                     {{ $t('global.default.cancel') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
 
                             {% block sw_theme_manager_detail_rename_modal_confirm %}
-                                <sw-button @click="onConfirmThemeRename"
-                                           variant="primary"
-                                           :disabled="newThemeName.length < 3"
-                                           size="small">
+                                <mt-button
+                                    variant="primary"
+                                    :disabled="newThemeName.length < 3"
+                                    size="small"
+                                    @click="onConfirmThemeRename"
+                                >
                                     {{ $t('global.default.save') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
                         </template>
                     {% endblock %}
@@ -683,9 +697,13 @@
                     {% block sw_theme_manager_detail_error_modal_footer %}
                         <template #modal-footer>
                             {% block sw_theme_manager_detail_error_modal_close %}
-                                <sw-button size="small" @click="onCloseErrorModal">
+                                <mt-button
+                                    variant="secondary"
+                                    size="small"
+                                    @click="onCloseErrorModal"
+                                >
                                     {{ $t('global.default.close') }}
-                                </sw-button>
+                                </mt-button>
                             {% endblock %}
                         </template>
                     {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Similar to https://github.com/shopware/shopware/pull/9655
Furthermore the context button besides the save button was not working. Not sure why, but when replacing it by the `mt-button` and `mt-icon` it worked again. 

However still there are two buttons nested, which is I guess not ideal (but is also the case for the context button on the product detail list).

### 2. What does this change do, exactly?
Look at the code.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
