### PR TITLE
fix: overwrite of CreatedByField with non-live version

### DIFF
--- a/changelog/_unreleased/2025-05-21-remove-write-of-createdbyfield-for-nonlive-versions.md
+++ b/changelog/_unreleased/2025-05-21-remove-write-of-createdbyfield-for-nonlive-versions.md
@@ -1,0 +1,12 @@
+---
+title: Remove overwrite of CreatedByField with non-live version
+issue: 9612
+author: Max Stegmeyer
+author_email: m.stegmeyer@shopware.com
+author_github: @mstegmeyer
+---
+# Core
+* Changed `Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\CreatedByFieldSerializer` to not write, when it's dealing with a non-live version
+___
+# Administration
+* Deprecated property and update method `createdById` for `sw-order-detail`. It will be removed in 6.8.0.

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@shopware-ag/meteor-admin-sdk": "6.0.0",
+        "@shopware-ag/meteor-admin-sdk": "^6.0.0",
         "@shopware-ag/meteor-component-library": "^4.11.1",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@shopware-ag/meteor-admin-sdk": "^6.0.0",
+        "@shopware-ag/meteor-admin-sdk": "6.0.0",
         "@shopware-ag/meteor-component-library": "^4.11.1",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -24,6 +24,7 @@ export default {
 
     provide() {
         return {
+            /** @deprecated tag:v6.8.0 - swOrderDetailOnCreatedByIdChange will be removed */
             swOrderDetailOnCreatedByIdChange: this.updateCreatedById,
             swOrderDetailOnLoadingChange: this.onUpdateLoading,
             swOrderDetailOnEditingChange: this.onUpdateEditing,
@@ -55,6 +56,7 @@ export default {
             isEditing: false,
             isLoading: true,
             isSaveSuccessful: false,
+            /** @deprecated tag:v6.8.0 - createdById will be removed */
             createdById: '',
             isDisplayingLeavePageWarning: false,
             nextRoute: null,
@@ -242,6 +244,9 @@ export default {
             }
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - createdById will be removed (there is a template usage that needs to be removed as well)
+         */
         updateCreatedById(createdById) {
             this.createdById = createdById;
         },

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializer.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer;
 
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedByField;
@@ -39,6 +40,11 @@ class CreatedByFieldSerializer extends FkFieldSerializer
         if ($data->getValue()) {
             yield from parent::encode($field, $existence, $data, $parameters);
 
+            return;
+        }
+
+        // don't rewrite when creating a separate version
+        if ($context->getVersionId() !== Defaults::LIVE_VERSION) {
             return;
         }
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
@@ -76,6 +76,27 @@ class CreatedByFieldTest extends TestCase
         static::assertNull($result->getCreatedById());
     }
 
+    public function testCreatedByNotCreateWithWrongVersion(): void
+    {
+        $orderRepository = $this->orderRepository;
+        $userId = $this->fetchFirstIdFromTable('user');
+        $context = $this->getAdminContext($userId)->createWithVersionId(Uuid::randomHex());
+
+        $payload = $this->createOrderPayload();
+
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($orderRepository, $payload): void {
+            $orderRepository->create([$payload], $context);
+        });
+
+        $result = $orderRepository->search(
+            new Criteria([$payload['id']]),
+            $context
+        )->getEntities()->first();
+
+        static::assertNotNull($result);
+        static::assertNull($result->getCreatedById());
+    }
+
     public function testCreateCreatedBy(): void
     {
         $orderRepository = $this->orderRepository;

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
@@ -9,9 +9,11 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedByField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\CreatedByFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
@@ -69,6 +71,165 @@ class CreatedByFieldSerializerTest extends TestCase
         )->current();
 
         static::assertSame($userId, Uuid::fromBytesToHex($return));
+    }
+
+    public function testEncodeWithInvalidField(): void
+    {
+        $data = new KeyValuePair('key', null, false);
+        $existence = $this->createMock(EntityExistence::class);
+        $parameters = new WriteParameterBag(
+            $this->createMock(EntityDefinition::class),
+            $this->createWriteContext(null),
+            '/',
+            new WriteCommandQueue(),
+        );
+
+        $wrongField = new JsonField('key', 'key');
+
+        $this->expectExceptionObject(DataAbstractionLayerException::invalidSerializerField(CreatedByField::class, $wrongField));
+
+        $this->fieldSerializer->encode(
+            $wrongField,
+            $existence,
+            $data,
+            $parameters
+        )->current();
+    }
+
+    public function testEncodeWithExistingEntity(): void
+    {
+        $data = new KeyValuePair('key', null, false);
+        $existence = $this->createMock(EntityExistence::class);
+        $existence->method('exists')->willReturn(true);
+        $parameters = new WriteParameterBag(
+            $this->createMock(EntityDefinition::class),
+            $this->createWriteContext(Uuid::randomHex()),
+            '/',
+            new WriteCommandQueue(),
+        );
+
+        $result = $this->fieldSerializer->encode(
+            new CreatedByField([Context::USER_SCOPE]),
+            $existence,
+            $data,
+            $parameters
+        )->current();
+
+        static::assertNull($result);
+    }
+
+    public function testEncodeWithInvalidScope(): void
+    {
+        $data = new KeyValuePair('key', null, false);
+        $existence = $this->createMock(EntityExistence::class);
+        $existence->method('exists')->willReturn(false);
+
+        $result = 'foo';
+        Context::createDefaultContext()->scope('invalid-scope', function (Context $context) use ($data, $existence, &$result): void {
+            $result = $this->fieldSerializer->encode(
+                new CreatedByField([Context::USER_SCOPE]),
+                $existence,
+                $data,
+                new WriteParameterBag(
+                    $this->createMock(EntityDefinition::class),
+                    WriteContext::createFromContext($context),
+                    '/',
+                    new WriteCommandQueue(),
+                )
+            )->current();
+        });
+
+        static::assertNull($result);
+    }
+
+    public function testEncodeWithProvidedValue(): void
+    {
+        $providedUserId = Uuid::randomHex();
+        $data = new KeyValuePair('key', $providedUserId, false);
+        $existence = $this->createMock(EntityExistence::class);
+        $existence->method('exists')->willReturn(false);
+        $parameters = new WriteParameterBag(
+            $this->createMock(EntityDefinition::class),
+            $this->createWriteContext(Uuid::randomHex()),
+            '/',
+            new WriteCommandQueue(),
+        );
+
+        $return = $this->fieldSerializer->encode(
+            new CreatedByField([Context::USER_SCOPE]),
+            $existence,
+            $data,
+            $parameters
+        )->current();
+
+        static::assertSame($providedUserId, Uuid::fromBytesToHex($return));
+    }
+
+    public function testEncodeWithSeparateVersion(): void
+    {
+        $data = new KeyValuePair('key', null, false);
+        $existence = $this->createMock(EntityExistence::class);
+        $existence->method('exists')->willReturn(false);
+        $versionId = Uuid::randomHex();
+        $parameters = new WriteParameterBag(
+            $this->createMock(EntityDefinition::class),
+            $this->createWriteContext(Uuid::randomHex(), $versionId),
+            '/',
+            new WriteCommandQueue(),
+        );
+
+        $result = $this->fieldSerializer->encode(
+            new CreatedByField([Context::USER_SCOPE]),
+            $existence,
+            $data,
+            $parameters
+        )->current();
+
+        static::assertNull($result);
+    }
+
+    public function testEncodeWithSalesChannelApiSource(): void
+    {
+        $data = new KeyValuePair('key', null, false);
+        $existence = $this->createMock(EntityExistence::class);
+        $existence->method('exists')->willReturn(false);
+        $parameters = new WriteParameterBag(
+            $this->createMock(EntityDefinition::class),
+            $this->createWriteContext(null, Defaults::LIVE_VERSION, false),
+            '/',
+            new WriteCommandQueue(),
+        );
+
+        $result = $this->fieldSerializer->encode(
+            new CreatedByField([Context::USER_SCOPE]),
+            $existence,
+            $data,
+            $parameters
+        )->current();
+
+        static::assertNull($result);
+    }
+
+    public function testEncodeWithNoUserId(): void
+    {
+        $data = new KeyValuePair('key', null, false);
+        $existence = $this->createMock(EntityExistence::class);
+        $existence->method('exists')->willReturn(false);
+        $parameters = new WriteParameterBag(
+            $this->createMock(EntityDefinition::class),
+            $this->createWriteContext(null),
+            '/',
+            new WriteCommandQueue(),
+        );
+
+        $result = $this->fieldSerializer->encode(
+            new CreatedByField([Context::USER_SCOPE]),
+            $existence,
+            $data,
+            $parameters
+        )->current();
+
+        static::assertNull($result);
     }
 
     private function createWriteContext(?string $userId, string $versionId = Defaults::LIVE_VERSION, bool $useAdminApiSource = true): WriteContext

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\FieldSerializer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedByField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\CreatedByFieldSerializer;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(CreatedByFieldSerializer::class)]
+class CreatedByFieldSerializerTest extends TestCase
+{
+    private DefinitionInstanceRegistry&MockObject $definitionInstanceRegistry;
+
+    private ValidatorInterface&MockObject $validator;
+
+    private CreatedByFieldSerializer $fieldSerializer;
+
+    protected function setUp(): void
+    {
+        $this->definitionInstanceRegistry = $this->createMock(DefinitionInstanceRegistry::class);
+        $this->validator = $this->createMock(ValidatorInterface::class);
+
+        $this->fieldSerializer = new CreatedByFieldSerializer(
+            $this->validator,
+            $this->definitionInstanceRegistry,
+        );
+    }
+
+    public function testEncode(): void
+    {
+        $data = new KeyValuePair('key', null, false);
+        $existence = $this->createMock(EntityExistence::class);
+        $existence->method('exists')->willReturn(false);
+        $userId = Uuid::randomHex();
+
+        $parameters = new WriteParameterBag(
+            $this->createMock(EntityDefinition::class),
+            $this->createWriteContext($userId),
+            '/',
+            new WriteCommandQueue(),
+        );
+
+        $return = $this->fieldSerializer->encode(
+            new CreatedByField([Context::USER_SCOPE]),
+            $existence,
+            $data,
+            $parameters
+        )->current();
+
+        static::assertSame($userId, Uuid::fromBytesToHex($return));
+    }
+
+    private function createWriteContext(?string $userId, string $versionId = Defaults::LIVE_VERSION, bool $useAdminApiSource = true): WriteContext
+    {
+        if ($useAdminApiSource) {
+            $source = new AdminApiSource($userId);
+        } else {
+            $source = new SalesChannelApiSource(TestDefaults::SALES_CHANNEL);
+        }
+
+        $context = Context::createDefaultContext($source)->createWithVersionId($versionId);
+
+        return WriteContext::createFromContext($context);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
CreatedByFields are not supposed to be overwritten after an entity is created. But: Creating a new version of an entity means, that the entity does not exist. For orders, this means, that whenever a version is created and then merged back into the live version, this field gets overwritten.

### 2. What does this change do, exactly?
Write this field only, if the live version does not exist and when we are in a live context.

### 3. Describe each step to reproduce the issue or behaviour.
- Create an order in the Storefront
- In the order list, it should not have the tag `Created by admin`
- Edit it (e.g. change shipping cost)
- Before: it will always get the tag `Created by admin`. Now: only orders created in the admin will get the tag.

### 4. Please link to the relevant issues (if any).
fixes #9612

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
