### PR TITLE
fix: sw-tabs-item outline when navigating by keyboard

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-deprecated/index.js
@@ -118,8 +118,9 @@ export default {
 
         sliderLength() {
             if (this.registeredTabItems[this.activeItem]) {
-                const activeChildren = this.registeredTabItems[this.activeItem];
-                return this.isVertical ? activeChildren.$el.offsetHeight : activeChildren.$el.offsetWidth;
+                const activeChildren = this.registeredTabItems[this.activeItem].$el;
+                const computedStyle = window.getComputedStyle(activeChildren);
+                return this.isVertical ? computedStyle.height : computedStyle.width;
             }
 
             return 0;
@@ -153,13 +154,13 @@ export default {
             if (this.isVertical) {
                 return `
                     transform: translate(0, ${this.sliderMovement}px) rotate(${this.alignRight ? '-90deg' : '90deg'});
-                    width: ${this.sliderLength}px;
+                    width: ${this.sliderLength};
                 `;
             }
 
             return `
                 transform: translate(${this.sliderMovement}px, 0) rotate(0deg);
-                width: ${this.sliderLength}px;
+                width: ${this.sliderLength};
                 bottom: ${this.scrollbarOffset}px;
             `;
         },

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.scss
@@ -30,6 +30,10 @@ $sw-side-navigation-item-link-distance: 10px;
         .sw-tabs-item__error-badge {
             color: $color-crimson-400;
         }
+
+        &:focus {
+            border-bottom: none;
+        }
     }
 
     &.sw-tabs-item--has-error {

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.scss
@@ -134,8 +134,6 @@
         }
 
         .sw-tabs-item {
-            padding: 10px 0;
-            margin-right: 16px;
             border-bottom: none;
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.scss
@@ -15,17 +15,6 @@
         .sw-tabs-item {
             position: relative;
             border: 0;
-
-            &::before {
-                content: "";
-                display: block;
-                position: absolute;
-                left: 0;
-                right: 0;
-                bottom: 0;
-                height: 2px;
-                background-color: $color-gray-300;
-            }
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix this issue: https://github.com/shopware/shopware/issues/9618

### 2. What does this change do, exactly?
Fixes the bottom border of the tab item when focus and the position of bottom line for active item

### 3. Describe each step to reproduce the issue or behaviour.
1. go to any tabs
2. press `tab` key in keyboard to start navigation until the tab item is selected

*Before*
![image](https://github.com/user-attachments/assets/5e72fcb8-093b-4eee-951d-398779b76eb9)


*After*
![image](https://github.com/user-attachments/assets/b8599cd5-6fe8-4cd0-b741-130a15098694)


### 4. Please link to the relevant issues (if any).
- closes #9618

