### PR TITLE
fix: notification icon has misaligned dot

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/sw-notification-center.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/sw-notification-center.scss
@@ -1,10 +1,16 @@
 @import "~scss/variables";
 
 .sw-notification-center__context-button {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--border-radius-button);
+    display: flex;
+    justify-content: center;
+    align-items: center;
     cursor: pointer;
 
     &.is--active {
-        color: $color-shopware-brand-500;
+        background: var(--color-interaction-secondary-hover);
     }
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Closes https://github.com/shopware/shopware/issues/9622

### 2. What does this change do, exactly?

Add the missing SCSS fixes for the notification icon. They were fixed here https://github.com/shopware/shopware/pull/8177 but we can't backport this PR. Therefore this little PR copies only the styling fixes
