### PR TITLE
chore: Add a11y banner for sliders [6.6.x]

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -171,46 +171,53 @@
                     </div>
                     {% endblock %}
 
-                    <div class="sw-cms-el-config-image-slider__setting-slide">
-                        {# @todo NEXT-40267 - Re-implement after tiny-slider has been replaced, due to accessibility issues #}
-                        <sw-switch-field
-                            :value="false"
-                            class="sw-cms-el-config-image-slider__setting-auto-slide"
-                            :label="$tc('sw-cms.elements.general.config.label.autoSlide')"
-                            :help-text="$tc('sw-cms.elements.general.config.helpText.autoSlide')"
-                            bordered
-                            disabled
+                    <div class="sw-cms-el-config-image-slider__setting-speed">
+                        <sw-number-field
+                            v-model:value="element.config.speed.value"
+                            class="sw-cms-el-config-image-slider__setting-speed-slide"
+                            number-type="int"
+                            :min="0"
+                            :max="3600000"
+                            :label="$tc('sw-cms.elements.general.config.label.speed')"
+                            :placeholder="$tc('sw-cms.elements.general.config.label.speed')"
+                            :help-text="$tc('sw-cms.elements.general.config.helpText.speed')"
                         />
                     </div>
 
-                    <div class="sw-cms-el-config-image-slider__setting-option">
-                        <div class="sw-cms-el-config-image-slider__setting-delay">
-                            <sw-number-field
-                                v-model:value="element.config.autoplayTimeout.value"
-                                class="sw-cms-el-config-image-slider__setting-delay-slide"
-                                number-type="int"
-                                :min="0"
-                                :max="3600000"
-                                :disabled="true"
-                                :label="$tc('sw-cms.elements.general.config.label.autoplayTimeout')"
-                                :placeholder="$tc('sw-cms.elements.general.config.label.autoplayTimeout')"
-                                :help-text="$tc('sw-cms.elements.general.config.helpText.autoplayTimeout')"
-                            />
+                    <mt-banner
+                        class="sw-cms-el-config-image-slider__setting-auto-slide-banner"
+                        variant="attention"
+                        :title="$tc('sw-cms.elements.general.config.infoText.autoSlideTitle')"
+                    >
+                        <p class="sw-cms-el-config-image-slider__setting-auto-slide-attention">
+                            {{ $tc('sw-cms.elements.general.config.infoText.autoSlide') }}
+                        </p>
+
+                        <div class="sw-cms-el-config-image-slider__setting-auto-slide-container sw-cms-el-config-image-slider__setting-option">
+                            <div class="sw-cms-el-config-image-slider__setting-slide">
+                                <sw-switch-field
+                                    v-model:value="element.config.autoSlide.value"
+                                    class="sw-cms-el-config-image-slider__setting-auto-slide"
+                                    :label="$tc('sw-cms.elements.general.config.label.autoSlide')"
+                                    bordered
+                                />
+                            </div>
+
+                            <div class="sw-cms-el-config-image-slider__setting-delay">
+                                <sw-number-field
+                                    v-model:value="element.config.autoplayTimeout.value"
+                                    class="sw-cms-el-config-image-slider__setting-delay-slide"
+                                    number-type="int"
+                                    :min="0"
+                                    :max="3600000"
+                                    :disabled="!element.config.autoSlide.value"
+                                    :label="$tc('sw-cms.elements.general.config.label.autoplayTimeout')"
+                                    :placeholder="$tc('sw-cms.elements.general.config.label.autoplayTimeout')"
+                                    :help-text="$tc('sw-cms.elements.general.config.helpText.autoplayTimeout')"
+                                />
+                            </div>
                         </div>
-                        <div class="sw-cms-el-config-image-slider__setting-speed">
-                            <sw-number-field
-                                v-model:value="element.config.speed.value"
-                                class="sw-cms-el-config-image-slider__setting-speed-slide"
-                                number-type="int"
-                                :min="0"
-                                :max="3600000"
-                                :disabled="true"
-                                :label="$tc('sw-cms.elements.general.config.label.speed')"
-                                :placeholder="$tc('sw-cms.elements.general.config.label.speed')"
-                                :help-text="$tc('sw-cms.elements.general.config.helpText.speed')"
-                            />
-                        </div>
-                    </div>
+                    </mt-banner>
 
                     {% block sw_cms_element_image_slider_config_settings_links %}
                     <div class="sw-cms-el-config-image-slider__settings-links sw-cms-el-config-image-slider__setting-option">

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.scss
@@ -3,8 +3,17 @@
 .sw-cms-el-config-image-slider {
     .sw-cms-el-config-image-slider__setting-option {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(370px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(335px, 1fr));
         gap: 0 32px;
+    }
+
+    &__setting-auto-slide,
+    &__setting-delay-slide {
+        margin-bottom: 0;
+    }
+
+    &__setting-auto-slide-banner {
+        margin-bottom: 32px;
     }
 
     .sw-cms-el-config-image-slider__setting-display-mode {
@@ -32,6 +41,8 @@
     }
 
     &__setting-auto-slide {
+        background-color: $color-white;
+
         &.sw-field--switch .sw-field__label label {
             margin-right: 0;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
@@ -275,48 +275,53 @@
                 {# @deprecated tag:v6.7.0 - Will be removed #}
                 {% block sw_cms_element_product_slider_config_settings_navigation %}{% endblock %}
 
-                <div class="sw-cms-el-config-product-slider__tab-settings-rotate">
-                    {% block sw_cms_element_product_slider_config_settings_rotate %}
-                    {# @todo NEXT-40267 - Re-implement after tiny-slider has been replaced, due to accessibility issues #}
-                    <sw-switch-field
-                        :value="false"
-                        class="sw-cms-el-config-product-slider__tab-settings-rotate-switch"
-                        :label="$tc('sw-cms.elements.general.config.label.autoSlide')"
-                        :help-text="$tc('sw-cms.elements.general.config.helpText.autoSlide')"
-                        bordered
-                        disabled
-                    />
-                    {% endblock %}
-                </div>
+                {% block sw_cms_element_product_slider_config_settings_autoplay_timeout %}
+                <sw-number-field
+                    v-model:value="element.config.speed.value"
+                    class="sw-cms-el-config-product-slider__tab-settings-rotate-speed"
+                    number-type="int"
+                    :min="0"
+                    :max="3600000"
+                    :label="$tc('sw-cms.elements.general.config.label.speed')"
+                    :placeholder="$tc('sw-cms.elements.general.config.label.speed')"
+                    :help-text="$tc('sw-cms.elements.general.config.helpText.speed')"
+                />
+                {% endblock %}
 
-                <div class="sw-cms-el-config-product-slider__tab-settings-rotate-config has--two-elements">
-                    {% block sw_cms_element_product_slider_config_settings_autoplay_timeout %}
-                    <sw-number-field
-                        v-model:value="element.config.autoplayTimeout.value"
-                        class="sw-cms-el-config-product-slider__tab-settings-rotate-autoplay"
-                        number-type="int"
-                        :min="0"
-                        :max="3600000"
-                        :disabled="true"
-                        :label="$tc('sw-cms.elements.general.config.label.autoplayTimeout')"
-                        :placeholder="$tc('sw-cms.elements.general.config.label.autoplayTimeout')"
-                        :help-text="$tc('sw-cms.elements.general.config.helpText.autoplayTimeout')"
-                    />
-                    {% endblock %}
+                <mt-banner
+                    class="sw-cms-el-config-product-slider__setting-auto-slide-banner"
+                    variant="attention"
+                    :title="$tc('sw-cms.elements.general.config.infoText.autoSlideTitle')"
+                >
+                    <p class="sw-cms-el-config-product-slider__setting-auto-slide-attention">
+                        {{ $tc('sw-cms.elements.general.config.infoText.autoSlide') }}
+                    </p>
 
-                    {% block sw_cms_element_product_slider_config_settings_autoplay_timeout %}
-                    <sw-number-field
-                        v-model:value="element.config.speed.value"
-                        class="sw-cms-el-config-product-slider__tab-settings-rotate-speed"
-                        number-type="int"
-                        :min="0"
-                        :max="3600000"
-                        :label="$tc('sw-cms.elements.general.config.label.speed')"
-                        :placeholder="$tc('sw-cms.elements.general.config.label.speed')"
-                        :help-text="$tc('sw-cms.elements.general.config.helpText.speed')"
-                    />
-                    {% endblock %}
-                </div>
+                    <div class="sw-cms-el-config-product-slider__tab-settings-rotate-config has--two-elements">
+                        {% block sw_cms_element_product_slider_config_settings_rotate %}
+                        <sw-switch-field
+                            v-model:value="element.config.rotate.value"
+                            class="sw-cms-el-config-product-slider__tab-settings-rotate-switch"
+                            :label="$tc('sw-cms.elements.general.config.label.autoSlide')"
+                            bordered
+                        />
+                        {% endblock %}
+
+                        {% block sw_cms_element_product_slider_config_settings_autoplay_timeout %}
+                        <sw-number-field
+                            v-model:value="element.config.autoplayTimeout.value"
+                            class="sw-cms-el-config-product-slider__tab-settings-rotate-autoplay"
+                            number-type="int"
+                            :min="0"
+                            :max="3600000"
+                            :disabled="!element.config.rotate.value"
+                            :label="$tc('sw-cms.elements.general.config.label.autoplayTimeout')"
+                            :placeholder="$tc('sw-cms.elements.general.config.label.autoplayTimeout')"
+                            :help-text="$tc('sw-cms.elements.general.config.helpText.autoplayTimeout')"
+                        />
+                        {% endblock %}
+                    </div>
+                </mt-banner>
             </sw-container>
             {% endblock %}
         </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.scss
@@ -34,6 +34,19 @@
         }
     }
 
+    &__tab-settings-rotate-switch,
+    &__tab-settings-rotate-autoplay {
+        margin-bottom: 0;
+    }
+
+    &__setting-auto-slide-banner {
+        margin-bottom: 32px;
+    }
+
+    &__tab-settings-rotate-switch {
+        background-color: $color-white;
+    }
+
     .sw-cms-el-config-product-slider__tab-content-product-stream-performance-hint {
         width: 100%;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -230,6 +230,8 @@
             "options": "Optionen"
           },
           "infoText": {
+            "autoSlideTitle": "Bedenken hinsichtlich der Barrierefreiheit",
+            "autoSlide": "Das Aktivieren dieser Funktion kann dazu führen, dass Teile Deiner Storefront für Menschen mit Einschränkungen nicht zugänglich sind. Dies kann eine Nichteinhaltung der in Deiner Gerichtsbarkeit geltenden Barrierefreiheitsgesetze darstellen (z.B. des Europäischen Rechtsakts zur Barrierefreiheit). Mit dem Fortfahren erkennst Du dieses Risiko an und übernimmst die volle Verantwortung.",
             "listingElement": "Die Produktdaten für dieses Element werden automatisiert über die Kategoriezuweisung befüllt. Der Inhalt zeigt nur eine ungefähre Vorschau."
           }
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -230,6 +230,8 @@
             "options": "Options"
           },
           "infoText": {
+            "autoSlideTitle": "Accessibility concerns",
+            "autoSlide": "Enabling this feature may make parts of your storefront inaccessible to users with disabilities. This may result in non-compliance with accessibility laws applicable in your jurisdiction (e.g., the European Accessibility Act). By proceeding, you acknowledge this risk and accept full responsibility.",
             "listingElement": "This element's product data is automatically loaded by the category associated with this layout. The content just shows a sample preview."
           }
         },

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
@@ -4,14 +4,13 @@
     {% set blockId = block.id %}
 
     <div class="cms-element-{{ element.type }}{% if sliderConfig.displayMode.value == "standard" and sliderConfig.verticalAlign.value %} has-vertical-alignment{% endif %}">
-        {# @todo NEXT-40267 - Re-implement autoplay, when tiny-slider solution has been replaced #}
         {% set baseSliderOptions = {
             slider: {
                 controls: sliderConfig.navigationArrows.value in visibleValues,
                 nav: sliderConfig.navigationDots.value in visibleValues,
                 navPosition: 'bottom',
                 mouseDrag: true,
-                autoplay: false,
+                autoplay: sliderConfig.autoSlide.value ? true : false,
                 autoplayButtonOutput: false,
                 autoplayTimeout: sliderConfig.autoplayTimeout.value,
                 speed: sliderConfig.speed.value,

--- a/src/Storefront/Resources/views/storefront/element/cms-element-product-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-product-slider.html.twig
@@ -15,12 +15,11 @@
                     <div class="cms-element-alignment{% if sliderConfig.verticalAlign.value == "center" %} align-self-center{% elseif sliderConfig.verticalAlign.value == "flex-end" %} align-self-end{% else %} align-self-start{% endif %}">
                 {% endif %}
 
-                {# @todo NEXT-40267 - Re-implement autoplay, when tiny-slider solution has been replaced #}
                 {% set productSliderOptionsSlider  = {
                     controls: sliderConfig.navigationArrows.value in visibleValues,
                     nav: sliderConfig.navigationArrows.value in visibleValues,
                     mouseDrag: true,
-                    autoplay: false,
+                    autoplay: sliderConfig.rotate.value ? true : false,
                     autoplayButtonOutput: false,
                     autoplayTimeout: sliderConfig.autoplayTimeout.value,
                     speed: sliderConfig.speed.value,


### PR DESCRIPTION
fixes #9504 

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Customers wished for a backport of the feature with warnings


### 2. What does this change do, exactly?
Re-implement autoslide but with an a11y banner

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
