### PR TITLE
fix: search term custom find weird icons

### DIFF
--- a/changelog/_unreleased/2025-05-22-fix-search-term-custom-find-weird-icons.md
+++ b/changelog/_unreleased/2025-05-22-fix-search-term-custom-find-weird-icons.md
@@ -1,0 +1,10 @@
+---
+title: Fix search term custom find weird icons
+issue: #9729
+author: Le Nguyen
+author_email: nguyenquocdaile@gmail.com
+author_github: @Le Nguyen
+---
+# Administration
+* Changed `getModuleEntities` method to filter which module doesn't have entity.
+* Changed `getFrequentlyUsedModules` method to filter frequently used modules that have null or undefined entity.

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
@@ -870,7 +870,7 @@ export default {
                 return [];
             }
 
-            const moduleEntities = [];
+            let moduleEntities = [];
 
             this.searchableModules.forEach((module) => {
                 const matcher =
@@ -894,6 +894,8 @@ export default {
             });
 
             moduleEntities.push(...this.getSalesChannelTypesBySearchTerm(regex));
+
+            moduleEntities = moduleEntities.filter((item) => item?.entity);
 
             return moduleEntities.slice(0, limit);
         },
@@ -987,7 +989,9 @@ export default {
                     return {
                         entity: 'frequently_used',
                         total: entities.length,
-                        entities: entities?.map((item) => this.getInfoModuleFrequentlyUsed(item)),
+                        entities: entities
+                            ?.map((item) => this.getInfoModuleFrequentlyUsed(item))
+                            .filter((item) => item),
                     };
                 })
                 .catch(() => {});
@@ -1060,7 +1064,7 @@ export default {
             const module = this.moduleFactory.getModuleByKey('name', moduleName);
 
             if (!module) {
-                return {};
+                return null;
             }
 
             const { routes, ...manifest } = module.manifest;


### PR DESCRIPTION
### Description 

1. If a module doesn't define an entity, it will lead to a bug if we search for the name of this module.
ex: custom-entity module [here](https://github.com/shopware/shopware/blob/trunk/src/Administration/Resources/app/administration/src/module/sw-custom-entity/index.ts#L39)

2. Filter frequently used modules when they have an entity.

### Solution

| Before   | After |
|---------------------------|-------------------------|
| ![Screenshot 2025-05-22 at 15 47 51](https://github.com/user-attachments/assets/c9ab83be-d1d0-409a-88c7-017c7ad59611)  | ![Screenshot 2025-05-22 at 15 53 57](https://github.com/user-attachments/assets/22b13a40-bc3e-41aa-a656-30e66d18c2d4) |
| ![Screenshot 2025-05-22 at 14 34 37](https://github.com/user-attachments/assets/c8cffb26-0ee7-44e1-846c-3739a20c14c2) | ![Screenshot 2025-05-22 at 15 54 12](https://github.com/user-attachments/assets/fe3d0e26-a768-477a-9b41-df8294c585c6) |
