### PR TITLE
fix: increase icon size to fill media preview

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-preview-v2/sw-media-preview-v2.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-preview-v2/sw-media-preview-v2.scss
@@ -12,6 +12,8 @@ $sw-media-preview-v2-locked-icon-z-index: 5;
     &.is--icon {
         .sw-media-preview-v2__item {
             transform: translate(-50%, -50%) scale(0.7);
+            width: 100%;
+            height: 100%;
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Icon media items in the media module are displayed with their actual size, which can lead difficult to see icons due to smaller sizes (for example all the Payment Method icons added by shopware/SwagPaypal).

![image](https://github.com/user-attachments/assets/6eb25bdd-2598-4fc0-b4b9-1f5647cacf30)

### 2. What does this change do, exactly?
Make the icons fill the available space.

![image](https://github.com/user-attachments/assets/249f4d2d-cff4-4b42-8b0e-5219130b4dc9)

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to the media module
2. Upload small (< ~100px per side) SVGs 

### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/9703
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
