### PR TITLE
fix: sw-tabs-item disabled not working when it is router-link

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.html.twig
@@ -30,7 +30,8 @@
     />
 </a>
 
-<router-link
+<component
+    :is="disabled ? 'span' : 'router-link'"
     v-else
     ref="sw-tabs-item"
     :class="tabsItemClasses"
@@ -58,5 +59,5 @@
         size="12px"
     />
     {% endblock %}
-</router-link>
+</component>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes https://github.com/shopware/shopware/issues/9719


### 2. What does this change do, exactly?
When the `sw-tabs-item` is a `RouterLink` component, the disabled attribute is not applied.
Also, the RouterLink does not have a disabled prop. So the solution is to render a dynamic component depending on the `disabled` prop.

### 4. Please link to the relevant issues (if any).
- closes #9719
