### PR TITLE
fix: add limit when loading options in property group page detail

### DIFF
--- a/changelog/_unreleased/2025-05-22-set-limit-when-loading-options-in-property-group-detail-page.md
+++ b/changelog/_unreleased/2025-05-22-set-limit-when-loading-options-in-property-group-detail-page.md
@@ -1,0 +1,8 @@
+---
+title: Set Limit when loading options in property group detail page
+issue: 9715
+---
+# Administration
+* Deprecated `dataSource` computed property in `src/module/sw-property/component/sw-property-option-list/index.js` due to unused 
+* Changed the template `src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig` to not use `localMode` of `sw-one-to-many-grid` component
+* Changed computed property `defaultCriteria` in `src/module/sw-property/page/sw-property-detail/index.js` to set a limit of the `options` association

--- a/changelog/_unreleased/2025-05-22-set-limit-when-loading-options-in-property-group-detail-page.md
+++ b/changelog/_unreleased/2025-05-22-set-limit-when-loading-options-in-property-group-detail-page.md
@@ -6,3 +6,5 @@ issue: 9715
 * Deprecated `dataSource` computed property in `src/module/sw-property/component/sw-property-option-list/index.js` due to unused 
 * Changed the template `src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig` to not use `localMode` of `sw-one-to-many-grid` component
 * Changed computed property `defaultCriteria` in `src/module/sw-property/page/sw-property-detail/index.js` to set a limit of the `options` association
+* Changed the component `src/module/sw-property/component/sw-property-option-list/index.js` to check the empty state after loading the options
+* Changed the template `src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig` to show the empty state when no options are available

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-detail/index.js
@@ -41,6 +41,16 @@ export default {
             return this.repositoryFactory.create('media');
         },
 
+        colorHexCode: {
+            set(value) {
+                this.currentOption.colorHexCode = value;
+            },
+
+            get() {
+                return this.currentOption?.colorHexCode || '';
+            },
+        },
+
         ...mapPropertyErrors('currentOption', ['name']),
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-detail/sw-property-option-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-detail/sw-property-option-detail.html.twig
@@ -31,7 +31,7 @@
 
     {% block sw_property_option_detail_color %}
     <mt-colorpicker
-        v-model="currentOption.colorHexCode"
+        v-model="colorHexCode"
         name="sw-field--currentOption-colorHexCode"
         :disabled="!allowEdit"
         :label="$tc('sw-property.detail.labelOptionColor')"

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
@@ -5,7 +5,7 @@
 import template from './sw-property-option-list.html.twig';
 import './sw-property-option-list.scss';
 
-const { Store, Mixin } = Shopware;
+const { Store } = Shopware;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
@@ -14,10 +14,6 @@ export default {
     inject: [
         'repositoryFactory',
         'acl',
-    ],
-
-    mixins: [
-        Mixin.getByName('listing'),
     ],
 
     props: {
@@ -69,6 +65,9 @@ export default {
             return this.propertyGroup.isLoading || !this.isSystemLanguage || !this.acl.can('property.editor');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed
+         */
         dataSource() {
             return this.propertyGroup.options && this.propertyGroup.options.slice(0, this.limit);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
@@ -21,6 +21,7 @@ export default {
             type: Object,
             required: true,
         },
+
         optionRepository: {
             type: Object,
             required: true,
@@ -38,6 +39,7 @@ export default {
             sortBy: 'name',
             sortDirection: 'ASC',
             showDeleteModal: false,
+            showEmptyState: false,
         };
     },
 
@@ -192,6 +194,10 @@ export default {
                     inlineEdit: 'number',
                 },
             ];
+        },
+
+        checkEmptyState() {
+            this.showEmptyState = this.$refs.grid?.total === 0;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig
@@ -74,19 +74,16 @@
             ref="grid"
             :is-loading="isLoading"
             :collection="propertyGroup.options"
-            :data-source="dataSource"
             :columns="getGroupColumns()"
             :full-page="false"
-            :local-mode="propertyGroup.isNew()"
+            :local-mode="false"
             :allow-inline-edit="allowInlineEdit"
             :sort-by="sortBy"
             :sort-direction="sortDirection"
             @selection-change="onGridSelectionChanged"
         >
-
             <template #column-name="{ item, isInlineEdit }">
                 <template v-if="isInlineEdit">
-
                     <mt-text-field
                         v-model="item.name"
                         size="small"
@@ -131,8 +128,9 @@
             </template>
             {% endblock %}
         </sw-one-to-many-grid>
-        {% endblock %}
     </template>
+    {% endblock %}
+
     {% block sw_property_option_list_detail %}
     <sw-property-option-detail
         v-if="currentOption"

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig
@@ -80,6 +80,7 @@
             :allow-inline-edit="allowInlineEdit"
             :sort-by="sortBy"
             :sort-direction="sortDirection"
+            @load-finish="checkEmptyState"
             @selection-change="onGridSelectionChanged"
         >
             <template #column-name="{ item, isInlineEdit }">
@@ -128,6 +129,16 @@
             </template>
             {% endblock %}
         </sw-one-to-many-grid>
+
+        {% block sw_settings_country_state_list_empty %}
+        <sw-empty-state
+            v-if="showEmptyState"
+            :absolute="false"
+            :title="$tc('sw-property.detail.messageOptionsEmpty')"
+            :subline="$tc('sw-property.detail.messageOptionsEmptySubline')"
+            auto-height
+        />
+        {% endblock %}
     </template>
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
@@ -79,7 +79,8 @@ async function createWrapper() {
                     create: () => ({
                         get: () => Promise.resolve(),
                         save: jest.fn(() => Promise.resolve()),
-                        search: () => Promise.resolve({ propertyGroup }),
+                        search: () =>
+                            Promise.resolve(new Shopware.Data.EntityCollection(null, null, {}, null, getOptions())),
                     }),
                 },
                 shortcutService: {
@@ -96,7 +97,9 @@ async function createWrapper() {
                 'sw-simple-search-field': {
                     template: '<div></div>',
                 },
-                'sw-one-to-many-grid': await wrapTestComponent('sw-one-to-many-grid', { sync: true }),
+                'sw-one-to-many-grid': await wrapTestComponent('sw-one-to-many-grid', {
+                    sync: true,
+                }),
                 'sw-pagination': {
                     template: '<div></div>',
                 },
@@ -137,6 +140,7 @@ async function createWrapper() {
                     template: '<div></div>',
                 },
                 'sw-extension-component-section': true,
+                'sw-empty-state': true,
                 'sw-context-menu-item': true,
                 'sw-loader': true,
                 'sw-ai-copilot-badge': true,
@@ -156,6 +160,7 @@ describe('module/sw-property/component/sw-property-option-list', () => {
         global.activeAclRoles = ['property.editor'];
 
         const wrapper = await createWrapper();
+        await flushPromises();
 
         const initialHexCodeValue = wrapper.find('.sw-data-grid__cell--colorHexCode span').text();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-detail/index.js
@@ -93,9 +93,9 @@ export default {
         },
 
         defaultCriteria() {
-            const criteria = new Criteria(this.page, this.limit);
+            const criteria = new Criteria();
             criteria.addAssociation('options');
-            criteria.setTerm(this.term);
+            criteria.getAssociation('options').setLimit(25);
 
             return criteria;
         },


### PR DESCRIPTION
Closes #9715

Also add the empty state for the grid:

<img width="997" alt="image" src="https://github.com/user-attachments/assets/f16c30e4-92d2-4a80-a4c7-ffc6368ade86" />
