### PR TITLE
fix: fix styling of app action buttons because they rely on external …

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
@@ -314,6 +314,8 @@ export default class VueAdapter extends ViewAdapter {
             'sw-multi-tag-ip-select',
             'sw-grouped-single-select',
             'sw-price-preview',
+            'sw-context-menu',
+            'sw-context-menu-item',
         ];
 
         syncComponents.forEach((componentName) => {


### PR DESCRIPTION
### 1. Why is this change necessary?

Closes https://github.com/shopware/shopware/issues/9657

### 2. What does this change do, exactly?

The component relies on external CSS of a sw-context-menu-item component. By making the component synchronous we are sure that the CSS gets loaded correctly beforehand
<img width="566" alt="Bildschirmfoto 2025-05-22 um 15 59 07" src="https://github.com/user-attachments/assets/d843bf1e-4f73-4002-8a11-c30f97839955" />

