### PR TITLE
refactor: order detail loading states

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
@@ -281,10 +281,7 @@ export default {
         },
 
         getTransitionOptions() {
-            Store.get('swOrderDetail').setLoading([
-                'states',
-                true,
-            ]);
+            Store.get('swOrderDetail').setLoading(['states', true]);
 
             const statePromises = [
                 this.stateMachineService.getState('order', this.order.id),
@@ -333,10 +330,7 @@ export default {
                     return Promise.resolve();
                 })
                 .finally(() => {
-                    Store.get('swOrderDetail').setLoading([
-                        'states',
-                        false,
-                    ]);
+                    Store.get('swOrderDetail').setLoading(['states', false]);
                 });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
@@ -215,12 +215,11 @@ export default {
             }
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed without replacement
+         */
         emitLoadingChange(state) {
-            if (this.swOrderDetailOnLoadingChange) {
-                this.swOrderDetailOnLoadingChange(state);
-            } else {
-                this.$emit('loading-change', state);
-            }
+            Shopware.Store.get('swOrderDetail').setLoading(['recalculation', state]);
         },
 
         /**
@@ -245,7 +244,7 @@ export default {
         },
 
         handleError(error) {
-            this.emitLoadingChange(false);
+            Shopware.Store.get('swOrderDetail').setLoading(['recalculation', false]);
 
             if (this.swOrderDetailOnError) {
                 this.swOrderDetailOnError(error);
@@ -281,10 +280,7 @@ export default {
          * @deprecated tag:v6.8.0 - Will be removed without replacement. See `applyAutomaticPromotions` for an alternative
          */
         async toggleAutomaticPromotions(state) {
-            this.emitLoadingChange(true);
-
             if (this.hasOrderUnsavedChanges) {
-                this.emitLoadingChange(false);
                 this.handleUnsavedOrderChangesResponse();
 
                 this.$nextTick(() => {
@@ -293,6 +289,8 @@ export default {
 
                 return Promise.resolve();
             }
+
+            Shopware.Store.get('swOrderDetail').setLoading(['recalculation', true]);
 
             await this.saveAndReload();
             await this.deleteAutomaticPromotions();
@@ -325,6 +323,7 @@ export default {
 
         handlePromotionResponse(response) {
             this.emitEntityData();
+            Shopware.Store.get('swOrderDetail').setLoading(['recalculation', false]);
 
             if (!response?.data?.errors) {
                 return;
@@ -401,7 +400,7 @@ export default {
         },
 
         async onRemoveExistingCode(removedItem) {
-            this.emitLoadingChange(true);
+            Shopware.Store.get('swOrderDetail').setLoading(['recalculation', true]);
 
             const lineItem = this.order.lineItems.find((item) => {
                 return item.type === 'promotion' && item.payload.code === removedItem.code;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
@@ -49,15 +49,16 @@ export default Component.wrapComponentConfig({
             type: Object as PropType<Entity<'order'>>,
             required: true,
         },
+        /** @deprecated tag:v6.8.0 - will be removed without replacment */
         isLoading: {
             type: Boolean,
-            required: true,
+            required: false,
+            default: false,
         },
     },
 
     data(): {
         dataSource: StateMachineHistoryData[];
-        statesLoading: boolean;
         limit: number;
         page: number;
         total: number;
@@ -65,7 +66,6 @@ export default Component.wrapComponentConfig({
     } {
         return {
             dataSource: [],
-            statesLoading: true,
             limit: 10,
             page: 1,
             total: 0,
@@ -147,6 +147,15 @@ export default Component.wrapComponentConfig({
 
         hasMultipleTransactions(): boolean {
             return (this.order?.transactions?.filter((v, idx, a) => a.indexOf(v) === idx)?.length ?? 0) > 1;
+        },
+
+        statesLoading: {
+            get(): boolean {
+                return Shopware.Store.get('swOrderDetail').loading.states;
+            },
+            set(value: boolean): void {
+                Shopware.Store.get('swOrderDetail').setLoading(['states', value]);
+            },
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -57,8 +57,6 @@ export default {
         return {
             /** @deprecated tag:v6.8.0 - isEditing will be removed, use editing instead */
             isEditing: false,
-            /** @deprecated tag:v6.8.0 - isSaveSuccessful will be removed, use savedSuccessful instead */
-            isSaveSuccessful: false,
             /** @deprecated tag:v6.8.0 - createdById will be removed */
             createdById: '',
             isDisplayingLeavePageWarning: false,
@@ -99,7 +97,14 @@ export default {
             },
         },
 
-        savedSuccessful: () => Store.get('swOrderDetail').savedSuccessful,
+        isSaveSuccessful: {
+            get() {
+                return Store.get('swOrderDetail').savedSuccessful;
+            },
+            set(value) {
+                Store.get('swOrderDetail').savedSuccessful = value;
+            },
+        },
 
         orderIdentifier() {
             return this.order?.orderNumber ?? '';
@@ -276,7 +281,6 @@ export default {
         saveEditsFinish() {
             this.isSaveSuccessful = false;
             this.isEditing = false;
-            Store.get('swOrderDetail').savedSuccessful = false;
         },
 
         /**
@@ -325,7 +329,7 @@ export default {
                 })
                 .then(() => this.createNewVersionId())
                 .then(() => {
-                    Store.get('swOrderDetail').savedSuccessful = true;
+                    this.isSaveSuccessful = true;
                 })
                 .catch((error) => {
                     this.onError('error', error);
@@ -601,7 +605,7 @@ export default {
 
         async onAskAndSaveEditsConfirm() {
             await this.onSaveEdits();
-            this.askForSaveBeforehand.resolve(Store.get('swOrderDetail').savedSuccessful);
+            this.askForSaveBeforehand.resolve(this.isSaveSuccessful);
             this.askForSaveBeforehand = null;
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -26,7 +26,9 @@ export default {
         return {
             /** @deprecated tag:v6.8.0 - swOrderDetailOnCreatedByIdChange will be removed */
             swOrderDetailOnCreatedByIdChange: this.updateCreatedById,
+            /** @deprecated tag:v6.8.0 - swOrderDetailOnLoadingChange will be removed */
             swOrderDetailOnLoadingChange: this.onUpdateLoading,
+            /** @deprecated tag:v6.8.0 - swOrderDetailOnEditingChange will be removed */
             swOrderDetailOnEditingChange: this.onUpdateEditing,
             swOrderDetailOnSaveAndRecalculate: this.onSaveAndRecalculate,
             swOrderDetailOnRecalculateAndReload: this.onRecalculateAndReload,
@@ -53,8 +55,9 @@ export default {
 
     data() {
         return {
+            /** @deprecated tag:v6.8.0 - isEditing will be removed, use editing instead */
             isEditing: false,
-            isLoading: true,
+            /** @deprecated tag:v6.8.0 - isSaveSuccessful will be removed, use savedSuccessful instead */
             isSaveSuccessful: false,
             /** @deprecated tag:v6.8.0 - createdById will be removed */
             createdById: '',
@@ -85,6 +88,18 @@ export default {
         editing: () => Store.get('swOrderDetail').editing,
 
         loading: () => Store.get('swOrderDetail').loading,
+
+        /** @deprecated tag:v6.8.0 - isLoading will be removed, use loading.order instead */
+        isLoading: {
+            get() {
+                return this.loading.order;
+            },
+            set(value) {
+                Store.get('swOrderDetail').setLoading(['order', value]);
+            },
+        },
+
+        savedSuccessful: () => Store.get('swOrderDetail').savedSuccessful,
 
         orderIdentifier() {
             return this.order?.orderNumber ?? '';
@@ -230,7 +245,10 @@ export default {
 
             Shopware.Store.get('shopwareApps').selectedIds = this.orderId ? [this.orderId] : [];
 
-            this.createNewVersionId();
+            Shopware.Store.get('swOrderDetail').setLoading(['order', true]);
+            this.createNewVersionId().finally(() => {
+                Shopware.Store.get('swOrderDetail').setLoading(['order', false]);
+            });
         },
 
         async beforeDestroyComponent() {
@@ -258,14 +276,18 @@ export default {
         saveEditsFinish() {
             this.isSaveSuccessful = false;
             this.isEditing = false;
+            Store.get('swOrderDetail').savedSuccessful = false;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - will be removed without replacement
+         */
         onStartEditing() {
             this.$root.$emit('order-edit-start');
         },
 
         async onSaveEdits() {
-            this.isLoading = true;
+            Store.get('swOrderDetail').setLoading(['order', true]);
 
             await this.handleOrderAddressUpdate(this.orderAddressIds);
 
@@ -281,10 +303,7 @@ export default {
                 });
 
                 this.createNewVersionId().then(() => {
-                    Store.get('swOrderDetail').setLoading([
-                        'order',
-                        false,
-                    ]);
+                    Store.get('swOrderDetail').setLoading(['order', false]);
                 });
 
                 return;
@@ -310,7 +329,9 @@ export default {
                 })
                 .catch((error) => {
                     this.onError('error', error);
-                    this.isLoading = false;
+                })
+                .finally(() => {
+                    Store.get('swOrderDetail').setLoading(['order', false]);
                 });
 
             this.$root.$emit('order-edit-save');
@@ -359,11 +380,7 @@ export default {
         },
 
         onCancelEditing() {
-            this.isLoading = true;
-            Store.get('swOrderDetail').setLoading([
-                'order',
-                true,
-            ]);
+            Store.get('swOrderDetail').setLoading(['order', true]);
 
             const oldVersionContext = this.versionContext;
             Store.get('swOrderDetail').versionContext = Shopware.Context.api;
@@ -382,20 +399,13 @@ export default {
                     this.missingProductLineItems = [];
 
                     return this.createNewVersionId().then(() => {
-                        Store.get('swOrderDetail').setLoading([
-                            'order',
-                            false,
-                        ]);
+                        Store.get('swOrderDetail').setLoading(['order', false]);
                     });
                 });
         },
 
         async onSaveAndRecalculate() {
-            Store.get('swOrderDetail').setLoading([
-                'order',
-                true,
-            ]);
-            this.isLoading = true;
+            Store.get('swOrderDetail').setLoading(['recalculation', true]);
 
             try {
                 await this.orderRepository.save(this.order, this.versionContext);
@@ -406,19 +416,12 @@ export default {
             } catch (error) {
                 this.onError('error', error);
             } finally {
-                this.isLoading = false;
-                Store.get('swOrderDetail').setLoading([
-                    'order',
-                    false,
-                ]);
+                Store.get('swOrderDetail').setLoading(['recalculation', false]);
             }
         },
 
         async onRecalculateAndReload() {
-            Store.get('swOrderDetail').setLoading([
-                'order',
-                true,
-            ]);
+            Store.get('swOrderDetail').setLoading(['recalculation', true]);
 
             try {
                 await this.orderService
@@ -428,18 +431,12 @@ export default {
             } catch (error) {
                 this.onError('error', error);
             } finally {
-                Store.get('swOrderDetail').setLoading([
-                    'order',
-                    false,
-                ]);
+                Store.get('swOrderDetail').setLoading(['recalculation', false]);
             }
         },
 
         onSaveAndReload() {
-            Store.get('swOrderDetail').setLoading([
-                'order',
-                true,
-            ]);
+            Store.get('swOrderDetail').setLoading(['recalculation', true]);
 
             return this.orderRepository
                 .save(this.order, this.versionContext)
@@ -448,17 +445,20 @@ export default {
                     this.onError('error', error);
                 })
                 .finally(() => {
-                    Store.get('swOrderDetail').setLoading([
-                        'order',
-                        false,
-                    ]);
+                    Store.get('swOrderDetail').setLoading(['recalculation', false]);
                 });
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - isLoading will be removed, use loading.order instead
+         */
         onUpdateLoading(loadingValue) {
             this.isLoading = loadingValue;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - isEditing will be removed, use editing instead
+         */
         onUpdateEditing(editingValue) {
             this.isEditing = editingValue;
         },
@@ -492,11 +492,6 @@ export default {
         },
 
         reloadEntityData(isSaved = true) {
-            Store.get('swOrderDetail').setLoading([
-                'order',
-                true,
-            ]);
-
             return this.orderRepository
                 .get(this.orderId, this.versionContext, this.orderCriteria)
                 .then((response) => {
@@ -505,13 +500,6 @@ export default {
                     }
 
                     Store.get('swOrderDetail').order = response;
-                })
-                .finally(() => {
-                    Store.get('swOrderDetail').setLoading([
-                        'order',
-                        false,
-                    ]);
-                    this.isLoading = false;
                 });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
@@ -52,7 +52,7 @@
                 showOnDisabledElements: true
             }"
             class="sw-order-detail__smart-bar-cancel-button"
-            :disabled="isLoading || !acl.can('order.editor')"
+            :disabled="loading.order || !acl.can('order.editor')"
             variant="secondary"
             size="default"
             @click="onCancelEditing"
@@ -70,9 +70,9 @@
             }"
             class="sw-order-detail__smart-bar-save-button"
             variant="primary"
-            :disabled="isLoading || !acl.can('order.editor')"
-            :is-loading="isLoading"
-            :process-success="isSaveSuccessful"
+            :disabled="loading.order || loading.recalculation || !acl.can('order.editor')"
+            :is-loading="loading.order"
+            :process-success="isSaveSuccessful || savedSuccessful"
             @update:process-success="saveEditsFinish"
             @click.prevent="onSaveEdits"
         >
@@ -206,19 +206,20 @@
             />
 
             {% block sw_order_detail_content_view %}
-            <template v-if="isLoading">
+            <template v-if="loading.order">
                 <sw-skeleton />
                 <sw-skeleton />
             </template>
 
             {# v-show is used here as underlying components influence the loading state and v-if would destroy this behaviour #}
+            {# @deprecated tag:v6.8.0 - remove `is-save-successful`, `is-editing`, `@created-by-id-change`, `@loading-change`, `@editing-change` #}
             <router-view
                 v-if="order"
-                v-show="!isLoading"
+                v-show="!loading.order"
                 ref="baseComponent"
                 :order-id="orderId"
                 :is-editing="isEditing"
-                :is-loading="isLoading"
+                :is-loading="loading.order"
                 :is-save-successful="isSaveSuccessful"
                 @created-by-id-change="updateCreatedById"
                 @loading-change="onUpdateLoading"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
@@ -72,7 +72,7 @@
             variant="primary"
             :disabled="loading.order || loading.recalculation || !acl.can('order.editor')"
             :is-loading="loading.order"
-            :process-success="isSaveSuccessful || savedSuccessful"
+            :process-success="isSaveSuccessful"
             @update:process-success="saveEditsFinish"
             @click.prevent="onSaveEdits"
         >

--- a/src/Administration/Resources/app/administration/src/module/sw-order/store/order-detail.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/store/order-detail.store.spec.js
@@ -18,10 +18,7 @@ describe('src/module/sw-order/state/order-detail.store', () => {
     });
 
     it('should be able to setLoading', () => {
-        Shopware.Store.get('swOrderDetail').setLoading([
-            'order',
-            true,
-        ]);
+        Shopware.Store.get('swOrderDetail').setLoading(['order', true]);
 
         expect(state.loading.order).toBe(true);
         expect(Shopware.Store.get('swOrderDetail').isLoading).toBe(true);

--- a/src/Administration/Resources/app/administration/src/module/sw-order/store/order-detail.store.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/store/order-detail.store.ts
@@ -17,7 +17,8 @@ const swOrderDetailStore = Shopware.Store.register({
         return {
             order: null as EntitySchema.order | null,
             loading: {
-                order: false,
+                order: false,         // live version id
+                recalculation: false, // custom version id
                 states: false,
             },
             editing: false,

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
@@ -67,9 +67,11 @@ export default {
             required: true,
         },
 
+        /** @deprecated tag:v6.8.0 - will be removed without replacement */
         isSaveSuccessful: {
             type: Boolean,
-            required: true,
+            required: false,
+            default: false,
         },
     },
 
@@ -81,6 +83,7 @@ export default {
     },
 
     computed: {
+        /** @deprecated tag:v6.8.0 - will be removed, use loading.order instead */
         isLoading: () => Store.get('swOrderDetail').isLoading,
 
         order: () => Store.get('swOrderDetail').order,
@@ -248,11 +251,11 @@ export default {
             }
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - will be removed without replacement
+         */
         updateLoading(loadingValue) {
-            Store.get('swOrderDetail').setLoading([
-                'order',
-                loadingValue,
-            ]);
+            Store.get('swOrderDetail').setLoading(['order', loadingValue]);
         },
 
         validateTrackingCode(searchTerm) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
@@ -278,7 +278,6 @@
     <sw-order-state-history-modal
         v-if="showStateHistoryModal"
         :order="order"
-        :is-loading="isLoading"
         @modal-close="showStateHistoryModal = false"
     />
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.spec.js
@@ -120,7 +120,6 @@ async function createWrapper() {
         },
         props: {
             orderId: '1a2b3c',
-            isSaveSuccessful: false,
         },
     });
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-documents/sw-order-detail-documents.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-documents/sw-order-detail-documents.html.twig
@@ -3,7 +3,6 @@
     {% block sw_order_detail_documents_card %}
     {# v-show is used here as underlying components influence the loading state and v-if would destroy this behaviour #}
     <sw-order-document-card
-        v-show="!isLoading"
         :order="order"
         @document-save="saveAndReload"
         @update-loading="onUpdateLoading"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/index.js
@@ -62,9 +62,11 @@ export default {
             required: true,
         },
 
+        /** @deprecated tag:v6.8.0 - will be removed without replacement */
         isSaveSuccessful: {
             type: Boolean,
-            required: true,
+            required: false,
+            default: false,
         },
     },
 
@@ -75,7 +77,10 @@ export default {
     },
 
     computed: {
+        /** @deprecated tag:v6.8.0 - will be removed, use loading.order instead */
         isLoading: () => Store.get('swOrderDetail').isLoading,
+
+        loading: () => Store.get('swOrderDetail').loading,
 
         order: () => Store.get('swOrderDetail').order,
 
@@ -190,11 +195,11 @@ export default {
             }
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - will be removed without replacement
+         */
         updateLoading(loadingValue) {
-            Store.get('swOrderDetail').setLoading([
-                'order',
-                loadingValue,
-            ]);
+            Store.get('swOrderDetail').setLoading(['order', loadingValue]);
         },
 
         reloadEntityData() {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
@@ -24,6 +24,7 @@
     <mt-card
         class="sw-order-detail-general__line-item-grid-card"
         position-identifier="sw-order-detail-general-line-items"
+        :is-loading="loading.recalculation"
         :title="$tc('sw-order.detailBase.cardTitleLineItems')"
     >
 
@@ -158,6 +159,7 @@
         position-identifier="sw-order-detail-general-promotions"
         :title="$tc('sw-order.detailBase.cardTitlePromotions')"
     >
+        {# @deprecated tag:v6.8.0 - remove `@loading-change` #}
         <sw-order-promotion-field
             class="sw-order-detail-general__promotions"
             @loading-change="updateLoading"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.spec.js
@@ -129,7 +129,6 @@ async function createWrapper() {
         },
         props: {
             orderId: '1a2b3c',
-            isSaveSuccessful: false,
         },
     });
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The Admin module `sw-order-detail` has a wild mixture of storing `isLoading` in local variables and in Stores.

### 2. What does this change do, exactly?
Trying to clean it up. Also having a `recalculating` state, that gets triggered on saving/reloading a versioned order, so it doesn't look like saving.

### 3. Describe each step to reproduce the issue or behaviour.
Have fun clicking around. 
Try to reproduce the linked issue.

### 4. Please link to the relevant issues (if any).
fixes #9617 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
