### PR TITLE
fix: inline media upload preview image option is broken

### DIFF
--- a/changelog/_unreleased/2025-05-23-fix-inline-media-upload-preview-image-option-is-broken.md
+++ b/changelog/_unreleased/2025-05-23-fix-inline-media-upload-preview-image-option-is-broken.md
@@ -1,0 +1,6 @@
+---
+title: Fix inline media upload preview image option is broken
+issue: 8790
+---
+# Administration
+* Changed method `onMediaInheritanceRemove` in `sw-product-variants-overview` component to add the `media`.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
@@ -595,18 +595,19 @@ export default {
             }
 
             variant.forceMediaInheritanceRemove = true;
-            this.product.media.forEach(({ id, mediaId, position }) => {
-                const media = this.productMediaRepository.create(Context.api);
-                Object.assign(media, {
+            this.product.media.forEach(({ id, mediaId, position, media }) => {
+                const productMedia = this.productMediaRepository.create(Context.api);
+                Object.assign(productMedia, {
                     mediaId,
                     position,
                     productId: this.product.id,
+                    media,
                 });
                 if (this.product.coverId === id) {
-                    variant.coverId = media.id;
+                    variant.coverId = productMedia.id;
                 }
 
-                variant.media.push(media);
+                variant.media.push(productMedia);
             });
         },
 


### PR DESCRIPTION
This pull request addresses a bug where the inline media upload preview image option was broken. The changes include fixes to the `sw-product-variants-overview` component, updates to its associated test suite, and documentation in the changelog.

### Fixes to `sw-product-variants-overview`:

* Updated the `onMediaInheritanceRemove` method to properly handle media inheritance removal by including the `media` property in the `productMedia` object. This ensures that the correct media data is assigned when creating a new `product_media` entity. (`src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js`, [src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.jsL598-R610](diffhunk://#diff-8b9a6d136495e64b6aeda008efe5ad10681239ae3d23289bbcb4b84728b8aa7fL598-R610))

### Test suite updates:

* Added a new test case to verify that a `product_media` entity is correctly created when media inheritance is removed. The test ensures that all relevant properties, including `mediaId`, `position`, and `media`, are correctly assigned. (`src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.js`, [src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.jsR543-R583](diffhunk://#diff-1057015d6a0b213f387220b5b7e172222b1178554da2d49a97b13489ce9ad472R543-R583))
* Enhanced the repository mock in the test setup to include a dedicated `productMediaRepositoryMock`. This allows for more accurate testing of `product_media` creation and related operations. (`src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.js`, [src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.jsR11-R32](diffhunk://#diff-1057015d6a0b213f387220b5b7e172222b1178554da2d49a97b13489ce9ad472R11-R32))

### Documentation:

* Added an entry to the changelog describing the fix to the `onMediaInheritanceRemove` method in the `sw-product-variants-overview` component. (`changelog/_unreleased/2025-05-23-fix-inline-media-upload-preview-image-option-is-broken.md`, [changelog/_unreleased/2025-05-23-fix-inline-media-upload-preview-image-option-is-broken.mdR1-R6](diffhunk://#diff-4e6205b44f071f416687989515ca0854b540d1019f8789949dc9c52efaf1e103R1-R6))