### PR TITLE
fix: replace sw-icon to mt-icon for styling

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.scss
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.scss
@@ -14,7 +14,7 @@
         border: 1px solid $color-module-purple-900;
         border-radius: $border-radius-default;
 
-        .sw-icon {
+        .mt-icon {
             flex-shrink: 0;
             margin-right: 8px;
             margin-top: 2px;


### PR DESCRIPTION
fixes: shopware/shopware#9660

From 
![image](https://github.com/user-attachments/assets/9bf1dcbe-f7cd-4245-85db-78cc161404a3)
to
![image](https://github.com/user-attachments/assets/529b0fb1-20a6-41f3-8596-b2269ffb11b2)
