### PR TITLE
fix: advanced price rule styling

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/sw-rule-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/sw-rule-modal.scss
@@ -3,10 +3,6 @@
         min-height: 700px;
 
         .sw-modal__body {
-            .sw-condition-or-container {
-                padding: 0;
-            }
-
             .sw-condition-tree > .sw-condition-or-container > .sw-condition-or-container__condition-content {
                 padding: 0;
             }


### PR DESCRIPTION
fixes: shopware/shopware#9760

Removing the custom styling to use the default one (with padding 24px)

Results:
![image](https://github.com/user-attachments/assets/3e3e01a8-9210-43e0-9c7c-c68300f2f23f)
