### PR TITLE
feat: Added MtModalTrigger and MtModalAction as global components

### DIFF
--- a/changelog/_unreleased/2025-05-23-register-mt-modal-componants-globally.md
+++ b/changelog/_unreleased/2025-05-23-register-mt-modal-componants-globally.md
@@ -1,0 +1,8 @@
+---
+title: Register mt-modal componants globally
+author: Sebastian Franze
+author_email: s.franze@shopware.com
+---
+# Administration
+* Added MtModalTrigger as a global component
+* Added MtModalAction as a global component

--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
@@ -381,6 +381,8 @@ export default class VueAdapter extends ViewAdapter {
             'MtModal',
             'MtModalRoot',
             'MtModalClose',
+            'MtModalTrigger',
+            'MtModalAction',
             'MtUrlField',
             'MtSearch',
             'MtLink',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

MtModal, MtModalRoot and MtModalClose are already registered as global components. We should do the same with MtModalTrigger and MtModalAction.