### PR TITLE
fix: negative shipping costs

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.html.twig
@@ -133,6 +133,7 @@
             class="sw-order-create-options__shipping-cost"
             :label="$tc('sw-order.initialModal.options.labelShippingCosts')"
             :step="1"
+            :min="0"
             @update:model-value="onChangeShippingCost"
         >
             <template #suffix>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
@@ -197,8 +197,10 @@ export default {
 
         // @deprecated tag:v6.8.0 - Will be removed, change shipping cost on order general view instead.
         onShippingChargeEdited: Utils.debounce(function onShippingChargeEdited(amount) {
-            this.delivery.shippingCosts.unitPrice = amount;
-            this.delivery.shippingCosts.totalPrice = amount;
+            if (amount >= 0) {
+                this.delivery.shippingCosts.unitPrice = amount;
+                this.delivery.shippingCosts.totalPrice = amount;
+            }
 
             this.saveAndRecalculate();
         }, 800),

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
@@ -88,6 +88,7 @@
             class="sw-order-detail-details__shipping-cost"
             :disabled="!acl.can('order.editor')"
             :step="1"
+            :min="0"
             :label="$tc('sw-order.detailDeliveries.labelShippingCosts')"
         >
             <template #suffix>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/index.js
@@ -161,8 +161,10 @@ export default {
         },
 
         onShippingChargeEdited() {
-            this.delivery.shippingCosts.unitPrice = this.shippingCosts;
-            this.delivery.shippingCosts.totalPrice = this.shippingCosts;
+            if (this.shippingCosts >= 0) {
+                this.delivery.shippingCosts.unitPrice = this.shippingCosts;
+                this.delivery.shippingCosts.totalPrice = this.shippingCosts;
+            }
 
             this.saveAndRecalculate();
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
@@ -79,6 +79,7 @@
                                     type="number"
                                     :editable="acl.can('order.editor')"
                                     :step="1"
+                                    :min="0"
                                     :value="delivery.shippingCosts.totalPrice"
                                     @value-change="onShippingChargeEdited"
                                     @update:value="onShippingChargeUpdated"


### PR DESCRIPTION
### 1. Why is this change necessary?
It should not be possible to set shipping costs to negative

### 2. What does this change do, exactly?
Stops it on an admin level, since there is no shipping cost validation during recalculation.

### 3. Describe each step to reproduce the issue or behaviour.
Create an order, try to modify shipping costs to -1.

### 4. Please link to the relevant issues (if any).
fixes #9728

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
