### PR TITLE
fix: Alignment logo manufacturer media field

### DIFF
--- a/changelog/_unreleased/2025-05-26-fix-alignment-logo-manufacture-media-field.md
+++ b/changelog/_unreleased/2025-05-26-fix-alignment-logo-manufacture-media-field.md
@@ -1,0 +1,10 @@
+---
+title: Fix alignment logo manufacturer media field not correct
+issue: 9367
+author: Tam Dao
+author_email: t.dao@shopware.com
+author_github: @daothithientamm
+---
+
+# Administration
+* Changed `shopware/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/sw-manufacturer-detail.scss` to align the manufacturer logo media field consistently with the input fields.

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/sw-manufacturer-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/sw-manufacturer-detail.scss
@@ -2,4 +2,21 @@
     .sw-manufacturer-detail__container {
         margin-bottom: 16px;
     }
+
+    .sw-manufacturer-detail__logo-upload {
+        .sw-media-upload-v2 {
+            &__header {
+                margin-bottom: 0;
+                min-height: 24px;
+            }
+
+            &__dropzone {
+                min-height: 150px;
+            }
+
+            &__url-form {
+                padding-left: 24px;
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

To ensure consistent alignment between the logo media field and input fields for a cleaner layout.

### 2. What does this change do, exactly?

It adjusts spacing and styling of the logo media field to match the alignment and appearance of the input fields.

| Before  | After |
| ------------- | ------------- |
| <img width="718" alt="image" src="https://github.com/user-attachments/assets/19f76f01-9b23-4f4f-ba75-c0a03b84d3ab" /> | <img width="718" alt="image" src="https://github.com/user-attachments/assets/d206f77d-3bfa-4784-83e6-e46c4db6eaf7" />  |
| <img width="718" alt="image" src="https://github.com/user-attachments/assets/ef1504d9-0239-4426-ac3a-e90c0cbf9448" /> | <img width="718" alt="image" src="https://github.com/user-attachments/assets/f380d1c1-28cf-4e27-b867-fd983f001b37" /> |

### 3. Describe each step to reproduce the issue or behaviour.

Open Manufacturer detail page.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #9367  - closes the issue #9367 when the PR is merged

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
