### PR TITLE
fix: sw-button-group borders with sw-context-buttons

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-button-group/sw-button-group.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-button-group/sw-button-group.scss
@@ -31,8 +31,7 @@
             border-bottom-right-radius: $border-radius-default;
         }
 
-        &:only-child,
-        &:first-child:has(+ .sw-popover) {
+        &:only-child {
             margin-left: -1px;
         }
 
@@ -47,6 +46,10 @@
     .sw-context-button {
         .mt-button {
             border-radius: 0;
+
+            &:first-child:has(+ .sw-popover) {
+                margin-left: -1px;
+            }
         }
 
         &:first-child .mt-button {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-button-group/sw-button-group.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-button-group/sw-button-group.scss
@@ -31,7 +31,8 @@
             border-bottom-right-radius: $border-radius-default;
         }
 
-        &:only-child, &:first-child:has(+ .sw-popover) {
+        &:only-child,
+        &:first-child:has(+ .sw-popover) {
             margin-left: -1px;
         }
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-button-group/sw-button-group.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-button-group/sw-button-group.scss
@@ -31,7 +31,7 @@
             border-bottom-right-radius: $border-radius-default;
         }
 
-        &:only-child {
+        &:only-child, &:first-child:has(+ .sw-popover) {
             margin-left: -1px;
         }
 


### PR DESCRIPTION
fixes #9619
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Because expanding the `sw-context-button` messes with the alignment given by the `sw-button-group`

### 2. What does this change do, exactly?
fixing it

### 3. Describe each step to reproduce the issue or behaviour.
see #9619

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
