### PR TITLE
chore(ci): add job to mention original issue in backport PRs

### DIFF
--- a/.github/bin/js/package-lock.json
+++ b/.github/bin/js/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@shopware-ag/gh-project-automation": "^1.5.0"
+        "@shopware-ag/gh-project-automation": "^1.6.0"
       }
     },
     "node_modules/@actions/core": {
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@shopware-ag/gh-project-automation": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.5.0.tgz",
-      "integrity": "sha512-WMXBox5A6MqXZ+fM6ZcGy2jZO9RZGi55XK5bWvfpDRPXMyiw/YNEYIyByO8a1BA0y721Dmg4TBBAA32swQ/zig==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.6.0.tgz",
+      "integrity": "sha512-/w9BzQWvb9e/WVti9EB8T/WJ70JTI0i5HBfpM01berpJ94YeGF+yRBmCgnyRuG/0+lJ9sQWRo+d3pzfRKnT7xA==",
       "optionalDependencies": {
         "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",

--- a/.github/bin/js/package-lock.json
+++ b/.github/bin/js/package-lock.json
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@shopware-ag/gh-project-automation": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.6.0.tgz",
-      "integrity": "sha512-/w9BzQWvb9e/WVti9EB8T/WJ70JTI0i5HBfpM01berpJ94YeGF+yRBmCgnyRuG/0+lJ9sQWRo+d3pzfRKnT7xA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.6.1.tgz",
+      "integrity": "sha512-jpDHc2/R28NcXCdVPA7ZvnMIRANMlbSDlDecTrMOtyb9nSexgqHyuvrpZ62PeqlDKhSYLjXMZfVpYwhi/dw2aw==",
       "optionalDependencies": {
         "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
-      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "version": "22.15.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.23.tgz",
+      "integrity": "sha512-7Ec1zaFPF4RJ0eXu1YT/xgiebqwqoJz8rYPDi/O2BcZ++Wpt0Kq9cl0eg6NN6bYbPnR67ZLo7St5Q3UK0SnARw==",
       "optional": true,
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/.github/bin/js/package.json
+++ b/.github/bin/js/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@shopware-ag/gh-project-automation": "^1.5.0"
+    "@shopware-ag/gh-project-automation": "^1.6.0"
   }
 }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,17 @@ permissions:
 jobs:
   find-related-issue:
     runs-on: ubuntu-24.04
+    if: >
+      github.event.act ||
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+          && contains(join(github.event.pull_request.labels.*.name, ','), 'backport-')
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport-')
+        )
+      )
     outputs:
       url: ${{ steps.issue.outputs.url }}
     steps:
@@ -43,9 +54,10 @@ jobs:
             core.setOutput('number', issue?.number || null)
             core.setOutput('url', issue?.url || null)
 
-  backport:
+  compute-targets:
     runs-on: ubuntu-24.04
     if: >
+      github.event.act ||
       github.event.pull_request.merged
       && (
         github.event.action == 'closed'
@@ -55,18 +67,66 @@ jobs:
           && contains(github.event.label.name, 'backport-')
         )
       )
-    needs: [ find-related-issue ]
+    outputs:
+      target-branches: ${{ steps.set-targets.outputs.targets }}
+    env:
+      LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+    steps:
+      - name: Set target branches
+        id: set-targets
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labels = JSON.parse(process.env.LABELS);
+            const targets = labels
+              .filter(label => label.name.startsWith('backport-'))
+              .map(label => label.name.replace('backport-', ''));
+            
+            core.setOutput('targets', JSON.stringify(targets))
+
+  backport:
+    runs-on: ubuntu-24.04
+    if: >
+      github.event.act ||
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+          && contains(join(github.event.pull_request.labels.*.name, ','), 'backport-')
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport-')
+        )
+      )
+    needs: [ find-related-issue, compute-targets ]
+    strategy:
+      matrix:
+        target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
+      fail-fast: true
     steps:
       - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
         id: sts-shopware-backport
+        if: ${{ !github.event.act }}
         with:
           scope: shopware
           identity: ShopwareBackport
+
       - name: Backporting
         uses: kiegroup/git-backporting@main
         with:
-          auth: ${{ steps.sts-shopware-backport.outputs.token }}
-          target-branch-pattern: "^backport-(?<target>([^ ]+))$"
+          auth: ${{ github.event.act && secrets.GITHUB_TOKEN || steps.sts-shopware-backport.outputs.token }}
+          target-branch: ${{ matrix.target-branch }}
           pull-request: ${{ github.event.pull_request.url }}
-          body-prefix: |-
-            Backport: {{ github.event.pull_request.url }} ${{ needs.find-related-issue.outputs.url && format('(Issue: {1})', needs.find-related-issue.outputs.url) }}
+          bp-branch-name: ${{ format('{0}-backport-{1}', github.event.pull_request.head.ref, matrix.target-branch) }}
+          title: >-
+            ${{ format('{0} (backport: {1}) ', github.event.pull_request.title, matrix.target-branch) }}
+          body-prefix: | # Reference original PR, as well as the related issue, if available
+            ${{ format('**Backport:** {0}', github.event.pull_request.url) }}
+            ${{ needs.find-related-issue.outputs.url && format('**Issue:** {0}', needs.find-related-issue.outputs.url) }}
+            ---
+          assignees: >- # Inherit original assignees
+            ${{ github.event.pull_request.assignees && join(github.event.pull_request.assignees.*.login, ',') || '' }}
+          reviewers: >- # Add the original assignees, as well as the reviewers of the original PR
+            ${{ github.event.pull_request.assignees && format('{0},', join(github.event.pull_request.assignees.*.login, ',')) || '' }}
+            ${{ github.event.pull_request.requested_reviewers && join(github.event.pull_request.requested_reviewers.*.login, ',') || '' }}
+          dry-run: ${{ github.event.act && true || false }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,6 +10,39 @@ permissions:
   id-token: write
 
 jobs:
+  find-related-issue:
+    runs-on: ubuntu-24.04
+    outputs:
+      url: ${{ steps.issue.outputs.url }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            .github/bin/js
+          sparse-checkout-cone-mode: false
+
+      - shell: bash
+        run: npm ci --prefix .github/bin/js/
+
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        id: issue
+        env:
+          PR_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_ASSIGNEE: ${{ github.event.pull_request.assignee && github.event.pull_request.assignee.login || '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { getDevelopmentIssueForPullRequest } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
+            const issue = await getDevelopmentIssueForPullRequest({github, core, context}, process.env.PR_REPO, parseInt(process.env.PR_NUMBER), process.env.PR_HEAD, process.env.PR_ASSIGNEE)
+
+            core.setOutput('id', issue?.id || null)
+            core.setOutput('title', issue?.title || null)
+            core.setOutput('number', issue?.number || null)
+            core.setOutput('url', issue?.url || null)
+
   backport:
     runs-on: ubuntu-24.04
     if: >
@@ -22,6 +55,7 @@ jobs:
           && contains(github.event.label.name, 'backport-')
         )
       )
+    needs: [ find-related-issue ]
     steps:
       - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
         id: sts-shopware-backport
@@ -34,3 +68,5 @@ jobs:
           auth: ${{ steps.sts-shopware-backport.outputs.token }}
           target-branch-pattern: "^backport-(?<target>([^ ]+))$"
           pull-request: ${{ github.event.pull_request.url }}
+          body-prefix: |-
+            Backport: {{ github.event.pull_request.url }} ${{ needs.find-related-issue.outputs.url && format('(Issue: {1})', needs.find-related-issue.outputs.url) }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
 
 jobs:
-  find-related-issue:
+  find-linked-issue:
     runs-on: ubuntu-24.04
     if: >
       github.event.act ||
@@ -24,8 +24,20 @@ jobs:
         )
       )
     outputs:
+      id: ${{ steps.issue.outputs.id }}
+      title: ${{ steps.issue.outputs.title }}
+      number: ${{ steps.issue.outputs.number }}
       url: ${{ steps.issue.outputs.url }}
+      owner: ${{ steps.issue.outputs.owner }}
+      repository: ${{ steps.issue.outputs.repository }}
     steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
+        id: sts-shopware-backport
+        if: ${{ !github.event.act }}
+        with:
+          scope: shopware
+          identity: ShopwareBackport
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
         with:
           fetch-depth: 0
@@ -44,7 +56,7 @@ jobs:
           PR_HEAD: ${{ github.event.pull_request.head.ref }}
           PR_ASSIGNEE: ${{ github.event.pull_request.assignee && github.event.pull_request.assignee.login || '' }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.event.act && secrets.GITHUB_TOKEN || steps.sts-shopware-backport.outputs.token }}
           script: |
             const { getDevelopmentIssueForPullRequest } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
             const issue = await getDevelopmentIssueForPullRequest({github, core, context}, process.env.PR_REPO, parseInt(process.env.PR_NUMBER), process.env.PR_HEAD, process.env.PR_ASSIGNEE)
@@ -53,6 +65,68 @@ jobs:
             core.setOutput('title', issue?.title || null)
             core.setOutput('number', issue?.number || null)
             core.setOutput('url', issue?.url || null)
+            core.setOutput('owner', issue?.owner || null)
+            core.setOutput('repository', issue?.repository || null)
+
+  reopen-linked-issue:
+    runs-on: ubuntu-24.04
+    if: >
+      github.event.act ||
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+          && contains(join(github.event.pull_request.labels.*.name, ','), 'backport-')
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport-')
+        )
+      )
+      && needs.find-linked-issue.outputs.id
+    needs: [ find-linked-issue ]
+    steps:
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
+        id: sts-shopware-backport
+        if: ${{ !github.event.act }}
+        with:
+          scope: shopware
+          identity: ShopwareBackport
+
+      - uses: actions/github-script@v7 # actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        env:
+          ISSUE_NUMBER: ${{ needs.find-linked-issue.outputs.number }}
+          ISSUE_OWNER: ${{ needs.find-linked-issue.outputs.owner }}
+          ISSUE_REPOSITORY: ${{ needs.find-linked-issue.outputs.repository }}
+          POST_COMMENT: 'Reopening issue because the related pull request needs to be backported.'
+        with:
+          github-token: ${{ github.event.act && secrets.GITHUB_TOKEN || steps.sts-shopware-backport.outputs.token }}
+          script: |
+            const issue = await github.rest.issues.get({
+              owner: process.env.ISSUE_OWNER,
+              repo: process.env.ISSUE_REPOSITORY,
+              issue_number: parseInt(process.env.ISSUE_NUMBER),
+            });
+            
+            if (issue.data.state === 'open') {
+              core.info(`Issue #${process.env.ISSUE_NUMBER} is already open, no action needed.`);
+              return;
+            }
+            
+            await github.rest.issues.update({
+              owner: process.env.ISSUE_OWNER,
+              repo: process.env.ISSUE_REPOSITORY,
+              issue_number: parseInt(process.env.ISSUE_NUMBER),
+              state: 'open',
+              state_reason: 'reopened',
+            });
+            
+            if (process.env.POST_COMMENT) {
+              await github.rest.issues.createComment({
+                owner: process.env.ISSUE_OWNER,
+                repo: process.env.ISSUE_REPOSITORY,
+                issue_number: parseInt(process.env.ISSUE_NUMBER),
+                body: process.env.POST_COMMENT,
+              });
+            }
 
   parse-labels:
     runs-on: ubuntu-24.04
@@ -105,7 +179,7 @@ jobs:
           && contains(github.event.label.name, 'backport-')
         )
       )
-    needs: [ find-related-issue, parse-labels ]
+    needs: [ find-linked-issue, parse-labels ]
     strategy:
       matrix:
         target-branch: ${{ fromJSON(needs.parse-labels.outputs.target-branches) }}
@@ -129,7 +203,7 @@ jobs:
             ${{ format('{0} (backport: {1}) ', github.event.pull_request.title, matrix.target-branch) }}
           body-prefix: | # Reference original PR, as well as the related issue, if available
             ${{ format('**Backport:** {0}', github.event.pull_request.html_url) }}
-            ${{ needs.find-related-issue.outputs.url && format('Resolves: {0}', needs.find-related-issue.outputs.url) }}
+            ${{ needs.find-linked-issue.outputs.url && format('Resolves: {0}', needs.find-linked-issue.outputs.url) }}
             ---
           assignees: >- # Inherit original assignees
             ${{ github.event.pull_request.assignees && join(github.event.pull_request.assignees.*.login, ',') || '' }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -129,7 +129,7 @@ jobs:
             ${{ format('{0} (backport: {1}) ', github.event.pull_request.title, matrix.target-branch) }}
           body-prefix: | # Reference original PR, as well as the related issue, if available
             ${{ format('**Backport:** {0}', github.event.pull_request.html_url) }}
-            ${{ needs.find-related-issue.outputs.url && format('**Issue:** {0}', needs.find-related-issue.outputs.url) }}
+            ${{ needs.find-related-issue.outputs.url && format('Resolves: {0}', needs.find-related-issue.outputs.url) }}
             ---
           assignees: >- # Inherit original assignees
             ${{ github.event.pull_request.assignees && join(github.event.pull_request.assignees.*.login, ',') || '' }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -54,7 +54,7 @@ jobs:
             core.setOutput('number', issue?.number || null)
             core.setOutput('url', issue?.url || null)
 
-  compute-targets:
+  parse-labels:
     runs-on: ubuntu-24.04
     if: >
       github.event.act ||
@@ -68,22 +68,29 @@ jobs:
         )
       )
     outputs:
-      target-branches: ${{ steps.set-targets.outputs.targets }}
+      target-branches: ${{ steps.parse-labels.outputs.target-branches }}
+      labels: ${{ steps.parse-labels.outputs.labels }}
     env:
       LABELS: ${{ toJSON(github.event.pull_request.labels) }}
     steps:
-      - name: Set target branches
-        id: set-targets
+      - name: Parse labels
+        id: parse-labels
         uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const labels = JSON.parse(process.env.LABELS);
-            const targets = labels
+            
+            const targetBranches = labels
               .filter(label => label.name.startsWith('backport-'))
               .map(label => label.name.replace('backport-', ''));
             
-            core.setOutput('targets', JSON.stringify(targets))
+            const filteredLabels = labels
+              .filter(label => !label.name.startsWith('backport-'))
+              .map(label => label.name);
+            
+            core.setOutput('target-branches', JSON.stringify(targetBranches));
+            core.setOutput('labels', JSON.stringify(filteredLabels));
 
   backport:
     runs-on: ubuntu-24.04
@@ -98,10 +105,10 @@ jobs:
           && contains(github.event.label.name, 'backport-')
         )
       )
-    needs: [ find-related-issue, compute-targets ]
+    needs: [ find-related-issue, parse-labels ]
     strategy:
       matrix:
-        target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
+        target-branch: ${{ fromJSON(needs.parse-labels.outputs.target-branches) }}
       fail-fast: true
     steps:
       - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
@@ -129,4 +136,6 @@ jobs:
           reviewers: >- # Add the original assignees, as well as the reviewers of the original PR
             ${{ github.event.pull_request.assignees && format('{0},', join(github.event.pull_request.assignees.*.login, ',')) || '' }}
             ${{ github.event.pull_request.requested_reviewers && join(github.event.pull_request.requested_reviewers.*.login, ',') || '' }}
+          labels: >- # Inherit original labels, except backport ones
+            ${{ needs.parse-labels.outputs.labels && join(fromJSON(needs.parse-labels.outputs.labels), ',') || '' }}
           dry-run: ${{ github.event.act && true || false }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -121,7 +121,7 @@ jobs:
           title: >-
             ${{ format('{0} (backport: {1}) ', github.event.pull_request.title, matrix.target-branch) }}
           body-prefix: | # Reference original PR, as well as the related issue, if available
-            ${{ format('**Backport:** {0}', github.event.pull_request.url) }}
+            ${{ format('**Backport:** {0}', github.event.pull_request.html_url) }}
             ${{ needs.find-related-issue.outputs.url && format('**Issue:** {0}', needs.find-related-issue.outputs.url) }}
             ---
           assignees: >- # Inherit original assignees


### PR DESCRIPTION
With this change, we'll search for the original development issue prior to creating a backport PR and mention it in the backport description.

Needs: https://github.com/shopware/gh-project-automation/pull/23
Needs: https://github.com/shopware/.github/pull/40

---

TODO:
- [x] Create release of gh-project-automation with the needed changes
- [x] Update `.github/bin/js` packages in this PR subsequently
- [x] Implement https://github.com/shopware/shopware/pull/7129
    - [x] Also add a target branch reference in such a way that it doesn't violate conventional commits style
- [x] Inherit labels, except of `backport-` ones
- [x] Not only mention, but inherit the development issue relation
    - Might be possible by mutation of `ProjectV2ItemFieldPullRequestValue` (it's not, see addendum below, also [docs](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects#updating-a-custom-text-number-or-date-field))
    - Using one of the [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) works, if only for the main branch
    - [x] Also re-open issue if it's been closed by merging the original PR
---
<details>
<summary>Excerpt from local test run</summary>

```
| [INFO ] [trunk] Cherry picking 7d857e6268d86f69219274c73581a4bacf809c5c                                                                                                                                                                                                                                                                                                                                                                    
| [DEBUG] [trunk] Cherry picking command git cherry-pick,-m,1,--strategy=recursive,--strategy-option=theirs,7d857e6268d86f69219274c73581a4bacf809c5c                                                                                                                                                                                                                                                                                         
| [INFO ] [trunk] {
|   "owner": "shopware",
|   "repo": "shopware",
|   "head": "doc-tasks-patch-20250523-1544-backport-trunk",
|   "base": "trunk",
|   "title": "chore(ci): adjust variable reference in doc tasks workflow (backport: trunk)",
|   "body": "**Backport:** https://api.github.com/repos/shopware/shopware/pulls/9838\n**Issue:** https://github.com/shopware/shopware/issues/8775\n---\nWorkflow run for testing: https://github.com/shopware/shopware/actions/runs/15211929403/job/42787931439\r\n\r\n\r\n![grafik](https://github.com/user-attachments/assets/41ca2881-a644-467e-a45a-319087302c54)\r\n",
|   "reviewers": [
|     "philipreinken",
|     "pweyck"
|   ],
|   "assignees": [
|     "philipreinken"
|   ],
|   "labels": [],
|   "comments": []
|   "comments": []
| }
| [INFO ] Process succeeded
```

</details>

---

Addendum: updating the linked Pull Request for an issue via REST is not supported. GraphQL exposes the field, but also doesn't support updates: 
<details>
<summary>API request</summary>

```
$: gh api graphql -F projectId="..." -F itemId="..." -F fieldId="..." -F pullRequestUrl="..." -f query='mutation updatePRLink($projectId: ID!, $itemId: ID!, $fieldId: ID!, $pullRequestUrl: String!) {
  updateProjectV2ItemFieldValue(
    input: {
      projectId: $projectId
      itemId: $itemId
      fieldId: $fieldId
      value: {
        text: $pullRequestUrl
      }
    }
  ) {
    clientMutationId
  }
}'
{
  "data": {
    "updateProjectV2ItemFieldValue": null
  },
  "errors": [
    {
      "type": "VALIDATION",
      "path": [
        "updateProjectV2ItemFieldValue"
      ],
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "message": "The field of type linked_pull_requests is currently not supported."
    }
  ]
}
gh: The field of type linked_pull_requests is currently not supported.
```

</details>