### PR TITLE
fix: Close button on modal is not centered

### DIFF
--- a/changelog/_unreleased/2025-05-26-close-button-x-modal-not-centered.md
+++ b/changelog/_unreleased/2025-05-26-close-button-x-modal-not-centered.md
@@ -1,0 +1,10 @@
+---
+title: Adjusted the styling of the "x" button on modal
+issue: #9623
+author: Tam Dao
+author_email: t.dao@shopware.com
+author_github: @daothithientamm
+---
+# Administration
+* Changed styling of the "x" button on modal in `src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss` for better alignment and consistency.
+* Added method close for `sw-media-url-form` modal in `src/Administration/Resources/app/administration/src/app/component/media/sw-media-url-form/sw-media-url-form.html.twig`.

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss
@@ -148,12 +148,6 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
             background-color: $color-gray-200;
             color: $color-darkgray-200;
         }
-
-        .mt-icon {
-            width: 16px;
-            height: 16px;
-            padding: 3px;
-        }
     }
 
     .sw-modal__body {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-url-form/sw-media-url-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-url-form/sw-media-url-form.html.twig
@@ -4,6 +4,7 @@
     class="sw-media-url-form"
     variant="small"
     :title="$tc('global.sw-media-url-form.title')"
+    @modal-close="closeModal"
 >
 
     {% block sw_media_url_form_input %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Close button centered within the grey background
The modal upload media is able closed by "x" button.

### 2. What does this change do, exactly?

* Updated the styling of the "x" (close) button in `sw-modal.scss` to improve alignment and visual consistency.
* Removed unused `.mt-icon` styles from `sw-modal.scss` to clean up the codebase.
* Added a `@modal-close` event handler in `sw-media-url-form.html.twig` to invoke the `closeModal` method for better modal functionality.

### 3. Describe each step to reproduce the issue or behaviour.
- Open any modals on administration -> focus to "x" button.

Test modal upload file:

- Content > Media
- Click the arrow to upload image by URL
- Click to "x" button

| Before  | After |
| ------------- | ------------- |
| <img width="655" alt="image" src="https://github.com/user-attachments/assets/38af952e-279f-46a0-813d-4e5ae6050041" /> | <img width="655" alt="image" src="https://github.com/user-attachments/assets/645b49ce-8972-4e07-93dc-84b849647688" />
 |

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #9466  - closes the issue #9466 when the PR is merged

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/620d25b02a6f57c656465f86a8ed885e610c8c11/changelog/_unreleased/2025-05-26-close-button-x-modal-not-centered.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
