### PR TITLE
fix: preview of mapped fields in cms in the admin

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-name/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-name/component/index.js
@@ -25,6 +25,7 @@ export default {
                 this.element.config.content.source = 'mapped';
                 this.element.config.content.value = 'product.name';
             }
+            this.updateDemoValue();
         },
 
         updateDemoValue() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/component.spec.js
@@ -93,4 +93,21 @@ describe('src/module/sw-cms/elements/text/component', () => {
         wrapper.vm.emitChanges('product.name');
         expect(wrapper.emitted()['element-update']).toBeUndefined();
     });
+
+    it('sets demoValue correctly when source is mapped', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.setProps({
+            element: {
+                config: {
+                    content: {
+                        source: 'mapped',
+                        value: 'product.name',
+                    },
+                },
+            },
+        });
+
+        expect(wrapper.vm.demoValue).toContain('<strong>product.name</strong>');
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/index.js
@@ -73,11 +73,14 @@ export default {
     methods: {
         createdComponent() {
             this.initElementConfig('text');
+            this.updateDemoValue();
         },
 
         updateDemoValue() {
             if (this.element.config.content.source === 'mapped') {
-                this.demoValue = this.getDemoValue(this.element.config.content.value);
+                const label = `<strong>${this.element.config.content.value}</strong>`;
+                const fallbackLabel = `${this.$t('sw-cms.detail.label.mappingPreview')} ${label}`;
+                this.demoValue = this.getDemoValue(this.element.config.content.value) || fallbackLabel;
             }
         },
 


### PR DESCRIPTION
fixes #9592

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The preview of mapped fields is currently blank in the admin

### 2. What does this change do, exactly?
Indroduces a fallback if no demo data entity is available and shows the mapping path

### 3. Describe each step to reproduce the issue or behaviour.
Create a products detail cms page and add mapped fields. For example a text field with product description. Also after saving the preview should be shown correct.

![{4842ED92-9615-42BE-B254-103F21602D44}](https://github.com/user-attachments/assets/ec258914-5aeb-45ce-abf4-fa29d83a5186)


### 4. Please link to the relevant issues (if any).
- closes #9592- closes the issue #9592 when the PR is merged


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
