### PR TITLE
fix: banner styling for bulk edit product variants

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.html.twig
@@ -73,19 +73,8 @@
                 position-identifier="sw-bulk-edit-product-inheritance"
             >
                 {% block sw_bulk_edit_product_content_inheritance_alert %}
-                <mt-banner variant="info">
-                    <template #customIcon>
-                        <div class="sw-bulk-edit-product__inheritance-icon">
-                            <mt-icon
-                                name="regular-link"
-                                color="#7363e5"
-                                size="16"
-                            />
-                        </div>
-                    </template>
-                    <template #default>
-                        {{ $tc('sw-bulk-edit.product.alertInheritance.message') }}
-                    </template>
+                <mt-banner variant="inherited">
+                    {{ $tc('sw-bulk-edit.product.alertInheritance.message') }}
                 </mt-banner>
                 {% endblock %}
             </mt-card>

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.scss
@@ -115,22 +115,8 @@
         margin-top: 0;
     }
 
-    &__inheritance.sw-card {
-        filter: none;
-    }
-
-    &__inheritance.sw-card .sw-card__content {
-        border: 0;
-    }
-
-    &__inheritance-icon {
-        position: relative;
-    }
-
-    &__inheritance-icon .mt-icon {
-        position: absolute;
-        top: 30px;
-        right: 10px;
+    &__inheritance .mt-banner {
+        margin-bottom: 0;
     }
 }
 


### PR DESCRIPTION
Use `mt-banner` component with variant `inherited` from the meteor library [here](https://meteor-component-library.vercel.app/?path=/docs/components-feedback-indicator-mt-banner--docs)

Before 
![Screenshot 2025-05-27 at 16 28 18](https://github.com/user-attachments/assets/6716b615-616a-477e-910e-781fe891bde9)

After 

![Screenshot 2025-05-27 at 16 15 04](https://github.com/user-attachments/assets/74059159-4d9a-4a7d-b8aa-74f918cf8a56)
