### PR TITLE
fix: document config error if itemsPerPage is numeric string

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
@@ -94,9 +94,9 @@ export default {
                 },
                 {
                     name: 'itemsPerPage',
-                    type: 'text',
+                    type: 'number',
                     config: {
-                        type: 'text',
+                        type: 'number',
                         label: this.$tc('sw-settings-document.detail.labelItemsPerPage'),
                     },
                 },

--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -441,4 +441,9 @@ class DocumentConfiguration extends Struct
     {
         $this->logo = $logo;
     }
+
+    public function setItemsPerPage(string|int|null $itemsPerPage): void
+    {
+        $this->itemsPerPage = (int) $itemsPerPage;
+    }
 }

--- a/tests/unit/Core/Checkout/Document/DocumentConfigurationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Document/DocumentConfigurationFactoryTest.php
@@ -102,4 +102,16 @@ class DocumentConfigurationFactoryTest extends TestCase
         static::assertIsArray($customData);
         static::assertSame('1', $customData['invoiceNumber']);
     }
+
+    public function testMergeConfigurationStringToIntConversion(): void
+    {
+        $baseConfig = new DocumentConfiguration();
+        $additionalConfig = [
+            'itemsPerPage' => '10',
+        ];
+
+        $mergedConfig = DocumentConfigurationFactory::mergeConfiguration($baseConfig, $additionalConfig);
+
+        static::assertSame(10, $mergedConfig->__get('itemsPerPage'));
+    }
 }


### PR DESCRIPTION
The type was not enforced before 6.7. Now, the type is enforced and it can throw errors for example if a numeric string is not a real integer.

As solution changed the input type in admin to number from string.

Additionally added a setter method which casts the value to integer. If for example before 6.7 update the value was a numeric string this would now throw error after the update. The casting fixes this scenario.

Changed `DocumentConfigurationFactory` so that if there is a setter method defined for a property of `DocumentConfiguration` prioritise calling it.