### PR TITLE
fix: correct stock color variant filter name in bulk edit modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/sw-product-variant-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/sw-product-variant-modal.html.twig
@@ -210,7 +210,7 @@
                 {% block sw_product_variant_modal_bulk_edit_modal_column_stock %}
                 <template #column-stock="{ item }">
                     {{ item.stock }}
-                    <sw-color-badge :variant="stockColorVariant(item.stock)" />
+                    <sw-color-badge :variant="stockColorVariantFilter(item.stock)" />
                 </template>
                 {% endblock %}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/367f25e1-984c-4ea4-adc0-9b03f57bb850)

issue already fix here in trunk 
https://github.com/shopware/shopware/pull/9910