### PR TITLE
chore: update meteor to 4.12.1

### DIFF
--- a/changelog/_unreleased/2025-05-28-update-meteor-to-4-12-1.md
+++ b/changelog/_unreleased/2025-05-28-update-meteor-to-4-12-1.md
@@ -2,5 +2,5 @@
 title: Update Meteor to 4.12.1
 ---
 # Administration
-* Updated "meteor-component-library" package to version 4.12.1.
+* Changed "meteor-component-library" package to version 4.12.1.
 

--- a/changelog/_unreleased/2025-05-28-update-meteor-to-4-12-1.md
+++ b/changelog/_unreleased/2025-05-28-update-meteor-to-4-12-1.md
@@ -1,0 +1,6 @@
+---
+title: Update Meteor to 4.12.1
+---
+# Administration
+* Updated "meteor-component-library" package to version 4.12.1.
+

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@shopware-ag/meteor-admin-sdk": "5.7.7",
-        "@shopware-ag/meteor-component-library": "^4.11.1",
+        "@shopware-ag/meteor-component-library": "^4.12.1",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",
         "@types/fs-extra": "^11.0.4",
@@ -5003,9 +5003,9 @@
       }
     },
     "node_modules/@shopware-ag/meteor-component-library": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.11.1.tgz",
-      "integrity": "sha512-udQpA3L5dg8wA/zsVDMPrM9EYJLfTBPkz8yuEyy5a7CCyXkAwHb/sMauArxjSxM6KnRC5k6emELZG0ql9LSx1g==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.12.1.tgz",
+      "integrity": "sha512-ffdGR9haSLZZIfTkOXCbPoFZjiX+miWe9pkrPTshE73XEL8x8dKdbDTvTNV50RkI8t6xBLAPx0qB/6Bc1qlDDA==",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@floating-ui/dom": "^1.4.3",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@shopware-ag/meteor-admin-sdk": "5.7.7",
-    "@shopware-ag/meteor-component-library": "^4.11.1",
+    "@shopware-ag/meteor-component-library": "^4.12.1",
     "@shopware-ag/meteor-icon-kit": "5.4.0",
     "@swc/core": "1.10.7",
     "@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
Update meteor to have default value for button variant set to `secondary`