### PR TITLE
fix: add recalculated custom line-items to delivery

### DIFF
--- a/changelog/_unreleased/2025-05-28-add-recalculated-custom-line-items-to-delivery.md
+++ b/changelog/_unreleased/2025-05-28-add-recalculated-custom-line-items-to-delivery.md
@@ -1,0 +1,9 @@
+---
+title: Add recalculated custom line-items to delivery
+issue: #8763
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed the `RecalculationService::addCustomLineItem` to add shipping cost aware line-items to the delivery too.

--- a/src/Core/Checkout/Cart/Order/RecalculationService.php
+++ b/src/Core/Checkout/Cart/Order/RecalculationService.php
@@ -136,9 +136,9 @@ class RecalculationService
 
         $recalculatedCart = $this->recalculateCart($cart, $salesChannelContext);
 
-        $new = $cart->get($lineItem->getId());
-        if ($new) {
-            $this->addProductToDeliveryPosition($new, $recalculatedCart);
+        $recalculatedLineItem = $recalculatedCart->get($lineItem->getId());
+        if ($recalculatedLineItem?->isShippingCostAware()) {
+            $this->addLineItemToDeliveryPosition($recalculatedLineItem, $recalculatedCart);
         }
 
         $conversionContext = $this->getOrderConversionContext()->setIncludeDeliveries(true);
@@ -161,6 +161,11 @@ class RecalculationService
         $cart->add($lineItem);
 
         $recalculatedCart = $this->recalculateCart($cart, $salesChannelContext);
+
+        $recalculatedLineItem = $recalculatedCart->get($lineItem->getId());
+        if ($recalculatedLineItem?->isShippingCostAware()) {
+            $this->addLineItemToDeliveryPosition($recalculatedLineItem, $recalculatedCart);
+        }
 
         $conversionContext = $this->getOrderConversionContext();
         $orderData = $this->orderConverter->convertToOrder($recalculatedCart, $salesChannelContext, $conversionContext);
@@ -336,12 +341,8 @@ class RecalculationService
         }
     }
 
-    private function addProductToDeliveryPosition(LineItem $item, Cart $cart): void
+    private function addLineItemToDeliveryPosition(LineItem $item, Cart $cart): void
     {
-        if ($cart->getDeliveries()->count() <= 0) {
-            return;
-        }
-
         $delivery = $cart->getDeliveries()->first();
         if (!$delivery) {
             return;

--- a/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
@@ -144,8 +144,14 @@ class RecalculationServiceTest extends TestCase
 
         $order = $this->orderRepository->search($criteria, $context)->get($orderId);
         static::assertNotNull($order);
-        static::assertCount(3, $order->getLineItems());
-        static::assertCount($positionCount, $order->getDeliveries()?->first()?->getPositions());
+
+        $lineItems = $order->getLineItems();
+        static::assertNotNull($lineItems);
+        static::assertCount(3, $lineItems);
+
+        $positions = $order->getDeliveries()?->first()?->getPositions();
+        static::assertNotNull($positions);
+        static::assertCount($positionCount, $positions);
     }
 
     public static function customLineItemProvider(): \Generator

--- a/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Checkout\Cart\Order;
 
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
@@ -20,8 +21,10 @@ use Shopware\Core\Checkout\Cart\Order\OrderConverter;
 use Shopware\Core\Checkout\Cart\Order\OrderPersister;
 use Shopware\Core\Checkout\Cart\Order\RecalculationService;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Processor;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRule;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Cart\Transaction\Struct\TransactionCollection;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
@@ -39,6 +42,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Cart\ProductCartProcessor;
+use Shopware\Core\Content\Product\State;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -122,6 +126,44 @@ class RecalculationServiceTest extends TestCase
         );
 
         $this->salesChannelContext->setRuleIds([$priceRuleId]);
+    }
+
+    #[DataProvider('customLineItemProvider')]
+    public function testAddCustomLineItemSdf(LineItem $lineItem, int $positionCount): void
+    {
+        $cart = $this->generateDemoCart();
+        $orderId = $this->persistCart($cart)['orderId'];
+        $versionId = $this->createVersionedOrder($orderId);
+        $context = Context::createDefaultContext()->createWithVersionId($versionId);
+
+        $this->getContainer()->get(RecalculationService::class)->addCustomLineItem($orderId, $lineItem, $context);
+
+        $criteria = (new Criteria([$orderId]))
+            ->addAssociation('lineItems')
+            ->addAssociation('deliveries.positions');
+
+        $order = $this->orderRepository->search($criteria, $context)->get($orderId);
+        static::assertNotNull($order);
+        static::assertCount(3, $order->getLineItems());
+        static::assertCount($positionCount, $order->getDeliveries()?->first()?->getPositions());
+    }
+
+    public static function customLineItemProvider(): \Generator
+    {
+        yield 'line item type custom, shipping cost aware' => [
+            (new LineItem(Uuid::randomHex(), LineItem::CUSTOM_LINE_ITEM_TYPE))
+                ->setLabel('Test custom line item')
+                ->setPriceDefinition(new QuantityPriceDefinition(10, new TaxRuleCollection([new TaxRule(19)]))),
+            3,
+        ];
+
+        yield 'line item type custom, not shipping cost aware' => [
+            (new LineItem(Uuid::randomHex(), LineItem::CUSTOM_LINE_ITEM_TYPE))
+                ->setLabel('Test custom line item')
+                ->setPriceDefinition(new QuantityPriceDefinition(10, new TaxRuleCollection([new TaxRule(19)])))
+                ->setStates([State::IS_DOWNLOAD]),
+            2,
+        ];
     }
 
     public function testPersistOrderAndConvertToCart(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Custom line-items, in contrast to product line-items, are not added to the delivery positions during a recalculation.
This behaviour differs from the normal checkout and the initial creation of an admin order, which shouldn't be the case.

### 2. What does this change do, exactly?
Respect the `shippingCostAware` flag of a line-item, like the `DeliveryBuilder` does, and add the line-item conditionally to the delivery positions.

### 3. Describe each step to reproduce the issue or behaviour.
- Place an order
- Add custom line-items with various tax rates
- None of these tax rates are considered in the shipping cost calculation

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #8763

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
