### PR TITLE
fix: card styling for bulk edit product variants

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.scss
@@ -24,17 +24,17 @@
         }
     }
 
-    .sw-card .sw-card__content {
+    .mt-card .mt-card__content {
         padding: 0;
 
-        .sw-card__quick-link {
+        .mt-card__quick-link {
             text-align: right;
             display: block;
             padding-top: 14px;
             cursor: pointer;
         }
 
-        .sw-card__quick-link.is--disabled {
+        .mt-card__quick-link.is--disabled {
             cursor: default;
             pointer-events: none;
             opacity: 0.5;
@@ -115,8 +115,15 @@
         margin-top: 0;
     }
 
-    &__inheritance .mt-banner {
-        margin-bottom: 0;
+    &__inheritance {
+        &.mt-card {
+            border: none;
+            border-radius: 0;
+        }
+
+        .mt-banner {
+            margin-bottom: 0;
+        }
     }
 }
 


### PR DESCRIPTION
### Description
Styling of `sw-card` component doesn't work with `mt-card` component anymore.

![Screenshot 2025-05-29 at 15 00 01](https://github.com/user-attachments/assets/a768afc5-fb7b-4a94-a937-491bf9790f9b)

