### PR TITLE
fix: Message routing overwrite for interfaces and abstract classes

### DIFF
--- a/changelog/_unreleased/2025-05-29-unwrap-messages-when-routing.md
+++ b/changelog/_unreleased/2025-05-29-unwrap-messages-when-routing.md
@@ -1,0 +1,6 @@
+---
+title: Unwrap messages when routing
+issue: NEXT-39749
+---
+# Core
+* Changed `\Shopware\Core\Framework\MessageQueue\Middleware\RoutingOverwriteMiddleware::getTransports` to unwrap Envelope message so that they are correctly routed

--- a/src/Core/Framework/MessageQueue/Middleware/RoutingOverwriteMiddleware.php
+++ b/src/Core/Framework/MessageQueue/Middleware/RoutingOverwriteMiddleware.php
@@ -56,9 +56,10 @@ class RoutingOverwriteMiddleware implements MiddlewareInterface
      *
      * @return array<string>|string|null
      */
-    private function getTransports(Envelope $message, array $overwrites, bool $inherited): array|string|null
+    private function getTransports(Envelope $envelope, array $overwrites, bool $inherited): array|string|null
     {
-        $class = $message->getMessage()::class;
+        $message = $envelope->getMessage();
+        $class = $message::class;
 
         if (\array_key_exists($class, $overwrites)) {
             return $overwrites[$class];

--- a/tests/unit/Core/Framework/MessageQueue/Middleware/RoutingOverwriteMiddlewareTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Middleware/RoutingOverwriteMiddlewareTest.php
@@ -142,6 +142,19 @@ class RoutingOverwriteMiddlewareTest extends MiddlewareTestCase
                 new BusNameStamp('test'),
             ],
         ];
+
+        yield 'Default config, no stamps, message in envelope, message implements interface' => [
+            'message' => (new Envelope(new LowPriorityMessage())),
+            'config' => [
+                AsyncMessageInterface::class => 'async',
+                LowPriorityMessageInterface::class => 'low_priority',
+                SendEmailMessage::class => 'async',
+            ],
+            'providedStamps' => [],
+            'expectedStamps' => [
+                new TransportNamesStamp(['low_priority']),
+            ],
+        ];
     }
 }
 
@@ -149,5 +162,12 @@ class RoutingOverwriteMiddlewareTest extends MiddlewareTestCase
  * @internal
  */
 class AsyncMessage
+{
+}
+
+/**
+ * @internal
+ */
+class LowPriorityMessage implements LowPriorityMessageInterface
 {
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Message routing overwrite is broken for interfaces and abstract classes

This was fixed in an earlier version of Shopware, but then reintroduced in a Messenger routing refactor. See https://github.com/shopware/shopware/issues/8434

### 2. What does this change do, exactly?

Unwrap the envelope and compare the correct message class with the configured overwrites.

### 3. Describe each step to reproduce the issue or behaviour.

Project has a message routing overwrite configured for all EntityIndexMessage objects:

```php
shopware:
  messenger:
    routing_overwrite:
      'Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage': transport_entity_index
```

In Shopware v6.6.10.3 the message is routed to the default transport async

The RoutingOverwriteMiddleware does not properly check for interfaces or abstract classes:

```php
        foreach ($overwrites as $class => $transports) {
            if ($message instanceof $class) {
                return $transports;
            }
        }
```

Since the $message object is the Envelope class, this only works for overwrites where the class is set to Symfony\Component\Messenger\Envelope

### 4. Please link to the relevant issues (if any).
- closes #8434
- relates to commit https://github.com/shopware/shopware/commit/ec0117751339750e6622e0e08288a9fffb0c4d29
- relates to Jira issue: https://shopware.atlassian.net/browse/NEXT-39749

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
