### PR TITLE
fix(iap): silence and log exceptions

### DIFF
--- a/changelog/_unreleased/2025-05-30-silence-and-log-exceptions-of-in-app-purchases.md
+++ b/changelog/_unreleased/2025-05-30-silence-and-log-exceptions-of-in-app-purchases.md
@@ -1,0 +1,9 @@
+---
+title: Silence and log exceptions of In-App purchases
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `InAppPurchaseProvider` to log `JWTException`
+* Changed `JWTDecoder` to correctly wrap contraint violations into `JWTException`

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -248,6 +248,7 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Core\Framework\JWT\JWTDecoder"/>
             <argument type="service" id="Shopware\Core\Framework\Store\InAppPurchase\Services\KeyFetcher"/>
+            <argument type="service" id="logger" />
         </service>
 
         <service id="Shopware\Core\Framework\Store\InAppPurchase\Api\InAppPurchasesController" public="true">

--- a/src/Core/Framework/JWT/JWTDecoder.php
+++ b/src/Core/Framework/JWT/JWTDecoder.php
@@ -6,7 +6,7 @@ use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Token\Parser;
 use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Validation\Constraint;
-use Lcobucci\JWT\Validation\ConstraintViolation;
+use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 use Lcobucci\JWT\Validation\Validator;
 use Shopware\Core\Framework\Log\Package;
 
@@ -21,12 +21,15 @@ final class JWTDecoder
         return $this->parseToken($jwt)->claims()->all();
     }
 
+    /**
+     * @throws JWTException
+     */
     public function validate(string $jwt, Constraint ...$constraints): void
     {
         try {
             $validator = new Validator();
             $validator->assert($this->parseToken($jwt), ...$constraints);
-        } catch (ConstraintViolation $e) {
+        } catch (RequiredConstraintsViolated $e) {
             throw JWTException::invalidJwt($e->getMessage(), $e);
         }
     }

--- a/src/Core/Framework/Store/InAppPurchase/Services/InAppPurchaseProvider.php
+++ b/src/Core/Framework/Store/InAppPurchase/Services/InAppPurchaseProvider.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\JWT\Constraints\HasValidRSAJWKSignature;
 use Shopware\Core\Framework\JWT\Constraints\MatchesLicenceDomain;
 use Shopware\Core\Framework\JWT\JWTDecoder;
 use Shopware\Core\Framework\JWT\JWTException;
+use Shopware\Core\Framework\JWT\Struct\JWKStruct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\StoreException;
 use Shopware\Core\System\SystemConfig\SystemConfigService;

--- a/src/Core/Framework/Store/InAppPurchase/Services/InAppPurchaseProvider.php
+++ b/src/Core/Framework/Store/InAppPurchase/Services/InAppPurchaseProvider.php
@@ -2,14 +2,15 @@
 
 namespace Shopware\Core\Framework\Store\InAppPurchase\Services;
 
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\JWT\Constraints\HasValidRSAJWKSignature;
 use Shopware\Core\Framework\JWT\Constraints\MatchesLicenceDomain;
 use Shopware\Core\Framework\JWT\JWTDecoder;
 use Shopware\Core\Framework\JWT\JWTException;
-use Shopware\Core\Framework\JWT\Struct\JWKStruct;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\StoreException;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
@@ -25,7 +26,8 @@ final class InAppPurchaseProvider
     public function __construct(
         private readonly SystemConfigService $systemConfig,
         private readonly JWTDecoder $decoder,
-        private readonly KeyFetcher $keyFetcher
+        private readonly KeyFetcher $keyFetcher,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -34,15 +36,7 @@ final class InAppPurchaseProvider
      */
     public function getPurchases(): array
     {
-        $purchases = $this->systemConfig->getString(self::CONFIG_STORE_IAP_KEY);
-        if (!$purchases) {
-            return [];
-        }
-
-        $purchases = json_decode($purchases, true);
-        if (!\is_array($purchases)) {
-            return [];
-        }
+        $purchases = $this->getPurchasesJWT();
 
         return $this->filterActive($this->decodePurchases($purchases));
     }
@@ -52,12 +46,13 @@ final class InAppPurchaseProvider
      */
     public function getPurchasesJWT(): array
     {
-        $purchases = $this->systemConfig->getString(self::CONFIG_STORE_IAP_KEY);
-        if (!$purchases) {
-            return [];
+        $purchases = \json_decode($this->systemConfig->getString(self::CONFIG_STORE_IAP_KEY), true);
+
+        if (\is_array($purchases)) {
+            return $purchases;
         }
 
-        return json_decode($purchases, true);
+        return [];
     }
 
     /**
@@ -70,25 +65,35 @@ final class InAppPurchaseProvider
         if ($encodedPurchases === []) {
             return [];
         }
-        $decodedPurchases = [];
 
         $context = Context::createDefaultContext();
 
         try {
             $jwks = $this->keyFetcher->getKey($context, $retried);
-            $signatureValidator = new HasValidRSAJWKSignature($jwks);
-            $domainValidator = new MatchesLicenceDomain($this->systemConfig);
-            foreach ($encodedPurchases as $extensionName => $purchaseJwt) {
+        } catch (AppException|StoreException $e) { // only StoreException::jwksNotFound() is thrown
+            $this->logger->error('Unable to decode In-App purchases: {message}', ['message' => $e->getMessage()]);
+
+            return [];
+        }
+
+        $signatureValidator = new HasValidRSAJWKSignature($jwks);
+        $domainValidator = new MatchesLicenceDomain($this->systemConfig);
+
+        $decodedPurchases = [];
+
+        foreach ($encodedPurchases as $extensionName => $purchaseJwt) {
+            try {
                 $this->decoder->validate($purchaseJwt, $signatureValidator, $domainValidator);
                 $decodedPurchases[$extensionName][] = DecodedPurchasesCollectionStruct::fromArray($this->decoder->decode($purchaseJwt));
-            }
-        } catch (JWTException $e) {
-            if (!$retried) {
+            } catch (JWTException $e) {
+                if ($retried) {
+                    $this->logger->error('Unable to decode In-App purchases for extension "{extension}": {message}', ['extension' => $extensionName, 'message' => $e->getMessage()]);
+
+                    return [];
+                }
+
                 return $this->decodePurchases($encodedPurchases, true);
             }
-            // ignore if already retried
-        } catch (AppException $e) {
-            // ignore
         }
 
         return $decodedPurchases;

--- a/src/Core/Framework/Test/Store/StaticInAppPurchaseFactory.php
+++ b/src/Core/Framework/Test/Store/StaticInAppPurchaseFactory.php
@@ -42,7 +42,12 @@ class StaticInAppPurchaseFactory
                         {
                         }
                     }
-                )
+                ),
+                new class extends Logger {
+                    public function __construct()
+                    {
+                    }
+                }
             )
         );
 

--- a/tests/integration/Core/Framework/Store/InAppPurchaseTest.php
+++ b/tests/integration/Core/Framework/Store/InAppPurchaseTest.php
@@ -56,8 +56,9 @@ class InAppPurchaseTest extends TestCase
                     static::getContainer()->get(StoreRequestOptionsProvider::class),
                     new StaticSystemConfigService(),
                     static::getContainer()->get('logger')
-                )
-            )
+                ),
+                static::getContainer()->get('logger')
+            ),
         );
 
         static::assertFalse($iap->isActive('ExtensionName', 'inactivePurchase'));
@@ -103,8 +104,9 @@ class InAppPurchaseTest extends TestCase
                     static::getContainer()->get(StoreRequestOptionsProvider::class),
                     $this->staticSystemConfigService,
                     static::getContainer()->get('logger')
-                )
-            )
+                ),
+                static::getContainer()->get('logger')
+            ),
         );
     }
 }

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Services/InAppPurchaseProviderTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Services/InAppPurchaseProviderTest.php
@@ -9,17 +9,18 @@ use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Token\Builder;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\JWT\JWTDecoder;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Store\Authentication\AbstractStoreRequestOptionsProvider;
 use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
 use Shopware\Core\Framework\Store\InAppPurchase;
 use Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseProvider;
 use Shopware\Core\Framework\Store\InAppPurchase\Services\KeyFetcher;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Framework\Store\Services\StoreService;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 
 /**
@@ -29,194 +30,167 @@ use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 #[Package('checkout')]
 class InAppPurchaseProviderTest extends TestCase
 {
-    public function testActivePurchases(): void
-    {
-        $jwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/valid-jwks.json');
-        static::assertIsString($jwks);
-        $jwks = trim($jwks);
+    private ClientInterface&MockObject $client;
 
-        $config = new StaticSystemConfigService([
-            InAppPurchaseProvider::CONFIG_STORE_IAP_KEY => $this->formatConfigKey([
-                'ActiveFeature1' => 'Extension1',
-                'ActiveFeature2' => 'Extension1',
-                'ActiveFeature3' => 'Extension2',
-            ]),
-            'core.store.licenseHost' => 'example.com',
-            KeyFetcher::CORE_STORE_JWKS => $jwks,
+    private TestHandler $logger;
+
+    private StaticSystemConfigService $config;
+
+    private string $validJwks;
+
+    private string $invalidJwks;
+
+    private InAppPurchase $iap;
+
+    protected function setUp(): void
+    {
+        $this->validJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/valid-jwks.json');
+        $this->invalidJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/invalid-jwks.json');
+        static::assertIsString($this->validJwks);
+        static::assertIsString($this->invalidJwks);
+
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->logger = new TestHandler();
+        $this->config = new StaticSystemConfigService([
+            StoreService::CONFIG_KEY_STORE_LICENSE_DOMAIN => 'example.com',
+            KeyFetcher::CORE_STORE_JWKS => $this->validJwks,
         ]);
 
-        $iap = new InAppPurchase(
+        $this->iap = new InAppPurchase(
             new InAppPurchaseProvider(
-                $config,
+                $this->config,
                 new JWTDecoder(),
                 new KeyFetcher(
-                    $this->createMock(ClientInterface::class),
-                    $this->createMock(AbstractStoreRequestOptionsProvider::class),
-                    $config,
-                    $this->createMock(LoggerInterface::class)
-                )
+                    $this->client,
+                    $this->createMock(StoreRequestOptionsProvider::class),
+                    $this->config,
+                    new Logger('test', [$this->logger])
+                ),
+                new Logger('test', [$this->logger]),
             )
         );
+    }
 
-        static::assertSame(['Extension1-ActiveFeature1', 'Extension1-ActiveFeature2', 'Extension2-ActiveFeature3'], $iap->formatPurchases());
-        static::assertSame(['ActiveFeature1', 'ActiveFeature2'], $iap->getByExtension('Extension1'));
-        static::assertSame(['ActiveFeature3'], $iap->getByExtension('Extension2'));
-        static::assertSame([], $iap->getByExtension('Extension3'));
+    public function testActivePurchases(): void
+    {
+        $this->config->set(InAppPurchaseProvider::CONFIG_STORE_IAP_KEY, $this->formatConfigKey([
+            'ActiveFeature1' => 'Extension1',
+            'ActiveFeature2' => 'Extension1',
+            'ActiveFeature3' => 'Extension2',
+        ]));
 
-        static::assertTrue($iap->isActive('Extension1', 'ActiveFeature1'));
-        static::assertTrue($iap->isActive('Extension1', 'ActiveFeature2'));
-        static::assertTrue($iap->isActive('Extension2', 'ActiveFeature3'));
-        static::assertFalse($iap->isActive('Extension2', 'this-one-is-not'));
+        static::assertSame(['Extension1-ActiveFeature1', 'Extension1-ActiveFeature2', 'Extension2-ActiveFeature3'], $this->iap->formatPurchases());
+        static::assertEquals([], $this->logger->getRecords());
+        static::assertSame(['ActiveFeature1', 'ActiveFeature2'], $this->iap->getByExtension('Extension1'));
+        static::assertSame(['ActiveFeature3'], $this->iap->getByExtension('Extension2'));
+        static::assertSame([], $this->iap->getByExtension('Extension3'));
+
+        static::assertTrue($this->iap->isActive('Extension1', 'ActiveFeature1'));
+        static::assertTrue($this->iap->isActive('Extension1', 'ActiveFeature2'));
+        static::assertTrue($this->iap->isActive('Extension2', 'ActiveFeature3'));
+        static::assertFalse($this->iap->isActive('Extension2', 'this-one-is-not'));
     }
 
     public function testExpiredPurchase(): void
     {
-        $jwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/valid-jwks.json');
-        static::assertIsString($jwks);
+        $this->config->set(InAppPurchaseProvider::CONFIG_STORE_IAP_KEY, $this->formatConfigKey(
+            ['ExpiredFeature' => 'Extension'],
+            '2000-01-01',
+        ));
 
-        $config = new StaticSystemConfigService([
-            InAppPurchaseProvider::CONFIG_STORE_IAP_KEY => $this->formatConfigKey([
-                'ExpiredFeature' => 'Extension',
-            ], '2000-01-01'),
-            'core.store.licenseHost' => 'example.com',
-            KeyFetcher::CORE_STORE_JWKS => $jwks,
-        ]);
-
-        $iap = new InAppPurchase(
-            new InAppPurchaseProvider(
-                $config,
-                new JWTDecoder(),
-                new KeyFetcher(
-                    $this->createMock(ClientInterface::class),
-                    $this->createMock(AbstractStoreRequestOptionsProvider::class),
-                    $config,
-                    $this->createMock(LoggerInterface::class)
-                )
-            )
-        );
-
-        static::assertSame([], $iap->formatPurchases());
-        static::assertSame([], $iap->getByExtension('extension'));
-        static::assertFalse($iap->isActive('Extension7', 'ExpiredFeature'));
+        static::assertSame([], $this->iap->formatPurchases());
+        static::assertEquals([], $this->logger->getRecords());
+        static::assertSame([], $this->iap->getByExtension('extension'));
+        static::assertFalse($this->iap->isActive('Extension7', 'ExpiredFeature'));
     }
 
     public function testEmptySystemConfig(): void
     {
-        $iap = new InAppPurchase(
-            new InAppPurchaseProvider(
-                new StaticSystemConfigService(),
-                new JWTDecoder(),
-                new KeyFetcher(
-                    $this->createMock(ClientInterface::class),
-                    $this->createMock(StoreRequestOptionsProvider::class),
-                    $this->createMock(SystemConfigService::class),
-                    $this->createMock(LoggerInterface::class)
-                ),
-            )
-        );
+        $this->config = new StaticSystemConfigService();
 
-        static::assertEmpty($iap->formatPurchases());
+        static::assertEmpty($this->iap->formatPurchases());
+        static::assertEquals([], $this->logger->getRecords());
     }
 
     public function testInvalidSystemConfig(): void
     {
-        $iap = new InAppPurchase(
-            new InAppPurchaseProvider(
-                new StaticSystemConfigService([InAppPurchaseProvider::CONFIG_STORE_IAP_KEY => 'not a json']),
-                new JWTDecoder(),
-                new KeyFetcher(
-                    $this->createMock(ClientInterface::class),
-                    $this->createMock(StoreRequestOptionsProvider::class),
-                    $this->createMock(SystemConfigService::class),
-                    $this->createMock(LoggerInterface::class)
-                ),
-            )
-        );
+        $this->config->set(InAppPurchaseProvider::CONFIG_STORE_IAP_KEY, 'not a json');
 
-        static::assertEmpty($iap->formatPurchases());
+        static::assertEmpty($this->iap->formatPurchases());
+        static::assertEquals([], $this->logger->getRecords());
     }
 
     public function testGetPurchasesWithInvalidKeyRetriesOnce(): void
     {
-        $invalidJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/invalid-jwks.json');
-        static::assertIsString($invalidJwks);
+        $this->config->set(KeyFetcher::CORE_STORE_JWKS, $this->invalidJwks);
+        $this->config->set(InAppPurchaseProvider::CONFIG_STORE_IAP_KEY, $this->formatConfigKey([
+            'ActiveFeature1' => 'Extension1',
+            'ActiveFeature2' => 'Extension1',
+            'ActiveFeature3' => 'Extension2',
+        ]));
 
-        $config = new StaticSystemConfigService([
-            InAppPurchaseProvider::CONFIG_STORE_IAP_KEY => $this->formatConfigKey([
-                'ActiveFeature1' => 'Extension1',
-                'ActiveFeature2' => 'Extension1',
-                'ActiveFeature3' => 'Extension2',
-            ]),
-            'core.store.licenseHost' => 'example.com',
-            KeyFetcher::CORE_STORE_JWKS => $invalidJwks,
-        ]);
-
-        $validJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/valid-jwks.json');
-        static::assertIsString($validJwks);
-
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $this->client
+            ->expects($this->once())
             ->method('request')
-            ->willReturn(new Response(200, [], $validJwks));
+            ->willReturn(new Response(200, [], $this->validJwks));
 
-        $iap = new InAppPurchase(
-            new InAppPurchaseProvider(
-                $config,
-                new JWTDecoder(),
-                new KeyFetcher(
-                    $client,
-                    $this->createMock(StoreRequestOptionsProvider::class),
-                    $config,
-                    $this->createMock(LoggerInterface::class)
-                ),
-            )
-        );
+        static::assertSame(['Extension1-ActiveFeature1', 'Extension1-ActiveFeature2', 'Extension2-ActiveFeature3'], $this->iap->formatPurchases());
+        static::assertEquals([], $this->logger->getRecords());
+        static::assertSame(['ActiveFeature1', 'ActiveFeature2'], $this->iap->getByExtension('Extension1'));
+        static::assertSame(['ActiveFeature3'], $this->iap->getByExtension('Extension2'));
+        static::assertSame([], $this->iap->getByExtension('Extension3'));
 
-        static::assertSame(['Extension1-ActiveFeature1', 'Extension1-ActiveFeature2', 'Extension2-ActiveFeature3'], $iap->formatPurchases());
-        static::assertSame(['ActiveFeature1', 'ActiveFeature2'], $iap->getByExtension('Extension1'));
-        static::assertSame(['ActiveFeature3'], $iap->getByExtension('Extension2'));
-        static::assertSame([], $iap->getByExtension('Extension3'));
-
-        static::assertTrue($iap->isActive('Extension1', 'ActiveFeature1'));
-        static::assertTrue($iap->isActive('Extension1', 'ActiveFeature2'));
-        static::assertTrue($iap->isActive('Extension2', 'ActiveFeature3'));
-        static::assertFalse($iap->isActive('Extension2', 'this-one-is-not'));
+        static::assertTrue($this->iap->isActive('Extension1', 'ActiveFeature1'));
+        static::assertTrue($this->iap->isActive('Extension1', 'ActiveFeature2'));
+        static::assertTrue($this->iap->isActive('Extension2', 'ActiveFeature3'));
+        static::assertFalse($this->iap->isActive('Extension2', 'this-one-is-not'));
     }
 
     public function testGetPurchasesWithInvalidKeyRetriesMultiple(): void
     {
-        $invalidJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/invalid-jwks.json');
-        static::assertIsString($invalidJwks);
+        $this->config->set(KeyFetcher::CORE_STORE_JWKS, $this->invalidJwks);
+        $this->config->set(InAppPurchaseProvider::CONFIG_STORE_IAP_KEY, $this->formatConfigKey([
+            'ActiveFeature1' => 'Extension1',
+            'ActiveFeature2' => 'Extension1',
+            'ActiveFeature3' => 'Extension2',
+        ]));
 
-        $config = new StaticSystemConfigService([
-            InAppPurchaseProvider::CONFIG_STORE_IAP_KEY => $this->formatConfigKey([
-                'ActiveFeature1' => 'Extension1',
-                'ActiveFeature2' => 'Extension1',
-                'ActiveFeature3' => 'Extension2',
-            ]),
-            'core.store.licenseHost' => 'example.com',
-            KeyFetcher::CORE_STORE_JWKS => $invalidJwks,
-        ]);
-
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $this->client
+            ->expects($this->once())
             ->method('request')
-            ->willReturn(new Response(200, [], $invalidJwks));
+            ->willReturn(new Response(200, [], $this->invalidJwks));
 
-        $iap = new InAppPurchase(
-            new InAppPurchaseProvider(
-                $config,
-                new JWTDecoder(),
-                new KeyFetcher(
-                    $client,
-                    $this->createMock(StoreRequestOptionsProvider::class),
-                    $config,
-                    $this->createMock(LoggerInterface::class)
-                ),
-            )
-        );
+        static::assertSame([], $this->iap->formatPurchases());
 
-        static::assertSame([], $iap->formatPurchases());
+        static::assertCount(1, $this->logger->getRecords());
+        $record = $this->logger->getRecords()[0];
+        static::assertSame('Unable to decode In-App purchases for extension "{extension}": {message}', $record['message']);
+        static::assertSame('Extension1', $record['context']['extension']);
+        static::assertSame('Invalid JWT: Key ID (kid) could not be found', $record['context']['message']);
+    }
+
+    public function testGetPurchasesWithoutJWKS(): void
+    {
+        $this->config->set(KeyFetcher::CORE_STORE_JWKS, '');
+        $this->config->set(InAppPurchaseProvider::CONFIG_STORE_IAP_KEY, $this->formatConfigKey([
+            'ActiveFeature1' => 'Extension1',
+            'ActiveFeature2' => 'Extension1',
+            'ActiveFeature3' => 'Extension2',
+        ]));
+
+        $this->client
+            ->expects($this->once())
+            ->method('request')
+            ->willReturn(new Response(500));
+
+        static::assertSame([], $this->iap->formatPurchases());
+
+        static::assertCount(2, $this->logger->getRecords());
+        $record = $this->logger->getRecords()[0];
+        static::assertSame('Could not fetch the JWKS from the SBP', $record['message']);
+        $record = $this->logger->getRecords()[1];
+        static::assertSame('Unable to decode In-App purchases: {message}', $record['message']);
+        static::assertSame('Unable to retrieve JWKS key', $record['context']['message']);
     }
 
     /**
@@ -226,7 +200,7 @@ class InAppPurchaseProviderTest extends TestCase
     {
         $formattedActivePurchases = [];
         foreach ($purchases as $identifier => $extensionName) {
-            $formattedActivePurchases[$extensionName][] = [
+            $formattedActivePurchases[$extensionName][$extensionName . $identifier] = [
                 'identifier' => $identifier,
                 'nextBookingDate' => $expiresAt,
                 'sub' => 'example.com',
@@ -248,8 +222,7 @@ class InAppPurchaseProviderTest extends TestCase
         $builder = Builder::new(new JoseEncoder(), new class implements ClaimsFormatter {
             public function formatClaims(array $claims): array
             {
-                /** @phpstan-ignore return.type (bypass the interface) */
-                return \array_values($claims);
+                return $claims;
             }
         });
 

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Services/InAppPurchaseProviderTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Services/InAppPurchaseProviderTest.php
@@ -44,10 +44,12 @@ class InAppPurchaseProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->validJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/valid-jwks.json');
-        $this->invalidJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/invalid-jwks.json');
-        static::assertIsString($this->validJwks);
-        static::assertIsString($this->invalidJwks);
+        $validJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/valid-jwks.json');
+        $invalidJwks = file_get_contents(__DIR__ . '/../../../JWT/_fixtures/invalid-jwks.json');
+        static::assertIsString($validJwks);
+        static::assertIsString($invalidJwks);
+        $this->validJwks = $validJwks;
+        $this->invalidJwks = $invalidJwks;
 
         $this->client = $this->createMock(ClientInterface::class);
         $this->logger = new TestHandler();
@@ -164,9 +166,9 @@ class InAppPurchaseProviderTest extends TestCase
 
         static::assertCount(1, $this->logger->getRecords());
         $record = $this->logger->getRecords()[0];
-        static::assertSame('Unable to decode In-App purchases for extension "{extension}": {message}', $record['message']);
-        static::assertSame('Extension1', $record['context']['extension']);
-        static::assertSame('Invalid JWT: Key ID (kid) could not be found', $record['context']['message']);
+        static::assertSame('Unable to decode In-App purchases for extension "{extension}": {message}', $record->message);
+        static::assertSame('Extension1', $record->context['extension']);
+        static::assertSame('Invalid JWT: Key ID (kid) could not be found', $record->context['message']);
     }
 
     public function testGetPurchasesWithoutJWKS(): void
@@ -187,10 +189,10 @@ class InAppPurchaseProviderTest extends TestCase
 
         static::assertCount(2, $this->logger->getRecords());
         $record = $this->logger->getRecords()[0];
-        static::assertSame('Could not fetch the JWKS from the SBP', $record['message']);
+        static::assertSame('Could not fetch the JWKS from the SBP', $record->message);
         $record = $this->logger->getRecords()[1];
-        static::assertSame('Unable to decode In-App purchases: {message}', $record['message']);
-        static::assertSame('Unable to retrieve JWKS key', $record['context']['message']);
+        static::assertSame('Unable to decode In-App purchases: {message}', $record->message);
+        static::assertSame('Unable to retrieve JWKS key', $record->context['message']);
     }
 
     /**
@@ -215,7 +217,7 @@ class InAppPurchaseProviderTest extends TestCase
     }
 
     /**
-     * @param array<int, array<string, int|string>> $payload
+     * @param array<string, array<string, int|string>> $payload
      */
     private function generateJwt(array $payload): string
     {
@@ -227,6 +229,7 @@ class InAppPurchaseProviderTest extends TestCase
         });
 
         foreach ($payload as $i => $iap) {
+            static::assertNotEmpty($i);
             $builder = $builder->withClaim((string) $i, $iap);
         }
 

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Services/InAppPurchaseUpdaterTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Services/InAppPurchaseUpdaterTest.php
@@ -80,7 +80,8 @@ class InAppPurchaseUpdaterTest extends TestCase
                     $this->createMock(StoreRequestOptionsProvider::class),
                     $systemConfig,
                     $this->createMock(LoggerInterface::class)
-                )
+                ),
+                $this->createMock(LoggerInterface::class)
             )
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- `JWTDecoder` catches the wrong exception, leaking the `RequiredConstraintsViolated` exception if the JWT was invalid
- `InAppPurchaseProvider` suppresses relevant exceptions without logging them
- `HasValidRSAJWKSignature` is throwing a `RequiredConstraintsViolated` instead of `ConstraintsViolated`

### 2. What does this change do, exactly?
- `JWTDecoder` catches the `RequiredConstraintsViolated` now
- `InAppPurchaseProvider` now logs exceptions
- `HasValidRSAJWKSignature` throws correct exception (feature flag)

### 3. Describe each step to reproduce the issue or behaviour.
- Setup IAPs
- Change the stored IAP to be invalid
- Reload any page

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
