### PR TITLE
chore(ci): update backport prefix format

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -204,6 +204,7 @@ jobs:
           body-prefix: | # Reference original PR, as well as the related issue, if available
             ${{ format('**Backport:** {0}', github.event.pull_request.html_url) }}
             ${{ needs.find-linked-issue.outputs.url && format('Resolves: {0}', needs.find-linked-issue.outputs.url) }}
+            
             ---
           assignees: >- # Inherit original assignees
             ${{ github.event.pull_request.assignees && join(github.event.pull_request.assignees.*.login, ',') || '' }}


### PR DESCRIPTION
Lines directly followed by a horizontal separator `---` are interpreted as headings on GitHub - this is not intended.
![image](https://github.com/user-attachments/assets/ba5918d0-0db0-4dc0-9240-31499b274f68)
