### PR TITLE
fix: admin promotion notifications [6.7.0.0]

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.html.twig
@@ -56,6 +56,7 @@
             class="sw-order-promotion-field__updates_modal__list_item"
         >
             {{ error.parameters.name }}
+            <br>
         </span>
 
         <p
@@ -70,6 +71,7 @@
             class="sw-order-promotion-field__updates_modal__list_item"
         >
             {{ error.parameters.name }}
+            <br>
         </span>
     </sw-modal>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
@@ -214,7 +214,7 @@ describe('src/module/sw-order/component/sw-order-promotion-field', () => {
         createStateMapper();
 
         const wrapper = await createWrapper();
-        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn();
+        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn((afterSaveFn) => afterSaveFn());
 
         await wrapper.vm.onSubmitCode('Redeem675');
         await flushPromises();
@@ -233,7 +233,7 @@ describe('src/module/sw-order/component/sw-order-promotion-field', () => {
         createStateMapper();
 
         const wrapper = await createWrapper();
-        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn();
+        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn((afterSaveFn) => afterSaveFn());
 
         await wrapper.vm.applyAutomaticPromotions();
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -33,7 +33,7 @@ export default {
             swOrderDetailOnSaveAndRecalculate: this.onSaveAndRecalculate,
             swOrderDetailOnRecalculateAndReload: this.onRecalculateAndReload,
             swOrderDetailOnReloadEntityData: this.reloadEntityData,
-            swOrderDetailOnSaveAndReload: this.onSaveAndReload,
+            swOrderDetailOnSaveAndReload: this.saveAndReload,
             swOrderDetailOnSaveEdits: this.onSaveEdits,
             swOrderDetailAskAndSaveEdits: this.askAndSaveEdits,
             swOrderDetailOnError: this.onError,
@@ -390,19 +390,11 @@ export default {
         },
 
         async onSaveAndRecalculate() {
-            Store.get('swOrderDetail').setLoading(['recalculation', true]);
-
-            try {
-                await this.orderRepository.save(this.order, this.versionContext);
-                await this.orderService
+            await this.saveAndReload(() => {
+                return this.orderService
                     .recalculateOrder(this.orderId, this.versionContext.versionId, {}, {})
                     .then(this.handleCartErrors.bind(this));
-                await this.reloadEntityData();
-            } catch (error) {
-                this.onError('error', error);
-            } finally {
-                Store.get('swOrderDetail').setLoading(['recalculation', false]);
-            }
+            });
         },
 
         async onRecalculateAndReload() {
@@ -420,18 +412,27 @@ export default {
             }
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be replaced by `saveAndReload`
+         */
         onSaveAndReload() {
+            return this.saveAndReload();
+        },
+
+        async saveAndReload(afterSaveFn = null) {
             Store.get('swOrderDetail').setLoading(['recalculation', true]);
 
-            return this.orderRepository
-                .save(this.order, this.versionContext)
-                .then(() => this.reloadEntityData())
-                .catch((error) => {
-                    this.onError('error', error);
-                })
-                .finally(() => {
-                    Store.get('swOrderDetail').setLoading(['recalculation', false]);
-                });
+            try {
+                await this.orderRepository.save(this.order, this.versionContext);
+                if (afterSaveFn) {
+                    await afterSaveFn();
+                }
+                await this.reloadEntityData();
+            } catch (error) {
+                this.onError('error', error);
+            } finally {
+                Store.get('swOrderDetail').setLoading(['recalculation', false]);
+            }
         },
 
         /**

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
@@ -227,7 +227,7 @@
                 @save-and-recalculate="onSaveAndRecalculate"
                 @recalculate-and-reload="onRecalculateAndReload"
                 @reload-entity-data="reloadEntityData"
-                @save-and-reload="onSaveAndReload"
+                @save-and-reload="saveAndReload"
                 @save-edits="onSaveEdits"
                 @error="onError"
             />

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -497,4 +497,16 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
         expect(await promise).toBe(true);
         expect(onSaveEditsSpy).toHaveBeenCalled();
     });
+
+    it('should call afterSaveFn of saveAndReload', async () => {
+        wrapper = await createWrapper();
+
+        let promiseResolved = false;
+        const afterSaveFn = jest.fn(() => (new Promise((r) => { r(); })).then(() => { promiseResolved = true; }));
+
+        await wrapper.vm.saveAndReload(afterSaveFn);
+
+        expect(afterSaveFn).toHaveBeenCalledTimes(1);
+        expect(promiseResolved).toBe(true);
+    });
 });


### PR DESCRIPTION
Backport of #9783
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- Notifications about promotions are not always displayed correctly
- On promotion update the updates aren't shown immediately due to caching duplicate requests

### 2. What does this change do, exactly?
- Map errors correctly to show them
- Allow code to be executed between save and reload

### 3. Describe each step to reproduce the issue or behaviour.
- Go to an admin order
- Add a promotion

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- fixes #10035

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
