### PR TITLE
[6.6.x] fix: admin promotion notifications

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
@@ -225,11 +225,11 @@ export default {
          * To prevent losing unsaved changes on reloading the order,
          * we need to save the **versioned** order beforehand.
          */
-        async saveAndReload() {
+        async saveAndReload(afterSaveFn = null) {
             if (this.swOrderDetailOnSaveAndReload) {
-                await this.swOrderDetailOnSaveAndReload();
+                await this.swOrderDetailOnSaveAndReload(afterSaveFn);
             } else {
-                this.$emit('save-and-reload');
+                this.$emit('save-and-reload', afterSaveFn);
             }
         },
 
@@ -306,35 +306,37 @@ export default {
         },
 
         async applyAutomaticPromotions() {
-            await this.saveAndReload();
-
-            return this.orderService.applyAutomaticPromotions(this.order.id, this.order.versionId)
+            await this.saveAndReload(() => this.orderService
+                .applyAutomaticPromotions(this.order.id, this.order.versionId)
                 .then(this.handlePromotionResponse.bind(this))
-                .catch(this.handleError.bind(this));
+                .catch(this.handleError.bind(this)));
         },
 
         async onSubmitCode(code) {
             this.emitLoadingChange(true);
 
-            await this.saveAndReload();
-
-            return this.orderService.addPromotionToOrder(this.order.id, this.order.versionId, code)
+            return this.saveAndReload(() => this.orderService
+                .addPromotionToOrder(this.order.id, this.order.versionId, code)
                 .then(this.handlePromotionResponse.bind(this))
-                .catch(this.handleError.bind(this));
+                .catch(this.handleError.bind(this)));
         },
 
         handlePromotionResponse(response) {
             this.emitEntityData();
 
-            if (!response?.data?.errors) {
+            if (typeof response?.data?.errors !== 'object') {
                 return;
             }
 
-            const [errors, promotionErrors] = response.data.errors.reduce(([general, promotion], e) => {
-                return ['promotion-discount-deleted', 'promotion-discount-added'].includes(e.messageKey)
-                    ? [general, [...promotion, e]]
-                    : [[...general, e], promotion];
-            }, [[], []]);
+            const [
+                errors,
+                promotionErrors,
+            ] = (Array.isArray(response.data.errors) ? response.data.errors : Object.values(response.data.errors))
+                .reduce(([general, promotion], e) => {
+                    return ['promotion-discount-deleted', 'promotion-discount-added'].includes(e.messageKey)
+                        ? [general, [...promotion, e]]
+                        : [[...general, e], promotion];
+                }, [[], []]);
 
             this.promotionUpdates = promotionErrors;
             response.data.errors = errors;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.html.twig
@@ -56,6 +56,7 @@
             class="sw-order-promotion-field__updates_modal__list_item"
         >
             {{ error.parameters.name }}
+            <br>
         </span>
 
         <p
@@ -70,6 +71,7 @@
             class="sw-order-promotion-field__updates_modal__list_item"
         >
             {{ error.parameters.name }}
+            <br>
         </span>
     </sw-modal>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
@@ -239,7 +239,7 @@ describe('src/module/sw-order/component/sw-order-promotion-field', () => {
         createStateMapper();
 
         const wrapper = await createWrapper();
-        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn();
+        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn((afterSaveFn) => afterSaveFn());
 
         await wrapper.vm.onSubmitCode('Redeem675');
         await flushPromises();
@@ -258,7 +258,7 @@ describe('src/module/sw-order/component/sw-order-promotion-field', () => {
         createStateMapper();
 
         const wrapper = await createWrapper();
-        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn();
+        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn((afterSaveFn) => afterSaveFn());
 
         await wrapper.vm.applyAutomaticPromotions();
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -35,7 +35,7 @@ export default {
             swOrderDetailOnSaveAndRecalculate: this.onSaveAndRecalculate,
             swOrderDetailOnRecalculateAndReload: this.onRecalculateAndReload,
             swOrderDetailOnReloadEntityData: this.reloadEntityData,
-            swOrderDetailOnSaveAndReload: this.onSaveAndReload,
+            swOrderDetailOnSaveAndReload: this.saveAndReload,
             swOrderDetailOnSaveEdits: this.onSaveEdits,
             swOrderDetailAskAndSaveEdits: this.askAndSaveEdits,
             swOrderDetailOnError: this.onError,
@@ -379,20 +379,11 @@ export default {
         },
 
         async onSaveAndRecalculate() {
-            State.commit('swOrderDetail/setLoading', ['order', true]);
-            this.isLoading = true;
-
-            try {
-                await this.orderRepository.save(this.order, this.versionContext);
-                await this.orderService.recalculateOrder(this.orderId, this.versionContext.versionId, {}, {})
+            await this.saveAndReload(() => {
+                return this.orderService
+                    .recalculateOrder(this.orderId, this.versionContext.versionId, {}, {})
                     .then(this.handleCartErrors.bind(this));
-                await this.reloadEntityData();
-            } catch (error) {
-                this.onError('error', error);
-            } finally {
-                this.isLoading = false;
-                State.commit('swOrderDetail/setLoading', ['order', false]);
-            }
+            });
         },
 
         async onRecalculateAndReload() {
@@ -409,18 +400,27 @@ export default {
             }
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be replaced by `saveAndReload`
+         */
         onSaveAndReload() {
+            return this.saveAndReload();
+        },
+
+        async saveAndReload(afterSaveFn = null) {
             State.commit('swOrderDetail/setLoading', ['order', true]);
 
-            return this.orderRepository
-                .save(this.order, this.versionContext)
-                .then(() => this.reloadEntityData())
-                .catch((error) => {
-                    this.onError('error', error);
-                })
-                .finally(() => {
-                    State.commit('swOrderDetail/setLoading', ['order', false]);
-                });
+            try {
+                await this.orderRepository.save(this.order, this.versionContext);
+                if (afterSaveFn) {
+                    await afterSaveFn();
+                }
+                await this.reloadEntityData();
+            } catch (error) {
+                this.onError('error', error);
+            } finally {
+                State.commit('swOrderDetail/setLoading', ['order', false]);
+            }
         },
 
         onUpdateLoading(loadingValue) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -388,6 +388,7 @@ export default {
 
         async onRecalculateAndReload() {
             State.commit('swOrderDetail/setLoading', ['order', true]);
+            this.isLoading = true;
 
             try {
                 await this.orderService.recalculateOrder(this.orderId, this.versionContext.versionId, {}, {})
@@ -396,6 +397,7 @@ export default {
             } catch (error) {
                 this.onError('error', error);
             } finally {
+                this.isLoading = false;
                 State.commit('swOrderDetail/setLoading', ['order', false]);
             }
         },
@@ -409,6 +411,7 @@ export default {
 
         async saveAndReload(afterSaveFn = null) {
             State.commit('swOrderDetail/setLoading', ['order', true]);
+            this.isLoading = true;
 
             try {
                 await this.orderRepository.save(this.order, this.versionContext);
@@ -419,6 +422,7 @@ export default {
             } catch (error) {
                 this.onError('error', error);
             } finally {
+                this.isLoading = false;
                 State.commit('swOrderDetail/setLoading', ['order', false]);
             }
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -379,10 +379,13 @@ export default {
         },
 
         async onSaveAndRecalculate() {
+            this.isLoading = true;
             await this.saveAndReload(() => {
                 return this.orderService
                     .recalculateOrder(this.orderId, this.versionContext.versionId, {}, {})
                     .then(this.handleCartErrors.bind(this));
+            }).then(() => {
+                this.isLoading = false;
             });
         },
 
@@ -411,7 +414,6 @@ export default {
 
         async saveAndReload(afterSaveFn = null) {
             State.commit('swOrderDetail/setLoading', ['order', true]);
-            this.isLoading = true;
 
             try {
                 await this.orderRepository.save(this.order, this.versionContext);
@@ -422,7 +424,6 @@ export default {
             } catch (error) {
                 this.onError('error', error);
             } finally {
-                this.isLoading = false;
                 State.commit('swOrderDetail/setLoading', ['order', false]);
             }
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
@@ -225,7 +225,7 @@
                 @save-and-recalculate="onSaveAndRecalculate"
                 @recalculate-and-reload="onRecalculateAndReload"
                 @reload-entity-data="reloadEntityData"
-                @save-and-reload="onSaveAndReload"
+                @save-and-reload="saveAndReload"
                 @save-edits="onSaveEdits"
                 @error="onError"
             />

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -496,4 +496,16 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
         expect(await promise).toBe(true);
         expect(onSaveEditsSpy).toHaveBeenCalled();
     });
+
+    it('should call afterSaveFn of saveAndReload', async () => {
+        wrapper = await createWrapper();
+
+        let promiseResolved = false;
+        const afterSaveFn = jest.fn(() => (new Promise((r) => { r(); })).then(() => { promiseResolved = true; }));
+
+        await wrapper.vm.saveAndReload(afterSaveFn);
+
+        expect(afterSaveFn).toHaveBeenCalledTimes(1);
+        expect(promiseResolved).toBe(true);
+    });
 });


### PR DESCRIPTION
Backport of #9783
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- Notifications about promotions are not always displayed correctly
- On promotion update the updates aren't shown immediately due to caching duplicate requests

### 2. What does this change do, exactly?
- Map errors correctly to show them
- Allow code to be executed between save and reload

### 3. Describe each step to reproduce the issue or behaviour.
- Go to an admin order
- Add a promotion

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- fixes #10035

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
