### PR TITLE
fix: imitate modal sales channel name

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.html.twig
@@ -58,7 +58,7 @@
                 gap="10px 0px"
             >
                 <div class="imitate-customer-modal-item-header">
-                    {{ salesChannelDomain.salesChannel.name }}
+                    {{ salesChannelDomain.salesChannel.translated.name }}
                 </div>
                 <div class="imitate-customer-modal-item-url">
                     {{ salesChannelDomain.url }}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.spec.js
@@ -17,7 +17,9 @@ responses.addResponse({
                     id: 'sales-channel-domain-id',
                     salesChannelId: 'sales-channel-id',
                     salesChannel: {
-                        name: 'Test sales channel',
+                        translated: {
+                            name: 'Test sales channel',
+                        },
                     },
                     url: 'http://localhost:8000',
                 },


### PR DESCRIPTION
### 1. Why is this change necessary?
With other context language, no sales channel name is displayed

### 2. What does this change do, exactly?
Display the correct name

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #10057 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
