### PR TITLE
fix: Fix health checks in combination with saas

### DIFF
--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -542,8 +542,8 @@
         </service>
 
         <service id="Shopware\Storefront\Framework\SystemCheck\SalesChannelsReadinessCheck">
-            <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil"/>
+            <argument type="service" id="Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider"/>
 
             <tag name="shopware.system_check"/>
         </service>
@@ -551,6 +551,7 @@
         <service id="Shopware\Storefront\Framework\SystemCheck\ProductDetailReadinessCheck">
             <argument type="service" id="Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider"/>
 
             <tag name="shopware.system_check"/>
         </service>
@@ -558,8 +559,13 @@
         <service id="Shopware\Storefront\Framework\SystemCheck\ProductListingReadinessCheck">
             <argument type="service" id="Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider"/>
 
             <tag name="shopware.system_check"/>
+        </service>
+
+        <service id="Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>
     </services>
 </container>

--- a/src/Storefront/Framework/SystemCheck/ProductDetailReadinessCheck.php
+++ b/src/Storefront/Framework/SystemCheck/ProductDetailReadinessCheck.php
@@ -4,7 +4,6 @@ namespace Shopware\Storefront\Framework\SystemCheck;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\SystemCheck\BaseCheck;
@@ -12,7 +11,7 @@ use Shopware\Core\Framework\SystemCheck\Check\Category;
 use Shopware\Core\Framework\SystemCheck\Check\Result;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
-use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,6 +31,7 @@ class ProductDetailReadinessCheck extends BaseCheck
     public function __construct(
         private readonly SalesChannelDomainUtil $util,
         private readonly Connection $connection,
+        private readonly AbstractSalesChannelDomainProvider $domainProvider,
     ) {
     }
 
@@ -61,7 +61,7 @@ class ProductDetailReadinessCheck extends BaseCheck
 
     private function doRun(): Result
     {
-        $domains = $this->fetchSalesChannelDomains();
+        $domains = $this->domainProvider->fetchSalesChannelDomains();
         $salesChannelIds = array_keys($domains);
         $productIds = $salesChannelIds ? $this->fetchProductIds($salesChannelIds) : null;
 
@@ -124,28 +124,6 @@ class ProductDetailReadinessCheck extends BaseCheck
             $sql,
             ['salesChannelIds' => $salesChannelIds],
             ['salesChannelIds' => ArrayParameterType::BINARY]
-        );
-
-        return FetchModeHelper::keyPair($result);
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function fetchSalesChannelDomains(): array
-    {
-        $sql = <<<'SQL'
-            SELECT `sales_channel`.`id`,
-                   `sales_channel_domain`.`url`
-            FROM `sales_channel_domain`
-            INNER JOIN `sales_channel` ON `sales_channel_domain`.`sales_channel_id` = `sales_channel`.`id`
-            WHERE `sales_channel`.`type_id` = :typeId
-            AND `sales_channel`.`active` = :active
-        SQL;
-
-        $result = $this->connection->fetchAllAssociative(
-            $sql,
-            ['typeId' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_STOREFRONT), 'active' => 1]
         );
 
         return FetchModeHelper::keyPair($result);

--- a/src/Storefront/Framework/SystemCheck/ProductDetailReadinessCheck.php
+++ b/src/Storefront/Framework/SystemCheck/ProductDetailReadinessCheck.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\SystemCheck\Check\Category;
 use Shopware\Core\Framework\SystemCheck\Check\Result;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,7 +63,7 @@ class ProductDetailReadinessCheck extends BaseCheck
     private function doRun(): Result
     {
         $domains = $this->domainProvider->fetchSalesChannelDomains();
-        $salesChannelIds = array_keys($domains);
+        $salesChannelIds = $domains->getKeys();
         $productIds = $salesChannelIds ? $this->fetchProductIds($salesChannelIds) : null;
 
         $extra = [];
@@ -74,7 +75,7 @@ class ProductDetailReadinessCheck extends BaseCheck
                 continue;
             }
 
-            $url = $this->util->generateDomainUrl($domain, self::DETAIL_PAGE, [
+            $url = $this->util->generateDomainUrl($domain->url, self::DETAIL_PAGE, [
                 'productId' => $productId,
             ]);
 
@@ -110,7 +111,7 @@ class ProductDetailReadinessCheck extends BaseCheck
     private function fetchProductIds(array $salesChannelIds): array
     {
         $sql = <<<'SQL'
-            SELECT `product_visibility`.`sales_channel_id`,
+            SELECT LOWER(HEX(`product_visibility`.`sales_channel_id`)),
                    LOWER(HEX(`product`.`id`))
             FROM `product`
             INNER JOIN `product_visibility` ON `product`.`id` = `product_visibility`.`product_id`
@@ -122,7 +123,7 @@ class ProductDetailReadinessCheck extends BaseCheck
 
         $result = $this->connection->fetchAllAssociative(
             $sql,
-            ['salesChannelIds' => $salesChannelIds],
+            ['salesChannelIds' => Uuid::fromHexToBytesList($salesChannelIds)],
             ['salesChannelIds' => ArrayParameterType::BINARY]
         );
 

--- a/src/Storefront/Framework/SystemCheck/ProductListingReadinessCheck.php
+++ b/src/Storefront/Framework/SystemCheck/ProductListingReadinessCheck.php
@@ -4,7 +4,6 @@ namespace Shopware\Storefront\Framework\SystemCheck;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\SystemCheck\BaseCheck;
@@ -12,7 +11,7 @@ use Shopware\Core\Framework\SystemCheck\Check\Category;
 use Shopware\Core\Framework\SystemCheck\Check\Result;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
-use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,6 +31,7 @@ class ProductListingReadinessCheck extends BaseCheck
     public function __construct(
         private readonly SalesChannelDomainUtil $util,
         private readonly Connection $connection,
+        private readonly AbstractSalesChannelDomainProvider $domainProvider,
     ) {
     }
 
@@ -61,7 +61,7 @@ class ProductListingReadinessCheck extends BaseCheck
 
     private function doRun(): Result
     {
-        $domains = $this->fetchSalesChannelDomains();
+        $domains = $this->domainProvider->fetchSalesChannelDomains();
         $salesChannelIds = array_keys($domains);
         $navigationIds = $salesChannelIds ? $this->fetchNavigationIds($salesChannelIds) : null;
 
@@ -145,28 +145,6 @@ class ProductListingReadinessCheck extends BaseCheck
             $sql,
             ['salesChannelIds' => $salesChannelIds],
             ['salesChannelIds' => ArrayParameterType::BINARY]
-        );
-
-        return FetchModeHelper::keyPair($result);
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function fetchSalesChannelDomains(): array
-    {
-        $sql = <<<'SQL'
-            SELECT `sales_channel`.`id`,
-                   `sales_channel_domain`.`url`
-            FROM `sales_channel_domain`
-            INNER JOIN `sales_channel` ON `sales_channel_domain`.`sales_channel_id` = `sales_channel`.`id`
-            WHERE `sales_channel`.`type_id` = :typeId
-            AND `sales_channel`.`active` = :active
-        SQL;
-
-        $result = $this->connection->fetchAllAssociative(
-            $sql,
-            ['typeId' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_STOREFRONT), 'active' => 1]
         );
 
         return FetchModeHelper::keyPair($result);

--- a/src/Storefront/Framework/SystemCheck/ProductListingReadinessCheck.php
+++ b/src/Storefront/Framework/SystemCheck/ProductListingReadinessCheck.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\SystemCheck\Check\Category;
 use Shopware\Core\Framework\SystemCheck\Check\Result;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,7 +63,7 @@ class ProductListingReadinessCheck extends BaseCheck
     private function doRun(): Result
     {
         $domains = $this->domainProvider->fetchSalesChannelDomains();
-        $salesChannelIds = array_keys($domains);
+        $salesChannelIds = $domains->getKeys();
         $navigationIds = $salesChannelIds ? $this->fetchNavigationIds($salesChannelIds) : null;
 
         $extra = [];
@@ -74,7 +75,7 @@ class ProductListingReadinessCheck extends BaseCheck
                 continue;
             }
 
-            $url = $this->util->generateDomainUrl($domain, self::LISTING_PAGE, [
+            $url = $this->util->generateDomainUrl($domain->url, self::LISTING_PAGE, [
                 'navigationId' => $navigationId,
             ]);
 
@@ -114,7 +115,7 @@ class ProductListingReadinessCheck extends BaseCheck
     private function fetchNavigationIds(array $salesChannelIds): array
     {
         $sql = <<<'SQL'
-            SELECT `sales_channel`.`id` AS `sales_channel_id`,
+            SELECT LOWER(HEX(`sales_channel`.`id`)) AS `sales_channel_id`,
                    LOWER(HEX(COALESCE(`category_child`.`id`, `category_root`.`id`))) AS `category_id`
             FROM `category` `category_root`
             LEFT JOIN `category` `category_child`
@@ -143,7 +144,7 @@ class ProductListingReadinessCheck extends BaseCheck
 
         $result = $this->connection->fetchAllAssociative(
             $sql,
-            ['salesChannelIds' => $salesChannelIds],
+            ['salesChannelIds' => Uuid::fromHexToBytesList($salesChannelIds)],
             ['salesChannelIds' => ArrayParameterType::BINARY]
         );
 

--- a/src/Storefront/Framework/SystemCheck/SalesChannelsReadinessCheck.php
+++ b/src/Storefront/Framework/SystemCheck/SalesChannelsReadinessCheck.php
@@ -2,15 +2,13 @@
 
 namespace Shopware\Storefront\Framework\SystemCheck;
 
-use Doctrine\DBAL\Connection;
-use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\SystemCheck\BaseCheck;
 use Shopware\Core\Framework\SystemCheck\Check\Category;
 use Shopware\Core\Framework\SystemCheck\Check\Result;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
-use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -30,8 +28,8 @@ class SalesChannelsReadinessCheck extends BaseCheck
      * @internal
      */
     public function __construct(
-        private readonly Connection $connection,
         private readonly SalesChannelDomainUtil $util,
+        private readonly AbstractSalesChannelDomainProvider $domainProvider,
     ) {
     }
 
@@ -51,7 +49,7 @@ class SalesChannelsReadinessCheck extends BaseCheck
 
     public function name(): string
     {
-        return 'SaleChannelsReadiness';
+        return 'SalesChannelsReadiness';
     }
 
     protected function allowedSystemCheckExecutionContexts(): array
@@ -61,7 +59,8 @@ class SalesChannelsReadinessCheck extends BaseCheck
 
     private function doRun(): Result
     {
-        $domains = $this->fetchSalesChannelDomains();
+        $domains = $this->domainProvider->fetchSalesChannelDomains();
+
         $extra = [];
         $requestStatus = [];
         foreach ($domains as $domain) {
@@ -85,21 +84,5 @@ class SalesChannelsReadinessCheck extends BaseCheck
             $finalStatus === Status::OK,
             $extra
         );
-    }
-
-    /**
-     * @return array<string>
-     */
-    private function fetchSalesChannelDomains(): array
-    {
-        $result = $this->connection->fetchAllAssociative(
-            'SELECT `url` FROM `sales_channel_domain`
-                    INNER JOIN `sales_channel` ON `sales_channel_domain`.`sales_channel_id` = `sales_channel`.`id`
-                    WHERE `sales_channel`.`type_id` = :typeId
-                    AND `sales_channel`.`active` = :active',
-            ['typeId' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_STOREFRONT), 'active' => 1]
-        );
-
-        return array_map(fn (array $row): string => $row['url'], $result);
     }
 }

--- a/src/Storefront/Framework/SystemCheck/SalesChannelsReadinessCheck.php
+++ b/src/Storefront/Framework/SystemCheck/SalesChannelsReadinessCheck.php
@@ -64,7 +64,7 @@ class SalesChannelsReadinessCheck extends BaseCheck
         $extra = [];
         $requestStatus = [];
         foreach ($domains as $domain) {
-            $url = $this->util->generateDomainUrl($domain, self::INDEX_PAGE);
+            $url = $this->util->generateDomainUrl($domain->url, self::INDEX_PAGE);
 
             $request = Request::create($url);
             $result = $this->util->handleRequest($request);

--- a/src/Storefront/Framework/SystemCheck/Util/AbstractSalesChannelDomainProvider.php
+++ b/src/Storefront/Framework/SystemCheck/Util/AbstractSalesChannelDomainProvider.php
@@ -10,8 +10,5 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 abstract class AbstractSalesChannelDomainProvider
 {
-    /**
-     * @return array<string, string>
-     */
-    abstract public function fetchSalesChannelDomains(): array;
+    abstract public function fetchSalesChannelDomains(): SalesChannelDomainCollection;
 }

--- a/src/Storefront/Framework/SystemCheck/Util/AbstractSalesChannelDomainProvider.php
+++ b/src/Storefront/Framework/SystemCheck/Util/AbstractSalesChannelDomainProvider.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\SystemCheck\Util;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+abstract class AbstractSalesChannelDomainProvider
+{
+    /**
+     * @return array<string, string>
+     */
+    abstract public function fetchSalesChannelDomains(): array;
+}

--- a/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomain.php
+++ b/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomain.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\SystemCheck\Util;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class SalesChannelDomain extends Struct
+{
+    private function __construct(
+        public readonly string $salesChannelId,
+        public readonly string $url,
+    ) {
+    }
+
+    public static function create(string $salesChannelId, string $url): self
+    {
+        return new self($salesChannelId, $url);
+    }
+}

--- a/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainCollection.php
+++ b/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainCollection.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\SystemCheck\Util;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Collection;
+
+/**
+ * @internal
+ *
+ * @extends Collection<SalesChannelDomain>
+ */
+#[Package('framework')]
+class SalesChannelDomainCollection extends Collection
+{
+    /**
+     * @param list<SalesChannelDomain> $elements
+     */
+    public function __construct(
+        array $elements,
+    ) {
+        $indexed = [];
+        foreach ($elements as $element) {
+            $indexed[$element->salesChannelId] = $element;
+        }
+
+        parent::__construct($indexed);
+    }
+
+    /**
+     * @return array<string, SalesChannelDomain>
+     */
+    public function getElements(): array
+    {
+        return $this->elements;
+    }
+}

--- a/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainCollection.php
+++ b/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainCollection.php
@@ -26,4 +26,9 @@ class SalesChannelDomainCollection extends Collection
 
         parent::__construct($indexed);
     }
+
+    protected function getExpectedClass(): string
+    {
+        return SalesChannelDomain::class;
+    }
 }

--- a/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainCollection.php
+++ b/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainCollection.php
@@ -26,12 +26,4 @@ class SalesChannelDomainCollection extends Collection
 
         parent::__construct($indexed);
     }
-
-    /**
-     * @return array<string, SalesChannelDomain>
-     */
-    public function getElements(): array
-    {
-        return $this->elements;
-    }
 }

--- a/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainProvider.php
+++ b/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainProvider.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\SystemCheck\Util;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class SalesChannelDomainProvider extends AbstractSalesChannelDomainProvider
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function fetchSalesChannelDomains(): array
+    {
+        $sql = <<<'SQL'
+            SELECT `sales_channel`.`id`,
+                   `sales_channel_domain`.`url`
+            FROM `sales_channel_domain`
+            INNER JOIN `sales_channel` ON `sales_channel_domain`.`sales_channel_id` = `sales_channel`.`id`
+            WHERE `sales_channel`.`type_id` = :typeId
+            AND `sales_channel`.`active` = :active
+        SQL;
+
+        $result = $this->connection->fetchAllAssociative(
+            $sql,
+            ['typeId' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_STOREFRONT), 'active' => 1]
+        );
+
+        return FetchModeHelper::keyPair($result);
+    }
+}

--- a/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainProvider.php
+++ b/src/Storefront/Framework/SystemCheck/Util/SalesChannelDomainProvider.php
@@ -4,7 +4,6 @@ namespace Shopware\Storefront\Framework\SystemCheck\Util;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -19,18 +18,16 @@ class SalesChannelDomainProvider extends AbstractSalesChannelDomainProvider
     ) {
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function fetchSalesChannelDomains(): array
+    public function fetchSalesChannelDomains(): SalesChannelDomainCollection
     {
         $sql = <<<'SQL'
-            SELECT `sales_channel`.`id`,
-                   `sales_channel_domain`.`url`
+            SELECT LOWER(HEX(`sales_channel`.`id`)) AS `sales_channel_id`,
+                   `sales_channel_domain`.`url` AS `url`
             FROM `sales_channel_domain`
             INNER JOIN `sales_channel` ON `sales_channel_domain`.`sales_channel_id` = `sales_channel`.`id`
             WHERE `sales_channel`.`type_id` = :typeId
             AND `sales_channel`.`active` = :active
+            GROUP BY `sales_channel`.`id`
         SQL;
 
         $result = $this->connection->fetchAllAssociative(
@@ -38,6 +35,11 @@ class SalesChannelDomainProvider extends AbstractSalesChannelDomainProvider
             ['typeId' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_STOREFRONT), 'active' => 1]
         );
 
-        return FetchModeHelper::keyPair($result);
+        $collection = array_map(
+            fn ($domain) => SalesChannelDomain::create($domain['sales_channel_id'], $domain['url']),
+            $result
+        );
+
+        return new SalesChannelDomainCollection($collection);
     }
 }

--- a/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Framework\SystemCheck\SalesChannelsReadinessCheck;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Shopware\Storefront\Framework\SystemCheck\Util\StorefrontHealthCheckResult;
 use Symfony\Component\HttpFoundation\Request;
@@ -117,8 +118,8 @@ class SalesChannelsReadinessCheckTest extends TestCase
     private function createCheck((SalesChannelDomainUtil&MockObject)|null $util = null): SalesChannelsReadinessCheck
     {
         return new SalesChannelsReadinessCheck(
-            $this->connection,
             $util ?? static::getContainer()->get(SalesChannelDomainUtil::class),
+            static::getContainer()->get(SalesChannelDomainProvider::class)
         );
     }
 

--- a/tests/unit/Storefront/Framework/Health/ProductDetailReadinessCheckTest.php
+++ b/tests/unit/Storefront/Framework/Health/ProductDetailReadinessCheckTest.php
@@ -11,6 +11,8 @@ use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\SystemCheck\ProductDetailReadinessCheck;
+use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Shopware\Storefront\Framework\SystemCheck\Util\StorefrontHealthCheckResult;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,9 +27,12 @@ class ProductDetailReadinessCheckTest extends TestCase
 
     private SalesChannelDomainUtil&MockObject $util;
 
+    private AbstractSalesChannelDomainProvider&MockObject $domainProvider;
+
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
+        $this->domainProvider = $this->createMock(SalesChannelDomainProvider::class);
 
         $this->initUtilMock();
     }
@@ -117,7 +122,7 @@ class ProductDetailReadinessCheckTest extends TestCase
 
     private function createCheck(): ProductDetailReadinessCheck
     {
-        return new ProductDetailReadinessCheck($this->util, $this->connection);
+        return new ProductDetailReadinessCheck($this->util, $this->connection, $this->domainProvider);
     }
 
     private function initUtilMock(): void

--- a/tests/unit/Storefront/Framework/Health/ProductDetailReadinessCheckTest.php
+++ b/tests/unit/Storefront/Framework/Health/ProductDetailReadinessCheckTest.php
@@ -10,8 +10,11 @@ use Shopware\Core\Framework\SystemCheck\Check\Result;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Framework\SystemCheck\ProductDetailReadinessCheck;
 use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomain;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainCollection;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Shopware\Storefront\Framework\SystemCheck\Util\StorefrontHealthCheckResult;
@@ -29,10 +32,13 @@ class ProductDetailReadinessCheckTest extends TestCase
 
     private AbstractSalesChannelDomainProvider&MockObject $domainProvider;
 
+    private IdsCollection $ids;
+
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
         $this->domainProvider = $this->createMock(SalesChannelDomainProvider::class);
+        $this->ids = new IdsCollection();
 
         $this->initUtilMock();
     }
@@ -57,7 +63,7 @@ class ProductDetailReadinessCheckTest extends TestCase
 
     public function testRunSuccessfully(): void
     {
-        $this->initConnectionMock();
+        $this->initDataMocks();
 
         $this->util->method('handleRequest')->willReturn(
             StorefrontHealthCheckResult::create(
@@ -97,7 +103,7 @@ class ProductDetailReadinessCheckTest extends TestCase
 
     public function testRunFailed(): void
     {
-        $this->initConnectionMock();
+        $this->initDataMocks();
 
         $this->util->method('handleRequest')->willReturn(
             StorefrontHealthCheckResult::create(
@@ -143,19 +149,22 @@ class ProductDetailReadinessCheckTest extends TestCase
         });
     }
 
-    private function initConnectionMock(): void
+    private function initDataMocks(): void
     {
-        $this->connection->method('fetchAllAssociative')->willReturnOnConsecutiveCalls(
+        $this->connection->method('fetchAllAssociative')->willReturn(
             [
-                ['id' => 'sales-channel-1', 'url' => 'http://localhost:8000/de'],
-                ['id' => 'sales-channel-2', 'url' => 'http://localhost:8000/en'],
-                ['id' => 'sales-channel-3', 'url' => 'http://localhost:8000/invalid'],
-            ],
-            [
-                ['id' => 'sales-channel-1', 'product_id' => Uuid::randomHex()],
-                ['id' => 'sales-channel-2', 'product_id' => Uuid::randomHex()],
+                ['id' => $this->ids->get('sales-channel-1'), 'product_id' => Uuid::randomHex()],
+                ['id' => $this->ids->get('sales-channel-2'), 'product_id' => Uuid::randomHex()],
             ]
         );
+
+        $collection = new SalesChannelDomainCollection([
+            SalesChannelDomain::create($this->ids->get('sales-channel-1'), 'http://localhost:8000/de'),
+            SalesChannelDomain::create($this->ids->get('sales-channel-2'), 'http://localhost:8000/en'),
+            SalesChannelDomain::create($this->ids->get('sales-channel-3'), 'http://localhost:8000/invalid'),
+        ]);
+
+        $this->domainProvider->method('fetchSalesChannelDomains')->willReturn($collection);
     }
 
     private function initCreateEmptyResult(): void

--- a/tests/unit/Storefront/Framework/Health/ProductListingReadinessCheckTest.php
+++ b/tests/unit/Storefront/Framework/Health/ProductListingReadinessCheckTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\SystemCheck\ProductListingReadinessCheck;
+use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Shopware\Storefront\Framework\SystemCheck\Util\StorefrontHealthCheckResult;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,9 +26,12 @@ class ProductListingReadinessCheckTest extends TestCase
 
     private SalesChannelDomainUtil&MockObject $util;
 
+    private AbstractSalesChannelDomainProvider&MockObject $domainProvider;
+
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
+        $this->domainProvider = $this->createMock(AbstractSalesChannelDomainProvider::class);
 
         $this->initUtilMock();
     }
@@ -117,7 +121,7 @@ class ProductListingReadinessCheckTest extends TestCase
 
     private function createCheck(): ProductListingReadinessCheck
     {
-        return new ProductListingReadinessCheck($this->util, $this->connection);
+        return new ProductListingReadinessCheck($this->util, $this->connection, $this->domainProvider);
     }
 
     private function initUtilMock(): void

--- a/tests/unit/Storefront/Framework/Health/ProductListingReadinessCheckTest.php
+++ b/tests/unit/Storefront/Framework/Health/ProductListingReadinessCheckTest.php
@@ -10,8 +10,11 @@ use Shopware\Core\Framework\SystemCheck\Check\Result;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Framework\SystemCheck\ProductListingReadinessCheck;
 use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomain;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainCollection;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 use Shopware\Storefront\Framework\SystemCheck\Util\StorefrontHealthCheckResult;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,10 +31,13 @@ class ProductListingReadinessCheckTest extends TestCase
 
     private AbstractSalesChannelDomainProvider&MockObject $domainProvider;
 
+    private IdsCollection $ids;
+
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
         $this->domainProvider = $this->createMock(AbstractSalesChannelDomainProvider::class);
+        $this->ids = new IdsCollection();
 
         $this->initUtilMock();
     }
@@ -56,7 +62,7 @@ class ProductListingReadinessCheckTest extends TestCase
 
     public function testRunSuccessfully(): void
     {
-        $this->initConnectionMock();
+        $this->initDataMocks();
 
         $this->util->method('handleRequest')->willReturn(
             StorefrontHealthCheckResult::create(
@@ -96,7 +102,7 @@ class ProductListingReadinessCheckTest extends TestCase
 
     public function testRunFailed(): void
     {
-        $this->initConnectionMock();
+        $this->initDataMocks();
 
         $this->util->method('handleRequest')->willReturn(
             StorefrontHealthCheckResult::create(
@@ -142,19 +148,22 @@ class ProductListingReadinessCheckTest extends TestCase
         });
     }
 
-    private function initConnectionMock(): void
+    private function initDataMocks(): void
     {
-        $this->connection->method('fetchAllAssociative')->willReturnOnConsecutiveCalls(
+        $this->connection->method('fetchAllAssociative')->willReturn(
             [
-                ['id' => 'sales-channel-1', 'url' => 'http://localhost:8000/de'],
-                ['id' => 'sales-channel-2', 'url' => 'http://localhost:8000/en'],
-                ['id' => 'sales-channel-3', 'url' => 'http://localhost:8000/invalid'],
-            ],
-            [
-                ['id' => 'sales-channel-1', 'category_id' => Uuid::randomHex()],
-                ['id' => 'sales-channel-2', 'category_id' => Uuid::randomHex()],
+                ['id' => $this->ids->get('sales-channel-1'), 'category_id' => Uuid::randomHex()],
+                ['id' => $this->ids->get('sales-channel-2'), 'category_id' => Uuid::randomHex()],
             ]
         );
+
+        $collection = new SalesChannelDomainCollection([
+            SalesChannelDomain::create($this->ids->get('sales-channel-1'), 'http://localhost:8000/de'),
+            SalesChannelDomain::create($this->ids->get('sales-channel-2'), 'http://localhost:8000/en'),
+            SalesChannelDomain::create($this->ids->get('sales-channel-3'), 'http://localhost:8000/invalid'),
+        ]);
+
+        $this->domainProvider->method('fetchSalesChannelDomains')->willReturn($collection);
     }
 
     private function initCreateEmptyResult(): void

--- a/tests/unit/Storefront/Framework/Health/SalesChannelsReadinessCheckTest.php
+++ b/tests/unit/Storefront/Framework/Health/SalesChannelsReadinessCheckTest.php
@@ -2,11 +2,11 @@
 
 namespace Shopware\Tests\Unit\Storefront\Framework\Health;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
 use Shopware\Storefront\Framework\SystemCheck\SalesChannelsReadinessCheck;
+use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
 use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainUtil;
 
 /**
@@ -22,8 +22,8 @@ class SalesChannelsReadinessCheckTest extends TestCase
         parent::setUp();
 
         $this->salesChannelReadinessCheck = new SalesChannelsReadinessCheck(
-            $this->createMock(Connection::class),
-            $this->createMock(SalesChannelDomainUtil::class)
+            $this->createMock(SalesChannelDomainUtil::class),
+            $this->createMock(AbstractSalesChannelDomainProvider::class)
         );
     }
 

--- a/tests/unit/Storefront/Framework/Health/Util/SalesChannelDomainCollectionTest.php
+++ b/tests/unit/Storefront/Framework/Health/Util/SalesChannelDomainCollectionTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Health\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomain;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainCollection;
+
+/**
+ * @internal
+ */
+#[CoversClass(SalesChannelDomainCollection::class)]
+class SalesChannelDomainCollectionTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $domain1 = SalesChannelDomain::create('test-sales-channel-id-1', 'http://localhost:8000');
+        $domain2 = SalesChannelDomain::create('test-sales-channel-id-2', 'http://localhost:8001');
+
+        $collection = new SalesChannelDomainCollection([$domain1, $domain2]);
+
+        static::assertCount(2, $collection);
+
+        $domain = $collection->get('test-sales-channel-id-1');
+        static::assertSame('http://localhost:8000', $domain->url);
+
+        $domain = $collection->get('test-sales-channel-id-2');
+        static::assertSame('http://localhost:8001', $domain->url);
+    }
+}

--- a/tests/unit/Storefront/Framework/Health/Util/SalesChannelDomainCollectionTest.php
+++ b/tests/unit/Storefront/Framework/Health/Util/SalesChannelDomainCollectionTest.php
@@ -23,9 +23,11 @@ class SalesChannelDomainCollectionTest extends TestCase
         static::assertCount(2, $collection);
 
         $domain = $collection->get('test-sales-channel-id-1');
+        static::assertInstanceOf(SalesChannelDomain::class, $domain);
         static::assertSame('http://localhost:8000', $domain->url);
 
         $domain = $collection->get('test-sales-channel-id-2');
+        static::assertInstanceOf(SalesChannelDomain::class, $domain);
         static::assertSame('http://localhost:8001', $domain->url);
     }
 }

--- a/tests/unit/Storefront/Framework/Health/Util/SalesChannelDomainProviderTest.php
+++ b/tests/unit/Storefront/Framework/Health/Util/SalesChannelDomainProviderTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Health\Util;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Storefront\Framework\SystemCheck\Util\AbstractSalesChannelDomainProvider;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomain;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider;
+
+/**
+ * @internal
+ */
+#[CoversClass(SalesChannelDomainProvider::class)]
+class SalesChannelDomainProviderTest extends TestCase
+{
+    private Connection&MockObject $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+    }
+
+    public function testFetchSalesChannelDomainsReturnsCollectionWithData(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([
+            ['sales_channel_id' => 'test-sales-channel-id-1', 'url' => 'http://localhost:8000'],
+            ['sales_channel_id' => 'test-sales-channel-id-2', 'url' => 'http://localhost:8001'],
+        ]);
+
+        $provider = $this->createProvider();
+
+        $collection = $provider->fetchSalesChannelDomains();
+        static::assertCount(2, $collection);
+        static::assertContainsOnlyInstancesOf(SalesChannelDomain::class, $collection);
+    }
+
+    public function testFetchSalesChannelDomainsHandlesEmptyResults(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([]);
+
+        $provider = $this->createProvider();
+
+        $collection = $provider->fetchSalesChannelDomains();
+        static::assertCount(0, $collection);
+    }
+
+    private function createProvider(): AbstractSalesChannelDomainProvider
+    {
+        return new SalesChannelDomainProvider($this->connection);
+    }
+}

--- a/tests/unit/Storefront/Framework/Health/Util/SalesChannelDomainTest.php
+++ b/tests/unit/Storefront/Framework/Health/Util/SalesChannelDomainTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Health\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomain;
+
+/**
+ * @internal
+ */
+#[CoversClass(SalesChannelDomain::class)]
+class SalesChannelDomainTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $salesChannelId = 'test-sales-channel-id';
+        $url = 'http://localhost:8000';
+
+        $domain = SalesChannelDomain::create($salesChannelId, $url);
+
+        static::assertSame($salesChannelId, $domain->salesChannelId);
+        static::assertSame($url, $domain->url);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Since saas has an own implementation of the fetchSalesChannelDomains method (https://github.com/shopware/saas/blob/trunk/src/Framework/SystemCheck/SaleChannelsReadinessCheck.php), the core implementation has to be at least protected. I implement here an own provider to have it easier to redefine in the saas project.


### 2. What does this change do, exactly?
I moved the fetchSalesChannelDomains logic into an own provider and implemented an Entity and a Collection for the data transfer.

### 3. Describe each step to reproduce the issue or behaviour.
/ 

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
