### PR TITLE
feat: added response from elasticsearch client to search result event

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -33,6 +33,7 @@ return [
         'ADDED: Parameter prefixMatch was added to Method __construct\(\) of class Shopware\\\\Elasticsearch\\\\Product\\\\SearchFieldConfig',
         'ADDED: Parameter label was added to Method __construct\(\) of class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Tax\\\\Struct\\\\CalculatedTax',
         'ADDED: Parameter senderName was added to Method __construct\(\) of class Shopware\\\\Core\\\\Content\\\\Mail\\\\Service\\\\SendMailTemplateParams',
+        'ADDED: Parameter response was added to Method __construct\(\) of class Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\ElasticsearchEntitySearcherSearchedEvent',
 
         // Fix to make promotions work with order recalculation
         'Value of constant Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\OrderConverter::ADMIN_EDIT_ORDER_PERMISSIONS changed from array \((\n.*)*skipPromotion.*(\n.*)*to array \((\n.*)*pinAutomaticPromotions',

--- a/changelog/_unreleased/2025-06-02-added-es-response-to-searched-event.md
+++ b/changelog/_unreleased/2025-06-02-added-es-response-to-searched-event.md
@@ -1,0 +1,11 @@
+---
+title: Added es response to searched event
+issue: 
+author: Oliver Skroblin
+author_email: oliver@goblin-coders.de
+author_github: OliverSkroblin
+---
+
+# Core
+
+* Added `response` from elasticsearch client to `ElasticsearchEntitySearcherSearchedEvent`

--- a/changelog/_unreleased/2025-06-02-added-es-response-to-searched-event.md
+++ b/changelog/_unreleased/2025-06-02-added-es-response-to-searched-event.md
@@ -6,5 +6,4 @@ author_github: OliverSkroblin
 ---
 
 # Core
-
 * Added `response` from Elasticsearch client to `\Shopware\Elasticsearch\Framework\DataAbstractionLayer\Event\ElasticsearchEntitySearcherSearchedEvent`

--- a/changelog/_unreleased/2025-06-02-added-es-response-to-searched-event.md
+++ b/changelog/_unreleased/2025-06-02-added-es-response-to-searched-event.md
@@ -1,6 +1,5 @@
 ---
-title: Added es response to searched event
-issue: 
+title: Added Elasticsearch response to ElasticsearchEntitySearcherSearchedEvent
 author: Oliver Skroblin
 author_email: oliver@goblin-coders.de
 author_github: OliverSkroblin
@@ -8,4 +7,4 @@ author_github: OliverSkroblin
 
 # Core
 
-* Added `response` from elasticsearch client to `ElasticsearchEntitySearcherSearchedEvent`
+* Added `response` from Elasticsearch client to `\Shopware\Elasticsearch\Framework\DataAbstractionLayer\Event\ElasticsearchEntitySearcherSearchedEvent`

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
@@ -87,7 +87,7 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
                 $definition,
                 $criteria,
                 $context,
-                $response
+                $response,
             ));
 
             $result->addState(self::RESULT_STATE);

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
@@ -77,16 +77,17 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
                 $params['track_scores'] = true;
             }
 
-            $result = $this->client->search($params);
+            $response = $this->client->search($params);
 
-            $result = $this->hydrator->hydrate($definition, $criteria, $context, $result);
+            $result = $this->hydrator->hydrate($definition, $criteria, $context, $response);
 
             $this->eventDispatcher->dispatch(new ElasticsearchEntitySearcherSearchedEvent(
                 $result,
                 $search,
                 $definition,
                 $criteria,
-                $context
+                $context,
+                $response
             ));
 
             $result->addState(self::RESULT_STATE);

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/Event/ElasticsearchEntitySearcherSearchedEvent.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/Event/ElasticsearchEntitySearcherSearchedEvent.php
@@ -17,12 +17,16 @@ use Symfony\Contracts\EventDispatcher\Event;
 #[Package('framework')]
 class ElasticsearchEntitySearcherSearchedEvent extends Event implements ShopwareEvent
 {
+    /**
+     * @param array<string, mixed> $response
+     */
     public function __construct(
         public readonly IdSearchResult $result,
         public readonly Search $search,
         public readonly EntityDefinition $definition,
         public readonly Criteria $criteria,
-        private readonly Context $context
+        private readonly Context $context,
+        public readonly array $response = []
     ) {
     }
 

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/Event/ElasticsearchEntitySearcherSearchedEvent.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/Event/ElasticsearchEntitySearcherSearchedEvent.php
@@ -26,7 +26,7 @@ class ElasticsearchEntitySearcherSearchedEvent extends Event implements Shopware
         public readonly EntityDefinition $definition,
         public readonly Criteria $criteria,
         private readonly Context $context,
-        public readonly array $response = []
+        public readonly array $response = [],
     ) {
     }
 


### PR DESCRIPTION
In some scenarios, you want to have access to the elastic result. For example when you add suggestions or something like this. Currently you have to decorate the hydrator