### PR TITLE
fix: deserialization of MediaThumbnailEntity

### DIFF
--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -20,7 +20,7 @@ class MediaThumbnailEntity extends Entity
 
     protected int $height;
 
-    protected string $url = '';
+    protected ?string $url = '';
 
     protected string $mediaId;
 
@@ -48,7 +48,7 @@ class MediaThumbnailEntity extends Entity
 
     public function getUrl(): string
     {
-        return $this->url;
+        return $this->url ?? '';
     }
 
     public function setUrl(string $url): void

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -46,11 +46,21 @@ class MediaThumbnailEntity extends Entity
         $this->height = $height;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - return type will be nullable and condition will be removed
+     */
     public function getUrl(): string
     {
-        return $this->url ?? '';
+        if ($this->url === null) {
+            return '';
+        }
+
+        return $this->url;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:parameter-type-extension - parameter $url will be nullable
+     */
     public function setUrl(string $url): void
     {
         $this->url = $url;

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/DeprecatedMethodsThrowDeprecationRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/DeprecatedMethodsThrowDeprecationRule.php
@@ -46,6 +46,8 @@ class DeprecatedMethodsThrowDeprecationRule implements Rule
         'reason:becomes-final',
         // If the return type change, the functionality itself is not deprecated, therefore they do not trigger deprecations.
         'reason:return-type-change',
+        // If a parameter becomes more flexible, this does not need action and trigger a deprecation warning.
+        'reason:parameter-type-extension',
         // If there will be in the class hierarchy of a class we mark the whole class as deprecated, but the functionality itself is not deprecated, therefore they do not trigger deprecations.
         'reason:class-hierarchy-change',
         // If we change the visibility of a method we can't know from where it was called and whether the call will be valid in the future, therefore they do not trigger deprecations.


### PR DESCRIPTION
### 1. Why is this change necessary?
Carts that have been serialized in 6.6 may not be able to be deserialized, because this field had `null` set as its value, but the new strong type does not support that.

### 2. What does this change do, exactly?
Change the property type to nullable.

### 3. Describe each step to reproduce the issue or behaviour.
- Login as a customer with a cart with thumbnails
- Upgrade to 6.7
- Login again.

### 4. Please link to the relevant issues (if any).
fixes #10040 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
