### PR TITLE
feat: use service registry base uri

### DIFF
--- a/src/Core/Service/DependencyInjection/services.xml
+++ b/src/Core/Service/DependencyInjection/services.xml
@@ -4,7 +4,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="env(SERVICE_REGISTRY_URL)" type="string">https://services.shopware.io</parameter>
+        <parameter key="env(SERVICE_REGISTRY_URL)" type="string">https://registry.services.shopware.io</parameter>
         <parameter key="env(ENABLE_SERVICES)" type="string">auto</parameter>
     </parameters>
 

--- a/src/Core/Service/DependencyInjection/services.xml
+++ b/src/Core/Service/DependencyInjection/services.xml
@@ -4,7 +4,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="env(SERVICE_REGISTRY_URL)" type="string">https://services.shopware.io/services.json</parameter>
+        <parameter key="env(SERVICE_REGISTRY_URL)" type="string">https://services.shopware.io</parameter>
         <parameter key="env(ENABLE_SERVICES)" type="string">auto</parameter>
     </parameters>
 

--- a/src/Core/Service/ServiceRegistryClient.php
+++ b/src/Core/Service/ServiceRegistryClient.php
@@ -47,7 +47,7 @@ class ServiceRegistryClient implements ResetInterface
         }
 
         try {
-            $response = $this->client->request('GET', $this->registryUrl, [
+            $response = $this->client->request('GET', $this->registryUrl . '/services.json', [
                 'headers' => [
                     'Accept' => 'application/json',
                 ],

--- a/src/Core/Service/ServiceRegistryClient.php
+++ b/src/Core/Service/ServiceRegistryClient.php
@@ -47,7 +47,7 @@ class ServiceRegistryClient implements ResetInterface
         }
 
         try {
-            $response = $this->client->request('GET', $this->registryUrl . '/services.json', [
+            $response = $this->client->request('GET', $this->registryUrl . '/api/service/', [
                 'headers' => [
                     'Accept' => 'application/json',
                 ],

--- a/src/Core/Service/ServiceRegistryClient.php
+++ b/src/Core/Service/ServiceRegistryClient.php
@@ -46,42 +46,69 @@ class ServiceRegistryClient implements ResetInterface
             return $this->services;
         }
 
-        try {
-            $response = $this->client->request('GET', $this->registryUrl . '/api/service/', [
-                'headers' => [
-                    'Accept' => 'application/json',
-                ],
-            ]);
+        $rawServices = [];
+        $page = 1;
 
-            if ($response->getStatusCode() !== 200) {
-                return [];
+        do {
+            $response = $this->fetchServices($page);
+            if ($response === null) {
+                break;
             }
 
-            $content = $response->toArray();
+            $rawServices = array_merge($rawServices, $response['services']);
+            ++$page;
+        } while ($page <= ($response['pagination']['pages'] ?? 1));
 
-            if (!$this->validateServicesResponse($content)) {
-                return [];
-            }
+        $this->services = array_map(
+            static fn (array $service) => new ServiceRegistryEntry(
+                $service['name'],
+                $service['label'],
+                $service['host'],
+                $service['app-endpoint'],
+                (bool) ($service['activate-on-install'] ?? true),
+                $service['license-sync-endpoint'] ?? null
+            ),
+            $rawServices
+        );
 
-            return $this->services = array_map(
-                static fn (array $service) => new ServiceRegistryEntry(
-                    $service['name'],
-                    $service['label'],
-                    $service['host'],
-                    $service['app-endpoint'],
-                    (bool) ($service['activate-on-install'] ?? true),
-                    $service['license-sync-endpoint'] ?? null
-                ),
-                $content['services']
-            );
-        } catch (ExceptionInterface $e) {
-            return [];
-        }
+        return $this->services;
     }
 
     public function reset(): void
     {
         $this->services = null;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function fetchServices(int $page): ?array
+    {
+        try {
+            $response = $this->client->request('GET', rtrim($this->registryUrl, '/') . '/api/service/', [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+                'query' => [
+                    'page' => $page,
+                    'limit' => 10,
+                ],
+            ]);
+
+            if ($response->getStatusCode() !== 200) {
+                return null;
+            }
+
+            $content = $response->toArray();
+
+            if (!$this->validateServicesResponse($content)) {
+                return null;
+            }
+
+            return $content;
+        } catch (ExceptionInterface $e) {
+            return null;
+        }
     }
 
     /**

--- a/tests/unit/Core/Service/ServiceRegistryClientTest.php
+++ b/tests/unit/Core/Service/ServiceRegistryClientTest.php
@@ -47,7 +47,7 @@ class ServiceRegistryClientTest extends TestCase
             $response = new MockResponse($response),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', $client);
 
         static::assertSame([], $registryClient->getAll());
         static::assertSame('https://www.shopware.com/services.json', $response->getRequestUrl());
@@ -59,7 +59,7 @@ class ServiceRegistryClientTest extends TestCase
             $response = new MockResponse('', ['http_code' => 503]),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', $client);
 
         static::assertSame([], $registryClient->getAll());
         static::assertSame('https://www.shopware.com/services.json', $response->getRequestUrl());
@@ -78,7 +78,7 @@ class ServiceRegistryClientTest extends TestCase
             $response = new MockResponse((string) json_encode($service)),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', $client);
 
         $entries = $registryClient->getAll();
 
@@ -110,7 +110,7 @@ class ServiceRegistryClientTest extends TestCase
             new MockResponse((string) json_encode($service)),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', $client);
 
         $entries1 = $registryClient->getAll();
         static::assertCount(2, $entries1);
@@ -145,7 +145,7 @@ class ServiceRegistryClientTest extends TestCase
             new MockResponse((string) json_encode($services2)),
         ]);
 
-        $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com', $client);
 
         $entries1 = $registryClient->getAll();
         static::assertCount(2, $entries1);

--- a/tests/unit/Core/Service/ServiceRegistryClientTest.php
+++ b/tests/unit/Core/Service/ServiceRegistryClientTest.php
@@ -50,7 +50,7 @@ class ServiceRegistryClientTest extends TestCase
         $registryClient = new ServiceRegistryClient('https://www.shopware.com', $client);
 
         static::assertSame([], $registryClient->getAll());
-        static::assertSame('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertSame('https://www.shopware.com/api/service/?page=1&limit=10', $response->getRequestUrl());
     }
 
     public function testFailRequestReturnsEmptyListOfServices(): void
@@ -62,7 +62,7 @@ class ServiceRegistryClientTest extends TestCase
         $registryClient = new ServiceRegistryClient('https://www.shopware.com', $client);
 
         static::assertSame([], $registryClient->getAll());
-        static::assertSame('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertSame('https://www.shopware.com/api/service/?page=1&limit=10', $response->getRequestUrl());
     }
 
     public function testSuccessfulRequestReturnsListOfServices(): void
@@ -93,7 +93,7 @@ class ServiceRegistryClientTest extends TestCase
         static::assertSame('My Cool Service 2', $entries[1]->description);
         static::assertSame('https://coolservice2.com', $entries[1]->host);
         static::assertSame('/app-endpoint', $entries[1]->appEndpoint);
-        static::assertSame('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertSame('https://www.shopware.com/api/service/?page=1&limit=10', $response->getRequestUrl());
         static::assertSame('/license-sync-endpoint', $entries[1]->licenseSyncEndPoint);
     }
 
@@ -154,5 +154,60 @@ class ServiceRegistryClientTest extends TestCase
 
         $entries2 = $registryClient->getAll();
         static::assertCount(3, $entries2);
+    }
+
+    public function testPaginationWorks(): void
+    {
+        $servicesPage1 = [
+            'services' => [['name' => 'MyCoolService1', 'host' => 'https://coolservice1.com', 'label' => 'My Cool Service 1', 'app-endpoint' => '/app-endpoint']],
+            'pagination' => ['page' => 1, 'pages' => 2, 'total' => 2, 'limit' => 10],
+        ];
+
+        $servicesPage2 = [
+            'services' => [['name' => 'MyCoolService2', 'host' => 'https://coolservice2.com', 'label' => 'My Cool Service 2', 'app-endpoint' => '/app-endpoint']],
+            'pagination' => ['page' => 2, 'pages' => 2, 'total' => 2, 'limit' => 10],
+        ];
+
+        $client = new MockHttpClient([
+            $response1 = new MockResponse((string) json_encode($servicesPage1)),
+            $response2 = new MockResponse((string) json_encode($servicesPage2)),
+        ]);
+
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com/', $client);
+        $entries = $registryClient->getAll();
+
+        static::assertCount(2, $entries);
+        static::assertSame('MyCoolService1', $entries[0]->name);
+        static::assertSame('My Cool Service 1', $entries[0]->description);
+        static::assertSame('https://coolservice1.com', $entries[0]->host);
+        static::assertSame('/app-endpoint', $entries[0]->appEndpoint);
+        static::assertSame('MyCoolService2', $entries[1]->name);
+        static::assertSame('My Cool Service 2', $entries[1]->description);
+        static::assertSame('https://coolservice2.com', $entries[1]->host);
+        static::assertSame('/app-endpoint', $entries[1]->appEndpoint);
+        static::assertSame('https://www.shopware.com/api/service/?page=1&limit=10', $response1->getRequestUrl());
+        static::assertSame('https://www.shopware.com/api/service/?page=2&limit=10', $response2->getRequestUrl());
+    }
+
+    public function testExtraBackslashDoesntBreakApp(): void
+    {
+        $service = [
+            'services' => [
+                ['name' => 'MyCoolService1', 'host' => 'https://coolservice1.com', 'label' => 'My Cool Service 1', 'app-endpoint' => '/app-endpoint'],
+            ],
+        ];
+        $servicePayload = (string) json_encode($service);
+        $expectedUrl = 'https://www.shopware.com/api/service/?page=1&limit=10';
+        $clientWithSlash = new MockHttpClient([$responseWithSlash = new MockResponse($servicePayload)]);
+        $registryClientWithSlash = new ServiceRegistryClient('https://www.shopware.com/', $clientWithSlash);
+        $entriesWithSlash = $registryClientWithSlash->getAll();
+        static::assertCount(1, $entriesWithSlash);
+        static::assertSame($expectedUrl, $responseWithSlash->getRequestUrl());
+
+        $clientWithoutSlash = new MockHttpClient([$responseWithoutSlash = new MockResponse($servicePayload)]);
+        $registryClientWithoutSlash = new ServiceRegistryClient('https://www.shopware.com', $clientWithoutSlash);
+        $entriesWithoutSlash = $registryClientWithoutSlash->getAll();
+        static::assertCount(1, $entriesWithoutSlash);
+        static::assertSame($expectedUrl, $responseWithoutSlash->getRequestUrl());
     }
 }


### PR DESCRIPTION
The registry's URL is injected into the Administration and used for calling various endpoints.

For this reason, the URL is changed to represent a base URI rather than an individual endpoint.