### PR TITLE
fix: exception in ThemeService caused by missing field type

### DIFF
--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -316,7 +316,7 @@ class ThemeService implements ResetInterface
             $outputStructure['tabs'][$tab]['blocks'][$block]['sections'][$section]['fields'][$fieldName] = [
                 'label' => $fieldConfig['label'],
                 'helpText' => $fieldConfig['helpText'] ?? null,
-                'type' => $fieldConfig['type'],
+                'type' => $fieldConfig['type'] ?? null,
                 'custom' => $fieldConfig['custom'],
                 'fullWidth' => $fieldConfig['fullWidth'],
             ];


### PR DESCRIPTION
### 1. Why is this change necessary?

When theme configuration field is removed from theme.json, but is configured, merged config contains field with missing `type` field. This requires check that field exists.

### 2. What does this change do, exactly?

Adds needed check.

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/shopware/shopware/issues/9988

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/9988

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
