### PR TITLE
fix: disable refreshing of extensions when runtime management is disabled

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.spec.js
@@ -41,6 +41,29 @@ describe('src/module/sw-extension/service/shopware-extension.service', () => {
                 route: 'test.foo',
             },
         };
+
+        if (Shopware.Store.get('context')) {
+            Shopware.Store.unregister('context');
+        }
+
+        Shopware.Store.register({
+            id: 'context',
+            state: () => ({
+                app: {
+                    config: {
+                        settings: {
+                            disableExtensionManagement: false,
+                        },
+                    },
+                },
+                api: {
+                    assetPath: 'http://localhost:8000/bundles/administration/',
+                    authToken: {
+                        token: 'testToken',
+                    },
+                },
+            }),
+        });
     });
 
     describe('it delegates lifecycle methods', () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.ts
@@ -95,11 +95,13 @@ export default class ShopwareExtensionService {
         await this.updateModules();
     }
 
-    public async updateExtensionData(): Promise<void> {
+    public async updateExtensionData(refreshExtensions: boolean = true): Promise<void> {
         Shopware.Store.get('shopwareExtensions').loadMyExtensions();
 
         try {
-            await this.extensionStoreActionService.refresh();
+            if (!Shopware.Store.get('context').app.config?.settings?.disableExtensionManagement && refreshExtensions) {
+                await this.extensionStoreActionService.refresh();
+            }
 
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             const myExtensions = await this.extensionStoreActionService.getMyExtensions();

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/store/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/store/index.ts
@@ -2,21 +2,24 @@ import type { ShopwareClass } from 'src/core/shopware';
 import useSession from '../../../app/composables/use-session';
 import './extensions.store';
 
+let initialLoad = false;
+
 /**
  * @sw-package checkout
  * @private
  */
 export default function initState(Shopware: ShopwareClass): void {
-    Shopware.Vue.watch(useSession().languageId, async (languageId) => {
+    Shopware.Vue.watch(useSession().languageId, async () => {
         if (!Shopware.Service('acl').can('system.plugin_maintain')) {
             return;
         }
 
         // Always on page load setAdminLocale will be called once. Catch it to not load refresh extensions
-        if (languageId === '') {
+        if (!initialLoad) {
+            initialLoad = true;
             return;
         }
 
-        await Shopware.Service('shopwareExtensionService').updateExtensionData();
+        await Shopware.Service('shopwareExtensionService').updateExtensionData(false);
     });
 }

--- a/src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
+++ b/src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
@@ -39,6 +39,10 @@ class ExtensionStoreActionsController extends AbstractController
     #[Route(path: '/api/_action/extension/refresh', name: 'api.extension.refresh', methods: ['POST'])]
     public function refreshExtensions(Context $context): Response
     {
+        if (!$this->runtimeExtensionManagementAllowed) {
+            return new Response('', Response::HTTP_NO_CONTENT);
+        }
+
         $this->pluginService->refreshPlugins($context, new NullIO());
 
         return new Response('', Response::HTTP_NO_CONTENT);

--- a/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
+++ b/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
@@ -41,6 +41,22 @@ class ExtensionStoreActionsControllerTest extends TestCase
         $controller->refreshExtensions(Context::createDefaultContext());
     }
 
+    public function testRefreshExtensionsDisabled(): void
+    {
+        $controller = new ExtensionStoreActionsController(
+            $this->createMock(ExtensionLifecycleService::class),
+            $this->createMock(ExtensionDownloader::class),
+            $pluginService = $this->createMock(PluginService::class),
+            $this->createMock(PluginManagementService::class),
+            $this->createFileSystemMock(),
+            false,
+        );
+
+        $pluginService->expects($this->never())->method('refreshPlugins');
+
+        $controller->refreshExtensions(Context::createDefaultContext());
+    }
+
     public function testUploadExtensionsWithInvalidFile(): void
     {
         $controller = new ExtensionStoreActionsController(


### PR DESCRIPTION
### 1. Why is this change necessary?

On blue green setups, the extensions may get removed which are getting deployed. The problem is refreshExtensions is deleting plugins not existing locally, so the old version deletes plugins from newer ones. in such sceneario they should use `bin/console plugin:refresh` or kinda deployment helper


### 2. What does this change do, exactly?

- Disable refreshExtensions in Admin Calls
- Controller does nothing when disabled


### 3. Describe each step to reproduce the issue or behaviour.

closes https://github.com/shopware/shopware/issues/10066

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
