### PR TITLE
fix: missing index should not abort system update

### DIFF
--- a/src/Elasticsearch/Framework/Indexing/IndexMappingUpdater.php
+++ b/src/Elasticsearch/Framework/Indexing/IndexMappingUpdater.php
@@ -4,6 +4,7 @@ namespace Shopware\Elasticsearch\Framework\Indexing;
 
 use OpenSearch\Client;
 use OpenSearch\Common\Exceptions\BadRequest400Exception;
+use OpenSearch\Common\Exceptions\Missing404Exception;
 use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -58,6 +59,8 @@ class IndexMappingUpdater
                     $exception = ElasticsearchProductException::cannotChangeFieldType($exception);
                 }
 
+                $this->elasticsearchHelper->logAndThrowException($exception);
+            } catch (Missing404Exception $exception) {
                 $this->elasticsearchHelper->logAndThrowException($exception);
             }
         }


### PR DESCRIPTION
In some scenario, where the indexes is not created before system:update:finish dispatched, the error shouldn't abort the process