### PR TITLE
fix: extension update caching issue

### DIFF
--- a/src/Core/Framework/App/AppEvents.php
+++ b/src/Core/Framework/App/AppEvents.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+class AppEvents
+{
+    final public const APP_WRITTEN_EVENT = 'app.written';
+
+    final public const APP_DELETED_EVENT = 'app.deleted';
+
+    final public const APP_LOADED_EVENT = 'app.loaded';
+
+    final public const APP_SEARCH_RESULT_LOADED_EVENT = 'app.search.result.loaded';
+
+    final public const APP_AGGREGATION_LOADED_EVENT = 'app.aggregation.result.loaded';
+
+    final public const APP_ID_SEARCH_RESULT_LOADED_EVENT = 'app.id.search.result.loaded';
+}

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -189,7 +189,6 @@
             <argument type="service" id="Shopware\Core\Framework\Plugin\PluginManagementService"/>
             <argument type="service" id="Symfony\Component\Filesystem\Filesystem"/>
             <argument>%shopware.deployment.runtime_extension_management%</argument>
-            <argument type="service" id="cache.object"/>
 
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
@@ -297,5 +296,9 @@
         </service>
 
         <service id="Shopware\Core\Framework\JWT\JWTDecoder"/>
+
+        <service id="Shopware\Core\Framework\Store\Subscriber\ExtensionChangedSubscriber">
+            <argument type="service" id="cache.object"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
+++ b/src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
@@ -44,8 +44,6 @@ class ExtensionStoreActionsController extends AbstractController
     {
         $this->pluginService->refreshPlugins($context, new NullIO());
 
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
-
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
@@ -115,6 +113,8 @@ class ExtensionStoreActionsController extends AbstractController
 
         $this->extensionLifecycleService->install($type, $technicalName, $context);
 
+        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
+
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
@@ -130,6 +130,8 @@ class ExtensionStoreActionsController extends AbstractController
             $context
         );
 
+        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
+
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
@@ -144,6 +146,8 @@ class ExtensionStoreActionsController extends AbstractController
             $request->request->getBoolean('keepUserData'),
             $context
         );
+
+        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }
@@ -180,6 +184,8 @@ class ExtensionStoreActionsController extends AbstractController
         $allowNewPermissions = $request->request->getBoolean('allowNewPermissions');
 
         $this->extensionLifecycleService->update($type, $technicalName, $allowNewPermissions, $context);
+
+        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
+++ b/src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\Plugin\PluginService;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Store\Services\AbstractExtensionLifecycle;
 use Shopware\Core\Framework\Store\Services\ExtensionDownloader;
-use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Store\StoreException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Filesystem\Filesystem;
@@ -19,7 +18,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * @internal
@@ -35,7 +33,6 @@ class ExtensionStoreActionsController extends AbstractController
         private readonly PluginManagementService $pluginManagementService,
         private readonly Filesystem $fileSystem,
         private readonly bool $runtimeExtensionManagementAllowed,
-        private readonly CacheInterface $cache,
     ) {
     }
 
@@ -89,8 +86,6 @@ class ExtensionStoreActionsController extends AbstractController
             throw $e;
         }
 
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
-
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
@@ -101,8 +96,6 @@ class ExtensionStoreActionsController extends AbstractController
 
         $this->extensionDownloader->download($technicalName, $context);
 
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
-
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
@@ -112,8 +105,6 @@ class ExtensionStoreActionsController extends AbstractController
         $this->checkExtensionManagementAllowed();
 
         $this->extensionLifecycleService->install($type, $technicalName, $context);
-
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }
@@ -130,8 +121,6 @@ class ExtensionStoreActionsController extends AbstractController
             $context
         );
 
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
-
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
@@ -147,8 +136,6 @@ class ExtensionStoreActionsController extends AbstractController
             $context
         );
 
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
-
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
@@ -159,8 +146,6 @@ class ExtensionStoreActionsController extends AbstractController
 
         $this->extensionLifecycleService->activate($type, $technicalName, $context);
 
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
-
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
@@ -170,8 +155,6 @@ class ExtensionStoreActionsController extends AbstractController
         $this->checkExtensionManagementAllowed();
 
         $this->extensionLifecycleService->deactivate($type, $technicalName, $context);
-
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }
@@ -184,8 +167,6 @@ class ExtensionStoreActionsController extends AbstractController
         $allowNewPermissions = $request->request->getBoolean('allowNewPermissions');
 
         $this->extensionLifecycleService->update($type, $technicalName, $allowNewPermissions, $context);
-
-        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/src/Core/Framework/Store/Subscriber/ExtensionChangedSubscriber.php
+++ b/src/Core/Framework/Store/Subscriber/ExtensionChangedSubscriber.php
@@ -2,7 +2,9 @@
 
 namespace Shopware\Core\Framework\Store\Subscriber;
 
+use Shopware\Core\Framework\App\AppEvents;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginEvents;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -21,8 +23,8 @@ readonly class ExtensionChangedSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            'plugin.written' => 'onExtensionChanged',
-            'app.written' => 'onExtensionChanged',
+            PluginEvents::PLUGIN_WRITTEN_EVENT => 'onExtensionChanged',
+            AppEvents::APP_WRITTEN_EVENT => 'onExtensionChanged',
         ];
     }
 

--- a/src/Core/Framework/Store/Subscriber/ExtensionChangedSubscriber.php
+++ b/src/Core/Framework/Store/Subscriber/ExtensionChangedSubscriber.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Store\Subscriber;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Services\StoreClient;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+readonly class ExtensionChangedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private CacheInterface $cache
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'plugin.written' => 'onExtensionChanged',
+            'app.written' => 'onExtensionChanged',
+        ];
+    }
+
+    public function onExtensionChanged(): void
+    {
+        $this->cache->delete(StoreClient::EXTENSION_LIST_CACHE);
+    }
+}

--- a/tests/integration/Core/Framework/Store/Subscriber/ExtensionChangedSubscriberTest.php
+++ b/tests/integration/Core/Framework/Store/Subscriber/ExtensionChangedSubscriberTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Store\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Services\StoreClient;
+use Shopware\Core\Framework\Store\Subscriber\ExtensionChangedSubscriber;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(ExtensionChangedSubscriber::class)]
+class ExtensionChangedSubscriberTest extends TestCase
+{
+    private ArrayAdapter $cache;
+
+    private EventDispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        $this->cache = new ArrayAdapter();
+        $this->dispatcher = new EventDispatcher();
+
+        $subscriber = new ExtensionChangedSubscriber($this->cache);
+        $this->dispatcher->addSubscriber($subscriber);
+
+        $this->cache->get(StoreClient::EXTENSION_LIST_CACHE, fn () => 'test-value');
+    }
+
+    public function testPluginWrittenEventClearsCache(): void
+    {
+        $item = $this->cache->getItem(StoreClient::EXTENSION_LIST_CACHE);
+        static::assertTrue($item->isHit());
+
+        $this->dispatcher->dispatch(new \stdClass(), 'plugin.written');
+
+        $item = $this->cache->getItem(StoreClient::EXTENSION_LIST_CACHE);
+        static::assertFalse($item->isHit());
+    }
+
+    public function testAppWrittenEventClearsCache(): void
+    {
+        $this->cache->get(StoreClient::EXTENSION_LIST_CACHE, fn () => 'test-value');
+
+        $item = $this->cache->getItem(StoreClient::EXTENSION_LIST_CACHE);
+        static::assertTrue($item->isHit());
+
+        $this->dispatcher->dispatch(new \stdClass(), 'app.written');
+
+        $item = $this->cache->getItem(StoreClient::EXTENSION_LIST_CACHE);
+        static::assertFalse($item->isHit());
+    }
+}

--- a/tests/integration/Core/Framework/Store/Subscriber/ExtensionChangedSubscriberTest.php
+++ b/tests/integration/Core/Framework/Store/Subscriber/ExtensionChangedSubscriberTest.php
@@ -4,7 +4,9 @@ namespace Shopware\Tests\Integration\Core\Framework\Store\Subscriber;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppEvents;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginEvents;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Store\Subscriber\ExtensionChangedSubscriber;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -37,7 +39,7 @@ class ExtensionChangedSubscriberTest extends TestCase
         $item = $this->cache->getItem(StoreClient::EXTENSION_LIST_CACHE);
         static::assertTrue($item->isHit());
 
-        $this->dispatcher->dispatch(new \stdClass(), 'plugin.written');
+        $this->dispatcher->dispatch(new \stdClass(), PluginEvents::PLUGIN_WRITTEN_EVENT);
 
         $item = $this->cache->getItem(StoreClient::EXTENSION_LIST_CACHE);
         static::assertFalse($item->isHit());
@@ -50,7 +52,7 @@ class ExtensionChangedSubscriberTest extends TestCase
         $item = $this->cache->getItem(StoreClient::EXTENSION_LIST_CACHE);
         static::assertTrue($item->isHit());
 
-        $this->dispatcher->dispatch(new \stdClass(), 'app.written');
+        $this->dispatcher->dispatch(new \stdClass(), AppEvents::APP_WRITTEN_EVENT);
 
         $item = $this->cache->getItem(StoreClient::EXTENSION_LIST_CACHE);
         static::assertFalse($item->isHit());

--- a/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
+++ b/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * @internal
@@ -34,8 +33,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $pluginService = $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $pluginService->expects($this->once())->method('refreshPlugins');
@@ -51,8 +49,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(true),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $request = new Request();
@@ -82,8 +79,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $fileSystemMock,
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $request = new Request();
@@ -104,8 +100,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $pluginManagement = $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(true),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $pluginManagement->method('uploadPlugin')->willThrowException(new \RuntimeException('Error'));
@@ -128,8 +123,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $request = new Request();
@@ -151,8 +145,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $request = new Request();
@@ -172,8 +165,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $downloader->expects($this->once())->method('download');
@@ -192,8 +184,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $lifecycle->expects($this->once())->method('install');
@@ -212,8 +203,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $lifecycle->expects($this->once())->method('uninstall');
@@ -232,8 +222,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $lifecycle->expects($this->once())->method('remove');
@@ -252,8 +241,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $lifecycle->expects($this->once())->method('activate');
@@ -272,8 +260,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $lifecycle->expects($this->once())->method('deactivate');
@@ -292,8 +279,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $lifecycle->expects($this->once())->method('update');
@@ -314,8 +300,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            true,
-            $this->createMock(CacheInterface::class)
+            true
         );
 
         $lifecycle->expects($this->once())->method('update');
@@ -336,8 +321,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
             $this->createMock(PluginService::class),
             $this->createMock(PluginManagementService::class),
             $this->createFileSystemMock(),
-            false,
-            $this->createMock(CacheInterface::class)
+            false
         );
 
         $context = Context::createDefaultContext();

--- a/tests/unit/Core/Framework/Store/Subscriber/ExtensionChangedSubscriberTest.php
+++ b/tests/unit/Core/Framework/Store/Subscriber/ExtensionChangedSubscriberTest.php
@@ -5,7 +5,9 @@ namespace Shopware\Tests\Unit\Core\Framework\Store\Subscriber;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppEvents;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginEvents;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Store\Subscriber\ExtensionChangedSubscriber;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -30,8 +32,8 @@ class ExtensionChangedSubscriberTest extends TestCase
     public function testItSubscribesToPluginAndAppWrittenEvents(): void
     {
         $expected = [
-            'plugin.written' => 'onExtensionChanged',
-            'app.written' => 'onExtensionChanged',
+            PluginEvents::PLUGIN_WRITTEN_EVENT => 'onExtensionChanged',
+            AppEvents::APP_WRITTEN_EVENT => 'onExtensionChanged',
         ];
 
         static::assertSame($expected, ExtensionChangedSubscriber::getSubscribedEvents());

--- a/tests/unit/Core/Framework/Store/Subscriber/ExtensionChangedSubscriberTest.php
+++ b/tests/unit/Core/Framework/Store/Subscriber/ExtensionChangedSubscriberTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Services\StoreClient;
+use Shopware\Core\Framework\Store\Subscriber\ExtensionChangedSubscriber;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(ExtensionChangedSubscriber::class)]
+class ExtensionChangedSubscriberTest extends TestCase
+{
+    private CacheInterface&MockObject $cache;
+
+    private ExtensionChangedSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->subscriber = new ExtensionChangedSubscriber($this->cache);
+    }
+
+    public function testItSubscribesToPluginAndAppWrittenEvents(): void
+    {
+        $expected = [
+            'plugin.written' => 'onExtensionChanged',
+            'app.written' => 'onExtensionChanged',
+        ];
+
+        static::assertSame($expected, ExtensionChangedSubscriber::getSubscribedEvents());
+    }
+
+    public function testItDeletesExtensionListCacheOnExtensionChanged(): void
+    {
+        $this->cache
+            ->expects($this->once())
+            ->method('delete')
+            ->with(StoreClient::EXTENSION_LIST_CACHE);
+
+        $this->subscriber->onExtensionChanged();
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the extension refresh is clearing the cache.

### 2. What does this change do, exactly?
It removes the cache clear on the refresh extensions route

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

fixes: https://github.com/shopware/shopware/issues/8333

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
