### PR TITLE
refactor: Remove Vue2 `this.$root.$emit(...)` events from the `sw-order-detail` component

### DIFF
--- a/changelog/_unreleased/2025-06-03-removed-global-vue2-event-emitter-from-the-sw-order-detail-component.md
+++ b/changelog/_unreleased/2025-06-03-removed-global-vue2-event-emitter-from-the-sw-order-detail-component.md
@@ -1,0 +1,9 @@
+---
+title: Removed global Vue2 event emitter from the `sw-order-detail` component
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Removed Vue2 `this.$root.$emit(...)` events from the `sw-order-detail` component, as they were doing nothing
+* Deprecated `onChangeLanguage` of the `sw-order-detail` component

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -283,9 +283,10 @@ export default {
             this.createdById = createdById;
         },
 
-        onChangeLanguage() {
-            this.$root.$emit('language-change');
-        },
+        /**
+         * @deprecated tag:v6.8.0 - will be removed without replacement
+         */
+        onChangeLanguage() {},
 
         saveEditsFinish() {
             this.isSaveSuccessful = false;
@@ -295,9 +296,7 @@ export default {
         /**
          * @deprecated tag:v6.8.0 - will be removed without replacement
          */
-        onStartEditing() {
-            this.$root.$emit('order-edit-start');
-        },
+        onStartEditing() {},
 
         async onSaveEdits() {
             Store.get('swOrderDetail').setLoading([
@@ -355,8 +354,6 @@ export default {
                         false,
                     ]);
                 });
-
-            this.$root.$emit('order-edit-save');
         },
 
         async handleOrderAddressUpdate(addressMappings) {


### PR DESCRIPTION
### 1. Why is this change necessary?
`this.$root.$emit(...)` has been removed with Vue3, but there are still three occurrences in the `sw-order-detail` component. As this does not do anything (as far as I can tell), the code can also be removed.

### 2. What does this change do, exactly?
Remove the `this.$root.$emit(...)` and deprecate the not needed function.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
