### PR TITLE
fix: inconsistency between login & register page for guest customers

### DIFF
--- a/changelog/_unreleased/2025-06-03-fix-inconsistency-between-login-and-register.md
+++ b/changelog/_unreleased/2025-06-03-fix-inconsistency-between-login-and-register.md
@@ -1,0 +1,8 @@
+---
+title: Fix inconsistency between login & register page for guest customers
+author: Max Stegmeyer
+author_email: m.stegmeyer@shopware.com
+author_github: @mstegmeyer
+---
+# Storefront
+* Changed `/account/login` to behave the same as `/account/register` for guest customers: logging the customer out

--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -69,12 +69,12 @@ class AuthController extends StorefrontController
             $request->attributes->remove(PlatformRequest::ATTRIBUTE_NO_STORE);
         }
 
-        /** @var string $redirect */
-        $redirect = $request->get('redirectTo', 'frontend.account.home.page');
-
         $customer = $context->getCustomer();
 
-        if ($customer !== null && $customer->getGuest() === false) {
+        /** @var string $redirect */
+        $redirect = $request->get('redirectTo', $customer?->getGuest() ? 'frontend.account.logout.page' : 'frontend.account.home.page');
+
+        if ($customer !== null) {
             $request->request->set('redirectTo', $redirect);
 
             return $this->createActionResponse($request);

--- a/tests/unit/Storefront/Controller/AuthControllerTest.php
+++ b/tests/unit/Storefront/Controller/AuthControllerTest.php
@@ -110,7 +110,7 @@ class AuthControllerTest extends TestCase
     public function testGuestCustomerOnLoginPageShouldBeLoggedOut(): void
     {
         $context = Generator::generateSalesChannelContext();
-        $context->getCustomer()->setGuest(true);
+        $context->getCustomer()?->setGuest(true);
 
         $this->controller->loginPage(new Request(), new RequestDataBag(), $context);
 

--- a/tests/unit/Storefront/Controller/AuthControllerTest.php
+++ b/tests/unit/Storefront/Controller/AuthControllerTest.php
@@ -107,6 +107,16 @@ class AuthControllerTest extends TestCase
         static::assertSame('account.orderGuestLoginWrongCredentials', $this->controller->flashBag['danger'][0]);
     }
 
+    public function testGuestCustomerOnLoginPageShouldBeLoggedOut(): void
+    {
+        $context = Generator::generateSalesChannelContext();
+        $context->getCustomer()->setGuest(true);
+
+        $this->controller->loginPage(new Request(), new RequestDataBag(), $context);
+
+        static::assertArrayHasKey('frontend.account.logout.page', $this->controller->redirected);
+    }
+
     public function testGenerateAccountRecoveryThrowsConstraintException(): void
     {
         $request = new Request();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The /account/login page does nothing, if a guest is logged in: it shows the login & register page. If done so, nothing happens, as the login routes return if there is already someone logged in.

### 2. What does this change do, exactly?
Make the /account/login route behave the same as the /account/register route: to log out the current customer

### 3. Describe each step to reproduce the issue or behaviour.
- Put something in the cart
- Register a guest via /checkout/register
- Navigate to /account/login

### 4. Please link to the relevant issues (if any).
fixes #10025

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
