### PR TITLE
fix: measurement units for sales channel

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.html.twig
@@ -72,7 +72,7 @@
             <template
                 #column-measurementSystemName="{ item, isInlineEdit }"
             >
-                {{ getMeasurementName(item.measurementUnits.name) }}
+                {{ getMeasurementName(item.measurementUnits.system) }}
             </template>
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/index.js
@@ -125,7 +125,7 @@ export default Shopware.Component.wrapComponentConfig({
                 return;
             }
 
-            this.measurementUnits.name = measurementSystem.technicalName;
+            this.measurementUnits.system = measurementSystem.technicalName;
             const units = measurementSystem.units;
 
             this.defaultMeasurementSystem = measurementSystem;
@@ -162,8 +162,8 @@ export default Shopware.Component.wrapComponentConfig({
             const criteria = cloneDeep(this.measurementSystemCriteria);
             criteria.setLimit(1);
 
-            if (this.measurementUnits.name) {
-                criteria.addFilter(Criteria.equals('technicalName', this.measurementUnits.name));
+            if (this.measurementUnits.system) {
+                criteria.addFilter(Criteria.equals('technicalName', this.measurementUnits.system));
             }
 
             const measurement = await this.measurementSystemRepository.search(criteria);

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.spec.js
@@ -92,7 +92,7 @@ async function createWrapper() {
         props: {
             salesChannel: {
                 measurementUnits: {
-                    name: 'metric',
+                    system: 'metric',
                     units: {
                         length: 'mm',
                         weight: 'kg',
@@ -158,7 +158,7 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-measurement', (
     it('should initialize with correct default values', async () => {
         const wrapper = await createWrapper();
         expect(wrapper.vm.measurementUnits).toEqual({
-            name: 'metric',
+            system: 'metric',
             units: {
                 length: 'mm',
                 weight: 'kg',
@@ -208,7 +208,7 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-measurement', (
         await typeElement.at(1).trigger('click');
         await flushPromises();
 
-        expect(wrapper.vm.measurementUnits.name).toBe('imperial');
+        expect(wrapper.vm.measurementUnits.system).toBe('imperial');
         expect(wrapper.vm.measurementUnits.units).toEqual({
             length: 'in',
             weight: 'lb',

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-create/index.js
@@ -46,7 +46,7 @@ export default {
             this.salesChannel.typeId = this.$route.params.typeId;
             this.salesChannel.active = false;
             this.salesChannel.measurementUnits = {
-                name: measurementUnits['core.measurementUnits.system'],
+                system: measurementUnits['core.measurementUnits.system'],
                 units: {
                     length: measurementUnits['core.measurementUnits.length'],
                     weight: measurementUnits['core.measurementUnits.weight'],

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-create/sw-sales-channel-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-create/sw-sales-channel-create.spec.js
@@ -99,7 +99,7 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-create', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm.salesChannel.measurementUnits).toEqual({
-            name: 'metric',
+            system: 'metric',
             units: {
                 length: 'mm',
                 weight: 'kg',


### PR DESCRIPTION
This pull request refactors the `measurementUnits` object across multiple files in the `sw-sales-channel` module by replacing the `name` property with `system`. The changes ensure consistency in naming conventions and improve code readability. Updates were also made to corresponding tests to align with the refactored property.

### Refactoring of `measurementUnits` object:

* [`src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.html.twig`](diffhunk://#diff-1cdaf19e732e1c42379ad37c176eb28357107af59ed678eebdd0680d46b9e9ecL75-R75): Updated the template to use `item.measurementUnits.system` instead of `item.measurementUnits.name`.
* [`src/module/sw-sales-channel/component/sw-sales-channel-measurement/index.js`](diffhunk://#diff-5408c55c7422af3fcb7b039e1c0ef92af849f0757873e5535e0a7ed5623669abL128-R128): Replaced references to `measurementUnits.name` with `measurementUnits.system` in multiple locations, including property assignments and criteria filtering. [[1]](diffhunk://#diff-5408c55c7422af3fcb7b039e1c0ef92af849f0757873e5535e0a7ed5623669abL128-R128) [[2]](diffhunk://#diff-5408c55c7422af3fcb7b039e1c0ef92af849f0757873e5535e0a7ed5623669abL165-R166)
* [`src/module/sw-sales-channel/page/sw-sales-channel-create/index.js`](diffhunk://#diff-f17935d13ad628ead7e14fb6ac804141c28ef54c0c00b7ad8c058f5d57da0d0aL49-R49): Changed the initialization of `measurementUnits` to use the `system` property instead of `name`.

### Updates to tests:

* [`src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.spec.js`](diffhunk://#diff-f1d6bc89ef4becb12db1e5e6201dd5d4cffe9878e3281262070441a8d57bb1deL95-R95): Adjusted test cases to validate `measurementUnits.system` instead of `measurementUnits.name`. [[1]](diffhunk://#diff-f1d6bc89ef4becb12db1e5e6201dd5d4cffe9878e3281262070441a8d57bb1deL95-R95) [[2]](diffhunk://#diff-f1d6bc89ef4becb12db1e5e6201dd5d4cffe9878e3281262070441a8d57bb1deL161-R161) [[3]](diffhunk://#diff-f1d6bc89ef4becb12db1e5e6201dd5d4cffe9878e3281262070441a8d57bb1deL211-R211)
* [`src/module/sw-sales-channel/page/sw-sales-channel-create/sw-sales-channel-create.spec.js`](diffhunk://#diff-40698297338dc8c8416d6ec81fd46d75997f6ac267907405cdb939e085318e39L102-R102): Updated test expectations to reflect the property change from `name` to `system` in `measurementUnits`.