### PR TITLE
fix: sw-plugin-box rendering

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-plugin-box/sw-plugin-box.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-plugin-box/sw-plugin-box.html.twig
@@ -20,7 +20,7 @@
             <div class="sw-plugin-box__description">
                 {% block sw_plugin_box_container_plugin_data_description_label %}
                 <p class="sw-plugin-box__label">
-                    {{ plugin.translated.label }}
+                    {{ plugin.translated?.label }}
                 </p>
                 {% endblock %}
                 {% block sw_plugin_box_container_plugin_data_description_author %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`sw-plugin-box` does not render as `this.plugin` is loaded async and therefore not available at the time of rendering the label with `plugin.translated.label`

### 2. What does this change do, exactly?
Use a null coalescing operator

### 3. Describe each step to reproduce the issue or behaviour.
- Open payment method details of an extension, like SwagPayPal

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
