### PR TITLE
chore(ci): fix priority sync

### DIFF
--- a/.github/bin/js/package-lock.json
+++ b/.github/bin/js/package-lock.json
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@shopware-ag/gh-project-automation": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.6.1.tgz",
-      "integrity": "sha512-jpDHc2/R28NcXCdVPA7ZvnMIRANMlbSDlDecTrMOtyb9nSexgqHyuvrpZ62PeqlDKhSYLjXMZfVpYwhi/dw2aw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.6.2.tgz",
+      "integrity": "sha512-E70w/pNJOdCEq3Eg0yCYQQFrOOpeLOCo5p9PXqyVtx06fSi0WyWdN4Lf24tOCyS/lFNh9ectszo1FWmNRYPF2w==",
       "optionalDependencies": {
         "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",


### PR DESCRIPTION
### 1. Why is this change necessary?
There was a bug in the `getProjectInfo` function of `gh-project-automation`.

### 2. What does this change do, exactly?
Update `gh-project-automation` to use the fixed version.

### 3. Describe each step to reproduce the issue or behaviour.
Label a issue with a `priority/` label.