### PR TITLE
chore(ci): add job to label community-contributed PRs

### DIFF
--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -36,7 +36,7 @@ jobs:
 
   apply-team-label:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'issues' && ( github.event.action == 'opened' || github.event.action == 'reopened' )
+    if: github.event.act || (github.event_name == 'issues' && ( github.event.action == 'opened' || github.event.action == 'reopened' ))
     env:
       TEAM_LABEL: "domain/customer-support"
     permissions:
@@ -44,6 +44,7 @@ jobs:
       issues: write
     steps:
       - id: sts
+        if: ${{ !github.event.act }}
         continue-on-error: true
         uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
         with:
@@ -53,7 +54,7 @@ jobs:
         id: actorTeams
         with:
           username: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ steps.sts.outputs.token }}
+          GITHUB_TOKEN: ${{ github.event.act && secrets.GITHUB_TOKEN || steps.sts.outputs.token }}
       - name: debug
         if: runner.debug
         run: |
@@ -74,6 +75,48 @@ jobs:
 
             if (response.status !== 200) {
               throw new Error(`Failed to add label ${teamLabel} to issue #${issueNumber}`);
+            }
+
+  apply-contributor-label:
+    runs-on: ubuntu-24.04
+    if: github.event.act || (github.event_name == 'pull_request' && ( github.event.action == 'opened' || github.event.action == 'reopened' ))
+    env:
+      CONTRIBUTOR_LABEL: "external-contribution"
+    permissions:
+      id-token: write
+      issues: write
+    steps:
+      - id: sts
+        if: ${{ !github.event.act }}
+        continue-on-error: true
+        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
+        with:
+          scope: shopware
+          identity: ReadCollaborators
+      - uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # 3
+        id: actorTeams
+        with:
+          username: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.event.act && secrets.GITHUB_TOKEN || steps.sts.outputs.token }}
+      - if: runner.debug
+        run: |
+          echo "${{ github.actor }} is member of teams: ${{ steps.actorTeams.outputs.teams }}"
+      - if: ${{ join(steps.actorTeams.outputs.teams, '') == '' }}
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        with:
+          script: |
+            const pullRequestNumber = context.payload.pull_request.number;
+            const contribLabel = process.env.CONTRIBUTOR_LABEL;
+
+            const response = await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequestNumber,
+              labels: [contribLabel],
+            });
+
+            if (response.status !== 200) {
+              throw new Error(`Failed to add label ${contribLabel} to issue #${pullRequestNumber}`);
             }
 
   move-to-wip:


### PR DESCRIPTION
With this change, PRs opened by contributors not belonging to any team of the shopware org, will be labeled with the `external-contribution` label.

Resolves: #9682 