### PR TITLE
feat: Products with variants should return the variant that match the search term in the product detail page

### DIFF
--- a/changelog/_unreleased/2025-06-05-products-with-variants-should-return-the-variant-that-match-the-search-term-in-the-product-detail-page.md
+++ b/changelog/_unreleased/2025-06-05-products-with-variants-should-return-the-variant-that-match-the-search-term-in-the-product-detail-page.md
@@ -1,0 +1,10 @@
+---
+title: Products with variants should return the variant that match the search term in the product detail page
+issue: 10297
+---
+# Core
+* Changed `Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute` to return the variant that matches the search term in the product detail page.
+___
+# Storefront
+* Changed `Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig` to pass the search term to the product detail route.
+* Changed `Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig` to show the variant options in the search suggest results.

--- a/changelog/_unreleased/2025-06-05-products-with-variants-should-return-the-variant-that-match-the-search-term-in-the-product-detail-page.md
+++ b/changelog/_unreleased/2025-06-05-products-with-variants-should-return-the-variant-that-match-the-search-term-in-the-product-detail-page.md
@@ -4,6 +4,7 @@ issue: 10297
 ---
 # Core
 * Changed `Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute` to return the variant that matches the search term in the product detail page.
+* Added `Shopware\Core\Migration\V6_7\Migration1749644517AddListingVariantNameSystemConfigOption` to add a system config option for the listing variant options.
 ___
 # Storefront
 * Changed `Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig` to pass the search term to the product detail route.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -796,12 +796,6 @@ parameters:
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
 			count: 1
-			path: src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
 			path: src/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRoute.php
 
 		-

--- a/src/Core/Content/Product/ProductException.php
+++ b/src/Core/Content/Product/ProductException.php
@@ -15,6 +15,7 @@ class ProductException extends HttpException
     public const PRODUCT_INVALID_CHEAPEST_PRICE_FACADE = 'PRODUCT_INVALID_CHEAPEST_PRICE_FACADE';
     public const PRODUCT_PROXY_MANIPULATION_NOT_ALLOWED_CODE = 'PRODUCT_PROXY_MANIPULATION_NOT_ALLOWED';
     public const PRODUCT_INVALID_PRICE_DEFINITION_CODE = 'PRODUCT_INVALID_PRICE_DEFINITION';
+    public const PRODUCT_NOT_FOUND = 'PRODUCT_PRODUCT_NOT_FOUND';
     public const CATEGORY_NOT_FOUND = 'PRODUCT__CATEGORY_NOT_FOUND';
     public const SORTING_NOT_FOUND = 'PRODUCT_SORTING_NOT_FOUND';
     public const PRODUCT_CONFIGURATION_OPTION_ALREADY_EXISTS = 'PRODUCT_CONFIGURATION_OPTION_EXISTS_ALREADY';
@@ -122,6 +123,16 @@ class ProductException extends HttpException
             'PRODUCT__NO_PRICE_FOR_CURRENCY',
             'No price found for currency "{{ currency }}"',
             ['currency' => $currency->getName() ?? $currency->getShortName() ?? $currency->getIsoCode()]
+        );
+    }
+
+    public static function productNotFound(string $productId): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::PRODUCT_NOT_FOUND,
+            self::$couldNotFindMessage,
+            ['entity' => 'product', 'field' => 'id', 'value' => $productId]
         );
     }
 }

--- a/src/Core/Content/Product/ProductException.php
+++ b/src/Core/Content/Product/ProductException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Product;
 
+use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\Exception\ReviewNotActiveExeption;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
@@ -126,8 +127,15 @@ class ProductException extends HttpException
         );
     }
 
-    public static function productNotFound(string $productId): self
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self
+     */
+    public static function productNotFound(string $productId): self|ProductNotFoundException
     {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new ProductNotFoundException($productId);
+        }
+
         return new self(
             Response::HTTP_NOT_FOUND,
             self::PRODUCT_NOT_FOUND,

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -191,7 +191,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             ->addSorting(new FieldSorting('product.price'))
             ->setLimit(1);
 
-        $criteria->setTitle('product-detail-route::find-best-variant');
+        $criteria->setTitle('product-detail-route::find-best-variant-by-term');
         $variantId = $this->productRepository->searchIds($criteria, $context);
 
         return $variantId->firstId() ?? $productId;

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -191,7 +191,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             ->addSorting(new FieldSorting('product.price'))
             ->setLimit(1);
 
-        $criteria->setTitle('product-detail-route::find-best-variant-by-term');
+        $criteria->setTitle('product-detail-route::find-best-variant');
         $variantId = $this->productRepository->searchIds($criteria, $context);
 
         return $variantId->firstId() ?? $productId;
@@ -206,7 +206,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         $criteria->addState(Criteria::STATE_ELASTICSEARCH_AWARE);
         $criteria->setTerm($term);
 
-        $criteria->setTitle('product-detail-route::find-best-variant');
+        $criteria->setTitle('product-detail-route::find-best-variant-by-term');
         $variantId = $this->productRepository->searchIds($criteria, $context);
 
         return $variantId->firstId();

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -7,7 +7,7 @@ use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
-use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\Detail\Event\ResolveVariantIdEvent;
 use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
@@ -74,7 +74,14 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             );
 
             $this->dispatcher->dispatch($resolveVariantIdEvent);
-            $productId = $resolveVariantIdEvent->getResolvedVariantId() ?? $this->findBestVariant($productId, $context);
+
+            if ($resolveVariantIdEvent->getResolvedVariantId()) {
+                $productId = $resolveVariantIdEvent->getResolvedVariantId();
+            } else {
+                $term = $request->query->get('search');
+                $variantId = $term ? $this->findBestVariantByTerm($term, $productId, $context) : null;
+                $productId = $variantId ?? $this->findBestVariant($productId, $context);
+            }
 
             $this->addFilters($context, $criteria);
 
@@ -86,7 +93,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                 ->first();
 
             if (!($product instanceof SalesChannelProductEntity)) {
-                throw new ProductNotFoundException($productId);
+                throw ProductException::productNotFound($productId);
             }
 
             $parent = $product->getParentId() ?? $product->getId();
@@ -188,6 +195,21 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         $variantId = $this->productRepository->searchIds($criteria, $context);
 
         return $variantId->firstId() ?? $productId;
+    }
+
+    private function findBestVariantByTerm(string $term, string $productId, SalesChannelContext $context): ?string
+    {
+        $criteria = (new Criteria())
+            ->addFilter(new EqualsFilter('product.parentId', $productId))
+            ->setLimit(1);
+
+        $criteria->addState(Criteria::STATE_ELASTICSEARCH_AWARE);
+        $criteria->setTerm($term);
+
+        $criteria->setTitle('product-detail-route::find-best-variant');
+        $variantId = $this->productRepository->searchIds($criteria, $context);
+
+        return $variantId->firstId();
     }
 
     private function createCriteria(string $pageId, Request $request): Criteria

--- a/src/Core/Migration/V6_7/Migration1749644517AddListingVariantNameSystemConfigOption.php
+++ b/src/Core/Migration/V6_7/Migration1749644517AddListingVariantNameSystemConfigOption.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1749644517AddListingVariantNameSystemConfigOption extends MigrationStep
+{
+    private const CONFIG_KEY = 'core.listing.showVariantOptionInSearchSuggestionResult';
+
+    public function getCreationTimestamp(): int
+    {
+        return 1749644517;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $configPresent = $connection->fetchOne('SELECT 1 FROM `system_config` WHERE `configuration_key` = ?', [self::CONFIG_KEY]);
+
+        if ($configPresent !== false) {
+            return;
+        }
+
+        $connection->insert('system_config', [
+            'id' => Uuid::randomBytes(),
+            'configuration_key' => self::CONFIG_KEY,
+            'configuration_value' => '{"_value": false}',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+}

--- a/src/Core/System/Resources/config/listing.xml
+++ b/src/Core/System/Resources/config/listing.xml
@@ -32,10 +32,10 @@
 
         <input-field type="bool">
             <name>showVariantOptionInSearchSuggestionResult</name>
-            <label>Show variant options in search suggestion result</label>
-            <label lang="de-DE">Anzeige von Variantenoptionen in Suchvorschlägen</label>
-            <helpText>Enable to show variant options bellow variant name in search suggestion result</helpText>
-            <helpText lang="de-DE">Aktivieren Sie die Anzeige von Variantenoptionen unter dem Variantennamen in den Suchvorschlägen.</helpText>
+            <label>Show variant options in the search suggestion results</label>
+            <label lang="de-DE">Anzeige von Variantenoptionen in den Suchvorschlägen</label>
+            <helpText>Allow the variant options to be displayed underneath the product name in the search suggestion results.</helpText>
+            <helpText lang="de-DE">Erlauben Sie die Anzeige der Variantenoptionen unterhalb des Produktnamens in den Suchvorschlägen.</helpText>
         </input-field>
 
         <input-field type="bool">

--- a/src/Core/System/Resources/config/listing.xml
+++ b/src/Core/System/Resources/config/listing.xml
@@ -31,6 +31,14 @@
         </input-field>
 
         <input-field type="bool">
+            <name>showVariantOptionInSearchSuggestionResult</name>
+            <label>Show variant options in search suggestion result</label>
+            <label lang="de-DE">Anzeige von Variantenoptionen in Suchvorschlägen</label>
+            <helpText>Enable to show variant options bellow variant name in search suggestion result</helpText>
+            <helpText lang="de-DE">Aktivieren Sie die Anzeige von Variantenoptionen unter dem Variantennamen in den Suchvorschlägen.</helpText>
+        </input-field>
+
+        <input-field type="bool">
             <name>showReview</name>
             <label>Show reviews</label>
             <label lang="de-DE">Bewertungen anzeigen</label>

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_search-suggest.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_search-suggest.scss
@@ -78,8 +78,6 @@ Contains styles for the search suggest popover in the shop header.
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    margin-left: 51px;
-    max-width: 449px;
 }
 
 .search-suggest-product-price {

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_search-suggest.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_search-suggest.scss
@@ -72,6 +72,16 @@ Contains styles for the search suggest popover in the shop header.
     text-overflow: ellipsis;
 }
 
+.search-suggest-product-variation {
+    font-size: $font-size-sm;
+    color: $gray-600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-left: 51px;
+    max-width: 449px;
+}
+
 .search-suggest-product-price {
     text-align: right;
     padding-right: 0.25rem;

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -8,6 +8,10 @@
         {% set headlineLevel = element.config.boxHeadlineLevel.value %}
         {% set headlineClasses = "product-name-headline mb-0" %}
 
+        {% set searchTerm = page.searchTerm %}
+        {% set childCount = product.childCount %}
+        {% set routeArguments = childCount > 0 and searchTerm ? { productId: id, search: searchTerm } : { productId: id } %}
+
         <div class="card product-box box-{{ layout }}" data-product-information="{{ {id, name}|json_encode }}">
             {% block component_product_box_content %}
                 <div class="card-body">
@@ -108,13 +112,13 @@
                             {% block component_product_box_name %}
                                 {% if headlineLevel is not empty %}
                                     {{ "<h#{headlineLevel} class=\"#{headlineClasses}\">"|raw }}
-                                        <a href="{{ seoUrl('frontend.detail.page', { productId: id }) }}"
+                                        <a href="{{ seoUrl('frontend.detail.page', routeArguments) }}"
                                            class="product-name stretched-link">
                                             {{ name }}
                                         </a>
                                     {{ "</h#{headlineLevel}>"|raw }}
                                 {% else %}
-                                    <a href="{{ seoUrl('frontend.detail.page', { productId: id }) }}"
+                                    <a href="{{ seoUrl('frontend.detail.page', routeArguments) }}"
                                        class="product-name stretched-link">
                                         {{ name }}
                                     </a>

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -56,7 +56,7 @@
                                                     {{ product.translated.name }}
 
                                                     {% block layout_search_suggest_result_variation %}
-                                                        {% if product.variation and config('core.listing.showVariantOptionInSearchSuggestionResult') %}
+                                                        {% if product.variation and product.name is null and config('core.listing.showVariantOptionInSearchSuggestionResult') %}
                                                             <div class="search-suggest-product-variation">
                                                                 {% for variation in product.variation %}
                                                                     {{ variation.group }}: {{ variation.option }}

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -54,6 +54,19 @@
                                             {% block layout_search_suggest_result_name %}
                                                 <div class="col search-suggest-product-name">
                                                     {{ product.translated.name }}
+
+                                                    {% block layout_search_suggest_result_variation %}
+                                                        {% if product.variation and config('core.listing.showVariantOptionInSearchSuggestionResult') %}
+                                                            <div class="search-suggest-product-variation">
+                                                                {% for variation in product.variation %}
+                                                                    {{ variation.group }}: {{ variation.option }}
+                                                                    {% if product.variation|last != variation %}
+                                                                        /
+                                                                    {% endif %}
+                                                                {% endfor %}
+                                                            </div>
+                                                        {% endif %}
+                                                    {% endblock %}
                                                 </div>
                                             {% endblock %}
 
@@ -86,19 +99,6 @@
                                                         <small class="search-suggest-product-list-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}</small>
                                                     {% endif %}
                                                 </div>
-                                            {% endblock %}
-
-                                            {% block layout_search_suggest_result_variation %}
-                                                {% if product.variation and config('core.listing.showVariantOptionInSearchSuggestionResult') %}
-                                                    <div class="search-suggest-product-variation">
-                                                        {% for variation in product.variation %}
-                                                            {{ variation.group }}: {{ variation.option }}
-                                                            {% if product.variation|last != variation %}
-                                                                /
-                                                            {% endif %}
-                                                        {% endfor %}
-                                                    </div>
-                                                {% endif %}
                                             {% endblock %}
                                         </div>
                                     </a>

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -4,7 +4,7 @@
     <div class="search-suggest js-search-result">
         {% block layout_search_suggest_container %}
 
-            <ul class="search-suggest-container" 
+            <ul class="search-suggest-container"
                 id="search-suggest-listbox"
                 aria-label="{{ 'header.searchDropdownTitle'|trans|striptags }}"
                 role="listbox">
@@ -86,6 +86,19 @@
                                                         <small class="search-suggest-product-list-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}</small>
                                                     {% endif %}
                                                 </div>
+                                            {% endblock %}
+
+                                            {% block layout_search_suggest_result_variation %}
+                                                {% if product.variation %}
+                                                    <div class="search-suggest-product-variation">
+                                                        {% for variation in product.variation %}
+                                                            {{ variation.group }}: {{ variation.option }}
+                                                            {% if product.variation|last != variation %}
+                                                                /
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                    </div>
+                                                {% endif %}
                                             {% endblock %}
                                         </div>
                                     </a>

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -89,7 +89,7 @@
                                             {% endblock %}
 
                                             {% block layout_search_suggest_result_variation %}
-                                                {% if product.variation %}
+                                                {% if product.variation and config('core.listing.showVariantOptionInSearchSuggestionResult') %}
                                                     <div class="search-suggest-product-variation">
                                                         {% for variation in product.variation %}
                                                             {{ variation.group }}: {{ variation.option }}

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -56,7 +56,7 @@
                                                     {{ product.translated.name }}
 
                                                     {% block layout_search_suggest_result_variation %}
-                                                        {% if product.variation and product.name is null and config('core.listing.showVariantOptionInSearchSuggestionResult') %}
+                                                        {% if product.variation and config('core.listing.showVariantOptionInSearchSuggestionResult') %}
                                                             <div class="search-suggest-product-variation">
                                                                 {% for variation in product.variation %}
                                                                     {{ variation.group }}: {{ variation.option }}

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsWidgetLoadedHook;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
@@ -14,6 +15,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -231,7 +233,11 @@ class ProductControllerTest extends TestCase
         $controller = static::getContainer()->get(ProductController::class);
 
         if ($shouldThrowException) {
-            $this->expectException(ProductException::class);
+            if (!Feature::isActive('v6.8.0.0')) {
+                $this->expectException(ProductNotFoundException::class);
+            } else {
+                $this->expectException(ProductException::class);
+            }
         }
 
         $response = $controller->index($context, $this->createDetailRequest($context, $this->ids->get($requestVariant)));

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
-use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsWidgetLoadedHook;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
@@ -231,7 +231,7 @@ class ProductControllerTest extends TestCase
         $controller = static::getContainer()->get(ProductController::class);
 
         if ($shouldThrowException) {
-            $this->expectException(ProductNotFoundException::class);
+            $this->expectException(ProductException::class);
         }
 
         $response = $controller->index($context, $this->createDetailRequest($context, $this->ids->get($requestVariant)));

--- a/tests/integration/Storefront/Integration/ProductVisibilityTest.php
+++ b/tests/integration/Storefront/Integration/ProductVisibilityTest.php
@@ -6,8 +6,8 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\DataAbstractionLayer\SearchKeywordUpdater;
-use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
@@ -163,7 +163,7 @@ class ProductVisibilityTest extends TestCase
                 continue;
             }
 
-            static::assertInstanceOf(ProductNotFoundException::class, $e, 'case #' . $index);
+            static::assertInstanceOf(ProductException::class, $e, 'case #' . $index);
         }
     }
 

--- a/tests/integration/Storefront/Integration/ProductVisibilityTest.php
+++ b/tests/integration/Storefront/Integration/ProductVisibilityTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\DataAbstractionLayer\SearchKeywordUpdater;
+use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
@@ -14,6 +15,7 @@ use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -163,7 +165,11 @@ class ProductVisibilityTest extends TestCase
                 continue;
             }
 
-            static::assertInstanceOf(ProductException::class, $e, 'case #' . $index);
+            if (!Feature::isActive('v6.8.0.0')) {
+                static::assertInstanceOf(ProductNotFoundException::class, $e, 'case #' . $index);
+            } else {
+                static::assertInstanceOf(ProductException::class, $e, 'case #' . $index);
+            }
         }
     }
 

--- a/tests/integration/Storefront/Page/Product/QuickView/MinimalQuickViewPageTest.php
+++ b/tests/integration/Storefront/Page/Product/QuickView/MinimalQuickViewPageTest.php
@@ -3,7 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Page\Product\QuickView;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Page\Product\QuickView\MinimalQuickViewPageCriteriaEvent;
@@ -35,7 +35,7 @@ class MinimalQuickViewPageTest extends TestCase
         $request = new Request([], [], ['productId' => '99999911ffff4fffafffffff19830531']);
         $context = $this->createSalesChannelContext();
 
-        $this->expectException(ProductNotFoundException::class);
+        $this->expectException(ProductException::class);
         $this->getPageLoader()->load($request, $context);
     }
 
@@ -47,7 +47,7 @@ class MinimalQuickViewPageTest extends TestCase
         $event = null;
         $this->catchEvent(MinimalQuickViewPageLoadedEvent::class, $event);
 
-        $this->expectException(ProductNotFoundException::class);
+        $this->expectException(ProductException::class);
         $this->getPageLoader()->load($request, $context);
     }
 

--- a/tests/integration/Storefront/Page/Product/QuickView/MinimalQuickViewPageTest.php
+++ b/tests/integration/Storefront/Page/Product/QuickView/MinimalQuickViewPageTest.php
@@ -3,7 +3,9 @@
 namespace Shopware\Tests\Integration\Storefront\Page\Product\QuickView;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Page\Product\QuickView\MinimalQuickViewPageCriteriaEvent;
@@ -35,7 +37,12 @@ class MinimalQuickViewPageTest extends TestCase
         $request = new Request([], [], ['productId' => '99999911ffff4fffafffffff19830531']);
         $context = $this->createSalesChannelContext();
 
-        $this->expectException(ProductException::class);
+        if (!Feature::isActive('v6.8.0.0')) {
+            $this->expectException(ProductNotFoundException::class);
+        } else {
+            $this->expectException(ProductException::class);
+        }
+
         $this->getPageLoader()->load($request, $context);
     }
 
@@ -47,7 +54,12 @@ class MinimalQuickViewPageTest extends TestCase
         $event = null;
         $this->catchEvent(MinimalQuickViewPageLoadedEvent::class, $event);
 
-        $this->expectException(ProductException::class);
+        if (!Feature::isActive('v6.8.0.0')) {
+            $this->expectException(ProductNotFoundException::class);
+        } else {
+            $this->expectException(ProductException::class);
+        }
+
         $this->getPageLoader()->load($request, $context);
     }
 

--- a/tests/integration/Storefront/Page/ProductPageTest.php
+++ b/tests/integration/Storefront/Page/ProductPageTest.php
@@ -7,8 +7,8 @@ use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockCollection;
 use Shopware\Core\Content\Cms\CmsPageEntity;
 use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
 use Shopware\Core\Content\Cms\DataResolver\FieldConfigCollection;
-use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -40,7 +40,7 @@ class ProductPageTest extends TestCase
         $request = new Request([], [], ['productId' => '99999911ffff4fffafffffff19830531']);
         $context = $this->createSalesChannelContextWithNavigation();
 
-        $this->expectException(ProductNotFoundException::class);
+        $this->expectException(ProductException::class);
         $this->getPageLoader()->load($request, $context);
     }
 
@@ -52,7 +52,7 @@ class ProductPageTest extends TestCase
         $event = null;
         $this->catchEvent(ProductPageLoadedEvent::class, $event);
 
-        $this->expectException(ProductNotFoundException::class);
+        $this->expectException(ProductException::class);
         $this->getPageLoader()->load($request, $context);
     }
 
@@ -120,7 +120,7 @@ class ProductPageTest extends TestCase
         $event = null;
         $this->catchEvent(ProductPageLoadedEvent::class, $event);
 
-        $this->expectException(ProductNotFoundException::class);
+        $this->expectException(ProductException::class);
         $this->getPageLoader()->load($request, $context);
     }
 

--- a/tests/integration/Storefront/Page/ProductPageTest.php
+++ b/tests/integration/Storefront/Page/ProductPageTest.php
@@ -7,9 +7,11 @@ use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockCollection;
 use Shopware\Core\Content\Cms\CmsPageEntity;
 use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
 use Shopware\Core\Content\Cms\DataResolver\FieldConfigCollection;
+use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -40,7 +42,12 @@ class ProductPageTest extends TestCase
         $request = new Request([], [], ['productId' => '99999911ffff4fffafffffff19830531']);
         $context = $this->createSalesChannelContextWithNavigation();
 
-        $this->expectException(ProductException::class);
+        if (!Feature::isActive('v6.8.0.0')) {
+            $this->expectException(ProductNotFoundException::class);
+        } else {
+            $this->expectException(ProductException::class);
+        }
+
         $this->getPageLoader()->load($request, $context);
     }
 
@@ -52,7 +59,12 @@ class ProductPageTest extends TestCase
         $event = null;
         $this->catchEvent(ProductPageLoadedEvent::class, $event);
 
-        $this->expectException(ProductException::class);
+        if (!Feature::isActive('v6.8.0.0')) {
+            $this->expectException(ProductNotFoundException::class);
+        } else {
+            $this->expectException(ProductException::class);
+        }
+
         $this->getPageLoader()->load($request, $context);
     }
 
@@ -120,7 +132,12 @@ class ProductPageTest extends TestCase
         $event = null;
         $this->catchEvent(ProductPageLoadedEvent::class, $event);
 
-        $this->expectException(ProductException::class);
+        if (!Feature::isActive('v6.8.0.0')) {
+            $this->expectException(ProductNotFoundException::class);
+        } else {
+            $this->expectException(ProductException::class);
+        }
+
         $this->getPageLoader()->load($request, $context);
     }
 

--- a/tests/migration/Core/V6_7/Migration1749644517AddListingVariantNameSystemConfigOptionTest.php
+++ b/tests/migration/Core/V6_7/Migration1749644517AddListingVariantNameSystemConfigOptionTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1749644517AddListingVariantNameSystemConfigOption;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1749644517AddListingVariantNameSystemConfigOption::class)]
+class Migration1749644517AddListingVariantNameSystemConfigOptionTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+        $this->connection->delete('system_config', ['configuration_key' => 'core.listing.showVariantOptionInSearchSuggestionResult']);
+    }
+
+    public function testMigration(): void
+    {
+        static::assertEmpty($this->getConfig());
+
+        $migration = new Migration1749644517AddListingVariantNameSystemConfigOption();
+        $migration->update($this->connection);
+
+        $record = $this->getConfig();
+
+        static::assertArrayHasKey('configuration_key', $record);
+        static::assertArrayHasKey('configuration_value', $record);
+        static::assertSame('core.listing.showVariantOptionInSearchSuggestionResult', $record['configuration_key']);
+
+        $value = \sprintf('{"_value": "%s"}', Uuid::randomHex());
+        $this->connection->update('system_config', ['configuration_value' => $value], ['configuration_key' => 'core.listing.showVariantOptionInSearchSuggestionResult']);
+
+        $migration->update($this->connection);
+
+        $record = $this->getConfig();
+
+        static::assertArrayHasKey('configuration_key', $record);
+        static::assertArrayHasKey('configuration_value', $record);
+        static::assertSame('core.listing.showVariantOptionInSearchSuggestionResult', $record['configuration_key']);
+        static::assertSame($value, $record['configuration_value']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getConfig(): array
+    {
+        return $this->connection->fetchAssociative(
+            'SELECT * FROM system_config WHERE configuration_key = \'core.listing.showVariantOptionInSearchSuggestionResult\''
+        ) ?: [];
+    }
+}

--- a/tests/unit/Core/Content/Product/ProductExceptionTest.php
+++ b/tests/unit/Core/Content/Product/ProductExceptionTest.php
@@ -59,6 +59,18 @@ class ProductExceptionTest extends TestCase
         static::assertSame(['property' => $property], $exception->getParameters());
     }
 
+    public function testProductNotFound(): void
+    {
+        $productId = 'product-id';
+
+        $exception = ProductException::productNotFound($productId);
+
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(ProductException::PRODUCT_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Could not find product with id "product-id"', $exception->getMessage());
+        static::assertSame(['entity' => 'product', 'field' => 'id', 'value' => $productId], $exception->getParameters());
+    }
+
     public function testCategoryNotFound(): void
     {
         $categoryId = 'category-id';

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
@@ -24,6 +25,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
@@ -306,7 +308,11 @@ class ProductDetailRouteTest extends TestCase
 
     public function testLoadProductNotFound(): void
     {
-        $this->expectException(ProductException::class);
+        if (!Feature::isActive('v6.8.0.0')) {
+            $this->expectException(ProductNotFoundException::class);
+        } else {
+            $this->expectException(ProductException::class);
+        }
 
         $this->route->load('1', new Request(), $this->context, new Criteria());
     }

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -10,8 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
-use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\Detail\Event\ResolveVariantIdEvent;
 use Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader;
@@ -150,6 +150,43 @@ class ProductDetailRouteTest extends TestCase
         static::assertTrue($result->getProduct()->getAvailable());
     }
 
+    public function testLoadBestVariantByTerm(): void
+    {
+        $productTerm = new SalesChannelProductEntity();
+        $productTerm->setCmsPageId('term');
+        $productTerm->setId($this->idsCollection->create('term'));
+        $productTerm->setUniqueIdentifier('term');
+        $productTerm->setName('term');
+
+        $idsSearchResult = new IdSearchResult(
+            1,
+            [
+                [
+                    'primaryKey' => $this->idsCollection->get('product1'),
+                    'data' => [],
+                ],
+            ],
+            new Criteria(),
+            $this->context->getContext()
+        );
+        $this->productRepository->method('searchIds')
+            ->willReturn(
+                $idsSearchResult
+            );
+        $this->productRepository->expects($this->once())
+            ->method('search')
+            ->willReturnOnConsecutiveCalls(
+                new EntitySearchResult('product', 4, new ProductCollection([$productTerm]), null, new Criteria(), $this->context->getContext())
+            );
+        $request = new Request();
+        $request->query->set('search', 'term');
+
+        $result = $this->route->load($this->idsCollection->get('product1'), $request, $this->context, new Criteria());
+
+        static::assertSame('term', $result->getProduct()->getCmsPageId());
+        static::assertSame('term', $result->getProduct()->getUniqueIdentifier());
+    }
+
     public function testLoadVariantListingConfig(): void
     {
         $this->connection
@@ -269,7 +306,7 @@ class ProductDetailRouteTest extends TestCase
 
     public function testLoadProductNotFound(): void
     {
-        $this->expectException(ProductNotFoundException::class);
+        $this->expectException(ProductException::class);
 
         $this->route->load('1', new Request(), $this->context, new Criteria());
     }


### PR DESCRIPTION
This pull request introduces functionality to ensure that products with variants return the most relevant variant matching the search term on the product detail page. It includes changes to the backend logic, storefront templates, and styles, along with corresponding unit tests.

### Core Functionality Enhancements:
* Updated `ProductDetailRoute` in `Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute` to handle search terms and return the best-matching variant using a new method, `findBestVariantByTerm`. This method filters variants based on the search term provided in the request. [[1]](diffhunk://#diff-cb9fa9dfc8f95fb7c43a2fb8ff60c815b8793ebe857fafcc3820421b4841291eL77-R84) [[2]](diffhunk://#diff-cb9fa9dfc8f95fb7c43a2fb8ff60c815b8793ebe857fafcc3820421b4841291eR200-R214)

* Before:
https://github.com/user-attachments/assets/8f36429b-9b38-43d6-8924-00e695ab107d

* After:
https://github.com/user-attachments/assets/35081912-ce6e-444e-b59f-b8b9db2c0243



### Storefront Template Updates:
* Modified `box-standard.html.twig` to pass the search term and product ID as route arguments when navigating to the product detail page. [[1]](diffhunk://#diff-7c2faf5b60c3fd2c552ea2143fa88e07c1bf9f41887b73ed6fd228afed8946acR11-R14) [[2]](diffhunk://#diff-7c2faf5b60c3fd2c552ea2143fa88e07c1bf9f41887b73ed6fd228afed8946acL111-R121)
* Enhanced `search-suggest.html.twig` to display variant options in the search suggestion results, showing both the product name and its variations.

* Before:
<img width="1141" alt="Screenshot 2025-06-05 at 14 47 56" src="https://github.com/user-attachments/assets/95d87727-2628-4eaf-ba3c-939817731009" />

* After:
![image](https://github.com/user-attachments/assets/ba6d5899-dced-489d-b48d-b25076b98c53)


* Enable / Disable in the admin settings
![image](https://github.com/user-attachments/assets/ee867077-a874-4a95-aad1-66b4dd56c2d7)

