### PR TITLE
fix: generate variants shows NaN%

### DIFF
--- a/changelog/_unreleased/2025-06-05-fix-generating-variants-shows-nan.md
+++ b/changelog/_unreleased/2025-06-05-fix-generating-variants-shows-nan.md
@@ -1,0 +1,7 @@
+---
+title: Fix generating variants shows NaN%
+issue: 10120
+---
+# Administration
+* Deprecated `progressInPercentage` computed property in `sw-product-modal-variant-generation` component
+* Changed `sw-product-modal-variant-generation` component template to correct the usage of `mt-progress-bar` component

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/index.js
@@ -91,6 +91,7 @@ export default {
             return this.repositoryFactory.create('media');
         },
 
+        // @deprecated tag:v6.8.0 - Will be removed, no longer needed
         progressInPercentage() {
             return this.actualProgress / (this.maxProgress * 100);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.html.twig
@@ -301,7 +301,8 @@
             >
                 <mt-progress-bar
                     class="generate-variant-progress-bar"
-                    :model-value="progressInPercentage"
+                    :model-value="actualProgress"
+                    :max-value="maxProgress"
                 />
 
                 <span class="generate-variant-progress-bar__description">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

There is a NaN% displayed in the progress bar when generating variants

### 2. What does this change do, exactly?

Passing down the correct data to the progress bar

### 3. Describe each step to reproduce the issue or behaviour.

Go to a product and create lots of variants.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

_

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
