### PR TITLE
fix: checkout product number input width

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
@@ -81,10 +81,6 @@ $cart-grid-gutter-width: $spacer-sm;
         display: block;
     }
 
-    .cart-add-product {
-        max-width: 250px;
-    }
-
     .cart-add-product-container {
         margin-bottom: 0;
     }

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -73,10 +73,8 @@
         {% block page_checkout_cart_add_product_and_shipping %}
             <div class="row">
                 {% block page_checkout_cart_add_product %}
-                    <div class="col-md-4 cart-add-product-container">
-                        <form action="{{ path('frontend.checkout.product.add-by-number') }}"
-                              class="cart-add-product"
-                              method="post">
+                    <div class="col-md-5 cart-add-product-container">
+                        <form action="{{ path('frontend.checkout.product.add-by-number') }}" method="post">
                             {% block page_checkout_cart_add_product_redirect %}
                                 <input type="hidden"
                                        name="redirectTo"
@@ -117,7 +115,7 @@
                 {% endblock %}
 
                 {% block page_checkout_cart_shipping_costs %}
-                    <div class="col-md-8 cart-shipping-costs-container">
+                    <div class="col-md-7 cart-shipping-costs-container">
                         <form name="precalc"
                               method="post"
                               action="{{ path('frontend.checkout.configure') }}"


### PR DESCRIPTION
fixes #10052 

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

You cannot see the placeholder in full without adjusting the width of the input. It is cut off.

### 2. What does this change do, exactly?

- Remove the max-width from the form
- Adjusted the column width

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
