### PR TITLE
fix: shipping address selectable with disabled shipping for country

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/address-manager/address-manager.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/address-manager/address-manager.plugin.js
@@ -190,11 +190,16 @@ export default class AddressManagerPlugin extends Plugin {
             return;
         }
 
+        const radio = element.querySelector('input[type="radio"]');
+        if (radio?.disabled) {
+            return;
+        }
+
         type === SHIPPING
             ? document.querySelector(this.options.currentShippingIdSelector).value = id
             : document.querySelector(this.options.currentBillingIdSelector).value = id;
 
-        element.querySelector('input[type="radio"]').checked = true;
+        radio.checked = true;
     }
 
     /**

--- a/src/Storefront/Resources/views/storefront/component/address/address-manager-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-manager-item.html.twig
@@ -10,6 +10,7 @@
                         id="{{ type }}-{{ address.id }}"
                         data-address-type="{{ type }}"
                         {% if address.id == activeAddressId %}checked{% endif %}
+                        {% if type === 'shipping' and not address.country.shippingAvailable %}disabled{% endif %}
                         class="form-check-input col-auto"
                     />
 
@@ -47,7 +48,7 @@
                                         {{ 'global.default.edit'|trans|sw_sanitize }}
                                     </a>
                                 </li>
-                                {% if defaultAddressId !== address.id %}
+                                {% if defaultAddressId !== address.id and not (type === 'shipping' and not address.country.shippingAvailable) %}
                                     <li>
                                         <a
                                             class="dropdown-item address-manager-modal-set-default-address"


### PR DESCRIPTION
### 1. Why is this change necessary?
Shipping addresses are selectable, if countries are not available for shipping

### 2. What does this change do, exactly?
Disables the selection and hides the `set as default shipping address` button (the latter only shows up after another fix in Commercial: shopware/SwagCommercial#750)

### 3. Describe each step to reproduce the issue or behaviour.
- Set a country to `Shipping` not available in the country settings
- Create an address with that country in the Storefront account backend
- Try to checkout and select that address in the checkout (not in the account backend, there the filtering already worked)

### 4. Please link to the relevant issues (if any).
fixes #10151

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
