### PR TITLE
fix: Product variants empty state list position doesnt correct

### DIFF
--- a/changelog/_unreleased/2025-06-05-product-variants-empty-state-list-position-doesn-t-correct.md
+++ b/changelog/_unreleased/2025-06-05-product-variants-empty-state-list-position-doesn-t-correct.md
@@ -1,0 +1,9 @@
+---
+title: Product variants empty state list position doesn't correct
+issue: #10006
+author: Le Nguyen
+author_email: nguyenquocdaile@gmail.com
+author_github: @Le Nguyen
+---
+# Administration
+* Deprecated `sw_product_detail_variants_sw_card_empty_state` due to duplicated empty state.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.html.twig
@@ -44,42 +44,23 @@
 
         <sw-skeleton v-if="isLoading" />
 
+        {# @deprecated tag:v6.8.0 - Will be removed without replacement #}
         {% block sw_product_detail_variants_sw_card_empty_state %}
-        <sw-empty-state
-            v-else-if="!propertiesAvailable"
-            class="sw-product-detail-variants__generated-variants-empty-state"
-            :absolute="false"
-            :title="$tc('sw-product.variations.emptyStatePropertyTitle')"
-            :subline="$tc('sw-product.variations.emptyStatePropertyDescription')"
-        >
+        {% endblock %}
 
-            <template #icon>
-                {% block sw_product_properties_empty_state_image %}
-                <img
-                    :src="assetFilter('/administration/administration/static/img/empty-states/products-empty-state.svg')"
-                    :alt="$tc('sw-product.properties.titleEmptyState')"
-                >
-                {% endblock %}
-            </template>
-
-            <template #actions>
-                {% block sw_product_properties_empty_state_button_property %}
-                <mt-button
-                    v-tooltip="{
-                        message: $tc('sw-privileges.tooltip.warning'),
-                        disabled: acl.can('product.editor'),
-                        showOnDisabledElements: true
-                    }"
-                    ghost
-                    :disabled="!acl.can('product.editor')"
-                    variant="secondary"
-                    @click="openAddPropertiesModal"
-                >
-                    {{ $tc('sw-product.properties.buttonAddProperties') }}
-                </mt-button>
-                {% endblock %}
-            </template>
-        </sw-empty-state>
+        {% block sw_product_detail_variants_sw_card_generated_variants_overview %}
+        <sw-product-variants-overview
+            v-if="product.id"
+            v-show="variantListHasContent && !isLoading"
+            ref="generatedVariants"
+            :product-states="currentProductStates"
+            :groups="groups"
+            :selected-groups="configSettingGroups"
+            :product-entity="productEntity"
+            @variants-finish-update="updateVariantListHasContent"
+            @generator-open="openModal('variantGeneration')"
+            @delivery-open="openModal('deliveryModal')"
+        />
         {% endblock %}
 
         {% block sw_product_detail_variants_sw_card_empty_state_variant %}
@@ -120,22 +101,6 @@
             </template>
         </sw-empty-state>
         {% endblock %}
-
-        {% block sw_product_detail_variants_sw_card_generated_variants_overview %}
-        <sw-product-variants-overview
-            v-if="product.id"
-            v-show="variantListHasContent && !isLoading"
-            ref="generatedVariants"
-            :product-states="currentProductStates"
-            :groups="groups"
-            :selected-groups="configSettingGroups"
-            :product-entity="productEntity"
-            @variants-finish-update="updateVariantListHasContent"
-            @generator-open="openModal('variantGeneration')"
-            @delivery-open="openModal('deliveryModal')"
-        />
-        {% endblock %}
-
     </mt-card>
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
@@ -206,16 +206,16 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
 
         await wrapper.setData({
             groups: [{}],
-            propertiesAvailable: false,
+            propertiesAvailable: true,
             isLoading: false,
         });
 
         await flushPromises();
 
         expect(wrapper.vm).toBeTruthy();
-        expect(wrapper.find('.sw-empty-state__title').text()).toBe('sw-product.variations.emptyStatePropertyTitle');
+        expect(wrapper.find('.sw-empty-state__title').text()).toBe('sw-product.variations.emptyStateTitle');
         expect(wrapper.find('.sw-empty-state__description-content').text()).toBe(
-            'sw-product.variations.emptyStatePropertyDescription',
+            'sw-product.variations.emptyStateDescription',
         );
     });
 


### PR DESCRIPTION
### Solution 

Empty state with no variant generated
![Screenshot 2025-06-05 at 16 00 26](https://github.com/user-attachments/assets/7a936cb4-71cc-495a-8f30-7173e110e48f)

Empty state with no result found
![Screenshot 2025-06-05 at 16 01 30](https://github.com/user-attachments/assets/d5300bc8-9846-4ad3-921e-e6fb0d2f8cee)
