### PR TITLE
fix: use latest version of webinstaller in integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -261,13 +261,6 @@ jobs:
           composer -d src/Storefront config version ${SW_RECOVERY_NEXT_VERSION}
           composer -d src/Elasticsearch config version ${SW_RECOVERY_NEXT_VERSION}
 
-      - name: Build updater
-        working-directory: new-shopware/src/WebInstaller
-        run: |
-          composer config platform.php 8.2
-          composer install
-          composer build-phar
-
       - name: Checkout template
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
         with:
@@ -288,8 +281,9 @@ jobs:
           sed -i -e "s/shopware.store.frw: '1'/shopware.store.frw: '0'"/ config/services.yaml
           bin/console system:install --basic-setup --drop-database --create-database
 
-      - name: Copy WebInstaller
-        run: cp new-shopware/src/WebInstaller/shopware-installer.phar.php old-shopware/public/shopware-installer.phar.php
+      - name: Download latest WebInstaller
+        run: |
+          curl -L https://github.com/shopware/web-installer/releases/latest/download/shopware-installer.phar.php -o old-shopware/public/shopware-installer.phar.php
 
       - name: Start web server
         working-directory: old-shopware


### PR DESCRIPTION
With this PR https://github.com/shopware/shopware/pull/9482 we removed the webinstaller from the platform repo in favor of it's own repo

This was by design not backported, however this meant that the latest version of the webinstaller was not in the repo anymore, but the pipeline used the version from the repo, so that lead to issues as esp. this check is missing in the 6.7.0.0 version of the webinstaller: https://github.com/shopware/web-installer/blob/main/Services/ProjectComposerJsonUpdater.php#L111