### PR TITLE
fix: offcanvas breaking lines

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_offcanvas-cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_offcanvas-cart.scss
@@ -21,6 +21,19 @@ Extends the basic offcanvas component with additional cart styles.
 
 .offcanvas-summary-list {
     margin-bottom: 0;
+    justify-content: space-between;
+
+    > * {
+        width: initial;
+    }
+}
+
+.offcanvas-shipping-info {
+    justify-content: space-between;
+
+    > * {
+        width: initial;
+    }
 }
 
 .offcanvas-cart-promotion-form {

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
@@ -12,13 +12,13 @@
         <dl class="row offcanvas-summary-list" aria-label="{{ 'checkout.summaryOffCanvasLabel'|trans|striptags }}">
             {% block component_offcanvas_summary_total %}
                 {% block component_offcanvas_summary_total_label %}
-                    <dt class="col-8 summary-label summary-total">
+                    <dt class="summary-label summary-total">
                         {{ 'checkout.subtotalAmount'|trans|sw_sanitize }}
                     </dt>
                 {% endblock %}
 
                 {% block component_offcanvas_summary_total_value %}
-                    <dd class="col-4 summary-value summary-total">
+                    <dd class="summary-value summary-total">
                         <strong>{{ page.cart.price.positionPrice|currency }}</strong>
                     </dd>
                 {% endblock %}
@@ -29,7 +29,7 @@
             {% for activeShipping in page.cart.deliveries.elements %}
                 {% block component_offcanvas_summary_content_info %}
                     <div class="row offcanvas-shipping-info">
-                        <span class="col-8 shipping-label shipping-cost">
+                        <span class="shipping-label shipping-cost">
                             <strong>{{ 'checkout.summaryShipping'|trans|sw_sanitize }}</strong>
                             {% if loop.first %}
                                 {% if page.shippingMethods|length %}
@@ -42,7 +42,7 @@
                             {% endif %}
                         </span>
 
-                        <span class="col-4 pb-2 shipping-value shipping-cost">
+                        <span class="pb-2 shipping-value shipping-cost">
                             {% set shippingTotalPrice = activeShipping.shippingCosts.totalPrice ?? 0 %}
                             <strong>{{ shippingTotalPrice < 0 ? '&minus;' : '+' }} {{ shippingTotalPrice|abs|currency }}</strong>
                         </span>


### PR DESCRIPTION
fixes #10049 

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If the subtotal and shipping costs are too high, the number will be too large and the lines will break.

### 2. What does this change do, exactly?

Removed the columns 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
