### PR TITLE
fix: remove import/export profiles grid height enforcement

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/view/sw-import-export-view-profiles/sw-import-export-view-profiles.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/view/sw-import-export-view-profiles/sw-import-export-view-profiles.scss
@@ -5,6 +5,10 @@
         .sw-data-grid.sw-data-grid--full-page {
             padding-top: 83px;
         }
+
+        .mt-card__content {
+            padding: 0;
+        }
     }
 
     .sw-import-export-view-profiles__toolbar {

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/view/sw-import-export-view-profiles/sw-import-export-view-profiles.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/view/sw-import-export-view-profiles/sw-import-export-view-profiles.scss
@@ -2,10 +2,6 @@
 
 .sw-import-export-view-profiles {
     .sw-import-export-view-profiles__grid-card {
-        .mt-card__content {
-            height: 600px;
-        }
-
         .sw-data-grid.sw-data-grid--full-page {
             padding-top: 83px;
         }


### PR DESCRIPTION
fixes: #10003 

Due to the height constraint the pagination is not visible and overflow is hidden, removing the height fixes these