### PR TITLE
fix: twig block in admin

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/component.spec.js
@@ -46,4 +46,19 @@ describe('module/sw-cms/elements/form/component', () => {
     it.each(formTemplates)('should render form of type "%s"', async (type) => {
         expect((await createWrapper(type)).get(type)).toBeTruthy();
     });
+
+    it('should return correct selectedForm for type "contact"', async () => {
+        const wrapper = await createWrapper('contact');
+        expect(wrapper.vm.selectedForm).toBe('sw-cms-el-form-template-contact');
+    });
+
+    it('should return correct selectedForm for type "newsletter"', async () => {
+        const wrapper = await createWrapper('newsletter');
+        expect(wrapper.vm.selectedForm).toBe('sw-cms-el-form-template-newsletter');
+    });
+
+    it('should return the type value for unknown types', async () => {
+        const wrapper = await createWrapper('custom-type');
+        expect(wrapper.vm.selectedForm).toBe('custom-type');
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/index.js
@@ -1,6 +1,4 @@
 import template from './sw-cms-el-form.html.twig';
-import contact from './templates/form-contact/index';
-import newsletter from './templates/form-newsletter/index';
 import './sw-cms-el-form.scss';
 
 const { Mixin } = Shopware;
@@ -16,13 +14,14 @@ export default {
         Mixin.getByName('cms-element'),
     ],
 
-    components: {
-        contact,
-        newsletter,
-    },
-
     computed: {
         selectedForm() {
+            if (this.element.config.type.value === 'contact') {
+                return 'sw-cms-el-form-template-contact';
+            }
+            if (this.element.config.type.value === 'newsletter') {
+                return 'sw-cms-el-form-template-newsletter';
+            }
             return this.element.config.type.value;
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/form.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/form.spec.js
@@ -10,5 +10,7 @@ describe('src/module/sw-cms/elements/form', () => {
         component: 'sw-cms-el-form',
         config: 'sw-cms-el-config-form',
         preview: 'sw-cms-el-preview-form',
+        contact: 'sw-cms-el-form-template-contact',
+        newsletter: 'sw-cms-el-form-template-newsletter',
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/index.ts
@@ -13,6 +13,16 @@ Shopware.Component.register('sw-cms-el-config-form', () => import('./config'));
  * @sw-package discovery
  */
 Shopware.Component.register('sw-cms-el-form', () => import('./component'));
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-el-form-template-contact', () => import('./component/templates/form-contact'));
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-el-form-template-newsletter', () => import('./component/templates/form-newsletter'));
 
 /**
  * @private


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Twig blocks not rendered in cms form element:
![image](https://github.com/user-attachments/assets/84248f2c-61a7-4aa3-86e9-8b691eccc13f)


### 2. What does this change do, exactly?
Render twig instead of printing it to the UI
![image](https://github.com/user-attachments/assets/a63ce533-5fda-4a1f-b78a-bf245b41522d)



### 3. Describe each step to reproduce the issue or behaviour.
use an form element in the cms

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
fixes #7013 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
