### PR TITLE
fix: Disable change field when inherited enable

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.html.twig
@@ -27,6 +27,7 @@
                 }"
                 selected=""
                 class="sw-category-tree-field__selected-label"
+                :dismissable="!disabled"
                 @dismiss="removeItem(selectedCategory)"
             >
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
@@ -188,6 +188,7 @@
                 class="sw-product-category-form__search-keyword-field"
                 :value="currentValue ? currentValue : []"
                 :placeholder="$tc('sw-product.categoryForm.placeholderSearchKeywords')"
+                :disabled="isInherited || !allowEdit"
                 @update:value="updateCurrentValue"
             >
                 <template #message-add-data>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.html.twig
@@ -286,6 +286,7 @@
             :disabled="isGenerateButtonDisabled"
             class="sw-product-variant-generation__generate-action"
             :variant="buttonVariant"
+            :is-loading="isLoading"
             size="small"
             @click="generateVariants()"
         >


### PR DESCRIPTION
Fixes #10136 
Fixes #10143 

### Solution 

![image](https://github.com/user-attachments/assets/017794c2-ecc0-4218-9048-8ba6d3139cc4)

Also, fix the prevent double-click save button when generating variants

https://github.com/user-attachments/assets/762a9b2f-c88b-4849-a134-8482529cb685

