### PR TITLE
fix: Revert and fix some asset loading

### DIFF
--- a/src/Administration/Resources/views/administration/index.html.twig
+++ b/src/Administration/Resources/views/administration/index.html.twig
@@ -5,7 +5,7 @@
         window._features_ = {{ features|json_encode|raw }};
 
         window.__sw__ = {
-            assetPath: '{{ asset('') }}',
+            assetPath: '{{ asset('', 'asset') }}',
         };
     </script>
 {% endblock %}
@@ -56,7 +56,7 @@
                     liveVersionId: '{{ liveVersionId }}',
                     systemLanguageId: '{{ systemLanguageId }}',
                     apiVersion: {{ apiVersion }},
-                    assetPath: '{{ asset('') }}'
+                    assetPath: '{{ asset('', 'asset') }}'
                 },
                 appContext: {
                     features: window._features_,

--- a/src/Core/Installer/Resources/views/installer/base.html.twig
+++ b/src/Core/Installer/Resources/views/installer/base.html.twig
@@ -7,20 +7,20 @@
 
         <title>{{ "shopware.installer.header_title"|trans }} | Shopware 6</title>
 
-        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('bundles/installer/assets/images/favicon/favicon-16x16.png', 'public') }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('bundles/installer/assets/images/favicon/favicon-32x32.png', 'public') }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('bundles/installer/assets/images/favicon/favicon-16x16.png', 'asset') }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('bundles/installer/assets/images/favicon/favicon-32x32.png', 'asset') }}">
         <meta name="msapplication-TileColor" content="#189eff">
         <meta name="theme-color" content="#189eff">
 
-        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/reset.css', 'public') }}?v={{ shopware.version }}" media="all"/>
-        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/fonts.css', 'public') }}?v={{ shopware.version }}" media="all"/>
-        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/icons.css', 'public') }}?v={{ shopware.version }}" media="all"/>
-        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/style.css', 'public') }}?v={{ shopware.version }}" media="all"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/reset.css', 'asset') }}?v={{ shopware.version }}" media="all"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/fonts.css', 'asset') }}?v={{ shopware.version }}" media="all"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/icons.css', 'asset') }}?v={{ shopware.version }}" media="all"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/style.css', 'asset') }}?v={{ shopware.version }}" media="all"/>
     </head>
     <body>
         <header class="header-main">
             <div class="header-main__branding">
-                <img class="header-main__logo" src="{{ asset('bundles/installer/assets/images/sw-logo-blue.svg', 'public') }}" width="148" alt="Shopware">
+                <img class="header-main__logo" src="{{ asset('bundles/installer/assets/images/sw-logo-blue.svg', 'asset') }}" width="148" alt="Shopware">
                 <div class="header-main__title">
                     {{ "shopware.installer.header_title"|trans }}
                 </div>

--- a/src/Core/Installer/Resources/views/installer/base.html.twig
+++ b/src/Core/Installer/Resources/views/installer/base.html.twig
@@ -7,20 +7,20 @@
 
         <title>{{ "shopware.installer.header_title"|trans }} | Shopware 6</title>
 
-        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('bundles/installer/assets/images/favicon/favicon-16x16.png') }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('bundles/installer/assets/images/favicon/favicon-32x32.png') }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('bundles/installer/assets/images/favicon/favicon-16x16.png', 'public') }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('bundles/installer/assets/images/favicon/favicon-32x32.png', 'public') }}">
         <meta name="msapplication-TileColor" content="#189eff">
         <meta name="theme-color" content="#189eff">
 
-        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/reset.css') }}?v={{ shopware.version }}" media="all"/>
-        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/fonts.css') }}?v={{ shopware.version }}" media="all"/>
-        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/icons.css') }}?v={{ shopware.version }}" media="all"/>
-        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/style.css') }}?v={{ shopware.version }}" media="all"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/reset.css', 'public') }}?v={{ shopware.version }}" media="all"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/fonts.css', 'public') }}?v={{ shopware.version }}" media="all"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/icons.css', 'public') }}?v={{ shopware.version }}" media="all"/>
+        <link rel="stylesheet" type="text/css" href="{{ asset('bundles/installer/assets/styles/style.css', 'public') }}?v={{ shopware.version }}" media="all"/>
     </head>
     <body>
         <header class="header-main">
             <div class="header-main__branding">
-                <img class="header-main__logo" src="{{ asset('bundles/installer/assets/images/sw-logo-blue.svg') }}" width="148" alt="Shopware">
+                <img class="header-main__logo" src="{{ asset('bundles/installer/assets/images/sw-logo-blue.svg', 'public') }}" width="148" alt="Shopware">
                 <div class="header-main__title">
                     {{ "shopware.installer.header_title"|trans }}
                 </div>

--- a/src/Core/Installer/Resources/views/installer/language-selection.html.twig
+++ b/src/Core/Installer/Resources/views/installer/language-selection.html.twig
@@ -9,7 +9,7 @@
         <div class="card__body is--align-center">
 
             <div class="welcome-illustration">
-                <img src="{{ asset('bundles/installer/assets/images/welcome.svg', 'public') }}" alt="">
+                <img src="{{ asset('bundles/installer/assets/images/welcome.svg', 'asset') }}" alt="">
             </div>
 
             <div class="welcome-container">
@@ -28,7 +28,7 @@
 
                 <div class="select-wrapper language">
                     <img class="language-flag"
-                         src="{{ asset('bundles/installer/assets/images/flags/' ~ app.request.locale ~ '.png', 'public') }}"
+                         src="{{ asset('bundles/installer/assets/images/flags/' ~ app.request.locale ~ '.png', 'asset') }}"
                          alt="{{ app.request.locale }}">
                     <select id="language" name="language" class="language-selection" onchange="this.form.submit();">
                         {% for language in supportedLanguages %}

--- a/src/Core/Installer/Resources/views/installer/language-selection.html.twig
+++ b/src/Core/Installer/Resources/views/installer/language-selection.html.twig
@@ -9,7 +9,7 @@
         <div class="card__body is--align-center">
 
             <div class="welcome-illustration">
-                <img src="{{ asset('bundles/installer/assets/images/welcome.svg') }}" alt="">
+                <img src="{{ asset('bundles/installer/assets/images/welcome.svg', 'public') }}" alt="">
             </div>
 
             <div class="welcome-container">
@@ -28,7 +28,7 @@
 
                 <div class="select-wrapper language">
                     <img class="language-flag"
-                         src="{{ asset('bundles/installer/assets/images/flags/' ~ app.request.locale ~ '.png') }}"
+                         src="{{ asset('bundles/installer/assets/images/flags/' ~ app.request.locale ~ '.png', 'public') }}"
                          alt="{{ app.request.locale }}">
                     <select id="language" name="language" class="language-selection" onchange="this.form.submit();">
                         {% for language in supportedLanguages %}


### PR DESCRIPTION
### 1. Why is this change necessary?

My assumption was wrong, that `'asset'` as package name could be left out, as it gives the same result. 
But it could be possible, that it is configured differently and therefore the change would mean a break. 
See https://github.com/shopware/shopware/blob/trunk/src/Core/Framework/Resources/config/packages/shopware.yaml#L147

### 2. What does this change do, exactly?

Partly revert https://github.com/shopware/shopware/pull/10324 and set the correct package name for the installer.
I already fixed that in the backport https://github.com/shopware/shopware/pull/10334

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
