### PR TITLE
fix: Reset value if below or equals zero

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
@@ -179,11 +179,5 @@ export default {
         generateFinish() {
             this.isGenerateSuccessful = false;
         },
-
-        checkPromotionMaxValue(property) {
-            if (this.promotion[property] <= 0) {
-                this.promotion[property] = null;
-            }
-        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
@@ -184,6 +184,6 @@ export default {
             if (value <= 0) {
                 this.promotion[property] = null;
             }
-        }
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
@@ -179,5 +179,11 @@ export default {
         generateFinish() {
             this.isGenerateSuccessful = false;
         },
+
+        checkPromotionMaxValue(value, property) {
+            if (value <= 0) {
+                this.promotion[property] = null;
+            }
+        }
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
@@ -180,8 +180,8 @@ export default {
             this.isGenerateSuccessful = false;
         },
 
-        checkPromotionMaxValue(value, property) {
-            if (value <= 0) {
+        checkPromotionMaxValue(property) {
+            if (this.promotion[property] <= 0) {
                 this.promotion[property] = null;
             }
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
@@ -84,6 +84,7 @@
                 :label="$tc('sw-promotion-v2.detail.base.general.maxUsesGlobalLabel')"
                 :placeholder="$tc('sw-promotion-v2.detail.base.general.maxUsesGlobalPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
+                @blur="checkPromotionMaxValue(promotion.maxRedemptionsGlobal, 'maxRedemptionsGlobal')"
                 allow-empty
             />
             {% endblock %}
@@ -96,6 +97,7 @@
                 :label="$tc('sw-promotion-v2.detail.base.general.maxUsesPerCustomerLabel')"
                 :placeholder="$tc('sw-promotion-v2.detail.base.general.maxUsesPerCustomerPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
+                @blur="checkPromotionMaxValue(promotion.maxRedemptionsPerCustomer, 'maxRedemptionsPerCustomer')"
                 allow-empty
             />
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
@@ -84,8 +84,8 @@
                 :label="$tc('sw-promotion-v2.detail.base.general.maxUsesGlobalLabel')"
                 :placeholder="$tc('sw-promotion-v2.detail.base.general.maxUsesGlobalPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
+                :min="1"
                 allow-empty
-                @blur="checkPromotionMaxValue('maxRedemptionsGlobal')"
             />
             {% endblock %}
 
@@ -97,8 +97,8 @@
                 :label="$tc('sw-promotion-v2.detail.base.general.maxUsesPerCustomerLabel')"
                 :placeholder="$tc('sw-promotion-v2.detail.base.general.maxUsesPerCustomerPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
+                :min="1"
                 allow-empty
-                @blur="checkPromotionMaxValue('maxRedemptionsPerCustomer')"
             />
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
@@ -85,7 +85,7 @@
                 :placeholder="$tc('sw-promotion-v2.detail.base.general.maxUsesGlobalPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
                 allow-empty
-                @blur="checkPromotionMaxValue(promotion.maxRedemptionsGlobal, 'maxRedemptionsGlobal')"
+                @blur="checkPromotionMaxValue('maxRedemptionsGlobal')"
             />
             {% endblock %}
 
@@ -98,7 +98,7 @@
                 :placeholder="$tc('sw-promotion-v2.detail.base.general.maxUsesPerCustomerPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
                 allow-empty
-                @blur="checkPromotionMaxValue(promotion.maxRedemptionsPerCustomer, 'maxRedemptionsPerCustomer')"
+                @blur="checkPromotionMaxValue('maxRedemptionsPerCustomer')"
             />
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
@@ -84,8 +84,8 @@
                 :label="$tc('sw-promotion-v2.detail.base.general.maxUsesGlobalLabel')"
                 :placeholder="$tc('sw-promotion-v2.detail.base.general.maxUsesGlobalPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
-                @blur="checkPromotionMaxValue(promotion.maxRedemptionsGlobal, 'maxRedemptionsGlobal')"
                 allow-empty
+                @blur="checkPromotionMaxValue(promotion.maxRedemptionsGlobal, 'maxRedemptionsGlobal')"
             />
             {% endblock %}
 
@@ -97,8 +97,8 @@
                 :label="$tc('sw-promotion-v2.detail.base.general.maxUsesPerCustomerLabel')"
                 :placeholder="$tc('sw-promotion-v2.detail.base.general.maxUsesPerCustomerPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
-                @blur="checkPromotionMaxValue(promotion.maxRedemptionsPerCustomer, 'maxRedemptionsPerCustomer')"
                 allow-empty
+                @blur="checkPromotionMaxValue(promotion.maxRedemptionsPerCustomer, 'maxRedemptionsPerCustomer')"
             />
             {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Promotion with max value below or equal to zero doesn't make much sense

### 2. What does this change do, exactly?
Check on blur, if the value is below or equal to zero

### 3. Describe each step to reproduce the issue or behaviour.
Set the max value to zero

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/10165
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
