### PR TITLE
fix: Document generation after updating from 6.6 to 6.7

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -452,6 +452,65 @@ jobs:
           DATABASE_URL: "mysql://root@127.0.0.1:3306/shopware_test"
         run: php .github/bin/blue-green-check.php
 
+  update-66-67:
+      name: "PHP update 6.6 -> 6.7"
+      runs-on: ubuntu-24.04
+      if: inputs.nightly == 'true'
+      env:
+          APP_ENV: test
+          APP_URL: http://localhost:8000
+          APP_SECRET: def00000bb5acb32b54ff8ee130270586eec0e878f7337dc7a837acc31d3ff00f93a56b595448b4b29664847dd51991b3314ff65aeeeb761a133b0ec0e070433bff08e48
+          OPENSEARCH_URL: 127.0.0.1:9200
+          BLUE_GREEN_DEPLOYMENT: 1
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+          PREVIOUS_MAJOR_VERSION_BRANCH: "6.6.x"
+
+      services:
+          elasticsearch:
+              image: "opensearchproject/opensearch:1"
+              env:
+                  discovery.type: single-node
+                  plugins.security.disabled: "true"
+              ports:
+                  - "9200:9200"
+
+      steps:
+          - name: Setup previous major version
+            uses: shopware/setup-shopware@main
+            with:
+                install: "false"
+                shopware-version: ${{ env.PREVIOUS_MAJOR_VERSION_BRANCH }}
+                shopware-repository: ${{ github.repository }}
+
+          - name: Start Webserver
+            run: symfony server:start -d
+
+          - name: Install Shopware in previous major version on test DB
+            run: composer init:testdb
+
+          - name: Checkout current major version
+            uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+            with:
+                ref: ${{ github.ref }}
+
+          - name: Update to current major version
+            env:
+                COMPOSER_ROOT_VERSION: "6.7.9999999-dev"
+                DATABASE_URL: "mysql://root@127.0.0.1:3306/shopware_test"
+            run: |
+                rm -rf vendor-bin
+                rm -rf vendor
+                composer update -o
+                bin/console system:update:finish
+
+          - name: Refresh theme
+            env:
+                DATABASE_URL: "mysql://root@127.0.0.1:3306/shopware_test"
+            run: bin/console theme:refresh
+
+          - name: Run integration tests
+            run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure
+
   # this allows us to specifiy just one required job/check
   # this is not practical with matrix jobs directly, because you've to specify all permutations
   check:
@@ -462,7 +521,10 @@ jobs:
       - win-checkout
       - code-ql
       - acceptance-update
+      - php-security
       - blue-green-66-67
+      - blue-green-67-68
+      - update-66-67
 
     runs-on: Ubuntu-latest
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -524,7 +524,6 @@ jobs:
       - php-security
       - blue-green-66-67
       - blue-green-67-68
-      - update-66-67
 
     runs-on: Ubuntu-latest
     steps:

--- a/src/Core/Migration/V6_7/Migration1737430168RemoveFileTypeOfDocumentTable.php
+++ b/src/Core/Migration/V6_7/Migration1737430168RemoveFileTypeOfDocumentTable.php
@@ -19,6 +19,7 @@ class Migration1737430168RemoveFileTypeOfDocumentTable extends MigrationStep
 
     public function update(Connection $connection): void
     {
+        $connection->executeStatement('ALTER TABLE `document` CHANGE COLUMN `file_type` `file_type` VARCHAR(255) NULL');
     }
 
     public function updateDestructive(Connection $connection): void

--- a/tests/integration/Core/Checkout/Document/DocumentGeneratorControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentGeneratorControllerTest.php
@@ -11,7 +11,6 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
-use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeCollection;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeEntity;
 use Shopware\Core\Checkout\Document\DocumentIdCollection;
 use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
@@ -107,11 +106,10 @@ class DocumentGeneratorControllerTest extends TestCase
     {
         $context = Context::createDefaultContext();
 
-        /** @var EntityRepository<DocumentTypeCollection> $documentTypeRepository */
         $documentTypeRepository = static::getContainer()->get('document_type.repository');
         $criteria = (new Criteria())->addFilter(new EqualsFilter('technicalName', 'invoice'));
-        /** @var DocumentTypeEntity $type */
         $type = $documentTypeRepository->search($criteria, $context)->first();
+        static::assertInstanceOf(DocumentTypeEntity::class, $type);
         $cart = $this->generateDemoCart(2);
         $orderId = $this->persistCart($cart);
 
@@ -452,7 +450,6 @@ class DocumentGeneratorControllerTest extends TestCase
 
         $this->orderRepository->upsert([$order], $context);
 
-        /** @var OrderEntity|null $order */
         $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->first();
 
         static::assertNotNull($order);

--- a/tests/migration/Core/V6_7/Migration1737430168RemoveFileTypeOfDocumentTableTest.php
+++ b/tests/migration/Core/V6_7/Migration1737430168RemoveFileTypeOfDocumentTableTest.php
@@ -23,6 +23,30 @@ class Migration1737430168RemoveFileTypeOfDocumentTableTest extends TestCase
         $this->connection = KernelLifecycleManager::getConnection();
     }
 
+    public function testUpdateSetsColumnToNullable(): void
+    {
+        $exists = $this->columnExists();
+
+        if (!$exists) {
+            $this->addColumn();
+        }
+
+        $migration = new Migration1737430168RemoveFileTypeOfDocumentTable();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $fileTypeColumn = $this->connection->fetchAssociative(
+            'SHOW COLUMNS FROM `document` WHERE `Field` LIKE "file_type"',
+        );
+        static::assertIsArray($fileTypeColumn);
+
+        static::assertSame('YES', $fileTypeColumn['Null']);
+
+        if (!$exists) {
+            $migration->updateDestructive($this->connection);
+        }
+    }
+
     public function testUpdateDestructiveRemovesColumn(): void
     {
         $exists = $this->columnExists();
@@ -45,7 +69,7 @@ class Migration1737430168RemoveFileTypeOfDocumentTableTest extends TestCase
     private function addColumn(): void
     {
         $this->connection->executeStatement(
-            'ALTER TABLE `document` ADD COLUMN `file_type` VARCHAR(255) DEFAULT NULL'
+            'ALTER TABLE `document` ADD COLUMN `file_type` VARCHAR(255) NOT NULL'
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

After an update from 6.6 to 6.7, the document generation did not work anymore. This is caused by a non-nullable DB column which is not written anymore. 

### 2. What does this change do, exactly?

The column will be removed with a destructive migration, but needs to be made nullable, so environments where blue-green database migrations are used still work.

I also added a new nightly job, which does an update from 6.6 to current trunk and runs all integration test. This would have been failing, if we would had it before :grin: 

### 3. Describe each step to reproduce the issue or behaviour.

Update from 6.6 to 6.7 and try to generate a document

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/10351

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
