### PR TITLE
fix: Extension icon style in settings

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-settings-item/sw-settings-item.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-settings-item/sw-settings-item.scss
@@ -28,10 +28,14 @@ $sw-settings-item-hover-text-color: $color-shopware-brand-500;
             margin-right: 12px;
             margin-left: 8px;
 
-            .swag-migration-settings_icon__img {
-                margin: auto;
-                width: 30px;
-                height: 30px;
+            img, svg {
+                /* Make the following with and height style important to prevent overwrites from third party styles */
+                max-width: 16px !important;
+                max-height: 16px !important;
+                width: 16px !important;
+                height: 16px !important;
+                object-fit: contain !important;
+                object-position: center !important;
             }
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-settings-item/sw-settings-item.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-settings-item/sw-settings-item.scss
@@ -28,7 +28,8 @@ $sw-settings-item-hover-text-color: $color-shopware-brand-500;
             margin-right: 12px;
             margin-left: 8px;
 
-            img, svg {
+            img,
+            svg {
                 /* Make the following with and height style important to prevent overwrites from third party styles */
                 max-width: 16px !important;
                 max-height: 16px !important;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
@@ -61,4 +61,14 @@
             }
         }
     }
+
+    .sw-settings-item .sw-settings-item__icon {
+        img {
+            /* Make the following with and height style important to prevent overwrites from third party styles */
+            max-width: 16px !important;
+            max-height: 16px !important;
+            width: 16px !important;
+            height: 16px !important;
+        }
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
@@ -69,6 +69,8 @@
             max-height: 16px !important;
             width: 16px !important;
             height: 16px !important;
+            object-fit: contain !important;
+            object-position: center !important;
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
@@ -61,16 +61,4 @@
             }
         }
     }
-
-    .sw-settings-item .sw-settings-item__icon {
-        img {
-            /* Make the following with and height style important to prevent overwrites from third party styles */
-            max-width: 16px !important;
-            max-height: 16px !important;
-            width: 16px !important;
-            height: 16px !important;
-            object-fit: contain !important;
-            object-position: center !important;
-        }
-    }
 }


### PR DESCRIPTION
Closes: #9981

Add height and with style for icons of extensions

Before
![image](https://github.com/user-attachments/assets/7486a2d7-9da8-42cb-9104-7daa1b7a4ee9)

After
![image](https://github.com/user-attachments/assets/15b25a7c-aba2-4d29-ab2e-c958ced01a72)

