### PR TITLE
feat: display theme config keys in administration labels

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
@@ -673,6 +673,14 @@ Component.register('sw-theme-manager-detail', {
         },
 
         /**
+         * Get field label with config key appended in parentheses
+         */
+        getFieldLabel(field, fieldName) {
+            const label = this.getSnippet(field.labelSnippetKey, field.label);
+            return `${label} (${fieldName})`;
+        },
+
+        /**
          * @deprecated tag:v6.8.0 - `fallback` will be removed and return `null` instead, since theme config helpTexts will be removed entirely.
          */
         getHelpText(key, fallback = null) {

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -288,7 +288,7 @@
                                                                             :ref="`wrapper-${fieldName}`"
                                                                             :has-parent="theme.baseConfig?.fields?.[fieldName] == null"
                                                                             :inherited-value="baseThemeConfig[fieldName].value"
-                                                                            :label="getSnippet(field.labelSnippetKey, field.label)"
+                                                                            :label="getFieldLabel(field, fieldName)"
                                                                             :customInheritationCheckFunction="checkInheritanceFunction(fieldName)"
                                                                             @update:value="handleInheritanceInput($event, fieldName)"
                                                                         >
@@ -313,7 +313,7 @@
                                                                             :ref="`wrapper-${fieldName}`"
                                                                             :has-parent="theme.baseConfig?.fields?.[fieldName] == null"
                                                                             :inherited-value="baseThemeConfig[fieldName].value"
-                                                                            :label="getSnippet(field.labelSnippetKey, field.label)"
+                                                                            :label="getFieldLabel(field, fieldName)"
                                                                             :customInheritationCheckFunction="checkInheritanceFunction(fieldName)"
                                                                             @update:value="handleInheritanceInput($event, fieldName)"
                                                                         >
@@ -341,7 +341,7 @@
                                                                             :ref="`wrapper-${fieldName}`"
                                                                             :has-parent="theme.baseConfig?.fields?.[fieldName] == null"
                                                                             :inherited-value="baseThemeConfig[fieldName].value"
-                                                                            :label="getSnippet(field.labelSnippetKey, field.label)"
+                                                                            :label="getFieldLabel(field, fieldName)"
                                                                             :customInheritationCheckFunction="checkInheritanceFunction(fieldName)"
                                                                             @update:value="handleInheritanceInput($event, fieldName)"
                                                                         >
@@ -369,7 +369,7 @@
                                                                             :ref="`wrapper-${fieldName}`"
                                                                             :has-parent="theme.baseConfig?.fields?.[fieldName] == null"
                                                                             :inherited-value="baseThemeConfig[fieldName].value"
-                                                                            :label="getSnippet(field.labelSnippetKey, field.label)"
+                                                                            :label="getFieldLabel(field, fieldName)"
                                                                             :customInheritationCheckFunction="checkInheritanceFunction(fieldName)"
                                                                             @update:value="handleInheritanceInput($event, fieldName)"
                                                                         >
@@ -401,7 +401,7 @@
                                                                             :ref="`wrapper-${fieldName}`"
                                                                             :has-parent="theme.baseConfig?.fields?.[fieldName] == null"
                                                                             :inherited-value="baseThemeConfig[fieldName].value"
-                                                                            :label="getSnippet(field.labelSnippetKey, field.label)"
+                                                                            :label="getFieldLabel(field, fieldName)"
                                                                             :customInheritationCheckFunction="checkInheritanceFunction(fieldName)"
                                                                             @update:value="handleInheritanceInput($event, fieldName)"
                                                                         >
@@ -743,7 +743,7 @@
                                                             :key="fieldName"
                                                             @click="onAddMediaToTheme(media.mediaItem, currentThemeConfig[fieldName])"
                                                         >
-                                                            {{ $t('sw-theme-manager.modal.addToMediaLabel', { name: getSnippet(field.labelSnippetKey, field.label) }) }}
+                                                            {{ $t('sw-theme-manager.modal.addToMediaLabel', { name: getFieldLabel(field, fieldName) }) }}
                                                         </sw-context-menu-item>
                                                     </template>
                                                 </template>


### PR DESCRIPTION
### 1. Why is this change necessary?
As a developer working with theme configurations, it's difficult to identify which variable names correspond to specific configuration options in the administration UI. This makes it harder to reference these variables in SCSS files or when debugging theme issues.

### 2. What does this change do, exactly?
This change adds the configuration key name in parentheses next to each field label in the theme manager. For example:
- "Primary Color (sw-color-brand-primary)"
- "Font Family (sw-font-family-base)"
- "Logo Image (sw-logo-desktop)"

The implementation:
- Adds a new `getFieldLabel()` method that appends the field key to the label
- Updates all field label bindings in the template to use this new method
- Also updates the media sidebar context menu to show config keys

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Administration > Theme Manager
2. Click on any theme (e.g., Storefront)
3. Navigate to any configuration tab
4. Observe that field labels now show the config key in parentheses

### 4. Please link to the relevant issues (if any).
N/A - This is a developer experience improvement

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.