### PR TITLE
fix: product seo url save on first attempt

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
@@ -4,6 +4,7 @@
 
 import './store';
 import template from './sw-seo-url.html.twig';
+import './sw-seo-url.scss';
 
 const Criteria = Shopware.Data.Criteria;
 const EntityCollection = Shopware.Data.EntityCollection;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.scss
@@ -1,0 +1,5 @@
+.sw-seo-url {
+    .sw-sales-channel-switch {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
Fixes #10219
Fixes #10131

Description:

A weird bug, when `sw-product-detail`.`onSaveFinished` is called, the `Shopware.Store.get('swSeoUrl').newOrModifiedUrls` is resetted (in `sw-seo-url` component), that's why it's not saved. For second attempt, the product is not changed, that will not trigger a re-render so we can save the seo url successfully.

Solution:

Collection the seoUrls promises that needs to be saved in `onSave` method and call the actual request in `onSaveFinished`