### PR TITLE
fix: invalid json measurement units

### DIFF
--- a/src/Administration/Resources/app/administration/blocks-list.json
+++ b/src/Administration/Resources/app/administration/blocks-list.json
@@ -196,6 +196,7 @@
  "sw_bulk_edit_product_content_labelling_card",
  "sw_bulk_edit_product_content_language_switch",
  "sw_bulk_edit_product_content_meansures_custom_field_card",
+ "sw_bulk_edit_product_content_meansures_packaging_card",
  "sw_bulk_edit_product_content_measurement_card",
  "sw_bulk_edit_product_content_media_card",
  "sw_bulk_edit_product_content_prices",

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.html.twig
@@ -343,6 +343,10 @@
             </mt-card>
             {% endblock %}
 
+            {# @deprecated tag:v6.8.0 - Block will be removed. #}
+            {% block sw_bulk_edit_product_content_meansures_packaging_card %}
+            {% endblock %}
+
             {% block sw_bulk_edit_product_content_measurement_card %}
             <mt-card
                 class="sw-bulk-edit-product-base__measures"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/index.js
@@ -6,7 +6,6 @@ import template from './sw-sales-channel-measurement.html.twig';
 import './sw-sales-channel-measurement.scss';
 
 const { Criteria } = Shopware.Data;
-const { cloneDeep } = Shopware.Utils.object;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default Shopware.Component.wrapComponentConfig({
@@ -46,6 +45,8 @@ export default Shopware.Component.wrapComponentConfig({
         return {
             defaultMeasurementSystem: null,
             defaultDisplayUnits: [],
+            measurementSystems: [],
+            measurementSystem: null,
         };
     },
 
@@ -77,34 +78,62 @@ export default Shopware.Component.wrapComponentConfig({
             return this.salesChannel.measurementUnits;
         },
 
-        lengthUnits() {
-            return (this.defaultMeasurementSystem?.units || []).filter((unit) => unit.type === 'length');
+        measurementSystemOptions() {
+            return this.measurementSystems.map((system) => ({
+                ...system,
+                label: system.translated?.name || system.name,
+                value: system.technicalName,
+            }));
         },
 
-        weightUnits() {
-            return (this.defaultMeasurementSystem?.units || []).filter((unit) => unit.type === 'weight');
+        lengthUnitOptions() {
+            return this.getUnitOptionsByType('length');
+        },
+
+        weightUnitOptions() {
+            return this.getUnitOptionsByType('weight');
         },
 
         defaultLengthUnit() {
-            return this.defaultDisplayUnits.find((u) => u.type === 'length');
+            const units = this.measurementSystem?.units || [];
+
+            const lengthUnit = this.defaultDisplayUnits.find((u) => u.type === 'length');
+            const defaultLengthUnit = units.find((unit) => unit.type === 'length' && unit.default);
+
+            return units.find((unit) => unit.shortName === lengthUnit.shortName) || defaultLengthUnit;
         },
 
         defaultWeightUnit() {
-            return this.defaultDisplayUnits.find((u) => u.type === 'weight');
+            const units = this.measurementSystem?.units || [];
+
+            const weightUnit = this.defaultDisplayUnits.find((u) => u.type === 'weight');
+            const defaultWeightUnit = units.find((unit) => unit.type === 'weight' && unit.default);
+
+            return units.find((unit) => unit.shortName === weightUnit.shortName) || defaultWeightUnit;
         },
 
-        measurementUnitId: {
-            get() {
-                if (!this.defaultMeasurementSystem?.id) {
-                    return null;
-                }
+        measurementUnitSystemError() {
+            if (!this.salesChannel?.id) {
+                return null;
+            }
 
-                return this.defaultMeasurementSystem.id;
-            },
+            return Shopware.Store.get('error').getApiError(this.salesChannel, 'measurementUnits.system');
+        },
 
-            set(value) {
-                this.defaultMeasurementSystem.id = value;
-            },
+        measurementLengthUnitError() {
+            if (!this.salesChannel?.id) {
+                return null;
+            }
+
+            return Shopware.Store.get('error').getApiError(this.salesChannel, 'measurementUnits.units.length');
+        },
+
+        measurementWeightUnitError() {
+            if (!this.salesChannel?.id) {
+                return null;
+            }
+
+            return Shopware.Store.get('error').getApiError(this.salesChannel, 'measurementUnits.units.weight');
         },
     },
 
@@ -114,37 +143,26 @@ export default Shopware.Component.wrapComponentConfig({
 
     methods: {
         async createdComponent() {
-            this.defaultMeasurementSystem = await this.getDefaultMeasurementSystem();
-            this.defaultDisplayUnits = (this.defaultMeasurementSystem?.units || []).filter((u) =>
+            this.measurementSystems = await this.getDefaultMeasurementSystems();
+            this.measurementSystem = this.measurementSystems.find(
+                (system) => system.technicalName === this.measurementUnits.system,
+            );
+
+            this.defaultDisplayUnits = (this.measurementSystem?.units || []).filter((u) =>
                 Object.values(this.measurementUnits.units).includes(u.shortName),
             );
         },
 
-        async onMeasurementSystemChange(_, measurementSystem) {
-            if (!measurementSystem) {
+        async onMeasurementSystemChange(technicalName) {
+            if ((Array.isArray(technicalName) && technicalName.length === 0) || !technicalName) {
                 return;
             }
 
-            this.measurementUnits.system = measurementSystem.technicalName;
-            const units = measurementSystem.units;
+            this.measurementSystem = this.measurementSystems.find((system) => system.technicalName === technicalName);
 
-            this.defaultMeasurementSystem = measurementSystem;
+            this.measurementUnits.units.length = this.defaultLengthUnit.shortName;
 
-            const defaultLengthUnit =
-                units.find((unit) => unit.shortName === this.defaultLengthUnit.shortName) ||
-                units.find((unit) => unit.type === 'length' && unit.default);
-
-            if (defaultLengthUnit) {
-                this.measurementUnits.units.length = defaultLengthUnit.shortName;
-            }
-
-            const defaultWeightUnit =
-                units.find((unit) => unit.shortName === this.defaultWeightUnit.shortName) ||
-                units.find((unit) => unit.type === 'weight' && unit.default);
-
-            if (defaultWeightUnit) {
-                this.measurementUnits.units.weight = defaultWeightUnit.shortName;
-            }
+            this.measurementUnits.units.weight = this.defaultWeightUnit.shortName;
         },
 
         formatUnitLabel(item) {
@@ -158,17 +176,18 @@ export default Shopware.Component.wrapComponentConfig({
             return `${name} (${shortName})`.trim();
         },
 
-        async getDefaultMeasurementSystem() {
-            const criteria = cloneDeep(this.measurementSystemCriteria);
-            criteria.setLimit(1);
+        getDefaultMeasurementSystems() {
+            return this.measurementSystemRepository.search(this.measurementSystemCriteria);
+        },
 
-            if (this.measurementUnits.system) {
-                criteria.addFilter(Criteria.equals('technicalName', this.measurementUnits.system));
-            }
-
-            const measurement = await this.measurementSystemRepository.search(criteria);
-
-            return measurement?.first();
+        getUnitOptionsByType(type) {
+            return (this.measurementSystem?.units || [])
+                .filter((unit) => unit.type === type)
+                .map((unit) => ({
+                    ...unit,
+                    label: this.formatUnitLabel(unit),
+                    value: unit.shortName,
+                }));
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.html.twig
@@ -2,59 +2,53 @@
     columns="1fr 1fr 1fr"
     gap="0 30px"
 >
-    <sw-entity-single-select
-        v-model:value="measurementUnitId"
-        entity="measurement_system"
+    <mt-select
+        v-model="measurementUnits.system"
+        required
+        hide-clearable-button
         :label="labelUnitSystem"
-        :criteria="measurementSystemCriteria"
-        @update:value="onMeasurementSystemChange"
+        :options="measurementSystemOptions"
+        :error="measurementUnitSystemError"
+        @update:model-value="onMeasurementSystemChange"
     />
 
-    <sw-single-select
-        v-model:value="measurementUnits.units.length"
+    <mt-select
+        v-model="measurementUnits.units.length"
         required
-        value-property="shortName"
+        hide-clearable-button
         :label="labelLengthUnit"
-        :popover-classes="['sw-sales-channel-measurement__selection-popover']"
-        :options="lengthUnits"
+        :options="lengthUnitOptions"
+        :error="measurementLengthUnitError"
     >
-        <template #selection-label-property="{ item }">
-            {{ formatUnitLabel(item) }}
-        </template>
-
         <template #result-label-property="{ item, searchTerm }">
             <sw-highlight-text
                 :text="item.translated.name || item.name"
                 :search-term="searchTerm"
             />
 
-            <span class="sw-sales-channel-measurement__length-unit-short-name">
+            <span class="mt-select-result-list-popover-wrapper__length-unit-short-name">
                 {{ item.shortName }}
             </span>
         </template>
-    </sw-single-select>
+    </mt-select>
 
-    <sw-single-select
-        v-model:value="measurementUnits.units.weight"
+    <mt-select
+        v-model="measurementUnits.units.weight"
         required
-        value-property="shortName"
         :label="labelWeightUnit"
-        :popover-classes="['sw-sales-channel-measurement__selection-popover']"
-        :options="weightUnits"
+        hide-clearable-button
+        :options="weightUnitOptions"
+        :error="measurementWeightUnitError"
     >
-        <template #selection-label-property="{ item }">
-            {{ formatUnitLabel(item) }}
-        </template>
-
         <template #result-label-property="{ item, searchTerm }">
             <sw-highlight-text
                 :text="item.translated.name || item.name"
                 :search-term="searchTerm"
             />
 
-            <span class="sw-sales-channel-measurement__mass-unit-short-name">
+            <span class="mt-select-result-list-popover-wrapper__mass-unit-short-name">
                 {{ item.shortName }}
             </span>
         </template>
-    </sw-single-select>
+    </mt-select>
 </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.scss
@@ -1,15 +1,19 @@
 @import "~scss/variables";
 
-.sw-sales-channel-measurement {
-    &__selection-popover {
-        .sw-select-result__result-item-text {
-            flex-direction: row;
-            gap: 8px;
-        }
+.mt-select-result-list-popover-wrapper {
+    .mt-select-result__result-item-text {
+        flex-direction: row;
+        gap: 8px;
     }
 
     &__length-unit-short-name,
     &__mass-unit-short-name {
+        color: $color-gray-500;
+    }
+
+    .mt-select-result > .mt-icon {
+        width: 12px;
+        height: 12px;
         color: $color-gray-500;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-measurement/sw-sales-channel-measurement.spec.js
@@ -5,7 +5,7 @@
 import { mount } from '@vue/test-utils';
 import EntityCollection from '../../../../core/data/entity-collection.data';
 
-async function createWrapper() {
+async function createWrapper(repositoryMock, measurementUnits = {}) {
     const mockDefaultUnits = new EntityCollection(
         '/measurement-system',
         'measurement_system',
@@ -22,8 +22,22 @@ async function createWrapper() {
                     null,
                     {},
                     [
-                        { id: 'mm', type: 'length', measurementSystemId: 'metric', shortName: 'mm', default: true },
-                        { id: 'kg', type: 'weight', measurementSystemId: 'metric', shortName: 'kg', default: true },
+                        {
+                            id: 'mm',
+                            type: 'length',
+                            measurementSystemId: 'metric',
+                            shortName: 'mm',
+                            name: 'Milimeter',
+                            default: true,
+                        },
+                        {
+                            id: 'kg',
+                            type: 'weight',
+                            measurementSystemId: 'metric',
+                            shortName: 'kg',
+                            name: 'Kilogram',
+                            default: true,
+                        },
                     ],
                     2,
                     null,
@@ -82,10 +96,11 @@ async function createWrapper() {
     );
 
     const repositoryFactory = {
-        create: () => ({
-            search: jest.fn().mockResolvedValue(mockDefaultUnits),
-            get: jest.fn().mockResolvedValue(),
-        }),
+        create: () =>
+            repositoryMock || {
+                search: jest.fn().mockResolvedValue(mockDefaultUnits),
+                get: jest.fn().mockResolvedValue(),
+            },
     };
 
     return mount(await wrapTestComponent('sw-sales-channel-measurement', { sync: true }), {
@@ -97,6 +112,7 @@ async function createWrapper() {
                         length: 'mm',
                         weight: 'kg',
                     },
+                    ...measurementUnits,
                 },
             },
         },
@@ -105,33 +121,28 @@ async function createWrapper() {
                 'sw-container': await wrapTestComponent('sw-container', {
                     sync: true,
                 }),
-                'sw-entity-single-select': await wrapTestComponent('sw-entity-single-select', {
-                    sync: true,
-                }),
-                'sw-select-base': await wrapTestComponent('sw-select-base', { sync: true }),
-                'sw-select-result-list': await wrapTestComponent('sw-select-result-list', { sync: true }),
-                'sw-select-result': await wrapTestComponent('sw-select-result', { sync: true }),
-                'sw-block-field': await wrapTestComponent('sw-block-field', { sync: true }),
-                'sw-base-field': await wrapTestComponent('sw-base-field', { sync: true }),
-                'sw-popover': await wrapTestComponent('sw-popover', { sync: true }),
-                'sw-popover-deprecated': await wrapTestComponent('sw-popover-deprecated', { sync: true }),
-                'sw-help-text': true,
-                'sw-inheritance-switch': true,
-                'sw-ai-copilot-badge': true,
                 'sw-field-error': true,
                 'sw-loader': true,
                 'sw-product-variant-info': true,
-                'sw-single-select': {
-                    props: [
-                        'value',
-                    ],
+                'mt-select': {
                     template: `
-                            <input
-                                class="sw-single-select__input"
-                                :value="value"
-                                @input="$emit('update:value', $event.target.value)"
-                            />
-                        `,
+                        <select
+                            class="mt-select__input"
+                            :value="modelValue"
+                            @change="$emit('update:modelValue', $event.target.value)"
+                        >
+                            <option
+                                v-for="option in options"
+                                :key="option.value"
+                                :value="option.value"
+                            >
+                                {{ option.label }}
+                            </option>
+                        </select>`,
+                    props: [
+                        'modelValue',
+                        'options',
+                    ],
                 },
                 'sw-highlight-text': true,
             },
@@ -197,49 +208,99 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-measurement', (
     it('should correctly update units on onMeasurementSystemChange', async () => {
         const wrapper = await createWrapper();
 
-        const selects = wrapper.findAll('.sw-entity-single-select');
-
-        const selection = selects.at(0).find('.sw-entity-single-select__selection');
-
-        await selection.trigger('click');
+        const systemInput = wrapper.findAll('.mt-select__input').at(0);
+        await systemInput.setValue('imperial');
         await flushPromises();
 
-        const typeElement = wrapper.findAll('.sw-select-result');
-        await typeElement.at(1).trigger('click');
-        await flushPromises();
-
-        expect(wrapper.vm.measurementUnits.system).toBe('imperial');
         expect(wrapper.vm.measurementUnits.units).toEqual({
             length: 'in',
             weight: 'lb',
         });
     });
 
-    it('should update lengthUnit prop on salesChannel when sw-single-select for length changes', async () => {
-        const wrapper = await createWrapper();
-        wrapper.vm.measurementSystemRepository.search = jest.fn(() => {
-            return Promise.resolve(
-                new EntityCollection('/measurement-system', 'measurement_system', null, {}, [
-                    {
-                        id: 'metric',
-                        name: 'Metric system',
-                        technicalName: 'metric',
-                        units: new EntityCollection('/measurement-display-unit', 'measurement_display_unit', null, {}, [
-                            { id: 'm', type: 'length', measurementSystemId: 'metric', shortName: 'm', default: false },
-                            { id: 'cm', type: 'length', measurementSystemId: 'metric', shortName: 'cm', default: true },
-                            { id: 'mm', type: 'length', measurementSystemId: 'metric', shortName: 'mm', default: false },
-                        ]),
-                    },
-                ]),
-            );
+    it('should update measurement units when measurement system changes', async () => {
+        const wrapper = await createWrapper(null, {
+            system: 'imperial',
+            units: {
+                length: 'in',
+                weight: 'lb',
+            },
         });
 
+        expect(wrapper.vm.measurementUnits.system).toBe('imperial');
+        expect(wrapper.vm.measurementUnits.units).toEqual({
+            length: 'in',
+            weight: 'lb',
+        });
+
+        const weightInput = wrapper.findAll('.mt-select__input').at(0);
+        await weightInput.setValue('metric');
         await flushPromises();
 
-        expect(wrapper.vm.lengthUnits.length).toBeGreaterThan(0);
+        expect(wrapper.vm.measurementUnits.units).toEqual({
+            length: 'mm',
+            weight: 'kg',
+        });
+    });
 
-        const lengthInput = wrapper.findAll('.sw-single-select__input');
-        await lengthInput[0].setValue('cm');
+    it('should update lengthUnit prop on salesChannel when sw-single-select for length changes', async () => {
+        const measurementSystemRepository = {
+            search: jest.fn(() => {
+                return Promise.resolve(
+                    new EntityCollection('/measurement-system', 'measurement_system', null, {}, [
+                        {
+                            id: 'metric',
+                            name: 'Metric system',
+                            technicalName: 'metric',
+                            units: new EntityCollection('/measurement-display-unit', 'measurement_display_unit', null, {}, [
+                                {
+                                    id: 'm',
+                                    type: 'length',
+                                    measurementSystemId: 'metric',
+                                    shortName: 'm',
+                                    name: 'Meter',
+                                    default: false,
+                                },
+                                {
+                                    id: 'cm',
+                                    type: 'length',
+                                    measurementSystemId: 'metric',
+                                    shortName: 'cm',
+                                    name: 'Centimeter',
+                                    default: true,
+                                },
+                                {
+                                    id: 'mm',
+                                    type: 'length',
+                                    measurementSystemId: 'metric',
+                                    shortName: 'mm',
+                                    name: 'Milimeter',
+                                    default: false,
+                                },
+                                {
+                                    id: 'kg',
+                                    type: 'weight',
+                                    measurementSystemId: 'metric',
+                                    shortName: 'kg',
+                                    name: 'Kilogram',
+                                    default: true,
+                                },
+                            ]),
+                        },
+                    ]),
+                );
+            }),
+            get: jest.fn().mockResolvedValue(),
+        };
+
+        const wrapper = await createWrapper(measurementSystemRepository);
+        await flushPromises();
+
+        expect(wrapper.vm.lengthUnitOptions.length).toBeGreaterThan(0);
+
+        const lengthInput = wrapper.findAll('.mt-select__input').at(1);
+        await lengthInput.setValue('cm');
+        await flushPromises();
 
         expect(wrapper.vm.salesChannel.measurementUnits.units).toEqual({
             length: 'cm',
@@ -248,29 +309,55 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-measurement', (
     });
 
     it('should update weightUnit prop on salesChannel when sw-single-select for weight changes', async () => {
-        const wrapper = await createWrapper();
-        wrapper.vm.measurementSystemRepository.search = jest.fn(() => {
-            return Promise.resolve(
-                new EntityCollection('/measurement-system', 'measurement_system', null, {}, [
-                    {
-                        id: 'metric',
-                        name: 'Metric system',
-                        technicalName: 'metric',
-                        units: new EntityCollection('/measurement-display-unit', 'measurement_display_unit', null, {}, [
-                            { id: 'kg', type: 'weight', measurementSystemId: 'metric', shortName: 'kg', default: true },
-                            { id: 'g', type: 'weight', measurementSystemId: 'metric', shortName: 'g', default: false },
-                        ]),
-                    },
-                ]),
-            );
-        });
+        const measurementSystemRepository = {
+            search: jest.fn(() => {
+                return Promise.resolve(
+                    new EntityCollection('/measurement-system', 'measurement_system', null, {}, [
+                        {
+                            id: 'metric',
+                            name: 'Metric system',
+                            technicalName: 'metric',
+                            units: new EntityCollection('/measurement-display-unit', 'measurement_display_unit', null, {}, [
+                                {
+                                    id: 'kg',
+                                    type: 'weight',
+                                    measurementSystemId: 'metric',
+                                    shortName: 'kg',
+                                    name: 'Kilogram',
+                                    default: true,
+                                },
+                                {
+                                    id: 'g',
+                                    type: 'weight',
+                                    measurementSystemId: 'metric',
+                                    shortName: 'g',
+                                    name: 'Gram',
+                                    default: false,
+                                },
+                                {
+                                    id: 'mm',
+                                    type: 'length',
+                                    measurementSystemId: 'metric',
+                                    shortName: 'mm',
+                                    name: 'Milimeter',
+                                    default: true,
+                                },
+                            ]),
+                        },
+                    ]),
+                );
+            }),
+            get: jest.fn().mockResolvedValue(),
+        };
 
+        const wrapper = await createWrapper(measurementSystemRepository);
         await flushPromises();
 
-        expect(wrapper.vm.weightUnits.length).toBeGreaterThan(0);
+        expect(wrapper.vm.weightUnitOptions.length).toBeGreaterThan(0);
 
-        const weightInput = wrapper.findAll('.sw-single-select__input');
-        await weightInput[1].setValue('g');
+        const weightInput = wrapper.findAll('.mt-select__input').at(2);
+        await weightInput.setValue('g');
+        await flushPromises();
 
         expect(wrapper.vm.salesChannel.measurementUnits.units.weight).toBe('g');
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/index.js
@@ -11,6 +11,11 @@ export default {
     emits: ['measurement-system-change'],
 
     props: {
+        measurementSystems: {
+            type: Array,
+            required: true,
+        },
+
         measurementSystem: {
             type: Object,
             required: true,
@@ -20,40 +25,53 @@ export default {
             type: Object,
             required: true,
         },
-
-        measurementSystemCriteria: {
-            type: Object,
-            required: true,
-        },
     },
 
     computed: {
-        lengthUnits() {
-            return (this.measurementSystem?.units || []).filter((unit) => unit.type === 'length');
+        lengthUnitOptions() {
+            return this.getUnitOptionsByType('length');
         },
 
-        weightUnits() {
-            return (this.measurementSystem?.units || []).filter((unit) => unit.type === 'weight');
+        weightUnitOptions() {
+            return this.getUnitOptionsByType('weight');
         },
 
-        measurementUnitId: {
-            get() {
-                if (!this.measurementSystem?.id) {
-                    return null;
-                }
+        measurementSystemOptions() {
+            return this.measurementSystems.map((system) => ({
+                ...system,
+                label: system.translated?.name || system.name,
+                value: system.technicalName,
+            }));
+        },
 
-                return this.measurementSystem.id;
-            },
+        measurementUnitSystemError() {
+            if (!this.measurementSystem?.id) {
+                return null;
+            }
 
-            set(value) {
-                this.measurementSystem.id = value;
-            },
+            return Shopware.Store.get('error').getApiError(this.measurementSystem, 'system');
+        },
+
+        measurementLengthUnitError() {
+            if (!this.measurementSystem?.id) {
+                return null;
+            }
+
+            return Shopware.Store.get('error').getApiError(this.measurementSystem, 'length');
+        },
+
+        measurementWeightUnitError() {
+            if (!this.measurementSystem?.id) {
+                return null;
+            }
+
+            return Shopware.Store.get('error').getApiError(this.measurementSystem, 'weight');
         },
     },
 
     methods: {
-        onChangeMeasurementSystem(_, measurement) {
-            this.$emit('measurement-system-change', measurement);
+        onChangeMeasurementSystem(technicalName) {
+            this.$emit('measurement-system-change', technicalName);
         },
 
         labelUnitCallback(item) {
@@ -65,6 +83,16 @@ export default {
             const shortName = item.shortName || item.name;
 
             return `${name} (${shortName})`.trim();
+        },
+
+        getUnitOptionsByType(type) {
+            return (this.measurementSystem?.units || [])
+                .filter((unit) => unit.type === type)
+                .map((unit) => ({
+                    ...unit,
+                    label: this.labelUnitCallback(unit),
+                    value: unit.shortName,
+                }));
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/sw-settings-measurement-default-units.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/sw-settings-measurement-default-units.html.twig
@@ -11,64 +11,54 @@
         columns="1fr 1fr 1fr"
         gap="0 32px"
     >
-        <sw-entity-single-select
-            v-model:value="measurementUnitId"
-            entity="measurement_system"
-            :criteria="measurementSystemCriteria"
+        <mt-select
+            v-model="measurementUnits.system"
+            required
+            hide-clearable-button
             :label="$t('sw-settings-measurement.defaultUnits.config.type')"
-            @update:value="onChangeMeasurementSystem"
-        >
-            <template #selection-label-property="{ item }">
-                {{ item.translated?.name || item.name }}
-            </template>
-        </sw-entity-single-select>
+            :options="measurementSystemOptions"
+            :error="measurementUnitSystemError"
+            @update:model-value="onChangeMeasurementSystem"
+        />
 
-        <sw-single-select
-            v-model:value="measurementUnits.length"
+        <mt-select
+            v-model="measurementUnits.length"
             required
-            value-property="shortName"
+            hide-clearable-button
             :label="$t('sw-settings-measurement.defaultUnits.config.lengthUnit')"
-            :popover-classes="['sw-settings-measurement-default-units__popover']"
-            :options="lengthUnits"
+            :options="lengthUnitOptions"
+            :error="measurementLengthUnitError"
         >
-            <template #selection-label-property="{ item }">
-                {{ labelUnitCallback(item) }}
-            </template>
-
             <template #result-label-property="{ item, searchTerm }">
                 <sw-highlight-text
                     :text="item.translated.name || item.name"
                     :search-term="searchTerm"
                 />
 
-                <span class="sw-settings-measurement-default-units__popover-short-name">
+                <span class="mt-select-result-list-popover-wrapper__popover-short-name">
                     {{ item.shortName }}
                 </span>
             </template>
-        </sw-single-select>
+        </mt-select>
 
-        <sw-single-select
-            v-model:value="measurementUnits.weight"
+        <mt-select
+            v-model="measurementUnits.weight"
             required
-            value-property="shortName"
+            hide-clearable-button
             :label="$t('sw-settings-measurement.defaultUnits.config.weightUnit')"
-            :popover-classes="['sw-settings-measurement-default-units__popover']"
-            :options="weightUnits"
+            :options="weightUnitOptions"
+            :error="measurementWeightUnitError"
         >
-            <template #selection-label-property="{ item }">
-                {{ labelUnitCallback(item) }}
-            </template>
-
             <template #result-label-property="{ item, searchTerm }">
                 <sw-highlight-text
                     :text="item.translated.name || item.name"
                     :search-term="searchTerm"
                 />
 
-                <span class="sw-settings-measurement-default-units__popover-short-name">
+                <span class="mt-select-result-list-popover-wrapper__popover-short-name">
                     {{ item.shortName }}
                 </span>
             </template>
-        </sw-single-select>
+        </mt-select>
     </sw-container>
 </mt-card>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/sw-settings-measurement-default-units.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/sw-settings-measurement-default-units.scss
@@ -4,13 +4,19 @@
     &__description {
         margin-bottom: 32px;
     }
+}
 
-    &__popover .sw-select-result__result-item-text {
+.mt-select-result-list-popover-wrapper {
+    .mt-select-result__result-item-text {
         flex-direction: row;
         gap: 8px;
     }
 
     &__popover-short-name {
+        color: $color-gray-500;
+    }
+
+    .mt-select-result > .mt-icon {
         color: $color-gray-500;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/sw-settings-measurement-default-units.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/sw-settings-measurement-default-units.spec.js
@@ -4,8 +4,6 @@
 import { mount } from '@vue/test-utils';
 import EntityCollection from '../../../../core/data/entity-collection.data';
 
-const { Criteria } = Shopware.Data;
-
 const createWrapper = async () => {
     const mockDefaultUnits = new EntityCollection(
         '/measurement-system',
@@ -31,6 +29,7 @@ const createWrapper = async () => {
                     4,
                     null,
                 ),
+                getEntityName: () => 'measurement_display_unit',
             },
             {
                 id: 'imperial',
@@ -78,23 +77,17 @@ const createWrapper = async () => {
                     4,
                     null,
                 ),
+                getEntityName: () => 'measurement_system',
             },
         ],
         2,
         null,
     );
 
-    const measurementSystemCriteria = () => {
-        const criteria = new Criteria(1, null);
-        criteria.addAssociation('units');
-
-        return criteria;
-    };
-
     const repositoryFactory = {
         create: () => ({
-            search: jest.fn().mockResolvedValue(mockDefaultUnits),
-            get: jest.fn().mockResolvedValue(mockDefaultUnits.first()),
+            search: jest.fn().mockResolvedValue({}),
+            get: jest.fn().mockResolvedValue({}),
         }),
     };
 
@@ -109,8 +102,8 @@ const createWrapper = async () => {
                     length: 'mm',
                     weight: 'kg',
                 },
+                measurementSystems: mockDefaultUnits,
                 measurementSystem: mockDefaultUnits.first(),
-                measurementSystemCriteria: measurementSystemCriteria(),
             },
             global: {
                 stubs: {
@@ -120,33 +113,27 @@ const createWrapper = async () => {
                     'sw-container': await wrapTestComponent('sw-container', {
                         sync: true,
                     }),
-                    'sw-entity-single-select': await wrapTestComponent('sw-entity-single-select', {
-                        sync: true,
-                    }),
-                    'sw-select-base': await wrapTestComponent('sw-select-base', { sync: true }),
-                    'sw-select-result-list': await wrapTestComponent('sw-select-result-list', { sync: true }),
-                    'sw-select-result': await wrapTestComponent('sw-select-result', { sync: true }),
-                    'sw-block-field': await wrapTestComponent('sw-block-field', { sync: true }),
-                    'sw-base-field': await wrapTestComponent('sw-base-field', { sync: true }),
-                    'sw-popover': await wrapTestComponent('sw-popover', { sync: true }),
-                    'sw-popover-deprecated': await wrapTestComponent('sw-popover-deprecated', { sync: true }),
-                    'sw-help-text': true,
-                    'sw-inheritance-switch': true,
-                    'sw-ai-copilot-badge': true,
-                    'sw-field-error': true,
                     'sw-loader': true,
                     'sw-product-variant-info': true,
-                    'sw-single-select': {
-                        props: [
-                            'value',
-                        ],
+                    'mt-select': {
                         template: `
-                            <input
-                                class="sw-single-select__input"
-                                :value="value"
-                                @input="$emit('update:value', $event.target.value)"
-                            />
-                        `,
+                        <select
+                            class="mt-select__input"
+                            :value="modelValue"
+                            @change="$emit('update:modelValue', $event.target.value)"
+                        >
+                            <option
+                                v-for="option in options"
+                                :key="option.value"
+                                :value="option.value"
+                            >
+                                {{ option.label }}
+                            </option>
+                        </select>`,
+                        props: [
+                            'modelValue',
+                            'options',
+                        ],
                     },
                     'sw-highlight-text': true,
                 },
@@ -179,35 +166,24 @@ describe('src/module/sw-settings-measurement/component/sw-settings-measurement-d
         expect(wrapper.find('.sw-settings-measurement-default-units').exists()).toBeTruthy();
         expect(wrapper.find('.sw-settings-measurement-default-units__description').exists()).toBeTruthy();
 
-        const swEntitySingleSelect = wrapper.findAll('.sw-entity-single-select');
-        expect(swEntitySingleSelect).toHaveLength(1);
+        const swSingleSelect = wrapper.findAll('.mt-select__input');
+        expect(swSingleSelect).toHaveLength(3);
 
-        const swSingleSelect = wrapper.findAll('.sw-single-select__input');
-        expect(swSingleSelect).toHaveLength(2);
+        expect(swSingleSelect.at(0).attributes().value).toBe('metric');
 
-        expect(swEntitySingleSelect[0].find('.sw-entity-single-select__selection').text()).toBe('Metric system');
-
-        expect(swSingleSelect[0].element.value).toBe('mm');
-        expect(swSingleSelect[1].element.value).toBe('kg');
+        expect(swSingleSelect.at(1).attributes().value).toBe('mm');
+        expect(swSingleSelect.at(2).attributes().value).toBe('kg');
     });
 
     it('should emit measurement-system-change event when measurement system changes', async () => {
         const wrapper = await createWrapper();
-        const selects = wrapper.findAll('.sw-entity-single-select');
+        const selects = wrapper.findAll('.mt-select__input');
 
-        const selection = selects.at(0).find('.sw-entity-single-select__selection');
-
-        await selection.trigger('click');
-        await flushPromises();
-
-        const typeElement = wrapper.findAll('.sw-select-result');
-        await typeElement.at(0).trigger('click');
+        await selects.at(0).setValue('imperial');
         await flushPromises();
 
         expect(wrapper.emitted('measurement-system-change')).toBeTruthy();
-        expect(wrapper.emitted('measurement-system-change')[0][0].id).toBe('metric');
-        expect(wrapper.emitted('measurement-system-change')[0][0].name).toBe('Metric system');
-        expect(wrapper.emitted('measurement-system-change')[0][0].technicalName).toBe('metric');
+        expect(wrapper.emitted('measurement-system-change')[0][0]).toBe('imperial');
     });
 
     it('should format unit label correctly', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/index.js
@@ -5,7 +5,7 @@ import template from './sw-settings-measurement.html.twig';
 
 const { Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
-const { cloneDeep } = Shopware.Utils.object;
+const { ShopwareError } = Shopware.Classes;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
@@ -34,6 +34,7 @@ export default {
                 weight: null,
             },
             defaultDisplayUnits: [],
+            measurementSystems: [],
             measurementSystem: null,
             isLoading: false,
         };
@@ -52,11 +53,33 @@ export default {
         },
 
         defaultLengthUnit() {
-            return this.defaultDisplayUnits.find((u) => u.type === 'length');
+            const units = this.measurementSystem?.units || [];
+
+            const lengthUnit = this.defaultDisplayUnits.find((u) => u.type === 'length');
+            const defaultLengthUnit = units.find((unit) => unit.type === 'length' && unit.default);
+
+            return units.find((unit) => unit.shortName === lengthUnit.shortName) || defaultLengthUnit;
         },
 
         defaultWeightUnit() {
-            return this.defaultDisplayUnits.find((u) => u.type === 'weight');
+            const units = this.measurementSystem?.units || [];
+
+            const weightUnit = this.defaultDisplayUnits.find((u) => u.type === 'weight');
+            const defaultWeightUnit = units.find((unit) => unit.type === 'weight' && unit.default);
+
+            return units.find((unit) => unit.shortName === weightUnit.shortName) || defaultWeightUnit;
+        },
+
+        requiredFields() {
+            const isEmptyArray = (arr) => {
+                return Array.isArray(arr) && arr.length === 0;
+            };
+
+            return {
+                system: isEmptyArray(this.measurementUnits.system) || !this.measurementUnits.system,
+                length: isEmptyArray(this.measurementUnits.length) || !this.measurementUnits.length,
+                weight: isEmptyArray(this.measurementUnits.weight) || !this.measurementUnits.weight,
+            };
         },
     },
 
@@ -73,7 +96,10 @@ export default {
                 weight: measurementUnits['core.measurementUnits.weight'],
             };
 
-            this.measurementSystem = await this.getDefaultMeasurementSystem();
+            this.measurementSystems = await this.getDefaultMeasurementSystems();
+            this.measurementSystem = this.measurementSystems.find(
+                (system) => system.technicalName === this.measurementUnits.system,
+            );
 
             this.defaultDisplayUnits = (this.measurementSystem?.units || []).filter((u) =>
                 [
@@ -87,37 +113,57 @@ export default {
             return this.systemConfigApiService.getValues('core.measurementUnits');
         },
 
-        async getDefaultMeasurementSystem() {
-            const criteria = cloneDeep(this.measurementSystemCriteria);
-            criteria.setLimit(1);
-
-            if (this.measurementUnits.system) {
-                criteria.addFilter(Criteria.equals('technicalName', this.measurementUnits.system));
-            }
-
-            const measurement = await this.measurementSystemRepository.search(criteria);
-
-            return measurement.first();
+        getDefaultMeasurementSystems() {
+            return this.measurementSystemRepository.search(this.measurementSystemCriteria);
         },
 
         async onSave() {
             this.isLoading = true;
+
+            const invalidFields = Object.keys(this.requiredFields).filter((field) => this.requiredFields[field]);
+
             try {
+                if (invalidFields.length > 0) {
+                    invalidFields.forEach((property) => {
+                        const expression = `measurement_system.${this.measurementSystem.id}.${property}`;
+                        const error = new ShopwareError({
+                            code: 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                            detail: 'This field must not be empty.',
+                            selfLink: expression,
+                        });
+
+                        Shopware.Store.get('error').addApiError({ expression, error });
+                    });
+                    this.isLoading = false;
+
+                    return;
+                }
+
                 await this.systemConfigApiService.saveValues({
                     'core.measurementUnits.system': this.measurementUnits.system,
                     'core.measurementUnits.length': this.measurementUnits.length,
                     'core.measurementUnits.weight': this.measurementUnits.weight,
                 });
+
                 this.createNotificationSuccess({
                     title: this.$t('global.default.success'),
                     message: this.$t('sw-settings-measurement.notification.saveMeasurementSuccess'),
                 });
+
+                Shopware.Store.get('error').resetApiErrors();
             } catch (error) {
                 this.createNotificationError({
                     title: this.$t('global.default.error'),
                     message: error.message || this.$t('sw-settings-measurement.notification.saveMeasurementError'),
                 });
             } finally {
+                this.defaultDisplayUnits = (this.measurementSystem?.units || []).filter((u) =>
+                    [
+                        this.measurementUnits.length,
+                        this.measurementUnits.weight,
+                    ].includes(u.shortName),
+                );
+
                 this.isLoading = false;
             }
         },
@@ -126,31 +172,20 @@ export default {
             Shopware.Store.get('context').setApiLanguageId(languageId);
         },
 
-        async onChangeMeasurementSystem(measurementSystem) {
-            if (!measurementSystem) {
+        async onChangeMeasurementSystem(technicalName) {
+            if ((Array.isArray(technicalName) && technicalName.length === 0) || !technicalName) {
                 return;
             }
 
-            this.measurementUnits.system = measurementSystem.technicalName;
-            const units = measurementSystem.units;
+            Shopware.Store.get('error').resetApiErrors();
 
-            this.measurementSystem = measurementSystem;
+            this.measurementSystem = this.measurementSystems.find((system) => system.technicalName === technicalName);
 
-            const defaultLengthUnit =
-                units.find((unit) => unit.shortName === this.defaultLengthUnit.shortName) ||
-                units.find((unit) => unit.type === 'length' && unit.default);
-
-            if (defaultLengthUnit) {
-                this.measurementUnits.length = defaultLengthUnit.shortName;
-            }
-
-            const defaultWeightUnit =
-                units.find((unit) => unit.shortName === this.defaultWeightUnit.shortName) ||
-                units.find((unit) => unit.type === 'weight' && unit.default);
-
-            if (defaultWeightUnit) {
-                this.measurementUnits.weight = defaultWeightUnit.shortName;
-            }
+            this.measurementUnits = {
+                system: technicalName,
+                length: this.defaultLengthUnit.shortName,
+                weight: this.defaultWeightUnit.shortName,
+            };
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/sw-settings-measurement.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/sw-settings-measurement.html.twig
@@ -31,9 +31,9 @@
     <template #content>
         <sw-card-view>
             <sw-settings-measurement-default-units
+                :measurement-systems="measurementSystems"
                 :measurement-system="measurementSystem"
                 :measurement-units="measurementUnits"
-                :measurement-system-criteria="measurementSystemCriteria"
                 @measurement-system-change="onChangeMeasurementSystem"
             />
         </sw-card-view>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/sw-settings-measurement.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/sw-settings-measurement.spec.js
@@ -29,13 +29,34 @@ const createWrapper = async (options = {}) => {
                     [
                         { id: 'mm', type: 'length', measurementSystemId: 'metric', shortName: 'mm', default: true },
                         { id: 'kg', type: 'weight', measurementSystemId: 'metric', shortName: 'kg', default: true },
+                        { id: 'cm', type: 'length', measurementSystemId: 'metric', shortName: 'cm', default: false },
+                        { id: 'g', type: 'weight', measurementSystemId: 'metric', shortName: 'g', default: false },
                     ],
                     2,
                     null,
                 ),
+                getEntityName: () => 'measurement_display_unit',
+            },
+            {
+                id: 'imperial',
+                name: 'Imperial system',
+                technicalName: 'imperial',
+                units: new EntityCollection(
+                    '/measurement-display-unit',
+                    'measurement_display_unit',
+                    null,
+                    {},
+                    [
+                        { id: 'in', type: 'length', measurementSystemId: 'imperial', shortName: 'in', default: true },
+                        { id: 'lb', type: 'weight', measurementSystemId: 'imperial', shortName: 'lb', default: true },
+                    ],
+                    2,
+                    null,
+                ),
+                getEntityName: () => 'measurement_display_unit',
             },
         ],
-        1,
+        2,
         null,
     );
 
@@ -47,6 +68,9 @@ const createWrapper = async (options = {}) => {
     const repositoryFactory = {
         create: () => ({
             search: jest.fn().mockResolvedValue(mockDefaultUnits),
+            create: jest.fn().mockResolvedValue({
+                id: 'new-id',
+            }),
         }),
     };
 
@@ -94,9 +118,20 @@ const createWrapper = async (options = {}) => {
 
 describe('src/module/sw-settings-measurement/page/sw-settings-measurement', () => {
     let wrapper;
+    const addApiError = jest.fn();
+    const resetApiErrors = jest.fn();
 
     beforeEach(async () => {
         wrapper = await createWrapper();
+
+        Shopware.Store.unregister('error');
+        Shopware.Store.register({
+            id: 'error',
+            actions: {
+                addApiError,
+                resetApiErrors,
+            },
+        });
     });
 
     it('should be a Vue component', async () => {
@@ -114,6 +149,24 @@ describe('src/module/sw-settings-measurement/page/sw-settings-measurement', () =
         expect(wrapper.vm.defaultDisplayUnits).toHaveLength(2);
         expect(wrapper.vm.defaultDisplayUnits[0].id).toBe('mm');
         expect(wrapper.vm.defaultDisplayUnits[1].id).toBe('kg');
+    });
+
+    it('should not save when measurement units are missing', async () => {
+        await wrapper.setData({
+            measurementUnits: {
+                system: null,
+                length: null,
+                weight: null,
+            },
+        });
+
+        await flushPromises();
+
+        const saveButton = wrapper.find('.sw-settings-measurement__save-action');
+        await saveButton.trigger('click');
+
+        expect(addApiError).toHaveBeenCalledTimes(3);
+        expect(wrapper.vm.systemConfigApiService.saveValues).not.toHaveBeenCalled();
     });
 
     it('should save measurement system settings successfully', async () => {
@@ -164,36 +217,9 @@ describe('src/module/sw-settings-measurement/page/sw-settings-measurement', () =
     });
 
     it('should update measurement units when system changes', async () => {
-        const mockImperialUnits = new EntityCollection(
-            '/measurement-system',
-            'measurement_system',
-            null,
-            { isShopwareContext: true },
-            [
-                {
-                    id: 'imperial',
-                    name: 'Imperial system',
-                    technicalName: 'imperial',
-                    units: new EntityCollection(
-                        '/measurement-display-unit',
-                        'measurement_display_unit',
-                        null,
-                        {},
-                        [
-                            { id: 'in', type: 'length', measurementSystemId: 'imperial', shortName: 'in', default: true },
-                            { id: 'lb', type: 'weight', measurementSystemId: 'imperial', shortName: 'lb', default: true },
-                        ],
-                        2,
-                        null,
-                    ),
-                },
-            ],
-            1,
-            null,
-        );
+        await wrapper.vm.onChangeMeasurementSystem('imperial');
 
-        await wrapper.vm.onChangeMeasurementSystem(mockImperialUnits.first());
-
+        expect(resetApiErrors).toHaveBeenCalled();
         expect(wrapper.vm.measurementUnits).toEqual({
             system: 'imperial',
             length: 'in',
@@ -225,46 +251,7 @@ describe('src/module/sw-settings-measurement/page/sw-settings-measurement', () =
             ]),
         );
 
-        const imperialUnitsCollection = new EntityCollection(
-            '/measurement-display-unit',
-            '',
-            null,
-            {},
-            [
-                { id: 'in', type: 'length', measurementSystemId: 'imperial', shortName: 'in', default: true, name: 'Inch' },
-                { id: 'ft', type: 'length', measurementSystemId: 'imperial', shortName: 'ft', default: false, name: 'Foot' },
-                { id: 'lb', type: 'weight', measurementSystemId: 'imperial', shortName: 'lb', default: true, name: 'Pound' },
-                {
-                    id: 'oz',
-                    type: 'weight',
-                    measurementSystemId: 'imperial',
-                    shortName: 'oz',
-                    default: false,
-                    name: 'Ounce',
-                },
-            ],
-            4,
-            null,
-        );
-
-        const mockImperialUnits = new EntityCollection(
-            '/measurement-system',
-            'measurement_system',
-            null,
-            {},
-            [
-                {
-                    id: 'imperial',
-                    name: 'Imperial system',
-                    technicalName: 'imperial',
-                    units: imperialUnitsCollection,
-                },
-            ],
-            1,
-            null,
-        );
-
-        await wrapper.vm.onChangeMeasurementSystem(mockImperialUnits.first());
+        await wrapper.vm.onChangeMeasurementSystem('imperial');
 
         expect(wrapper.vm.measurementUnits).toEqual({
             system: 'imperial',
@@ -272,39 +259,7 @@ describe('src/module/sw-settings-measurement/page/sw-settings-measurement', () =
             weight: 'lb',
         });
 
-        const metricUnitsCollection = new EntityCollection(
-            '/measurement-display-unit',
-            'measurement_display_unit',
-            null,
-            { isShopwareContext: true },
-            [
-                { id: 'mm', type: 'length', measurementSystemId: 'metric', shortName: 'mm', default: true },
-                { id: 'cm', type: 'length', measurementSystemId: 'metric', shortName: 'cm', default: false },
-                { id: 'kg', type: 'weight', measurementSystemId: 'metric', shortName: 'kg', default: true },
-                { id: 'g', type: 'weight', measurementSystemId: 'metric', shortName: 'g', default: false },
-            ],
-            4,
-            null,
-        );
-
-        const mockMetricUnits = new EntityCollection(
-            '/measurement-system',
-            'measurement_system',
-            null,
-            { isShopwareContext: true },
-            [
-                {
-                    id: 'metric',
-                    name: 'Metric system',
-                    technicalName: 'metric',
-                    units: metricUnitsCollection,
-                },
-            ],
-            1,
-            null,
-        );
-
-        await wrapper.vm.onChangeMeasurementSystem(mockMetricUnits.first());
+        await wrapper.vm.onChangeMeasurementSystem('metric');
 
         expect(wrapper.vm.measurementUnits).toEqual({
             system: 'metric',


### PR DESCRIPTION
This pull request introduces a comprehensive measurement system to enhance flexibility in handling product measurements across various contexts, such as sales channels, APIs, and the storefront. Key changes include the implementation of a default metric system, dynamic unit conversion, API header overrides, and improved administration tools for managing measurement settings. Below are the most important changes grouped by theme:

### Core Functionality
* Introduced a `MeasurementSystem` class and related infrastructure to support metric and imperial units, with dynamic conversion based on sales channel configuration. Added runtime fields (`measurementUnits`) for products to calculate and display measurements in the configured units. (`adr/2025-05-12-implement-measurement-system.md`, [adr/2025-05-12-implement-measurement-system.mdR1-R254](diffhunk://#diff-a60ed9bf4a075f4fdbcef2c71056653340335d1a53a98c083193c304e2ebf99fR1-R254))
* Added new migrations to create database tables for the measurement system and default configurations. (`changelog/_unreleased/2025-04-02-create-migration-and-dal-for-scale-unit.md`, [[1]](diffhunk://#diff-11d29c9d9718ea8145dc3c4dbd180f9b2cd1f23021ad9b4cb900e2f5cc18c8e7R1-R7); `changelog/_unreleased/2025-06-10-add-measurement-system.md`, [[2]](diffhunk://#diff-1aff14df9447edf0fadac2f325a2314309d8f01013fa845ae1e757505a516c81R1-R63)

### API Enhancements
* Added new request headers (`sw-measurement-length-unit`, `sw-measurement-weight-unit`) to allow API consumers to override default measurement units when reading or writing product measurements. (`adr/2025-05-12-implement-measurement-system.md`, [[1]](diffhunk://#diff-a60ed9bf4a075f4fdbcef2c71056653340335d1a53a98c083193c304e2ebf99fR1-R254); `changelog/_unreleased/2025-06-10-add-measurement-system.md`, [[2]](diffhunk://#diff-1aff14df9447edf0fadac2f325a2314309d8f01013fa845ae1e757505a516c81R1-R63)

### Storefront Integration
* Updated storefront templates to dynamically display product measurements based on the configured measurement system instead of fixed units (e.g., mm, kg). Introduced a new Twig filter (`sw_convert_unit`) for on-the-fly unit conversions in templates. (`adr/2025-05-12-implement-measurement-system.md`, [[1]](diffhunk://#diff-a60ed9bf4a075f4fdbcef2c71056653340335d1a53a98c083193c304e2ebf99fR1-R254); `changelog/_unreleased/2025-06-10-add-measurement-system.md`, [[2]](diffhunk://#diff-1aff14df9447edf0fadac2f325a2314309d8f01013fa845ae1e757505a516c81R1-R63)

### Administration Improvements
* Added new components (`sw-sales-channel-measurement`, `sw-product-measurement-form`) and settings to manage measurement configurations in the sales channel and product detail pages. Enhanced bulk editing capabilities to support the new measurement system. (`changelog/_unreleased/2025-04-25-add-measurement-settings-into-sales-channel-configuration.md`, [[1]](diffhunk://#diff-09dea0604aef9b37fd2f6a72e1593e4475677782113d6d15ff3b88a7c6e7ed9fR1-R9); `changelog/_unreleased/2025-05-14-add-sw-product-measurement-form-component.md`, [[2]](diffhunk://#diff-bbea3d0ebd379c925300ce0f922010ebb8e279f6c710ebd5eccc6712ec93aa70R1-R8); `changelog/_unreleased/2025-05-19-adjust-bulk-editing-products-with-new-product-measurements.md`, [[3]](diffhunk://#diff-a059636abec3082c7ab869ac3dd8c952d0fb0a9a041bc0f4bb70fe4ce90299e9R1-R10)
* Updated domain configuration and listing to include measurement system information. (`changelog/_unreleased/2025-05-05-add-measurement-settings-into-sales-channel-domain-configuration.md`, [[1]](diffhunk://#diff-75f54acd0bfc6882c53cf8ba2b6d99e2f281deabe021db081917a1d5cf292361R1-R12); `changelog/_unreleased/2025-05-05-update-domain-listing-to-show-measurement-information.md`, [[2]](diffhunk://#diff-ddfd874bfd0d0a4e64c2b202063183c766ae0d5378303c07abc7ced9d107b38cR1-R11)

### Deprecations and Backward Compatibility
* Deprecated certain blocks and properties in existing components to align with the new measurement system. Ensured backward compatibility by retaining the default metric units (mm, kg) for stored product measurements. (`changelog/_unreleased/2025-04-22-add-selling-packaging-card.md`, [[1]](diffhunk://#diff-d0b0bfd62018adc9b8433e678799039c01b7634172e5eb1283e916feff11bd32R1-R11); `adr/2025-05-12-implement-measurement-system.md`, [[2]](diffhunk://#diff-a60ed9bf4a075f4fdbcef2c71056653340335d1a53a98c083193c304e2ebf99fR1-R254)
  
  
<img width="964" alt="Screenshot 2025-06-11 at 15 55 51" src="https://github.com/user-attachments/assets/19f2f05f-bed4-4379-960a-dc698c95f5e4" />
<img width="959" alt="Screenshot 2025-06-11 at 15 56 00" src="https://github.com/user-attachments/assets/223b42b1-0aee-4670-8d88-3402508e0e32" />
<img width="969" alt="Screenshot 2025-06-11 at 15 56 07" src="https://github.com/user-attachments/assets/064a07ca-5dac-4a1b-a3bb-437dd00f0386" />
<img width="952" alt="Screenshot 2025-06-11 at 15 56 20" src="https://github.com/user-attachments/assets/d40b7382-78dd-419e-9c82-5443927f978c" />
