### PR TITLE
fix: sw-entity-single-select collapse when other is expanded

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
@@ -32,7 +32,7 @@
             {% block sw_entity_single_select_single_selection_inner %}
             {% block sw_entity_single_select_single_selection_inner_label %}
             <div
-                v-if="!isExpanded"
+                v-show="!isExpanded"
                 class="sw-entity-single-select__selection-text"
                 :class="selectionTextClasses"
             >

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-base-line-item/sw-condition-base-line-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-base-line-item/sw-condition-base-line-item.scss
@@ -2,8 +2,4 @@
     display: grid;
     gap: 4px;
     grid-template-columns: auto 1fr;
-
-    &__matches-all {
-        width: 128px;
-    }
 }


### PR DESCRIPTION

### 1. Why is this change necessary?
To fix this issue: https://github.com/shopware/shopware/issues/10129


### 2. What does this change do, exactly?
The sw-entity-single-select had an issue with the click bubbling, because when clicked in the selection-text, the element is removed due to `v-if`.
That makes the click event not be emitted most of the times


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Settings > Languages
2. Click on Add a new Language
3. Click on the placeholder of the Locale and leave the select open
4. Click on the placeholder of the Iso code
5. The first select should be closed


### 4. Please link to the relevant issues (if any).
- closes #10129 