### PR TITLE
fix: Vue3 compatibility for template refs in cross-selling component

### DIFF
--- a/changelog/_unreleased/2025-06-09-vue3-compatibility-for-template-refs-in-cross-selling-component.md
+++ b/changelog/_unreleased/2025-06-09-vue3-compatibility-for-template-refs-in-cross-selling-component.md
@@ -1,0 +1,8 @@
+---
+title: Vue3 compatibility for template refs in cross-selling component
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed the admin component `sw-cms-el-cross-selling` to be compatible with Vue3 and make sure that the product box width is recalculated when the component width changes

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/component.spec.js
@@ -44,8 +44,30 @@ async function createWrapper(element = defaultElement) {
     );
 }
 
+// Mock ResizeObserver which is not available in JSDOM
+class ResizeObserverMock {
+    constructor(callback) {
+        this.callback = callback;
+        // Make callback accessible for testing
+        this.triggerResize = () => {
+            this.callback([{ target: this.observedElement }]);
+        };
+    }
+
+    observe(element) {
+        this.observedElement = element;
+        setTimeout(() => this.callback([{ target: element }]), 0);
+    }
+
+    unobserve() {}
+    disconnect() {}
+}
+
 describe('module/sw-cms/elements/cross-selling/component', () => {
     beforeAll(async () => {
+        // Add ResizeObserver mock to global
+        global.ResizeObserver = ResizeObserverMock;
+
         await setupCmsEnvironment();
         await import('src/module/sw-cms/elements/cross-selling');
     });
@@ -75,5 +97,57 @@ describe('module/sw-cms/elements/cross-selling/component', () => {
                 value: 'standard',
             },
         });
+    });
+
+    it('updates sliderBoxLimit based on element width and device view', async () => {
+        const wrapper = await createWrapper();
+
+        // Initial value from component creation
+        expect(wrapper.vm.sliderBoxLimit).toBe(1);
+
+        Object.defineProperty(wrapper.vm.$refs.productHolder, 'offsetWidth', {
+            configurable: true,
+            value: 700,
+        });
+
+        wrapper.vm.setSliderRowLimit();
+
+        // This should be floor(700 / ((300 - 100) + 32)) = 3
+        expect(wrapper.vm.sliderBoxLimit).toBe(3);
+
+        // Test with 1100px width - should fit 4 items
+        Object.defineProperty(wrapper.vm.$refs.productHolder, 'offsetWidth', {
+            configurable: true,
+            value: 1100,
+        });
+
+        wrapper.vm.setSliderRowLimit();
+
+        // This should be floor(1100 / ((300 - 100) + 32)) = 4
+        expect(wrapper.vm.sliderBoxLimit).toBe(4);
+
+        // Test mobile view - always shows 1 item
+        wrapper.vm.cmsPageState.currentCmsDeviceView = 'mobile';
+        wrapper.vm.setSliderRowLimit();
+        expect(wrapper.vm.sliderBoxLimit).toBe(1);
+    });
+
+    it('ResizeObserver triggers setSliderRowLimit when resized', async () => {
+        const wrapper = await createWrapper();
+
+        // Spy on the setSliderRowLimit method
+        const spy = jest.spyOn(wrapper.vm, 'setSliderRowLimit');
+
+        // Clear previous calls
+        spy.mockClear();
+
+        // Trigger the observer callback
+        wrapper.vm.resizeObserver.triggerResize();
+
+        // Wait for any async operations
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        // Verify the method was called
+        expect(spy).toHaveBeenCalled();
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/component.spec.js
@@ -60,6 +60,7 @@ class ResizeObserverMock {
     }
 
     unobserve() {}
+
     disconnect() {}
 }
 
@@ -145,7 +146,9 @@ describe('module/sw-cms/elements/cross-selling/component', () => {
         wrapper.vm.resizeObserver.triggerResize();
 
         // Wait for any async operations
-        await new Promise(resolve => setTimeout(resolve, 20));
+        await new Promise(resolve => {
+            setTimeout(resolve, 20);
+        });
 
         // Verify the method was called
         expect(spy).toHaveBeenCalled();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/component.spec.js
@@ -146,7 +146,7 @@ describe('module/sw-cms/elements/cross-selling/component', () => {
         wrapper.vm.resizeObserver.triggerResize();
 
         // Wait for any async operations
-        await new Promise(resolve => {
+        await new Promise((resolve) => {
             setTimeout(resolve, 20);
         });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/index.js
@@ -164,7 +164,7 @@ export default {
             }
 
             const productHolder = this.$refs.productHolder;
-            if (this.currentDeviceView === 'mobile' || (productHolder && productHolder.offsetWidth < 500)) {
+            if (this.currentDeviceView === 'mobile' || productHolder?.offsetWidth < 500) {
                 this.sliderBoxLimit = 1;
                 return;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/index.js
@@ -19,6 +19,7 @@ export default {
     data() {
         return {
             sliderBoxLimit: 3,
+            resizeObserver: null,
         };
     },
 
@@ -91,6 +92,16 @@ export default {
                 this.setSliderRowLimit();
             }, 400);
         },
+
+        '$refs.productHolder': {
+            handler(newVal) {
+                if (newVal && this.resizeObserver) {
+                    // Re-attach observer when ref becomes available
+                    this.resizeObserver.observe(newVal);
+                }
+            },
+            immediate: true,
+        },
     },
 
     created() {
@@ -101,6 +112,10 @@ export default {
         this.mountedComponent();
     },
 
+    beforeUnmount() {
+        this.beforeUnmountComponent();
+    },
+
     methods: {
         createdComponent() {
             this.initElementConfig('cross-selling');
@@ -109,6 +124,38 @@ export default {
 
         mountedComponent() {
             this.setSliderRowLimit();
+            this.initResizeObserver();
+        },
+
+        beforeUnmountComponent() {
+            this.destroyResizeObserver();
+        },
+
+        initResizeObserver() {
+            this.destroyResizeObserver();
+
+            this.resizeObserver = new ResizeObserver(() => {
+                window.requestAnimationFrame(() => {
+                    this.setSliderRowLimit();
+                });
+            });
+
+            if (this.$refs.productHolder) {
+                this.resizeObserver.observe(this.$refs.productHolder);
+            }
+
+            this.$nextTick(() => {
+                if (this.$refs.productHolder && this.resizeObserver) {
+                    this.resizeObserver.observe(this.$refs.productHolder);
+                }
+            });
+        },
+
+        destroyResizeObserver() {
+            if (this.resizeObserver) {
+                this.resizeObserver.disconnect();
+                this.resizeObserver = null;
+            }
         },
 
         setSliderRowLimit() {
@@ -116,10 +163,8 @@ export default {
                 this.createdComponent();
             }
 
-            if (
-                this.currentDeviceView === 'mobile' ||
-                (this.$refs.productHolder && this.$refs.productHolder.offsetWidth < 500)
-            ) {
+            const productHolder = this.$refs.productHolder;
+            if (this.currentDeviceView === 'mobile' || (productHolder && productHolder.offsetWidth < 500)) {
                 this.sliderBoxLimit = 1;
                 return;
             }
@@ -137,9 +182,13 @@ export default {
                 return;
             }
 
+            if (!productHolder) {
+                return;
+            }
+
             // Subtract to fake look in storefront which has more width
             const fakeLookWidth = 100;
-            const boxWidth = this.$refs.productHolder.offsetWidth;
+            const boxWidth = productHolder.offsetWidth;
             const elGap = 32;
             let elWidth = parseInt(this.element.config.elMinWidth.value.replace('px', ''), 10);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When adding a new cross selling element in a shopping experience layout, the following error is triggered:
![image](https://github.com/user-attachments/assets/9625c040-a6cd-4881-b7b0-22954e339931)

Furthermore the box width is not adjusted when the element is resized.

### 2. What does this change do, exactly?
Make sure that the reference always exist and adjust width of product box elements when resizing the element.

### 3. Describe each step to reproduce the issue or behaviour.
Add a new cross selling element in the adminsitration.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
