### PR TITLE
fix: Delete discounts onSave

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-detail-discounts/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-detail-discounts/index.js
@@ -17,7 +17,13 @@ export default {
 
     data() {
         return {
+            /**
+             * @deprecated tag:v6.8.0 - will be removed without replacement
+             */
             deleteDiscountId: null,
+            /**
+             * @deprecated tag:v6.8.0 - will be removed without replacement
+             */
             repository: null,
         };
     },
@@ -64,18 +70,7 @@ export default {
         },
 
         deleteDiscount(discount) {
-            if (discount.isNew()) {
-                this.discounts.remove(discount.id);
-                return;
-            }
-
-            this.isLoading = true;
-            const promotionDiscountRepository = this.repositoryFactory.create(this.discounts.entity, this.discounts.source);
-
-            promotionDiscountRepository.delete(discount.id, this.discounts.context).then(() => {
-                this.discounts.remove(discount.id);
-                this.isLoading = false;
-            });
+            this.discounts.remove(discount.id);
         },
     },
 };


### PR DESCRIPTION
### 1. Why is this change necessary?
After discount delete, an API call will be made. With a click on "save", an attempt is made to delete the discount again. This second call will be failing and create a error message

### 2. What does this change do, exactly?
Remove the first delete API call.

### 3. Describe each step to reproduce the issue or behaviour.
Create a promotion with a discount. Delete the discount and click the "save" button

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/10256

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
