### PR TITLE
fix: visible dragging element in product media form

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-product-image/sw-product-image.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-product-image/sw-product-image.scss
@@ -112,4 +112,8 @@
         max-width: 64px;
         max-height: 55px;
     }
+
+    &.is--droppable.is--draggable.is--drag-element {
+        position: absolute;
+    }
 }


### PR DESCRIPTION
### Description 
When dragging an image in the product media form. The dragging image will not be visible 

### Solution 

![Screenshot 2025-06-10 at 15 52 53](https://github.com/user-attachments/assets/509b3df0-eb8a-4d0c-940d-f74164818197)
