### PR TITLE
fix: Allow to set the file extension for media entities via admin api

### DIFF
--- a/changelog/_unreleased/2025-06-10-removed-write-protection-flag-from-fileextension-field-in-the-mediadefinition.md
+++ b/changelog/_unreleased/2025-06-10-removed-write-protection-flag-from-fileextension-field-in-the-mediadefinition.md
@@ -1,0 +1,9 @@
+---
+title: Removed write protection flag from fileExtension field in the MediaDefinition
+issue: #7993
+author: Martin Krzykawski
+author_github: @MartinKrzykawski
+---
+# Core
+* Removed write protection flag from `fileExtension` field in the `Shopware\Core\Content\Media\MediaDefinition`. 
+* Changed `Shopware\Core\Content\Media\MediaDefinition` that media entities can now be created via the Admin API, allowing the file extension to be set freely.

--- a/src/Core/Content/Media/MediaDefinition.php
+++ b/src/Core/Content/Media/MediaDefinition.php
@@ -92,7 +92,7 @@ class MediaDefinition extends EntityDefinition
             new FkField('user_id', 'userId', UserDefinition::class),
             new FkField('media_folder_id', 'mediaFolderId', MediaFolderDefinition::class),
             (new StringField('mime_type', 'mimeType'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::LOW_SEARCH_RANKING)),
-            (new StringField('file_extension', 'fileExtension'))->addFlags(new ApiAware(), new WriteProtected(Context::SYSTEM_SCOPE)),
+            (new StringField('file_extension', 'fileExtension'))->addFlags(new ApiAware()),
             (new DateTimeField('uploaded_at', 'uploadedAt'))->addFlags(new ApiAware(), new WriteProtected(Context::SYSTEM_SCOPE)),
             (new LongTextField('file_name', 'fileName'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new IntField('file_size', 'fileSize'))->addFlags(new ApiAware(), new WriteProtected(Context::SYSTEM_SCOPE)),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

Closes #7993

### 1. Why is this change necessary?
When media entities are created via the Admin API—for example, during [remote thumbnail generation](https://developer.shopware.com/docs/guides/plugins/plugins/content/media/remote-thumbnail-generation.html)—the fileExtension field is null.
This is because it’s only set when using specific API routes and not populated through the Admin API. Additionally, the fileExtension field is write-protected and therefore cannot be manually set via the Admin API.

### 2. What does this change do, exactly?
I have removed the write protection for the fileExtension field to allow setting this field via Admin API.

### 3. Describe each step to reproduce the issue or behaviour.
1. Set up admin API
2. Create a media entity and include the fileExtension field in your request payload.
3. Check if the media entity was created and check for the fileExtension.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
