### PR TITLE
fix: correct dateType property and remove default value

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-time-range/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-time-range/index.js
@@ -3,7 +3,6 @@ import './sw-condition-time-range.scss';
 
 const { Component } = Shopware;
 const { mapPropertyErrors } = Component.getComponentHelper();
-const defaultTimeValue = '12:00';
 
 /**
  * @sw-package fundamentals@after-sales
@@ -25,12 +24,8 @@ export default {
         fromTime: {
             get() {
                 this.ensureValueExist();
-                if (!this.condition.value.fromTime) {
-                    // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-                    this.condition.value.fromTime = defaultTimeValue;
-                }
 
-                return this.condition.value.fromTime;
+                return this.condition.value.fromTime || null;
             },
             set(fromTime) {
                 this.ensureValueExist();
@@ -40,12 +35,8 @@ export default {
         toTime: {
             get() {
                 this.ensureValueExist();
-                if (!this.condition.value.toTime) {
-                    // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-                    this.condition.value.toTime = defaultTimeValue;
-                }
 
-                return this.condition.value.toTime;
+                return this.condition.value.toTime || null;
             },
             set(toTime) {
                 this.ensureValueExist();

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-time-range/sw-condition-time-range.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-time-range/sw-condition-time-range.html.twig
@@ -5,7 +5,7 @@
         v-model="fromTime"
         name="sw-field--fromTime"
         size="medium"
-        dateType="time"
+        date-type="time"
         required
         :config="datepickerConfig"
         :disabled="disabled || undefined"
@@ -18,7 +18,7 @@
         v-model="toTime"
         name="sw-field--toTime"
         size="medium"
-        dateType="time"
+        date-type="time"
         required
         :config="datepickerConfig"
         :disabled="disabled || undefined"

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-time-range/sw-condition-time-range.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-time-range/sw-condition-time-range.html.twig
@@ -5,7 +5,7 @@
         v-model="fromTime"
         name="sw-field--fromTime"
         size="medium"
-        date-type="time"
+        dateType="time"
         required
         :config="datepickerConfig"
         :disabled="disabled || undefined"
@@ -18,7 +18,7 @@
         v-model="toTime"
         name="sw-field--toTime"
         size="medium"
-        date-type="time"
+        dateType="time"
         required
         :config="datepickerConfig"
         :disabled="disabled || undefined"


### PR DESCRIPTION
### What does this change do, exactly?
- remove hardcoded default value that caused display/storage inconsistency **BUT**: this will change also the visual default time to `01:00` instead the actual time when the rule was created.

### how to reproduce
- create a rule with a time-range condition
- open the developer tools > network
- do not adjust the time! just save
- "12:00" are passed as default values in the /api/rule payload
![image](https://github.com/user-attachments/assets/6f660bd3-e144-4819-a0e1-383c1ca1c872)

relates [#10109](https://github.com/shopware/shopware/issues/10109)

The meteor-component issue will be fixed here: https://github.com/shopware/meteor/issues/762