### PR TITLE
refactor: Cleanup `sw-promotion-discount-component`

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -179,7 +179,7 @@ export default {
         // only show advanced max value settings if
         // at least a base max value has been set
         showMaxValueAdvancedPrices() {
-            return this.discount.type === DiscountTypes.PERCENTAGE && this.discount.maxValue !== null;
+            return this.discount.type === DiscountTypes.PERCENTAGE && this.discount.maxValue !== null && this.discount.maxValue !== undefined;
         },
 
         /** @deprecated tag:v6.8.0 - Will be removed without replacement */
@@ -297,7 +297,7 @@ export default {
         },
 
         isPickingModeVisible() {
-            if (this.discount.scope.startsWith(DiscountScopes.SETGROUP)) {
+            if (this.discount.scope?.startsWith(DiscountScopes.SETGROUP)) {
                 return true;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -179,8 +179,11 @@ export default {
         // only show advanced max value settings if
         // at least a base max value has been set
         showMaxValueAdvancedPrices() {
-            return this.discount.type === DiscountTypes.PERCENTAGE
-                && this.discount.maxValue !== null && this.discount.maxValue !== undefined;
+            return (
+                this.discount.type === DiscountTypes.PERCENTAGE &&
+                this.discount.maxValue !== null &&
+                this.discount.maxValue !== undefined
+            );
         },
 
         /** @deprecated tag:v6.8.0 - Will be removed without replacement */

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -179,7 +179,8 @@ export default {
         // only show advanced max value settings if
         // at least a base max value has been set
         showMaxValueAdvancedPrices() {
-            return this.discount.type === DiscountTypes.PERCENTAGE && this.discount.maxValue !== null && this.discount.maxValue !== undefined;
+            return this.discount.type === DiscountTypes.PERCENTAGE
+                && this.discount.maxValue !== null && this.discount.maxValue !== undefined;
         },
 
         /** @deprecated tag:v6.8.0 - Will be removed without replacement */

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.html.twig
@@ -4,23 +4,25 @@
     position-identifier="sw-promotion-discount-component"
     :title="$tc('sw-promotion.detail.main.discounts.card')"
 >
-    <sw-context-button class="sw-promotion-discount-component__context-button">
-        {% block sw_promotion_detail_discounts_item_context_button_delete %}
-        <sw-context-menu-item
-            v-tooltip="{
-                message: $tc('sw-privileges.tooltip.warning'),
-                disabled: acl.can('promotion.editor'),
-                showOnDisabledElements: true
-            }"
-            variant="danger"
-            class="sw-promotion-context-item__delete-action"
-            :disabled="isEditingDisabled"
-            @click="onShowDeleteModal"
-        >
-            {{ $tc('sw-promotion.detail.main.discounts.buttonDeleteDiscount') }}
-        </sw-context-menu-item>
-        {% endblock %}
-    </sw-context-button>
+    <template #headerRight>
+        <sw-context-button class="sw-promotion-discount-component__context-button">
+            {% block sw_promotion_detail_discounts_item_context_button_delete %}
+            <sw-context-menu-item
+                v-tooltip="{
+                    message: $tc('sw-privileges.tooltip.warning'),
+                    disabled: acl.can('promotion.editor'),
+                    showOnDisabledElements: true
+                }"
+                variant="danger"
+                class="sw-promotion-context-item__delete-action"
+                :disabled="isEditingDisabled"
+                @click="onShowDeleteModal"
+            >
+                {{ $tc('sw-promotion.detail.main.discounts.buttonDeleteDiscount') }}
+            </sw-context-menu-item>
+            {% endblock %}
+        </sw-context-button>
+    </template>
 
     <sw-container
         columns="1fr 1fr"
@@ -55,7 +57,7 @@
 
     {% block sw_promotion_discount_condition_rules_form %}
     <template v-if="!shippingScope && discount.considerAdvancedRules === true">
-        <div v-if="!isSetGroup">
+        <template v-if="!isSetGroup">
             <sw-promotion-v2-rule-select
                 v-model:collection="discount.discountRules"
                 class="sw-promotion-discount-component__select-discount-rules"
@@ -68,7 +70,7 @@
                 :restriction-snippet="promotionDiscountSnippet"
                 rule-aware-group-key="promotionDiscounts"
             />
-        </div>
+        </template>
 
         <sw-container
             columns="1fr 1fr"

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.scss
@@ -1,37 +1,5 @@
-@import "~scss/variables";
-
-.sw-promotion-discount-component {
-    .sw-promotion-discount-component__context-button {
-        float: right;
-    }
-
-    p {
-        margin-bottom: 30px;
-    }
-
-    .sw-promotion-discount-component__select-discount-rules {
-        margin-bottom: 20px;
-    }
-
-    .sw-card__quick-link.advanced-prices {
-        cursor: pointer;
-    }
-
-    .sw-field .sw-field__help-text {
-        position: relative;
-        top: 40px;
-        right: 65px;
-    }
-}
-
 .sw-promotion-discount-form__advanced-prices-modal.sw-modal .sw-modal__body {
     padding: 0;
-
-    .sw-data-grid .sw-data-grid__header .sw-data-grid__cell-label {
-        white-space: normal;
-        overflow: visible;
-        text-overflow: initial;
-    }
 
     .mt-block-field__block {
         min-height: unset;

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.spec.js
@@ -31,7 +31,7 @@ async function createWrapper() {
                         template: '<div class="sw-loader"></div>',
                     },
                     'mt-card': {
-                        template: '<div class="mt-card"><slot></slot></div>',
+                        template: '<div class="mt-card"><slot name="headerRight"></slot><slot></slot></div>',
                     },
                     'sw-context-button': {
                         template: '<div class="sw-context-button"><slot></slot></div>',


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the promotion discount component does not look nice: 
![image](https://github.com/user-attachments/assets/4a7b5de8-eeaf-44e7-ad7c-6d1f7ba4d721)

### 2. What does this change do, exactly?
This PR tries to improve the situation a little bit:
![image](https://github.com/user-attachments/assets/cb5a19ed-dd18-4890-bdc0-f2d15850639c)

Also a most of the (S)CSS is not needed, which is removed in this PR as well.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
