### PR TITLE
fix: shipping method active field margin

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.html.twig
@@ -72,7 +72,7 @@
                     :is-loading="isLoading"
                 >
                     <sw-container
-                        columns="3fr 3fr 1fr"
+                        columns="3fr 3fr"
                         gap="0px 30px"
                     >
                         {% block sw_settings_shipping_detail_base_content_field_name %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Margins are different
![image](https://github.com/user-attachments/assets/f3a05022-6395-40a5-a52a-fe2bcef58a9e)


### 2. What does this change do, exactly?
Change the columns from 3 to 2.
The position placeholder will not be cut as well

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/beb2371b-021e-443e-9f8a-27f0f27a755a" />


### 3. Describe each step to reproduce the issue or behaviour.
Create a new shipping method or edit the existing one

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/10161

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
