### PR TITLE
feat: improve elasticssearch scoring for numeric tokens

### DIFF
--- a/changelog/_unreleased/2025-06-11-improve-es-search-scoring-for-numeric-tokens.md
+++ b/changelog/_unreleased/2025-06-11-improve-es-search-scoring-for-numeric-tokens.md
@@ -1,0 +1,9 @@
+---
+title: Improve ES search scoring for numeric tokens
+author: thuong.le
+author_email: levienthuong@gmail.com
+author_github: @thuong.le
+---
+# Core
+* Changed the logic in `\Shopware\Elasticsearch\TokenQueryBuilder::build` to omit the fuzziness for numeric tokens query to improve search relevance
+* Added new method `\Shopware\Elasticsearch\Product\SearchFieldConfig::getFuzziness` to return the fuzziness of the search config DTO

--- a/src/Elasticsearch/Product/SearchFieldConfig.php
+++ b/src/Elasticsearch/Product/SearchFieldConfig.php
@@ -50,4 +50,15 @@ class SearchFieldConfig
     {
         return $this->prefixMatch;
     }
+
+    public function getFuzziness(string $token): string|int
+    {
+        $fuzziness = $this->tokenize ? 'auto' : 1;
+
+        if (is_numeric($token) || preg_match('/\d{3,}/', $token)) {
+            $fuzziness = 0; // Disable fuzziness for numeric tokens or a serial of at least 3 digits
+        }
+
+        return $fuzziness;
+    }
 }

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -111,7 +111,7 @@ class TokenQueryBuilder
 
             $queries[] = new MatchQuery($searchField, $token, [
                 'boost' => $config->getRanking(),
-                'fuzziness' => $config->tokenize() ? 'auto' : 1,
+                'fuzziness' => $config->getFuzziness($token),
                 'operator' => $operator,
             ]);
 

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -472,6 +472,10 @@ class ProductSearchQueryBuilderTest extends TestCase
             'boost' => (float) $boost,
         ];
 
+        if (is_numeric($query) || preg_match('/\d{3,}/', (string) $query)) {
+            $fuzziness = 0;
+        }
+
         if ($fuzziness !== null) {
             $payload['fuzziness'] = $fuzziness;
         }

--- a/tests/unit/Elasticsearch/Product/SearchFieldConfigTest.php
+++ b/tests/unit/Elasticsearch/Product/SearchFieldConfigTest.php
@@ -30,4 +30,23 @@ class SearchFieldConfigTest extends TestCase
         $searchConfig->setRanking(2500.5);
         static::assertSame(2500.5, $searchConfig->getRanking());
     }
+
+    public function testGetFuzziness(): void
+    {
+        $searchConfig = new SearchFieldConfig('fooField', 1000.0, true);
+
+        static::assertSame('auto', $searchConfig->getFuzziness('foo'));
+        static::assertSame('auto', $searchConfig->getFuzziness('f'));
+        static::assertSame(0, $searchConfig->getFuzziness('123'));
+        static::assertSame(0, $searchConfig->getFuzziness('1234'));
+        static::assertSame(0, $searchConfig->getFuzziness('1234.5'));
+
+        $searchConfig = new SearchFieldConfig('fooField', 1000.0, false);
+
+        static::assertSame(1, $searchConfig->getFuzziness('foo'));
+        static::assertSame(1, $searchConfig->getFuzziness('f'));
+        static::assertSame(0, $searchConfig->getFuzziness('123'));
+        static::assertSame(0, $searchConfig->getFuzziness('1234'));
+        static::assertSame(0, $searchConfig->getFuzziness('1234.5'));
+    }
 }

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -444,6 +444,10 @@ class TokenQueryBuilderTest extends TestCase
             'boost' => (float) $boost,
         ];
 
+        if (preg_match('/\d{3,}/', (string) $query)) {
+            $fuzziness = 0;
+        }
+
         if ($fuzziness !== null) {
             $payload['fuzziness'] = $fuzziness;
         }


### PR DESCRIPTION
There's many occasion that the search by numeric bring unexpected result due to the fuzziness of the query. It reality, the search by number rarely have a typo.

How to reproduce:

- Create a product named "Product 3000"
- Create another named "Product X3800"

Search "3800" in the storefront:

- "Product 3000" is ranked higher despite of the fact that "3800" is more relevant, because "Product X3800" is a partial match and "Product 3000" is an exact match (with a allowed typo). With this improvement, we remove the "allowed typo" (fuzziness) if the token is a numeric or a serial of 3 digits)