### PR TITLE
fix: caching issues in acceptance tests

### DIFF
--- a/tests/acceptance/tests/Product/ProductVisibility.spec.ts
+++ b/tests/acceptance/tests/Product/ProductVisibility.spec.ts
@@ -26,6 +26,7 @@ test('Product is visible in listing and storefront search when set to "Visible".
 
     await test.step('Verify the product appears in the Home category listing.', async () => {
         await ShopCustomer.goesTo(StorefrontHome.url());
+        await StorefrontHome.mainNavigationLink.getByText('Home').click();
         const productLocators = await StorefrontHome.getListingItemByProductName(product.name);
         await ShopCustomer.expects(productLocators.productName).toBeVisible();
     });
@@ -70,6 +71,7 @@ test('Product is visible in storefront search but hidden from listing when set t
 
     await test.step('Verify the product does not appear in the Home category listing.', async () => {
         await ShopCustomer.goesTo(StorefrontHome.url());
+        await StorefrontHome.mainNavigationLink.getByText('Home').click();
         const productLocators = await StorefrontHome.getListingItemByProductName(product.name);
         await ShopCustomer.expects(productLocators.productName).not.toBeVisible();
     });
@@ -115,6 +117,7 @@ test('Product is hidden from both listing and storefront search when set to "Hid
 
     await test.step('Verify the product does not appear in the Home category listing.', async () => {
         await ShopCustomer.goesTo(StorefrontHome.url());
+        await StorefrontHome.mainNavigationLink.getByText('Home').click();
         const productLocators = await StorefrontHome.getListingItemByProductName(product.name);
         await ShopCustomer.expects(productLocators.productName).not.toBeVisible();
     });
@@ -150,6 +153,7 @@ test('Product is not visible without adding it to the sales channel.', { tag: '@
 
     await test.step('Verify the product does not appear in the Home category listing.', async () => {
         await ShopCustomer.goesTo(StorefrontHome.url());
+        await StorefrontHome.mainNavigationLink.getByText('Home').click();
         const productLocators = await StorefrontHome.getListingItemByProductName(product.name);
         await ShopCustomer.expects(productLocators.productName).not.toBeVisible();
     });


### PR DESCRIPTION
### 1. Why is this change necessary?
There are several caching issue in SaaS with acceptance tests

### 2. What does this change do, exactly?
We introduced a click() on the page to refresh the view (not the page)

### 3. Describe each step to reproduce the issue or behaviour.
Open SaaS and add a product
Check the storefront product listing with an already open view of the product listing

### 4. Please link to the relevant issues (if any).

In case of issue existing only on Jira, link to the Jira issue.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
