### PR TITLE
fix: Use correct syntax for getting the value from the Vue i18n component

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-field-deprecated/index.js
@@ -67,11 +67,11 @@ export default {
 
     computed: {
         locale() {
-            return this.$root.$i18n.locale;
+            return this.$root.$i18n.locale.value;
         },
 
         fallbackLocale() {
-            return this.$root.$i18n.fallbackLocale;
+            return this.$root.$i18n.fallbackLocale.value;
         },
 
         swFieldSelectClasses() {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/index.js
@@ -55,7 +55,7 @@ export default {
 
     computed: {
         locale() {
-            return this.$root.$i18n.locale;
+            return this.$root.$i18n.locale.value;
         },
 
         defaultContextMenuClass() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-detail/index.js
@@ -49,10 +49,10 @@ export default {
     computed: {
         locales() {
             if (this.set.config.translated && this.set.config.translated === true) {
-                return Object.keys(this.$root.$i18n.messages);
+                return Object.keys(this.$root.$i18n.messages.value);
             }
 
-            return [this.$root.$i18n.fallbackLocale];
+            return [this.$root.$i18n.fallbackLocale.value];
         },
 
         canSave() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-translated-labels/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-translated-labels/index.js
@@ -39,7 +39,7 @@ export default {
 
     computed: {
         fallbackLocale() {
-            return this.$root.$i18n.fallbackLocale;
+            return this.$root.$i18n.fallbackLocale.value;
         },
 
         localeCount() {
@@ -72,7 +72,7 @@ export default {
 
         getLabel(label, locale) {
             const snippet = this.getInlineSnippet(label);
-            const language = this.$tc(`locale.${locale.value ?? locale}`);
+            const language = this.$tc(`locale.${locale}`);
 
             return `${snippet} (${language})`;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-translated-labels/sw-custom-field-translated-labels.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-translated-labels/sw-custom-field-translated-labels.spec.js
@@ -16,8 +16,9 @@ const config = {
 };
 
 const intl = {
-    locale: en,
-    fallbackLocale: en,
+    fallbackLocale: {
+        value: en,
+    },
 };
 
 const defaultProps = {
@@ -40,12 +41,10 @@ async function createWrapper(props = defaultProps) {
         }),
         {
             props,
-            provide: {
-                $root: {
+            global: {
+                mocks: {
                     $i18n: intl,
                 },
-            },
-            global: {
                 stubs: {
                     'sw-tabs': await wrapTestComponent('sw-tabs'),
                     'sw-tabs-deprecated': await wrapTestComponent('sw-tabs-deprecated', { sync: true }),
@@ -148,7 +147,7 @@ describe('src/module/sw-settings-custom-field/component/sw-custom-field-translat
 
         expect(wrapper.vm.config).toHaveProperty('test');
         expect(wrapper.vm.config.test).toStrictEqual({
-            [intl.fallbackLocale]: null,
+            [intl.fallbackLocale.value]: null,
         });
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-base/index.js
@@ -36,10 +36,10 @@ export default {
     computed: {
         locales() {
             if (this.set.config.hasOwnProperty('translated') && this.set.config.translated === true) {
-                return Object.keys(this.$root.$i18n.messages);
+                return Object.keys(this.$root.$i18n.messages.value);
             }
 
-            return [this.$root.$i18n.fallbackLocale];
+            return [this.$root.$i18n.fallbackLocale.value];
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-date/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-date/index.js
@@ -15,26 +15,26 @@ export default {
             },
             types: [
                 {
-                    id: 'datetime',
-                    name: this.$tc('sw-settings-custom-field.customField.detail.labelDatetime'),
+                    option: 'datetime',
+                    label: this.$tc('sw-settings-custom-field.customField.detail.labelDatetime'),
                 },
                 {
-                    id: 'date',
-                    name: this.$tc('sw-settings-custom-field.customField.detail.labelDate'),
+                    option: 'date',
+                    label: this.$tc('sw-settings-custom-field.customField.detail.labelDate'),
                 },
                 {
-                    id: 'time',
-                    name: this.$tc('sw-settings-custom-field.customField.detail.labelTime'),
+                    option: 'time',
+                    label: this.$tc('sw-settings-custom-field.customField.detail.labelTime'),
                 },
             ],
             timeForms: [
                 {
-                    id: 'true',
-                    name: this.$tc('global.default.yes'),
+                    option: 'true',
+                    label: this.$tc('global.default.yes'),
                 },
                 {
-                    id: 'false',
-                    name: this.$tc('global.default.no'),
+                    option: 'false',
+                    label: this.$tc('global.default.no'),
                 },
             ],
         };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.spec.js
@@ -69,7 +69,9 @@ async function createWrapper(props = defaultProps) {
             renderStubDefaultSlot: true,
             mocks: {
                 $i18n: {
-                    fallbackLocale: 'en-GB',
+                    fallbackLocale: {
+                        value: 'en-GB',
+                    },
                 },
             },
             stubs: {


### PR DESCRIPTION
### 1. Why is this change necessary?

- translations of custom fields were not saved correctly
- date time custom field config did not shown options correctly

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/10441
- closes https://github.com/shopware/shopware/issues/10404

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
