### PR TITLE
fix: bc break in the theme configuration processing

### DIFF
--- a/src/Storefront/Theme/Controller/ThemeController.php
+++ b/src/Storefront/Theme/Controller/ThemeController.php
@@ -33,7 +33,9 @@ class ThemeController extends AbstractController
     public function configuration(string $themeId, Context $context): JsonResponse
     {
         if (!Feature::isActive('v6.8.0.0')) {
-            $themeConfiguration = $this->themeService->getPlainThemeConfiguration($themeId, $context, true);
+            $themeConfiguration = Feature::silent('v6.8.0.0', function () use ($themeId, $context) {
+                return $this->themeService->getThemeConfiguration($themeId, true, $context);
+            });
 
             return new JsonResponse($themeConfiguration);
         }
@@ -82,7 +84,9 @@ class ThemeController extends AbstractController
     public function structuredFields(string $themeId, Context $context): JsonResponse
     {
         if (!Feature::isActive('v6.8.0.0')) {
-            $themeConfiguration = $this->themeService->getThemeConfigurationFieldStructure($themeId, $context, true);
+            $themeConfiguration = Feature::silent('v6.8.0.0', function () use ($themeId, $context) {
+                return $this->themeService->getThemeConfigurationStructuredFields($themeId, true, $context);
+            });
 
             return new JsonResponse($themeConfiguration);
         }

--- a/src/Storefront/Theme/ResolvedConfigLoader.php
+++ b/src/Storefront/Theme/ResolvedConfigLoader.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Theme;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -31,7 +32,14 @@ class ResolvedConfigLoader extends AbstractResolvedConfigLoader
 
     public function load(string $themeId, SalesChannelContext $context): array
     {
-        $config = $this->service->getPlainThemeConfiguration($themeId, $context->getContext());
+        if (!Feature::isActive('v6.8.0.0')) {
+            $config = Feature::silent('v6.8.0.0', function () use ($themeId, $context) {
+                return $this->service->getThemeConfiguration($themeId, false, $context->getContext());
+            });
+        } else {
+            $config = $this->service->getPlainThemeConfiguration($themeId, $context->getContext());
+        }
+
         $resolvedConfig = [];
         $mediaItems = [];
         if (!\array_key_exists('fields', $config)) {

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -361,7 +361,9 @@ class ThemeService implements ResetInterface
         $isLegacy = !Feature::isActive('v6.8.0.0');
         if ($isLegacy) {
             $translate = \func_num_args() === 3 ? func_get_arg(2) : false;
-            $themeConfig = $this->getPlainThemeConfiguration($themeId, $context, $translate);
+            $themeConfig = Feature::silent('v6.8.0.0', function () use ($themeId, $translate, $context) {
+                return $this->getThemeConfiguration($themeId, $translate, $context);
+            });
         } else {
             $themeConfig = $this->getPlainThemeConfiguration($themeId, $context);
         }


### PR DESCRIPTION
### 1. Why is this change necessary?

In https://github.com/shopware/shopware/pull/9850 bc break was introduced - deprecated methods for public code are not called in the current version. That will break services decorating `ThemeService`

### 2. What does this change do, exactly?

Returns calls to the deprecated methods behind the feature flag checks, while silencing deprecations report (so platform users do not get them in the logs).

### 3. Describe each step to reproduce the issue or behaviour.

Decorate `ThemeService` and override `getThemeConfiguration` or `getThemeConfigurationStructuredFields`

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/10359

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
