### PR TITLE
chore(ci): adjust labeler job for external contributors, in order not to rely on an octo-sts token

### DIFF
--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -79,44 +79,43 @@ jobs:
 
   apply-contributor-label:
     runs-on: ubuntu-24.04
-    if: github.event.act || (github.event_name == 'pull_request' && ( github.event.action == 'opened' || github.event.action == 'reopened' ))
+    if: github.event.act || (github.event_name == 'pull_request' && contains(fromJSON('["opened", "reopened"]'), github.event.action) )
     env:
       CONTRIBUTOR_LABEL: "external-contribution"
     permissions:
-      id-token: write
-      issues: write
+      contents: read
+      pull-requests: write
     steps:
-      - id: sts
-        if: ${{ !github.event.act }}
-        continue-on-error: true
-        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
-        with:
-          scope: shopware
-          identity: ReadCollaborators
-      - uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # 3
-        id: actorTeams
-        with:
-          username: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ github.event.act && secrets.GITHUB_TOKEN || steps.sts.outputs.token }}
-      - if: runner.debug
-        run: |
-          echo "${{ github.actor }} is member of teams: ${{ steps.actorTeams.outputs.teams }}"
-      - if: ${{ join(steps.actorTeams.outputs.teams, '') == '' }}
-        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
         with:
           script: |
             const pullRequestNumber = context.payload.pull_request.number;
             const contribLabel = process.env.CONTRIBUTOR_LABEL;
+            
+            const permissionLevel = await github.rest.repos.getCollaboratorPermissionLevel({
+              ...context.repo,
+              username: context.actor,
+            });
+            
+            if (permissionLevel.status !== 200) {
+              throw new Error(`Failed to get permission level for ${context.actor}`);
+            }
+            
+            core.debug(`Permission level for ${context.actor}: ${permissionLevel.data.permission}`);
+
+            if (['admin', 'write'].includes(permissionLevel.data.permission)) {
+              core.info(`User ${context.actor} has write access, skipping label addition.`);
+              return;
+            }
 
             const response = await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              ...context.repo,
               issue_number: pullRequestNumber,
               labels: [contribLabel],
             });
 
             if (response.status !== 200) {
-              throw new Error(`Failed to add label ${contribLabel} to issue #${pullRequestNumber}`);
+              throw new Error(`Failed to add label ${contribLabel} to #${pullRequestNumber}`);
             }
 
   move-to-wip:

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -2,6 +2,7 @@ name: Label Issues and PRs
 
 on:
   pull_request:
+  pull_request_target:
   issues:
   workflow_dispatch:
   schedule:
@@ -79,7 +80,7 @@ jobs:
 
   apply-contributor-label:
     runs-on: ubuntu-24.04
-    if: github.event.act || (github.event_name == 'pull_request' && contains(fromJSON('["opened", "reopened"]'), github.event.action) )
+    if: github.event.act || (github.event_name == 'pull_request_target' && contains(fromJSON('["opened", "reopened"]'), github.event.action) )
     env:
       CONTRIBUTOR_LABEL: "external-contribution"
     permissions:
@@ -92,30 +93,33 @@ jobs:
             const pullRequestNumber = context.payload.pull_request.number;
             const contribLabel = process.env.CONTRIBUTOR_LABEL;
             
+            let hasWriteAccess = false;
+            
             const permissionLevel = await github.rest.repos.getCollaboratorPermissionLevel({
               ...context.repo,
               username: context.actor,
             });
             
             if (permissionLevel.status !== 200) {
-              throw new Error(`Failed to get permission level for ${context.actor}`);
-            }
-            
-            core.debug(`Permission level for ${context.actor}: ${permissionLevel.data.permission}`);
-
-            if (['admin', 'write'].includes(permissionLevel.data.permission)) {
-              core.info(`User ${context.actor} has write access, skipping label addition.`);
-              return;
+              core.info(`Failed to get permission level for "${context.actor}", assuming no write access.`);
+            } else {
+              hasWriteAccess = ['admin', 'write'].includes(permissionLevel?.data?.permission);
             }
 
-            const response = await github.rest.issues.addLabels({
-              ...context.repo,
-              issue_number: pullRequestNumber,
-              labels: [contribLabel],
-            });
-
-            if (response.status !== 200) {
-              throw new Error(`Failed to add label ${contribLabel} to #${pullRequestNumber}`);
+            if (hasWriteAccess) {
+              core.info(`User "${context.actor}" has write access, skipping label addition.`);
+            } else {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: pullRequestNumber,
+                labels: [contribLabel],
+              }).then(res => {
+                if (res.status !== 200) {
+                  throw new Error(`Failed to add label "${contribLabel}" to pull request #${pullRequestNumber}`);
+                } else {
+                  core.info(`Label "${contribLabel}" added to pull request #${pullRequestNumber}`);
+                }
+              });
             }
 
   move-to-wip:

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -2,7 +2,6 @@ name: Label Issues and PRs
 
 on:
   pull_request:
-  pull_request_target:
   issues:
   workflow_dispatch:
   schedule:
@@ -76,50 +75,6 @@ jobs:
 
             if (response.status !== 200) {
               throw new Error(`Failed to add label ${teamLabel} to issue #${issueNumber}`);
-            }
-
-  apply-contributor-label:
-    runs-on: ubuntu-24.04
-    if: github.event.act || (github.event_name == 'pull_request_target' && contains(fromJSON('["opened", "reopened"]'), github.event.action) )
-    env:
-      CONTRIBUTOR_LABEL: "external-contribution"
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
-        with:
-          script: |
-            const pullRequestNumber = context.payload.pull_request.number;
-            const contribLabel = process.env.CONTRIBUTOR_LABEL;
-            
-            let hasWriteAccess = false;
-            
-            const permissionLevel = await github.rest.repos.getCollaboratorPermissionLevel({
-              ...context.repo,
-              username: context.actor,
-            });
-            
-            if (permissionLevel.status !== 200) {
-              core.info(`Failed to get permission level for "${context.actor}", assuming no write access.`);
-            } else {
-              hasWriteAccess = ['admin', 'write'].includes(permissionLevel?.data?.permission);
-            }
-
-            if (hasWriteAccess) {
-              core.info(`User "${context.actor}" has write access, skipping label addition.`);
-            } else {
-              await github.rest.issues.addLabels({
-                ...context.repo,
-                issue_number: pullRequestNumber,
-                labels: [contribLabel],
-              }).then(res => {
-                if (res.status !== 200) {
-                  throw new Error(`Failed to add label "${contribLabel}" to pull request #${pullRequestNumber}`);
-                } else {
-                  core.info(`Label "${contribLabel}" added to pull request #${pullRequestNumber}`);
-                }
-              });
             }
 
   move-to-wip:

--- a/.github/workflows/external-contributor-label.yml
+++ b/.github/workflows/external-contributor-label.yml
@@ -1,0 +1,49 @@
+name: Add the "external-contribution" label to PRs created by community members
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-24.04
+    env:
+      CONTRIBUTOR_LABEL: "external-contribution"
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        with:
+          script: |
+            const pullRequestNumber = context.payload.pull_request.number;
+            const contribLabel = process.env.CONTRIBUTOR_LABEL;
+            
+            let hasWriteAccess = false;
+            
+            const permissionLevel = await github.rest.repos.getCollaboratorPermissionLevel({
+              ...context.repo,
+              username: context.actor,
+            });
+            
+            if (permissionLevel.status !== 200) {
+              core.info(`Failed to get permission level for "${context.actor}", assuming no write access.`);
+            } else {
+              hasWriteAccess = ['admin', 'write'].includes(permissionLevel?.data?.permission);
+            }
+            
+            if (hasWriteAccess) {
+              core.info(`User "${context.actor}" has write access, skipping label addition.`);
+            } else {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: pullRequestNumber,
+                labels: [contribLabel],
+              }).then(res => {
+                if (res.status !== 200) {
+                  throw new Error(`Failed to add label "${contribLabel}" to pull request #${pullRequestNumber}`);
+                } else {
+                  core.info(`Label "${contribLabel}" added to pull request #${pullRequestNumber}`);
+                }
+              });
+            }


### PR DESCRIPTION
My [previous PR](https://github.com/shopware/shopware/pull/10290) relied on generating an octo-sts token which can be used to query org and team membership; this does not work for accounts that don't have write permission on the shopware repo.

Instead, the job now checks the [repository permissions](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user) to see, whether the triggering account has write access, which would apply to org members and invited collaborators.

Test run: https://github.com/shopware/shopware/pull/10449#discussion_r2142667370