### PR TITLE
fix: set http status 400 for domain mapping exception page

### DIFF
--- a/src/Storefront/Framework/Routing/DomainNotMappedListener.php
+++ b/src/Storefront/Framework/Routing/DomainNotMappedListener.php
@@ -46,7 +46,7 @@ readonly class DomainNotMappedListener
         ];
 
         $event->setResponse(
-            new Response($this->container->get('twig')->render('@Storefront/storefront/page/error/error-domain-mapping.html.twig', $vars))
+            new Response($this->container->get('twig')->render('@Storefront/storefront/page/error/error-domain-mapping.html.twig', $vars), Response::HTTP_BAD_REQUEST)
         );
     }
 }

--- a/tests/integration/Storefront/Framework/HealthCheck/ProductDetailReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/ProductDetailReadinessCheckTest.php
@@ -81,7 +81,7 @@ class ProductDetailReadinessCheckTest extends TestCase
                     'languageId' => Defaults::LANGUAGE_SYSTEM,
                     'currencyId' => Defaults::CURRENCY,
                     'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
-                    'url' => 'https://test.to',
+                    'url' => 'http://example.com',
                 ],
             ],
         ]);
@@ -92,7 +92,7 @@ class ProductDetailReadinessCheckTest extends TestCase
                     'languageId' => Defaults::LANGUAGE_SYSTEM,
                     'currencyId' => Defaults::CURRENCY,
                     'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
-                    'url' => 'https://foo.to',
+                    'url' => 'http://shop.test',
                 ],
             ],
         ]);

--- a/tests/integration/Storefront/Framework/HealthCheck/ProductDetailReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/ProductDetailReadinessCheckTest.php
@@ -11,8 +11,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
-use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Framework\SystemCheck\ProductDetailReadinessCheck;
@@ -23,8 +22,7 @@ use Shopware\Storefront\Framework\SystemCheck\ProductDetailReadinessCheck;
 #[CoversClass(ProductDetailReadinessCheck::class)]
 class ProductDetailReadinessCheckTest extends TestCase
 {
-    use DatabaseTransactionBehaviour;
-    use KernelTestBehaviour;
+    use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
     private Connection $connection;

--- a/tests/integration/Storefront/Framework/HealthCheck/ProductDetailReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/ProductDetailReadinessCheckTest.php
@@ -11,7 +11,9 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
-use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Framework\SystemCheck\ProductDetailReadinessCheck;
@@ -22,7 +24,9 @@ use Shopware\Storefront\Framework\SystemCheck\ProductDetailReadinessCheck;
 #[CoversClass(ProductDetailReadinessCheck::class)]
 class ProductDetailReadinessCheckTest extends TestCase
 {
-    use IntegrationTestBehaviour;
+    use CacheTestBehaviour;
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
     private Connection $connection;

--- a/tests/integration/Storefront/Framework/HealthCheck/ProductListingReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/ProductListingReadinessCheckTest.php
@@ -12,8 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
-use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
@@ -26,8 +25,7 @@ use Shopware\Storefront\Framework\SystemCheck\ProductListingReadinessCheck;
 #[CoversClass(ProductListingReadinessCheck::class)]
 class ProductListingReadinessCheckTest extends TestCase
 {
-    use DatabaseTransactionBehaviour;
-    use KernelTestBehaviour;
+    use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
     private Connection $connection;

--- a/tests/integration/Storefront/Framework/HealthCheck/ProductListingReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/ProductListingReadinessCheckTest.php
@@ -12,7 +12,9 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
-use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
@@ -25,7 +27,9 @@ use Shopware\Storefront\Framework\SystemCheck\ProductListingReadinessCheck;
 #[CoversClass(ProductListingReadinessCheck::class)]
 class ProductListingReadinessCheckTest extends TestCase
 {
-    use IntegrationTestBehaviour;
+    use CacheTestBehaviour;
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
     private Connection $connection;

--- a/tests/integration/Storefront/Framework/HealthCheck/ProductListingReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/ProductListingReadinessCheckTest.php
@@ -93,7 +93,7 @@ class ProductListingReadinessCheckTest extends TestCase
                     'languageId' => Defaults::LANGUAGE_SYSTEM,
                     'currencyId' => Defaults::CURRENCY,
                     'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
-                    'url' => 'https://test.to',
+                    'url' => 'http://example.com',
                 ],
             ],
         ]);
@@ -104,7 +104,7 @@ class ProductListingReadinessCheckTest extends TestCase
                     'languageId' => Defaults::LANGUAGE_SYSTEM,
                     'currencyId' => Defaults::CURRENCY,
                     'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
-                    'url' => 'https://foo.to',
+                    'url' => 'http://shop.test',
                 ],
             ],
         ]);

--- a/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
@@ -8,7 +8,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
-use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Framework\SystemCheck\SalesChannelsReadinessCheck;
@@ -24,7 +26,9 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(SalesChannelsReadinessCheck::class)]
 class SalesChannelsReadinessCheckTest extends TestCase
 {
-    use IntegrationTestBehaviour;
+    use CacheTestBehaviour;
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
     private Connection $connection;

--- a/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
@@ -134,7 +134,7 @@ class SalesChannelsReadinessCheckTest extends TestCase
                     'languageId' => Defaults::LANGUAGE_SYSTEM,
                     'currencyId' => Defaults::CURRENCY,
                     'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
-                    'url' => 'https://test.to',
+                    'url' => 'http://example.com',
                 ],
             ],
         ]);
@@ -145,7 +145,7 @@ class SalesChannelsReadinessCheckTest extends TestCase
                     'languageId' => Defaults::LANGUAGE_SYSTEM,
                     'currencyId' => Defaults::CURRENCY,
                     'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
-                    'url' => 'https://foo.to',
+                    'url' => 'http://shop.test',
                 ],
             ],
         ]);

--- a/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
-use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Framework\SystemCheck\SalesChannelsReadinessCheck;
@@ -25,8 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(SalesChannelsReadinessCheck::class)]
 class SalesChannelsReadinessCheckTest extends TestCase
 {
-    use DatabaseTransactionBehaviour;
-    use KernelTestBehaviour;
+    use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
     private Connection $connection;

--- a/tests/unit/Storefront/Framework/Health/ProductDetailReadinessCheckTest.php
+++ b/tests/unit/Storefront/Framework/Health/ProductDetailReadinessCheckTest.php
@@ -151,12 +151,16 @@ class ProductDetailReadinessCheckTest extends TestCase
 
     private function initDataMocks(): void
     {
-        $this->connection->method('fetchAllAssociative')->willReturn(
-            [
-                ['id' => $this->ids->get('sales-channel-1'), 'product_id' => Uuid::randomHex()],
-                ['id' => $this->ids->get('sales-channel-2'), 'product_id' => Uuid::randomHex()],
-            ]
-        );
+        $counter = 0;
+        $this->connection->method('fetchOne')->willReturnCallback(function () use (&$counter) {
+            ++$counter;
+
+            if ($counter >= 3) {
+                return null;
+            }
+
+            return Uuid::randomHex();
+        });
 
         $collection = new SalesChannelDomainCollection([
             SalesChannelDomain::create($this->ids->get('sales-channel-1'), 'http://localhost:8000/de'),

--- a/tests/unit/Storefront/Framework/Routing/DomainNotMappedListenerTest.php
+++ b/tests/unit/Storefront/Framework/Routing/DomainNotMappedListenerTest.php
@@ -8,6 +8,7 @@ use Shopware\Storefront\Framework\Routing\DomainNotMappedListener;
 use Shopware\Storefront\Framework\Routing\Exception\SalesChannelMappingException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Twig\Environment;
@@ -50,5 +51,8 @@ class DomainNotMappedListenerTest extends TestCase
         );
 
         $listener($event);
+
+        $response = $event->getResponse();
+        static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
     }
 }

--- a/tests/unit/Storefront/Framework/Routing/DomainNotMappedListenerTest.php
+++ b/tests/unit/Storefront/Framework/Routing/DomainNotMappedListenerTest.php
@@ -53,6 +53,6 @@ class DomainNotMappedListenerTest extends TestCase
         $listener($event);
 
         $response = $event->getResponse();
-        static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $response?->getStatusCode());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Reverse proxy tend to cache the page as it was 200

### 2. What does this change do, exactly?

change http status 400


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
