### PR TITLE
test: improve stability of ats tests on saas

### DIFF
--- a/tests/acceptance/tests/Product/ProductVisibility.spec.ts
+++ b/tests/acceptance/tests/Product/ProductVisibility.spec.ts
@@ -24,10 +24,14 @@ test('Product is visible in listing and storefront search when set to "Visible".
         });
     });
 
-    await test.step('Verify the product appears in the Home category listing.', async () => {
-        await ShopCustomer.goesTo(StorefrontHome.url());
-        const productLocators = await StorefrontHome.getListingItemByProductName(product.name);
-        await ShopCustomer.expects(productLocators.productName).toBeVisible();
+    await ShopCustomer.expects(async () => {
+        await test.step('Verify the product appears in the Home category listing.', async () => {
+            await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
+            const productLocators = await StorefrontHome.getListingItemByProductName(product.name);
+            await ShopCustomer.expects(productLocators.productName).toBeVisible();
+        });
+    }).toPass({
+        intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
     });
 
     await test.step('Verify the product appears in storefront search results.', async () => {
@@ -74,14 +78,18 @@ test('Product is visible in storefront search but hidden from listing when set t
         await ShopCustomer.expects(productLocators.productName).not.toBeVisible();
     });
 
-    await test.step('Verify the product appears in storefront search results.', async () => {
-        await ShopCustomer.attemptsTo(SearchForTerm(product.name));
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestLineItemName.getByText(product.name)).toBeVisible();
-        const totalCount1 = await StorefrontSearchSuggest.getTotalSearchResultCount();
+    await ShopCustomer.expects(async () => {
+        await test.step('Verify the product appears in storefront search results.', async () => {
+            await ShopCustomer.attemptsTo(SearchForTerm(product.name));
+            await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestLineItemName.getByText(product.name)).toBeVisible();
+            const totalCount1 = await StorefrontSearchSuggest.getTotalSearchResultCount();
 
-        // if we create other products in parallel - for example by using workers - we might find multiple results
-        await ShopCustomer.expects(totalCount1).toBeGreaterThanOrEqual(1);
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestLineItemName.getByText(product.name)).toBeVisible();
+            // if we create other products in parallel - for example by using workers - we might find multiple results
+            await ShopCustomer.expects(totalCount1).toBeGreaterThanOrEqual(1);
+            await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestLineItemName.getByText(product.name)).toBeVisible();
+        });
+    }).toPass({
+        intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
     });
 
     await test.step('Verify the product can be accessed directly via its URL.', async () => {

--- a/tests/acceptance/tests/SalesChannels/StorefrontCurrencies.spec.ts
+++ b/tests/acceptance/tests/SalesChannels/StorefrontCurrencies.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@fixtures/AcceptanceTest';
 
-test ('Shop customers should be able to view products in different currencies.', {tag: '@Currencies'}, async ({
+test('Shop customers should be able to view products in different currencies.', { tag: '@Currencies' }, async ({
     ShopCustomer,
     TestDataService,
     StorefrontHome,
@@ -9,14 +9,18 @@ test ('Shop customers should be able to view products in different currencies.',
     const salesChannelId = TestDataService.defaultSalesChannel.id;
     const currency = await TestDataService.createCurrency();
     await TestDataService.assignSalesChannelCurrency(salesChannelId, currency.id);
-
     const product = await TestDataService.createBasicProduct();
+
     const productListing = await StorefrontHome.getListingItemByProductName(product.name);
 
-    await test.step('Customer can view currencies menu', async () => {
-        await ShopCustomer.goesTo(StorefrontHome.url());
-        await ShopCustomer.expects(StorefrontHome.currenciesDropdown).toContainText('Euro');
-        await ShopCustomer.expects(productListing.productPrice).toContainText('€');
+    await ShopCustomer.expects(async () => {
+        await test.step('Customer can view currencies menu', async () => {
+            await ShopCustomer.goesTo(StorefrontHome.url());
+            await ShopCustomer.expects(StorefrontHome.currenciesDropdown).toContainText('Euro');
+            await ShopCustomer.expects(productListing.productPrice).toContainText('€');
+        });
+    }).toPass({
+        intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
     });
 
     await test.step('Customer can select a different currency', async () => {

--- a/tests/acceptance/tests/SalesChannels/StorefrontLanguages.spec.ts
+++ b/tests/acceptance/tests/SalesChannels/StorefrontLanguages.spec.ts
@@ -1,6 +1,6 @@
 import { getLanguageData, getSnippetSetId, test } from '@fixtures/AcceptanceTest';
 
-test ('Shop customers should be able to view products in different languages.', {tag: '@Languages'}, async ({
+test('Shop customers should be able to view products in different languages.', { tag: '@Languages' }, async ({
     ShopCustomer,
     TestDataService,
     StorefrontHome,
@@ -16,15 +16,17 @@ test ('Shop customers should be able to view products in different languages.', 
 
     await TestDataService.clearCaches();
 
-    await StorefrontHome.page.goto(StorefrontHome.url());
+    const productListing = StorefrontHome.productListItems.filter({ has: StorefrontHome.page.getByRole('link', { name: product.name }) });
+    const addToCartButton = productListing.filter({ has: StorefrontHome.page.getByRole('button') });
 
-    const productListing = StorefrontHome.productListItems.filter({ has: StorefrontHome.page.getByRole('link', { name: product.name })});
-    const addToCartButton = productListing.filter({ has: StorefrontHome.page.getByRole('button')});
-
-    await test.step('Customer can view languages menu', async () => {
-        await ShopCustomer.goesTo(StorefrontHome.url());
-        await ShopCustomer.expects(StorefrontHome.languagesDropdown).toContainText('English');
-        await ShopCustomer.expects(addToCartButton).toContainText('Add to shopping cart');
+    await ShopCustomer.expects(async () => {
+        await test.step('Customer can view languages menu', async () => {
+            await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
+            await ShopCustomer.expects(StorefrontHome.languagesDropdown).toContainText('English');
+            await ShopCustomer.expects(addToCartButton).toContainText('Add to shopping cart');
+        });
+    }).toPass({
+        intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
     });
 
     await test.step('Customer can select a different language', async () => {

--- a/tests/acceptance/tests/Search/ProductSearch.spec.ts
+++ b/tests/acceptance/tests/Search/ProductSearch.spec.ts
@@ -9,51 +9,65 @@ test('Customer is able to search products in shop', { tag: '@Search' }, async ({
     IdProvider,
     InstanceMeta,
 }) => {
-        const productNameSuffix1 = IdProvider.getIdPair().uuid;
-        await TestDataService.createBasicProduct({
-            name: `Bottle${productNameSuffix1}`,
-        });
-        await TestDataService.createBasicProduct({
-            name: `Bowl${productNameSuffix1}`,
-        });
+    const productNameSuffix1 = IdProvider.getIdPair().uuid;
+    await TestDataService.createBasicProduct({
+        name: `Bottle${productNameSuffix1}`,
+    });
+    await TestDataService.createBasicProduct({
+        name: `Bowl${productNameSuffix1}`,
+    });
 
-        await test.step('Customer searches with an invalid input and sees no results', async () => {
-            await ShopCustomer.goesTo(StorefrontHome.url());
-            await ShopCustomer.attemptsTo(SearchForTerm('thisShouldNotFindAnything'));
-            await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestNoResult).toBeVisible();
-        });
+    await TestDataService.clearCaches();
 
-        await test.step('Customer searches term and sees a single matching product', async () => {
-            await ShopCustomer.attemptsTo(SearchForTerm(`Bottle${productNameSuffix1}`));
-            // eslint-disable-next-line playwright/no-conditional-in-test
-            if (InstanceMeta.isSaaS) {
-                let productFound = false;
-                for (const lineItem of await StorefrontSearchSuggest.searchSuggestLineItemName.all()) {
-                    const lineItemText = await lineItem.textContent();
-                    // eslint-disable-next-line playwright/no-conditional-in-test
-                    if (lineItemText.includes(`Bottle${productNameSuffix1}`)) {
-                        productFound = true;
-                        break;
-                    }
+    await ShopCustomer.expects(async () => {
+        await test.step('Wait for products to be visible.', async () => {
+            await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
+            const productLocator1 = await StorefrontHome.getListingItemByProductName(`Bottle${productNameSuffix1}`);
+            await ShopCustomer.expects(productLocator1.productName).toBeVisible();
+            const productLocator2 = await StorefrontHome.getListingItemByProductName(`Bowl${productNameSuffix1}`);
+            await ShopCustomer.expects(productLocator2.productName).toBeVisible();
+        });
+    }).toPass({
+        intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
+    });
+
+    await test.step('Customer searches with an invalid input and sees no results', async () => {
+        await ShopCustomer.goesTo(StorefrontHome.url());
+        await ShopCustomer.attemptsTo(SearchForTerm('thisShouldNotFindAnything'));
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestNoResult).toBeVisible();
+    });
+
+    await test.step('Customer searches term and sees a single matching product', async () => {
+        await ShopCustomer.attemptsTo(SearchForTerm(`Bottle${productNameSuffix1}`));
+        // eslint-disable-next-line playwright/no-conditional-in-test
+        if (InstanceMeta.isSaaS) {
+            let productFound = false;
+            for (const lineItem of await StorefrontSearchSuggest.searchSuggestLineItemName.all()) {
+                const lineItemText = await lineItem.textContent();
+                // eslint-disable-next-line playwright/no-conditional-in-test
+                if (lineItemText.includes(`Bottle${productNameSuffix1}`)) {
+                    productFound = true;
+                    break;
                 }
-                ShopCustomer.expects(productFound).toBe(true);
-            } else {
-                const totalCount1 = await StorefrontSearchSuggest.getTotalSearchResultCount();
-                await ShopCustomer.expects(totalCount1).toBe(1);
             }
-        });
+            ShopCustomer.expects(productFound).toBe(true);
+        } else {
+            const totalCount1 = await StorefrontSearchSuggest.getTotalSearchResultCount();
+            await ShopCustomer.expects(totalCount1).toBe(1);
+        }
+    });
 
-        await test.step('Customer searches for a partial term and sees multiple matching products', async () => {
-            await ShopCustomer.attemptsTo(SearchForTerm(productNameSuffix1));
-            const totalCount2 = await StorefrontSearchSuggest.getTotalSearchResultCount();
-            await ShopCustomer.expects(totalCount2).toBe(2);
-        });
+    await test.step('Customer searches for a partial term and sees multiple matching products', async () => {
+        await ShopCustomer.attemptsTo(SearchForTerm(productNameSuffix1));
+        const totalCount2 = await StorefrontSearchSuggest.getTotalSearchResultCount();
+        await ShopCustomer.expects(totalCount2).toBe(2);
+    });
 
-        await test.step('Customer navigates to the results page to view all matching products', async () => {
-            await StorefrontSearchSuggest.searchSuggestTotalLink.click();
-            await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText(productNameSuffix1);
-            const listedItemsCount = await StorefrontSearchSuggest.productListItems.count();
-            await ShopCustomer.expects(listedItemsCount).toBe(2);
-        });
-    }
+    await test.step('Customer navigates to the results page to view all matching products', async () => {
+        await StorefrontSearchSuggest.searchSuggestTotalLink.click();
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText(productNameSuffix1);
+        const listedItemsCount = await StorefrontSearchSuggest.productListItems.count();
+        await ShopCustomer.expects(listedItemsCount).toBe(2);
+    });
+}
 );

--- a/tests/acceptance/tests/Settings/Wishlist/WishlistGuestFunctionalities.spec.ts
+++ b/tests/acceptance/tests/Settings/Wishlist/WishlistGuestFunctionalities.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@fixtures/AcceptanceTest';
 
-test('Guest customer is able to add and remove products to the wishlist',{ tag: '@Wishlist' }, async ({
+test('Guest customer is able to add and remove products to the wishlist', { tag: '@Wishlist' }, async ({
     TestDataService,
     ShopCustomer,
     StorefrontHome,
@@ -15,6 +15,18 @@ test('Guest customer is able to add and remove products to the wishlist',{ tag: 
     const product2 = await TestDataService.createBasicProduct();
     const product1Locators = await StorefrontHome.getListingItemByProductName(product1.name);
     const product2Locators = await StorefrontHome.getListingItemByProductName(product2.name);
+
+    await TestDataService.clearCaches();
+
+    await ShopCustomer.expects(async () => {
+        await test.step('Wait for products to be visible.', async () => {
+            await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
+            await ShopCustomer.expects(product1Locators.productName).toBeVisible();
+            await ShopCustomer.expects(product2Locators.productName).toBeVisible();
+        });
+    }).toPass({
+        intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
+    });
 
     await test.step('Accept all cookies and reload page', async () => {
         await TestDataService.setSystemConfig({ 'core.basicInformation.acceptAllCookies': true });
@@ -47,6 +59,7 @@ test('Guest customer is able to add and remove products to the wishlist',{ tag: 
 
     await test.step('Add product2 to the wishlist and verify', async () => {
         await ShopCustomer.attemptsTo(AddProductToWishlist(product2));
+
         await ShopCustomer.expects(product2Locators.wishlistAddedIcon).toBeVisible({ timeout: 15_000 });
     });
 

--- a/tests/acceptance/tests/Settings/Wishlist/WishlistRegisteredCustomerFunctionalities.spec.ts
+++ b/tests/acceptance/tests/Settings/Wishlist/WishlistRegisteredCustomerFunctionalities.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@fixtures/AcceptanceTest';
 
-test('Customers can add or remove products from their wishlist.',{ tag: '@Wishlist' }, async ({
+test('Customers can add or remove products from their wishlist.', { tag: '@Wishlist' }, async ({
     TestDataService,
     ShopCustomer,
     StorefrontHome,
@@ -20,6 +20,19 @@ test('Customers can add or remove products from their wishlist.',{ tag: '@Wishli
     const product1Locators = await StorefrontHome.getListingItemByProductName(product1.name);
     const product2Locators = await StorefrontHome.getListingItemByProductName(product2.name);
     const product3Locators = await StorefrontHome.getListingItemByProductName(product3.name);
+
+    await TestDataService.clearCaches();
+
+    await ShopCustomer.expects(async () => {
+        await test.step('Wait for products to be visible.', async () => {
+            await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
+            await ShopCustomer.expects(product1Locators.productName).toBeVisible();
+            await ShopCustomer.expects(product2Locators.productName).toBeVisible();
+            await ShopCustomer.expects(product3Locators.productName).toBeVisible();
+        });
+    }).toPass({
+        intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
+    });
 
     await test.step('Add three products to the wishlist and verify the basket count updates to 3', async () => {
         await ShopCustomer.attemptsTo(Login());


### PR DESCRIPTION
It can take a few seconds until a product is fully indexed so that it's accessible in the storefront. 

Use `expect().toPass()` to retry assertions that make sure the product is fully indexed before continuing with the tests

This is just a quick fix, we should abstract this or refactor to a different pattern altogether. 