### PR TITLE
fix: convert error success messages

### DIFF
--- a/changelog/_unreleased/2025-06-11-filter-cart-success-error-messages.md
+++ b/changelog/_unreleased/2025-06-11-filter-cart-success-error-messages.md
@@ -2,5 +2,5 @@
 title: Filter cart success error messages
 issue: #10146
 ---
-# Core
-* Changed `\Shopware\Storefront\Controller\CartLineItemController`. `\Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError` will be converted into a success message on every route.
+# Storefront
+* Changed error convert behaviour in `\Shopware\Storefront\Controller\CartLineItemController`. `\Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError` will be converted into a success message on every `CartLineItemController` route.

--- a/changelog/_unreleased/2025-06-11-filter-cart-success-error-messages.md
+++ b/changelog/_unreleased/2025-06-11-filter-cart-success-error-messages.md
@@ -4,4 +4,3 @@ issue: #10146
 ---
 # Core
 * Changed `\Shopware\Storefront\Controller\CartLineItemController`. `\Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError` will be converted into a success message on every route.
-___

--- a/changelog/_unreleased/2025-06-11-filter-cart-success-error-messages.md
+++ b/changelog/_unreleased/2025-06-11-filter-cart-success-error-messages.md
@@ -1,0 +1,7 @@
+---
+title: Filter cart success error messages
+issue: #10146
+---
+# Core
+* Changed `\Shopware\Storefront\Controller\CartLineItemController`. `\Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError` will be converted into a success message on every route.
+___

--- a/tests/unit/Storefront/Controller/CartLineItemControllerTest.php
+++ b/tests/unit/Storefront/Controller/CartLineItemControllerTest.php
@@ -2,11 +2,14 @@
 
 namespace Shopware\Tests\Unit\Storefront\Controller;
 
+use Composer\Autoload\ClassLoader;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartException;
+use Shopware\Core\Checkout\Cart\Error\Error;
 use Shopware\Core\Checkout\Cart\Error\GenericCartError;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
@@ -697,6 +700,74 @@ class CartLineItemControllerTest extends TestCase
         $this->controller->updateLineItems($cart, new RequestDataBag($request->request->all()), $request, $context);
 
         static::assertArrayHasKey('danger', $session->getFlashBag()->peekAll());
+    }
+
+    /**
+     * @param class-string<Error> $class
+     */
+    #[DataProvider('errorProvider')]
+    public function testFilterErrorSuccessMessages(string $class, bool $filtered): void
+    {
+        $id = Uuid::randomHex();
+
+        $request = new Request(['quantity' => 1]);
+        $cart = new Cart(Uuid::randomHex());
+        $cart->addLineItems(new LineItemCollection([new LineItem($id, LineItem::PRODUCT_LINE_ITEM_TYPE)]));
+
+        $session = new Session(new MockArraySessionStorage());
+        $this->translatorCallback($session);
+
+        $this->cartService
+            ->expects($this->once())
+            ->method('changeQuantity')
+            ->willReturn($cart);
+
+        /** @var Error&MockObject $error */
+        $error = $this->createMock($class);
+        $cart->addErrors($error);
+
+        $this->controller->changeQuantity($cart, $id, $request, $this->createMock(SalesChannelContext::class));
+
+        if ($filtered) {
+            static::assertCount(0, $cart->getErrors());
+
+            static::assertArrayHasKey('success', $session->getFlashBag()->peekAll());
+        } else {
+            static::assertCount(1, $cart->getErrors());
+        }
+    }
+
+    /**
+     * @return list<array{class-string<Error>, bool}>
+     */
+    public static function errorProvider(): array
+    {
+        $filtered = [
+            PromotionCartAddedInformationError::class,
+        ];
+
+        $classLoader = require __DIR__ . '/../../../../vendor/autoload.php';
+        static::assertInstanceOf(ClassLoader::class, $classLoader);
+
+        $errors = [];
+        foreach ($classLoader->getClassMap() as $class => $_) {
+            if (!str_starts_with($class, 'Shopware\\')) {
+                continue;
+            }
+
+            if ($class !== Error::class && !\is_subclass_of($class, Error::class)) {
+                continue;
+            }
+
+            $refClass = new \ReflectionClass($class);
+            if ($refClass->isAbstract()) {
+                continue;
+            }
+
+            $errors[] = [$class, \in_array($class, $filtered, true)];
+        }
+
+        return $errors;
     }
 
     private function translatorCallback(?Session $session = null): void


### PR DESCRIPTION
### 1. Why is this change necessary?
The error message was only checked and converted into a success message on `addPromotion`. While adding a product, an automatic promotion can be added and then the "success" will be displayed as a notification.

### 2. What does this change do, exactly?
Checks and converts the error message `\Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError` on every route `\Shopware\Storefront\Controller\CartLineItemController`.

### 3. Describe each step to reproduce the issue or behaviour.
Create a promotion without any code and e.g. a valid rule (always valid). Add a product to your cart.

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/10146

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
