### PR TITLE
fix: Add default entity to property collection in sales channel detail

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/index.js
@@ -210,7 +210,7 @@ export default {
             this.defaultId = defaultId;
 
             if (!!defaultId && !this.propertyCollection.has(defaultId)) {
-                this.propertyCollection.add(defaultEntity);
+                this.propertyCollection = this.propertyCollection.concat([defaultEntity]);
             }
         },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

Closes #10115

### 1. Why is this change necessary?
Countries, languages, currencies, payment and shipping methods are not visually added, when selected with the defaults dropdown in the sales channel detail page.

### 2. What does this change do, exactly?
Previously, the default item was only added to the propertyCollection (the element list), but since propertyCollection is not reactive, the component wasn’t updated. I changed the logic to reassign propertyCollection to the main property to trigger a reload and ensure the component refreshes properly.

<img width="1047" alt="Bildschirmfoto 2025-06-12 um 10 34 17" src="https://github.com/user-attachments/assets/eb3d384e-9c68-4c96-bc93-3873713a4d44" />

### 3. Describe each step to reproduce the issue or behaviour.
1. Open sales channel detail page in admin
2. Select a new default value for countries, languages, currencies, payment or shipping methods that is not included in the general list.
3. The default has been added to the general list.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
