### PR TITLE
fix: flaky infoControllerTest in integration

### DIFF
--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -108,7 +108,11 @@ class InfoController extends AbstractController
     #[Route(path: '/api/_info/message-stats.json', name: 'api.info.message-stats', methods: ['GET'])]
     public function messageStats(): JsonResponse
     {
-        return new JsonResponse($this->messageStatsService->getStats());
+        $response = new JsonResponse();
+        $response->setEncodingOptions($response->getEncodingOptions() | \JSON_PRESERVE_ZERO_FRACTION);
+        $response->setData($this->messageStatsService->getStats());
+
+        return $response;
     }
 
     #[Route(


### PR DESCRIPTION
### 1. Why is this change necessary?

Nightly recently failed https://github.com/shopware/shopware/actions/runs/15599501536/job/43936711250

This is due to one value `averageTimeInQueue` reached `1.00`, and since Json encoding was done without fraction preservation, it is then decoded in `1` as an integer and not a float => failing the integration test 

### 2. What does this change do, exactly?
- reproduce the issue in unit test for InfoController (failing test, first commit)
- fixes the encoding preservation in the method involved (second commit)


### 3. Describe each step to reproduce the issue or behaviour.
See the unit test created

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/10482

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
