### PR TITLE
fix: flaky DocumentMergerTest in integration 

### DIFF
--- a/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php
@@ -370,13 +370,8 @@ class DocumentMergerTest extends TestCase
         $orderNumber = $order->getOrderNumber();
 
         for ($i = 0; $i < $zip->numFiles; ++$i) {
-            $fileInfo = $zip->statIndex($i);
-            static::assertNotFalse($fileInfo);
-            static::assertArrayHasKey('name', $fileInfo);
-            static::assertSame(
-                $orderNumber . '_' . DeliveryNoteRenderer::TYPE . '_' . $documentNumbers[$i] . '.' . FileTypes::PDF,
-                $fileInfo['name']
-            );
+            $documentName = $orderNumber . '_' . DeliveryNoteRenderer::TYPE . '_' . $documentNumbers[$i] . '.' . FileTypes::PDF;
+            static::assertIsInt($zip->locateName($documentName), 'zip should contain file with name: ' . $documentName);
         }
 
         $zip->close();


### PR DESCRIPTION
### 1. Why is this change necessary?
Recently Nightly is failing with https://github.com/shopware/shopware/actions/runs/15599750715/job/43937385935

```
1) Shopware\Tests\Integration\Core\Checkout\Document\Service\DocumentMergerTest::testMergeWithFpdiFallbackCreatesZipWithCorrectContent
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'10000_delivery_note_1001.pdf'
+'10000_delivery_note_1002.pdf'

/home/runner/work/shopware/shopware/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php:372
```

Most probably the order in zipped file is not guaranteed once opened and browsed through a for loop within that integration test.

In short: 
zip contains 10000_delivery_note_1001.pdf, 10000_delivery_note_1002.pdf 
zip unzipped gives 10000_delivery_note_1002.pdf, 10000_delivery_note_1001.pdf


### 2. What does this change do, exactly?
- revisit the integration test: only check we have the expected documents, independently from their order in the zip
- verify with code author if the order in zip should be enforced (we assume not)


### 3. Describe each step to reproduce the issue or behaviour.

Run the integration tests

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/10488


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
