### PR TITLE
chore: get rid of the extra space inside variant overview

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.scss
@@ -9,6 +9,10 @@
         }
     }
 
+    &__generated-variants.mt-card .sw-tabs .sw-tabs__custom-content {
+        padding: 0;
+    }
+
     .sw-product-detail-variants__generated-variants.is--loading .mt-card__content {
         min-height: 250px;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

to get rid of the extra space inside the variant overview

### 2. What does this change do, exactly?

sets the padding of the relevant part into zero

### 3. Describe each step to reproduce the issue or behaviour.

<img width="1166" alt="Screenshot 2025-06-13 at 14 54 08" src="https://github.com/user-attachments/assets/0f002ede-0555-4556-bb80-1176983e4627" />

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

_

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
