### PR TITLE
fix: Handle finalizeTransaction route correctly

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -241,8 +241,14 @@ The Twig breadcrumb functions `sw_breadcrumb_full` and `sw_breadcrumb_full_by_id
 ```
 
 ## Removal of DeleteThemeFilesMessage and its handler
+
 The `\Shopware\Storefront\Theme\Message\DeleteThemeFilesMessage` and its handler `\Shopware\Storefront\Theme\Message\DeleteThemeFilesHandler` are removed.
 Unused theme files are deleted by using the `\Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTask` scheduled task.
+
+## Storefront routes now require route scope
+
+Storefront routes require a defined route scope from now on.
+If it is not possible to add a route scope to the route, you can add the route name to the `storefront.router.allowed_routes` configuration in the `storefront.yaml`.
 
 </details>
 

--- a/changelog/_unreleased/2025-06-13-storefront-routes-without-route-scope-are-deprecated.md
+++ b/changelog/_unreleased/2025-06-13-storefront-routes-without-route-scope-are-deprecated.md
@@ -1,0 +1,18 @@
+---
+title: Storefront routes without route scope are deprecated
+author: Michael Telgmann
+author_github: @mitelg
+---
+# Storefront
+
+* Deprecated storefront routes without route scope. Add a route scope to the route or add the route name to the `storefront.router.allowed_routes` configuration in `storefront.yaml`
+
+___
+
+# Upgrade Information
+
+## Deprecation of Storefront routes without route scope
+
+Storefront routes should always have a defined route scope from now on.
+Not providing a route scope for routes with the prefixes `frontend.`, `widgets.` and `payment.` is deprecated.
+If it is not possible to add a route scope to the route, you can add the route name to the `storefront.router.allowed_routes` configuration in the `storefront.yaml`.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -97,7 +97,6 @@ parameters:
            paths:
             - **/*Test.php
             - src/Core/Installer
-            - src/Core/Checkout/Payment/Controller/PaymentController.php
 
         -
            message: '#No global Command directories allowed, put your commands in the right domain directory#'

--- a/src/Core/Checkout/Payment/Controller/PaymentController.php
+++ b/src/Core/Checkout/Payment/Controller/PaymentController.php
@@ -40,6 +40,13 @@ class PaymentController extends AbstractController
     ) {
     }
 
+    /**
+     * The route scope could not be defined as this route is called from external.
+     * An API route scope would imply an authentication, which external callers could not provide.
+     * Only a storefront route scope could also not be used, as it also needs to work on headless environments.
+     *
+     * @phpstan-ignore shopware.routeScope
+     */
     #[Route(path: '/payment/finalize-transaction', name: 'payment.finalize.transaction', methods: ['GET', 'POST'])]
     public function finalizeTransaction(Request $request): Response
     {

--- a/src/Storefront/DependencyInjection/Configuration.php
+++ b/src/Storefront/DependencyInjection/Configuration.php
@@ -34,6 +34,13 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('validate_on_compile')->defaultFalse()->end()
                     ->end()
                 ->end()
+                ->arrayNode('router')
+                    ->children()
+                        ->arrayNode('allowed_routes')
+                            ->prototype('string')->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -74,6 +74,7 @@
         <service id="Shopware\Storefront\Framework\Routing\Router" decorates="router">
             <argument type="service" id="Shopware\Storefront\Framework\Routing\Router.inner"/>
             <argument type="service" id="request_stack"/>
+            <argument>%storefront.router.allowed_routes%</argument>
         </service>
 
         <service id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver">

--- a/src/Storefront/Framework/Routing/Router.php
+++ b/src/Storefront/Framework/Routing/Router.php
@@ -194,6 +194,11 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     private function isStorefrontRoute(string $name): bool
     {
+        /** Exception for @see \Shopware\Core\Checkout\Payment\Controller\PaymentController::finalizeTransaction */
+        if (str_starts_with($name, 'payment.')) {
+            return true;
+        }
+
         $routeScopes = $this->getRouteCollection()->get($name)?->getDefault(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE) ?? [];
 
         return \in_array(StorefrontRouteScope::ID, $routeScopes, true);

--- a/src/Storefront/Framework/Routing/Router.php
+++ b/src/Storefront/Framework/Routing/Router.php
@@ -216,6 +216,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
                     'v6.8.0.0',
                     \sprintf('Routes without a defined route scope are deprecated, please add a route scope to the route "%s" or add it to "storefront.router.allowed_routes" in "storefront.yaml" configuration.', $name)
                 );
+
                 return true;
             }
         }

--- a/src/Storefront/Framework/Routing/Router.php
+++ b/src/Storefront/Framework/Routing/Router.php
@@ -208,14 +208,16 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
         }
 
         if (!Feature::isActive('v6.8.0.0')) {
-            Feature::triggerDeprecationOrThrow(
-                'v6.8.0.0',
-                \sprintf('Routes without a defined route scope are deprecated, please add a route scope to the route "%s"', $name)
-            );
-
-            return str_starts_with($name, 'frontend.')
+            if (str_starts_with($name, 'frontend.')
                 || str_starts_with($name, 'widgets.')
-                || str_starts_with($name, 'payment.');
+                || str_starts_with($name, 'payment.')
+            ) {
+                Feature::triggerDeprecationOrThrow(
+                    'v6.8.0.0',
+                    \sprintf('Routes without a defined route scope are deprecated, please add a route scope to the route "%s" or add it to "storefront.router.allowed_routes" in "storefront.yaml" configuration.', $name)
+                );
+                return true;
+            }
         }
 
         return false;

--- a/src/Storefront/Framework/Routing/Router.php
+++ b/src/Storefront/Framework/Routing/Router.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Storefront\Framework\Routing;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\PlatformRequest;
 use Symfony\Bundle\FrameworkBundle\Routing\Router as SymfonyRouter;
@@ -24,10 +25,13 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     /**
      * @internal
+     *
+     * @param list<string> $allowedRoutes
      */
     public function __construct(
         private readonly SymfonyRouter $decorated,
-        private readonly RequestStack $requestStack
+        private readonly RequestStack $requestStack,
+        private readonly array $allowedRoutes = [],
     ) {
     }
 
@@ -194,13 +198,26 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     private function isStorefrontRoute(string $name): bool
     {
-        /** Exception for @see \Shopware\Core\Checkout\Payment\Controller\PaymentController::finalizeTransaction */
-        if (str_starts_with($name, 'payment.')) {
+        if (\in_array($name, $this->allowedRoutes, true)) {
             return true;
         }
 
         $routeScopes = $this->getRouteCollection()->get($name)?->getDefault(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE) ?? [];
+        if ($routeScopes !== []) {
+            return \in_array(StorefrontRouteScope::ID, $routeScopes, true);
+        }
 
-        return \in_array(StorefrontRouteScope::ID, $routeScopes, true);
+        if (!Feature::isActive('v6.8.0.0')) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                \sprintf('Routes without a defined route scope are deprecated, please add a route scope to the route "%s"', $name)
+            );
+
+            return str_starts_with($name, 'frontend.')
+                || str_starts_with($name, 'widgets.')
+                || str_starts_with($name, 'payment.');
+        }
+
+        return false;
     }
 }

--- a/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
+++ b/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
@@ -64,8 +64,8 @@ class HeaderPageletLoader implements HeaderPageletLoaderInterface
                 throw SalesChannelException::languageNotFound($context->getLanguageId());
             }
 
-            $page->setActiveLanguage($contextLanguage);
-            $page->setActiveCurrency($context->getCurrency());
+            Feature::callSilentIfInactive('v6.8.0.0', static fn () => $page->setActiveLanguage($contextLanguage));
+            Feature::callSilentIfInactive('v6.8.0.0', static fn () => $page->setActiveCurrency($context->getCurrency()));
         }
 
         $this->eventDispatcher->dispatch(new HeaderPageletLoadedEvent($page, $context, $request));

--- a/src/Storefront/Resources/config/packages/storefront.yaml
+++ b/src/Storefront/Resources/config/packages/storefront.yaml
@@ -4,4 +4,4 @@ storefront:
         validate_on_compile: false
     router:
         allowed_routes:
-            - 'payment.finalize.transaction'
+            - 'payment.finalize.transaction' # See \Shopware\Core\Checkout\Payment\Controller\PaymentController::finalizeTransaction

--- a/src/Storefront/Resources/config/packages/storefront.yaml
+++ b/src/Storefront/Resources/config/packages/storefront.yaml
@@ -2,3 +2,6 @@ storefront:
     theme:
         allowed_scss_values: [ '^\$.*' ]
         validate_on_compile: false
+    router:
+        allowed_routes:
+            - 'payment.finalize.transaction'

--- a/tests/unit/Storefront/Framework/Routing/RouterTest.php
+++ b/tests/unit/Storefront/Framework/Routing/RouterTest.php
@@ -34,7 +34,7 @@ class RouterTest extends TestCase
         $this->symfonyRouterMock = $this->createMock(SymfonyRouter::class);
         $this->requestStackMock = $this->createMock(RequestStack::class);
 
-        $this->router = new Router($this->symfonyRouterMock, $this->requestStackMock);
+        $this->router = new Router($this->symfonyRouterMock, $this->requestStackMock, ['payment.finalize.transaction']);
     }
 
     public function testGetSubscribedServices(): void

--- a/tests/unit/Storefront/Framework/Routing/RouterTest.php
+++ b/tests/unit/Storefront/Framework/Routing/RouterTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Unit\Storefront\Framework\Routing;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
 use Shopware\Core\PlatformRequest;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
@@ -99,8 +98,7 @@ class RouterTest extends TestCase
 
         $this->requestStackMock
             ->expects($this->once())
-            ->method('getMainRequest')
-            ->willReturn(new Request([], [], [], [], [], ['SCRIPT_NAME' => '/base-path']));
+            ->method('getMainRequest');
 
         $result = $this->router->generate('test_route', [], Router::PATH_INFO);
 
@@ -175,32 +173,46 @@ class RouterTest extends TestCase
         $this->symfonyRouterMock
             ->expects($this->once())
             ->method('generate')
-            ->with('storefront_route', [])
+            ->with($routeName, [])
             ->willReturn('/base-path/storefront-route');
 
         $this->requestStackMock
             ->expects($this->exactly(2)) // only when the route is a storefront route it is called twice
-            ->method('getMainRequest')
-            ->willReturn(new Request(server: ['SCRIPT_NAME' => '/base-path']));
+            ->method('getMainRequest');
 
-        $result = $this->router->generate('storefront_route');
+        $result = $this->router->generate($routeName);
 
         static::assertSame('/base-path/storefront-route', $result);
     }
 
-    public function testGenerateWithNonStorefrontRoute(): void
+    public function testGenerateWithPaymentRoute(): void
     {
-        $routeName = 'storefront_route';
-        $routeCollection = new RouteCollection();
-        $route = new Route('/base-path/storefront-route', [
-            PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID],
-        ]);
-        $routeCollection->add($routeName, $route);
+        $routeName = 'payment.finalize.transaction';
+
+        $this->symfonyRouterMock
+            ->expects($this->never())
+            ->method('getRouteCollection');
 
         $this->symfonyRouterMock
             ->expects($this->once())
-            ->method('getRouteCollection')
-            ->willReturn($routeCollection);
+            ->method('generate')
+            ->with($routeName, [])
+            ->willReturn('/base-path/payment/finalize-transaction');
+
+        $this->requestStackMock
+            ->expects($this->exactly(2)) // only when the route is a storefront route it is called twice
+            ->method('getMainRequest');
+
+        $result = $this->router->generate($routeName);
+
+        static::assertSame('/base-path/payment/finalize-transaction', $result);
+    }
+
+    public function testGenerateWithNonStorefrontRoute(): void
+    {
+        $this->symfonyRouterMock
+            ->expects($this->once())
+            ->method('getRouteCollection');
 
         $this->symfonyRouterMock
             ->expects($this->once())
@@ -234,7 +246,7 @@ class RouterTest extends TestCase
         $this->symfonyRouterMock
             ->expects($this->once())
             ->method('generate')
-            ->with('test_route', [])
+            ->with($routeName, [])
             ->willReturn('/base-path/test-route');
 
         $this->symfonyRouterMock
@@ -249,15 +261,9 @@ class RouterTest extends TestCase
 
         $this->requestStackMock
             ->expects($this->exactly(2))
-            ->method('getMainRequest')
-            ->willReturn(new Request(server: [
-                'SCRIPT_NAME' => '/base-path',
-                'HTTPS' => 'on',
-                'HTTP_HOST' => 'example.com',
-                'SERVER_PORT' => 443,
-            ]));
+            ->method('getMainRequest');
 
-        $result = $this->router->generate('test_route', [], Router::ABSOLUTE_URL);
+        $result = $this->router->generate($routeName, [], Router::ABSOLUTE_URL);
 
         static::assertSame('https://example.com/base-path/test-route', $result);
     }
@@ -279,7 +285,7 @@ class RouterTest extends TestCase
         $this->symfonyRouterMock
             ->expects($this->once())
             ->method('generate')
-            ->with('test_route', [])
+            ->with($routeName, [])
             ->willReturn('/base-path/test-route');
 
         $this->symfonyRouterMock
@@ -294,15 +300,9 @@ class RouterTest extends TestCase
 
         $this->requestStackMock
             ->expects($this->exactly(2))
-            ->method('getMainRequest')
-            ->willReturn(new Request(server: [
-                'SCRIPT_NAME' => '/base-path',
-                'HTTPS' => 'off',
-                'HTTP_HOST' => 'example.com',
-                'SERVER_PORT' => 80,
-            ]));
+            ->method('getMainRequest');
 
-        $result = $this->router->generate('test_route', [], Router::ABSOLUTE_URL);
+        $result = $this->router->generate($routeName, [], Router::ABSOLUTE_URL);
 
         static::assertSame('http://example.com/base-path/test-route', $result);
     }
@@ -324,7 +324,7 @@ class RouterTest extends TestCase
         $this->symfonyRouterMock
             ->expects($this->once())
             ->method('generate')
-            ->with('test_route', [])
+            ->with($routeName, [])
             ->willReturn('/base-path/test-route');
 
         $this->symfonyRouterMock
@@ -340,15 +340,9 @@ class RouterTest extends TestCase
 
         $this->requestStackMock
             ->expects($this->exactly(2))
-            ->method('getMainRequest')
-            ->willReturn(new Request(server: [
-                'SCRIPT_NAME' => '/base-path',
-                'HTTPS' => 'off',
-                'HTTP_HOST' => 'example.com',
-                'SERVER_PORT' => 8000,
-            ]));
+            ->method('getMainRequest');
 
-        $result = $this->router->generate('test_route', [], Router::ABSOLUTE_URL);
+        $result = $this->router->generate($routeName, [], Router::ABSOLUTE_URL);
 
         static::assertSame('http://example.com:8000/base-path/test-route', $result);
     }
@@ -370,7 +364,7 @@ class RouterTest extends TestCase
         $this->symfonyRouterMock
             ->expects($this->once())
             ->method('generate')
-            ->with('test_route', [])
+            ->with($routeName, [])
             ->willReturn('/base-path/test-route');
 
         $this->symfonyRouterMock
@@ -386,15 +380,9 @@ class RouterTest extends TestCase
 
         $this->requestStackMock
             ->expects($this->exactly(2))
-            ->method('getMainRequest')
-            ->willReturn(new Request(server: [
-                'SCRIPT_NAME' => '/base-path',
-                'HTTPS' => 'on',
-                'HTTP_HOST' => 'example.com',
-                'SERVER_PORT' => 8443,
-            ]));
+            ->method('getMainRequest');
 
-        $result = $this->router->generate('test_route', [], Router::ABSOLUTE_URL);
+        $result = $this->router->generate($routeName, [], Router::ABSOLUTE_URL);
 
         static::assertSame('https://example.com:8443/base-path/test-route', $result);
     }
@@ -416,7 +404,7 @@ class RouterTest extends TestCase
         $this->symfonyRouterMock
             ->expects($this->once())
             ->method('generate')
-            ->with('test_route', [])
+            ->with($routeName, [])
             ->willReturn('/base-path/test-route');
 
         $this->symfonyRouterMock
@@ -431,14 +419,9 @@ class RouterTest extends TestCase
 
         $this->requestStackMock
             ->expects($this->exactly(2))
-            ->method('getMainRequest')
-            ->willReturn(new Request(server: [
-                'SCRIPT_NAME' => '/base-path',
-                'HTTP_HOST' => 'example.com',
-                'SERVER_PORT' => 80,
-            ]));
+            ->method('getMainRequest');
 
-        $result = $this->router->generate('test_route', [], Router::NETWORK_PATH);
+        $result = $this->router->generate($routeName, [], Router::NETWORK_PATH);
 
         static::assertSame('//example.com/base-path/test-route', $result);
     }
@@ -460,7 +443,7 @@ class RouterTest extends TestCase
         $this->symfonyRouterMock
             ->expects($this->once())
             ->method('generate')
-            ->with('test_route', [], Router::RELATIVE_PATH)
+            ->with($routeName, [], Router::RELATIVE_PATH)
             ->willReturn('/test-route');
 
         $this->symfonyRouterMock
@@ -469,10 +452,9 @@ class RouterTest extends TestCase
 
         $this->requestStackMock
             ->expects($this->exactly(2))
-            ->method('getMainRequest')
-            ->willReturn(new Request(server: ['SCRIPT_NAME' => '/base-path']));
+            ->method('getMainRequest');
 
-        $result = $this->router->generate('test_route', [], Router::RELATIVE_PATH);
+        $result = $this->router->generate($routeName, [], Router::RELATIVE_PATH);
 
         static::assertSame('/test-route', $result);
     }
@@ -487,8 +469,7 @@ class RouterTest extends TestCase
 
         $this->requestStackMock
             ->expects($this->once())
-            ->method('getMainRequest')
-            ->willReturn(new Request(server: ['SCRIPT_NAME' => '/base-path']));
+            ->method('getMainRequest');
 
         $result = $this->router->generate('test_route');
 


### PR DESCRIPTION
### 1. Why is this change necessary?

With https://github.com/shopware/shopware/pull/8464 we changed the check in the router for Storefront routes, but this broke the handling of the `payment.finalize.transaction` route, as this has no route scope defined.

### 2. What does this change do, exactly?

Add exception to the check

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
