### PR TITLE
fix: docker compose requires start_perioid

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -43,6 +43,7 @@ services:
         healthcheck:
             test: [ "CMD", "mariadb-admin" ,"ping", "-h", "localhost", "-proot" ]
             start_interval: 3s
+            start_period: 10s
             interval: 5s
             timeout: 1s
             retries: 10


### PR DESCRIPTION
### 1. Why is this change necessary?

sneaky BC in a docker minor


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
