### PR TITLE
refactor: Simplify profile personal form template company fields

### DIFF
--- a/changelog/_unreleased/2025-06-14-simplify-personal-company-fields.md
+++ b/changelog/_unreleased/2025-06-14-simplify-personal-company-fields.md
@@ -1,0 +1,12 @@
+---
+title: Simplify personal company fields
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Deprecated variable `showVatIdField` in `@Storefront/storefront/page/account/profile/index.html.twig` template which will be replaced by `showCompanyFields` which controls the visibility of the company fields, i.e. the company name and VAT ID
+* Deprecated unused variable `editMode` in `@Storefront/storefront/component/address/address-personal.html.twig` template
+* Deprecated blocks `component_address_personal_company`, `component_address_personal_company_fields`, `component_address_personal_vat_id`, and `component_address_personal_vat_id_fields`  in `@Storefront/storefront/component/address/address-personal.html.twig` template use `component_address_personal_company_name` or `component_address_personal_company_vat_id` instead
+* Added block `component_address_personal_company_section` in `@Storefront/storefront/component/address/address-personal.html.twig` template
+* Changed `@Storefront/storefront/component/address/address-personal.html.twig` template to show VAT ID field next to the company name field instead of below it

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -199,10 +199,10 @@
         </div>
     {% endblock %}
 
-    {% block component_address_personal_company %}
-        {% if (onlyCompanyRegistration or config('core.loginRegistration.showAccountTypeSelection')) and activeRoute == 'frontend.account.profile.page' %}
-            <div class="js-field-toggle-contact-type-company{% if customToggleTarget %}-{{ prefix }}{% endif %}">
-                {% block component_address_personal_company_fields %}
+    {% if feature('v6.8.0.0') %}
+        {% block component_address_personal_company_section %}
+            {% if (config('core.loginRegistration.showAccountTypeSelection') or onlyCompanyRegistration) and showCompanyFields %}
+                <div class="js-field-toggle-contact-type-company{% if customToggleTarget %}-{{ prefix }}{% endif %}">
                     <div class="row g-2">
                         {% block component_address_personal_company_name %}
                             {% if formViolations.getViolations("/company") is not empty %}
@@ -223,29 +223,47 @@
                                 } %}
                             {% endblock %}
                         {% endblock %}
-                    </div>
-                {% endblock %}
-            </div>
-        {% endif %}
-    {% endblock %}
 
-    {% block component_address_personal_vat_id %}
-        {% if showVatIdField %}
-            {% if config('core.loginRegistration.showAccountTypeSelection') or onlyCompanyRegistration %}
-                <div class="js-field-toggle-contact-type-company{% if customToggleTarget %}-{{ prefix }}{% endif %} js-field-toggle-contact-type-vat-id">
-                    {% block component_address_personal_vat_id_fields %}
-                        <div class="row g-2">
-                            {# This is only rendered on the customer profile edit page. #}
+                        {% block component_address_personal_company_vat_id %}
+                            {# @deprecated tag:v6.8.0 - Unused variable `editMode` and will be removed #}
+                            {% set editMode = true %}
+
                             {% sw_include '@Storefront/storefront/component/address/address-personal-vat-id.html.twig' with {
                                 'vatIds': data.get('vatIds'),
-                                'editMode': true
                             } %}
+                        {% endblock %}
+                    </div>
+                </div>
+            {% endif %}
+        {% endblock %}
+    {% else %}
+        {# @deprecated tag:v6.8.0 - Block will be removed use block `component_address_personal_company_name` instead #}
+        {% block component_address_personal_company %}
+            {% if (onlyCompanyRegistration or config('core.loginRegistration.showAccountTypeSelection')) and activeRoute == 'frontend.account.profile.page' %}
+                <div class="js-field-toggle-contact-type-company{% if customToggleTarget %}-{{ prefix }}{% endif %}">
+                    {% block component_address_personal_company_fields %}
+                        <div class="row g-2">
+                            {{ block('component_address_personal_company_name') }}
                         </div>
                     {% endblock %}
                 </div>
             {% endif %}
-        {% endif %}
-    {% endblock %}
+        {% endblock %}
+
+        {# @deprecated tag:v6.8.0 - Block will be removed use block `component_address_personal_company_vat_id` instead #}
+        {% block component_address_personal_vat_id %}
+            {% if (onlyCompanyRegistration or config('core.loginRegistration.showAccountTypeSelection')) and showVatIdField %}
+                <div class="js-field-toggle-contact-type-company{% if customToggleTarget %}-{{ prefix }}{% endif %} js-field-toggle-contact-type-vat-id">
+                    {% block component_address_personal_vat_id_fields %}
+                        <div class="row g-2">
+                            {# This is only rendered on the customer profile edit page. #}
+                            {{ block('component_address_personal_company_vat_id') }}
+                        </div>
+                    {% endblock %}
+                </div>
+            {% endif %}
+        {% endblock %}
+    {% endif %}
 
     {% block component_address_personal_fields_birthday %}
         {% if showBirthdayField %}

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -257,7 +257,7 @@
                     {% block component_address_personal_vat_id_fields %}
                         <div class="row g-2">
                             {# This is only rendered on the customer profile edit page. #}
-                            {{ block('component_address_personal_company_vat_id') }}
+                            {{ sw_block('component_address_personal_company_vat_id') }}
                         </div>
                     {% endblock %}
                 </div>

--- a/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
@@ -31,12 +31,15 @@
                                       action="{{ path('frontend.account.profile.save') }}"
                                       data-form-handler="true">
                                     {% block page_account_profile_personal_fields %}
+                                        {# @deprecated tag:v6.8.0 - Unused variable `showVatIdField` will be removed, use variable showCompanyFields instead #}
+                                        {% set showVatIdField = true %}
+
                                         {% sw_include '@Storefront/storefront/component/address/address-personal.html.twig' with {
                                             prefix: '',
                                             showBirthdayField: config('core.loginRegistration.showBirthdayField'),
-                                            showVatIdField: true,
                                             data: context.customer,
                                             onlyCompanyRegistration: context.currentCustomerGroup.translated.registrationOnlyCompanyRegistration ?? false,
+                                            showCompanyFields: true,
                                         } %}
                                     {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the company name and vat id fields are quite strange organized in the `address-personal.html.twig` template by two different `if` conditions, which are only true simultaneously. Interestingly this is also stated by a comment in the template `{# This is only rendered on the customer profile edit page. #}`.

Furthermore the fields are displayed not in an optimal way:
![image](https://github.com/user-attachments/assets/14c70778-b8c4-4a16-b99e-d74f9fbf568b)

### 2. What does this change do, exactly?
Simplify the `if` conditions by adding a new variable to control displaying the fields simultaneously and move them into a single container to display them side by side:
![image](https://github.com/user-attachments/assets/e2e0d25a-bad9-45b9-bbff-ed30ce9ba968)

Note, I am not sure if the `if` condition is good, as it currently is implemented (`config('core.loginRegistration.showAccountTypeSelection') or onlyCompanyRegistration`). As I think it should also be displayed if the customer has a business account (or maybe this should be the only condition).

### 3. Describe each step to reproduce the issue or behaviour.
Enable the company fields in the personal account.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
