### PR TITLE
fix: Be able to load meteor apps from Shopware bundles

### DIFF
--- a/changelog/_unreleased/2025-06-13-allow-admin-scripts-provided-by-bundles.md
+++ b/changelog/_unreleased/2025-06-13-allow-admin-scripts-provided-by-bundles.md
@@ -5,4 +5,5 @@ author_email: code@joshua-behrens.de
 author_github: @JoshuaBehrens
 ---
 # Core
-* Change focus in administration asset path detection from `\Shopware\Core\Framework\Plugin` to `\Shopware\Core\Framework\Bundle` to be able to load meteor apps from bundles  
+* Changed focus in administration asset path detection from `\Shopware\Core\Framework\Plugin` to `\Shopware\Core\Framework\Bundle` to be able to load meteor apps from bundles  
+* Changed bundle suffix in administration asset path building in `\Shopware\Core\Framework\Api\Controller\InfoController` by removing bundle suffix

--- a/changelog/_unreleased/2025-06-13-allow-admin-scripts-provided-by-bundles.md
+++ b/changelog/_unreleased/2025-06-13-allow-admin-scripts-provided-by-bundles.md
@@ -1,0 +1,8 @@
+---
+title: Allow admininistration scripts being provided by bundles
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Change focus in administration asset path detection from `\Shopware\Core\Framework\Plugin` to `\Shopware\Core\Framework\Bundle` to be able to load meteor apps from bundles  

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -295,10 +295,6 @@ class InfoController extends AbstractController
 
     private function getBaseUrl(Bundle $bundle): ?string
     {
-        if (!$bundle instanceof Plugin) {
-            return null;
-        }
-
         if ($bundle->getAdminBaseUrl()) {
             return $bundle->getAdminBaseUrl();
         }

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -308,7 +308,13 @@ class InfoController extends AbstractController
             return $this->router->generate(
                 'administration.plugin.index',
                 [
-                    'pluginName' => \mb_strtolower($bundle->getName()),
+                    /**
+                     * Adopted from symfony, as they also strip the bundle suffix:
+                     * https://github.com/symfony/symfony/blob/7.2/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php#L128
+                     *
+                     * @see Plugin\Util\AssetService::getTargetDirectory
+                     */
+                    'pluginName' => preg_replace('/bundle$/', '', mb_strtolower($bundle->getName())),
                 ],
                 UrlGeneratorInterface::ABSOLUTE_URL
             );

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -99,6 +99,14 @@ abstract class Bundle extends SymfonyBundle
     }
 
     /**
+     * Used to configure the BaseUrl for the Admin Extension API
+     */
+    public function getAdminBaseUrl(): ?string
+    {
+        return null;
+    }
+
+    /**
      * Returns a list of all action event class references of this bundle. The events will be registered inside the `\Shopware\Core\Framework\Event\BusinessEventRegistry`.
      *
      * @return array<class-string>

--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -117,14 +117,6 @@ abstract class Plugin extends Bundle
         return [];
     }
 
-    /**
-     * Used to configure the BaseUrl for the Admin Extension API
-     */
-    public function getAdminBaseUrl(): ?string
-    {
-        return null;
-    }
-
     private function computePluginClassPath(): string
     {
         $canonicalizedPluginClassPath = $this->getPath();

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -448,6 +448,7 @@ class InfoControllerTest extends TestCase
 
         $kernel = new StubKernel([
             new AdminExtensionApiBundle(),
+            new AdminExtensionApiWithoutSelfKnownBaseUrlBundle(),
             new AdminExtensionApiPlugin(true, __DIR__ . '/Fixtures/InfoController'),
             new AdminExtensionApiPluginWithLocalEntryPoint(true, __DIR__ . '/Fixtures/AdminExtensionApiPluginWithLocalEntryPoint'),
         ]);
@@ -498,11 +499,13 @@ class InfoControllerTest extends TestCase
         $content = $infoController->config(Context::createDefaultContext(), Request::create($appUrl))->getContent();
         static::assertNotFalse($content);
         $config = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
-        static::assertCount(3, $config['bundles']);
+        static::assertCount(4, $config['bundles']);
 
         static::assertArrayHasKey('AdminExtensionApiBundle', $config['bundles']);
         static::assertSame('https://extension-bundle.test', $config['bundles']['AdminExtensionApiBundle']['baseUrl']);
         static::assertSame('plugin', $config['bundles']['AdminExtensionApiBundle']['type']);
+
+        static::assertArrayNotHasKey('AdminExtensionApiWithoutSelfKnownBaseUrlBundle', $config['bundles']);
 
         static::assertArrayHasKey('AdminExtensionApiPlugin', $config['bundles']);
         static::assertSame('https://extension-api.test', $config['bundles']['AdminExtensionApiPlugin']['baseUrl']);
@@ -795,6 +798,13 @@ class AdminExtensionApiBundle extends Bundle
     {
         return 'https://extension-bundle.test';
     }
+}
+
+/**
+ * @internal
+ */
+class AdminExtensionApiWithoutSelfKnownBaseUrlBundle extends Bundle
+{
 }
 
 /**

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\Controller\InfoController;
 use Shopware\Core\Framework\Api\Route\ApiRouteInfoResolver;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
+use Shopware\Core\Framework\Bundle;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
 use Shopware\Core\Framework\Event\BusinessEventCollector;
@@ -446,6 +447,7 @@ class InfoControllerTest extends TestCase
         $this->loadAppsFromDir(__DIR__ . '/Fixtures/AdminExtensionApiApp');
 
         $kernel = new StubKernel([
+            new AdminExtensionApiBundle(),
             new AdminExtensionApiPlugin(true, __DIR__ . '/Fixtures/InfoController'),
             new AdminExtensionApiPluginWithLocalEntryPoint(true, __DIR__ . '/Fixtures/AdminExtensionApiPluginWithLocalEntryPoint'),
         ]);
@@ -497,6 +499,10 @@ class InfoControllerTest extends TestCase
         static::assertNotFalse($content);
         $config = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
         static::assertCount(3, $config['bundles']);
+
+        static::assertArrayHasKey('AdminExtensionApiBundle', $config['bundles']);
+        static::assertSame('https://extension-bundle.test', $config['bundles']['AdminExtensionApiBundle']['baseUrl']);
+        static::assertSame('plugin', $config['bundles']['AdminExtensionApiBundle']['type']);
 
         static::assertArrayHasKey('AdminExtensionApiPlugin', $config['bundles']);
         static::assertSame('https://extension-api.test', $config['bundles']['AdminExtensionApiPlugin']['baseUrl']);
@@ -777,6 +783,17 @@ class InfoControllerTest extends TestCase
             'privileges' => json_encode(['users_and_permissions.viewer']),
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);
+    }
+}
+
+/**
+ * @internal
+ */
+class AdminExtensionApiBundle extends Bundle
+{
+    public function getAdminBaseUrl(): ?string
+    {
+        return 'https://extension-bundle.test';
     }
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

There has been a trend towards providing changes by bundle instead of plugin due to the added complexity of the plugin management, that does not need to be managed if not used. To still provide an administration experience with new Meteor SDK you need to be a plugin.

To be able to only ship in bundles in Shopware 6.6 you have to have a Shopware bundle with an additional bundle, that is technically a plugin and ship it like this:

```php
final class InterimBundle extends Bundle
{
    #[\Override]
    public function getAdditionalBundles(AdditionalBundleParameters $parameters): array
    {
        $projectDir = $parameters->getKernelParameters()['kernel.project_dir'];
        $pluginDir = __DIR__ . DIRECTORY_SEPARATOR . 'RealBundle . DIRECTORY_SEPARATOR;

        return [
            new BundleDisguisedAsPlugin(true, \mb_substr($pluginDir, \mb_strlen($projectDir) + 1), $projectDir),
        ];
    }
}
```

When you want to have a working suffix you also need to have a patch in the webpack.config to remove the bundle suffix as well but this is not practical as shopware-cli always pulls a fresh Shopware installation out of the hat. So you better do not name your bundle like Symfony tells you to do.

So please just let us clean this up for Shopware 6.7 to not be an issue anymore :) 

### 2. What does this change do, exactly?

It moves a method to a base classes and change one check from plugin to bundle class.

It adds one bundle suffix removal as this is very Symfony-esque to do that:

* Create bundle with suffix bundle
* Remove bundle suffix everywhere else e.g. find extension class and assets path

### 3. Describe each step to reproduce the issue or behaviour.

1. Folow the tutorial to start with meteor
2. Have a bundle with a with a file `Resources/app/administration/index.html` and `Resources/app/administration/src/main.js`
3. Compile the admin
4. Install assets
5. Have no  ![grafik](https://github.com/user-attachments/assets/8e92877a-3109-4bb4-8dc3-63c8df3b5ce6)
6. but rather a 404

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
