### PR TITLE
chore: correct count of extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you like Shopware 6, give us a&nbsp;⭐️ &nbsp;on GitHub!
 
 * 🙋‍♂️ &nbsp;[Be part of shopware!](https://www.shopware.com/en/jobs/) ‍&nbsp;We are hiring!  🙋
 * 🌎 &nbsp;Discover our [website](https://www.shopware.com/en/)
-* 🧩 &nbsp;Browse more than [5,200 extensions](https://store.shopware.com/en/) in our community store
+* 🧩 &nbsp;Browse more than [3,100 extensions](https://store.shopware.com/en/) in our community store
 * 📖 &nbsp;Learn how to [develop extensions](https://developer.shopware.com) and everything else about the tech behind Shopware
 * 🉐 &nbsp;[Translate](https://translate.shopware.com) Shopware or help by contributing to existing languages
 * 🛠 &nbsp;[Report bugs](https://github.com/shopware/shopware/issues) in our issue tracker


### PR DESCRIPTION
### 1. Why is this change necessary?
There are 3104 extensions for Shopware 6 available in store.

Additional things to do:

1. You might want to change the "about" of github, too.
![image](https://github.com/user-attachments/assets/7977b9f9-0c61-4fe8-94f4-92c88f443c75)
2. The last page is always empty
![image](https://github.com/user-attachments/assets/462bfa3b-c679-42ce-bc15-ba788b9ee0a4)


### 2. What does this change do, exactly?
correct the number.

### 3. Describe each step to reproduce the issue or behaviour.
see store.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
