### PR TITLE
fix: empty test mail headers

### DIFF
--- a/tests/integration/Core/Content/Mail/Service/MailServiceTest.php
+++ b/tests/integration/Core/Content/Mail/Service/MailServiceTest.php
@@ -258,6 +258,7 @@ class MailServiceTest extends TestCase
             'order' => [
                 'deepLinkCode' => 'home',
             ],
+            'eventName' => 'state_enter.order_transaction.state.paid',
         ];
 
         $context = Context::createDefaultContext();

--- a/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\MailTemplate\Service\Event\MailBeforeSentEvent;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailBeforeValidateEvent;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailErrorEvent;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailSentEvent;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -68,6 +69,11 @@ class MailServiceTest extends TestCase
      */
     private AbstractMailSender $mailSender;
 
+    /**
+     * @var MockObject&LanguageLocaleCodeProvider
+     */
+    private LanguageLocaleCodeProvider $languageLocaleCodeProvider;
+
     protected function setUp(): void
     {
         $this->mailFactory = $this->createMock(AbstractMailFactory::class);
@@ -76,6 +82,7 @@ class MailServiceTest extends TestCase
         $this->salesChannelRepository = $this->createMock(EntityRepository::class);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->mailSender = $this->createMock(AbstractMailSender::class);
+        $this->languageLocaleCodeProvider = $this->createMock(LanguageLocaleCodeProvider::class);
 
         $this->mailService = new MailService(
             $this->createMock(DataValidator::class),
@@ -87,7 +94,7 @@ class MailServiceTest extends TestCase
             $this->createMock(SystemConfigService::class),
             $this->eventDispatcher,
             $this->logger,
-            $this->createMock(LanguageLocaleCodeProvider::class)
+            $this->languageLocaleCodeProvider,
         );
     }
 
@@ -330,5 +337,64 @@ class MailServiceTest extends TestCase
         static::assertSame('Could not send mail with error message: Mail sending failed', $mailErrorEvent->getMessage());
         static::assertSame('Content html', $mailErrorEvent->getTemplate());
         static::assertEmpty($mailErrorEvent->getTemplateData());
+    }
+
+    public function testMailInTestModeHasNoEmptyHeaders(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $context = Context::createDefaultContext();
+
+        $salesChannelResult = new EntitySearchResult(
+            'sales_channel',
+            1,
+            new SalesChannelCollection([$salesChannel]),
+            null,
+            new Criteria(),
+            $context
+        );
+
+        $this->salesChannelRepository->expects($this->once())->method('search')->willReturn($salesChannelResult);
+
+        $data = [
+            'testMode' => true,
+            'recipients' => [],
+            'senderName' => 'me',
+            'senderEmail' => 'me@shopware.com',
+            'subject' => 'Test email',
+            'contentPlain' => 'Content plain',
+            'contentHtml' => 'Content html',
+            'salesChannelId' => $salesChannelId,
+        ];
+
+        $email = (new Email())->subject($data['subject'])
+            ->html($data['contentHtml'])
+            ->text($data['contentPlain'])
+            ->to('me@shopware.com')
+            ->from(new Address($data['senderEmail']));
+
+        $this->mailFactory->expects($this->once())->method('create')->willReturn($email);
+        $this->templateRenderer->expects($this->exactly(4))->method('render')->willReturn('');
+        $this->eventDispatcher->expects($this->exactly(3))->method('dispatch')->willReturnOnConsecutiveCalls(
+            static::isInstanceOf(MailBeforeValidateEvent::class),
+            static::isInstanceOf(MailBeforeSentEvent::class),
+            static::isInstanceOf(MailSentEvent::class)
+        );
+        $this->languageLocaleCodeProvider->expects($this->once())->method('getLocaleForLanguageId')->willReturn('en-GB');
+
+        $email = $this->mailService->send($data, Context::createDefaultContext());
+
+        static::assertInstanceOf(Email::class, $email);
+        $headers = $email->getHeaders();
+        static::assertSame($headers->get('X-Shopware-Language-Id')?->getBody(), Defaults::LANGUAGE_SYSTEM);
+        static::assertSame($headers->get('X-Shopware-Sales-Channel-Id')?->getBody(), $salesChannelId);
+
+        // check that no header is empty (e.g. Amazon SES doesn't like that)
+        foreach ($headers->all() as $header) {
+            echo $header->getName();
+            static::assertNotEmpty($header->getBody(), 'mail header ' . $header->getName() . ' should not be empty');
+        }
     }
 }

--- a/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
@@ -29,6 +29,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\HeaderInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -393,8 +394,8 @@ class MailServiceTest extends TestCase
 
         // check that no header is empty (e.g. Amazon SES doesn't like that)
         foreach ($headers->all() as $header) {
-            echo $header->getName();
-            static::assertNotEmpty($header->getBody(), 'mail header ' . $header->getName() . ' should not be empty');
+            static::assertInstanceOf(HeaderInterface::class, $header);
+            static::assertNotEmpty($header->getBodyAsString(), 'mail header ' . $header->getName() . ' should not be empty');
         }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
e.g. Amazon SES mail service doesn't like mail headers without a value and rejects requests like that.

### 2. What does this change do, exactly?
Fixes test mode mails to not set headers without a value.

### 3. Describe each step to reproduce the issue or behaviour.
in Shopware SaaS go to settings -> mail templates -> order confirmation -> on the sidebar send a test mail. That mail never gets delivered.

### 4. Please link to the relevant issues (if any).
closes #10325 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
