### PR TITLE
fix: deprecation message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
         "monolog/monolog": "^3.3.1",
         "nyholm/psr7": "^1.5",
         "opensearch-project/opensearch-php": "^2.3.1",
-        "pentatrion/vite-bundle": "^7.0",
+        "pentatrion/vite-bundle": "^8.1",
         "psr/cache": "^3.0.0",
         "psr/event-dispatcher": "^1.0.0",
         "psr/http-factory": "^1.0.1",

--- a/src/Administration/composer.json
+++ b/src/Administration/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "doctrine/dbal": "^4.2",
-        "pentatrion/vite-bundle": "^7.0",
+        "pentatrion/vite-bundle": "^8.1",
         "shopware/core": "*",
         "symfony/framework-bundle": "~7.2.0",
         "symfony/http-foundation": "~7.2.0",

--- a/src/Core/Framework/Adapter/Twig/TokenParser/ReturnNodeTokenParser.php
+++ b/src/Core/Framework/Adapter/Twig/TokenParser/ReturnNodeTokenParser.php
@@ -24,7 +24,7 @@ final class ReturnNodeTokenParser extends AbstractTokenParser
 
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        return new ReturnNode($nodes, [], $token->getLine(), $this->getTag());
+        return new ReturnNode($nodes, [], $token->getLine());
     }
 
     public function getTag(): string

--- a/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
+++ b/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
@@ -64,8 +64,10 @@ class HeaderPageletLoader implements HeaderPageletLoaderInterface
                 throw SalesChannelException::languageNotFound($context->getLanguageId());
             }
 
-            $page->setActiveLanguage($contextLanguage);
-            $page->setActiveCurrency($context->getCurrency());
+            Feature::callSilentIfInactive('v6.8.0.0', function () use ($contextLanguage, $context, $page) {
+                $page->setActiveLanguage($contextLanguage);
+                $page->setActiveCurrency($context->getCurrency());
+            });
         }
 
         $this->eventDispatcher->dispatch(new HeaderPageletLoadedEvent($page, $context, $request));

--- a/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
+++ b/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
@@ -64,7 +64,7 @@ class HeaderPageletLoader implements HeaderPageletLoaderInterface
                 throw SalesChannelException::languageNotFound($context->getLanguageId());
             }
 
-            Feature::callSilentIfInactive('v6.8.0.0', function () use ($contextLanguage, $context, $page) {
+            Feature::callSilentIfInactive('v6.8.0.0', function () use ($contextLanguage, $context, $page): void {
                 $page->setActiveLanguage($contextLanguage);
                 $page->setActiveCurrency($context->getCurrency());
             });


### PR DESCRIPTION
### 1. Why is this change necessary?

- Fixed that the deprecation for the header is shown even when we called it for bc reason
- Updated vite bundle to fix Symfony deprecation, no real change happend there https://github.com/lhapaipai/vite-bundle/compare/v7.1.0...v8.1.1
- Remove tag constructor parameter from node, it's deprecated 


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
