### PR TITLE
fix: price matrix now updates db correctly

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/index.js
@@ -489,6 +489,7 @@ export default {
         onQuantityEndChange(price) {
             // when not last price
             if (this.priceGroup.prices.indexOf(price) + 1 !== this.priceGroup.prices.length) {
+                this.changeNextPrice(this.priceGroup.prices.indexOf(price));
                 return;
             }
 
@@ -497,6 +498,10 @@ export default {
 
         updateShowAllPrices() {
             this.showAllPrices = true;
+        },
+
+        changeNextPrice(index) {
+            this.priceGroup.prices[index + 1].quantityStart = this.priceGroup.prices[index].quantityEnd;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.spec.js
@@ -150,4 +150,76 @@ describe('module/sw-settings-shipping/component/sw-settings-shipping-price-matri
         expect(wrapper.vm.showAllPrices).toBeTruthy();
         expect(wrapper.vm.shippingMethod.prices).toHaveLength(length + 1);
     });
+
+    describe('Price matrix quantity handling', () => {
+        it('should update next price start value when quantity end changes (quantity calculation)', async () => {
+            const wrapper = await createWrapper();
+            wrapper.vm.updateShowAllPrices(); // Show all prices
+            wrapper.vm.priceGroup.calculation = 1; // Set to quantity calculation
+
+            // Set initial values
+            wrapper.vm.priceGroup.prices[0].quantityEnd = 5;
+            wrapper.vm.priceGroup.prices[1].quantityStart = 6;
+
+            // Change quantity end of first price
+            wrapper.vm.onQuantityEndChange(wrapper.vm.priceGroup.prices[0]);
+
+            // Check if next price start was updated
+            expect(wrapper.vm.priceGroup.prices[1].quantityStart).toBe(5);
+        });
+
+        it('should update next price start value when quantity end changes (price calculation)', async () => {
+            const wrapper = await createWrapper();
+            wrapper.vm.updateShowAllPrices(); // Show all prices
+            wrapper.vm.priceGroup.calculation = 2; // Set to price calculation
+
+            // Set initial values
+            wrapper.vm.priceGroup.prices[0].quantityEnd = 100;
+            wrapper.vm.priceGroup.prices[1].quantityStart = 101;
+
+            // Change quantity end of first price
+            wrapper.vm.onQuantityEndChange(wrapper.vm.priceGroup.prices[0]);
+
+            // Check if next price start was updated
+            expect(wrapper.vm.priceGroup.prices[1].quantityStart).toBe(100);
+        });
+
+        it('should handle changeNextPrice for middle price in matrix', async () => {
+            const wrapper = await createWrapper();
+            wrapper.vm.updateShowAllPrices(); // Show all prices
+
+            // Add a third price to test middle price behavior
+            const newPrice = {
+                _isNew: true,
+                id: 'priceId3',
+                shippingMethodId: 'shippingMethodId',
+                quantityStart: 3,
+                quantityEnd: null,
+                ruleId: 'ruleId',
+                rule: {},
+                calculation: 1,
+                currencyPrice: [
+                    {
+                        currencyId: 'euro',
+                        gross: 0,
+                        linked: false,
+                        net: 0,
+                    },
+                ],
+            };
+            wrapper.vm.priceGroup.prices.push(newPrice);
+
+            // Set values for testing
+            wrapper.vm.priceGroup.prices[0].quantityEnd = 5;
+            wrapper.vm.priceGroup.prices[1].quantityStart = 6;
+            wrapper.vm.priceGroup.prices[1].quantityEnd = 10;
+            wrapper.vm.priceGroup.prices[2].quantityStart = 11;
+
+            // Change middle price's end value
+            wrapper.vm.onQuantityEndChange(wrapper.vm.priceGroup.prices[1]);
+
+            // Check if next price start was updated
+            expect(wrapper.vm.priceGroup.prices[2].quantityStart).toBe(10);
+        });
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
There was an issue where the db didn't update correctly causing a problem when prices were calculated with shipping

### 2. What does this change do, exactly?
This updates the front end box immediately with the correct value, which marks it as dirty, meaning it gets passed to the backend and stored.

### 3. Describe each step to reproduce the issue or behaviour.
Add a price matrix
Add 2 price rules based on the shopping cart value
Rule 1: From 0 to 23.99 € : Shipping costs 4.99 €
Rule 2: From 23.99 € to infinity: shipping costs 0 €
Save the shipping method
Change the “Shipping costs to” in rule 1 to 29.99
Click on Save immediately

### 4. Please link to the relevant issues (if any).
fixes #10526

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
