### PR TITLE
fix: press esc key in the modal will go back listing page

### DIFF
--- a/changelog/_unreleased/2025-06-17-press-esc-key-in-the-modal-will-go-back-listing-page.md
+++ b/changelog/_unreleased/2025-06-17-press-esc-key-in-the-modal-will-go-back-listing-page.md
@@ -1,0 +1,9 @@
+---
+title: Press ESC key in the modal will go back listing page
+issue: #10518
+author: Le Nguyen
+author_email: nguyenquocdaile@gmail.com
+author_github: @Le Nguyen
+---
+# Administration
+* Changed `handleKeyDownDebounce` method to check if the event originates from within a modal in `src/app/plugin/shortcut.plugin.js`.

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
@@ -78,12 +78,19 @@ export default {
                         return false;
                     }
 
-                    const isModalShown = !!document.querySelector('.sw-modal__dialog');
+                    // Check if event originates from within a modal
+                    const eventTarget = event.target instanceof Element ? event.target : null;
+                    const isFromModal =
+                        eventTarget?.closest('.sw-modal') ||
+                        eventTarget?.closest('.sw-modal__dialog') ||
+                        !!document.querySelector('.sw-modal__dialog') ||
+                        !!document.querySelector('.sw-modal');
+
                     const systemKey = this.$device.getSystemKey();
                     const { key, altKey, ctrlKey } = event;
                     const systemKeyPressed = systemKey === 'CTRL' ? ctrlKey : altKey;
 
-                    if (isModalShown) {
+                    if (isFromModal) {
                         return false;
                     }
 

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
@@ -406,4 +406,61 @@ describe('app/plugins/shortcut.plugin', () => {
         expect(onSaveMock).toHaveBeenCalledWith();
         expect(testString).toBe('foobar');
     });
+
+    it('should call the onEsc method when Escape key is pressed outside a modal', async () => {
+        const onEscMock = jest.fn();
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                Escape: 'onEsc',
+            },
+            methods: {
+                onEsc() {
+                    onEscMock();
+                },
+            },
+        });
+
+        expect(onEscMock).not.toHaveBeenCalled();
+
+        // Simulate Escape keydown event outside a modal
+        await wrapper.trigger('keydown', {
+            key: 'Escape',
+        });
+
+        expect(onEscMock).toHaveBeenCalledWith();
+    });
+
+    it('should NOT call the onEsc method when Escape key is pressed inside a modal', async () => {
+        const onEscMock = jest.fn();
+
+        // Create a modal element in the DOM
+        const modal = document.createElement('div');
+        modal.className = 'sw-modal';
+        document.body.appendChild(modal);
+
+        wrapper = await createWrapper({
+            shortcuts: {
+                Escape: 'onEsc',
+            },
+            methods: {
+                onEsc() {
+                    onEscMock();
+                },
+            },
+        });
+
+        expect(onEscMock).not.toHaveBeenCalled();
+
+        // Simulate Escape keydown event with the target inside the modal
+        const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+        Object.defineProperty(event, 'target', { value: modal, enumerable: true });
+
+        document.dispatchEvent(event);
+
+        expect(onEscMock).not.toHaveBeenCalled();
+
+        // Clean up
+        document.body.removeChild(modal);
+    });
 });


### PR DESCRIPTION
### Description 
Please read the issue.

### Solution
Go to any page detail with a shortcut that has been implemented
Open any modal 
Press the `Esc` key on the keyboard. 
Modal will close, but not go back to the listing page.

https://github.com/user-attachments/assets/ce8d45a5-c115-4a3d-9221-b9abc160c05d
