### PR TITLE
feat: ES should work correctly with ScoreQuery

### DIFF
--- a/changelog/_unreleased/2025-06-17-es-should-work-correctly-with-scorequery.md
+++ b/changelog/_unreleased/2025-06-17-es-should-work-correctly-with-scorequery.md
@@ -1,0 +1,6 @@
+---
+title: ES should work correctly with ScoreQuery
+issue: 8471
+---
+# Core
+* Changed `addQueries` method in `Shopware\Elasticsearch\Framework\ElasticsearchHelper` to ensure that the score in `ScoreQuery` is correctly applied to the search query.

--- a/src/Elasticsearch/Framework/ElasticsearchHelper.php
+++ b/src/Elasticsearch/Framework/ElasticsearchHelper.php
@@ -170,10 +170,12 @@ class ElasticsearchHelper
         foreach ($queries as $query) {
             $parsed = $this->parser->parseFilter($query->getQuery(), $definition, $definition->getEntityName(), $context);
 
-            if ($parsed instanceof MatchQuery) {
+            if ($query->getScore() && method_exists($parsed, 'addParameter')) {
                 $score = (string) $query->getScore();
-
                 $parsed->addParameter('boost', $score);
+            }
+
+            if ($parsed instanceof MatchQuery) {
                 $parsed->addParameter('fuzziness', '2');
             }
 


### PR DESCRIPTION
This pull request improves Elasticsearch functionality by ensuring that `ScoreQuery` is correctly applied to search queries. The changes primarily involve modifications to the `addQueries` method in the `ElasticsearchHelper` class.

### Elasticsearch functionality improvements:

* [`src/Elasticsearch/Framework/ElasticsearchHelper.php`](diffhunk://#diff-59bc1b72ce8bd1d01d1047cb4d6ffa82bc69d086fc14b56c3da1957269b26834R181-R186): Updated the `addQueries` method to check if a query is an instance of `ScoreQuery` and apply the score as a boost parameter to the parsed query.
