### PR TITLE
fix: fix hidden items in entity-multi-select and category-tree-selection

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.scss
@@ -13,6 +13,7 @@ $sw-category-tree-field-transition-results: all ease-in-out 0.2s;
         flex-wrap: wrap;
         box-sizing: border-box;
         padding: 0 8px;
+        height: auto;
     }
 
     .sw-category-tree__input-field {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.scss
@@ -51,7 +51,7 @@
     }
 }
 
-.sw-entity-multi-select .sw-block-field__block {
+.sw-entity-multi-select.sw-block-field .sw-block-field__block {
     min-height: 48px;
     height: auto;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/10519

### 2. What does this change do, exactly?

Now the height is flexible and the hidden items, which were below the field, are now visible again and working like in 6.6

### 3. Describe each step to reproduce the issue or behaviour.

See issue