### PR TITLE
fix: live search page broken if the data is empty

### DIFF
--- a/changelog/_unreleased/2025-06-18-live-search-page-broken-if-the-data-is-empty.md
+++ b/changelog/_unreleased/2025-06-18-live-search-page-broken-if-the-data-is-empty.md
@@ -1,0 +1,9 @@
+---
+title: Live search page broken if the data is empty
+issue: #10682
+author: Le Nguyen
+author_email: nguyenquocdaile@gmail.com
+author_github: @Le Nguyen
+---
+# Administration
+* Changed `getLatestProductKeywordIndexed` method to return early if the data product is empty in `src/module/sw-settings-search/component/sw-settings-search-search-index/index.js`.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/index.js
@@ -84,6 +84,10 @@ export default {
             this.productSearchKeywordRepository
                 .search(this.productSearchKeywordsCriteria, Context.api)
                 .then((result) => {
+                    if (!result.total) {
+                        return;
+                    }
+
                     this.latestIndex = {
                         firstDate: result.aggregations.firstDate.min,
                         lastDate: result.aggregations.lastDate.max,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.spec.js
@@ -182,4 +182,13 @@ describe('module/sw-settings-search/component/sw-settings-search-search-index', 
             message: 'sw-settings-search.notification.index.success',
         });
     });
+
+    it('should return early and not set latestIndex when result.total === 0', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.productSearchKeywordRepository.search = jest.fn(() => Promise.resolve({ total: 0 }));
+        wrapper.vm.latestIndex = null;
+        await wrapper.vm.getLatestProductKeywordIndexed();
+        expect(wrapper.vm.latestIndex).toBeNull();
+    });
 });


### PR DESCRIPTION
### Solution 

![image](https://github.com/user-attachments/assets/57c707bf-df66-460a-889a-2898c8cf9a81)
