### PR TITLE
refactor: Use global Vue PropType

### DIFF
--- a/changelog/_unreleased/2025-06-19-use-global-vue-prop-type.md
+++ b/changelog/_unreleased/2025-06-19-use-global-vue-prop-type.md
@@ -1,0 +1,8 @@
+---
+title: Use global Vue PropType
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Added Vue's `PropType` type to the global types, allowing its use in ts files without a additional import

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system.spec.ts
@@ -9,7 +9,7 @@
 
 import { createExtendableSetup, overrideComponentSetup, _overridesMap } from 'src/app/adapter/composition-extension-system';
 import { mount } from '@vue/test-utils';
-import type { EmitFn, PropType } from 'vue';
+import type { EmitFn } from 'vue';
 import { ref, computed, reactive, defineComponent } from 'vue';
 import type { SetupContext, Slot } from '@vue/runtime-core';
 import ExampleExtendableScriptSetupComponent from './_mocks_/example-extendable-script-setup-component.vue';

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-address/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-address/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import type { RouteLocationNamedRaw } from 'vue-router';
 import type { Address } from 'src/core/service/api/custom-snippet.api.service';
 import template from './sw-address.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-alert-deprecated/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-alert-deprecated/index.ts
@@ -1,5 +1,4 @@
 import type { NotificationVariant } from 'src/app/store/notification.store';
-import type { PropType } from 'vue';
 import template from './sw-alert-deprecated.html.twig';
 import './sw-alert-deprecated.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import type { TabItem } from '@shopware-ag/meteor-component-library/dist/esm/components/navigation/mt-tabs/mt-tabs';
 import template from './sw-tabs.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-popover/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-popover/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import { MtPopover } from '@shopware-ag/meteor-component-library';
 import template from './sw-extension-teaser-popover.html.twig';
 import './sw-extension-teaser-popover.scss';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-string-filter/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-string-filter/index.ts
@@ -2,7 +2,6 @@
  * @sw-package framework
  */
 
-import type { PropType } from 'vue';
 import template from './sw-string-filter.html.twig';
 
 const { Criteria } = Shopware.Data;

--- a/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-sortable-list.html.twig';
 import './sw-sortable-list.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-datepicker/index.ts
@@ -1,5 +1,4 @@
 import { MtDatepicker as MtDatepickerOriginal } from '@shopware-ag/meteor-component-library';
-import type { PropType } from 'vue';
 // eslint-disable-next-line max-len
 import type { DateTimeOptions } from 'vue-i18n';
 import template from './mt-datepicker.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-tabs/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-tabs/index.ts
@@ -1,5 +1,4 @@
 import { MtTabs } from '@shopware-ag/meteor-component-library';
-import type { PropType } from 'vue';
 import type { TabItem } from '@shopware-ag/meteor-component-library/dist/esm/components/navigation/mt-tabs/mt-tabs';
 import template from './mt-tabs.html.twig';
 import type { TabItemEntry } from '../../../store/tabs.store';

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/index.ts
@@ -1,7 +1,6 @@
 import { MtTextEditor as MtTextEditorOriginal } from '@shopware-ag/meteor-component-library';
 // eslint-disable-next-line max-len
 import type { CustomButton } from '@shopware-ag/meteor-component-library/dist/esm/components/form/mt-text-editor/_internal/mt-text-editor-toolbar';
-import type { PropType } from 'vue';
 import template from './mt-text-editor.html.twig';
 import './mt-text-editor.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-link/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-link/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import type { Editor } from '@tiptap/vue-3';
 // eslint-disable-next-line max-len
 import type { CustomButton } from '@shopware-ag/meteor-component-library/dist/esm/components/form/mt-text-editor/_internal/mt-text-editor-toolbar';

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-navigation/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-navigation/index.ts
@@ -1,5 +1,4 @@
 import type { RouteLocationNamedRaw } from 'vue-router';
-import type { PropType } from 'vue';
 import template from './sw-meteor-navigation.html.twig';
 import './sw-meteor-navigation.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import type { RouteLocationNamedRaw } from 'vue-router';
 import type { ModuleManifest } from 'src/core/factory/module.factory';
 import template from './sw-meteor-page.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-block/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-block/index.ts
@@ -2,7 +2,7 @@
  * @sw-package framework
  *
  */
-import { computed, onBeforeUnmount, provide, ref, type ComponentInternalInstance, type PropType, type Slot } from 'vue';
+import { computed, onBeforeUnmount, provide, ref, type ComponentInternalInstance, type Slot } from 'vue';
 import parentsInjectionKey from './parents-injection-key';
 import useBlockContext from '../../../../composables/use-block-context';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-time-ago.html.twig';
 
 /**

--- a/src/Administration/Resources/app/administration/src/app/mixin/form-field.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/form-field.mixin.ts
@@ -2,7 +2,6 @@
  * @sw-package framework
  */
 
-import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
 
 /**

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -28,7 +28,7 @@ import type FilterFactoryData from 'src/core/data/filter-factory.data';
 import type UserApiService from 'src/core/service/api/user.api.service';
 import type UserConfigService from 'src/core/service/api/user-config.api.service';
 import type ApiServiceFactory from 'src/core/factory/api-service.factory';
-import type { ComponentInternalInstance } from 'vue';
+import type { ComponentInternalInstance, PropType as VuePropType } from 'vue';
 import type { I18n } from 'vue-i18n';
 import type {
     Store,
@@ -416,6 +416,8 @@ declare global {
         swBulkEdit: SwBulkStore;
         mediaModal: MediaModalStore;
     }
+
+    type PropType<T> = VuePropType<T>;
 
     /**
      * define global Component

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/app/app-renderer/component/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/app/app-renderer/component/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-cms-block-app-renderer.html.twig';
 
 /**

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/app/app-renderer/preview/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/app/app-renderer/preview/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-cms-block-app-preview-renderer.html.twig';
 import './sw-cms-block-app-preview-renderer.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-block.html.twig';
 import './sw-cms-block.scss';
 import type CmsVisibility from '../../shared/CmsVisibility';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-block-config.html.twig';
 import './sw-cms-block-config.scss';
 import type MediaUploadResult from '../../../shared/MediaUploadResult';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-layout-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-layout-config/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-block-layout-config.html.twig';
 import './sw-cms-block-layout-config.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-create-wizard.html.twig';
 import './sw-cms-create-wizard.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
 import EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import { difference } from 'lodash';
-import { type PropType } from 'vue';
 import template from './sw-cms-layout-assignment-modal.html.twig';
 import './sw-cms-layout-assignment-modal.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-list-item.html.twig';
 import './sw-cms-list-item.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-mapping-field.html.twig';
 import './sw-cms-mapping-field.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-missing-element-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-missing-element-modal/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-missing-element-modal.html.twig';
 import './sw-cms-missing-element-modal.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-page-form.html.twig';
 import './sw-cms-page-form.scss';
 import CMS from '../../constant/sw-cms.constant';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-section.html.twig';
 import './sw-cms-section.scss';
 import type CmsVisibility from '../../shared/CmsVisibility';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-actions/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-actions/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-section-actions.html.twig';
 import './sw-cms-section-actions.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-section-config.html.twig';
 import './sw-cms-section-config.scss';
 import type MediaUploadResult from '../../../shared/MediaUploadResult';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-sidebar.html.twig';
 import CMS from '../../constant/sw-cms.constant';
 import './sw-cms-sidebar.scss';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-sidebar-nav-element.html.twig';
 import './sw-cms-sidebar-nav-element.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-slot.html.twig';
 import './sw-cms-slot.scss';
 import { type CmsElementConfig } from '../../service/cms.service';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-visibility-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-visibility-config/index.ts
@@ -1,4 +1,3 @@
-import { type PropType } from 'vue';
 import template from './sw-cms-visibility-config.html.twig';
 import './sw-cms-visibility-config.scss';
 import type CmsVisibility from '../../shared/CmsVisibility';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/component/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/component/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-cms-el-location-renderer.html.twig';
 import './sw-cms-el-location-renderer.scss';
 import type { ElementDataProp } from '../index';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/config/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-cms-el-config-location-renderer.html.twig';
 import type { ElementDataProp } from '../index';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/preview/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/preview/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-cms-el-preview-location-renderer.html.twig';
 import type { ElementDataProp } from '../index';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -1,4 +1,4 @@
-import { defineComponent, type PropType } from 'vue';
+import { defineComponent } from 'vue';
 import { type RuntimeSlot } from '../service/cms.service';
 import '../../sw-category/page/sw-category-detail/store';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-custom-entity-input-field.html.twig';
 
 /**

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-cms-page-assignment/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-cms-page-assignment/index.ts
@@ -1,6 +1,5 @@
 import type ChangesetGenerator from 'src/core/data/changeset-generator.data';
 import type Repository from 'src/core/data/repository.data';
-import type { PropType } from 'vue';
 
 import Criteria from '@shopware-ag/meteor-admin-sdk/es/data/Criteria';
 import template from './sw-generic-cms-page-assignment.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/index.ts
@@ -2,8 +2,6 @@
  * @sw-package inventory
  */
 
-import type { PropType } from 'vue';
-
 import template from './sw-generic-seo-general-card.html.twig';
 import './sw-generic-seo-general-card.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/index.ts
@@ -3,9 +3,6 @@
  */
 
 import './sw-generic-social-media-card.scss';
-
-import type { PropType } from 'vue';
-
 import type Repository from 'src/core/data/repository.data';
 import template from './sw-generic-social-media-card.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/component/sw-plugin-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/component/sw-plugin-card/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import type { ExtensionType } from 'src/module/sw-extension/service/extension-store-action.service';
 import template from './sw-plugin-card.html.twig';
 import './sw-plugin-card.scss';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-general-info/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-general-info/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import './sw-order-create-general-info.scss';
 import template from './sw-order-create-general-info.html.twig';
 import type { Cart, SalesChannelContext } from '../../order.types';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import type CriteriaType from 'src/core/data/criteria.data';
 
 import template from './sw-order-create-options.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-order-customer-address-select.html.twig';
 import './sw-order-customer-address-select.scss';
 import type CriteriaType from '../../../../core/data/criteria.data';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import type RepositoryType from 'src/core/data/repository.data';
 import type CriteriaType from 'src/core/data/criteria.data';
 import template from './sw-order-state-history-modal.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-multi-snippet-drag-and-drop/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-multi-snippet-drag-and-drop/index.ts
@@ -1,4 +1,4 @@
-import type { PropType, ComponentObjectPropsOptions } from 'vue';
+import type { ComponentObjectPropsOptions } from 'vue';
 import type { DragConfig } from 'src/app/directive/dragdrop.directive';
 import template from './sw-multi-snippet-drag-and-drop.html.twig';
 import './sw-multi-snippet-drag-and-drop.scss';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-address-handling/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-address-handling/index.ts
@@ -1,6 +1,5 @@
 import camelCase from 'lodash/camelCase';
 import type CriteriaType from 'src/core/data/criteria.data';
-import type { PropType } from 'vue';
 import type { DragConfig } from 'src/app/directive/dragdrop.directive';
 import template from './sw-settings-country-address-handling.html.twig';
 import './sw-settings-country-address-handling.scss';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-new-snippet-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-new-snippet-modal/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import template from './sw-settings-country-new-snippet-modal.html.twig';
 import './sw-settings-country-new-snippet-modal.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-provider-sorting-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-provider-sorting-modal/index.ts
@@ -1,4 +1,3 @@
-import type { PropType } from 'vue';
 import type Repository from 'src/core/data/repository.data';
 import template from './sw-settings-tax-provider-sorting-modal.html.twig';
 import './sw-settings-tax-provider-sorting-modal.scss';


### PR DESCRIPTION
### 1. Why is this change necessary?
- In Shopware 6.6 there was a global export of all vue types, now in 6.7 only the vue functions are exported through Shopware.Vue which doesn't allow a type import of `PropType` which is required if you like to pass prop objects in a typescript file. This makes it harder to use the `PropType` type
- This PR exports the `PropType` type of Vue in the global types, which allows us to remove all the imports for `PropType` too
- See https://github.com/shopware/shopware/commit/eb791bb8f9046ff20fc89161594222453164dd87#diff-b3bce64f880320078d702572b42509fd17ffb646e0bf7a251fecf5a29d687679L22-L26

### 2. What does this change do, exactly?
* Added Vue's `PropType` type to the global types, allowing its use in ts files without a additional import

### 3. Describe each step to reproduce the issue or behaviour.
- Try to use 

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
