### PR TITLE
fix: Session usage and session start behaviour

### DIFF
--- a/changelog/_unreleased/2025-06-19-fix-session-usage-and-session-start-behaviour.md
+++ b/changelog/_unreleased/2025-06-19-fix-session-usage-and-session-start-behaviour.md
@@ -1,0 +1,13 @@
+---
+title: Fix session usage and session start behaviour
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Added `FALLBACK_SESSION_NAME` to `PlatformRequest` to unify the fallback name
+___
+# Storefront
+* Changed `Framework\Cookie\CookieProvider` to correctly use the session name from the session options instead of a hardcoded string
+* Changed `Framework\Routing\StorefrontSubscriber` to correctly use the session name from the session options instead of a hardcoded string
+* Changed `Framework\Routing\StorefrontSubscriber` to no longer modify an already active session, which previously could cause an exception

--- a/changelog/_unreleased/2025-06-19-fix-session-usage-and-session-start-behaviour.md
+++ b/changelog/_unreleased/2025-06-19-fix-session-usage-and-session-start-behaviour.md
@@ -9,5 +9,4 @@ author_github: gecolay
 ___
 # Storefront
 * Changed `Framework\Cookie\CookieProvider` to correctly use the session name from the session options instead of a hardcoded string
-* Changed `Framework\Routing\StorefrontSubscriber` to correctly use the session name from the session options instead of a hardcoded string
-* Changed `Framework\Routing\StorefrontSubscriber` to no longer modify an already active session, which previously could cause an exception
+* Changed `Framework\Routing\StorefrontSubscriber` to no longer modify the session name

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2305,18 +2305,6 @@ parameters:
 			path: src/Core/Framework/Struct/Struct.php
 
 		-
-			message: '#^Mixed variable in a `\$oldBag\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
-			identifier: typePerfect.noMixedMethodCaller
-			count: 3
-			path: src/Core/Framework/Test/TestSessionStorage.php
-
-		-
-			message: '#^Property Shopware\\Core\\Framework\\Test\\TestSessionStorage\:\:\$data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Test/TestSessionStorage.php
-
-		-
 			message: '#^Method Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\BusinessEventEncoderTestInterface\:\:getEncodeValues\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Core/Framework/Adapter/Cache/Http/CacheStore.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheStore.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheHitEvent;
 use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheStoreEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\MaintenanceModeResolver;
+use Shopware\Core\PlatformRequest;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -43,7 +44,7 @@ class CacheStore implements StoreInterface
         array $sessionOptions,
         private readonly CacheTagCollector $collector
     ) {
-        $this->sessionName = $sessionOptions['name'] ?? 'session-';
+        $this->sessionName = $sessionOptions['name'] ?? PlatformRequest::FALLBACK_SESSION_NAME;
     }
 
     public function lookup(Request $request): ?Response

--- a/src/Core/Framework/Test/TestSessionStorage.php
+++ b/src/Core/Framework/Test/TestSessionStorage.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Test;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
@@ -20,7 +21,7 @@ class TestSessionStorage implements SessionStorageInterface
 
     private static string $id = 'test-id';
 
-    private static string $name = 'session-';
+    private static string $name = PlatformRequest::FALLBACK_SESSION_NAME;
 
     public function start(): bool
     {

--- a/src/Core/Framework/Test/TestSessionStorage.php
+++ b/src/Core/Framework/Test/TestSessionStorage.php
@@ -17,6 +17,9 @@ use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
 #[Package('framework')]
 class TestSessionStorage implements SessionStorageInterface
 {
+    /**
+     * @var array<string, SessionBagInterface>
+     */
     private static array $data = [];
 
     private static string $id = 'test-id';
@@ -70,7 +73,6 @@ class TestSessionStorage implements SessionStorageInterface
 
     public function clear(): void
     {
-        /** @var SessionBagInterface $bag */
         foreach (self::$data as $bag) {
             $bag->clear();
         }

--- a/src/Core/PlatformRequest.php
+++ b/src/Core/PlatformRequest.php
@@ -66,9 +66,6 @@ final class PlatformRequest
     public const ATTRIBUTE_OAUTH_USER_ID = 'oauth_user_id';
     public const ATTRIBUTE_OAUTH_SCOPES = 'oauth_scopes';
 
-    /**
-     * Session
-     */
     public const FALLBACK_SESSION_NAME = 'session-';
 
     private function __construct()

--- a/src/Core/PlatformRequest.php
+++ b/src/Core/PlatformRequest.php
@@ -66,6 +66,11 @@ final class PlatformRequest
     public const ATTRIBUTE_OAUTH_USER_ID = 'oauth_user_id';
     public const ATTRIBUTE_OAUTH_SCOPES = 'oauth_scopes';
 
+    /**
+     * Session
+     */
+    public const FALLBACK_SESSION_NAME = 'session-';
+
     private function __construct()
     {
     }

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -161,6 +161,7 @@
             <argument type="service" id="router"/>
             <argument type="service" id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument>%session.storage.options%</argument>
 
             <tag name="kernel.event_subscriber"/>
         </service>
@@ -444,7 +445,9 @@
             <tag name="console.command"/>
         </service>
 
-        <service id="Shopware\Storefront\Framework\Cookie\CookieProviderInterface" class="Shopware\Storefront\Framework\Cookie\CookieProvider"/>
+        <service id="Shopware\Storefront\Framework\Cookie\CookieProviderInterface" class="Shopware\Storefront\Framework\Cookie\CookieProvider">
+            <argument>%session.storage.options%</argument>
+        </service>
 
         <service id="Shopware\Storefront\Framework\Cookie\AppCookieProvider" decorates="Shopware\Storefront\Framework\Cookie\CookieProviderInterface">
             <argument type="service" id="Shopware\Storefront\Framework\Cookie\AppCookieProvider.inner"/>

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -161,7 +161,6 @@
             <argument type="service" id="router"/>
             <argument type="service" id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument>%session.storage.options%</argument>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Storefront/Framework/Cookie/CookieProvider.php
+++ b/src/Storefront/Framework/Cookie/CookieProvider.php
@@ -3,6 +3,7 @@
 namespace Shopware\Storefront\Framework\Cookie;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
 
 #[Package('framework')]
 class CookieProvider implements CookieProviderInterface
@@ -14,7 +15,6 @@ class CookieProvider implements CookieProviderInterface
         'entries' => [
             [
                 'snippet_name' => 'cookie.groupRequiredSession',
-                'cookie' => 'session-',
             ],
             [
                 'snippet_name' => 'cookie.groupRequiredTimezone',
@@ -79,6 +79,19 @@ class CookieProvider implements CookieProviderInterface
         ],
     ];
 
+    private readonly string $sessionName;
+
+    /**
+     * @internal
+     *
+     * @param array<string, mixed> $sessionOptions
+     */
+    public function __construct(
+        array $sessionOptions = [],
+    ) {
+        $this->sessionName = $sessionOptions['name'] ?? PlatformRequest::FALLBACK_SESSION_NAME;
+    }
+
     /**
      * A group CAN be a cookie, it's entries MUST be a cookie.
      * If a "group" is a cookie itself, it should not contain "children", because it may lead to unexpected UI behavior.
@@ -110,6 +123,7 @@ class CookieProvider implements CookieProviderInterface
     public function getCookieGroups(): array
     {
         $requiredCookies = self::REQUIRED_COOKIES;
+        $requiredCookies['entries'][0]['cookie'] = $this->sessionName;
 
         return [
             $requiredCookies,

--- a/src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php
+++ b/src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php
@@ -41,12 +41,12 @@ class NotFoundSubscriber implements EventSubscriberInterface, ResetInterface
      */
     private bool $handled = false;
 
-    private string $sessionName;
+    private readonly string $sessionName;
 
     /**
      * @internal
      *
-     * @param array{name?: string} $sessionOptions
+     * @param array<string, mixed> $sessionOptions
      */
     public function __construct(
         private readonly HttpKernelInterface $httpKernel,
@@ -58,7 +58,7 @@ class NotFoundSubscriber implements EventSubscriberInterface, ResetInterface
         private readonly EventDispatcherInterface $eventDispatcher,
         array $sessionOptions = []
     ) {
-        $this->sessionName = $sessionOptions['name'] ?? 'session-';
+        $this->sessionName = $sessionOptions['name'] ?? PlatformRequest::FALLBACK_SESSION_NAME;
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -32,15 +32,21 @@ use Symfony\Component\Routing\RouterInterface;
 #[Package('framework')]
 class StorefrontSubscriber implements EventSubscriberInterface
 {
+    private readonly string $sessionName;
+
     /**
      * @internal
+     *
+     * @param array<string, mixed> $sessionOptions
      */
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly RouterInterface $router,
         private readonly MaintenanceModeResolver $maintenanceModeResolver,
-        private readonly SystemConfigService $systemConfigService
+        private readonly SystemConfigService $systemConfigService,
+        array $sessionOptions = [],
     ) {
+        $this->sessionName = $sessionOptions['name'] ?? PlatformRequest::FALLBACK_SESSION_NAME;
     }
 
     public static function getSubscribedEvents(): array
@@ -86,8 +92,10 @@ class StorefrontSubscriber implements EventSubscriberInterface
         $session = $mainRequest->getSession();
 
         if (!$session->isStarted()) {
-            $session->setName('session-');
-            $session->start();
+            if (session_status() !== \PHP_SESSION_ACTIVE) {
+                $session->setName($this->sessionName);
+                $session->start();
+            }
             $session->set('sessionId', $session->getId());
         }
 

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -92,10 +92,7 @@ class StorefrontSubscriber implements EventSubscriberInterface
         $session = $mainRequest->getSession();
 
         if (!$session->isStarted()) {
-            if (session_status() !== \PHP_SESSION_ACTIVE) {
-                $session->setName($this->sessionName);
-                $session->start();
-            }
+            $session->start();
             $session->set('sessionId', $session->getId());
         }
 

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -32,21 +32,15 @@ use Symfony\Component\Routing\RouterInterface;
 #[Package('framework')]
 class StorefrontSubscriber implements EventSubscriberInterface
 {
-    private readonly string $sessionName;
-
     /**
      * @internal
-     *
-     * @param array<string, mixed> $sessionOptions
      */
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly RouterInterface $router,
         private readonly MaintenanceModeResolver $maintenanceModeResolver,
         private readonly SystemConfigService $systemConfigService,
-        array $sessionOptions = [],
     ) {
-        $this->sessionName = $sessionOptions['name'] ?? PlatformRequest::FALLBACK_SESSION_NAME;
     }
 
     public static function getSubscribedEvents(): array

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -156,7 +156,7 @@ class AuthControllerTest extends TestCase
 
         $browser = $this->login();
 
-        $sessionCookie = $browser->getCookieJar()->get('session-');
+        $sessionCookie = $browser->getCookieJar()->get(PlatformRequest::FALLBACK_SESSION_NAME);
         static::assertNotNull($sessionCookie);
 
         $browser->request('GET', '/account/logout', []);

--- a/tests/unit/Storefront/Controller/CookieControllerTest.php
+++ b/tests/unit/Storefront/Controller/CookieControllerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Storefront\Controller;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics\SalesChannelAnalyticsCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics\SalesChannelAnalyticsEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -19,6 +20,38 @@ use Shopware\Storefront\Framework\Cookie\CookieProvider;
 #[CoversClass(CookieController::class)]
 class CookieControllerTest extends TestCase
 {
+    public function testResponseSessionCookieName(): void
+    {
+        $salesChannelContext = Generator::generateSalesChannelContext();
+
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
+        $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
+
+        // Test with fallback session cookie name
+        $controller = new CookieControllerTestClass(
+            new CookieProvider(),
+            $this->createMock(SystemConfigService::class),
+            $repository
+        );
+
+        $controller->offcanvas($salesChannelContext);
+        $cookieGroups = $controller->renderStorefrontParameters['cookieGroups'];
+
+        static::assertEquals(PlatformRequest::FALLBACK_SESSION_NAME, $cookieGroups[0]['entries'][0]['cookie']);
+
+        // Test with a custom session cookie name
+        $controller = new CookieControllerTestClass(
+            new CookieProvider(['name' => 'test-session-cookie']),
+            $this->createMock(SystemConfigService::class),
+            $repository
+        );
+
+        $controller->offcanvas($salesChannelContext);
+        $cookieGroups = $controller->renderStorefrontParameters['cookieGroups'];
+
+        static::assertEquals('test-session-cookie', $cookieGroups[0]['entries'][0]['cookie']);
+    }
+
     public function testResponseDoesNotIncludeGoogleAnalyticsCookieByDefault(): void
     {
         $salesChannelContext = Generator::generateSalesChannelContext();

--- a/tests/unit/Storefront/Controller/CookieControllerTest.php
+++ b/tests/unit/Storefront/Controller/CookieControllerTest.php
@@ -37,7 +37,7 @@ class CookieControllerTest extends TestCase
         $controller->offcanvas($salesChannelContext);
         $cookieGroups = $controller->renderStorefrontParameters['cookieGroups'];
 
-        static::assertEquals(PlatformRequest::FALLBACK_SESSION_NAME, $cookieGroups[0]['entries'][0]['cookie']);
+        static::assertSame(PlatformRequest::FALLBACK_SESSION_NAME, $cookieGroups[0]['entries'][0]['cookie']);
 
         // Test with a custom session cookie name
         $controller = new CookieControllerTestClass(
@@ -49,7 +49,7 @@ class CookieControllerTest extends TestCase
         $controller->offcanvas($salesChannelContext);
         $cookieGroups = $controller->renderStorefrontParameters['cookieGroups'];
 
-        static::assertEquals('test-session-cookie', $cookieGroups[0]['entries'][0]['cookie']);
+        static::assertSame('test-session-cookie', $cookieGroups[0]['entries'][0]['cookie']);
     }
 
     public function testResponseDoesNotIncludeGoogleAnalyticsCookieByDefault(): void

--- a/tests/unit/Storefront/Framework/Routing/NotFound/NotFoundSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/NotFound/NotFoundSubscriberTest.php
@@ -96,7 +96,7 @@ class NotFoundSubscriberTest extends TestCase
         $httpKernel = $this->createMock(HttpKernelInterface::class);
         $response = new Response();
         $response->headers->setCookie(new Cookie('extension-cookie', '1'));
-        $response->headers->setCookie(new Cookie('session-', '1'));
+        $response->headers->setCookie(new Cookie(PlatformRequest::FALLBACK_SESSION_NAME, '1'));
         $httpKernel
             ->expects($this->once())
             ->method('handle')


### PR DESCRIPTION
### 1. Why is this change necessary?
First issue:
- Currently, the session name is hardcoded in some places. Changing the `session.storage.options.name` key in the configuration causes issues
- This PR correctly uses the value of the dynamic configuration option and only falls back to the new `FALLBACK_SESSION_NAME` value in the `PlatformRequest` if the session name is missing
- Setting the session name is not required, we can remove the setName call

### 2. What does this change do, exactly?
* Added `FALLBACK_SESSION_NAME` to `PlatformRequest` to unify the fallback name
* Changed `Framework\Cookie\CookieProvider` to correctly use the session name from the session options instead of a hardcoded string
* Changed `Framework\Routing\StorefrontSubscriber` to no longer modify the session name

### 3. Describe each step to reproduce the issue or behaviour.
- It's difficult to reproduce this intentionally. In my tests, the best way to reproduce this issue with near certainty is to:
- Refresh the page as often as possible, as the site takes longer to load. For example, clear the cache & reload the site to get the cache to rebuild
- You will hit a `Cannot change the name of an active session` exception

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
