### PR TITLE
fix: update product and property option names to use translated values

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
@@ -389,7 +389,7 @@ export default {
 
                     return {
                         id: group.id,
-                        name: group.name,
+                        name: group.translated.name || group.name,
                         childCount: children.length,
                         parentId: null,
                         afterId: index > 0 ? this.selectedGroups[index - 1].id : null,
@@ -417,7 +417,7 @@ export default {
 
                         return {
                             id: option.id,
-                            name: option.name,
+                            name: option.translated.name || option.name,
                             childCount: 0,
                             parentId: option.groupId,
                             afterId,

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-detail/index.js
@@ -4,7 +4,7 @@
 
 import template from './sw-property-option-detail.html.twig';
 
-const { Component } = Shopware;
+const { Component, Mixin } = Shopware;
 const { mapPropertyErrors } = Component.getComponentHelper();
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
@@ -14,6 +14,10 @@ export default {
     inject: [
         'repositoryFactory',
         'acl',
+    ],
+
+    mixins: [
+        Mixin.getByName('placeholder'),
     ],
 
     props: {
@@ -49,6 +53,10 @@ export default {
             get() {
                 return this.currentOption?.colorHexCode || '';
             },
+        },
+
+        modalTitle() {
+            return this.currentOption?.translated?.name || this.$tc('sw-property.detail.textOptionHeadline');
         },
 
         ...mapPropertyErrors('currentOption', ['name']),

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-detail/sw-property-option-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-detail/sw-property-option-detail.html.twig
@@ -1,6 +1,6 @@
 {% block sw_property_option_detail %}
 <sw-modal
-    :title="currentOption.name ? currentOption.name : $tc('sw-property.detail.textOptionHeadline')"
+    :title="modalTitle"
     @modal-close="onCancel"
 >
     {% block sw_property_option_detail_name %}
@@ -11,7 +11,7 @@
         validation="required"
         :label="$tc('sw-property.detail.labelOptionName')"
         :disabled="!allowEdit"
-        :placeholder="$tc('sw-property.detail.placeholderOptionName')"
+        :placeholder="placeholder(currentOption, 'name', $tc('sw-property.detail.placeholderOptionName'))"
         :error="currentOptionNameError"
         required
     />


### PR DESCRIPTION
### Solution

| Before   | After |
|---------------------------|-------------------------|
| <img width="1097" alt="_2025-01-29 um 12 22 22" src="https://github.com/user-attachments/assets/865320d4-2cc9-4167-aead-bef1d7ca2b77" /> | ![image](https://github.com/user-attachments/assets/aeeb0820-b4be-438d-a162-61df113b8532) |
| <img width="802" alt="_2025-01-29 um 12 22 46" src="https://github.com/user-attachments/assets/86796b01-a184-477e-8a6b-458c320c794b" /> | ![Screenshot 2025-06-19 at 16 31 44](https://github.com/user-attachments/assets/cac6437d-e510-49aa-ba3a-1296d1edf9b1)
 |
