### PR TITLE
feat: Changed Admin-SDK handler contextAppInformation to return permissions

### DIFF
--- a/changelog/_unreleased/2025-06-19-changed-admin-sdk-handler-for-context-can.md
+++ b/changelog/_unreleased/2025-06-19-changed-admin-sdk-handler-for-context-can.md
@@ -6,5 +6,5 @@ author_email: s.franze@shopware.com
 ---
 # Administration
 * Changed Admin-SDK handler `AdminSDK.Context.getAppInformation`  
-* Added `permissions` to response of `AdminSDK.Context.getAppInformation`
+  * Added `privileges` to response of `AdminSDK.Context.getAppInformation`
 * Changed type of `Extension.permissions` in `src/app/store/extension.store.js` to use `privileges` type from the Admin-SDK

--- a/changelog/_unreleased/2025-06-19-changed-admin-sdk-handler-for-context-can.md
+++ b/changelog/_unreleased/2025-06-19-changed-admin-sdk-handler-for-context-can.md
@@ -1,0 +1,10 @@
+---
+title: Changed Admin-SDK handler for context.can
+issue: https://github.com/shopware/service-enablement/issues/17
+author: Sebastian Franze
+author_email: s.franze@shopware.com
+---
+# Administration
+* Changed Admin-SDK handler `AdminSDK.Context.getAppInformation`  
+* Added `permissions` to response of `AdminSDK.Context.getAppInformation`
+* Changed type of `Extension.permissions` in `src/app/store/extension.store.js` to use `privileges` type from the Admin-SDK

--- a/src/Administration/Resources/app/administration/src/app/init/context.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/context.init.spec.js
@@ -101,7 +101,9 @@ describe('src/app/init/context.init.ts', () => {
         Shopware.Store.get('extensions').addExtension({
             name: 'jestapp',
             baseUrl: '',
-            permissions: [],
+            permissions: {
+                read: ['product_read'],
+            },
             version: '1.0.0',
             type: 'app',
             integrationId: '123',
@@ -114,6 +116,9 @@ describe('src/app/init/context.init.ts', () => {
                     name: 'jestapp',
                     version: '1.0.0',
                     type: 'app',
+                    permissions: {
+                        read: ['product_read'],
+                    },
                 }),
             );
         });

--- a/src/Administration/Resources/app/administration/src/app/init/context.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/context.init.spec.js
@@ -102,7 +102,7 @@ describe('src/app/init/context.init.ts', () => {
             name: 'jestapp',
             baseUrl: '',
             permissions: {
-                read: ['product_read'],
+                read: ['product'],
             },
             version: '1.0.0',
             type: 'app',
@@ -116,8 +116,8 @@ describe('src/app/init/context.init.ts', () => {
                     name: 'jestapp',
                     version: '1.0.0',
                     type: 'app',
-                    permissions: {
-                        read: ['product_read'],
+                    privileges: {
+                        read: ['product'],
                     },
                 }),
             );

--- a/src/Administration/Resources/app/administration/src/app/init/context.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/context.init.ts
@@ -109,26 +109,31 @@ export default function initializeContext(): void {
 
     Shopware.ExtensionAPI.handle('contextAppInformation', (_, { _event_ }) => {
         const appOrigin = _event_.origin;
-        const extension = Object.entries(Shopware.Store.get('extensions').extensionsState).find((ext) => {
+        const extensionEntry = Object.entries(Shopware.Store.get('extensions').extensionsState).find((ext) => {
             return ext[1].baseUrl.startsWith(appOrigin);
         });
 
-        if (!extension || !extension[0] || !extension[1]) {
-            const type: 'app' | 'plugin' = 'app';
-
+        if (extensionEntry === undefined) {
             return {
                 name: 'unknown',
-                type: type,
+                type: 'app' as const,
                 version: '0.0.0',
-                inAppPurchases: null,
+                inAppPurchases: [],
+                permissions: {},
             };
         }
 
+        const [
+            extensionName,
+            extension,
+        ] = extensionEntry;
+
         return {
-            name: extension[0],
-            type: extension[1].type,
-            version: extension[1].version ?? '',
-            inAppPurchases: Shopware.InAppPurchase.getByExtension(extension[1].name),
+            name: extensionName,
+            type: extension.type,
+            version: extension.version ?? '',
+            inAppPurchases: Shopware.InAppPurchase.getByExtension(extension.name),
+            permissions: extension.permissions,
         };
     });
 

--- a/src/Administration/Resources/app/administration/src/app/init/context.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/context.init.ts
@@ -119,7 +119,7 @@ export default function initializeContext(): void {
                 type: 'app' as const,
                 version: '0.0.0',
                 inAppPurchases: [],
-                permissions: {},
+                privileges: {},
             };
         }
 
@@ -133,7 +133,7 @@ export default function initializeContext(): void {
             type: extension.type,
             version: extension.version ?? '',
             inAppPurchases: Shopware.InAppPurchase.getByExtension(extension.name),
-            permissions: extension.permissions,
+            privileges: extension.permissions,
         };
     });
 

--- a/src/Administration/Resources/app/administration/src/app/store/extensions.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extensions.store.ts
@@ -3,6 +3,7 @@
  * @private
  */
 import { setExtensions } from '@shopware-ag/meteor-admin-sdk/es/channel';
+import type { privileges } from '@shopware-ag/meteor-admin-sdk/es/_internals/privileges';
 
 /**
  * @private
@@ -10,7 +11,7 @@ import { setExtensions } from '@shopware-ag/meteor-admin-sdk/es/channel';
 export interface Extension {
     name: string;
     baseUrl: string;
-    permissions: Record<string, unknown>;
+    permissions: privileges;
     version?: string;
     type: 'app' | 'plugin';
     integrationId?: string;


### PR DESCRIPTION
### 1. What does this change do, exactly?

Added permissions to the response of `AdminSDK.Context.getAppInformation` to be used by `AdminSDK.Context.can` handler or to handle your app's granted permissions by yourself. 

Channel is created in https://github.com/shopware/meteor/pull/740


### 2. Please link to the relevant issues (if any).
closes https://github.com/shopware/service-enablement/issues/17

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
