### PR TITLE
fix: respect missing shipping method currency prices

### DIFF
--- a/changelog/_unreleased/2025-06-20-respect-missing-shipping-method-currency-prices.md
+++ b/changelog/_unreleased/2025-06-20-respect-missing-shipping-method-currency-prices.md
@@ -1,0 +1,9 @@
+---
+title: Respect missing shipping method currency prices
+issue: #10696
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `Shopware\Core\Checkout\Cart\Delivery\DeliveryCalculator` to respect missing currency prices within the price matrices of a shipping method.

--- a/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
@@ -225,13 +225,11 @@ class DeliveryCalculator
     {
         $shippingPrices->sort(
             function (ShippingMethodPriceEntity $priceEntityA, ShippingMethodPriceEntity $priceEntityB) use ($context) {
-                /** @var PriceCollection $priceCollectionA */
                 $priceCollectionA = $priceEntityA->getCurrencyPrice();
-                $priceA = $this->getCurrencyPrice($priceCollectionA, $context);
+                $priceA = $priceCollectionA ? $this->getCurrencyPrice($priceCollectionA, $context) : null;
 
-                /** @var PriceCollection $priceCollectionB */
                 $priceCollectionB = $priceEntityB->getCurrencyPrice();
-                $priceB = $this->getCurrencyPrice($priceCollectionB, $context);
+                $priceB = $priceCollectionB ? $this->getCurrencyPrice($priceCollectionB, $context) : null;
 
                 return $priceA <=> $priceB;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`shipping_method.prices.currency_price` is a nullable field and should be treated like it is. In most places this is the case, except in the sort function of the `DeliveryCalculator`

### 2. What does this change do, exactly?
Handle `null` values properly 

### 3. Describe each step to reproduce the issue or behaviour.
- Create a shipping method
- Set the `currency_price` of the shipping method price to `null`

### 4. Please link to the relevant issues (if any).
- fixes #10696 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
