### PR TITLE
fix: admin-api field as required in ProductPrice definition

### DIFF
--- a/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceDefinition.php
@@ -64,12 +64,10 @@ class ProductPriceDefinition extends EntityDefinition
             (new FkField('rule_id', 'ruleId', RuleDefinition::class))->addFlags(new Required()),
             (new PriceField('price', 'price'))->addFlags(new Required()),
             (new IntField('quantity_start', 'quantityStart'))->addFlags(new Required()),
-            (new BoolField('linked', 'linked'))->addFlags(new Required()),
             new IntField('quantity_end', 'quantityEnd'),
             (new ManyToOneAssociationField('product', 'product_id', ProductDefinition::class, 'id', false))->addFlags(new ReverseInherited('prices')),
             new ManyToOneAssociationField('rule', 'rule_id', RuleDefinition::class, 'id', false),
             new CustomFields(),
-            
         ]);
     }
 }

--- a/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceDefinition.php
@@ -64,10 +64,12 @@ class ProductPriceDefinition extends EntityDefinition
             (new FkField('rule_id', 'ruleId', RuleDefinition::class))->addFlags(new Required()),
             (new PriceField('price', 'price'))->addFlags(new Required()),
             (new IntField('quantity_start', 'quantityStart'))->addFlags(new Required()),
+            (new BoolField('linked', 'linked'))->addFlags(new Required()),
             new IntField('quantity_end', 'quantityEnd'),
             (new ManyToOneAssociationField('product', 'product_id', ProductDefinition::class, 'id', false))->addFlags(new ReverseInherited('prices')),
             new ManyToOneAssociationField('rule', 'rule_id', RuleDefinition::class, 'id', false),
             new CustomFields(),
+            
         ]);
     }
 }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/Price.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/Price.json
@@ -47,7 +47,8 @@
                         },
                         "required": [
                             "gross",
-                            "net"
+                            "net",
+                            "linked"
                         ]
                     },
                     "regulationPrice": {
@@ -73,14 +74,16 @@
                         },
                         "required": [
                             "gross",
-                            "net"
+                            "net",
+                            "linked"
                         ]
                     }
                 },
                 "required": [
                     "currencyId",
                     "gross",
-                    "net"
+                    "net",
+                    "linked"
                 ]
             }
         }


### PR DESCRIPTION

### 1. Why is this change necessary?
The linked field is required by the backend when updating product prices, but it wasn't marked as required in the definition. This caused validation errors ("This field is missing." → /0/price/0/linked) when calling the Admin API. This change aligns the schema with actual backend expectations.

### 2. What does this change do, exactly?
It marks the linked field in ProductPriceDefinition as required by adding the Required flag. This ensures the Admin API schema correctly reflects that linked must be included in price objects.


### 3. Describe each step to reproduce the issue or behaviour.

Request-Body: {"id": "0196913615de73ceab089f839f175a82","productId": "d04043666ae64f07897333bf39040f70","ruleId": "019690e4e95e7e9a87d66ff5078990b5","quantityStart": 1,"quantityEnd": null, "price": [ {"currencyId" : "b7d2554b0ce847cd82f3ac9bd1c0dfca","net" : 70.5,"gross" : 70.5} ]}
Request URL: https://covetrus-ch-staging.shopware.store/api/product-price/0196913615de73ceab089f839f175a82
Fehler: { "errors" : [ { "code" : "2fa2158c-2a7f-484b-98aa-975522539ff8", "status" : "400", "detail" : "This field is missing.", "template" : "This field is missing.", "meta" : { "parameters" : { "{{ field }}" : "\"linked\"" } }, "source" : { "pointer" : "/0/price/0/linked" } } ] }

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/DX-635
--> 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
