### PR TITLE
feat: use primaryOrderTransaction for documents

### DIFF
--- a/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
@@ -90,7 +90,11 @@ abstract class AbstractDocumentRenderer
             return false;
         }
 
-        $orderDelivery = $order->getDeliveries()?->first();
+        $orderDelivery = $order->getPrimaryOrderDelivery();
+        if (!Feature::isActive('v6.8.0.0')) {
+            $orderDelivery = $order->getDeliveries()?->first();
+        }
+
         if (!$orderDelivery) {
             return false;
         }

--- a/src/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactory.php
+++ b/src/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactory.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Checkout\Document\Renderer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
@@ -27,8 +28,8 @@ final class OrderDocumentCriteriaFactory
         $criteria->addAssociations([
             'primaryOrderDelivery',
             'lineItems',
-            'transactions.paymentMethod',
-            'transactions.stateMachineState',
+            'primaryOrderTransaction.paymentMethod',
+            'primaryOrderTransaction.stateMachineState',
             'currency',
             'language.locale',
             'addresses.country',
@@ -42,8 +43,13 @@ final class OrderDocumentCriteriaFactory
             'orderCustomer.salutation',
         ]);
 
+        if (!Feature::isActive('v6.8.0.0')) {
+            $criteria->getAssociation('transactions')
+                ->addAssociations(['paymentMethod', 'stateMachineState'])
+                ->addSorting(new FieldSorting('createdAt'));
+        }
+
         $criteria->getAssociation('lineItems')->addSorting(new FieldSorting('position'));
-        $criteria->getAssociation('transactions')->addSorting(new FieldSorting('createdAt'));
         $criteria->getAssociation('deliveries')->addSorting(new FieldSorting('createdAt'));
 
         if ($documentType) {

--- a/src/Core/Checkout/Document/Zugferd/ZugferdBuilder.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdBuilder.php
@@ -45,9 +45,11 @@ class ZugferdBuilder
         }
 
         $deliveryDate = $order->getPrimaryOrderDelivery()?->getShippingDateLatest();
+        $transaction = $order->getPrimaryOrderTransaction();
 
         if (!Feature::isActive('v6.8.0.0')) {
             $deliveryDate = $order->getDeliveries()?->first()?->getShippingDateLatest();
+            $transaction = $order->getTransactions()?->last();
         }
 
         if ($deliveryDate instanceof \DateTimeImmutable) {
@@ -65,7 +67,6 @@ class ZugferdBuilder
 
         $this->addLineItems($document, $order->getLineItems());
 
-        $transaction = $order->getTransactions()?->last();
         if ($transaction !== null) {
             if ($transaction->getStateMachineState()?->getTechnicalName() === 'paid') {
                 $document->withPaidAmount($order->getAmountTotal());

--- a/tests/unit/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactoryTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactoryTest.php
@@ -17,8 +17,52 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(OrderDocumentCriteriaFactory::class)]
 class OrderDocumentCriteriaFactoryTest extends TestCase
 {
-    #[DisabledFeatures(['v6.8.0.0'])]
     public function testCreate(): void
+    {
+        $id = Uuid::randomHex();
+
+        $criteria = OrderDocumentCriteriaFactory::create([$id], 'test');
+
+        static::assertSame($id, $criteria->getIds()[0]);
+
+        $associations = $criteria->getAssociations();
+
+        static::assertArrayHasKey('lineItems', $associations);
+        static::assertArrayHasKey('primaryOrderTransaction', $associations);
+        static::assertArrayHasKey('currency', $associations);
+        static::assertArrayHasKey('language', $associations);
+        static::assertArrayHasKey('addresses', $associations);
+        static::assertArrayHasKey('orderCustomer', $associations);
+
+        $primaryOrderTransactionCriteria = $associations['primaryOrderTransaction'];
+        static::assertInstanceOf(Criteria::class, $primaryOrderTransactionCriteria);
+        static::assertInstanceOf(Criteria::class, $primaryOrderTransactionCriteria->getAssociations()['paymentMethod']);
+        static::assertInstanceOf(Criteria::class, $primaryOrderTransactionCriteria->getAssociations()['stateMachineState']);
+
+        $languageCriteria = $associations['language'];
+        static::assertInstanceOf(Criteria::class, $languageCriteria);
+        static::assertInstanceOf(Criteria::class, $languageCriteria->getAssociations()['locale']);
+
+        $addressesCriteria = $associations['addresses'];
+        static::assertInstanceOf(Criteria::class, $addressesCriteria);
+        static::assertInstanceOf(Criteria::class, $addressesCriteria->getAssociations()['country']);
+
+        $orderCustomerCriteria = $associations['orderCustomer'];
+        static::assertInstanceOf(Criteria::class, $orderCustomerCriteria);
+        static::assertInstanceOf(Criteria::class, $orderCustomerCriteria->getAssociations()['customer']);
+
+        $deliveryCriteria = $associations['deliveries'];
+        static::assertInstanceOf(Criteria::class, $deliveryCriteria);
+        static::assertInstanceOf(Criteria::class, $deliveryCriteria->getAssociations()['shippingMethod']);
+        static::assertInstanceOf(Criteria::class, $deliveryCriteria->getAssociations()['positions']);
+        static::assertInstanceOf(Criteria::class, $deliveryCriteria->getAssociations()['shippingOrderAddress']);
+
+        $shippingAddressCriteria = $deliveryCriteria->getAssociations()['shippingOrderAddress'];
+        static::assertInstanceOf(Criteria::class, $shippingAddressCriteria->getAssociations()['country']);
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testCreateDeprecated(): void
     {
         $id = Uuid::randomHex();
 

--- a/tests/unit/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactoryTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactoryTest.php
@@ -61,6 +61,9 @@ class OrderDocumentCriteriaFactoryTest extends TestCase
         static::assertInstanceOf(Criteria::class, $shippingAddressCriteria->getAssociations()['country']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed. testCreate will cover the new behavior
+     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testCreateDeprecated(): void
     {
@@ -74,7 +77,6 @@ class OrderDocumentCriteriaFactoryTest extends TestCase
 
         static::assertArrayHasKey('lineItems', $associations);
         static::assertArrayHasKey('primaryOrderTransaction', $associations);
-        /** @deprecated tag:v6.8.0 - will be removed. Use primaryOrderTransaction instead */
         static::assertArrayHasKey('transactions', $associations);
         static::assertArrayHasKey('currency', $associations);
         static::assertArrayHasKey('language', $associations);

--- a/tests/unit/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactoryTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactoryTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Document\Renderer\OrderDocumentCriteriaFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -16,6 +17,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[CoversClass(OrderDocumentCriteriaFactory::class)]
 class OrderDocumentCriteriaFactoryTest extends TestCase
 {
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testCreate(): void
     {
         $id = Uuid::randomHex();
@@ -27,15 +29,23 @@ class OrderDocumentCriteriaFactoryTest extends TestCase
         $associations = $criteria->getAssociations();
 
         static::assertArrayHasKey('lineItems', $associations);
+        static::assertArrayHasKey('primaryOrderTransaction', $associations);
+        /** @deprecated tag:v6.8.0 - will be removed. Use primaryOrderTransaction instead */
         static::assertArrayHasKey('transactions', $associations);
         static::assertArrayHasKey('currency', $associations);
         static::assertArrayHasKey('language', $associations);
         static::assertArrayHasKey('addresses', $associations);
         static::assertArrayHasKey('orderCustomer', $associations);
 
+        $primaryOrderTransactionCriteria = $associations['primaryOrderTransaction'];
+        static::assertInstanceOf(Criteria::class, $primaryOrderTransactionCriteria);
+        static::assertInstanceOf(Criteria::class, $primaryOrderTransactionCriteria->getAssociations()['paymentMethod']);
+        static::assertInstanceOf(Criteria::class, $primaryOrderTransactionCriteria->getAssociations()['stateMachineState']);
+
         $transactionCriteria = $associations['transactions'];
         static::assertInstanceOf(Criteria::class, $transactionCriteria);
         static::assertInstanceOf(Criteria::class, $transactionCriteria->getAssociations()['paymentMethod']);
+        static::assertInstanceOf(Criteria::class, $transactionCriteria->getAssociations()['stateMachineState']);
 
         $languageCriteria = $associations['language'];
         static::assertInstanceOf(Criteria::class, $languageCriteria);


### PR DESCRIPTION
### 1. Why is this change necessary?
For order documents the new `primaryOrderTransaction` was not considered.

### 2. What does this change do, exactly?
Adds `primaryOrderTransaction` association to `Shopware\Core\Checkout\Document\Renderer\OrderDocumentCriteriaFactory`.
Deprecates `transactions` for `v6.8.0`