### PR TITLE
fix: Use `remote.autoForwardPortsSource` `process` in vs code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
       "PHP2408"
     ]
   },
+  "remote.autoForwardPortsSource": "process",
   "search.exclude": {
     "**/node_modules": true,
     "**/bower_components": true,


### PR DESCRIPTION
### 1. Why is this change necessary?
- With the latest change the to administration (switch to vite setup) now all plugins run their own vite server in the background
- If you develop with vs code in a dev environment or container you rely on the auto forward of ports for some programs
- vs code uses 2 modes to auto forward ports, terminal regex detection (`http(s)://host:port`) and running process checking
- With the new vite setup and the several vite servers running in the background the url's of the plugin servers do not get printed to the console, so option 1 will not work (unless we print all host:port to the console)
- Mode 2 needs to be enabled by setting, this is what this PR does
- After this PR change you can now rely on auto forward again

### 2. What does this change do, exactly?
- Use `remote.autoForwardPortsSource` `process` in vs code settings

### 3. Describe each step to reproduce the issue or behaviour.
- Use the admin watch script with multiple plugins
- The plugins will create a child process which runs in the background
- They will not log their host:port to the console, so the vs code terminal listener will not track this new port and will therefore not auto forward it

### 4. Please link to the relevant issues (if any).
- #9393 

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
