### PR TITLE
fix: duplicate grid settings space

### DIFF
--- a/changelog/_unreleased/2025-06-23-fix-duplicate-grid-settings-space.md
+++ b/changelog/_unreleased/2025-06-23-fix-duplicate-grid-settings-space.md
@@ -1,0 +1,8 @@
+---
+title: Fix duplicate grid settings space
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Changed `sw-data-grid-settings.scss` to remove the duplicate space between the settings elements

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-settings/sw-data-grid-settings.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-settings/sw-data-grid-settings.scss
@@ -35,10 +35,6 @@
         display: flex;
         align-items: center;
 
-        &:not(:last-child) {
-            margin-bottom: 10px;
-        }
-
         .sw-data-grid__settings-column-item-controls {
             margin-left: auto;
             flex-shrink: 0;


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currency the space between the column names in the administration data grid settings is duplicate, as it uses margin + flex row-gap
- We can remove the margin and just use the flex row-gap

Before:
![image](https://github.com/user-attachments/assets/1f0dfc69-cac9-43f5-b12e-41af36bc7134)

After:
![image](https://github.com/user-attachments/assets/97f42407-025a-4504-956f-d7e86488a7c8)

### 2. What does this change do, exactly?
* Changed `sw-data-grid-settings.scss` to remove the duplicate space between the settings elements

### 3. Describe each step to reproduce the issue or behaviour.
- Open the settings of a data grid in the administration

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
