### PR TITLE
fix: Seo url not generating anymore

### DIFF
--- a/changelog/_unreleased/2025-06-23-fix-issue-seo-url-not-generating-anymore.md
+++ b/changelog/_unreleased/2025-06-23-fix-issue-seo-url-not-generating-anymore.md
@@ -1,0 +1,6 @@
+---
+title: Fix issue SEO url not generating anymore
+issue: 10513
+---
+# Core
+* Changed `updateSeoUrls` method in `Shopware\Core\Content\Seo\SeoUrlPersister` to set `is_canonical` and `is_modified` fields of default seo url to true if a foreignKey's seo url is deleted.

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -55,7 +55,6 @@ class SeoUrlPersister
                 $seoUrl = $seoUrl->jsonSerialize();
             }
             $updates[] = $seoUrl;
-            $seoPathInfos[] = $seoUrl['seoPathInfo'];
 
             $fk = $seoUrl['foreignKey'];
             $salesChannelId = $seoUrl['salesChannelId'] ??= null;
@@ -86,6 +85,8 @@ class SeoUrlPersister
                 $obsoleted[] = $existing['id'];
             }
 
+            $seoPathInfos[] = $seoUrl['seoPathInfo'];
+
             $insert = [];
             $insert['id'] = Uuid::randomBytes();
 
@@ -108,7 +109,7 @@ class SeoUrlPersister
             $insertQuery->addInsert($this->seoUrlRepository->getDefinition()->getEntityName(), $insert);
         }
 
-        $inuseSeoUrls = $this->findInuseSeoUrls($seoPathInfos);
+        $inuseSeoUrls = $this->findInUseCanonicalSeoUrls($seoPathInfos);
 
         RetryableTransaction::retryable($this->connection, function () use ($obsoleted, $insertQuery, $foreignKeys, $updatedFks, $salesChannelId): void {
             $this->obsoleteIds($obsoleted, $salesChannelId);
@@ -125,7 +126,7 @@ class SeoUrlPersister
         // the existing row is seamlessly replaced due to the useReplace flag being set to true within the MultiInsertQueryQueue configuration above.
         // Hence, we have to find the default seoUrls for Entity A and update it accordingly to set is_canonical and is_modified to true,
         // thereby preserving the canonical SEO URL for Entity A.
-        $this->updateDefaultSeoUrls($inuseSeoUrls);
+        $this->updateCanonicalSeoUrls($inuseSeoUrls);
 
         $this->eventDispatcher->dispatch(new SeoUrlUpdateEvent($updates));
     }
@@ -195,7 +196,7 @@ class SeoUrlPersister
      *
      * @return array<array<string, mixed>>
      */
-    private function findInuseSeoUrls(array $seoPathInfos): array
+    private function findInUseCanonicalSeoUrls(array $seoPathInfos): array
     {
         return $this->connection->fetchAllAssociative(
             'SELECT id, language_id languageId, sales_channel_id salesChannelId, foreign_key foreignKey, route_name routeName
@@ -211,7 +212,7 @@ class SeoUrlPersister
      *
      * @param array<array<string, mixed>> $seoUrls
      */
-    private function updateDefaultSeoUrls(array $seoUrls): void
+    private function updateCanonicalSeoUrls(array $seoUrls): void
     {
         if (empty($seoUrls)) {
             return;

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -227,7 +227,7 @@ class SeoUrlPersister
                    AND foreign_key = :foreignKey
                    AND sales_channel_id = :salesChannelId
                    AND route_name = :routeName
-                   AND is_canonical IS NULL
+                   AND is_canonical IS NULL AND is_deleted = 0
                  ORDER BY created_at ASC
                  LIMIT 1',
                 [

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -46,6 +46,8 @@ class SeoUrlPersister
 
         $processed = [];
 
+        $seoPathInfos = [];
+
         $salesChannelId = $salesChannel->getId();
         $updates = [];
         foreach ($seoUrls as $seoUrl) {
@@ -53,6 +55,7 @@ class SeoUrlPersister
                 $seoUrl = $seoUrl->jsonSerialize();
             }
             $updates[] = $seoUrl;
+            $seoPathInfos[] = $seoUrl['seoPathInfo'];
 
             $fk = $seoUrl['foreignKey'];
             $salesChannelId = $seoUrl['salesChannelId'] ??= null;
@@ -105,6 +108,8 @@ class SeoUrlPersister
             $insertQuery->addInsert($this->seoUrlRepository->getDefinition()->getEntityName(), $insert);
         }
 
+        $inuseSeoUrls = $this->findInuseSeoUrls($seoPathInfos);
+
         RetryableTransaction::retryable($this->connection, function () use ($obsoleted, $insertQuery, $foreignKeys, $updatedFks, $salesChannelId): void {
             $this->obsoleteIds($obsoleted, $salesChannelId);
             $insertQuery->execute();
@@ -115,6 +120,12 @@ class SeoUrlPersister
             $this->markAsDeleted(true, $deletedIds, $salesChannelId);
             $this->markAsDeleted(false, $notDeletedIds, $salesChannelId);
         });
+
+        // When a seoPathInfo is added that is already associated with a foreignKey, EX: Entity A,
+        // the existing row is seamlessly replaced due to the useReplace flag being set to true within the MultiInsertQueryQueue configuration above.
+        // Hence, we have to find the default seoUrls for Entity A and update it accordingly to set is_canonical and is_modified to true,
+        // thereby preserving the canonical SEO URL for Entity A.
+        $this->updateDefaultSeoUrls($inuseSeoUrls);
 
         $this->eventDispatcher->dispatch(new SeoUrlUpdateEvent($updates));
     }
@@ -177,6 +188,69 @@ class SeoUrlPersister
         }
 
         return $canonicals;
+    }
+
+    /**
+     * @param array<string> $seoPathInfos
+     *
+     * @return array<array<string, mixed>>
+     */
+    private function findInuseSeoUrls(array $seoPathInfos): array
+    {
+        return $this->connection->fetchAllAssociative(
+            'SELECT id, language_id languageId, sales_channel_id salesChannelId, foreign_key foreignKey, route_name routeName
+            FROM seo_url
+            WHERE is_canonical = 1 AND seo_path_info IN (:seoPathInfos)',
+            ['seoPathInfos' => $seoPathInfos],
+            ['seoPathInfos' => ArrayParameterType::BINARY]
+        );
+    }
+
+    /**
+     * Find the earliest valid SEO URL created. This means it is the default SEO URL and update the `is_canonical` and `is_modified` fields.
+     *
+     * @param array<array<string, mixed>> $seoUrls
+     */
+    private function updateDefaultSeoUrls(array $seoUrls): void
+    {
+        if (empty($seoUrls)) {
+            return;
+        }
+
+        $ids = [];
+        foreach ($seoUrls as $seoUrl) {
+            $id = $this->connection->fetchOne(
+                'SELECT HEX(id) AS id
+                 FROM seo_url
+                 WHERE language_id = :languageId
+                   AND foreign_key = :foreignKey
+                   AND sales_channel_id = :salesChannelId
+                   AND route_name = :routeName
+                   AND is_canonical IS NULL
+                 ORDER BY created_at ASC
+                 LIMIT 1',
+                [
+                    'languageId' => $seoUrl['languageId'],
+                    'foreignKey' => $seoUrl['foreignKey'],
+                    'salesChannelId' => $seoUrl['salesChannelId'],
+                    'routeName' => (string) $seoUrl['routeName'],
+                ]
+            );
+
+            if ($id !== false) {
+                $ids[] = $id;
+            }
+        }
+
+        if (empty($ids)) {
+            return;
+        }
+
+        $this->connection->executeStatement(
+            'UPDATE seo_url SET is_canonical = 1, is_modified = 1 WHERE id IN (:ids)',
+            ['ids' => Uuid::fromHexToBytesList($ids)],
+            ['ids' => ArrayParameterType::BINARY]
+        );
     }
 
     /**

--- a/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\SeoUrlPersister;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(SeoUrlPersister::class)]
+class SeoUrlPersisterTest extends TestCase
+{
+    private Connection $connection;
+
+    private SeoUrlPersister $seoUrlPersister;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->seoUrlPersister = new SeoUrlPersister(
+            $this->connection,
+            $this->createMock(EntityRepository::class),
+            $this->createMock(EventDispatcherInterface::class)
+        );
+    }
+
+    public function testUpdateSeoUrlsWithNewSeoPaths(): void
+    {
+        $seoUrls = [
+            [
+                'languageId' => Uuid::randomHex(),
+                'foreignKey' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomHex(),
+                'routeName' => 'test-route',
+                'seoPathInfo' => 'path1',
+            ],
+            [
+                'languageId' => Uuid::randomHex(),
+                'foreignKey' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomHex(),
+                'routeName' => 'test-route',
+                'seoPathInfo' => 'path2',
+            ],
+        ];
+
+        $this->connection->method('fetchAllAssociative')->willReturn([]);
+
+        $this->connection->method('fetchOne')->willReturn([]);
+
+        $this->connection->expects($this->never())->method('executeStatement');
+
+        $this->seoUrlPersister->updateSeoUrls(
+            Context::createDefaultContext(),
+            'test-route',
+            [
+                'foreignKey' => Uuid::randomHex(),
+            ],
+            $seoUrls,
+            $this->createMock(SalesChannelEntity::class),
+        );
+    }
+
+    public function testUpdateSeoUrlsWithInuseSeoPaths(): void
+    {
+        $seoUrls = [
+            [
+                'languageId' => Uuid::randomHex(),
+                'foreignKey' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomHex(),
+                'routeName' => 'test-route',
+                'seoPathInfo' => 'path1',
+            ],
+            [
+                'languageId' => Uuid::randomHex(),
+                'foreignKey' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomHex(),
+                'routeName' => 'test-route',
+                'seoPathInfo' => 'path2',
+            ],
+        ];
+
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+        $expectedIds = [$id1, $id2];
+
+        $this->connection->method('fetchAllAssociative')->willReturn([
+            [
+                'id' => 'id1',
+                'languageId' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomHex(),
+                'foreignKey' => Uuid::randomHex(),
+                'routeName' => 'test-route',
+            ],
+            [
+                'id' => 'id2',
+                'languageId' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomHex(),
+                'foreignKey' => Uuid::randomHex(),
+                'routeName' => 'test-route',
+            ],
+        ]);
+
+        // Mock updateInuseSeoUrls behavior
+        $this->connection->method('fetchOne')->willReturnOnConsecutiveCalls($id1, $id2);
+
+        $this->connection->expects($this->once())
+            ->method('executeStatement')
+            ->with(
+                'UPDATE seo_url SET is_canonical = 1, is_modified = 1 WHERE id IN (:ids)',
+                ['ids' => Uuid::fromHexToBytesList($expectedIds)],
+                ['ids' => ArrayParameterType::BINARY]
+            );
+
+        $seoChannel = new SalesChannelEntity();
+        $seoChannel->setId(Uuid::randomHex());
+
+        $this->seoUrlPersister->updateSeoUrls(
+            Context::createDefaultContext(),
+            'test-route',
+            [
+                'foreignKey' => Uuid::randomHex(),
+            ],
+            $seoUrls,
+            $seoChannel
+        );
+    }
+}

--- a/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Seo;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\SeoUrlPersister;
 use Shopware\Core\Framework\Context;
@@ -21,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(SeoUrlPersister::class)]
 class SeoUrlPersisterTest extends TestCase
 {
-    private Connection $connection;
+    private Connection&MockObject $connection;
 
     private SeoUrlPersister $seoUrlPersister;
 
@@ -43,6 +44,7 @@ class SeoUrlPersisterTest extends TestCase
                 'foreignKey' => Uuid::randomHex(),
                 'salesChannelId' => Uuid::randomHex(),
                 'routeName' => 'test-route',
+                'pathInfo' => 'path1',
                 'seoPathInfo' => 'path1',
             ],
             [
@@ -50,15 +52,24 @@ class SeoUrlPersisterTest extends TestCase
                 'foreignKey' => Uuid::randomHex(),
                 'salesChannelId' => Uuid::randomHex(),
                 'routeName' => 'test-route',
+                'pathInfo' => 'path2',
                 'seoPathInfo' => 'path2',
             ],
         ];
 
-        $this->connection->method('fetchAllAssociative')->willReturn([]);
+        $this->connection->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
 
-        $this->connection->method('fetchOne')->willReturn([]);
+        $this->connection->expects($this->never())
+            ->method('fetchOne')
+            ->willReturn([]);
 
-        $this->connection->expects($this->never())->method('executeStatement');
+        $this->connection->expects($this->never())
+            ->method('executeStatement');
+
+        $seoChannel = new SalesChannelEntity();
+        $seoChannel->setId(Uuid::randomHex());
 
         $this->seoUrlPersister->updateSeoUrls(
             Context::createDefaultContext(),
@@ -67,7 +78,7 @@ class SeoUrlPersisterTest extends TestCase
                 'foreignKey' => Uuid::randomHex(),
             ],
             $seoUrls,
-            $this->createMock(SalesChannelEntity::class),
+            $seoChannel
         );
     }
 
@@ -79,6 +90,7 @@ class SeoUrlPersisterTest extends TestCase
                 'foreignKey' => Uuid::randomHex(),
                 'salesChannelId' => Uuid::randomHex(),
                 'routeName' => 'test-route',
+                'pathInfo' => 'path1',
                 'seoPathInfo' => 'path1',
             ],
             [
@@ -86,6 +98,7 @@ class SeoUrlPersisterTest extends TestCase
                 'foreignKey' => Uuid::randomHex(),
                 'salesChannelId' => Uuid::randomHex(),
                 'routeName' => 'test-route',
+                'pathInfo' => 'path2',
                 'seoPathInfo' => 'path2',
             ],
         ];
@@ -94,25 +107,28 @@ class SeoUrlPersisterTest extends TestCase
         $id2 = Uuid::randomHex();
         $expectedIds = [$id1, $id2];
 
-        $this->connection->method('fetchAllAssociative')->willReturn([
-            [
-                'id' => 'id1',
-                'languageId' => Uuid::randomHex(),
-                'salesChannelId' => Uuid::randomHex(),
-                'foreignKey' => Uuid::randomHex(),
-                'routeName' => 'test-route',
-            ],
-            [
-                'id' => 'id2',
-                'languageId' => Uuid::randomHex(),
-                'salesChannelId' => Uuid::randomHex(),
-                'foreignKey' => Uuid::randomHex(),
-                'routeName' => 'test-route',
-            ],
-        ]);
+        $this->connection->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'id' => 'id1',
+                    'languageId' => Uuid::randomHex(),
+                    'salesChannelId' => Uuid::randomHex(),
+                    'foreignKey' => Uuid::randomHex(),
+                    'routeName' => 'test-route',
+                ],
+                [
+                    'id' => 'id2',
+                    'languageId' => Uuid::randomHex(),
+                    'salesChannelId' => Uuid::randomHex(),
+                    'foreignKey' => Uuid::randomHex(),
+                    'routeName' => 'test-route',
+                ],
+            ]);
 
-        // Mock updateInuseSeoUrls behavior
-        $this->connection->method('fetchOne')->willReturnOnConsecutiveCalls($id1, $id2);
+        $this->connection->expects($this->exactly(2))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls($id1, $id2);
 
         $this->connection->expects($this->once())
             ->method('executeStatement')


### PR DESCRIPTION
This pull request addresses a bug in the SEO URL generation process by updating the `updateSeoUrls` method in the `SeoUrlPersister` class and introducing new methods to handle canonical SEO URLs.

### Bug Fixes and Enhancements to SEO URL Handling:
* Modified `updateSeoUrls` in `SeoUrlPersister` to update the `is_canonical` and `is_modified` fields for default SEO URLs when a foreign key's SEO URL is replaced or deleted. This ensures that canonical URLs are preserved correctly.
* Added a new private method `findInuseSeoUrls` to fetch existing canonical SEO URLs based on `seoPathInfo`.
* Introduced another private method `updateDefaultSeoUrls` to identify and update the earliest valid SEO URL as the default, setting its `is_canonical` and `is_modified` fields to `true`.

### Before

https://github.com/user-attachments/assets/6639c262-28d2-49c5-b78e-2b681a6ff844


### After

https://github.com/user-attachments/assets/89add368-bc93-44d9-b01d-0e136d221fee


