### PR TITLE
fix: remove 6.8.0.0 feature flag [6.6.x]

### DIFF
--- a/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
@@ -26,7 +26,6 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
@@ -76,8 +75,6 @@ class ZugferdDocument
     {
         $calculator = func_get_arg(1);
         if (!$calculator instanceof AmountCalculator) {
-            Feature::triggerDeprecationOrThrow('v6.8.0.0', 'New required parameter $calculator missing');
-
             $calculator = new AmountCalculator(
                 new CashRounding(),
                 new PercentageTaxRuleBuilder(),
@@ -173,9 +170,8 @@ class ZugferdDocument
         }
 
         $this->addMappedPrice(self::LINE_TOTAL_AMOUNT, $price);
-        if (!Feature::isActive('v6.8.0.0')) {
-            $this->addLineTotalAmount($totalNet);
-        }
+        $this->addLineTotalAmount($totalNet);
+
         $this->zugferdBuilder
             ->addNewPosition($parentPosition . $lineItem->getPosition())
             ->setDocumentPositionNetPrice(\round($totalNet / $lineItem->getQuantity(), 2), $lineItem->getQuantity(), ZugferdUnitCodes::REC20_PIECE)
@@ -211,13 +207,12 @@ class ZugferdDocument
         foreach ($lineItem->getPrice()->getCalculatedTaxes() as $calculatedTax) {
             $actualAmount = $this->getPrice($calculatedTax);
 
-            if (!Feature::isActive('v6.8.0.0')) {
-                if ($isCharge) {
-                    $this->addChargeAmount($actualAmount);
-                } else {
-                    $this->addAllowanceAmount($actualAmount);
-                }
+            if ($isCharge) {
+                $this->addChargeAmount($actualAmount);
+            } else {
+                $this->addAllowanceAmount($actualAmount);
             }
+
             $this->zugferdBuilder->addDocumentAllowanceCharge(
                 ...[
                     'actualAmount' => abs($actualAmount),
@@ -253,9 +248,8 @@ class ZugferdDocument
             foreach ($delivery->getShippingCosts()->getCalculatedTaxes() as $calculatedTax) {
                 $actualAmount = $this->getPrice($calculatedTax);
 
-                if (!Feature::isActive('v6.8.0.0')) {
-                    $this->addChargeAmount($actualAmount);
-                }
+                $this->addChargeAmount($actualAmount);
+
                 $this->zugferdBuilder->addDocumentAllowanceCharge(
                     $actualAmount,
                     true,
@@ -301,8 +295,6 @@ class ZugferdDocument
      */
     protected function addChargeAmount(float $chargeAmount): void
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', 'Method and parameter will be removed. Use addMappedPrice instead.');
-
         $this->chargeAmount += $chargeAmount;
     }
 
@@ -311,8 +303,6 @@ class ZugferdDocument
      */
     protected function addLineTotalAmount(float $lineTotalAmount): void
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', 'Method and parameter will be removed. Use addMappedPrice instead.');
-
         $this->lineTotalAmount += $lineTotalAmount;
     }
 
@@ -321,8 +311,6 @@ class ZugferdDocument
      */
     protected function addAllowanceAmount(float $allowanceAmount): void
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', 'Method and parameter will be removed. Use addMappedPrice instead.');
-
         $this->allowanceAmount += $allowanceAmount;
     }
 

--- a/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
@@ -70,6 +70,8 @@ class ZugferdDocument
 
     /**
      * @deprecated tag:v6.8.0 - added new parameter $calculator
+     *
+     * @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
      */
     public function getContent(OrderEntity $order/* , AmountCalculator $calculator */): string
     {
@@ -292,6 +294,8 @@ class ZugferdDocument
 
     /**
      * @deprecated tag:v6.8.0 - Will be removed. Use addMappedPrice instead
+     *
+     * @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
      */
     protected function addChargeAmount(float $chargeAmount): void
     {
@@ -300,6 +304,8 @@ class ZugferdDocument
 
     /**
      * @deprecated tag:v6.8.0 - Will be removed. Use addMappedPrice instead
+     *
+     * @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
      */
     protected function addLineTotalAmount(float $lineTotalAmount): void
     {
@@ -308,6 +314,8 @@ class ZugferdDocument
 
     /**
      * @deprecated tag:v6.8.0 - Will be removed. Use addMappedPrice instead
+     *
+     * @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
      */
     protected function addAllowanceAmount(float $allowanceAmount): void
     {

--- a/src/Core/Framework/Plugin/PluginException.php
+++ b/src/Core/Framework/Plugin/PluginException.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Framework\Plugin;
 
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
@@ -119,20 +118,11 @@ class PluginException extends HttpException
      */
     public static function projectDirNotInContainer(): self
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            Feature::triggerDeprecationOrThrow(
-                'v6.8.0.0',
-                Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0', 'PluginException::invalidContainerParameter')
-            );
-
-            return new self(
-                Response::HTTP_INTERNAL_SERVER_ERROR,
-                self::PROJECT_DIR_IS_NOT_A_STRING,
-                'Container parameter "kernel.project_dir" needs to be a string'
-            );
-        }
-
-        return self::invalidContainerParameter('kernel.project_dir', 'string');
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::PROJECT_DIR_IS_NOT_A_STRING,
+            'Container parameter "kernel.project_dir" needs to be a string'
+        );
     }
 
     public static function invalidContainerParameter(string $name, string $expectedType): self
@@ -232,20 +222,7 @@ class PluginException extends HttpException
      */
     public static function pluginComposerRequire(string $pluginName, string $pluginComposerName, string $output): self|PluginComposerRequireException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new PluginComposerRequireException($pluginName, $pluginComposerName, $output);
-        }
-
-        return new self(
-            Response::HTTP_BAD_REQUEST,
-            self::PLUGIN_COMPOSER_REQUIRE,
-            \sprintf('Could not execute "composer require" for plugin "{{ pluginName }} ({{ pluginComposerName }}). Output:%s{{ output }}', \PHP_EOL),
-            [
-                'pluginName' => $pluginName,
-                'pluginComposerName' => $pluginComposerName,
-                'output' => $output,
-            ]
-        );
+        return new PluginComposerRequireException($pluginName, $pluginComposerName, $output);
     }
 
     /**
@@ -253,19 +230,6 @@ class PluginException extends HttpException
      */
     public static function pluginComposerRemove(string $pluginName, string $pluginComposerName, string $output): self|PluginComposerRemoveException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new PluginComposerRemoveException($pluginName, $pluginComposerName, $output);
-        }
-
-        return new self(
-            Response::HTTP_BAD_REQUEST,
-            self::PLUGIN_COMPOSER_REMOVE,
-            \sprintf('Could not execute "composer remove" for plugin "{{ pluginName }} ({{ pluginComposerName }}). Output:%s{{ output }}', \PHP_EOL),
-            [
-                'pluginName' => $pluginName,
-                'pluginComposerName' => $pluginComposerName,
-                'output' => $output,
-            ]
-        );
+        return new PluginComposerRemoveException($pluginName, $pluginComposerName, $output);
     }
 }

--- a/src/Core/Framework/Plugin/PluginException.php
+++ b/src/Core/Framework/Plugin/PluginException.php
@@ -115,6 +115,8 @@ class PluginException extends HttpException
 
     /**
      * @deprecated tag:v6.8.0 - Will be removed with next major. Use PluginException::invalidContainerParameter instead
+     *
+     * @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
      */
     public static function projectDirNotInContainer(): self
     {

--- a/src/Core/System/Country/Aggregate/CountryState/CountryStateCollection.php
+++ b/src/Core/System/Country/Aggregate/CountryState/CountryStateCollection.php
@@ -26,6 +26,8 @@ class CountryStateCollection extends EntityCollection
 
     /**
      * @deprecated tag:v6.8.0 - will be removed, use sorting via SQL instead
+     *
+     * @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
      */
     public function sortByPositionAndName(): void
     {

--- a/src/Core/System/Country/Aggregate/CountryState/CountryStateCollection.php
+++ b/src/Core/System/Country/Aggregate/CountryState/CountryStateCollection.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\System\Country\Aggregate\CountryState;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -30,8 +29,6 @@ class CountryStateCollection extends EntityCollection
      */
     public function sortByPositionAndName(): void
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', 'Use sorting via SQL instead of this method.');
-
         uasort($this->elements, static function (CountryStateEntity $a, CountryStateEntity $b) {
             $aPosition = $a->getPosition();
             $bPosition = $b->getPosition();

--- a/src/Core/System/Country/CountryCollection.php
+++ b/src/Core/System/Country/CountryCollection.php
@@ -13,6 +13,8 @@ class CountryCollection extends EntityCollection
 {
     /**
      * @deprecated tag:v6.8.0 - will be removed, use sorting via SQL instead
+     *
+     * @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
      */
     public function sortCountryAndStates(): void
     {
@@ -27,6 +29,8 @@ class CountryCollection extends EntityCollection
 
     /**
      * @deprecated tag:v6.8.0 - will be removed, use sorting via SQL instead
+     *
+     * @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
      */
     public function sortByPositionAndName(): void
     {

--- a/src/Core/System/Country/CountryCollection.php
+++ b/src/Core/System/Country/CountryCollection.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\System\Country;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -17,8 +16,6 @@ class CountryCollection extends EntityCollection
      */
     public function sortCountryAndStates(): void
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', 'Use sorting via SQL instead of this method.');
-
         $this->sortByPositionAndName();
 
         foreach ($this->getIterator() as $country) {
@@ -33,8 +30,6 @@ class CountryCollection extends EntityCollection
      */
     public function sortByPositionAndName(): void
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', 'Use sorting via SQL instead of this method.');
-
         uasort($this->elements, static function (CountryEntity $a, CountryEntity $b) {
             $aPosition = $a->getPosition();
             $bPosition = $b->getPosition();

--- a/src/Storefront/Theme/Message/DeleteThemeFilesHandler.php
+++ b/src/Storefront/Theme/Message/DeleteThemeFilesHandler.php
@@ -4,7 +4,6 @@ namespace Shopware\Storefront\Theme\Message;
 
 use League\Flysystem\FilesystemOperator;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\AbstractThemePathBuilder;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -29,11 +28,6 @@ final class DeleteThemeFilesHandler
 
     public function __invoke(DeleteThemeFilesMessage $message): void
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0')
-        );
-
         $currentPath = $this->pathBuilder->assemblePath($message->getSalesChannelId(), $message->getThemeId());
         if ($currentPath === $message->getThemePath()) {
             return;

--- a/src/Storefront/Theme/Message/DeleteThemeFilesMessage.php
+++ b/src/Storefront/Theme/Message/DeleteThemeFilesMessage.php
@@ -22,16 +22,19 @@ class DeleteThemeFilesMessage implements AsyncMessageInterface
     ) {
     }
 
+    // @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
     public function getThemePath(): string
     {
         return $this->themePath;
     }
 
+    // @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
     public function getSalesChannelId(): string
     {
         return $this->salesChannelId;
     }
 
+    // @phpstan-ignore-next-line shopware.deprecatedClass - Deprecations for 6.8.0.0 should only be soft
     public function getThemeId(): string
     {
         return $this->themeId;

--- a/src/Storefront/Theme/Message/DeleteThemeFilesMessage.php
+++ b/src/Storefront/Theme/Message/DeleteThemeFilesMessage.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Storefront\Theme\Message;
 
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\AsyncMessageInterface;
 
@@ -25,31 +24,16 @@ class DeleteThemeFilesMessage implements AsyncMessageInterface
 
     public function getThemePath(): string
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0')
-        );
-
         return $this->themePath;
     }
 
     public function getSalesChannelId(): string
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0')
-        );
-
         return $this->salesChannelId;
     }
 
     public function getThemeId(): string
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0')
-        );
-
         return $this->themeId;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The 6.6.x version cannot have the 6.8.0.0 feature flag. Using it will always result in a `FeatureException`. This makes certain features unnecessarily difficult to use, or even impossible.

### 2. What does this change do, exactly?
Remove all calls to `Feature::` that uses the 6.8.0.0 feature flag. It would result in `false` anyway, making deprecation and conditions unnecessary.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
