### PR TITLE
fix(admin): Unify spaces of dashboard

### DIFF
--- a/changelog/_unreleased/2025-06-24-unify-margins-of-admin-dashboard.md
+++ b/changelog/_unreleased/2025-06-24-unify-margins-of-admin-dashboard.md
@@ -1,0 +1,8 @@
+---
+title: Unify margins of admin dashboard
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed margins of admin dashboard to match the spaces used in other places

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.scss
@@ -5,7 +5,7 @@ $content-max-width: 960px;
 .sw-dashboard-index {
     &__welcome-text {
         max-width: $content-max-width;
-        margin: 0 auto;
+        margin: 0 auto 32px;
     }
 
     &__welcome-title {
@@ -53,7 +53,7 @@ $content-max-width: 960px;
 
     &__card-grid {
         max-width: $content-max-width;
-        margin: 32px auto;
+        margin: 0 auto var(--scale-size-40);
 
         @media (min-width: 1024px) {
             display: grid;
@@ -69,13 +69,11 @@ $content-max-width: 960px;
         border-radius: $border-radius-lg;
         box-shadow: 0 4px 9px 0 rgba(120, 138, 155, 5%);
         padding: 21px 27px;
-        margin-bottom: 32px;
         height: 200px;
         max-height: 200px;
         overflow-y: auto;
 
         &--dimmed {
-            border: 1px solid $color-gray-300;
             background-color: $color-gray-50;
             text-align: center;
         }
@@ -96,7 +94,6 @@ $content-max-width: 960px;
 
     &__card-title {
         font-size: $font-size-s;
-        color: $color-darkgray-200;
         margin-bottom: 12px;
     }
 
@@ -163,6 +160,6 @@ $content-max-width: 960px;
     }
 
     .sw-dashboard__before-content {
-        margin-top: 32px;
+        margin-bottom: var(--scale-size-40);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-usage-data-consent-banner/sw-usage-data-consent-banner.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-usage-data-consent-banner/sw-usage-data-consent-banner.scss
@@ -3,7 +3,7 @@
 .sw-usage-data-consent-banner {
     background: $color-white;
     max-width: $content-width;
-    margin: 32px auto;
+    margin: 0 auto var(--scale-size-40);
     border-radius: $border-radius-lg;
     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 10%), 0 2px 1px 0 rgba(0, 0, 0, 6%), 0 1px 1px 0 rgba(0, 0, 0, 8%);
     position: relative;
@@ -237,7 +237,7 @@
     justify-content: space-between;
     align-items: center;
     max-width: $content-width;
-    margin: 32px auto;
+    margin: 0 auto var(--scale-size-40);
     border-radius: $border-radius-lg;
     border: 1px solid $color-gray-300;
     color: $color-darkgray-700;


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the margins of the admin dashboard are not unified, i.e. between the consent banner cards there is a margin of `32px` in all other places (also between the statistics cards) the margin is `40px`, also above the statistics panels the margin is `2*32px`:
![image](https://github.com/user-attachments/assets/3e3cb9ee-a3b7-472a-83f6-186695fc6513)

### 2. What does this change do, exactly?
Unify the margins to 40px:
![image](https://github.com/user-attachments/assets/cb2bbd94-bb64-4d74-85b5-495cc172b98d)

The margin below the welcome text, I left at 32px.

In addition I am not sure, if the margin between the two boxes should also be `40px`, or left at `24px`. For comparison here is a screenshot with 40px:
![image](https://github.com/user-attachments/assets/c7619139-6415-49af-8e9b-65e43691ae16)

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
