### PR TITLE
perf: Do not regenerate the category URL if it is a SalesChannelCategoryEntity

### DIFF
--- a/src/Core/Framework/Adapter/Twig/Extension/CategoryUrlExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/CategoryUrlExtension.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Adapter\Twig\Extension;
 
 use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelCategoryEntity;
 use Shopware\Core\Content\Category\Service\AbstractCategoryUrlGenerator;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
@@ -47,6 +48,10 @@ class CategoryUrlExtension extends AbstractExtension
             'v6.8.0.0',
             'The "category_url" function is deprecated and will be removed in v6.8.0.0. Use SalesChannelCategoryEntity::getSeoUrl() instead.'
         );
+
+        if ($category instanceof SalesChannelCategoryEntity) {
+            return $category->getSeoUrl();
+        }
 
         $salesChannel = null;
         if (\array_key_exists('context', $twigContext) && $twigContext['context'] instanceof SalesChannelContext) {


### PR DESCRIPTION
### 1. Why is this change necessary?
A small performance improvement, but if it is a `SalesChannelCategoryEntity` we do not need to call the Category URL generator again, as it was already done in the `CategorySubscriber`.

### 2. What does this change do, exactly?
:shrug: 

### 3. Describe each step to reproduce the issue or behaviour.
:shrug:

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
