### PR TITLE
fix: Make custom field set name unique in app manifest XSD file

### DIFF
--- a/changelog/_unreleased/2025-06-24-custom-field-set-name-is-now-unique-for-apps.md
+++ b/changelog/_unreleased/2025-06-24-custom-field-set-name-is-now-unique-for-apps.md
@@ -1,0 +1,20 @@
+---
+title: Custom field set name is now unique for apps
+issue: #10738
+author: Michael Telgmann
+author_github: @mitelg
+---
+
+# Core
+
+* Changed `src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd` to add a unique constraint to the `name` element of the `custom-field-set`.
+
+___
+
+# Upgrade Information
+
+## Custom field set name is now unique for apps
+
+The `name` element of the `custom-field-set` in the app manifest is now unique per app.
+It should not be the case for your app anyway as it caused problems,
+but you should check your app manifest and ensure that the `name` of the `custom-field-set` is unique.

--- a/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
+++ b/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
@@ -71,6 +71,10 @@
                             Register custom-fields your app needs.
                         </xs:documentation>
                     </xs:annotation>
+                    <xs:unique name="uniqueCustomFieldSetName">
+                        <xs:selector xpath="custom-field-set"/>
+                        <xs:field xpath="name"/>
+                    </xs:unique>
                 </xs:element>
                 <xs:element name="webhooks" type="webhooks" minOccurs="0">
                     <xs:annotation>

--- a/tests/unit/Core/Framework/App/Manifest/ManifestTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/ManifestTest.php
@@ -144,4 +144,16 @@ class ManifestTest extends TestCase
 
         static::assertSame(['test' => 'test'], $manifest->getSourceConfig());
     }
+
+    public function testDuplicateCustomFieldSetNamesAreNotAllowed(): void
+    {
+        $file = __DIR__ . '/_fixtures/duplicate-custom-field-set-name.xml';
+        $fileContent = file_get_contents($file);
+        static::assertIsString($fileContent);
+
+        $this->expectException(AppException::class);
+        $this->expectExceptionMessageMatches("/Element \'custom-field-set\'\: Duplicate key-sequence \[\'duplicated_custom_field_set\'\] in unique identity-constraint \'uniqueCustomFieldSetName\'/");
+
+        Manifest::validate($fileContent, $file);
+    }
 }

--- a/tests/unit/Core/Framework/App/Manifest/_fixtures/duplicate-custom-field-set-name.xml
+++ b/tests/unit/Core/Framework/App/Manifest/_fixtures/duplicate-custom-field-set-name.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>test</name>
+        <label>Test Swag Shipping App</label>
+        <description>Test for App System Shipping</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>0.0.1</version>
+        <license>MIT</license>
+    </meta>
+
+    <custom-fields>
+        <custom-field-set>
+            <name>duplicated_custom_field_set</name>
+            <label>label</label>
+            <related-entities>
+                <category/>
+            </related-entities>
+            <fields>
+                <text name="test_text">
+                    <label>text label</label>
+                </text>
+            </fields>
+        </custom-field-set>
+        <custom-field-set>
+            <name>duplicated_custom_field_set</name>
+            <label>label 2</label>
+            <related-entities>
+                <category/>
+            </related-entities>
+            <fields>
+                <text name="test_text">
+                    <label>text label 2</label>
+                </text>
+            </fields>
+        </custom-field-set>
+    </custom-fields>
+</manifest>


### PR DESCRIPTION
### 1. Why is this change necessary?

The name of a custom field set must be unique per app. This prevents issue like in https://github.com/shopware/shopware/issues/10738

### 2. What does this change do, exactly?

Add a unique constraint to the app manifest XSD file

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/shopware/shopware/issues/10738

### 4. Please link to the relevant issues (if any)
- relates to https://github.com/shopware/shopware/issues/10738. it does not fix it right away, but prevents the issue in the future.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
