### PR TITLE
fix: Handle duplicate custom field set names

### DIFF
--- a/changelog/_unreleased/2025-06-24-fix-apps-with-duplicated-custom-field-sets.md
+++ b/changelog/_unreleased/2025-06-24-fix-apps-with-duplicated-custom-field-sets.md
@@ -3,4 +3,4 @@ title: Fix apps with duplicated custom field sets
 issue: #10738
 ---
 # Core
-* Changed `Shopware\Core\Checkout\Cart\Delivery\DeliveryCalculator` to respect missing currency prices within the price matrices of a shipping method.
+* Changed `\Shopware\Core\Framework\App\Lifecycle\Persister\CustomFieldPersister::upsertCustomFieldSets` to remove custom field sets and recreate them if their names are duplicated and we can not map them properly.

--- a/changelog/_unreleased/2025-06-24-fix-apps-with-duplicated-custom-field-sets.md
+++ b/changelog/_unreleased/2025-06-24-fix-apps-with-duplicated-custom-field-sets.md
@@ -1,0 +1,6 @@
+---
+title: Fix apps with duplicated custom field sets
+issue: #10738
+---
+# Core
+* Changed `Shopware\Core\Checkout\Cart\Delivery\DeliveryCalculator` to respect missing currency prices within the price matrices of a shipping method.

--- a/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -414,7 +414,22 @@ class AppLifecycleTest extends TestCase
             ],
             'customFieldSets' => [
                 [
-                    'name' => 'test',
+                    'name' => 'custom_field_test',
+                    'customFields' => [
+                        [
+                            'name' => 'bla_test2',
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'name' => 'custom_field_test', // same name used twice, sets should be deleted and recreated
+                    'customFields' => [
+                        [
+                            'name' => 'bla_test',
+                            'type' => 'text',
+                        ],
+                    ],
                 ],
             ],
             'aclRole' => [


### PR DESCRIPTION
When custom field set names are duplicated the initial install works, but the later update fails

with https://github.com/shopware/shopware/pull/10772 that is not possible anymore, however we need to offer a way forward when a broken app was already installed
