### PR TITLE
fix: Allow partial loading in CustomerRoute via PHP

### DIFF
--- a/changelog/_unreleased/2025-06-25-allow-partial-loading-in-customerroute-via-php.md
+++ b/changelog/_unreleased/2025-06-25-allow-partial-loading-in-customerroute-via-php.md
@@ -6,4 +6,4 @@ author_email: m.bade@shopware.com
 author_github: @cyl3x
 ---
 # Core
-* Changed `Shopware\Core\Checkout\Customer\SalesChannel\CustomerResponse` to support partial customer entity loading in `Shopware\Core\Checkout\Customer\SalesChannel\CustomerRoute` via PHP
+* Changed `Shopware\Core\Checkout\Customer\SalesChannel\CustomerResponse` to account for partial customer entity loading in `Shopware\Core\Checkout\Customer\SalesChannel\CustomerRoute` via PHP

--- a/changelog/_unreleased/2025-06-25-allow-partial-loading-in-customerroute-via-php.md
+++ b/changelog/_unreleased/2025-06-25-allow-partial-loading-in-customerroute-via-php.md
@@ -1,0 +1,9 @@
+---
+title: Allow partial loading in CustomerRoute via PHP
+issue: #9778
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `Shopware\Core\Checkout\Customer\SalesChannel\CustomerResponse` to support partial customer entity loading in `Shopware\Core\Checkout\Customer\SalesChannel\CustomerRoute` via PHP

--- a/src/Core/Checkout/Customer/SalesChannel/CustomerResponse.php
+++ b/src/Core/Checkout/Customer/SalesChannel/CustomerResponse.php
@@ -20,8 +20,8 @@ class CustomerResponse extends StoreApiResponse
      */
     public function getCustomer(): CustomerEntity
     {
-        if ($partial = $this->getPartialCustomer()) {
-            return (new CustomerEntity())->assign($partial->all());
+        if ($this->object instanceof PartialEntity) {
+            return (new CustomerEntity())->assign($this->object->all());
         }
 
         return $this->object;

--- a/src/Core/Checkout/Customer/SalesChannel/CustomerResponse.php
+++ b/src/Core/Checkout/Customer/SalesChannel/CustomerResponse.php
@@ -13,8 +13,22 @@ use Shopware\Core\System\SalesChannel\StoreApiResponse;
 #[Package('checkout')]
 class CustomerResponse extends StoreApiResponse
 {
-    public function getCustomer(): PartialEntity|CustomerEntity
+    /**
+     * If the criteria used to load the customer results in a partial entity,
+     * the customer entity returned may be incomplete.
+     * Use {@see CustomerResponse::getPartialCustomer} to check for a partial entity.
+     */
+    public function getCustomer(): CustomerEntity
     {
+        if ($partial = $this->getPartialCustomer()) {
+            return (new CustomerEntity())->assign($partial->all());
+        }
+
         return $this->object;
+    }
+
+    public function getPartialCustomer(): ?PartialEntity
+    {
+        return $this->object instanceof PartialEntity ? $this->object : null;
     }
 }

--- a/src/Core/Checkout/Customer/SalesChannel/CustomerResponse.php
+++ b/src/Core/Checkout/Customer/SalesChannel/CustomerResponse.php
@@ -3,16 +3,17 @@
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 
 /**
- * @extends StoreApiResponse<CustomerEntity>
+ * @extends StoreApiResponse<PartialEntity|CustomerEntity>
  */
 #[Package('checkout')]
 class CustomerResponse extends StoreApiResponse
 {
-    public function getCustomer(): CustomerEntity
+    public function getCustomer(): PartialEntity|CustomerEntity
     {
         return $this->object;
     }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/account.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/account.json
@@ -428,7 +428,7 @@
                             "schema": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/components/schemas/NoneFieldsCriteria"
+                                        "$ref": "#/components/schemas/Criteria"
                                     }
                                 ]
                             }

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/CustomerRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/CustomerRouteTest.php
@@ -63,13 +63,15 @@ class CustomerRouteTest extends TestCase
         $criteria = new Criteria([$id]);
         $criteria->addFields(['email']);
 
-        $partialCustomer = $this->getContainer()
+        $response = $this->getContainer()
             ->get(CustomerRoute::class)
-            ->load(new Request(), $salesChannelContext, $criteria, $customer)
-            ->getCustomer();
+            ->load(new Request(), $salesChannelContext, $criteria, $customer);
 
-        static::assertInstanceOf(PartialEntity::class, $partialCustomer);
-        static::assertEquals(['id' => $id, 'email' => $email], $partialCustomer->all());
+        static::assertInstanceOf(PartialEntity::class, $response->getPartialCustomer());
+        static::assertEquals(
+            ['id' => $id, '_uniqueIdentifier' => $id, 'email' => $email],
+            \array_filter($response->getCustomer()->jsonSerialize()),
+        );
     }
 
     public function testNotLoggedin(): void

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/CustomerRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/CustomerRouteTest.php
@@ -4,14 +4,22 @@ namespace Shopware\Tests\Integration\Core\Checkout\Customer\SalesChannel;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\SalesChannel\CustomerRoute;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\Test\Integration\Traits\CustomerTestTrait;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -35,6 +43,33 @@ class CustomerRouteTest extends TestCase
             'id' => $this->ids->create('sales-channel'),
         ]);
         $this->assignSalesChannelContext($this->browser);
+    }
+
+    public function testPartialEntityLoading(): void
+    {
+        $email = Uuid::randomHex() . '@example.com';
+        $id = $this->createCustomer($email);
+
+        $parameters = new SalesChannelContextServiceParameters(
+            TestDefaults::SALES_CHANNEL,
+            Random::getAlphanumericString(32),
+            customerId: $id,
+        );
+        $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get($parameters);
+        $customer = $salesChannelContext->getCustomer();
+
+        static::assertNotNull($customer);
+
+        $criteria = new Criteria([$id]);
+        $criteria->addFields(['email']);
+
+        $partialCustomer = $this->getContainer()
+            ->get(CustomerRoute::class)
+            ->load(new Request(), $salesChannelContext, $criteria, $customer)
+            ->getCustomer();
+
+        static::assertInstanceOf(PartialEntity::class, $partialCustomer);
+        static::assertEquals(['id' => $id, 'email' => $email], $partialCustomer->all());
     }
 
     public function testNotLoggedin(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When providing criteria including the `fields` property to the `CustomerRoute` via PHP, you cannot access the loaded customer via `CustomerResponse::getCustomer`, as its strictly typed as `CustomerEntity` and does not allow for a `PartialEntity`.

### 2. What does this change do, exactly?
Change `CustomerResponse::getCustomer` to also allow `PartialEntity`

### 3. Describe each step to reproduce the issue or behaviour.
- See test case

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
fixes #9774

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
