### PR TITLE
fix: tax rule type needs to be nullable

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2899,24 +2899,6 @@ parameters:
 			path: src/Core/System/SystemConfig/SystemConfigService.php
 
 		-
-			message: '#^Method Shopware\\Core\\System\\Tax\\Aggregate\\TaxRule\\TaxRuleEntity\:\:getData\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
-
-		-
-			message: '#^Method Shopware\\Core\\System\\Tax\\Aggregate\\TaxRule\\TaxRuleEntity\:\:setData\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
-
-		-
-			message: '#^Property Shopware\\Core\\System\\Tax\\Aggregate\\TaxRule\\TaxRuleEntity\:\:\$data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
-
-		-
 			message: '#^Method Shopware\\Core\\System\\Unit\\Aggregate\\UnitTranslation\\UnitTranslationCollection\:\:getLanguageIds\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
+++ b/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Tax\Aggregate\TaxRuleType\TaxRuleTypeEntity;
 use Shopware\Core\System\Tax\TaxEntity;
 
+/**
+ * @phpstan-type TaxRuleData array{states?: list<string>, zipCode?: string, fromZipCode?: string, toZipCode?: string}
+ */
 #[Package('checkout')]
 class TaxRuleEntity extends Entity
 {
@@ -24,10 +27,13 @@ class TaxRuleEntity extends Entity
 
     protected string $taxRuleTypeId;
 
-    protected TaxRuleTypeEntity $type;
+    protected ?TaxRuleTypeEntity $type = null;
 
     protected float $taxRate;
 
+    /**
+     * @var TaxRuleData|null
+     */
     protected ?array $data = null;
 
     protected ?\DateTimeInterface $activeFrom = null;
@@ -82,8 +88,15 @@ class TaxRuleEntity extends Entity
         $this->taxRuleTypeId = $taxRuleTypeId;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - return type will be nullable and condition will be removed
+     */
     public function getType(): TaxRuleTypeEntity
     {
+        if ($this->type === null) {
+            return new TaxRuleTypeEntity();
+        }
+
         return $this->type;
     }
 
@@ -105,11 +118,17 @@ class TaxRuleEntity extends Entity
         $this->taxRate = $taxRate;
     }
 
+    /**
+     * @return TaxRuleData|null
+     */
     public function getData(): ?array
     {
         return $this->data;
     }
 
+    /**
+     * @param TaxRuleData|null $data
+     */
     public function setData(?array $data): void
     {
         $this->data = $data;


### PR DESCRIPTION
### 1. Why is this change necessary?

Many-To-One-Association properties need to be nullable

### 2. What does this change do, exactly?

Make the field nullable

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
