### PR TITLE
fix: handle multiple null values in AfterSort

### DIFF
--- a/changelog/_unreleased/2025-06-25-fix-after-sort-with-multiple-null-values.md
+++ b/changelog/_unreleased/2025-06-25-fix-after-sort-with-multiple-null-values.md
@@ -1,0 +1,10 @@
+---
+title: fix AfterSort with multiple null values
+issue: Ocarthon
+author: Philip Standt
+author_email: philip.standt@strix.net
+author_github: @Philip Standt
+---
+
+# Core
+* Changed `Shopware\Core\Framework\DataAbstractionLayer\Util\AfterSort` to correctly sort collections with multiple null `afterId` values

--- a/src/Core/Framework/DataAbstractionLayer/Util/AfterSort.php
+++ b/src/Core/Framework/DataAbstractionLayer/Util/AfterSort.php
@@ -75,13 +75,12 @@ class AfterSort
             $nextItem = array_shift($elements);
             if ($nextItem && method_exists($nextItem, 'getId')) {
                 $sorted[$nextItem->getId()] = $nextItem;
+                $lastId = $nextItem->getId();
             }
 
             if (!\count($elements)) {
                 break;
             }
-
-            $lastId = $nextItem->$propertyName;
         }
 
         return $sorted;

--- a/tests/unit/Core/Framework/Util/AfterSortTest.php
+++ b/tests/unit/Core/Framework/Util/AfterSortTest.php
@@ -147,6 +147,10 @@ class AfterSortTest extends TestCase
 
     public function testSortingByAfterIdWithMultipleNullValues(): void
     {
+        $root0 = new TestEntity();
+        $root0->setId(Uuid::randomHex());
+        $root0->setName('Root #0');
+
         $root1 = new TestEntity();
         $root1->setId(Uuid::randomHex());
         $root1->setName('Root #1');
@@ -170,13 +174,15 @@ class AfterSortTest extends TestCase
         $root5->setId(Uuid::randomHex());
         $root5->setName('Root #5');
 
-        $afterSortCollection = new AfterSortCollection([$root1, $root2, $root3, $root4, $root5]);
+        // The order of the elements is deliberately wrong
+        $afterSortCollection = new AfterSortCollection([$root0, $root1, $root3, $root2, $root4, $root5]);
 
         $afterSortCollection->sortByAfter();
 
-        $expectedNames = $afterSortCollection->map(fn (TestEntity $entity) => $entity->getName());
+        $expectedNames = array_values($afterSortCollection->map(fn (TestEntity $entity) => $entity->getName()));
+        sort($expectedNames);
 
-        $actualNames = array_map(fn (TestEntity $entity) => $entity->getName(), $afterSortCollection->getElements());
+        $actualNames = array_values(array_map(fn (TestEntity $entity) => $entity->getName(), $afterSortCollection->getElements()));
 
         static::assertSame($expectedNames, $actualNames);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The current `AfterSort` implementation has a bug when handling multiple null `afterId` values. In the test for this case, the values were already sorted.

### 2. What does this change do, exactly?

When no next category is found in `AfterSort`, the `lastId` value is now set to the ID of the next element in the remaining element list. Previously the element's `afterId` was used, which is wrong.

### 3. Describe each step to reproduce the issue or behaviour.

- Go to Shopware administration, create multiple subcategories and shuffle their sorting after creating them
- Create category via the Admin API and set the parent category
```
POST http://localhost/api/category

{
    "name": "test-philip",
    "parentId": "01954d38abd57099af2551701a2b67ad"
}
```
- Reload category overview in administration
- See that the sorting is messed up
- Delete category via Admin-API (doing this via the administration will persist the wrong sorting)
- Reload category overview in administration
- See that the sorting is back

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
