### PR TITLE
feat: allow limiting how many parallel webpack processes are running

### DIFF
--- a/src/Storefront/Resources/app/storefront/webpack.config.js
+++ b/src/Storefront/Resources/app/storefront/webpack.config.js
@@ -532,3 +532,5 @@ const mergedCoreConfig = merge([
 
 // Use multi-compiler
 module.exports = [mergedCoreConfig, ...pluginConfigs];
+// Default is infinity @see https://github.com/webpack/webpack/blob/c109f97b1bf5eceb2e0e498d399f46321f40b07f/lib/MultiCompiler.js#L83
+module.exports.parallelism = process.env.SHOPWARE_BUILD_PARALLELISM ? parseInt(process.env.SHOPWARE_BUILD_PARALLELISM, 10) : Infinity;


### PR DESCRIPTION
### 1. Why is this change necessary?

This allows with env limiting how many webpack processes are running parallel, it's important when you are building ~20 bundles at once. 


### 2. What does this change do, exactly?

Adds new env to limit

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
