### PR TITLE
fix: composer ecs script/command to work on php 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -344,8 +344,14 @@
             "@php bin/console assets:install"
         ],
         "check:license": "bash -c \"vendor/bin/composer-license-checker check -a $(sed -z 's/\\n/ -a /g' .allowed-licenses)\"",
-        "ecs": "php-cs-fixer fix --dry-run --diff",
-        "ecs-fix": "php-cs-fixer fix",
+        "ecs": [
+            "@putenv PHP_CS_FIXER_IGNORE_ENV=true",
+            "php-cs-fixer fix --dry-run --diff"
+        ],
+        "ecs-fix": [
+            "@putenv PHP_CS_FIXER_IGNORE_ENV=true",
+            "php-cs-fixer fix"
+        ],
         "eslint": [
             "@eslint:admin",
             "@eslint:storefront"
@@ -378,7 +384,8 @@
             "export PROJECT_ROOT=\"$PWD\"; \"$PROJECT_ROOT\"/bin/install-extension-npm"
         ],
         "init:testdb": [
-            "FORCE_INSTALL=true vendor/bin/phpunit --group=none --testsuite migration,unit,integration,devops"
+            "@putenv FORCE_INSTALL=true",
+            "vendor/bin/phpunit --group=none --testsuite migration,unit,integration,devops"
         ],
         "lint": [
             "@stylelint",


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently, the Composer PHP version range includes PHP 8.4. If you use this version and try to format the project with "composer ecs-fix," you'll see an error message stating that php-cs-fixer officially only supports PHP versions up to 8.3.
- However, the command works perfectly with PHP 8.4. Therefore, we should simply use the PHP_CS_FIXER_IGNORE_ENV environment variable to enable the command.
- I've also used the Composer function @putenv (https://getcomposer.org/doc/articles/scripts.md#setting-environment-variables) where possible. This currently only works for static exports such as "true," not for other environment variables such as PWD or commands.

### 2. What does this change do, exactly?
- Added the env var `PHP_CS_FIXER_IGNORE_ENV` to the ecs scripts
- Used @putenv where possible

### 3. Describe each step to reproduce the issue or behaviour.
- Use PHP 8.4
- Run "composer:ecs" or "composer:ecs-fix"
- You get the error message `PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.3.*.` even though the command works perfectly in the project

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
