### PR TITLE
chore: make MailServiceTest expected value correct

### DIFF
--- a/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
@@ -389,8 +389,8 @@ class MailServiceTest extends TestCase
 
         static::assertInstanceOf(Email::class, $email);
         $headers = $email->getHeaders();
-        static::assertSame($headers->get('X-Shopware-Language-Id')?->getBody(), Defaults::LANGUAGE_SYSTEM);
-        static::assertSame($headers->get('X-Shopware-Sales-Channel-Id')?->getBody(), $salesChannelId);
+        static::assertSame(Defaults::LANGUAGE_SYSTEM, $headers->get('X-Shopware-Language-Id')?->getBody());
+        static::assertSame($salesChannelId, $headers->get('X-Shopware-Sales-Channel-Id')?->getBody());
 
         // check that no header is empty (e.g. Amazon SES doesn't like that)
         foreach ($headers->all() as $header) {


### PR DESCRIPTION
See https://github.com/shopware/shopware/pull/10540#discussion_r2166846840

This swaps the expected value with the actual value to produce the correct error message in case the test fails.