### PR TITLE
fix: stacking line items marks modified

### DIFF
--- a/changelog/_unreleased/2025-06-26-fix-stacking-line-items-does-not-recalculate-advanced-prices.md
+++ b/changelog/_unreleased/2025-06-26-fix-stacking-line-items-does-not-recalculate-advanced-prices.md
@@ -1,0 +1,10 @@
+---
+title: Fix stacking line items does not recalculate advanced prices
+issue: #10667
+author: Max Stegmeyer
+author_email: m.stegmeyer@shopware.com
+author_github: @mstegmeyer
+
+---
+# Core
+* Changed `\Shopware\Core\Checkout\Cart\LineItem\LineItemCollection` to always mark line items as modified when stacking line items to fix caching behavior.

--- a/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
@@ -49,6 +49,7 @@ class LineItemCollection extends Collection
             }
 
             $exists->setQuantity($newQuantity);
+            $exists->markModified();
 
             return;
         }

--- a/tests/unit/Core/Checkout/Cart/LineItem/LineItemCollectionTest.php
+++ b/tests/unit/Core/Checkout/Cart/LineItem/LineItemCollectionTest.php
@@ -99,7 +99,7 @@ class LineItemCollectionTest extends TestCase
 
         static::assertEquals(
             new LineItemCollection([
-                (new LineItem('A', 'a', null, 6))->setStackable(true)->assign(['uniqueIdentifier' => 'A']),
+                (new LineItem('A', 'a', null, 6))->setStackable(true)->assign(['uniqueIdentifier' => 'A', 'modified' => true]),
             ]),
             $collection
         );
@@ -270,7 +270,7 @@ class LineItemCollectionTest extends TestCase
 
         static::assertEquals(
             new LineItemCollection([
-                (new LineItem('A', 'test', null, 6))->setStackable(true)->assign(['uniqueIdentifier' => 'A']),
+                (new LineItem('A', 'test', null, 6))->setStackable(true)->assign(['uniqueIdentifier' => 'A', 'modified' => true]),
             ]),
             $collection
         );
@@ -285,6 +285,21 @@ class LineItemCollectionTest extends TestCase
         $this->expectException(CartException::class);
 
         $cart->add(new LineItem('a', 'other-type'));
+    }
+
+    public function testStackingLineItemsMarksModified(): void
+    {
+        $cart = new Cart('test');
+
+        $existingLineItem = new LineItem('a', 'type');
+        $existingLineItem->markUnmodified();
+        $existingLineItem->setStackable(true);
+        $cart->add($existingLineItem);
+
+        $cart->add(new LineItem('a', 'type'));
+
+        static::assertTrue($existingLineItem->isModified());
+        static::assertSame(2, $existingLineItem->getQuantity());
     }
 
     public function testGetLineItemByIdentifier(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
More aggressive caching in 6.7 now does not always recalculate advanced prices anymore, when recalculating the cart, for performance reasons.
When stacking line items upon each other, there is no marker set in the line item, that it is modified.

### 2. What does this change do, exactly?
Set the modified flag when stacking.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a product with a different price level at quantity `n`.
- Put `n-1` quantity of that product into a cart.
- Click `Add to cart` on that product again
- The price of the product should be the next level, but isn't in 6.7.0.0

### 4. Please link to the relevant issues (if any).
fixes #10667 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
