### PR TITLE
fix: partial loading in order route via PHP

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/order.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/order.json
@@ -88,7 +88,7 @@
                             "schema": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/components/schemas/NoneFieldsCriteria"
+                                        "$ref": "#/components/schemas/Criteria"
                                     },
                                     {
                                         "properties": {

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -576,7 +576,7 @@ class OrderRouteTest extends TestCase
         $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get($parameters);
 
         $criteria = new Criteria([$this->orderId]);
-        $criteria->addFields(['paymentMethodId']);
+        $criteria->addFields(['currencyId']);
 
         $orders = $this->getContainer()
             ->get(OrderRoute::class)

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -18,12 +18,14 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryStates;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderStates;
+use Shopware\Core\Checkout\Order\SalesChannel\OrderRoute;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailSentEvent;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -38,12 +40,15 @@ use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
 use Shopware\Core\Test\Integration\Traits\Promotion\PromotionIntegrationTestBehaviour;
 use Shopware\Core\Test\Integration\Traits\Promotion\PromotionTestFixtureBehaviour;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Controller\AccountOrderController;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -559,6 +564,35 @@ class OrderRouteTest extends TestCase
         static::assertArrayHasKey('id', $response['orders']['elements'][0]);
         static::assertSame($this->orderId, $response['orders']['elements'][0]['id']);
         static::assertSame(TestDefaults::SALES_CHANNEL, $response['orders']['elements'][0]['salesChannelId']);
+    }
+
+    public function testPartialEntityLoading(): void
+    {
+        $parameters = new SalesChannelContextServiceParameters(
+            TestDefaults::SALES_CHANNEL,
+            $this->browser->getServerParameter('HTTP_SW_CONTEXT_TOKEN'),
+            customerId: $this->customerId,
+        );
+        $salesChannelContext = $this->getContainer()->get(SalesChannelContextService::class)->get($parameters);
+
+        $criteria = new Criteria([$this->orderId]);
+        $criteria->addFields(['paymentMethodId']);
+
+        $orders = $this->getContainer()
+            ->get(OrderRoute::class)
+            ->load(new Request(), $salesChannelContext, $criteria)
+            ->getOrders();
+
+        static::assertCount(1, $orders);
+
+        $order = $orders->first();
+
+        static::assertInstanceOf(PartialEntity::class, $order);
+        static::assertEquals([
+            'id' => $this->orderId,
+            'versionId' => Defaults::LIVE_VERSION,
+            'currencyId' => Defaults::CURRENCY,
+        ], $order->all());
     }
 
     protected function getValidPaymentMethods(): PaymentMethodCollection


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When providing criteria including the `fields` property to the `OrderRoute` via PHP - no error occurs. We can safely allow partial entity loading.

### 2. What does this change do, exactly?
Change store-api definition back to normal criteria

### 3. Describe each step to reproduce the issue or behaviour.
- See test case

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
fixes #9778

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
