### PR TITLE
feat: changed file_exists to suitable is_dir/is_file in namespace storefront

### DIFF
--- a/changelog/_unreleased/2025-06-26-remove-usage-of-file_exists.md
+++ b/changelog/_unreleased/2025-06-26-remove-usage-of-file_exists.md
@@ -1,0 +1,10 @@
+---
+title: Remove usage of file_exists
+issue: 5913
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Storefront
+* Changed usage of `file_exists` to better suiting functions `is_dir` or `is_file`

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -64,7 +64,7 @@ class ThemeCreateCommand extends Command
 
         $directory = \sprintf('%s/custom/%splugins/%s', $this->projectDir, $staticPrefix, $pluginName);
 
-        if (file_exists($directory)) {
+        if (\is_dir($directory)) {
             $io->error(\sprintf('Plugin directory %s already exists', $directory));
 
             return self::FAILURE;

--- a/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+++ b/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
@@ -135,7 +135,7 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
 
         $scriptPath = $path . \sprintf('/Resources/app/storefront/dist/storefront/js/%s/%s.js', $assetName, $assetName);
 
-        if (file_exists($scriptPath)) {
+        if (\is_file($scriptPath)) {
             $config->setScriptFiles(FileCollection::createFromArray([$this->stripBasePath($scriptPath, $path . '/Resources')]));
 
             return $config;
@@ -191,11 +191,11 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
     {
         $path = rtrim($path, '/') . '/Resources/app/storefront/src';
 
-        if (file_exists($path . '/main.ts')) {
+        if (\is_file($path . '/main.ts')) {
             return 'app/storefront/src/main.ts';
         }
 
-        if (file_exists($path . '/main.js')) {
+        if (\is_file($path . '/main.js')) {
             return 'app/storefront/src/main.js';
         }
 

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -144,12 +144,12 @@ class ThemeCompiler implements ThemeCompilerInterface
                     $filename = basename($originalPath);
                     $extension = $this->getImportFileExtension(pathinfo($filename, \PATHINFO_EXTENSION));
                     $path = $dirname . \DIRECTORY_SEPARATOR . $filename . $extension;
-                    if (file_exists($path)) {
+                    if (\is_file($path)) {
                         return $path;
                     }
 
                     $path = $dirname . \DIRECTORY_SEPARATOR . '_' . $filename . $extension;
-                    if (file_exists($path)) {
+                    if (\is_file($path)) {
                         return $path;
                     }
                 }
@@ -193,8 +193,9 @@ class ThemeCompiler implements ThemeCompilerInterface
 
             $targetPath = $themePath . '/js/' . $folderName;
             foreach ($files as $file) {
-                if (file_exists($file->getRealPath())) {
-                    $copyFiles[] = new CopyBatchInput($file->getRealPath(), [$targetPath . '/' . $file->getFilename()], $this->themeFilesystemConfig['visibility'] ?? Visibility::PUBLIC);
+                $filePath = $file->getRealPath();
+                if ($filePath) {
+                    $copyFiles[] = new CopyBatchInput($filePath, [$targetPath . '/' . $file->getFilename()], $this->themeFilesystemConfig['visibility'] ?? Visibility::PUBLIC);
                 }
             }
         }

--- a/src/Storefront/Theme/ThemeFileResolver.php
+++ b/src/Storefront/Theme/ThemeFileResolver.php
@@ -115,7 +115,7 @@ class ThemeFileResolver
         foreach ($files as $file) {
             $filepath = $file->getFilepath();
             if (!$this->isInclude($filepath)) {
-                if (file_exists($filepath)) {
+                if (\is_file($filepath)) {
                     $resolvedFiles->add($file);
 
                     continue;


### PR DESCRIPTION
### 1. Why is this change necessary?
see #5913

This is the successor of PR #9541 ( @nfortier-shopware  )

### 2. What does this change do, exactly?
Changed any usage of `file_exists` to `is_dir` or `is_file` in Storefront namespace.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
#5913

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
