### PR TITLE
fix: stacking line items marks [6.7.0.0]

### DIFF
--- a/changelog/_unreleased/2025-06-26-fix-stacking-line-items-does-not-recalculate-advanced-prices.md
+++ b/changelog/_unreleased/2025-06-26-fix-stacking-line-items-does-not-recalculate-advanced-prices.md
@@ -1,0 +1,10 @@
+---
+title: Fix stacking line items does not recalculate advanced prices
+issue: #10667
+author: Max Stegmeyer
+author_email: m.stegmeyer@shopware.com
+author_github: @mstegmeyer
+
+---
+# Core
+* Changed `\Shopware\Core\Checkout\Cart\LineItem\LineItemCollection` to always mark line items as modified when stacking line items to fix caching behavior.

--- a/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
@@ -49,6 +49,7 @@ class LineItemCollection extends Collection
             }
 
             $exists->setQuantity($newQuantity);
+            $exists->markModified();
 
             return;
         }

--- a/tests/unit/Core/Checkout/Cart/LineItem/LineItemCollectionTest.php
+++ b/tests/unit/Core/Checkout/Cart/LineItem/LineItemCollectionTest.php
@@ -99,7 +99,7 @@ class LineItemCollectionTest extends TestCase
 
         static::assertEquals(
             new LineItemCollection([
-                (new LineItem('A', 'a', null, 6))->setStackable(true)->assign(['uniqueIdentifier' => 'A']),
+                (new LineItem('A', 'a', null, 6))->setStackable(true)->assign(['uniqueIdentifier' => 'A', 'modified' => true]),
             ]),
             $collection
         );
@@ -270,7 +270,7 @@ class LineItemCollectionTest extends TestCase
 
         static::assertEquals(
             new LineItemCollection([
-                (new LineItem('A', 'test', null, 6))->setStackable(true)->assign(['uniqueIdentifier' => 'A']),
+                (new LineItem('A', 'test', null, 6))->setStackable(true)->assign(['uniqueIdentifier' => 'A', 'modified' => true]),
             ]),
             $collection
         );
@@ -285,6 +285,21 @@ class LineItemCollectionTest extends TestCase
         $this->expectException(CartException::class);
 
         $cart->add(new LineItem('a', 'other-type'));
+    }
+
+    public function testStackingLineItemsMarksModified(): void
+    {
+        $cart = new Cart('test');
+
+        $existingLineItem = new LineItem('a', 'type');
+        $existingLineItem->markUnmodified();
+        $existingLineItem->setStackable(true);
+        $cart->add($existingLineItem);
+
+        $cart->add(new LineItem('a', 'type'));
+
+        static::assertTrue($existingLineItem->isModified());
+        static::assertSame(2, $existingLineItem->getQuantity());
     }
 
     public function testGetLineItemByIdentifier(): void


### PR DESCRIPTION
Manual backport of #10821 
fixes #10667 