### PR TITLE
fix: unable to fall back to parent language on product entity

### DIFF
--- a/changelog/_unreleased/2025-06-27-fix-unable-to-fall-back-to-parent-language-on-product-entity.md
+++ b/changelog/_unreleased/2025-06-27-fix-unable-to-fall-back-to-parent-language-on-product-entity.md
@@ -1,0 +1,9 @@
+---
+title: Fix unable to fall back to parent language on product entity
+issue: 9909
+---
+# Administration
+* Changed `validate` method in `entity-validation` service to allow ignoring fields when validating product entity.
+* Changed method `onSave` in `sw-product-detail` component to set ignore fields to validate product entity with ignored field.
+* Added `ignoreFieldsValidate` computed in `sw-product-detail` component to get ignore fields with language inherited.
+* Added `loadLanguage` method in `sw-product-detail` component to load language data when change language.

--- a/src/Administration/Resources/app/administration/src/app/service/entity-validation.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/entity-validation.service.spec.js
@@ -178,4 +178,28 @@ describe('src/app/service/entity-validation.service.js', () => {
         expect(customValidator.mock.calls[0][2]).toBe(Shopware.EntityDefinition.get(testEntity.getEntityName())); // entity definition
         expect(customValidator.mock.results[0].value).toEqual(expectedErrors); // should return the errors
     });
+
+    it('should validate a complete product with ignore fields and report no errors', () => {
+        const service = createService();
+        service.errorResolver.handleWriteErrors = jest.fn(() => undefined);
+        const testEntity = entityFactory.create('product');
+        testEntity.name = null;
+        testEntity.stock = 5;
+        testEntity.productNumber = 'MyProductNumber';
+        testEntity.taxId = 'some-tax-uuid';
+        testEntity.price = [
+            {
+                gross: 10,
+                net: 10,
+            },
+        ];
+
+        const ignoreFields = ['name'];
+
+        const isValid = service.validate(testEntity, undefined, ignoreFields);
+        expect(isValid).toBe(true);
+
+        expect(service.errorResolver.handleWriteErrors.mock.calls).toHaveLength(1);
+        expect(service.errorResolver.handleWriteErrors.mock.calls[0][1].errors).toEqual([]);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/service/entity-validation.service.ts
+++ b/src/Administration/Resources/app/administration/src/app/service/entity-validation.service.ts
@@ -68,7 +68,11 @@ export default class EntityValidationService {
      * A CustomValidator callback can be provided to modify or add to the found errors.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public validate(entity: Entity<any>, customValidator: CustomValidator | undefined): boolean {
+    public validate(
+        entity: Entity<any>,
+        customValidator: CustomValidator | undefined,
+        ignoreFields: string[] = [],
+    ): boolean {
         // eslint-disable-next-line max-len
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
         const entityName = entity.getEntityName();
@@ -78,7 +82,12 @@ export default class EntityValidationService {
         let errors: ValidationError[] = [];
 
         // check for required fields
-        const requiredFields = definition.getRequiredFields() as Record<string, never>;
+        const requiredFields = Object.fromEntries(
+            Object.entries(definition.getRequiredFields() as Record<string, never>).filter(
+                ([key]) => !ignoreFields.includes(key),
+            ),
+        ) as Omit<Record<string, any>, (typeof ignoreFields)[number]>;
+
         errors.push(...this.getRequiredErrors(entity, requiredFields));
 
         // run custom validator

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
@@ -545,4 +545,128 @@ describe('module/sw-product/page/sw-product-detail', () => {
         ]);
         expect(wrapper.vm.loadProduct).toHaveBeenCalled();
     });
+
+    it('should not validate fields when language is inherited', async () => {
+        const spyValidationService = jest.spyOn(wrapper.vm.entityValidationService, 'validate');
+
+        wrapper.vm.getCmsPageOverrides = jest.fn(() => {
+            return null;
+        });
+        wrapper.vm.product.isNew = jest.fn(() => {
+            return false;
+        });
+        wrapper.vm.product.prices = [];
+        wrapper.vm.product.price = [
+            {
+                currencyId: undefined,
+                linked: true,
+                gross: 100,
+                net: 84.034,
+                listPrice: {
+                    currencyId: undefined,
+                    linked: true,
+                    gross: 0,
+                    net: 0,
+                },
+                regulationPrice: {
+                    currencyId: undefined,
+                    linked: true,
+                    gross: 0,
+                    net: 0,
+                },
+            },
+        ];
+
+        wrapper.vm.saveProduct = jest.fn(() => {
+            return Promise.resolve();
+        });
+
+        wrapper.vm.product.getEntityName = () => 'product';
+        Shopware.EntityDefinition.get = () => ({
+            properties: {
+                name: {
+                    type: 'string',
+                    flags: {
+                        required: true,
+                    },
+                },
+            },
+        });
+
+        Shopware.Store.get('context').api.language = {
+            id: '1a2b3c',
+            parentId: 'd4e5f6',
+        };
+
+        wrapper.vm.product.name = null;
+
+        await wrapper.vm.onSave();
+
+        expect(wrapper.vm.ignoreFieldsValidation).toContain('name');
+        expect(spyValidationService).toHaveBeenCalledWith(
+            wrapper.vm.product,
+            expect.anything(),
+            expect.arrayContaining(['name']),
+        );
+    });
+
+    it('should validate fields when language is not inherited', async () => {
+        const spyValidationService = jest.spyOn(wrapper.vm.entityValidationService, 'validate');
+
+        wrapper.vm.getCmsPageOverrides = jest.fn(() => {
+            return null;
+        });
+        wrapper.vm.product.isNew = jest.fn(() => {
+            return false;
+        });
+        wrapper.vm.product.prices = [];
+        wrapper.vm.product.price = [
+            {
+                currencyId: undefined,
+                linked: true,
+                gross: 100,
+                net: 84.034,
+                listPrice: {
+                    currencyId: undefined,
+                    linked: true,
+                    gross: 0,
+                    net: 0,
+                },
+                regulationPrice: {
+                    currencyId: undefined,
+                    linked: true,
+                    gross: 0,
+                    net: 0,
+                },
+            },
+        ];
+
+        wrapper.vm.saveProduct = jest.fn(() => {
+            return Promise.resolve();
+        });
+
+        wrapper.vm.product.getEntityName = () => 'product';
+        Shopware.EntityDefinition.get = () => ({
+            properties: {
+                name: {
+                    type: 'string',
+                    flags: {
+                        required: true,
+                    },
+                },
+            },
+        });
+
+        Shopware.Store.get('context').api.language = {
+            id: '1a2b3c',
+            parentId: null,
+        };
+
+        wrapper.vm.product.name = null;
+
+        await wrapper.vm.onSave();
+
+        expect(wrapper.vm.ignoreFieldsValidation).not.toContain('name');
+        expect(spyValidationService).toHaveBeenCalledWith(wrapper.vm.product, expect.anything(), []);
+    });
 });


### PR DESCRIPTION
This pull request introduces a fix for the issue where product entities were unable to fall back to the parent language, along with enhancements to the entity validation process. The most significant changes include adding support for ignoring certain fields during validation, implementing language inheritance handling for product entities, and updating the relevant tests to ensure correctness.

### Enhancements to Entity Validation:

* Modified the `validate` method in `EntityValidationService` to accept an `ignoreFields` parameter, allowing specific fields to be excluded from validation. Updated the logic to filter out ignored fields when checking for required fields. (`src/Administration/Resources/app/administration/src/app/service/entity-validation.service.ts`, [[1]](diffhunk://#diff-4f9b310423bdcfaa4e3e82e968697dfd80abacbcb0fcfc0175363965753a96f7L71-R75) [[2]](diffhunk://#diff-4f9b310423bdcfaa4e3e82e968697dfd80abacbcb0fcfc0175363965753a96f7L81-R96)

### Language Inheritance Handling for Product Entities:

* Added a new method `ignoreFieldsValidate` in the `sw-product-detail` component to dynamically determine which fields to ignore during validation based on language inheritance. (`src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js`, [src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.jsR1244-R1265](diffhunk://#diff-e2d623f2b3caa0af769855ca06293d72a1822a8fbdff1fac4dd5ff32adb65877R1244-R1265))
* Updated the `onSave` method to use the `ignoreFieldsValidate` method when calling the `validate` method of `EntityValidationService`. (`src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js`, [src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.jsL891-R901](diffhunk://#diff-e2d623f2b3caa0af769855ca06293d72a1822a8fbdff1fac4dd5ff32adb65877L891-R901))
* Introduced a `loadLanguage` method to handle language inheritance and ensure proper context when switching languages. (`src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js`, [src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.jsR1244-R1265](diffhunk://#diff-e2d623f2b3caa0af769855ca06293d72a1822a8fbdff1fac4dd5ff32adb65877R1244-R1265))

### Test Coverage:

* Added unit tests to verify the behavior of `ignoreFieldsValidate` for both inherited and non-inherited languages. (`src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js`, [src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.jsR548-R603](diffhunk://#diff-6e74a5057b0cc8999f5567e415d1a83a79135cc6f740bdcad83563825f127997R548-R603))
* Added a test case to ensure validation succeeds when ignored fields are excluded. (`src/Administration/Resources/app/administration/src/app/service/entity-validation.service.spec.js`, [src/Administration/Resources/app/administration/src/app/service/entity-validation.service.spec.jsR181-R204](diffhunk://#diff-10f27c35135bf6cbf921c7a8f47fa52f021961654e45a5c4612d35cf758ce232R181-R204))