### PR TITLE
Feat: Allow to ignore bound sales channel

### DIFF
--- a/changelog/_unreleased/2025-06-27-add-option-to-ignore-bound-sales-channel.md
+++ b/changelog/_unreleased/2025-06-27-add-option-to-ignore-bound-sales-channel.md
@@ -1,0 +1,10 @@
+---
+title: Add option to ignore bound sales channel when building a context
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+* Changed: Added new parameter to ignore bound sales channel when building a sales channel context in `Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory`

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
@@ -243,10 +243,12 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
         $source = $context->getSource();
         \assert($source instanceof SalesChannelApiSource);
 
-        $criteria->addFilter(new MultiFilter(MultiFilter::CONNECTION_OR, [
-            new EqualsFilter('customer.boundSalesChannelId', null),
-            new EqualsFilter('customer.boundSalesChannelId', $source->getSalesChannelId()),
-        ]));
+        if (!isset($options[SalesChannelContextService::IGNORE_SALES_CHANNEL_BOUND]) || !$options[SalesChannelContextService::IGNORE_SALES_CHANNEL_BOUND]) {
+            $criteria->addFilter(new MultiFilter(MultiFilter::CONNECTION_OR, [
+                new EqualsFilter('customer.boundSalesChannelId', null),
+                new EqualsFilter('customer.boundSalesChannelId', $source->getSalesChannelId()),
+            ]));
+        }
 
         $customer = $this->customerRepository->search($criteria, $context)->getEntities()->get($customerId);
         if (!$customer) {

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -44,6 +44,8 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
 
     final public const IMITATING_USER_ID = 'imitatingUserId';
 
+    final public const IGNORE_SALES_CHANNEL_BOUND = 'ignore_sales_channel_bound';
+
     /**
      * @internal
      */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When we build a sales channel context for a customer, we always take its bounded sales channel into account but in some cases we do not want this. In our specific case, this is when we create an order for a customer (that is linked to the webshop sales channel) via the POS (other sales channel) as the store.

### 2. What does this change do, exactly?
This change adds an option to ignore the bounded sales channel when building a sales channel context.

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
