### PR TITLE
feat: mark generated demo data

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1893,18 +1893,6 @@ parameters:
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Framework/Demodata/DemodataService.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Framework/Demodata/Generator/ProductGenerator.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DependencyInjection/CompilerPass/FeatureFlagCompilerPass.php
 

--- a/src/Core/Framework/Demodata/DemodataException.php
+++ b/src/Core/Framework/Demodata/DemodataException.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Demodata;
+
+use Shopware\Core\Framework\HttpException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore
+ */
+#[Package('framework')]
+class DemodataException extends HttpException
+{
+    final public const WRONG_EXECUTION_ORDER = 'FRAMEWORK__WRONG_EXECUTION_ORDER';
+    final public const NO_GENERATOR_FOUND = 'FRAMEWORK__NO_GENERATOR_FOUND';
+
+    public static function wrongExecutionOrder(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::WRONG_EXECUTION_ORDER,
+            'This demo data command should be executed after the original demo data was executed at least one time',
+            []
+        );
+    }
+
+    public static function noGeneratorFound(string $entity): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::NO_GENERATOR_FOUND,
+            'Could not generate demodata for "{{ entity }}" because no generator is registered.',
+            ['entity' => $entity]
+        );
+    }
+}

--- a/src/Core/Framework/Demodata/DemodataService.php
+++ b/src/Core/Framework/Demodata/DemodataService.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[Package('framework')]
 class DemodataService
 {
+    public const DEMODATA_CUSTOM_FIELDS_KEY = 'shopwareDemoData';
+
     /**
      * @internal
      *
@@ -54,9 +56,7 @@ class DemodataService
             $validGenerators = array_filter(iterator_to_array($this->generators), static fn (DemodataGeneratorInterface $generator) => $generator->getDefinition() === $definitionClass);
 
             if (empty($validGenerators)) {
-                throw new \RuntimeException(
-                    \sprintf('Could not generate demodata for "%s" because no generator is registered.', $definitionClass)
-                );
+                throw DemodataException::noGeneratorFound($definitionClass);
             }
 
             $start = microtime(true);

--- a/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -95,6 +96,7 @@ class CategoryGenerator implements DemodataGeneratorInterface
             'mediaId' => $context->getRandomId('media'),
             'description' => $context->getFaker()->text(),
             'tags' => $this->getTags($tags),
+            'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
         ];
 
         if ($current >= $max) {

--- a/src/Core/Framework/Demodata/Generator/CustomerGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CustomerGenerator.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
@@ -94,6 +95,7 @@ class CustomerGenerator implements DemodataGeneratorInterface
             'salesChannelId' => $salesChannelIds[array_rand($salesChannelIds)],
             'defaultBillingAddressId' => $billingAddressId,
             'defaultShippingAddressId' => $shippingAddressId,
+            'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             'addresses' => [
                 [
                     'id' => $shippingAddressId,
@@ -182,6 +184,7 @@ class CustomerGenerator implements DemodataGeneratorInterface
                 'addresses' => $addresses,
                 'tags' => $this->getTags($tags),
                 'createdAt' => $randomDate->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             ];
 
             $payload[] = $customer;

--- a/src/Core/Framework/Demodata/Generator/FlowGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/FlowGenerator.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Event\BusinessEventCollector;
 use Shopware\Core\Framework\Event\BusinessEventDefinition;
 use Shopware\Core\Framework\Log\Package;
@@ -106,6 +107,7 @@ class FlowGenerator implements DemodataGeneratorInterface
                 'eventName' => $event->getName(),
                 'priority' => $i + 1,
                 'active' => true,
+                'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             ];
 
             $sequenceTreeCount = random_int(1, $maxSequenceTree);

--- a/src/Core/Framework/Demodata/Generator/MailHeaderFooterGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MailHeaderFooterGenerator.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -87,6 +88,7 @@ class MailHeaderFooterGenerator implements DemodataGeneratorInterface
                 $context
             ),
             'footerPlain' => $faker->text(),
+            'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
         ];
     }
 

--- a/src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -102,6 +103,7 @@ class MailTemplateGenerator implements DemodataGeneratorInterface
             ),
             'contentPlain' => $faker->text(),
             'mailTemplateTypeId' => $mailTypeId,
+            'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
         ];
     }
 

--- a/src/Core/Framework/Demodata/Generator/MediaGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MediaGenerator.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -74,6 +75,7 @@ class MediaGenerator implements DemodataGeneratorInterface
                         'mediaFolderId' => $isDownloadFile ? $downloadFolderId : $mediaFolderId,
                         'private' => $isDownloadFile,
                         'tags' => $this->getTags($tags),
+                        'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
                     ],
                 ],
                 $writeContext

--- a/src/Core/Framework/Demodata/Generator/OrderGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/OrderGenerator.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
@@ -111,6 +112,7 @@ class OrderGenerator implements DemodataGeneratorInterface
 
             $tempOrder['orderDateTime'] = $randomDate->format(Defaults::STORAGE_DATE_TIME_FORMAT);
             $tempOrder['tags'] = $this->getTags($tags);
+            $tempOrder['customFields'] = [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true];
 
             $orders[] = $tempOrder;
 

--- a/src/Core/Framework/Demodata/Generator/ProductGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductGenerator.php
@@ -15,7 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Indexing\InheritanceUpdater;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Demodata\DemodataContext;
+use Shopware\Core\Framework\Demodata\DemodataException;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -67,7 +69,7 @@ class ProductGenerator implements DemodataGeneratorInterface
         $taxes = $this->getTaxes($context);
 
         if ($taxes->count() === 0) {
-            throw new \RuntimeException('This demo data command should be executed after the original demo data was executed at least one time');
+            throw DemodataException::wrongExecutionOrder();
         }
 
         $properties = $this->getProperties();
@@ -298,6 +300,7 @@ class ProductGenerator implements DemodataGeneratorInterface
             'categories' => $this->getCategoryIds(),
             'tags' => $this->getTags($tags),
             'stock' => $this->faker->numberBetween(1, 50),
+            'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
         ];
     }
 

--- a/src/Core/Framework/Demodata/Generator/ProductManufacturerGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductManufacturerGenerator.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -40,6 +41,7 @@ class ProductManufacturerGenerator implements DemodataGeneratorInterface
                 'id' => Uuid::randomHex(),
                 'name' => $context->getFaker()->format('company'),
                 'link' => $context->getFaker()->format('url'),
+                'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             ];
         }
 

--- a/src/Core/Framework/Demodata/Generator/ProductReviewGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductReviewGenerator.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -70,6 +71,7 @@ class ProductReviewGenerator implements DemodataGeneratorInterface
                 'content' => $context->getFaker()->text(),
                 'points' => $context->getFaker()->randomElement($points),
                 'status' => (bool) random_int(0, 1),
+                'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             ];
 
             if (\count($payload) >= 100) {

--- a/src/Core/Framework/Demodata/Generator/ProductStreamGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductStreamGenerator.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -70,6 +71,7 @@ class ProductStreamGenerator implements DemodataGeneratorInterface
                 'name' => $faker->format('productName'),
                 'description' => $faker->text(),
                 'filters' => [['type' => 'multi', 'operator' => 'OR', 'queries' => $filters]],
+                'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             ];
         }
 

--- a/src/Core/Framework/Demodata/Generator/PromotionGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/PromotionGenerator.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -101,6 +102,7 @@ class PromotionGenerator implements DemodataGeneratorInterface
             'code' => $this->faker->unique()->format('promotionCode'),
             'useCodes' => true,
             'discounts' => $this->createDiscounts(),
+            'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
         ];
     }
 

--- a/src/Core/Framework/Demodata/Generator/PropertyGroupGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/PropertyGroupGenerator.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -66,6 +67,7 @@ class PropertyGroupGenerator implements DemodataGeneratorInterface
                         'options' => $mapped,
                         'sorting_type' => PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC,
                         'display_type' => PropertyGroupDefinition::DISPLAY_TYPE_TEXT,
+                        'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
                     ],
                 ],
                 $context->getContext()

--- a/src/Core/Framework/Demodata/Generator/RuleGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/RuleGenerator.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Container\AndRule;
 use Shopware\Core\Framework\Rule\Container\Container;
@@ -112,6 +113,7 @@ class RuleGenerator implements DemodataGeneratorInterface
                 'priority' => $i,
                 'name' => implode(' + ', $names),
                 'description' => $context->getFaker()->text(),
+                'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             ];
 
             $ruleData['conditions'][] = $this->buildChildRule(null, (new OrRule())->assign(['rules' => $classes]));

--- a/src/Core/Framework/Demodata/Generator/TagGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/TagGenerator.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Tag\TagDefinition;
@@ -39,6 +40,7 @@ class TagGenerator implements DemodataGeneratorInterface
             $payload[] = [
                 'id' => Uuid::randomHex(),
                 'name' => $context->getFaker()->format('productName') . ' Tag',
+                'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             ];
         }
 

--- a/src/Core/Framework/Demodata/Generator/UserGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/UserGenerator.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
@@ -58,6 +59,7 @@ class UserGenerator implements DemodataGeneratorInterface
                 'email' => $id . $context->getFaker()->format('safeEmail'),
                 'password' => 'shopware',
                 'localeId' => $this->getLocaleId($context->getContext()),
+                'customFields' => [DemodataService::DEMODATA_CUSTOM_FIELDS_KEY => true],
             ];
 
             $payload[] = $user;


### PR DESCRIPTION
### 1. Why is this change necessary?

When u ran on production data demo data generate, you can't easily remove the demo data.


### 2. What does this change do, exactly?

You can now delete them by custom field data:

```sql
DELETE FROM customer WHERE JSON_UNQUOTE(JSON_EXTRACT(custom_fields, '$.demodata')) = 'true'
```


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
