### PR TITLE
ci: fix environment namings

### DIFF
--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -79,7 +79,7 @@ jobs:
   split:
     needs: build
     runs-on: ubuntu-24.04
-    environment: ${{ format('manyrepos_', github.ref_type) }}
+    environment: ${{ format('manyrepos_{0}', github.ref_type) }}
     # we use this image to get an older git version, which does not suffer from a performance regression
     container: node:alpine3.19
     if: github.repository == 'shopware/shopware'

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -79,7 +79,7 @@ jobs:
   split:
     needs: build
     runs-on: ubuntu-24.04
-    environment: ${{ format('manyrepos ({0})', github.ref_type) }}
+    environment: ${{ format('manyrepos_', github.ref_type) }}
     # we use this image to get an older git version, which does not suffer from a performance regression
     container: node:alpine3.19
     if: github.repository == 'shopware/shopware'


### PR DESCRIPTION
octo sts does not allow `()` in subject

See https://github.com/octo-sts/app/commit/b3976e39bd8c8c217c0670747d34a4499043da92#diff-53f80501c6cd3e68ea7e0860642e466c42ab1fe47a1313bdd99f2fb2b3bb568e