### PR TITLE
fix: duplicate checkout gateway filter

### DIFF
--- a/changelog/_unreleased/2025-06-27-fix-duplicate-checkout-gateway-filter.md
+++ b/changelog/_unreleased/2025-06-27-fix-duplicate-checkout-gateway-filter.md
@@ -5,4 +5,4 @@ author_email: Discord.Benjamin@web.de
 author_github: gecolay
 ---
 # Core
-* Changed `CheckoutGatewayRoute` to directly use the `paymentMethodRoute` & `shippingMethodRoute` as they are already filtered by the `onlyAvailable` parameter
+* Changed `Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRoute` to directly use the `paymentMethodRoute` & `shippingMethodRoute` as they are already filtered by the `onlyAvailable` parameter

--- a/changelog/_unreleased/2025-06-27-fix-duplicate-checkout-gateway-filter.md
+++ b/changelog/_unreleased/2025-06-27-fix-duplicate-checkout-gateway-filter.md
@@ -1,0 +1,8 @@
+---
+title: Fix duplicate checkout gateway filter
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `CheckoutGatewayRoute` to directly use the `paymentMethodRoute` & `shippingMethodRoute` as they are already filtered by the `onlyAvailable` parameter

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -206,7 +206,6 @@
             <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRoute"/>
             <argument type="service" id="Shopware\Core\Framework\App\Checkout\Gateway\AppCheckoutGateway"/>
-            <argument type="service" id="Shopware\Core\Framework\Rule\RuleIdMatcher"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Gateway\Command\Registry\CheckoutGatewayCommandRegistry">

--- a/src/Core/Checkout/Gateway/SalesChannel/CheckoutGatewayRoute.php
+++ b/src/Core/Checkout/Gateway/SalesChannel/CheckoutGatewayRoute.php
@@ -13,7 +13,6 @@ use Shopware\Core\Checkout\Shipping\SalesChannel\AbstractShippingMethodRoute;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Rule\RuleIdMatcher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -29,7 +28,6 @@ class CheckoutGatewayRoute extends AbstractCheckoutGatewayRoute
         private readonly AbstractPaymentMethodRoute $paymentMethodRoute,
         private readonly AbstractShippingMethodRoute $shippingMethodRoute,
         private readonly CheckoutGatewayInterface $checkoutGateway,
-        private readonly RuleIdMatcher $ruleIdMatcher,
     ) {
     }
 

--- a/src/Core/Checkout/Gateway/SalesChannel/CheckoutGatewayRoute.php
+++ b/src/Core/Checkout/Gateway/SalesChannel/CheckoutGatewayRoute.php
@@ -47,13 +47,11 @@ class CheckoutGatewayRoute extends AbstractCheckoutGatewayRoute
         $paymentCriteria->addAssociation('appPaymentMethod.app');
         $shippingCriteria->addAssociation('appShippingMethod.app');
 
+        // Only load available payment and shipping methods from the routes
         $request->query->set('onlyAvailable', '1');
 
-        $result = $this->paymentMethodRoute->load($request, $context, $paymentCriteria);
-        $paymentMethods = $this->ruleIdMatcher->filterCollection($result->getPaymentMethods(), $context->getRuleIds());
-
-        $result = $this->shippingMethodRoute->load($request, $context, $shippingCriteria);
-        $shippingMethods = $this->ruleIdMatcher->filterCollection($result->getShippingMethods(), $context->getRuleIds());
+        $paymentMethods = $this->paymentMethodRoute->load($request, $context, $paymentCriteria)->getPaymentMethods();
+        $shippingMethods = $this->shippingMethodRoute->load($request, $context, $shippingCriteria)->getShippingMethods();
 
         $payload = new CheckoutGatewayPayloadStruct($cart, $context, $paymentMethods, $shippingMethods);
         $response = $this->checkoutGateway->process($payload);

--- a/tests/unit/Core/Checkout/Gateway/SalesChannel/CheckoutGatewayRouteTest.php
+++ b/tests/unit/Core/Checkout/Gateway/SalesChannel/CheckoutGatewayRouteTest.php
@@ -32,7 +32,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Rule\RuleIdMatcher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\Test\Generator;
@@ -51,7 +50,6 @@ class CheckoutGatewayRouteTest extends TestCase
             $this->createMock(AbstractPaymentMethodRoute::class),
             $this->createMock(AbstractShippingMethodRoute::class),
             $this->createMock(CheckoutGatewayInterface::class),
-            $this->createMock(RuleIdMatcher::class),
         );
 
         $this->expectException(DecorationPatternException::class);
@@ -126,13 +124,7 @@ class CheckoutGatewayRouteTest extends TestCase
             ->with(static::equalTo($payload))
             ->willReturn($response);
 
-        $ruleIdMatcher = $this->createMock(RuleIdMatcher::class);
-        $ruleIdMatcher
-            ->expects($this->exactly(2))
-            ->method('filterCollection')
-            ->willReturnArgument(0);
-
-        $route = new CheckoutGatewayRoute($paymentMethodRoute, $shippingMethodRoute, $checkoutGateway, $ruleIdMatcher);
+        $route = new CheckoutGatewayRoute($paymentMethodRoute, $shippingMethodRoute, $checkoutGateway);
         $result = $route->load($request, $cart, $context);
 
         static::assertSame($paymentMethods->getPaymentMethods(), $result->getPaymentMethods());
@@ -217,17 +209,10 @@ class CheckoutGatewayRouteTest extends TestCase
             ->with(static::equalTo($payload))
             ->willReturn($response);
 
-        $ruleIdMatcher = $this->createMock(RuleIdMatcher::class);
-        $ruleIdMatcher
-            ->expects($this->exactly(2))
-            ->method('filterCollection')
-            ->willReturnArgument(0);
-
         $route = new CheckoutGatewayRoute(
             $paymentMethodRoute,
             $shippingMethodRoute,
             $checkoutGateway,
-            $ruleIdMatcher
         );
 
         $result = $route->load($request, $cart, $context);
@@ -277,7 +262,6 @@ class CheckoutGatewayRouteTest extends TestCase
             $paymentMethodRoute,
             $shippingMethodRoute,
             $checkoutGateway,
-            new RuleIdMatcher()
         );
 
         $route->load(new Request(), new Cart('hatoken'), $context);


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the `CheckoutGatewayRoute` adds the `onlyAvailable` to the request, which gets passed to the `paymentMethodRoute` & `shippingMethodRoute`
- Because of this parameter the `paymentMethodRoute` & `shippingMethodRoute` already return a filtered collection
- We don't have to filter the result again

#### Alternative to the current PR changes:
- Remove the `$request->query->set('onlyAvailable', '1');` from the `CheckoutGatewayRoute` and always filter only inside the `CheckoutGatewayRoute`

### 2. What does this change do, exactly?
* Changed `CheckoutGatewayRoute` to directly use the `paymentMethodRoute` & `shippingMethodRoute` as they are already filtered by the `onlyAvailable` parameter

### 3. Describe each step to reproduce the issue or behaviour.
- Load the CheckoutGatewayRoute

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
