### PR TITLE
feat: Theme config validation

### DIFF
--- a/changelog/_unreleased/2025-06-27-add-theme-config-validation.md
+++ b/changelog/_unreleased/2025-06-27-add-theme-config-validation.md
@@ -1,0 +1,10 @@
+---
+title: Add validation for theme configuration
+issue: #10679
+---
+# Storefront
+* Added new method `validateThemeConfig()` to `ThemeService.php` for validating theme configuration changes.
+* Added new boolean parameter `validate` to API route `/api/_action/theme/{themeId}` in `ThemeController.php` which will activate the config validation on theme update.
+* Added new boolean parameter `sanitize` to API route `/api/_action/theme/{themeId}` in `ThemeController.php` which will activate config sanitization during validation. Only applies if `validate` is set.
+# Administration
+* Changed the theme manager module to trigger theme config validation on theme update. Reported errors will be mapped to the corresponding form fields to show the user which fields are invalid.

--- a/changelog/_unreleased/2025-06-27-add-theme-config-validation.md
+++ b/changelog/_unreleased/2025-06-27-add-theme-config-validation.md
@@ -3,9 +3,9 @@ title: Add validation for theme configuration
 issue: #10679
 ---
 # Storefront
-* Added new method `validateThemeConfig()` to `ThemeService.php` for validating theme configuration changes.
-* Added new boolean parameter `validate` to API route `/api/_action/theme/{themeId}` in `ThemeController.php` which will activate the config validation on theme update.
-* Added new boolean parameter `sanitize` to API route `/api/_action/theme/{themeId}` in `ThemeController.php` which will activate config sanitization during validation. Only applies if `validate` is set.
+* Added new method `validateThemeConfig` to `\Shopware\Storefront\Theme\ThemeService` for validating theme configuration changes.
+* Added new boolean parameter `validate` to API route `/api/_action/theme/{themeId}` in `\Shopware\Storefront\Theme\Controller\ThemeController` which will activate the config validation on theme update.
+* Added new boolean parameter `sanitize` to API route `/api/_action/theme/{themeId}` in `\Shopware\Storefront\Theme\Controller\ThemeController` which will activate config sanitization during validation. Only applies if `validate` is set.
 ___
 # Administration
 * Changed the theme manager module to trigger theme config validation on theme update. Reported errors will be mapped to the corresponding form fields to show the user which fields are invalid.

--- a/changelog/_unreleased/2025-06-27-add-theme-config-validation.md
+++ b/changelog/_unreleased/2025-06-27-add-theme-config-validation.md
@@ -6,5 +6,6 @@ issue: #10679
 * Added new method `validateThemeConfig()` to `ThemeService.php` for validating theme configuration changes.
 * Added new boolean parameter `validate` to API route `/api/_action/theme/{themeId}` in `ThemeController.php` which will activate the config validation on theme update.
 * Added new boolean parameter `sanitize` to API route `/api/_action/theme/{themeId}` in `ThemeController.php` which will activate config sanitization during validation. Only applies if `validate` is set.
+___
 # Administration
 * Changed the theme manager module to trigger theme config validation on theme update. Reported errors will be mapped to the corresponding form fields to show the user which fields are invalid.

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -16,7 +16,8 @@
       "DUPLICATED_URL": "Diese URL wird bereits genutzt. Bitte wähle eine andere Domain.",
       "DUPLICATED_NAME": "Dieser Name wird bereits genutzt.",
       "CONTENT__MEDIA_EMPTY_FILE": "Gib einen gültigen Dateinamen an.",
-      "CONTENT__INVALID_CUSTOM_ENTITY_FIELD_TYPE": "Datentyp kann nicht gerendert werden. Bitte kontaktiere Deinen Administrator."
+      "CONTENT__INVALID_CUSTOM_ENTITY_FIELD_TYPE": "Datentyp kann nicht gerendert werden. Bitte kontaktiere Deinen Administrator.",
+      "THEME__INVALID_SCSS_VAR": "SCSS Wert \"{value}\" ist nicht gültig für Typ \"{type}\"."
     },
     "default": {
       "add": "Hinzufügen",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -16,7 +16,8 @@
       "DUPLICATED_URL": "This URL is already in use. Please choose another URL.",
       "DUPLICATED_NAME": "This name is already in use.",
       "CONTENT__MEDIA_EMPTY_FILE": "A valid filename must be provided.",
-      "CONTENT__INVALID_CUSTOM_ENTITY_FIELD_TYPE": "Field type cannot be rendered. Please contact your administrator."
+      "CONTENT__INVALID_CUSTOM_ENTITY_FIELD_TYPE": "Field type cannot be rendered. Please contact your administrator.",
+      "THEME__INVALID_SCSS_VAR": "SCSS Value \"{value}\" is not valid for type \"{type}\"."
     },
     "default": {
       "add": "Add",

--- a/src/Storefront/DependencyInjection/theme.xml
+++ b/src/Storefront/DependencyInjection/theme.xml
@@ -74,6 +74,7 @@
             <argument type="service" id="theme.repository"/>
             <argument type="service" id="theme_sales_channel.repository"/>
             <argument type="service" id="Shopware\Storefront\Theme\ThemeCompiler"/>
+            <argument type="service" id="Shopware\Storefront\Theme\ScssPhpCompiler"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Storefront\Theme\ConfigLoader\AbstractConfigLoader"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>

--- a/src/Storefront/Resources/Schema/AdminApi/theme.json
+++ b/src/Storefront/Resources/Schema/AdminApi/theme.json
@@ -2,6 +2,73 @@
     "openapi": "3.1.0",
     "info": [],
     "paths": {
+        "/_action/theme/{themeId}": {
+            "patch": {
+                "tags": ["Theme"],
+                "summary": "Update theme configuration",
+                "description": "Updates the configuration of a theme. The theme configuration is a collection of fields that are provided as variables in the theme's SCSS files and the templates.",
+                "operationId": "updateThemeConfiguration",
+                "parameters": [
+                    {
+                        "name": "themeId",
+                        "description": "The ID of the theme to update",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "parentThemeId",
+                        "description": "The ID of the parent theme to inherit the configuration from.",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "reset",
+                        "description": "If true, the theme configuration will be reset to the default values from the theme.json file.",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "validate",
+                        "description": "If true, the theme configuration will be validated before being updated.",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "sanitize",
+                        "description": "If true, the theme configuration will be sanitized during validation. before being updated. Only applies if validate is true.",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Theme updated successfully.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/_action/theme/{themeId}/configuration": {
             "get": {
                 "tags": ["Theme"],

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -379,6 +379,7 @@
                                                                                     :helpText="getHelpText(field.helpTextSnippetKey, field.helpText)"
                                                                                     :disabled="isInherited || !acl.can('theme.editor') || themeConfig[fieldName].editable === false"
                                                                                     :value="currentValue"
+                                                                                    :error="themeConfigErrors[fieldName]"
                                                                                     zIndex="100"
                                                                                     @update:value="updateCurrentValue"
                                                                                 />
@@ -388,6 +389,7 @@
                                                                                     :helpText="getHelpText(field.helpTextSnippetKey, field.helpText)"
                                                                                     :disabled="isInherited || !acl.can('theme.editor') || themeConfig[fieldName].editable === false"
                                                                                     :model-value="cssValue(currentValue)"
+                                                                                    :error="themeConfigErrors[fieldName]"
                                                                                     @update:modelValue="updateCurrentValue"
                                                                                 />
                                                                             </template>
@@ -410,6 +412,7 @@
                                                                                     v-bind="getBind(field)"
                                                                                     :value="currentValue"
                                                                                     :disabled="isInherited || !acl.can('theme.editor')"
+                                                                                    :error="themeConfigErrors[fieldName]"
                                                                                     @update:value="updateCurrentValue"
                                                                                 >
                                                                                 </sw-form-field-renderer>

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/de-DE.json
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/de-DE.json
@@ -202,6 +202,10 @@
         "themeCompile": {
           "title": "Das Theme konnte nicht kompiliert werden",
           "message": "Das Theme konnte nicht kompiliert werden. Bitte prüfen Sie die vollständige Fehlermeldung, um dieses Problem zu beheben."
+        },
+        "invalidConfiguration": {
+          "title": "Ungültige Konfiguration",
+          "message": "Die Konfiguration ist fehlerhaft. Das Theme kann nicht gespeichert werden."
         }
       }
     },

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/en-GB.json
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/snippet/en-GB.json
@@ -202,6 +202,10 @@
         "themeCompile": {
           "title": "Error compiling theme",
           "message": "The theme could not be compiled. Please check the full error message to resolve this issue."
+        },
+        "invalidConfiguration": {
+          "title": "Invalid configuration",
+          "message": "The configuration is faulty. The theme cannot be saved."
         }
       }
     },

--- a/src/Storefront/Theme/Controller/ThemeController.php
+++ b/src/Storefront/Theme/Controller/ThemeController.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\AbstractScssCompiler;
+use Shopware\Storefront\Theme\Exception\ThemeConfigException;
 use Shopware\Storefront\Theme\ThemeService;
 use Shopware\Storefront\Theme\Validator\SCSSValidator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -29,6 +30,17 @@ class ThemeController extends AbstractController
     ) {
     }
 
+    /**
+     * Retrieves the configuration for a specific theme.
+     *
+     * This endpoint returns the theme configuration including all configurable fields,
+     * their current values, and metadata.
+     *
+     * @param string $themeId The unique identifier of the theme
+     * @param Context $context The application context containing user and system information
+     *
+     * @return JsonResponse Returns a JSON response containing the theme configuration
+     */
     #[Route(path: '/api/_action/theme/{themeId}/configuration', name: 'api.action.theme.configuration', methods: ['GET'])]
     public function configuration(string $themeId, Context $context): JsonResponse
     {
@@ -45,10 +57,38 @@ class ThemeController extends AbstractController
         return new JsonResponse($themeConfiguration);
     }
 
+    /**
+     * Updates the configuration of a specific theme.
+     *
+     * This endpoint allows updating theme configuration values.
+     * If the reset parameter is provided, the theme will be reset
+     * to its default configuration before applying any new values.
+     * If the validate parameter is provided, the theme config will be validated before updating the theme.
+     * If the sanitize parameter is provided, the theme config will be sanitized during validation.
+     *
+     * @param string $themeId The unique identifier of the theme to update
+     * @param Request $request The HTTP request containing configuration data
+     * @param Context $context The application context containing user and system information
+     *
+     * @return JsonResponse Returns an empty JSON response on successful update
+     */
     #[Route(path: '/api/_action/theme/{themeId}', name: 'api.action.theme.update', methods: ['PATCH'])]
     public function updateTheme(string $themeId, Request $request, Context $context): JsonResponse
     {
         $config = $request->request->all('config');
+
+        $validateConfig = $request->query->getBoolean('validate', false);
+
+        // Validate the theme config before updating the theme.
+        if ($validateConfig) {
+            $config = $this->themeService->validateThemeConfig(
+                $themeId,
+                $config,
+                $context,
+                $this->customAllowedRegex,
+                $request->request->getBoolean('sanitize', false)
+            );
+        }
 
         if ($request->query->getBoolean('reset')) {
             $this->themeService->resetTheme($themeId, $context);
@@ -64,6 +104,20 @@ class ThemeController extends AbstractController
         return new JsonResponse([]);
     }
 
+    /**
+     * Assigns a theme to a specific sales channel.
+     *
+     * This endpoint links a theme to a sales channel, making it the active theme
+     * for that channel. This determines the visual appearance and styling of the
+     * storefront for customers visiting that sales channel. Only one theme can be
+     * active per sales channel at a time.
+     *
+     * @param string $themeId The unique identifier of the theme to assign
+     * @param string $salesChannelId The unique identifier of the sales channel
+     * @param Context $context The application context containing user and system information
+     *
+     * @return JsonResponse Returns an empty JSON response on successful assignment
+     */
     #[Route(path: '/api/_action/theme/{themeId}/assign/{salesChannelId}', name: 'api.action.theme.assign', methods: ['POST'])]
     public function assignTheme(string $themeId, string $salesChannelId, Context $context): JsonResponse
     {
@@ -72,6 +126,19 @@ class ThemeController extends AbstractController
         return new JsonResponse([]);
     }
 
+    /**
+     * Resets a theme to its default configuration.
+     *
+     * This endpoint reverts all custom theme configuration values back to their
+     * default settings as defined in the theme's configuration files. This is useful
+     * when you want to start fresh with theme customization or when troubleshooting
+     * theme-related issues.
+     *
+     * @param string $themeId The unique identifier of the theme to reset
+     * @param Context $context The application context containing user and system information
+     *
+     * @return JsonResponse Returns an empty JSON response on successful reset
+     */
     #[Route(path: '/api/_action/theme/{themeId}/reset', name: 'api.action.theme.reset', methods: ['PATCH'])]
     public function resetTheme(string $themeId, Context $context): JsonResponse
     {
@@ -80,6 +147,19 @@ class ThemeController extends AbstractController
         return new JsonResponse([]);
     }
 
+    /**
+     * Retrieves the structured field configuration for a theme.
+     *
+     * This endpoint returns the theme configuration organized in a structured format
+     * that includes field grouping, dependencies, and metadata. This is particularly
+     * useful for building theme configuration interfaces in the administration panel.
+     * The response format differs based on the Shopware version for backward compatibility.
+     *
+     * @param string $themeId The unique identifier of the theme
+     * @param Context $context The application context containing user and system information
+     *
+     * @return JsonResponse Returns a JSON response containing the structured field configuration
+     */
     #[Route(path: '/api/_action/theme/{themeId}/structured-fields', name: 'api.action.theme.structuredFields', methods: ['GET'])]
     public function structuredFields(string $themeId, Context $context): JsonResponse
     {
@@ -96,10 +176,24 @@ class ThemeController extends AbstractController
         return new JsonResponse($themeConfiguration);
     }
 
+    /**
+     * Validates theme configuration field values.
+     *
+     * This endpoint validates theme configuration values against their defined types
+     * and constraints. It performs SCSS validation for color values, typography settings,
+     * and other theme-specific fields. This is typically used in the administration
+     * panel to provide real-time validation feedback when users are configuring themes.
+     *
+     * @param Request $request The HTTP request containing the fields to validate
+     *
+     * @return JsonResponse Returns an empty JSON response if validation passes, or validation errors
+     */
     #[Route(path: '/api/_action/theme/validate-fields', name: 'api.action.theme.validate', methods: ['POST'])]
     public function validateVariables(Request $request): JsonResponse
     {
         $fields = $request->request->all('fields');
+
+        $themeConfigException = new ThemeConfigException();
 
         foreach ($fields as $key => $data) {
             // if no type is set just use the value and continue
@@ -107,8 +201,14 @@ class ThemeController extends AbstractController
                 continue;
             }
 
-            $data['value'] = SCSSValidator::validate($this->scssCompiler, $data, $this->customAllowedRegex);
+            try {
+                $data['value'] = SCSSValidator::validate($this->scssCompiler, $data, $this->customAllowedRegex);
+            } catch (\Throwable $exception) {
+                $themeConfigException->add($exception);
+            }
         }
+
+        $themeConfigException->tryToThrow();
 
         return new JsonResponse([]);
     }

--- a/src/Storefront/Theme/Controller/ThemeController.php
+++ b/src/Storefront/Theme/Controller/ThemeController.php
@@ -86,7 +86,7 @@ class ThemeController extends AbstractController
                 $config,
                 $context,
                 $this->customAllowedRegex,
-                $request->request->getBoolean('sanitize', false)
+                $request->query->getBoolean('sanitize', false)
             );
         }
 

--- a/src/Storefront/Theme/Exception/ThemeConfigException.php
+++ b/src/Storefront/Theme/Exception/ThemeConfigException.php
@@ -62,7 +62,7 @@ class ThemeConfigException extends ShopwareHttpException
     }
 
     /**
-     * @return \Throwable[]
+     * @return list<\Throwable>
      */
     public function getExceptions(): array
     {

--- a/src/Storefront/Theme/Exception/ThemeConfigException.php
+++ b/src/Storefront/Theme/Exception/ThemeConfigException.php
@@ -61,6 +61,9 @@ class ThemeConfigException extends ShopwareHttpException
         }
     }
 
+    /**
+     * @return \Throwable[]
+     */
     public function getExceptions(): array
     {
         return $this->exceptions;

--- a/src/Storefront/Theme/Exception/ThemeConfigException.php
+++ b/src/Storefront/Theme/Exception/ThemeConfigException.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Theme\Exception;
+
+use Shopware\Core\Framework\Api\EventListener\ErrorResponseFactory;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Package('framework')]
+class ThemeConfigException extends ShopwareHttpException
+{
+    private const MESSAGE = 'There are {{ errorCount }} error(s) while validating the theme config.';
+
+    /**
+     * @var \Throwable[]
+     */
+    private array $exceptions = [];
+
+    public function __construct()
+    {
+        parent::__construct(self::MESSAGE, ['errorCount' => 0]);
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'THEME_CONFIG_EXCEPTION';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function add(\Throwable $exception): ThemeConfigException
+    {
+        $this->exceptions[] = $exception;
+        $this->updateMessage();
+
+        return $this;
+    }
+
+    public function tryToThrow(): void
+    {
+        if (\count($this->exceptions)) {
+            throw $this;
+        }
+    }
+
+    public function getErrors(bool $withTrace = false): \Generator
+    {
+        foreach ($this->getExceptions() as $innerException) {
+            if ($innerException instanceof ShopwareHttpException) {
+                yield from $innerException->getErrors($withTrace);
+
+                continue;
+            }
+
+            $errorFactory = new ErrorResponseFactory();
+            yield from $errorFactory->getErrorsFromException($innerException, $withTrace);
+        }
+    }
+
+    public function getExceptions(): array
+    {
+        return $this->exceptions;
+    }
+
+    private function updateMessage(): void
+    {
+        $this->message = $this->parse(self::MESSAGE, ['errorCount' => \count($this->exceptions)]);
+    }
+}

--- a/src/Storefront/Theme/Exception/ThemeConfigException.php
+++ b/src/Storefront/Theme/Exception/ThemeConfigException.php
@@ -13,7 +13,7 @@ class ThemeConfigException extends ShopwareHttpException
     private const MESSAGE = 'There are {{ errorCount }} error(s) while validating the theme config.';
 
     /**
-     * @var \Throwable[]
+     * @var list<\Throwable>
      */
     private array $exceptions = [];
 

--- a/src/Storefront/Theme/Exception/ThemeException.php
+++ b/src/Storefront/Theme/Exception/ThemeException.php
@@ -59,7 +59,7 @@ class ThemeException extends HttpException
         );
     }
 
-    public static function InvalidScssValue(mixed $value, string $type, string $name = ''): self
+    public static function InvalidScssValue(mixed $value, string $type, string $name): self
     {
         return new self(
             Response::HTTP_BAD_REQUEST,

--- a/src/Storefront/Theme/Exception/ThemeException.php
+++ b/src/Storefront/Theme/Exception/ThemeException.php
@@ -59,12 +59,12 @@ class ThemeException extends HttpException
         );
     }
 
-    public static function InvalidScssValue(mixed $value, string $type, string $name): self
+    public static function InvalidScssValue(mixed $value, string $type, string $name = ''): self
     {
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::INVALID_SCSS_VAR,
-            'SCSS Value "{{ name }}" with value "{{ value }}" is not valid for type "{{ type }}"',
+            'SCSS Value "{{ value }}" is not valid for type "{{ type }}".',
             ['name' => $name, 'value' => $value, 'type' => $type]
         );
     }
@@ -74,7 +74,7 @@ class ThemeException extends HttpException
         return new ThemeCompileException(
             $themeName,
             $message,
-            $e
+            $e,
         );
     }
 

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -313,9 +313,9 @@ class ThemeCompiler implements ThemeCompilerInterface
             );
         } catch (\Throwable $exception) {
             throw ThemeException::themeCompileException(
-                $configuration->getTechnicalName(),
+                $configuration->getTechnicalName() . ' - Theme-ID: ' . $themeId,
                 $exception->getMessage(),
-                $exception
+                $exception,
             );
         }
 
@@ -404,7 +404,7 @@ class ThemeCompiler implements ThemeCompilerInterface
             }
 
             if (
-                \in_array($data['type'], ['media', 'textarea'], true)
+                \in_array($data['type'], ['media', 'textarea', 'url'], true)
                 && \is_string($data['value'])
                 && !\str_starts_with($data['value'], '\'')
                 && !\str_ends_with($data['value'], '\'')

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -20,9 +20,11 @@ use Shopware\Storefront\Theme\Event\ThemeAssignedEvent;
 use Shopware\Storefront\Theme\Event\ThemeConfigChangedEvent;
 use Shopware\Storefront\Theme\Event\ThemeConfigResetEvent;
 use Shopware\Storefront\Theme\Exception\InvalidThemeConfigException;
+use Shopware\Storefront\Theme\Exception\ThemeConfigException;
 use Shopware\Storefront\Theme\Exception\ThemeException;
 use Shopware\Storefront\Theme\Message\CompileThemeMessage;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
+use Shopware\Storefront\Theme\Validator\SCSSValidator;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -46,6 +48,7 @@ class ThemeService implements ResetInterface
         private readonly EntityRepository $themeRepository,
         private readonly EntityRepository $themeSalesChannelRepository,
         private readonly ThemeCompilerInterface $themeCompiler,
+        private readonly AbstractScssCompiler $scssCompiler,
         private readonly EventDispatcherInterface $dispatcher,
         private readonly AbstractConfigLoader $configLoader,
         private readonly Connection $connection,
@@ -210,6 +213,61 @@ class ThemeService implements ResetInterface
 
         // Refresh runtime config after resetting theme config
         $this->themeRuntimeConfigService->refreshConfigValues($themeId, $context);
+    }
+
+    /**
+     * Validates if the theme config can be compiled in SCSS.
+     *
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    public function validateThemeConfig(
+        string $themeId,
+        array $config,
+        Context $context,
+        array $customAllowedRegex = [],
+        bool $sanitize = false
+    ): array {
+        // Get the merged theme config including inherited parent themes.
+        $themeConfig = $this->getPlainThemeConfiguration($themeId, $context);
+
+        // Single validation errors are collected in a wrapping exception.
+        $themeConfigException = new ThemeConfigException();
+
+        foreach ($config as $name => &$field) {
+            // Lookup the field in the original theme config to get the field type.
+            $fieldConfig = $themeConfig['fields'][$name] ?? null;
+
+            // Skip fields that are not editable or excluded from SCSS compilation.
+            if (!$fieldConfig
+                || $fieldConfig['editable'] === false
+                || $fieldConfig['scss'] === false) {
+                continue;
+            }
+
+            $changedField = [
+                'name' => $name,
+                'value' => $field['value'],
+                'type' => $fieldConfig['type'],
+            ];
+
+            try {
+                $field['value'] = SCSSValidator::validate(
+                    $this->scssCompiler,
+                    $changedField,
+                    $customAllowedRegex,
+                    $sanitize
+                );
+            } catch (\Throwable $exception) {
+                $themeConfigException->add($exception);
+            }
+        }
+
+        // Check if there are any validation errors.
+        $themeConfigException->tryToThrow();
+
+        return $config;
     }
 
     /**

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -219,6 +219,7 @@ class ThemeService implements ResetInterface
      * Validates if the theme config can be compiled in SCSS.
      *
      * @param array<string, mixed> $config
+     * @param array<int, string> $customAllowedRegex
      *
      * @return array<string, mixed>
      */

--- a/tests/integration/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeCompilerTest.php
@@ -158,6 +158,21 @@ class ThemeCompilerTest extends TestCase
                     'type' => 'switch',
                     'value' => true,
                 ],
+                'sw-text-field' => [
+                    'name' => 'sw-text-field',
+                    'type' => 'text',
+                    'value' => '2px solid #000',
+                ],
+                'sw-textarea-field' => [
+                    'name' => 'sw-text-field',
+                    'type' => 'textarea',
+                    'value' => 'Lorem ipsum dolor',
+                ],
+                'sw-url-field' => [
+                    'name' => 'sw-url-field',
+                    'type' => 'url',
+                    'value' => 'https://www.example.com',
+                ],
                 'sw-multi-test' => [
                     'name' => 'sw-multi-test',
                     'type' => 'text',
@@ -199,6 +214,9 @@ class ThemeCompilerTest extends TestCase
 \$sw-custom-footer: 1;
 \$sw-custom-cart: 0;
 \$sw-custom-product-box: 1;
+\$sw-text-field: 2px solid #000;
+\$sw-textarea-field: 'Lorem ipsum dolor';
+\$sw-url-field: 'https://www.example.com';
 \$sw-asset-theme-url: 'http://localhost';
 
 PHP_EOL;

--- a/tests/integration/Storefront/Theme/ThemeTest.php
+++ b/tests/integration/Storefront/Theme/ThemeTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Theme\ConfigLoader\DatabaseConfigLoader;
 use Shopware\Storefront\Theme\Exception\ThemeCompileException;
+use Shopware\Storefront\Theme\ScssPhpCompiler;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationFactory;
 use Shopware\Storefront\Theme\StorefrontPluginRegistry;
@@ -558,6 +559,8 @@ class ThemeTest extends TestCase
                 })
             );
 
+        $scssCompilerMock = $this->createMock(ScssPhpCompiler::class);
+
         $kernel = new class(static::getContainer()->get('kernel')) implements KernelInterface {
             private readonly SimpleTheme $simpleTheme;
 
@@ -664,6 +667,7 @@ class ThemeTest extends TestCase
             static::getContainer()->get('theme.repository'),
             static::getContainer()->get('theme_sales_channel.repository'),
             $themeCompilerMock,
+            $scssCompilerMock,
             static::getContainer()->get('event_dispatcher'),
             new DatabaseConfigLoader(
                 static::getContainer()->get('theme.repository'),

--- a/tests/unit/Storefront/Theme/Exception/ThemeConfigExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeConfigExceptionTest.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Theme\Exception\ThemeConfigException;
+use Shopware\Storefront\Theme\Exception\ThemeException;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ThemeConfigException::class)]
+class ThemeConfigExceptionTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $exception = new ThemeConfigException();
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame('THEME_CONFIG_EXCEPTION', $exception->getErrorCode());
+        static::assertSame('There are 0 error(s) while validating the theme config.', $exception->getMessage());
+        static::assertEmpty($exception->getExceptions());
+    }
+
+    public function testAddException(): void
+    {
+        $exception = new ThemeConfigException();
+        $innerException = new \RuntimeException('Test error');
+
+        $result = $exception->add($innerException);
+
+        static::assertSame($exception, $result);
+        static::assertCount(1, $exception->getExceptions());
+        static::assertSame($innerException, $exception->getExceptions()[0]);
+        static::assertSame('There are 1 error(s) while validating the theme config.', $exception->getMessage());
+    }
+
+    public function testAddMultipleExceptions(): void
+    {
+        $exception = new ThemeConfigException();
+        $innerException1 = new \RuntimeException('Test error 1');
+        $innerException2 = new \InvalidArgumentException('Test error 2');
+
+        $exception->add($innerException1);
+        $exception->add($innerException2);
+
+        static::assertCount(2, $exception->getExceptions());
+        static::assertSame($innerException1, $exception->getExceptions()[0]);
+        static::assertSame($innerException2, $exception->getExceptions()[1]);
+        static::assertSame('There are 2 error(s) while validating the theme config.', $exception->getMessage());
+    }
+
+    public function testTryToThrowWithNoExceptions(): void
+    {
+        $exception = new ThemeConfigException();
+
+        // Should not throw when no exceptions are added
+        $exception->tryToThrow();
+
+        static::assertCount(0, $exception->getExceptions());
+    }
+
+    public function testTryToThrowWithExceptions(): void
+    {
+        $exception = new ThemeConfigException();
+        $innerException = new \RuntimeException('Test error');
+        $exception->add($innerException);
+
+        $this->expectException(ThemeConfigException::class);
+        $this->expectExceptionMessage('There are 1 error(s) while validating the theme config.');
+
+        $exception->tryToThrow();
+    }
+
+    public function testGetErrorsWithNoExceptions(): void
+    {
+        $exception = new ThemeConfigException();
+
+        $errors = [];
+        foreach ($exception->getErrors(true) as $error) {
+            $errors[] = $error;
+        }
+
+        static::assertEmpty($errors);
+    }
+
+    public function testGetErrorsWithTrace(): void
+    {
+        $exception = new ThemeConfigException();
+        $innerException = new \RuntimeException('Test error');
+        $exception->add($innerException);
+
+        $errors = [];
+        foreach ($exception->getErrors(true) as $error) {
+            $errors[] = $error;
+        }
+
+        static::assertCount(1, $errors);
+        static::assertArrayHasKey('meta', $errors[0]);
+        static::assertArrayHasKey('trace', $errors[0]['meta']);
+        static::assertIsArray($errors[0]['meta']['trace']);
+    }
+
+    public function testGetErrorsWithMultipleExceptions(): void
+    {
+        $exception = new ThemeConfigException();
+        $innerException1 = ThemeException::InvalidScssValue('#invalid-color', 'color', 'sw-color-brand-primary');
+        $innerException2 = ThemeException::InvalidScssValue('#invalid-color', 'color', 'sw-color-brand-secondary');
+        $exception->add($innerException1);
+        $exception->add($innerException2);
+
+        $errors = [];
+        foreach ($exception->getErrors() as $error) {
+            $errors[] = $error;
+        }
+
+        static::assertCount(2, $errors);
+        static::assertSame('400', $errors[0]['status']);
+        static::assertSame('400', $errors[1]['status']);
+    }
+
+    public function testGetExceptions(): void
+    {
+        $exception = new ThemeConfigException();
+        $innerException1 = new \RuntimeException('Test error 1');
+        $innerException2 = new \InvalidArgumentException('Test error 2');
+
+        $exception->add($innerException1);
+        $exception->add($innerException2);
+
+        $exceptions = $exception->getExceptions();
+
+        static::assertCount(2, $exceptions);
+        static::assertSame($innerException1, $exceptions[0]);
+        static::assertSame($innerException2, $exceptions[1]);
+    }
+
+    public function testMessageUpdateAfterAddingExceptions(): void
+    {
+        $exception = new ThemeConfigException();
+        static::assertSame('There are 0 error(s) while validating the theme config.', $exception->getMessage());
+
+        $exception->add(new \RuntimeException('Error 1'));
+        static::assertSame('There are 1 error(s) while validating the theme config.', $exception->getMessage());
+
+        $exception->add(new \RuntimeException('Error 2'));
+        static::assertSame('There are 2 error(s) while validating the theme config.', $exception->getMessage());
+    }
+
+    public function testChainingAddMethod(): void
+    {
+        $exception = new ThemeConfigException();
+        $innerException1 = new \RuntimeException('Test error 1');
+        $innerException2 = new \RuntimeException('Test error 2');
+
+        $result = $exception
+            ->add($innerException1)
+            ->add($innerException2);
+
+        static::assertSame($exception, $result);
+        static::assertCount(2, $exception->getExceptions());
+    }
+}

--- a/tests/unit/Storefront/Theme/Exception/ThemeExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeExceptionTest.php
@@ -67,7 +67,7 @@ class ThemeExceptionTest extends TestCase
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
         static::assertSame(ThemeException::INVALID_SCSS_VAR, $exception->getErrorCode());
-        static::assertSame('SCSS Value "primary-color" with value "invalid-value" is not valid for type "color"', $exception->getMessage());
+        static::assertSame('SCSS Value "invalid-value" is not valid for type "color".', $exception->getMessage());
         static::assertSame(['name' => $name, 'value' => $value, 'type' => $type], $exception->getParameters());
     }
 

--- a/tests/unit/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/unit/Storefront/Theme/ThemeCompilerTest.php
@@ -262,6 +262,11 @@ class ThemeCompilerTest extends TestCase
                         'type' => 'media',
                         'value' => [123],
                     ],
+                    'sw-custom-url' => [
+                        'name' => 'sw-custom-url',
+                        'type' => 'url',
+                        'value' => 'https://www.shopware.com',
+                    ],
                     'sw-custom-media' => [
                         'name' => 'sw-custom-media',
                         'type' => 'media',
@@ -309,6 +314,7 @@ class ThemeCompilerTest extends TestCase
 \$sw-custom-cart: 0;
 \$sw-custom-product-box: 1;
 \$sw-custom-textarea: '123';
+\$sw-custom-url: 'https://www.shopware.com';
 \$sw-custom-media: '456';
 \$sw-asset-theme-url: 'http://localhost';
 

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -82,6 +82,13 @@ class SCSSValidatorTest extends TestCase
             ],
             '"Inter", Sans-serif',
         ];
+        yield 'text correct' => [
+            [
+                'type' => 'text',
+                'value' => '2px solid #000',
+            ],
+            '2px solid #000',
+        ];
         yield 'color correct hex 4' => [
             [
                 'type' => 'color',
@@ -190,6 +197,13 @@ class SCSSValidatorTest extends TestCase
         yield 'font family empty' => [
             [
                 'type' => 'fontFamily',
+                'value' => '',
+            ],
+            null,
+        ];
+        yield 'text empty' => [
+            [
+                'type' => 'text',
                 'value' => '',
             ],
             null,
@@ -330,6 +344,13 @@ class SCSSValidatorTest extends TestCase
             ],
             'inherit',
         ];
+        yield 'text incorrect and sanitized name' => [
+            [
+                'type' => 'text',
+                'value' => '"§"$/)(!"§&)=}[];"{',
+            ],
+            'inherit',
+        ];
         yield 'col incorrect and sanitized' => [
             [
                 'type' => 'color',
@@ -376,6 +397,13 @@ class SCSSValidatorTest extends TestCase
                 'value' => '\'Inter\', Sans-serif',
             ],
             '"Inter", Sans-serif',
+        ];
+        yield 'text correct' => [
+            [
+                'type' => 'text',
+                'value' => '2px solid #000',
+            ],
+            '2px solid #000',
         ];
         yield 'color correct hex 4' => [
             [
@@ -594,6 +622,13 @@ class SCSSValidatorTest extends TestCase
             ],
             null,
         ];
+        yield 'text empty' => [
+            [
+                'type' => 'text',
+                'value' => '',
+            ],
+            null,
+        ];
         // Zero values
         yield 'color with "0" value is not valid' => [
             [
@@ -618,7 +653,7 @@ class SCSSValidatorTest extends TestCase
             ],
             '0',
         ];
-        // Incorrect and sanitized
+        // Incorrect and throws exception
         yield 'color incorrect name' => [
             [
                 'type' => 'color',
@@ -639,6 +674,14 @@ class SCSSValidatorTest extends TestCase
             [
                 'type' => 'fontFamily',
                 'value' => 'Arial%&$',
+            ],
+            '',
+            true,
+        ];
+        yield 'text incorrect' => [
+            [
+                'type' => 'text',
+                'value' => '"§"$/)(!"§&)=}[];"{',
             ],
             '',
             true,


### PR DESCRIPTION
fixes: #10679  

### 1. Why is this change necessary?

Incorrect user input within the theme configuration often leads to invalid configuration values, which will cause errors during compilation. This can cause a lot of troubleshooting, especially during cloud deployments.

In the past, an error was shown when the actual theme compilation failed, but the theme config was updated anyway, and the theme could still be assigned to a sales channel.

### 2. What does this change do, exactly?

The theme update route can now validate the passed theme configuration before the theme is updated with the new values. Potential errors are passed back to the administration and mapped to the corresponding input fields to show the user which values are invalid.

### 3. Describe each step to reproduce the issue or behaviour.

Go to the theme manager in the administration and open the theme configuration of any theme. Try to save the configuration with an invalid config field, for example, changing a color field to `#invalid`.

![image](https://github.com/user-attachments/assets/a8c71bac-5130-4438-871e-c506be54ca1d)

