### PR TITLE
fix: don't silently ignore ESI errors

### DIFF
--- a/changelog/_unreleased/2025-06-27-dont-ignore-esi-render-errors.md
+++ b/changelog/_unreleased/2025-06-27-dont-ignore-esi-render-errors.md
@@ -1,0 +1,10 @@
+---
+title: Don't ignore ESI render errors
+---
+# Storefront
+* Changed `base.html.twig` to not ignore ESI render errors for the header and footer. This means that if an ESI tag fails to render, it will now throw an error instead of silently failing. This change is intended to help developers identify and fix issues with ESI includes more easily.
+___
+# Upgrade Information
+## ESI render errors are not ignored anymore
+When rendering the `/header` and `/footer` ESI tags, errors will now be thrown instead of ignored. This change is intended to help developers identify and fix issues with ESI includes more easily.
+If you want to keep the old behaviour you need to overwrite the template blocks and remove the `ignore_errors: false` option from the `render_esi` function call.

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -76,7 +76,7 @@
         {% endblock %}
 
         {% block base_esi_footer %}
-            {{ render_esi(url('frontend.footer', { footerParameters: footerParameters })) }}
+            {{ render_esi(url('frontend.footer', { footerParameters: footerParameters }), { ignore_errors: false } ) }}
         {% endblock %}
 
     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -36,7 +36,7 @@
         {% endblock %}
 
         {% block base_esi_header %}
-            {{ render_esi(url('frontend.header', { headerParameters: headerParameters })) }}
+            {{ render_esi(url('frontend.header', { headerParameters: headerParameters }), { ignore_errors: false } ) }}
         {% endblock %}
 
         {# @deprecated tag:v6.8.0 - Block will be removed. The active styling class `.active` is set by navbar.plugin.js. #}


### PR DESCRIPTION
By default symfony displays ESI errors depending on the `debug` variable, if debug is set to false (as it should be in prod environments), if ignore_errors is then set to true all errors during esi rendering will be silenced and it will simply skipping rendering that fragment (technically it just renders an empty string)

Header and footer are so essential to the look & feel of the shop that I don't think we should treat those as optional, but rather let the error bubble up, this also makes sure that the error is correctly logged and monitoring system can pick it up, because it let's the main request fail as well

## alternative approach

We could still ignore the errors, but improve the logging, so we get the necessary info to debug this, however IMHO that is not the preferred solution, as it is easy that those issues go unnoticed to monitoring etc, because in the end the main request still succeeds , so those errors are still hard to detect automatically