### PR TITLE
fix: Track if translator should be reset, this should be true on every injection

### DIFF
--- a/changelog/_unreleased/2025-06-27-improve-translator-injection-handling.md
+++ b/changelog/_unreleased/2025-06-27-improve-translator-injection-handling.md
@@ -1,10 +1,9 @@
 ---
 title: Improve translator injection handling
-issue: NEXT-00000
 author: Jasper Peeters
 author_email: jasper.peeters@meteor.be
 author_github: JasperP98
 ---
 
 # Core
-* Changed: Added tracking flag to monitor translation injection state in `Shopware\Core\Framework\Adapter\Translation\Translator` to better manage when injections need to be reset
+* Added tracking flag to monitor translation injection state in `Shopware\Core\Framework\Adapter\Translation\Translator` to better manage when injections need to be reset

--- a/changelog/_unreleased/2025-06-27-improve-translator-injection-handling.md
+++ b/changelog/_unreleased/2025-06-27-improve-translator-injection-handling.md
@@ -1,0 +1,10 @@
+---
+title: Improve translator injection handling
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+* Changed: Added tracking flag to monitor translation injection state in `Shopware\Core\Framework\Adapter\Translation\Translator` to better manage when injections need to be reset

--- a/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
@@ -105,7 +105,7 @@ class SendMailAction extends FlowAction implements DelayableAction
             return;
         }
 
-        $injectedTranslator = $this->injectTranslator($flow->getContext(), $flow->getData(MailAware::SALES_CHANNEL_ID));
+        $this->translator->shouldResetInjection = $this->injectTranslator($flow->getContext(), $flow->getData(MailAware::SALES_CHANNEL_ID));
 
         $data = new DataBag();
 
@@ -160,13 +160,13 @@ class SendMailAction extends FlowAction implements DelayableAction
             ...$flow->data(),
         ];
 
-        $this->send($data, $flow->getContext(), $templateData, $extension, $injectedTranslator);
+        $this->send($data, $flow->getContext(), $templateData, $extension);
     }
 
     /**
      * @param array<string, mixed> $templateData
      */
-    private function send(DataBag $data, Context $context, array $templateData, MailSendSubscriberConfig $extension, bool $injectedTranslator): void
+    private function send(DataBag $data, Context $context, array $templateData, MailSendSubscriberConfig $extension): void
     {
         try {
             $this->emailService->send(
@@ -184,7 +184,7 @@ class SendMailAction extends FlowAction implements DelayableAction
             );
         }
 
-        if ($injectedTranslator) {
+        if ($this->translator->shouldResetInjection) {
             $this->translator->resetInjection();
         }
     }

--- a/src/Core/Framework/Adapter/Translation/AbstractTranslator.php
+++ b/src/Core/Framework/Adapter/Translation/AbstractTranslator.php
@@ -12,6 +12,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[Package('framework')]
 abstract class AbstractTranslator implements TranslatorInterface, TranslatorBagInterface, LocaleAwareInterface, ResetInterface
 {
+    public bool $shouldResetInjection = false;
+    
     /**
      * @param string $cacheDir
      */

--- a/src/Core/Framework/Adapter/Translation/AbstractTranslator.php
+++ b/src/Core/Framework/Adapter/Translation/AbstractTranslator.php
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 abstract class AbstractTranslator implements TranslatorInterface, TranslatorBagInterface, LocaleAwareInterface, ResetInterface
 {
     public bool $shouldResetInjection = false;
-    
+
     /**
      * @param string $cacheDir
      */

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -62,6 +62,8 @@ class Translator extends AbstractTranslator
      */
     private array $snippets = [];
 
+    public bool $shouldResetInjection = false;
+
     /**
      * @internal
      */

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -62,8 +62,6 @@ class Translator extends AbstractTranslator
      */
     private array $snippets = [];
 
-    public bool $shouldResetInjection = false;
-
     /**
      * @internal
      */

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -233,6 +233,7 @@ class Translator extends AbstractTranslator
         $this->setLocale($locale);
         $this->resolveSnippetSetId($salesChannelId, $languageId, $locale);
         $this->getCatalogue($locale);
+        $this->shouldResetInjection = true;
     }
 
     public function resetInjection(): void
@@ -245,6 +246,7 @@ class Translator extends AbstractTranslator
         $this->setLocale($this->localeBeforeInject);
         $this->snippetSetId = null;
         $this->salesChannelId = null;
+        $this->shouldResetInjection = false;
     }
 
     public function getSnippetSetId(?string $locale = null): ?string

--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -763,7 +763,10 @@ class SendMailActionTest extends TestCase
         $order = $this->orderRepository->search($criteria, $context->getContext())->first();
         $event = new CheckoutOrderPlacedEvent($context, $order);
 
+        /** @var Translator $translator */
         $translator = static::getContainer()->get(Translator::class);
+        $flagDuringMailProcessing = null;
+
         $mailService = new TestEmailService(static::getContainer()->get(MailFactory::class));
         $subscriber = new SendMailAction(
             $mailService,
@@ -777,20 +780,17 @@ class SendMailActionTest extends TestCase
             true
         );
 
-        static::assertFalse($translator->shouldResetInjection);
+        static::getContainer()->get('event_dispatcher')->addListener(FlowSendMailActionEvent::class, function () use ($translator, &$flagDuringMailProcessing): void {
+            $flagDuringMailProcessing = $translator->shouldResetInjection;
+        });
 
         $flowFactory = static::getContainer()->get(FlowFactory::class);
         $flow = $flowFactory->create($event);
         $flow->setConfig($config);
 
-        $beforeHandleFlow = false;
-        static::getContainer()->get('event_dispatcher')->addListener(FlowSendMailActionEvent::class, function () use ($translator, &$beforeHandleFlow): void {
-            $beforeHandleFlow = $translator->shouldResetInjection;
-        });
-
         $subscriber->handleFlow($flow);
 
-        static::assertTrue($beforeHandleFlow);
+        static::assertTrue($flagDuringMailProcessing);
         static::assertFalse($translator->shouldResetInjection);
     }
 

--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -740,6 +740,60 @@ class SendMailActionTest extends TestCase
         }
     }
 
+    public function testTranslatorShouldResetInjectionFlag(): void
+    {
+        $criteria = new Criteria();
+        $criteria->setLimit(1);
+
+        $context = Generator::generateSalesChannelContext();
+
+        $customerId = $this->createCustomer($context->getContext());
+        $orderId = $this->createOrder($customerId, $context->getContext());
+
+        $mailTemplateId = $this->retrieveMailTemplateId();
+
+        $config = [
+            'mailTemplateId' => $mailTemplateId,
+            'recipient' => ['type' => 'customer'],
+        ];
+
+        $criteria = new Criteria([$orderId]);
+        $criteria->addAssociation('transactions.stateMachineState');
+        /** @var OrderEntity $order */
+        $order = $this->orderRepository->search($criteria, $context->getContext())->first();
+        $event = new CheckoutOrderPlacedEvent($context, $order);
+
+        $translator = static::getContainer()->get(Translator::class);
+        $mailService = new TestEmailService(static::getContainer()->get(MailFactory::class));
+        $subscriber = new SendMailAction(
+            $mailService,
+            static::getContainer()->get('mail_template.repository'),
+            static::getContainer()->get('logger'),
+            static::getContainer()->get('event_dispatcher'),
+            static::getContainer()->get('mail_template_type.repository'),
+            $translator,
+            static::getContainer()->get(Connection::class),
+            static::getContainer()->get(LanguageLocaleCodeProvider::class),
+            true
+        );
+
+        static::assertFalse($translator->shouldResetInjection);
+
+        $flowFactory = static::getContainer()->get(FlowFactory::class);
+        $flow = $flowFactory->create($event);
+        $flow->setConfig($config);
+
+        $beforeHandleFlow = false;
+        static::getContainer()->get('event_dispatcher')->addListener(FlowSendMailActionEvent::class, function () use ($translator, &$beforeHandleFlow): void {
+            $beforeHandleFlow = $translator->shouldResetInjection;
+        });
+
+        $subscriber->handleFlow($flow);
+
+        static::assertTrue($beforeHandleFlow);
+        static::assertFalse($translator->shouldResetInjection);
+    }
+
     private function createCustomer(Context $context): string
     {
         $customerId = Uuid::randomHex();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The translator is only reset when its injected on one use case. But not in the core injection function. This will create mismatching translations when injecting different settings on different places.

When we send a mail but we inject settings via the flow subscriber, this will not be reset because it is not injected on the SendMailAction.

### 2. What does this change do, exactly?
This will track if the translator should be reset. This way we know the state of the translator and we should reset is after we are done with an action like when sending mails.

### 3. Describe each step to reproduce the issue or behaviour.
/ 

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
