### PR TITLE
feat: Add possibility to allow custom route names as Storefront routes

### DIFF
--- a/changelog/_unreleased/2025-08-04-allow-storefront-routes-without-prefix.md
+++ b/changelog/_unreleased/2025-08-04-allow-storefront-routes-without-prefix.md
@@ -8,6 +8,8 @@ author_github: @mitelg
 * Added the possibility to add the route name to the `storefront.router.allowed_routes` configuration in `storefront.yaml`.
   This allows the usage of routes without the `frontend`, `widgets` or `payment` prefix.
 
+___
+
 # Upgrade Information
 
 ## Allow custom route names for Storefront controllers

--- a/changelog/_unreleased/2025-08-04-allow-storefront-routes-without-prefix.md
+++ b/changelog/_unreleased/2025-08-04-allow-storefront-routes-without-prefix.md
@@ -1,0 +1,24 @@
+---
+title: Allow Storefront routes without prefix
+author: Michael Telgmann
+author_github: @mitelg
+---
+# Storefront
+
+* Added the possibility to add the route name to the `storefront.router.allowed_routes` configuration in `storefront.yaml`.
+  This allows the usage of routes without the `frontend`, `widgets` or `payment` prefix.
+
+# Upgrade Information
+
+## Allow custom route names for Storefront controllers
+
+It is now possible to add custom route names for Storefront controllers in the `storefront.yaml` configuration file.
+This allows the route to be identified as a Storefront route without the usage of the `frontend`, `widgets` or `payment` prefixes.
+Add the following configuration to your `storefront.yaml` file:
+
+```yaml
+storefront:
+    router:
+        allowed_routes:
+            - swag.test.foo-bar
+```

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -97,7 +97,6 @@ parameters:
            paths:
             - **/*Test.php
             - src/Core/Installer
-            - src/Core/Checkout/Payment/Controller/PaymentController.php
 
         -
            message: '#No global Command directories allowed, put your commands in the right domain directory#'

--- a/src/Core/Checkout/Payment/Controller/PaymentController.php
+++ b/src/Core/Checkout/Payment/Controller/PaymentController.php
@@ -40,7 +40,18 @@ class PaymentController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/payment/finalize-transaction', name: 'payment.finalize.transaction', methods: ['GET', 'POST'])]
+    /**
+     * The route scope could not be defined as this route is called from external.
+     * An API route scope would normally imply an authentication, which external callers could not provide.
+     * Only a storefront route scope could also not be used, as it also needs to work on headless environments.
+     *
+     * @phpstan-ignore shopware.routeScope
+     */
+    #[Route(
+        path: '/payment/finalize-transaction',
+        name: 'payment.finalize.transaction',
+        methods: [Request::METHOD_GET, Request::METHOD_POST]
+    )]
     public function finalizeTransaction(Request $request): Response
     {
         $paymentToken = $request->get('_sw_payment_token');

--- a/src/Storefront/DependencyInjection/Configuration.php
+++ b/src/Storefront/DependencyInjection/Configuration.php
@@ -34,6 +34,13 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('validate_on_compile')->defaultFalse()->end()
                     ->end()
                 ->end()
+                ->arrayNode('router')
+                    ->children()
+                        ->arrayNode('allowed_routes')
+                            ->prototype('string')->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -74,6 +74,7 @@
         <service id="Shopware\Storefront\Framework\Routing\Router" decorates="router">
             <argument type="service" id="Shopware\Storefront\Framework\Routing\Router.inner"/>
             <argument type="service" id="request_stack"/>
+            <argument>%storefront.router.allowed_routes%</argument>
         </service>
 
         <service id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver">

--- a/src/Storefront/Framework/Routing/Router.php
+++ b/src/Storefront/Framework/Routing/Router.php
@@ -24,10 +24,13 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     /**
      * @internal
+     *
+     * @param list<string> $allowedRoutes
      */
     public function __construct(
         private readonly SymfonyRouter $decorated,
-        private readonly RequestStack $requestStack
+        private readonly RequestStack $requestStack,
+        private readonly array $allowedRoutes = [],
     ) {
     }
 
@@ -159,7 +162,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     private function removePrefix(string $subject, string $prefix): string
     {
-        if (!$prefix || mb_strpos($subject, $prefix) !== 0) {
+        if (!$prefix || !str_starts_with($subject, $prefix)) {
             return $subject;
         }
 
@@ -194,6 +197,10 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     private function isStorefrontRoute(string $name): bool
     {
+        if (\in_array($name, $this->allowedRoutes, true)) {
+            return true;
+        }
+
         return str_starts_with($name, 'frontend.')
             || str_starts_with($name, 'widgets.')
             || str_starts_with($name, 'payment.');

--- a/src/Storefront/Resources/config/packages/storefront.yaml
+++ b/src/Storefront/Resources/config/packages/storefront.yaml
@@ -2,3 +2,5 @@ storefront:
     theme:
         allowed_scss_values: [ '^\$.*' ]
         validate_on_compile: false
+    router:
+        allowed_routes:

--- a/tests/unit/Storefront/Framework/Routing/RouterTest.php
+++ b/tests/unit/Storefront/Framework/Routing/RouterTest.php
@@ -38,13 +38,15 @@ class RouterTest extends TestCase
             $routeCollection = new RouteCollection();
             $routeCollection->add('frontend.home.page', new Route('/', ['_controller' => 'Shopware\Storefront\Controller\HomeController::index']));
             $routeCollection->add('frontend.navigation.page', new Route('/navigation/{navigationId}', ['_controller' => 'Shopware\Storefront\Controller\NavigationController::index']));
+            $routeCollection->add('custom.route', new Route('/custom-route', ['_controller' => 'Shopware\Storefront\Controller\CustomController::index']));
 
             $this->collection = $routeCollection;
         }, $symfonyRouter, SymfonyRouter::class)();
 
         $router = new Router(
             $symfonyRouter,
-            $stack
+            $stack,
+            $case->allowedRoutes,
         );
         $router->setContext(new RequestContext('', 'GET', $case->host));
 
@@ -54,122 +56,122 @@ class RouterTest extends TestCase
     }
 
     /**
-     * @return UrlCase[][]
+     * @return \Generator<list<UrlCase>>
      */
-    public static function urlCases(): array
+    public static function urlCases(): \Generator
     {
         $id = Uuid::randomHex();
 
-        return [
-            'test-home-page-without-suffix' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/', '', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/de/', '/de', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-and-slash' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/de/', '/de/', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-without-slash' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/de/', 'de', 'frontend.home.page'),
-            ],
-            'test-home-page-with-null' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/', null, 'frontend.home.page'),
-            ],
-            'test-navigation-page-with-de' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, "/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id]),
-            ],
-            'test-home-page-without-suffix-relative' => [
-                new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, '', '', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-relative' => [
-                new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, 'de/', '/de', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-and-slash-relative' => [
-                new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, 'de/', '/de/', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-without-slash-relative' => [
-                new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, 'de/', 'de', 'frontend.home.page'),
-            ],
-            'test-home-page-with-null-relative' => [
-                new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, '', null, 'frontend.home.page'),
-            ],
-            'test-navigation-page-with-de-relative' => [
-                new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, "de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id]),
-            ],
-            'test-home-page-without-suffix-absolute-url' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/', '', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-absolute-url' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/de/', '/de', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-and-slash-absolute-url' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/de/', '/de/', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-without-slash-absolute-url' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/de/', 'de', 'frontend.home.page'),
-            ],
-            'test-home-page-with-null-absolute-url' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/', null, 'frontend.home.page'),
-            ],
-            'test-navigation-page-with-de-absolute-url' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, "http://test.de/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id]),
-            ],
-            'test-home-page-without-suffix-network-path' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/', '', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-network-path' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/de/', '/de', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-and-slash-network-path' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/de/', '/de/', 'frontend.home.page'),
-            ],
-            'test-home-page-with-de-without-slash-network-path' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/de/', 'de', 'frontend.home.page'),
-            ],
-            'test-home-page-with-null-network-path' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/', null, 'frontend.home.page'),
-            ],
-            'test-navigation-page-with-de-network-path' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, "//test.de/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id]),
-            ],
-
-            'test-home-page-without-suffix-absolute-url-with-port' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/', '', 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-home-page-with-de-absolute-url-with-port' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/de/', '/de', 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-home-page-with-de-and-slash-absolute-url-with-port' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/de/', '/de/', 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-home-page-with-de-without-slash-absolute-url-with-port' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/de/', 'de', 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-home-page-with-null-absolute-url-with-port' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/', null, 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-navigation-page-with-de-absolute-url-with-port' => [
-                new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, "http://test.de:8000/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id], 'test.de:8000'),
-            ],
-            'test-home-page-without-suffix-network-path-with-port' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/', '', 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-home-page-with-de-network-path-with-port' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/de/', '/de', 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-home-page-with-de-and-slash-network-path-with-port' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/de/', '/de/', 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-home-page-with-de-without-slash-network-path-with-port' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/de/', 'de', 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-home-page-with-null-network-path-with-port' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/', null, 'frontend.home.page', [], 'test.de:8000'),
-            ],
-            'test-navigation-page-with-de-network-path-with-port' => [
-                new UrlCase(UrlGeneratorInterface::NETWORK_PATH, "//test.de:8000/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id], 'test.de:8000'),
-            ],
+        yield 'test-home-page-without-suffix' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/', '', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/de/', '/de', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-and-slash' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/de/', '/de/', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-without-slash' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/de/', 'de', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-null' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, '/', null, 'frontend.home.page'),
+        ];
+        yield 'test-navigation-page-with-de' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_PATH, "/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id]),
+        ];
+        yield 'test-home-page-without-suffix-relative' => [
+            new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, '', '', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-relative' => [
+            new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, 'de/', '/de', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-and-slash-relative' => [
+            new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, 'de/', '/de/', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-without-slash-relative' => [
+            new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, 'de/', 'de', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-null-relative' => [
+            new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, '', null, 'frontend.home.page'),
+        ];
+        yield 'test-navigation-page-with-de-relative' => [
+            new UrlCase(UrlGeneratorInterface::RELATIVE_PATH, "de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id]),
+        ];
+        yield 'test-home-page-without-suffix-absolute-url' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/', '', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-absolute-url' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/de/', '/de', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-and-slash-absolute-url' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/de/', '/de/', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-without-slash-absolute-url' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/de/', 'de', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-null-absolute-url' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/', null, 'frontend.home.page'),
+        ];
+        yield 'test-navigation-page-with-de-absolute-url' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, "http://test.de/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id]),
+        ];
+        yield 'test-home-page-without-suffix-network-path' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/', '', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-network-path' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/de/', '/de', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-and-slash-network-path' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/de/', '/de/', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-de-without-slash-network-path' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/de/', 'de', 'frontend.home.page'),
+        ];
+        yield 'test-home-page-with-null-network-path' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de/', null, 'frontend.home.page'),
+        ];
+        yield 'test-navigation-page-with-de-network-path' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, "//test.de/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id]),
+        ];
+        yield 'test-home-page-without-suffix-absolute-url-with-port' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/', '', 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-home-page-with-de-absolute-url-with-port' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/de/', '/de', 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-home-page-with-de-and-slash-absolute-url-with-port' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/de/', '/de/', 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-home-page-with-de-without-slash-absolute-url-with-port' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/de/', 'de', 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-home-page-with-null-absolute-url-with-port' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de:8000/', null, 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-navigation-page-with-de-absolute-url-with-port' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, "http://test.de:8000/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id], 'test.de:8000'),
+        ];
+        yield 'test-home-page-without-suffix-network-path-with-port' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/', '', 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-home-page-with-de-network-path-with-port' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/de/', '/de', 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-home-page-with-de-and-slash-network-path-with-port' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/de/', '/de/', 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-home-page-with-de-without-slash-network-path-with-port' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/de/', 'de', 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-home-page-with-null-network-path-with-port' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, '//test.de:8000/', null, 'frontend.home.page', [], 'test.de:8000'),
+        ];
+        yield 'test-navigation-page-with-de-network-path-with-port' => [
+            new UrlCase(UrlGeneratorInterface::NETWORK_PATH, "//test.de:8000/de/navigation/{$id}", '/de', 'frontend.navigation.page', ['navigationId' => $id], 'test.de:8000'),
+        ];
+        yield 'test-custom-route-allowed-with-base-url' => [
+            new UrlCase(UrlGeneratorInterface::ABSOLUTE_URL, 'http://test.de/de/custom-route', '/de', 'custom.route', allowedRoutes: ['custom.route']),
         ];
     }
 }
@@ -181,6 +183,7 @@ class UrlCase
 {
     /**
      * @param array<string, string> $params
+     * @param list<string> $allowedRoutes
      */
     public function __construct(
         public int $type,
@@ -188,7 +191,8 @@ class UrlCase
         public ?string $baseUrl,
         public string $route,
         public array $params = [],
-        public string $host = 'test.de'
+        public string $host = 'test.de',
+        public array $allowedRoutes = [],
     ) {
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Custom routes may not always want to start with the prefixes. 

### 2. What does this change do, exactly?

Add a possibility to allow custom route names as Storefront routes

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
