### PR TITLE
fix: fix ref access to getSelection in sw-grid

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/index.js
@@ -117,6 +117,7 @@ export default {
         'startInlineEditing',
         'selectAll',
         'selectItem',
+        'getSelection',
     ],
 
     data() {


### PR DESCRIPTION
### 1. Why is this change necessary?

https://github.com/shopware/shopware/issues/10760

### 2. What does this change do, exactly?

Expose `getSelection` which wasn't exposed before and therefore the deletion does not work
