### PR TITLE
feat: Do not merge version when live version is more recent

### DIFF
--- a/changelog/_unreleased/2025-06-27-improve-version-timestamp-checking.md
+++ b/changelog/_unreleased/2025-06-27-improve-version-timestamp-checking.md
@@ -1,0 +1,10 @@
+---
+title: Improve version timestamp checking
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+* Changed: Added a merge block (`Shopware\Core\Framework\DataAbstractionLayer\VersionManager::checkVersionTimestamps`) when a version is trying to merge that is older than the live version

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -46,6 +46,7 @@ class DataAbstractionLayerException extends HttpException
     public const INVALID_LANGUAGE_ID = 'FRAMEWORK__INVALID_LANGUAGE_ID';
     public const VERSION_NO_COMMITS_FOUND = 'FRAMEWORK__VERSION_NO_COMMITS_FOUND';
     public const VERSION_NOT_EXISTS = 'FRAMEWORK__VERSION_NOT_EXISTS';
+    public const VERSION_IS_OLDER_THAN_LIVE_VERSION = 'FRAMEWORK__VERSION_IS_OLDER_THAN_LIVE_VERSION';
     public const MIGRATION_STUB_NOT_FOUND = 'FRAMEWORK__MIGRATION_STUB_NOT_FOUND';
     public const MIGRATION_DIRECTORY_NOT_FOUND = 'FRAMEWORK__MIGRATION_DIRECTORY_NOT_FOUND';
     public const DATABASE_PLATFORM_INVALID = 'FRAMEWORK__DATABASE_PLATFORM_INVALID';
@@ -231,6 +232,16 @@ class DataAbstractionLayerException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::VERSION_NOT_EXISTS,
             'Version {{ versionId }} does not exist. Version was probably deleted or already merged.',
+            ['versionId' => $versionId]
+        );
+    }
+
+    public static function versionIsOlderThanLiveVersion(string $versionId): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::VERSION_IS_OLDER_THAN_LIVE_VERSION,
+            'Version {{ versionId }} is older than the live version. Cannot merge.',
             ['versionId' => $versionId]
         );
     }

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer;
 
+use LensOnline\Exception\VersionMergeOutdatedException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Sync\SyncOperation;
@@ -168,6 +169,8 @@ class VersionManager
             throw DataAbstractionLayerException::versionNotExists($versionId);
         }
 
+        $this->checkVersionTimestamps($versionId, $writeContext);
+
         // load all commits of the provided version
         $commits = $this->getCommits($versionId, $writeContext);
 
@@ -210,6 +213,44 @@ class VersionManager
 
         $versionContext->removeState(self::MERGE_SCOPE);
         $liveContext->addState(self::MERGE_SCOPE);
+    }
+
+    private function checkVersionTimestamps(string $versionId, WriteContext $writeContext): void
+    {
+        $commits = $this->getCommits($versionId, $writeContext);
+        if ($commits->count() === 0) {
+            return;
+        }
+
+        foreach ($commits as $commit) {
+            foreach ($commit->getData() as $commitData) {
+                $commitCreatedAt = $commitData->getCreatedAt();
+                if (!$commitCreatedAt) {
+                    continue;
+                }
+
+                $entityName = $commitData->getEntityName();
+                $entityId = $commitData->getEntityId();
+
+                if (!$entityName || !$entityId) {
+                    continue;
+                }
+
+                $liveEntity = $this->entityReader->read(
+                    $this->registry->getByEntityName($entityName),
+                    new Criteria([$entityId['id']]),
+                    $writeContext->getContext()->createWithVersionId(Defaults::LIVE_VERSION)
+                )->first();
+
+                if (!$liveEntity || !$liveEntity->getUpdatedAt()) {
+                    continue;
+                }
+
+                if ($commitCreatedAt < $liveEntity->getUpdatedAt()) {
+                    throw DataAbstractionLayerException::versionIsOlderThanLiveVersion($versionId);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When you have a version from the entity and in the meantime the live version of that entity is updated, and then you merge the old version, the live version its change is overwritten by the old version. We should block this merge.

### 2. What does this change do, exactly?
This change will block merges when a version is older than the latest update from its live version.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open an order in the admin
2. Do a change to that order (like adding a product) but do not save
3. Open the same order in another window
4. Set the order state to completed and save it
5. Go to the other window and save
6. Now the state will be back to open

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
