### PR TITLE
fix: allow customization of document number with prefix/suffix

### DIFF
--- a/changelog/_unreleased/2025-06-27-fix-document-number-customization.md
+++ b/changelog/_unreleased/2025-06-27-fix-document-number-customization.md
@@ -1,0 +1,8 @@
+---
+title: Fix invoice creation with a custom number
+author: Justus Geramb
+author_email: justus@devite.io
+author_github: @jgeramb
+---
+# Administration
+* Allows the auto-completed document number to be changed if a prefix/suffix is configured for the document type. This enables the creation of alternative exports (e.g. e-invoice) of invoices while preserving the same document number.

--- a/changelog/_unreleased/2025-06-27-fix-document-number-customization.md
+++ b/changelog/_unreleased/2025-06-27-fix-document-number-customization.md
@@ -5,4 +5,4 @@ author_email: justus@devite.io
 author_github: @jgeramb
 ---
 # Administration
-    * Removed the value type conversion of the document number field to allow any string value. This enables document numbers with prefixes and/or suffixes.
+* Removed the value type conversion of the document number field to allow any string value. This enables document numbers with prefixes and/or suffixes.

--- a/changelog/_unreleased/2025-06-27-fix-document-number-customization.md
+++ b/changelog/_unreleased/2025-06-27-fix-document-number-customization.md
@@ -5,4 +5,4 @@ author_email: justus@devite.io
 author_github: @jgeramb
 ---
 # Administration
-* Allows the auto-completed document number to be changed if a prefix/suffix is configured for the document type. This enables the creation of alternative exports (e.g. e-invoice) of invoices while preserving the same document number.
+    * Removed the value type conversion of the document number field to allow any string value. This enables document numbers with prefixes and/or suffixes.

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -316,7 +316,6 @@ const missingTests = [
     'src/module/sw-order/component/sw-order-create-promotion-modal/index.js',
     'src/module/sw-order/component/sw-order-customer-comment/index.js',
     'src/module/sw-order/component/sw-order-document-settings-delivery-note-modal/index.js',
-    'src/module/sw-order/component/sw-order-document-settings-invoice-modal/index.js',
     'src/module/sw-order/component/sw-order-inline-field/index.js',
     'src/module/sw-order/component/sw-order-leave-page-modal/index.js',
     'src/module/sw-order/component/sw-order-nested-line-items-row/index.js',

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/index.js
@@ -45,7 +45,7 @@ export default {
                 return String(this.documentConfig.documentNumber);
             },
             set(value) {
-                this.documentConfig.documentNumber = Number(value);
+                this.documentConfig.documentNumber = value;
             },
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
@@ -412,4 +412,12 @@ describe('sw-order-document-settings-credit-note-modal', () => {
         const createContextMenu = wrapper.find('.sw-context-button');
         expect(createContextMenu.attributes().disabled).toBeUndefined();
     });
+
+    it('should allow any text input in the document number field', async () => {
+        const documentNumberFieldInput = wrapper.findByLabel('sw-order.documentModal.labelDocumentNumber');
+        expect(documentNumberFieldInput.exists()).toBeTruthy();
+
+        await documentNumberFieldInput.setValue('Prefix-1000-Suffix');
+        expect(documentNumberFieldInput.element.value).toBe('Prefix-1000-Suffix');
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-invoice-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-invoice-modal/index.js
@@ -22,7 +22,7 @@ export default {
                 return String(this.documentConfig.documentNumber);
             },
             set(value) {
-                this.documentConfig.documentNumber = Number(value);
+                this.documentConfig.documentNumber = value;
             },
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-invoice-modal/sw-order-document-settings-invoice-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-invoice-modal/sw-order-document-settings-invoice-modal.spec.js
@@ -1,4 +1,4 @@
-import {mount} from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 
 /**
  * @sw-package checkout
@@ -18,58 +18,55 @@ const orderFixture = {
 };
 
 async function createWrapper() {
-    return mount(
-        await wrapTestComponent('sw-order-document-settings-invoice-modal', { sync: true, }),
-        {
-            global: {
-                stubs: {
-                    'sw-order-document-settings-modal': await wrapTestComponent('sw-order-document-settings-modal', {
-                        sync: true,
-                    }),
-                    'sw-modal': {
-                        template: '<div class="sw-modal"><slot></slot><slot name="modal-footer"></slot></div>',
-                    },
-                    'sw-container': {
-                        template: '<div class="sw-container"><slot></slot></div>',
-                    },
-                    'sw-text-field': true,
-                    'sw-datepicker': true,
-                    'sw-checkbox-field': true,
+    return mount(await wrapTestComponent('sw-order-document-settings-invoice-modal', { sync: true }), {
+        global: {
+            stubs: {
+                'sw-order-document-settings-modal': await wrapTestComponent('sw-order-document-settings-modal', {
+                    sync: true,
+                }),
+                'sw-modal': {
+                    template: '<div class="sw-modal"><slot></slot><slot name="modal-footer"></slot></div>',
+                },
+                'sw-container': {
+                    template: '<div class="sw-container"><slot></slot></div>',
+                },
+                'sw-text-field': true,
+                'sw-datepicker': true,
+                'sw-checkbox-field': true,
 
-                    'sw-context-button': {
-                        template: '<div class="sw-context-button"><slot></slot></div>',
-                    },
-                    'sw-button-group': await wrapTestComponent('sw-button-group', { sync: true }),
-                    'sw-context-menu-item': true,
-                    'sw-upload-listener': true,
-                    'sw-textarea-field': true,
-                    'sw-block-field': await wrapTestComponent('sw-block-field', { sync: true }),
-                    'sw-base-field': await wrapTestComponent('sw-base-field', {
-                        sync: true,
-                    }),
-                    'sw-field-error': true,
-                    'sw-loader': true,
-                    'sw-media-upload-v2': true,
-                    'sw-media-modal-v2': true,
-                    'sw-inheritance-switch': true,
-                    'sw-ai-copilot-badge': true,
-                    'sw-help-text': true,
-                    'router-link': true,
+                'sw-context-button': {
+                    template: '<div class="sw-context-button"><slot></slot></div>',
                 },
-                provide: {
-                    numberRangeService: {
-                        reserve: () => Promise.resolve({ number: 1337 }),
-                    },
-                },
+                'sw-button-group': await wrapTestComponent('sw-button-group', { sync: true }),
+                'sw-context-menu-item': true,
+                'sw-upload-listener': true,
+                'sw-textarea-field': true,
+                'sw-block-field': await wrapTestComponent('sw-block-field', { sync: true }),
+                'sw-base-field': await wrapTestComponent('sw-base-field', {
+                    sync: true,
+                }),
+                'sw-field-error': true,
+                'sw-loader': true,
+                'sw-media-upload-v2': true,
+                'sw-media-modal-v2': true,
+                'sw-inheritance-switch': true,
+                'sw-ai-copilot-badge': true,
+                'sw-help-text': true,
+                'router-link': true,
             },
-            props: {
-                order: orderFixture,
-                currentDocumentType: {},
-                isLoadingDocument: false,
-                isLoadingPreview: false,
+            provide: {
+                numberRangeService: {
+                    reserve: () => Promise.resolve({ number: 1337 }),
+                },
             },
         },
-    );
+        props: {
+            order: orderFixture,
+            currentDocumentType: {},
+            isLoadingDocument: false,
+            isLoadingPreview: false,
+        },
+    });
 }
 
 describe('src/module/sw-order/component/sw-order-document-settings-invoice-modal', () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-invoice-modal/sw-order-document-settings-invoice-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-invoice-modal/sw-order-document-settings-invoice-modal.spec.js
@@ -1,0 +1,90 @@
+import {mount} from '@vue/test-utils';
+
+/**
+ * @sw-package checkout
+ */
+
+const orderFixture = {
+    id: 'order1',
+    documents: [],
+    currency: {
+        isoCode: 'EUR',
+    },
+    taxStatus: 'gross',
+    orderNumber: '10000',
+    amountNet: 80,
+    amountGross: 100,
+    lineItems: [],
+};
+
+async function createWrapper() {
+    return mount(
+        await wrapTestComponent('sw-order-document-settings-invoice-modal', { sync: true, }),
+        {
+            global: {
+                stubs: {
+                    'sw-order-document-settings-modal': await wrapTestComponent('sw-order-document-settings-modal', {
+                        sync: true,
+                    }),
+                    'sw-modal': {
+                        template: '<div class="sw-modal"><slot></slot><slot name="modal-footer"></slot></div>',
+                    },
+                    'sw-container': {
+                        template: '<div class="sw-container"><slot></slot></div>',
+                    },
+                    'sw-text-field': true,
+                    'sw-datepicker': true,
+                    'sw-checkbox-field': true,
+
+                    'sw-context-button': {
+                        template: '<div class="sw-context-button"><slot></slot></div>',
+                    },
+                    'sw-button-group': await wrapTestComponent('sw-button-group', { sync: true }),
+                    'sw-context-menu-item': true,
+                    'sw-upload-listener': true,
+                    'sw-textarea-field': true,
+                    'sw-block-field': await wrapTestComponent('sw-block-field', { sync: true }),
+                    'sw-base-field': await wrapTestComponent('sw-base-field', {
+                        sync: true,
+                    }),
+                    'sw-field-error': true,
+                    'sw-loader': true,
+                    'sw-media-upload-v2': true,
+                    'sw-media-modal-v2': true,
+                    'sw-inheritance-switch': true,
+                    'sw-ai-copilot-badge': true,
+                    'sw-help-text': true,
+                    'router-link': true,
+                },
+                provide: {
+                    numberRangeService: {
+                        reserve: () => Promise.resolve({ number: 1337 }),
+                    },
+                },
+            },
+            props: {
+                order: orderFixture,
+                currentDocumentType: {},
+                isLoadingDocument: false,
+                isLoadingPreview: false,
+            },
+        },
+    );
+}
+
+describe('src/module/sw-order/component/sw-order-document-settings-invoice-modal', () => {
+    let wrapper;
+
+    beforeEach(async () => {
+        wrapper = await createWrapper();
+        await flushPromises();
+    });
+
+    it('should allow any text input in the document number field', async () => {
+        const documentNumberFieldInput = wrapper.findByLabel('sw-order.documentModal.labelDocumentNumber');
+        expect(documentNumberFieldInput.exists()).toBeTruthy();
+
+        await documentNumberFieldInput.setValue('Prefix-1000-Suffix');
+        expect(documentNumberFieldInput.element.value).toBe('Prefix-1000-Suffix');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/index.js
@@ -97,7 +97,7 @@ export default {
                 return String(this.documentConfig.documentNumber);
             },
             set(value) {
-                this.documentConfig.documentNumber = Number(value);
+                this.documentConfig.documentNumber = value;
             },
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/sw-order-document-settings-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/sw-order-document-settings-modal.spec.js
@@ -110,13 +110,18 @@ async function createWrapper() {
 }
 
 describe('src/module/sw-order/component/sw-order-document-settings-modal', () => {
+    let wrapper;
+
+    beforeEach(async () => {
+        wrapper = await createWrapper();
+        await flushPromises();
+    });
+
     it('should be a Vue.js component', async () => {
-        const wrapper = await createWrapper();
         expect(wrapper.vm).toBeTruthy();
     });
 
     it('should emit `preview-show` event when click on Preview button', async () => {
-        const wrapper = await createWrapper();
         const previewButton = wrapper.find('.sw-order-document-settings-modal__preview-button');
 
         await previewButton.trigger('click');
@@ -126,7 +131,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
     });
 
     it('should show file or hide custom document file when toggling Upload custom document', async () => {
-        const wrapper = await createWrapper();
         const inputUploadCustomDoc = wrapper.find('input[name="sw-field--uploadDocument"]');
         await inputUploadCustomDoc.setChecked(true);
 
@@ -135,8 +139,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
     });
 
     it('should emit `create` event when click on Create button', async () => {
-        const wrapper = await createWrapper();
-
         const createButton = wrapper.find('.sw-order-document-settings-modal__create');
         await createButton.trigger('click');
 
@@ -144,8 +146,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
     });
 
     it('should emit `document-create` event when click on Create and send button', async () => {
-        const wrapper = await createWrapper();
-
         const createAndSendButton = wrapper.find('.sw-order-document-settings-modal__send-button');
         await createAndSendButton.trigger('click');
 
@@ -154,8 +154,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
     });
 
     it('should emit `document-create` event when click on Create and download button', async () => {
-        const wrapper = await createWrapper();
-
         const createAndSendButton = wrapper.find('.sw-order-document-settings-modal__download-button');
         await createAndSendButton.trigger('click');
 
@@ -164,8 +162,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
     });
 
     it('should able to add file from media modal if media is suitable', async () => {
-        const wrapper = await createWrapper();
-
         const customDocumentToggle = wrapper.find('input[name="sw-field--uploadDocument"]');
         await customDocumentToggle.setChecked(true);
 
@@ -182,8 +178,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
     });
 
     it('should able to add file uploaded from url if media is suitable', async () => {
-        const wrapper = await createWrapper();
-
         const customDocumentToggle = wrapper.find('input[name="sw-field--uploadDocument"]');
         await customDocumentToggle.setChecked(true);
 
@@ -195,8 +189,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
     });
 
     it('should able to show modal title responding to document type', async () => {
-        const wrapper = await createWrapper();
-
         await wrapper.setProps({
             currentDocumentType: {
                 id: '1',
@@ -210,13 +202,19 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
     });
 
     it('should emit `preview-show` event when click on Preview of the HTML button', async () => {
-        const wrapper = await createWrapper();
-
         const previewButton = wrapper.findAll('.sw-button-group').at(0);
         await previewButton.find('.sw-order-document-settings-modal__preview-button-html').trigger('click');
 
         expect(wrapper.emitted()['preview-show']).toBeTruthy();
         expect(wrapper.emitted()['preview-show'][0][1]).toBe('html');
         expect(wrapper.emitted()['preview-show'][0][0].fileTypes).toEqual(['html']);
+    });
+
+    it('should allow any text input in the document number field', async () => {
+        const documentNumberFieldInput = wrapper.findByLabel('sw-order.documentModal.labelDocumentNumber');
+        expect(documentNumberFieldInput.exists()).toBeTruthy();
+
+        await documentNumberFieldInput.setValue('Prefix-1000-Suffix');
+        expect(documentNumberFieldInput.element.value).toBe('Prefix-1000-Suffix');
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-storno-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-storno-modal/index.js
@@ -57,7 +57,7 @@ export default {
                 return String(this.documentConfig.documentNumber);
             },
             set(value) {
-                this.documentConfig.documentNumber = Number(value);
+                this.documentConfig.documentNumber = value;
             },
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-storno-modal/sw-order-document-settings-storno-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-storno-modal/sw-order-document-settings-storno-modal.spec.js
@@ -127,14 +127,18 @@ async function createWrapper() {
 }
 
 describe('src/module/sw-order/component/sw-order-document-settings-storno-modal', () => {
+    let wrapper;
+
+    beforeEach(async () => {
+        wrapper = await createWrapper();
+        await flushPromises();
+    });
+
     it('should be a Vue.js component', async () => {
-        const wrapper = await createWrapper();
         expect(wrapper.vm).toBeTruthy();
     });
 
     it('should show only invoice numbers in invoice number select field', async () => {
-        const wrapper = await createWrapper();
-
         const invoiceSelect = wrapper.find('.mt-select input');
         await invoiceSelect.trigger('click');
 
@@ -146,8 +150,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-storno-modal'
     });
 
     it('should disable create button if there is no selected invoice', async () => {
-        const wrapper = await createWrapper();
-
         const createButton = wrapper.find('.sw-order-document-settings-modal__create');
         expect(createButton.attributes().disabled).toBeDefined();
 
@@ -156,8 +158,6 @@ describe('src/module/sw-order/component/sw-order-document-settings-storno-modal'
     });
 
     it('should enable create button if there is at least one selected invoice', async () => {
-        const wrapper = await createWrapper();
-
         await selectMtSelectOptionByText(wrapper, '1001', '.sw-order-document-settings-storno-modal__invoice-select input');
 
         const createButton = wrapper.find('.sw-order-document-settings-modal__create');
@@ -165,5 +165,13 @@ describe('src/module/sw-order/component/sw-order-document-settings-storno-modal'
 
         const createContextMenu = wrapper.find('.sw-context-button');
         expect(createContextMenu.attributes().disabled).toBeUndefined();
+    });
+
+    it('should allow any text input in the document number field', async () => {
+        const documentNumberFieldInput = wrapper.findByLabel('sw-order.documentModal.labelDocumentStornoNumber');
+        expect(documentNumberFieldInput.exists()).toBeTruthy();
+
+        await documentNumberFieldInput.setValue('Prefix-1000-Suffix');
+        expect(documentNumberFieldInput.element.value).toBe('Prefix-1000-Suffix');
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
See the related issue.

### 2. What does this change do, exactly?
It removes the number conversion of the document number input, allowing text inputs. This should not introduce any side-effects since the SQL column type is 'varchar(255)' and the API works fine with string values.

### 3. Describe each step to reproduce the issue or behaviour.
See the related issue.

### 4. Please link to the relevant issues (if any).
- closes #10873 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
