### PR TITLE
fix: order version during credit note creation

### DIFF
--- a/changelog/_unreleased/2025-06-28-fix-credit-note-order-version.md
+++ b/changelog/_unreleased/2025-06-28-fix-credit-note-order-version.md
@@ -5,4 +5,5 @@ author_email: justus@devite.io
 author_github: @jgeramb
 ---
 # Core
-* Uses the LIVE version of the order to determine the credit items and then creates a new version to maintain the document state.
+* Changed the order version for determining credit items to LIVE.
+* Added a new order version before document generation to maintain the document state.

--- a/changelog/_unreleased/2025-06-28-fix-credit-note-order-version.md
+++ b/changelog/_unreleased/2025-06-28-fix-credit-note-order-version.md
@@ -1,0 +1,8 @@
+---
+title: Fix order version for determining credit notes when creating credit notes
+author: Justus Geramb
+author_email: justus@devite.io
+author_github: @jgeramb
+---
+# Core
+* Uses the LIVE version of the order to determine the credit items and then creates a new version to maintain the document state.


### PR DESCRIPTION
### 1. Why is this change necessary?
Without this change, a new invoice including the credit note items must be created in order to create a credit note. Credit notes should be created for existing invoices and include all credit note items added up to the time the credit note is created. 

### 2. What does this change do, exactly?
It removes any association with the order version of the invoice and instead uses the LIVE version of the order to search for credit items. A new version of the order is then created to permanently retain the document data.

### 3. Describe each step to reproduce the issue or behaviour.
See the related issue.

### 4. Please link to the relevant issues (if any).
- closes #8838 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
