### PR TITLE
fix: Only allow to edit price of line item if price definition is set

### DIFF
--- a/changelog/_unreleased/2025-06-30-prevent-line-item-price-editing-in-admin-if-price-definition-is-missing.md
+++ b/changelog/_unreleased/2025-06-30-prevent-line-item-price-editing-in-admin-if-price-definition-is-missing.md
@@ -1,0 +1,8 @@
+---
+title: Prevent line item price editing in admin if price definition is missing
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed `sw-order-line-items-grid` component to only allow for editing the price if a price definition is set

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
@@ -200,7 +200,7 @@
 
             {% block sw_order_line_items_grid_grid_columns_unit_price_inline_edit %}
             <mt-number-field
-                v-if="isInlineEdit && !itemCreatedFromProduct(item.id)"
+                v-if="isInlineEdit && !itemCreatedFromProduct(item.id) && item.priceDefinition"
                 v-model="item.priceDefinition.price"
                 name="sw-field--item-priceDefinition-price"
                 placeholder="0"


### PR DESCRIPTION
### 1. Why is this change necessary?
It is not required that every line item has a price definition (although it can have a calculated price). In our case this happens when we have nested line items, where the price is determined from the prices of the child items.

However this leads to an error when one tries to edit the line item in the administration:
![image](https://github.com/user-attachments/assets/8935e625-7a82-414f-83de-b2963acae5cb)

Leading to an empty price:
![image](https://github.com/user-attachments/assets/2ce3adb9-8d51-483a-a928-5080e889d35a)

### 2. What does this change do, exactly?
Add a check and only try to allow editing the price, if a price definition is set:
![image](https://github.com/user-attachments/assets/9a7da1ba-822a-4f06-b0e9-a03ce07cb643)

### 3. Describe each step to reproduce the issue or behaviour.
Edit a line item in the administration of an order, which has no price definition set.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
