### PR TITLE
chore(ci): adjust input naming for visual tests, don't fail when single artifact steps fail

### DIFF
--- a/.github/actions/ats/action.yaml
+++ b/.github/actions/ats/action.yaml
@@ -140,9 +140,11 @@ runs:
       if: ${{ contains(inputs.project, 'visual') && !contains(inputs.extra-options, 'update-snapshots') }}
       uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
       with:
+        workflow_search: 'true'
         branch: ${{ github.ref_name }}
         name: visual-snapshots-${{ hashFiles('.git/HEAD') }}
         path: .
+        search_artifacts: 'true'
       continue-on-error: true
 
     - name: Run your tests

--- a/.github/actions/ats/action.yaml
+++ b/.github/actions/ats/action.yaml
@@ -156,6 +156,7 @@ runs:
         CURRENTS_BUILD_ID: "${{ format('{0}-{1}-{2}', github.repository, github.run_id, github.run_attempt) }}${{ matrix.major && 'major' }}"
         ATS_CMD: ${{ inputs.use-currents && 'pwc' || 'playwright'}}
       run: npx $ATS_CMD test --project=${{ inputs.project }} --workers=${{ inputs.workers }} --shard=${{ inputs.shard }}/${{ inputs.shard-count }} ${{ inputs.extra-options }}
+      continue-on-error: ${{ contains(inputs.project, 'visual') }} # Visual tests are allowed to fail; the results will be uploaded regardless and checked regularly
 
     - uses: actions/upload-artifact@v4
       if: always()

--- a/.github/actions/ats/action.yaml
+++ b/.github/actions/ats/action.yaml
@@ -143,6 +143,7 @@ runs:
         branch: ${{ github.ref_name }}
         name: visual-snapshots-${{ hashFiles('.git/HEAD') }}
         path: .
+      continue-on-error: true
 
     - name: Run your tests
       shell: bash
@@ -160,6 +161,7 @@ runs:
         name: ats-${{ inputs.project }}-${{ inputs.shard }}-php${{ inputs.php-version }}-${{ inputs.major && '-major' || '' }}
         path: ${{ inputs.directory }}/test-results/
         retention-days: 3
+      continue-on-error: true
 
     - name: Upload visual testing snapshots
       if: ${{ contains(inputs.project, 'visual') && contains(inputs.extra-options, 'update-snapshots') }}
@@ -169,4 +171,5 @@ runs:
         path: |
           .gitignore
           tests/acceptance/tests/**/*-snapshots/*.png
-        retention-days: 3
+        retention-days: 90
+      continue-on-error: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
-      nightly: true
+      currents: 'true'
   php:
     uses: ./.github/workflows/php.yml
     secrets: inherit

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -9,8 +9,8 @@ on:
         description: 'Update snapshots?'
         type: boolean
         default: false
-      nightly:
-        description: 'Running as part of the nightly build?'
+      currents:
+        description: 'Report to currents?'
         type: boolean
         default: false
 
@@ -20,8 +20,8 @@ on:
         description: 'Update snapshots?'
         type: boolean
         default: false
-      nightly:
-        description: 'Running as part of the nightly build?'
+      currents:
+        description: 'Report to currents?'
         type: boolean
         default: false
 
@@ -40,7 +40,7 @@ jobs:
           install: 'true'
           extra-options: >-
             ${{ inputs.update-snapshots && ' --update-snapshots' || '' }}
-          use-currents: ${{ inputs.nightly && 'true' || '' }} 
+          use-currents: ${{ inputs.currents && 'true' || '' }}
           currents-project-id: ${{ secrets.CURRENTS_PROJECT_ID_VISUAL }}
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
-          
+        continue-on-error: true


### PR DESCRIPTION
With this PR I've adjusted input naming to clearly state their purpose. Also, I've adjusted the artifact steps, in order not to stop the entire job in case one fails.

The action responsible for finding visual testing artifacts is now allowed to search for artifacts named correctly _across workflows_. Until now, the nightly workflow only allowed referencing artifacts from other nightly workflows.
When "approving" a visual testing build, though, we need to trigger the visual testing workflow manually, outside of the nightly; this prevented the nightly to reference visual testing artifacts for the trunk branch until now.
The artifact is essentially now identified _solely_ by its name, which is a hash of the branch the visual tests were executed from.

Visual tests are allowed to fail now and won't result in the whole job failing; quali-ops is taking care of reviewing the visual testing artifacts regularly. Failures should also still be reported to currents as well.

### Test

- Test run with `--update-snapshots`: https://github.com/shopware/shopware/actions/runs/15974007439
- Test run without: https://github.com/shopware/shopware/actions/runs/15974168672/job/45052165938