### PR TITLE
fix: reduce too many cache cleaning operations

### DIFF
--- a/changelog/_unreleased/2025-07-01-add-lock-for-cache-clearer.md
+++ b/changelog/_unreleased/2025-07-01-add-lock-for-cache-clearer.md
@@ -1,0 +1,10 @@
+---
+title: Add lock for CacheClearer
+issue: 10706
+author: nfortier
+author_email: n.fortier@shopware.com
+author_github: nfortier-shopware
+---
+
+# Core
+* Added a lock of 30s to `CacheClearer` for `cleanupOldContainerCacheDirectories` and `clearContainerCache` methods to limit concurrent execution and fatal error due to PHP files destroyed by one process and required by the other.

--- a/changelog/_unreleased/2025-07-01-add-lock-for-cache-clearer.md
+++ b/changelog/_unreleased/2025-07-01-add-lock-for-cache-clearer.md
@@ -7,4 +7,4 @@ author_github: nfortier-shopware
 ---
 
 # Core
-* Added a lock of 30s to `CacheClearer` for `cleanupOldContainerCacheDirectories` and `clearContainerCache` methods to limit concurrent execution and fatal error due to PHP files destroyed by one process and required by the other.
+* Added a lock of 30s and shared key to `\Shopware\Core\Framework\Adapter\CacheCacheClearer` for `cleanupOldContainerCacheDirectories` and `clearContainerCache` methods to limit concurrent execution resulting in fatal error due to PHP files destroyed by one process and required by the other.

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -164,10 +164,16 @@ class CacheClearer
         }
     }
 
+    /**
+     * Locks the execution of the closure to prevent concurrent executions.
+     *
+     * @see https://symfony.com/doc/current/components/lock.html
+     */
     private function lock(\Closure $closure, string $key, int $timeToLive): void
     {
         $lock = $this->lockFactory->createLock('cache-clearer::' . $key, $timeToLive);
 
+        // The execution is blocked until the key is found or the time to live is reached.
         if ($lock->acquire(true)) {
             $closure();
 

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -22,6 +22,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 class CacheClearer
 {
     private const LOCK_TTL = 30;
+    private const LOCK_KEY_CONTAINER = 'container-cache-directories';
 
     /**
      * @internal
@@ -96,7 +97,7 @@ class CacheClearer
 
         $this->lock(function () use ($containerCaches): void {
             $this->filesystem->remove($containerCaches);
-        }, __FUNCTION__, self::LOCK_TTL);
+        }, self::LOCK_KEY_CONTAINER, self::LOCK_TTL);
     }
 
     public function scheduleCacheFolderCleanup(): void
@@ -149,7 +150,7 @@ class CacheClearer
         if ($remove !== []) {
             $this->lock(function () use ($remove): void {
                 $this->filesystem->remove($remove);
-            }, __FUNCTION__, self::LOCK_TTL);
+            }, self::LOCK_KEY_CONTAINER, self::LOCK_TTL);
         }
     }
 

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -12,6 +12,7 @@ use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -20,6 +21,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[Package('framework')]
 class CacheClearer
 {
+    private const LOCK_TTL = 30;
+
     /**
      * @internal
      *
@@ -36,7 +39,8 @@ class CacheClearer
         private readonly bool $clusterMode,
         private readonly bool $reverseHttpCacheEnabled,
         private readonly MessageBusInterface $messageBus,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly LockFactory $lockFactory,
     ) {
     }
 
@@ -90,7 +94,9 @@ class CacheClearer
             $containerCaches[] = $containerPaths->getRealPath();
         }
 
-        $this->filesystem->remove($containerCaches);
+        $this->lock(function () use ($containerCaches): void {
+            $this->filesystem->remove($containerCaches);
+        }, __FUNCTION__, self::LOCK_TTL);
     }
 
     public function scheduleCacheFolderCleanup(): void
@@ -133,7 +139,6 @@ class CacheClearer
         if (!$finder->hasResults()) {
             return;
         }
-
         $remove = [];
         foreach ($finder->getIterator() as $directory) {
             if ($directory->getPathname() !== $this->cacheDir) {
@@ -142,7 +147,9 @@ class CacheClearer
         }
 
         if ($remove !== []) {
-            $this->filesystem->remove($remove);
+            $this->lock(function () use ($remove): void {
+                $this->filesystem->remove($remove);
+            }, __FUNCTION__, self::LOCK_TTL);
         }
     }
 
@@ -153,6 +160,17 @@ class CacheClearer
         // if reverse proxy is not enabled, clear the http pool
         if ($this->reverseProxyCache === null) {
             $this->adapters['http']->clear();
+        }
+    }
+
+    private function lock(\Closure $closure, string $key, int $timeToLive): void
+    {
+        $lock = $this->lockFactory->createLock('cache-clearer::' . $key, $timeToLive);
+
+        if ($lock->acquire(true)) {
+            $closure();
+
+            $lock->release();
         }
     }
 

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -76,6 +76,7 @@
             <argument>%shopware.http_cache.reverse_proxy.enabled%</argument>
             <argument type="service" id="messenger.default_bus"/>
             <argument type="service" id="logger"/>
+            <argument type="service" id="lock.factory"/>
         </service>
 
         <service id="Shopware\Core\Framework\Adapter\Cache\Message\CleanupOldCacheFoldersHandler">

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -202,7 +202,8 @@ class PluginManagementServiceTest extends TestCase
             false,
             false,
             static::getContainer()->get('messenger.default_bus'),
-            static::getContainer()->get('logger')
+            static::getContainer()->get('logger'),
+            static::getContainer()->get('lock.factory')
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

There are concurrent calls from SwagExtensionCore, shopaware main application, that are invoking 2 cache cleaning:
- cache container cleaning 
- general cache

This can result to fatal error, while one process is destroying those php files cached, that were loaded and required by the application on another process.

### 2. What does this change do, exactly?

This PR add a simple lock with a time to live of 30s to these 2 methods, from anywhere they are invoked. 
This will reduce the possibility of race condition.

### 3. Describe each step to reproduce the issue or behaviour.

See issue, this can be done on local also without using the store to install extensions (with zip install)

### 4. Please link to the relevant issues (if any).

- closes [#10706](https://github.com/shopware/shopware/issues/10706)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
