### PR TITLE
fix: Change path of header and footer routes to avoid collisions

### DIFF
--- a/changelog/_unreleased/2025-07-01-change-path-of-header-and-footer-routes.md
+++ b/changelog/_unreleased/2025-07-01-change-path-of-header-and-footer-routes.md
@@ -1,0 +1,11 @@
+---
+title: Change path of header and footer routes
+issue: 10906
+author: Michael Telgmann
+author_github: @mitelg
+---
+
+# Storefront
+
+* Changed the path of the header (`frontend.header`) and footer (`frontend.footer`) routes to avoid collisions with SEO URLs as they were too generic.
+  The new paths are `/_esi/global/header` and `/_esi/global/footer`.

--- a/src/Storefront/Controller/NavigationController.php
+++ b/src/Storefront/Controller/NavigationController.php
@@ -47,7 +47,8 @@ class NavigationController extends StorefrontController
         path: '/',
         name: 'frontend.home.page',
         options: ['seo' => true],
-        defaults: ['_httpCache' => true], methods: ['GET']
+        defaults: ['_httpCache' => true],
+        methods: ['GET'],
     )]
     public function home(Request $request, SalesChannelContext $context): Response
     {
@@ -63,7 +64,7 @@ class NavigationController extends StorefrontController
         name: 'frontend.navigation.page',
         options: ['seo' => true],
         defaults: ['_httpCache' => true],
-        methods: ['GET']
+        methods: ['GET'],
     )]
     public function index(SalesChannelContext $context, Request $request): Response
     {
@@ -92,7 +93,7 @@ class NavigationController extends StorefrontController
         path: '/widgets/menu/offcanvas',
         name: 'frontend.menu.offcanvas',
         defaults: ['XmlHttpRequest' => true, '_httpCache' => true],
-        methods: ['GET']
+        methods: ['GET'],
     )]
     public function offcanvas(Request $request, SalesChannelContext $context): Response
     {
@@ -114,7 +115,7 @@ class NavigationController extends StorefrontController
         path: '/_esi/global/header',
         name: 'frontend.header',
         defaults: ['XmlHttpRequest' => true, '_httpCache' => true, '_esi' => true],
-        methods: ['GET']
+        methods: ['GET'],
     )]
     public function header(Request $request, SalesChannelContext $context): Response
     {
@@ -132,7 +133,7 @@ class NavigationController extends StorefrontController
         path: '/_esi/global/footer',
         name: 'frontend.footer',
         defaults: ['XmlHttpRequest' => true, '_httpCache' => true, '_esi' => true],
-        methods: ['GET']
+        methods: ['GET'],
     )]
     public function footer(Request $request, SalesChannelContext $context): Response
     {

--- a/src/Storefront/Controller/NavigationController.php
+++ b/src/Storefront/Controller/NavigationController.php
@@ -43,7 +43,12 @@ class NavigationController extends StorefrontController
     ) {
     }
 
-    #[Route(path: '/', name: 'frontend.home.page', options: ['seo' => true], defaults: ['_httpCache' => true], methods: ['GET'])]
+    #[Route(
+        path: '/',
+        name: 'frontend.home.page',
+        options: ['seo' => true],
+        defaults: ['_httpCache' => true], methods: ['GET']
+    )]
     public function home(Request $request, SalesChannelContext $context): Response
     {
         $page = $this->navigationPageLoader->load($request, $context);
@@ -53,7 +58,13 @@ class NavigationController extends StorefrontController
         return $this->renderStorefront('@Storefront/storefront/page/content/index.html.twig', ['page' => $page]);
     }
 
-    #[Route(path: '/navigation/{navigationId}', name: 'frontend.navigation.page', options: ['seo' => true], defaults: ['_httpCache' => true], methods: ['GET'])]
+    #[Route(
+        path: '/navigation/{navigationId}',
+        name: 'frontend.navigation.page',
+        options: ['seo' => true],
+        defaults: ['_httpCache' => true],
+        methods: ['GET']
+    )]
     public function index(SalesChannelContext $context, Request $request): Response
     {
         $page = $this->navigationPageLoader->load($request, $context);
@@ -77,7 +88,12 @@ class NavigationController extends StorefrontController
         return $this->renderStorefront('@Storefront/storefront/page/content/index.html.twig', ['page' => $page]);
     }
 
-    #[Route(path: '/widgets/menu/offcanvas', name: 'frontend.menu.offcanvas', defaults: ['XmlHttpRequest' => true, '_httpCache' => true], methods: ['GET'])]
+    #[Route(
+        path: '/widgets/menu/offcanvas',
+        name: 'frontend.menu.offcanvas',
+        defaults: ['XmlHttpRequest' => true, '_httpCache' => true],
+        methods: ['GET']
+    )]
     public function offcanvas(Request $request, SalesChannelContext $context): Response
     {
         $page = $this->offcanvasLoader->load($request, $context);
@@ -94,7 +110,12 @@ class NavigationController extends StorefrontController
         return $response;
     }
 
-    #[Route(path: '/header', name: 'frontend.header', defaults: ['XmlHttpRequest' => true, '_httpCache' => true, '_esi' => true], methods: ['GET'])]
+    #[Route(
+        path: '/_esi/global/header',
+        name: 'frontend.header',
+        defaults: ['XmlHttpRequest' => true, '_httpCache' => true, '_esi' => true],
+        methods: ['GET']
+    )]
     public function header(Request $request, SalesChannelContext $context): Response
     {
         $header = $this->headerLoader->load($request, $context);
@@ -107,7 +128,12 @@ class NavigationController extends StorefrontController
         ]);
     }
 
-    #[Route(path: '/footer', name: 'frontend.footer', defaults: ['XmlHttpRequest' => true, '_httpCache' => true, '_esi' => true], methods: ['GET'])]
+    #[Route(
+        path: '/_esi/global/footer',
+        name: 'frontend.footer',
+        defaults: ['XmlHttpRequest' => true, '_httpCache' => true, '_esi' => true],
+        methods: ['GET']
+    )]
     public function footer(Request $request, SalesChannelContext $context): Response
     {
         $footer = $this->footerLoader->load($request, $context);


### PR DESCRIPTION
### 1. Why is this change necessary?

the path of the header and footer routes was too generic. It could cause collisions for example if a category named "Header" is created. 

### 2. What does this change do, exactly?

Change the path of header and footer routes to something that is more likely not causing name collision issues

### 3. Describe each step to reproduce the issue or behaviour.

- Create a category named "Header"
- Generate SEO URLs
- call any page of the shop

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/10906

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
