### PR TITLE
chore(ci): fix nightly workflow definition

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
-      currents: 'true'
+      currents: true
   php:
     uses: ./.github/workflows/php.yml
     secrets: inherit


### PR DESCRIPTION
Only a boolean value is accepted for the `currents` input.