### PR TITLE
fix: keep promotion codes after login

### DIFF
--- a/src/Core/Checkout/DependencyInjection/promotion.xml
+++ b/src/Core/Checkout/DependencyInjection/promotion.xml
@@ -219,5 +219,9 @@
         <service id="Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\SetScopeDiscountPackager">
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder"/>
         </service>
+
+        <service id="Shopware\Core\Checkout\Promotion\Cart\CartPromotionsSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Checkout/Promotion/Cart/CartPromotionsSubscriber.php
+++ b/src/Core/Checkout/Promotion/Cart/CartPromotionsSubscriber.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Promotion\Cart;
+
+use Shopware\Core\Checkout\Cart\Event\BeforeCartMergeEvent;
+use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class CartPromotionsSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [BeforeCartMergeEvent::class => 'onBeforeCartMerge'];
+    }
+
+    public function onBeforeCartMerge(BeforeCartMergeEvent $event): void
+    {
+        $guestCart = $event->getGuestCart();
+        $customerCart = $event->getCustomerCart();
+
+        if (!$guestCart->hasExtension(CartExtension::KEY)) {
+            return;
+        }
+
+        /** @var CartExtension $guestPromotions */
+        $guestPromotions = $guestCart->getExtension(CartExtension::KEY);
+        /** @var CartExtension $customerPromotions */
+        $customerPromotions = $customerCart->getExtension(CartExtension::KEY) ?? new CartExtension();
+
+        $customerCart->addExtension(CartExtension::KEY, $customerPromotions->merge($guestPromotions));
+    }
+}

--- a/src/Core/Checkout/Promotion/Cart/CartPromotionsSubscriber.php
+++ b/src/Core/Checkout/Promotion/Cart/CartPromotionsSubscriber.php
@@ -27,10 +27,8 @@ class CartPromotionsSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var CartExtension $guestPromotions */
-        $guestPromotions = $guestCart->getExtension(CartExtension::KEY);
-        /** @var CartExtension $customerPromotions */
-        $customerPromotions = $customerCart->getExtension(CartExtension::KEY) ?? new CartExtension();
+        $guestPromotions = $guestCart->getExtensionOfType(CartExtension::KEY, CartExtension::class) ?? new CartExtension();
+        $customerPromotions = $customerCart->getExtensionOfType(CartExtension::KEY, CartExtension::class) ?? new CartExtension();
 
         $customerCart->addExtension(CartExtension::KEY, $customerPromotions->merge($guestPromotions));
     }

--- a/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
+++ b/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
@@ -89,7 +89,7 @@ class CartExtension extends Struct
         return $this->blockedPromotionIds;
     }
 
-    public function merge(self $extension): self
+    public function merge(self $extension): static
     {
         $new = clone $this;
 

--- a/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
+++ b/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
@@ -80,4 +80,27 @@ class CartExtension extends Struct
     {
         return \in_array($id, $this->blockedPromotionIds, true);
     }
+
+    /**
+     * @return array<string>
+     */
+    public function getBlockedPromotions(): array
+    {
+        return $this->blockedPromotionIds;
+    }
+
+    public function merge(self $extension): self
+    {
+        $new = clone $this;
+
+        foreach ($extension->getCodes() as $code) {
+            $new->addCode($code);
+        }
+
+        foreach ($extension->getBlockedPromotions() as $id) {
+            $new->blockPromotion($id);
+        }
+
+        return $new;
+    }
 }

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/Extension/CartExtensionTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/Extension/CartExtensionTest.php
@@ -81,4 +81,57 @@ class CartExtensionTest extends TestCase
 
         static::assertSame(['c456'], $extension->getCodes());
     }
+
+    #[Group('promotions')]
+    public function testMerge(): void
+    {
+        $extension1 = new CartExtension();
+        $extension1->addCode('c123');
+        $extension1->blockPromotion('p123');
+
+        $extension2 = new CartExtension();
+        $extension2->addCode('c456');
+        $extension2->blockPromotion('p456');
+
+        $merged = $extension1->merge($extension2);
+
+        static::assertEquals(['c123', 'c456'], $merged->getCodes());
+        static::assertTrue($merged->isPromotionBlocked('p123'));
+        static::assertTrue($merged->isPromotionBlocked('p456'));
+    }
+
+    #[Group('promotions')]
+    public function testMergeCreatesImmutable(): void
+    {
+        $extension1 = new CartExtension();
+        $extension1->addCode('c123');
+        $extension1->blockPromotion('p123');
+
+        $extension2 = new CartExtension();
+        $extension2->addCode('c456');
+        $extension2->blockPromotion('p456');
+
+        $merged = $extension1->merge($extension2);
+
+        static::assertNotSame($extension1, $merged);
+        static::assertNotSame($extension2, $merged);
+    }
+
+    #[Group('promotions')]
+    public function testMergeKillsDuplicates(): void
+    {
+        $extension1 = new CartExtension();
+        $extension1->addCode('c123');
+        $extension1->blockPromotion('p123');
+
+        $extension2 = new CartExtension();
+        $extension2->addCode('c123'); // Duplicate code
+        $extension2->blockPromotion('p456');
+
+        $merged = $extension1->merge($extension2);
+
+        static::assertEquals(['c123'], $merged->getCodes());
+        static::assertTrue($merged->isPromotionBlocked('p123'));
+        static::assertTrue($merged->isPromotionBlocked('p456'));
+    }
 }

--- a/tests/unit/Core/Checkout/Promotion/Cart/CartPromotionsSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/CartPromotionsSubscriberTest.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Promotion\Cart;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Event\BeforeCartMergeEvent;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Checkout\Promotion\Cart\CartPromotionsSubscriber;
+use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Generator;
+
+/**
+ * @internal
+ */
+#[CoversClass(CartPromotionsSubscriber::class)]
+#[Package('checkout')]
+class CartPromotionsSubscriberTest extends TestCase
+{
+    #[Group('promotions')]
+    public function testGetSubscribedEvents(): void
+    {
+        static::assertSame([BeforeCartMergeEvent::class => 'onBeforeCartMerge'], CartPromotionsSubscriber::getSubscribedEvents());
+    }
+
+    #[Group('promotions')]
+    public function testOnBeforeCartMergesPromotions(): void
+    {
+        $guestPromotions = new CartExtension();
+        $guestPromotions->addCode('tenpercent');
+        $guestPromotions->blockPromotion('foo');
+
+        $guestCart = new Cart('guest');
+        $guestCart->addExtension(CartExtension::KEY, $guestPromotions);
+
+        $customerPromotions = new CartExtension();
+        $customerPromotions->addCode('twentypercent');
+        $customerPromotions->blockPromotion('bar');
+
+        $customerCart = new Cart('customer');
+        $customerCart->addExtension(CartExtension::KEY, $customerPromotions);
+
+        $event = new BeforeCartMergeEvent($customerCart, $guestCart, new LineItemCollection(), Generator::generateSalesChannelContext());
+
+        $subscriber = new CartPromotionsSubscriber();
+        $subscriber->onBeforeCartMerge($event);
+
+        $customerCart = $event->getCustomerCart();
+
+        static::assertTrue($customerCart->hasExtension(CartExtension::KEY));
+
+        /** @var CartExtension $customerPromotions */
+        $customerPromotions = $customerCart->getExtension(CartExtension::KEY);
+
+        static::assertCount(2, $customerPromotions->getCodes());
+        static::assertTrue($customerPromotions->hasCode('tenpercent'));
+        static::assertTrue($customerPromotions->hasCode('twentypercent'));
+        static::assertFalse($customerPromotions->hasCode('thrirtypercent'));
+
+        static::assertTrue($customerPromotions->isPromotionBlocked('foo'));
+        static::assertTrue($customerPromotions->isPromotionBlocked('bar'));
+        static::assertFalse($customerPromotions->isPromotionBlocked('baz'));
+    }
+
+    #[Group('promotions')]
+    public function testMergeDoesNotDuplicatePromotions(): void
+    {
+        $guestPromotions = new CartExtension();
+        $guestPromotions->addCode('tenpercent');
+        $guestPromotions->blockPromotion('foo');
+
+        $guestCart = new Cart('guest');
+        $guestCart->addExtension(CartExtension::KEY, $guestPromotions);
+
+        $customerPromotions = new CartExtension();
+        $customerPromotions->addCode('tenpercent');
+        $customerPromotions->blockPromotion('foo');
+
+        $customerCart = new Cart('customer');
+        $customerCart->addExtension(CartExtension::KEY, $customerPromotions);
+
+        $event = new BeforeCartMergeEvent($customerCart, $guestCart, new LineItemCollection(), Generator::generateSalesChannelContext());
+
+        $subscriber = new CartPromotionsSubscriber();
+        $subscriber->onBeforeCartMerge($event);
+
+        $customerCart = $event->getCustomerCart();
+
+        static::assertTrue($customerCart->hasExtension(CartExtension::KEY));
+
+        /** @var CartExtension $customerPromotions */
+        $customerPromotions = $customerCart->getExtension(CartExtension::KEY);
+
+        static::assertCount(1, $customerPromotions->getCodes());
+        static::assertTrue($customerPromotions->hasCode('tenpercent'));
+        static::assertFalse($customerPromotions->hasCode('tenPercent'));
+    }
+
+    #[Group('promotions')]
+    public function testSkipsExecutionIfGuestPromotionsAreEmpty(): void
+    {
+        $guestCart = new Cart('guest');
+
+        $customerPromotions = new CartExtension();
+        $customerPromotions->addCode('twentypercent');
+
+        $customerCart = new Cart('customer');
+        $customerCart->addExtension(CartExtension::KEY, $customerPromotions);
+
+        $event = new BeforeCartMergeEvent($customerCart, $guestCart, new LineItemCollection(), Generator::generateSalesChannelContext());
+
+        $subscriber = new CartPromotionsSubscriber();
+        $subscriber->onBeforeCartMerge($event);
+
+        $customerCart = $event->getCustomerCart();
+
+        static::assertTrue($customerCart->hasExtension(CartExtension::KEY));
+
+        /** @var CartExtension $customerPromotions */
+        $customerPromotions = $customerCart->getExtension(CartExtension::KEY);
+
+        static::assertCount(1, $customerPromotions->getCodes());
+
+        static::assertTrue($customerPromotions->hasCode('twentypercent'));
+    }
+}


### PR DESCRIPTION
fixes [#10809](https://github.com/shopware/shopware/issues/10809)