### PR TITLE
fix: find correct admin root without explict env, fixes #10754

### DIFF
--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -31,7 +31,7 @@ import injectHtml from './vite-plugins/inject-html';
 
 const VITE_MODE = process.env.VITE_MODE || 'development';
 const isDev = VITE_MODE === 'development';
-const adminSrcPath = path.join(path.dirname(__dirname), 'src');
+const adminSrcPath = process.env.ADMIN_ROOT || path.join(path.dirname(__dirname), 'src');
 
 const host = process.env.VITE_HOST || (isInsideDockerContainer() ? getContainerIP() : undefined) || 'localhost';
 

--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -31,9 +31,8 @@ import injectHtml from './vite-plugins/inject-html';
 
 const VITE_MODE = process.env.VITE_MODE || 'development';
 const isDev = VITE_MODE === 'development';
+const adminSrcPath = path.join(path.dirname(__dirname), 'src');
 
-// This env variable is provided by the symfony recipes
-const hasAdminRootEnv = !!process.env.ADMIN_ROOT;
 const host = process.env.VITE_HOST || (isInsideDockerContainer() ? getContainerIP() : undefined) || 'localhost';
 
 const extensionEntries = loadExtensions();
@@ -98,21 +97,10 @@ const getBaseConfig = (extension: ExtensionDefinition, isProd = false) => {
                     find: /^src\//,
                     replacement: '/src/',
                 },
-
-                // In the symfony recipes, shopware lies in the vendor folder, therefore we can't use the PROJECT_ROOT
-                ...(hasAdminRootEnv
-                    ? [
-                          {
-                              find: /^~scss\/(.*)/,
-                              replacement: `${process.env.ADMIN_ROOT}/Resources/app/administration/src/app/assets/scss/$1.scss`,
-                          },
-                      ]
-                    : [
-                          {
-                              find: /^~scss\/(.*)/,
-                              replacement: `${process.env.PROJECT_ROOT}/src/Administration/Resources/app/administration/src/app/assets/scss/$1.scss`,
-                          },
-                      ]),
+                {
+                    find: /^~scss\/(.*)/,
+                    replacement: `${adminSrcPath}/app/assets/scss/$1.scss`,
+                },
                 {
                     find: /^~(.*)$/,
                     replacement: '$1',

--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -31,8 +31,7 @@ import injectHtml from './vite-plugins/inject-html';
 
 const VITE_MODE = process.env.VITE_MODE || 'development';
 const isDev = VITE_MODE === 'development';
-const adminSrcPath = process.env.ADMIN_ROOT || path.join(path.dirname(__dirname), 'src');
-
+const adminSrcPath = process.env.ADMIN_ROOT ? path.join(process.env.ADMIN_ROOT, 'Resources', 'app', 'administration', 'src') : path.join(path.dirname(__dirname), 'src');
 const host = process.env.VITE_HOST || (isInsideDockerContainer() ? getContainerIP() : undefined) || 'localhost';
 
 const extensionEntries = loadExtensions();

--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -31,7 +31,9 @@ import injectHtml from './vite-plugins/inject-html';
 
 const VITE_MODE = process.env.VITE_MODE || 'development';
 const isDev = VITE_MODE === 'development';
-const adminSrcPath = process.env.ADMIN_ROOT ? path.join(process.env.ADMIN_ROOT, 'Resources', 'app', 'administration', 'src') : path.join(path.dirname(__dirname), 'src');
+const adminSrcPath = process.env.ADMIN_ROOT
+    ? path.join(process.env.ADMIN_ROOT, 'Resources', 'app', 'administration', 'src')
+    : path.join(path.dirname(__dirname), 'src');
 const host = process.env.VITE_HOST || (isInsideDockerContainer() ? getContainerIP() : undefined) || 'localhost';
 
 const extensionEntries = loadExtensions();


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/10754 many people didnt upgraded the build-administration.sh and therefore the build fails


### 2. What does this change do, exactly?

We don't need that new environment variable, just find from the current directory the correct root

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
