### PR TITLE
chore: Remove duplicated content from upgrade guides

### DIFF
--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -1,4 +1,5 @@
 # 6.7.0.1
+
 ## ESI render errors are not ignored anymore
 When rendering the `/header` and `/footer` ESI tags, errors will now be thrown instead of ignored. This change is intended to help developers identify and fix issues with ESI includes more easily.
 If you want to keep the old behaviour you need to overwrite the template blocks and remove the `ignore_errors: false` option from the `render_esi` function call.
@@ -15,13 +16,6 @@ This means that when your plugins depends on a custom `webpack.config.js` file, 
 Additionally, this means that you will need to distribute a separate plugin version starting for 6.7, when you extend the administration to distribute the correct build files.
 For more information please take a look at the [docs](https://developer.shopware.com/docs/guides/plugins/plugins/administration/system-updates/vite.html).
 
-# Making all administration components async
-We are making all administration components async by default with this PR: https://github.com/shopware/shopware/pull/9129. This means that all components will be loaded asynchronously and not synchronously.
-This can lead to some issues when accessing components directly in the template with a `ref`. If you run into this issue you need to check before accessing the component if it is available. A good pattern for this is to use the `@vue:mounted` event to check if the component is mounted.
-
-Some components are still synchronously loaded, like the `sw-alert` component. This is because they are used in a lot of places and we want to avoid loading them asynchronously everywhere. You can see the full list of components in this file:
-
-`src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts` (method: `initDependencies`)
 # Making all administration components async
 We are making all administration components async by default with this PR: https://github.com/shopware/shopware/pull/9129. This means that all components will be loaded asynchronously and not synchronously.
 This can lead to some issues when accessing components directly in the template with a `ref`. If you run into this issue you need to check before accessing the component if it is available. A good pattern for this is to use the `@vue:mounted` event to check if the component is mounted.
@@ -587,8 +581,6 @@ The default payment method "Direct debit" will no longer automatically change th
 The `technicalName` property will be required for payment and shipping methods in the API.
 The `technical_name` column will be made non-nullable for the `payment_method` and `shipping_method` tables in the database.
 
-Plugin developers will be required to supply a `technicalName` for their payment and shipping methods.  
-**If no technical name is specified before the migration is run, a temporary placeholder `temporary_<method-id>` will be used instead.**
 Plugin developers will be required to supply a `technicalName` for their payment and shipping methods.  
 **If no technical name is specified before the migration is run, a temporary placeholder `temporary_<method-id>` will be used instead.**
 
@@ -2614,45 +2606,6 @@ Example:
   <sw-button />
 </template>
 
-
-<!-- Uses sw-button-deprecated in 6.6 and 6.7 -->
-<template>
-  <sw-button deprecated />
-</template>
-```
-
-
-### Deprecated admin notification entity + related classes
-
-We have moved the notification entity, collection and definition to core. You should update your code to reference the new classes. The old classes are deprecated.
-
-* `Shopware\Administration\Notification\NotificationCollection` -> `Shopware\Core\Framework\Notification\NotificationCollection`
-* `Shopware\Administration\Notification\NotificationDefinition` -> `Shopware\Core\Framework\Notification\NotificationDefinition`
-* `Shopware\Administration\Notification\NotificationEntity` -> `Shopware\Core\Framework\Notification\NotificationEntity`
-
-### Deprecated notification controller
-
-`\Shopware\Administration\Controller\NotificationController` is now moved to core `\Shopware\Core\Framework\Notification\Api\NotificationController` - if you type hint on this class, please update it. The HTTP route is still the same. The old class is deprecated.
-
-### Mitigate Meteor components migration with deprecated components
-
-To support extension developers and ensure compatibility between Shopware 6.6 and Shopware 6.7, a new prop called `deprecated` has been added to Shopware components.
-
-- **Prop Name**: `deprecated`
-- **Default Value**: `false` (uses the new Meteor Components by default)
-- **Purpose**:
-    - When `deprecated` is set to `true`, the component will render the old (deprecated) version instead of the new Meteor Component.
-    - This allows extension developers to maintain a single codebase compatible with both Shopware 6.6 and 6.7 without being forced to immediately migrate to Meteor Components.
-
-Example:
-
-```html
-<!-- Uses mt-button in 6.7 and sw-button-deprecated in 6.6 -->
-<template>
-  <sw-button />
-</template>
-
-
 <!-- Uses sw-button-deprecated in 6.6 and 6.7 -->
 <template>
   <sw-button deprecated />
@@ -2672,11 +2625,6 @@ We made some changes in the Storefront, which might affect your plugins and them
   Extend `\Shopware\Storefront\Pagelet\Header\HeaderPageletLoader` or `\Shopware\Storefront\Pagelet\Footer\FooterPageletLoader` instead.
 * The properties `header`, `footer`, `salesChannelShippingMethods` and `salesChannelPaymentMethods` and their getter and setter Methods in `\Shopware\Storefront\Page\Page` were removed.
   Extend `\Shopware\Storefront\Pagelet\Header\HeaderPagelet` or `\Shopware\Storefront\Pagelet\Footer\FooterPagelet` instead.
-  Use the following alternatives in templates instead:
-    * `context.currency` instead of `page.header.activeCurrency`
-    * `shopware.navigation.id` instead of `page.header.navigation.active.id`
-    * `shopware.navigation.pathIdList` instead of `page.header.navigation.active.path`
-    * `context.languageInfo` instead of `page.header.activeLanguage`
   Use the following alternatives in templates instead:
     * `context.currency` instead of `page.header.activeCurrency`
     * `shopware.navigation.id` instead of `page.header.navigation.active.id`
@@ -2707,11 +2655,6 @@ We made some changes in the Storefront, which might affect your plugins and them
 * The template variables `activeId` and `activePath` in `src/Storefront/Resources/views/storefront/layout/navbar/categories.html.twig` were removed.
 * The template variable `activePath` in `src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig` was removed.
 * The parameter `activeResult` of `src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig` was removed.
-* The global `showStagingBanner` Twig variable was removed. Use `shopware.showStagingBanner` instead.
-
-## FooterPagelet changes
-The former optional parameter `serviceMenu` of type `\Shopware\Core\Content\Category\CategoryCollection` in `\Shopware\Storefront\Pagelet\Footer\FooterPagelet` is now required.
-Make sure to pass it to the constructor.
 * The global `showStagingBanner` Twig variable was removed. Use `shopware.showStagingBanner` instead.
 
 ## FooterPagelet changes

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -2,19 +2,8 @@
 
 ## Introduced in 6.7.0.0
 
-* Deprecated the following snippet keys:
-    - `global.sw-condition.condition.cartTaxDisplay`
-    - `global.sw-condition.condition.lineItemOfTypeRule`
-    - `global.sw-condition.condition.promotionCodeOfTypeRule`
-    - `global.sw-condition.condition.dayOfWeekRule`
+## Settings Menu Structure was changed
 
-* Added the following keys to `sw-condition-generic`:
-    - `promotionCodeOfType`
-    - `cartLineItemProductStates`
-
-  The old keys can be used until the next major version, where they will be removed.
-  
-## Settings Menu Structure was changed 
 The menu structure on the settings page has changed from tab structure to a grid structure. The new structure groups settings into different categories for better usability. If you extend or customize the settings menu, ensure that your changes are compatible with the new structure.
 
 The new settings groups are:
@@ -40,37 +29,46 @@ New blocks have been added in `sw-settings-index.html.twig`:
 * `sw_settings_content_card_content_grid`
 * `sw_settings_content_card_view`
 * `sw_settings_content_card_view_header`
+
 ## ApiClient confidential flag
 
 * You must explicitly pass a boolean value to the `confidential` parameter  of `\Shopware\Core\Framework\Api\OAuth\Client\ApiClient`.
 * You must pass the `confidential` parameter as the third parameter of the constructor.
 * You must pass the `name` parameter as the fourth parameter of the constructor.
-```
+
 ## Storefront
+
 ### Deprecated DomAccess Helper
+
 We deprecated DomAccess Helper, because it does not add much value compared to native browser APIs and to reduce Shopware specific code complexity. You simply replace its usage with the corresponding native methods. Here are some RegEx to help you:
 
-#### hasAttribute()  
+#### hasAttribute()
+
 **RegEx**: `DomAccess\.hasAttribute\(\s*([^,]+)\s*,\s*([^,)]+)(?:,\s*[^)]+)?\)`  
 **Replacement**: `$1.hasAttribute($2)`
 
 #### getAttribute()
+
 **RegEx**: `DomAccess\.getAttribute\(\s*([^,]+)\s*,\s*([^,)]+)(?:,\s*[^)]+)?\)`  
 **Replacement**: `$1.getAttribute($2)`
 
 #### getDataAttribute()
+
 **RegEx**: `DomAccess\.getDataAttribute\(\s*([^,]+)\s*,\s*([^,)]+)(?:,\s*[^)]+)?\)`  
 **Replacement**: `$1.getAttribute($2)`
 
 #### querySelector()
+
 **RegEx**: ``DomAccess\.querySelector\(\s*([^,]+)\s*,\s*((?:`[^`]*`|'[^']*'|"[^"]*")|[^,)]+)(?:,\s*[^)]+)?\)``  
 **Replacement**: `$1.querySelector($2)`
 
 #### querySelectorAll()
+
 **RegEx**: ``DomAccess\.querySelectorAll\(\s*([^,]+)\s*,\s*((?:`[^`]*`|'[^']*'|"[^"]*")|[^,)]+)(?:,\s*[^)]+)?\)``  
 **Replacement**: `$1.querySelectorAll($2)`
 
 #### getFocusableElements()
+
 This method was moved to FocusHandler Helper. Use this instead.
 
 ```JavaScript
@@ -78,6 +76,7 @@ const focusableElements = window.focusHandler.getFocusableElements();
 ```
 
 #### getFirstFocusableElement()
+
 This method was moved to FocusHandler Helper. Use this instead.
 
 ```JavaScript
@@ -85,84 +84,7 @@ const firstFocusableEl = window.focusHandler.getFirstFocusableElement();
 ```
 
 #### getLastFocusableElement()
-This method was moved to FocusHandler Helper. Use this instead.
 
-```JavaScript
-const lastFocusableEl = window.focusHandler.getLastFocusableElement();
-```
-
-## Introduced in 6.7.0.0
-## Settings Menu Structure was changed 
-The menu structure on the settings page has changed from tab structure to a grid structure. The new structure groups settings into different categories for better usability. If you extend or customize the settings menu, ensure that your changes are compatible with the new structure.
-
-The new settings groups are:
-* General
-* Customer
-* Automation
-* Localization
-* Content
-* Commerce
-* System
-* Account
-* Extensions
-
-As a result blocks have been removed in `sw-settings-index.html.twig`:
-* `sw_settings_content_tab_shop`
-* `sw_settings_content_tab_system`
-* `sw_settings_content_tab_plugins`
-* `sw_settings_content_card`
-* `sw_settings_content_header`
-* `sw_settings_content_card_content`
-
-New blocks have been added in `sw-settings-index.html.twig`:
-* `sw_settings_content_card_content_grid`
-* `sw_settings_content_card_view`
-* `sw_settings_content_card_view_header`
-## ApiClient confidential flag
-
-* You must explicitly pass a boolean value to the `confidential` parameter  of `\Shopware\Core\Framework\Api\OAuth\Client\ApiClient`.
-* You must pass the `confidential` parameter as the third parameter of the constructor.
-* You must pass the `name` parameter as the fourth parameter of the constructor.
-```
-## Storefront
-### Deprecated DomAccess Helper
-We deprecated DomAccess Helper, because it does not add much value compared to native browser APIs and to reduce Shopware specific code complexity. You simply replace its usage with the corresponding native methods. Here are some RegEx to help you:
-
-#### hasAttribute()  
-**RegEx**: `DomAccess\.hasAttribute\(\s*([^,]+)\s*,\s*([^,)]+)(?:,\s*[^)]+)?\)`  
-**Replacement**: `$1.hasAttribute($2)`
-
-#### getAttribute()
-**RegEx**: `DomAccess\.getAttribute\(\s*([^,]+)\s*,\s*([^,)]+)(?:,\s*[^)]+)?\)`  
-**Replacement**: `$1.getAttribute($2)`
-
-#### getDataAttribute()
-**RegEx**: `DomAccess\.getDataAttribute\(\s*([^,]+)\s*,\s*([^,)]+)(?:,\s*[^)]+)?\)`  
-**Replacement**: `$1.getAttribute($2)`
-
-#### querySelector()
-**RegEx**: ``DomAccess\.querySelector\(\s*([^,]+)\s*,\s*((?:`[^`]*`|'[^']*'|"[^"]*")|[^,)]+)(?:,\s*[^)]+)?\)``  
-**Replacement**: `$1.querySelector($2)`
-
-#### querySelectorAll()
-**RegEx**: ``DomAccess\.querySelectorAll\(\s*([^,]+)\s*,\s*((?:`[^`]*`|'[^']*'|"[^"]*")|[^,)]+)(?:,\s*[^)]+)?\)``  
-**Replacement**: `$1.querySelectorAll($2)`
-
-#### getFocusableElements()
-This method was moved to FocusHandler Helper. Use this instead.
-
-```JavaScript
-const focusableElements = window.focusHandler.getFocusableElements();
-```
-
-#### getFirstFocusableElement()
-This method was moved to FocusHandler Helper. Use this instead.
-
-```JavaScript
-const firstFocusableEl = window.focusHandler.getFirstFocusableElement();
-```
-
-#### getLastFocusableElement()
 This method was moved to FocusHandler Helper. Use this instead.
 
 ```JavaScript
@@ -170,9 +92,11 @@ const lastFocusableEl = window.focusHandler.getLastFocusableElement();
 ```
 
 ### Remove route `widgets.account.order.detail`
+
 Remove all references to `widgets.account.order.detail` and ensure that affected components handle navigation and display correctly
 
 ### Removed `@Storefront/storefront/component/checkout/cart-alerts.html.twig`
+
 Remove all references to `@Storefront/storefront/component/checkout/cart-alerts.html.twig` and use `@Storefront/storefront/utilities/alert.html.twig` instead.
 
 **NOTE:** All the breaking changes described here can be already opted in by activating the `v6.8.0.0` [feature flag](https://developer.shopware.com/docs/resources/references/adr/2022-01-20-feature-flags-for-major-versions.html#activating-the-flag) on previous versions.
@@ -232,6 +156,7 @@ The concrete events being removed:
 - `\Shopware\Core\Content\Sitemap\Event\SitemapRouteCacheTagsEvent`
 
 ## Theme Configuration Changes
+
 As part of optimizing theme configuration loading, several changes are being made to the theme system:
 
 * The `\Shopware\Storefront\Theme\CachedResolvedConfigLoader` has been removed. This class was previously used to cache theme configurations but has been replaced by a more efficient database-based solution using the new `theme_runtime_config` table.
@@ -245,11 +170,16 @@ Use the new `Shopware\Core\Framework\Rule\RuleIdMatcher` instead.
 It allows filtering of `RuleIdAware` objects in either arrays or collections.
 
 ## Added `primaryOrderDelivery` and `primaryOrderTransaction`
+
 Currently, there are multiple order deliveries and multiple order transactions per order. If only one, the "primary", order delivery and order transaction is displayed and used in the administration, there is now an easy way in version 6.8 using the `primaryOrderDelivery` and `primaryOrderTransaction`. All existing orders will be updated with a migration so that they also have the primary values.
 From now on, the `OrderTransactionStatusRule::match` will always use the `primaryOrderTransaction` instead of the most recently successful transaction.
+
 ## Use `primaryOrderDelivery`
+
 Get the first order delivery with `primaryOrderDelivery` so you should replace methods like `deliveries.first()` or `deliveries[0]`
+
 ## Use `primaryOrderTransaction`
+
 Get the latest order transaction with `primaryOrderTransaction` so you should replace methods like `transaction.last()`
 
 </details>
@@ -274,7 +204,16 @@ The old classes are removed:
 
 ## Removed notification controller
 
-`\Shopware\Administration\Controller\NotificationController` has been moved to core: `\Shopware\Core\Framework\Notification\Api\NotificationController` - if you type hint on this class, please refactor, it is now internal. The HTTP route is still the same. The old class has been removed.
+`\Shopware\Administration\Controller\NotificationController` has been moved to core: `\Shopware\Core\Framework\Notification\Api\NotificationController` - if you type hint on this class, please refactor, it is now internal.
+The HTTP route is still the same. The old class has been removed.
+
+## Removal of snippets
+
+The following snippet keys have been removed:
+* `global.sw-condition.condition.cartTaxDisplay`
+* `global.sw-condition.condition.lineItemOfTypeRule`
+* `global.sw-condition.condition.promotionCodeOfTypeRule`
+* `global.sw-condition.condition.dayOfWeekRule`
 
 </details>
 
@@ -340,6 +279,7 @@ The Twig breadcrumb functions `sw_breadcrumb_full` and `sw_breadcrumb_full_by_id
 ```
 
 ## Removal of DeleteThemeFilesMessage and its handler
+
 The `\Shopware\Storefront\Theme\Message\DeleteThemeFilesMessage` and its handler `\Shopware\Storefront\Theme\Message\DeleteThemeFilesHandler` are removed.
 Unused theme files are deleted by using the `\Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTask` scheduled task.
 

--- a/changelog/release-6-7-0-0/2025-04-17-fix-broken-snippets-in-rule-builder-conditions.md
+++ b/changelog/release-6-7-0-0/2025-04-17-fix-broken-snippets-in-rule-builder-conditions.md
@@ -8,19 +8,3 @@ author_email: p.dinkhoff@shopware.com
 
 * Deprecated snippet keys `global.sw-condition.condition.cartTaxDisplay`, `global.sw-condition.condition.lineItemOfTypeRule`, `global.sw-condition.condition.promotionCodeOfTypeRule`, and `global.sw-condition.condition.dayOfWeekRule`. These were restructured and moved to the generic `sw-condition-generic` group to improve consistency.
 * Added snippet keys `promotionCodeOfType` and `cartLineItemProductStates` to the `sw-condition-generic` group.
-
-___
-
-# Next Major Version Changes
-
-* Deprecated the following snippet keys:
-    - `global.sw-condition.condition.cartTaxDisplay`
-    - `global.sw-condition.condition.lineItemOfTypeRule`
-    - `global.sw-condition.condition.promotionCodeOfTypeRule`
-    - `global.sw-condition.condition.dayOfWeekRule`
-
-* Added the following keys to `sw-condition-generic`:
-    - `promotionCodeOfType`
-    - `cartLineItemProductStates`
-
-  The old keys can be used until the next major version, where they will be removed.


### PR DESCRIPTION
### 1. Why is this change necessary?

The merge back in https://github.com/shopware/shopware/pull/10920 resulted in some duplicated content. 

### 2. What does this change do, exactly?

Cleaning up the upgrade guides

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
