### PR TITLE
fix: Check all form attributes in js form plugins

### DIFF
--- a/changelog/_unreleased/2025-07-02-check-all-form-attributes-in-js-form-plugins.md
+++ b/changelog/_unreleased/2025-07-02-check-all-form-attributes-in-js-form-plugins.md
@@ -1,0 +1,10 @@
+---
+title: Check all form attributes in js form plugins
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Storefront
+* Added `noValidate` option to `Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js` to skip the form validation check
+* Changed `Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js` to correctly check for `formNoValidate` on form and `formAction` on event submitter
+* Changed `Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js` to correctly check for `formAction` on event submitter


### PR DESCRIPTION
### 1. Why is this change necessary?
- The form-submit js plugins currently doesn't support the html spec attributes `formNoValidate` (https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/formNoValidate) and `formAction` (https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/formAction)

### 2. What does this change do, exactly?
* Added `noValidate` option to `Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js` to skip the form validation check
* Changed `Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js` to correctly check for `formNoValidate` on form and `formAction` on event submitter
* Changed `Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js` to correctly check for `formAction` on event submitter

### 3. Describe each step to reproduce the issue or behaviour.
- Try to use the in the html spec defined attributes `formnovalidate` or `formaction` in combination with the form-submit js plugins

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
