### PR TITLE
fix: promotion order count update

### DIFF
--- a/changelog/_unreleased/2025-07-02-multiple-promotions-order-count-fix.md
+++ b/changelog/_unreleased/2025-07-02-multiple-promotions-order-count-fix.md
@@ -1,0 +1,9 @@
+---
+title: Multiple promotions order count fix
+issue: #10774
+---
+# Core
+* Changed calculation of promotion `order_count` and `orders_per_customer_count` in `Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionRedemptionUpdater`. Uniform the calculation of these values. Promotions will be grouped by `order_id`, so multiple promotion line items per order will count as one usage.
+___
+# Administration
+* Added grouped by promotion output in `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
@@ -51,6 +51,7 @@ export default {
         'loading-change',
         'reload-entity-data',
         'save-and-reload',
+        'save-and-recalculate',
     ],
 
     mixins: [
@@ -97,7 +98,20 @@ export default {
         },
 
         manualPromotions() {
-            return this.order.lineItems.filter((item) => item.type === 'promotion' && item.referencedId !== null);
+            const promotionIds = [];
+            return this.order.lineItems.filter((item) => {
+                if (item.type !== 'promotion' || item.referencedId === null) {
+                    return false;
+                }
+
+                if (promotionIds.includes(item.referencedId)) {
+                    return false;
+                }
+
+                promotionIds.push(item.referencedId);
+
+                return true;
+            });
         },
 
         /**
@@ -107,9 +121,6 @@ export default {
             return this.order.lineItems.filter((item) => item.type === 'promotion' && item.referencedId === null);
         },
 
-        /**
-         * @deprecated tag:v6.8.0 - Will be removed without replacement
-         */
         promotionCodeTags: {
             get() {
                 return this.manualPromotions.map((item) => item.payload);
@@ -417,16 +428,9 @@ export default {
                 true,
             ]);
 
-            const lineItem = this.order.lineItems.find((item) => {
-                return item.type === 'promotion' && item.payload.code === removedItem.code;
-            });
+            this.order.lineItems = this.order.lineItems.filter(item => item.type !== 'promotion' && item.promotionId !== removedItem.promotionId);
 
-            await this.saveAndReload();
-
-            return this.orderLineItemRepository
-                .delete(lineItem.id, this.versionContext)
-                .then(this.emitEntityData.bind(this))
-                .catch(this.handleError.bind(this));
+            await this.$emit('save-and-recalculate');
         },
 
         dismissPromotionUpdates() {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
@@ -428,7 +428,9 @@ export default {
                 true,
             ]);
 
-            this.order.lineItems = this.order.lineItems.filter(item => item.type !== 'promotion' && item.promotionId !== removedItem.promotionId);
+            this.order.lineItems = this.order.lineItems.filter(
+                item => item.type !== 'promotion' && item.promotionId !== removedItem.promotionId,
+            );
 
             await this.$emit('save-and-recalculate');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
@@ -252,15 +252,11 @@ export default {
             }
         },
 
-        /**
-         * To prevent losing unsaved changes on recalculate the order,
-         * we need to save the **versioned** order beforehand.
-         */
-        async saveAndRecalculate(afterRecalculateFn = null) {
+        async saveAndRecalculate() {
             if (this.swOrderDetailOnSaveAndRecalculate) {
-                await this.swOrderDetailOnSaveAndRecalculate(afterRecalculateFn);
+                await this.swOrderDetailOnSaveAndRecalculate();
             } else {
-                this.$emit('save-and-recalculate', afterRecalculateFn);
+                this.$emit('save-and-recalculate');
             }
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
@@ -28,6 +28,10 @@ export default {
             from: 'swOrderDetailOnSaveAndReload',
             default: null,
         },
+        swOrderDetailOnSaveAndRecalculate: {
+            from: 'swOrderDetailOnSaveAndRecalculate',
+            default: null,
+        },
         swOrderDetailHandleCartErrors: {
             from: 'swOrderDetailHandleCartErrors',
             default: null,
@@ -249,6 +253,18 @@ export default {
         },
 
         /**
+         * To prevent losing unsaved changes on recalculate the order,
+         * we need to save the **versioned** order beforehand.
+         */
+        async saveAndRecalculate(afterRecalculateFn = null) {
+            if (this.swOrderDetailOnSaveAndRecalculate) {
+                await this.swOrderDetailOnSaveAndRecalculate(afterRecalculateFn);
+            } else {
+                this.$emit('save-and-recalculate', afterRecalculateFn);
+            }
+        },
+
+        /**
          * @deprecated tag:v6.8.0 - Will be removed without replacement
          */
         handleUnsavedOrderChangesResponse() {
@@ -429,10 +445,10 @@ export default {
             ]);
 
             this.order.lineItems = this.order.lineItems.filter(
-                item => item.type !== 'promotion' && item.promotionId !== removedItem.promotionId,
+                item => item.type !== 'promotion' || item.promotionId !== removedItem.promotionId,
             );
 
-            await this.$emit('save-and-recalculate');
+            await this.saveAndRecalculate();
         },
 
         dismissPromotionUpdates() {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
@@ -445,7 +445,7 @@ export default {
             ]);
 
             this.order.lineItems = this.order.lineItems.filter(
-                item => item.type !== 'promotion' || item.promotionId !== removedItem.promotionId,
+                (item) => item.type !== 'promotion' || item.promotionId !== removedItem.promotionId,
             );
 
             await this.saveAndRecalculate();

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.html.twig
@@ -5,8 +5,8 @@
         v-model:value="promotionCodeTags"
         :disabled="!hasLineItem || isLoading || !acl.can('order.editor') || undefined"
         :currency="currency"
-        :label="$tc('sw-order.detailsTab.promotionsField.labelPromotions')"
-        :placeholder="$tc('sw-order.detailsTab.promotionsField.placeholderPromotions')"
+        :label="$t('sw-order.detailsTab.promotionsField.labelPromotions')"
+        :placeholder="$t('sw-order.detailsTab.promotionsField.placeholderPromotions')"
         :error="promotionError"
         @on-remove-code="onRemoveExistingCode"
     />
@@ -14,11 +14,11 @@
 
     {% block sw_order_promotion_field_switch %}
     <h3 class="sw-order-promotion-field__apply_auto_promotions__title">
-        {{ $tc('sw-order.detailsTab.promotionsField.automaticPromotions.title') }}
+        {{ $t('sw-order.detailsTab.promotionsField.automaticPromotions.title') }}
     </h3>
 
     <p class="sw-order-promotion-field__apply_auto_promotions__text">
-        {{ $tc('sw-order.detailsTab.promotionsField.automaticPromotions.text') }}
+        {{ $t('sw-order.detailsTab.promotionsField.automaticPromotions.text') }}
     </p>
 
     <mt-button
@@ -29,7 +29,7 @@
         :is-loading="isOrderLoading || isLoading"
         @click="applyAutomaticPromotions"
     >
-        {{ $tc('sw-order.detailsTab.promotionsField.automaticPromotions.labelButton') }}
+        {{ $t('sw-order.detailsTab.promotionsField.automaticPromotions.labelButton') }}
     </mt-button>
     {% endblock %}
 
@@ -37,18 +37,18 @@
     <sw-modal
         v-if="promotionUpdates.length > 0"
         class="sw-order-promotion-field__updates_modal"
-        :title="$tc('sw-order.detailsTab.promotionsField.updatesModal.title')"
+        :title="$t('sw-order.detailsTab.promotionsField.updatesModal.title')"
         @modal-close="dismissPromotionUpdates"
     >
         <p class="sw-order-promotion-field__updates_modal__description">
-            {{ $tc('sw-order.detailsTab.promotionsField.updatesModal.description') }}
+            {{ $t('sw-order.detailsTab.promotionsField.updatesModal.description') }}
         </p>
 
         <p
             v-show="promotionsAdded.length > 0"
             class="sw-order-promotion-field__updates_modal__list_title"
         >
-            {{ $tc('sw-order.detailsTab.promotionsField.updatesModal.promotionAddedTitle') }}
+            {{ $t('sw-order.detailsTab.promotionsField.updatesModal.promotionAddedTitle') }}
         </p>
         <span
             v-for="(error, idx) in promotionsAdded"
@@ -63,7 +63,7 @@
             v-show="promotionsRemoved.length > 0"
             class="sw-order-promotion-field__updates_modal__list_title"
         >
-            {{ $tc('sw-order.detailsTab.promotionsField.updatesModal.promotionRemovedTitle') }}
+            {{ $t('sw-order.detailsTab.promotionsField.updatesModal.promotionRemovedTitle') }}
         </p>
         <span
             v-for="(error, idx) in promotionsRemoved"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
@@ -19,7 +19,8 @@ const orderFixture = {
             payload: {
                 code: 'Redeem3456',
             },
-        },{
+        },
+        {
             id: '11111111-1111-1111-1111-111111111111',
             type: 'test',
             referencedId: '50669d0c-b1d2-470a-bb80-ac5ffa06ef10',
@@ -277,11 +278,13 @@ describe('src/module/sw-order/component/sw-order-promotion-field', () => {
         expect(wrapper.emitted('error')).toBeUndefined();
 
         expect(wrapper.vm.order.lineItems).toHaveLength(3);
-        expect(wrapper.vm.order.lineItems.map(item => item.id).sort()).toEqual([
-            '11111111-1111-1111-1111-111111111111',
-            '6066b693-97ce-4b91-a3e2-e015f0ddfb79',
-            '05b5decd-072f-437e-84a3-8be5fb5e5fa7'
-        ].sort());
+        expect(wrapper.vm.order.lineItems.map((item) => item.id).sort()).toEqual(
+            [
+                '11111111-1111-1111-1111-111111111111',
+                '6066b693-97ce-4b91-a3e2-e015f0ddfb79',
+                '05b5decd-072f-437e-84a3-8be5fb5e5fa7',
+            ].sort(),
+        );
     });
 
     it('should disable the fields with missing roles', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
@@ -15,14 +15,24 @@ const orderFixture = {
             id: 'a4b4b1cf-95a7-4050-981b-0a1f301f5727',
             type: 'promotion',
             referencedId: '50669d0c-b1d2-470a-bb80-ac5ffa06ef10',
+            promotionId: '50669d0c-b1d2-470a-bb80-ac5ffa06ef10',
             payload: {
                 code: 'Redeem3456',
+            },
+        },{
+            id: '11111111-1111-1111-1111-111111111111',
+            type: 'test',
+            referencedId: '50669d0c-b1d2-470a-bb80-ac5ffa06ef10',
+            promotionId: '50669d0c-b1d2-470a-bb80-ac5ffa06ef10',
+            payload: {
+                code: 'Fake-line-item',
             },
         },
         {
             id: '6066b693-97ce-4b91-a3e2-e015f0ddfb79',
             type: 'promotion',
             referencedId: 'f13ed3d3-158b-4fdf-bd54-d6fa8b880b83',
+            promotionId: 'f13ed3d3-158b-4fdf-bd54-d6fa8b880b83',
             payload: {
                 code: 'Redeem23',
             },
@@ -31,6 +41,7 @@ const orderFixture = {
             id: '05b5decd-072f-437e-84a3-8be5fb5e5fa7',
             type: 'promotion',
             referencedId: null,
+            promotionId: null,
             payload: {
                 code: null,
             },
@@ -255,15 +266,22 @@ describe('src/module/sw-order/component/sw-order-promotion-field', () => {
         createStateMapper();
 
         const wrapper = await createWrapper();
-        wrapper.vm.swOrderDetailOnSaveAndReload = jest.fn();
+        wrapper.vm.swOrderDetailOnSaveAndRecalculate = jest.fn();
 
-        wrapper.vm.onRemoveExistingCode({ code: 'Redeem3456' });
+        expect(wrapper.vm.order.lineItems).toHaveLength(4);
+        wrapper.vm.onRemoveExistingCode({ promotionId: '50669d0c-b1d2-470a-bb80-ac5ffa06ef10' });
         await flushPromises();
 
-        expect(wrapper.vm.swOrderDetailOnSaveAndReload).toHaveBeenCalledTimes(1);
+        expect(wrapper.vm.swOrderDetailOnSaveAndRecalculate).toHaveBeenCalledTimes(1);
         expect(wrapper.vm.promotionCodeTags).toEqual([{ code: 'Redeem23' }]);
         expect(wrapper.emitted('error')).toBeUndefined();
-        expect(wrapper.emitted('reload-entity-data')).toBeTruthy();
+
+        expect(wrapper.vm.order.lineItems).toHaveLength(3);
+        expect(wrapper.vm.order.lineItems.map(item => item.id).sort()).toEqual([
+            '11111111-1111-1111-1111-111111111111',
+            '6066b693-97ce-4b91-a3e2-e015f0ddfb79',
+            '05b5decd-072f-437e-84a3-8be5fb5e5fa7'
+        ].sort());
     });
 
     it('should disable the fields with missing roles', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
@@ -166,7 +166,6 @@
             @loading-change="updateLoading"
             @reload-entity-data="reloadEntityData"
             @save-and-reload="saveAndReload"
-            @save-and-recalculate="saveAndRecalculate"
             @error="showError"
         />
     </mt-card>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
@@ -166,6 +166,7 @@
             @loading-change="updateLoading"
             @reload-entity-data="reloadEntityData"
             @save-and-reload="saveAndReload"
+            @save-and-recalculate="saveAndRecalculate"
             @error="showError"
         />
     </mt-card>

--- a/src/Core/Checkout/DependencyInjection/promotion.xml
+++ b/src/Core/Checkout/DependencyInjection/promotion.xml
@@ -202,7 +202,6 @@
 
         <service id="Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionRedemptionUpdater">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
-            <argument type="service" id="order_line_item.repository"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Core/Checkout/DependencyInjection/promotion.xml
+++ b/src/Core/Checkout/DependencyInjection/promotion.xml
@@ -202,7 +202,7 @@
 
         <service id="Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionRedemptionUpdater">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
-            <argument type="service" id="order.repository"/>
+            <argument type="service" id="order_line_item.repository"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -4,58 +4,100 @@ namespace Shopware\Core\Checkout\Promotion\DataAbstractionLayer;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemDefinition;
-use Shopware\Core\Checkout\Order\OrderCollection;
-use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEvents;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeletedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWriteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @internal
  */
 #[Package('checkout')]
-class PromotionRedemptionUpdater implements EventSubscriberInterface, ResetInterface
+class PromotionRedemptionUpdater implements EventSubscriberInterface
 {
     /**
-     * @var array<string, true>
+     * @var array<string>
      */
-    private array $processedPromotions = [];
+    private array $promotionIds = [];
 
     /**
      * @internal
-     *
-     * @param EntityRepository<OrderCollection> $orderRepository
      */
     public function __construct(
-        private readonly Connection $connection,
-        private readonly EntityRepository $orderRepository
+        private readonly Connection $connection
     ) {
     }
 
-    /**
-     * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
-     */
     public static function getSubscribedEvents(): array
     {
         return [
-            EntityWriteEvent::class => 'beforeDeletePromotionLineItems',
-            OrderEvents::ORDER_WRITTEN_EVENT => 'orderUpdated',
+            EntityWriteEvent::class => 'beforeDelete',
+            OrderEvents::ORDER_LINE_ITEM_DELETED_EVENT => 'lineItemDeleted',
+            OrderEvents::ORDER_LINE_ITEM_WRITTEN_EVENT => 'lineItemCreated',
         ];
+    }
+
+    public function beforeDelete(EntityWriteEvent $event): void
+    {
+        if ($event->getContext()->getVersionId() !== Defaults::LIVE_VERSION) {
+            return;
+        }
+
+        $lineItemsIds = [];
+        foreach ($event->getCommandsForEntity('order_line_item') as $command) {
+            if ($command instanceof DeleteCommand) {
+                $lineItemsIds[] = $command->getDecodedPrimaryKey()['id'];
+            }
+        }
+
+        if (empty($lineItemsIds)) {
+            return;
+        }
+
+        $sql = <<<SQL
+            SELECT LOWER(HEX(`promotion_id`)) FROM `order_line_item`
+            WHERE `promotion_id` IS NOT NULL AND `type` = :type AND `id` IN (:ids);
+        SQL;
+
+        $this->promotionIds = $this->connection->fetchFirstColumn(
+            $sql,
+            [
+                'type' => PromotionProcessor::LINE_ITEM_TYPE,
+                'ids' => Uuid::fromHexToBytesList($lineItemsIds)],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+    }
+
+    public function lineItemDeleted(EntityDeletedEvent $event): void
+    {
+        if (!empty($this->promotionIds)) {
+            // Update all promotions, we searched beforeDelete
+            $this->update($this->promotionIds, $event->getContext());
+
+            $this->promotionIds = [];
+        }
+    }
+
+    public function lineItemCreated(EntityWrittenEvent $event): void
+    {
+        $promotionIds = [];
+        foreach ($event->getWriteResults() as $writeResult) {
+            $type = $writeResult->getPayload()['type'] ?? null;
+            if ($writeResult->getOperation() === EntityWriteResult::OPERATION_INSERT && $type === PromotionProcessor::LINE_ITEM_TYPE) {
+                $promotionIds[] = $writeResult->getPayload()['promotionId'] ?? null;
+            }
+        }
+
+        $this->update($promotionIds, $event->getContext());
     }
 
     /**
@@ -70,19 +112,21 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface, ResetInter
         }
 
         $sql = <<<'SQL'
-                SELECT LOWER(HEX(order_line_item.promotion_id)) as promotion_id,
-                       COUNT(DISTINCT order_line_item.id) as total,
-                       LOWER(HEX(order_customer.customer_id)) as customer_id
-                FROM order_line_item
-                INNER JOIN order_customer
-                    ON order_customer.order_id = order_line_item.order_id
-                    AND order_customer.version_id = order_line_item.version_id
-                WHERE order_line_item.type = :type
-                AND order_line_item.promotion_id IN (:ids)
-                AND order_line_item.version_id = :versionId
-                GROUP BY order_line_item.promotion_id, order_customer.customer_id
-SQL;
+            SELECT LOWER(HEX(promotion.id)) as promotion_id,
+                   COUNT(DISTINCT order_line_item.order_id) as total,
+                   LOWER(HEX(order_customer.customer_id)) as customer_id
+            FROM promotion
+                     LEFT JOIN order_line_item
+                               ON (promotion.id = order_line_item.promotion_id AND order_line_item.type = :type AND
+                                   order_line_item.version_id = :versionId)
+                     LEFT JOIN order_customer
+                               ON (order_customer.order_id = order_line_item.order_id
+                                   AND order_customer.version_id = order_line_item.version_id)
+            WHERE promotion.id IN (:ids)
+            GROUP BY order_line_item.promotion_id, order_customer.customer_id
+        SQL;
 
+        /** @var list<array{promotion_id: string, total: int, customer_id: ?string}> $promotions */
         $promotions = $this->connection->fetchAllAssociative(
             $sql,
             ['type' => PromotionProcessor::LINE_ITEM_TYPE, 'ids' => Uuid::fromHexToBytesList($ids), 'versionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)],
@@ -102,292 +146,31 @@ SQL;
         $promotions = $this->groupByPromotion($promotions);
 
         foreach ($promotions as $id => $totals) {
-            $total = array_sum($totals);
-
             $update->execute([
                 'id' => Uuid::fromHexToBytes($id),
-                'count' => (int) $total,
-                'customerCount' => json_encode($totals, \JSON_THROW_ON_ERROR),
+                'count' => (int) array_sum($totals),
+                'customerCount' => !empty($totals) ? json_encode($totals, \JSON_THROW_ON_ERROR) : null,
             ]);
-
-            $this->processedPromotions[$id] = true;
         }
-    }
-
-    public function orderUpdated(EntityWrittenEvent $event): void
-    {
-        if ($event->getEntityName() !== OrderDefinition::ENTITY_NAME) {
-            return;
-        }
-
-        if ($event->getContext()->getVersionId() !== Defaults::LIVE_VERSION) {
-            return;
-        }
-
-        $criteria = new Criteria($event->getIds());
-        $criteria->addAssociations(['lineItems', 'orderCustomer']);
-
-        $order = $this->orderRepository->search($criteria, $event->getContext())->getEntities()->first();
-        $promotions = $order?->getLineItems()?->filterByType(PromotionProcessor::LINE_ITEM_TYPE);
-        $customer = $order?->getOrderCustomer();
-
-        $this->processOrder($promotions, $customer);
-    }
-
-    public function beforeDeletePromotionLineItems(EntityWriteEvent $event): void
-    {
-        if ($event->getContext()->getVersionId() !== Defaults::LIVE_VERSION) {
-            return;
-        }
-
-        $ids = $this->getDeletedLineItemIds($event);
-
-        if (empty($ids)) {
-            return;
-        }
-
-        $promotions = $this->fetchOrderLineItemsByIds($ids);
-
-        if (empty($promotions)) {
-            return;
-        }
-
-        $event->addSuccess(function () use ($promotions): void {
-            $groupedPromotions = $this->groupByPromotion($promotions);
-
-            $allCustomerCounts = $this->getAllCustomerCounts(array_keys($groupedPromotions));
-
-            $update = new RetryableQuery(
-                $this->connection,
-                $this->connection->prepare('UPDATE promotion SET order_count = order_count - :orderCount, orders_per_customer_count = :customerCount WHERE id = :id')
-            );
-
-            foreach ($groupedPromotions as $promotionId => $totals) {
-                $orderCount = array_sum($totals);
-
-                foreach ($totals as $customerId => $total) {
-                    if (!isset($allCustomerCounts[$promotionId][$customerId])) {
-                        continue;
-                    }
-                    $allCustomerCounts[$promotionId][$customerId] -= $total;
-
-                    if ($allCustomerCounts[$promotionId][$customerId] <= 0) {
-                        unset($allCustomerCounts[$promotionId][$customerId]);
-                    }
-                }
-
-                $update->execute([
-                    'id' => Uuid::fromHexToBytes($promotionId),
-                    'customerCount' => json_encode($allCustomerCounts[$promotionId], \JSON_THROW_ON_ERROR),
-                    'orderCount' => (int) $orderCount,
-                ]);
-            }
-
-            $promotionCodes = [];
-            foreach ($promotions as $promotion) {
-                $payload = json_decode($promotion['payload'], true, 512, \JSON_THROW_ON_ERROR) ?? [];
-                $promotionCodes[] = $payload['code'] ?? '';
-            }
-
-            $promotionCodes = array_unique(array_filter($promotionCodes));
-
-            if (empty($promotionCodes)) {
-                return;
-            }
-
-            $this->connection->executeStatement(
-                'UPDATE promotion_individual_code set payload = NULL WHERE code IN (:codes)',
-                ['codes' => $promotionCodes],
-                ['codes' => ArrayParameterType::STRING]
-            );
-        });
-    }
-
-    public function reset(): void
-    {
-        $this->processedPromotions = [];
     }
 
     /**
-     * @return array<string>
-     */
-    private function getDeletedLineItemIds(EntityWriteEvent $event): array
-    {
-        return array_map(
-            static fn (WriteCommand $command) => $command->getPrimaryKey()['id'],
-            array_filter($event->getCommandsForEntity(OrderLineItemDefinition::ENTITY_NAME), static function (WriteCommand $command) {
-                if ($command instanceof DeleteCommand) {
-                    return true;
-                }
-
-                return false;
-            })
-        );
-    }
-
-    /**
-     * @param array<string> $ids
+     * @param non-empty-list<array{promotion_id: string, total: int, customer_id: ?string}> $promotions
      *
-     * @return array<array<string, string>>
-     */
-    private function fetchOrderLineItemsByIds(array $ids): array
-    {
-        $sql = <<<'SQL'
-        SELECT LOWER(HEX(order_line_item.promotion_id)) as promotion_id,
-               order_line_item.payload as payload,
-               COUNT(DISTINCT order_line_item.id) as total,
-               LOWER(HEX(order_customer.customer_id)) as customer_id
-        FROM order_line_item
-        INNER JOIN order_customer
-            ON order_customer.order_id = order_line_item.order_id
-            AND order_customer.version_id = order_line_item.version_id
-        WHERE order_line_item.type = :type
-        AND order_line_item.id IN (:ids)
-        AND order_line_item.version_id = :versionId
-        GROUP BY order_line_item.promotion_id, order_customer.customer_id
-        SQL;
-
-        /** @var array<array<string, string>> $result */
-        $result = $this->connection->fetchAllAssociative($sql, [
-            'ids' => $ids,
-            'versionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
-            'type' => PromotionProcessor::LINE_ITEM_TYPE,
-        ], [
-            'ids' => ArrayParameterType::BINARY,
-        ]);
-
-        return $result;
-    }
-
-    /**
-     * @param array<mixed> $promotions
-     *
-     * @return array<mixed>
+     * @return array<string, array<string, int>>
      */
     private function groupByPromotion(array $promotions): array
     {
         $grouped = [];
         foreach ($promotions as $promotion) {
-            $id = $promotion['promotion_id'];
             $customerId = $promotion['customer_id'];
-            $grouped[$id][$customerId] = (int) $promotion['total'];
+            if (!$customerId) {
+                $grouped[$promotion['promotion_id']] ??= [];
+            } else {
+                $grouped[$promotion['promotion_id']][$customerId] = (int) $promotion['total'];
+            }
         }
 
         return $grouped;
-    }
-
-    /**
-     * @param array<string> $promotionIds
-     *
-     * @return array<string>
-     */
-    private function getAllCustomerCounts(array $promotionIds): array
-    {
-        $allCustomerCounts = [];
-        $countResult = $this->connection->fetchAllAssociative(
-            'SELECT `id`, `orders_per_customer_count` FROM `promotion` WHERE `id` IN (:ids)',
-            ['ids' => Uuid::fromHexToBytesList($promotionIds)],
-            ['ids' => ArrayParameterType::BINARY]
-        );
-
-        foreach ($countResult as $row) {
-            if (!\is_string($row['orders_per_customer_count'])) {
-                $allCustomerCounts[Uuid::fromBytesToHex($row['id'])] = [];
-
-                continue;
-            }
-
-            $customerCount = json_decode($row['orders_per_customer_count'], true, 512, \JSON_THROW_ON_ERROR);
-            if (!$customerCount) {
-                $allCustomerCounts[Uuid::fromBytesToHex($row['id'])] = [];
-
-                continue;
-            }
-
-            $allCustomerCounts[Uuid::fromBytesToHex($row['id'])] = $customerCount;
-        }
-
-        return $allCustomerCounts;
-    }
-
-    /**
-     * @param list<string> $promotionIds
-     *
-     * @return array<int|string, int>
-     */
-    private function fetchPromotionCounts(array $promotionIds): array
-    {
-        $sql = <<<'SQL'
-    SELECT LOWER(HEX(promotion_id)) as promotion_id, COUNT(*) as count
-    FROM order_line_item
-    WHERE version_id = :versionId
-    AND type = :type
-    AND promotion_id IN (:promotionIds)
-    GROUP BY promotion_id
-SQL;
-
-        $promotionIdsBytes = Uuid::fromHexToBytesList($promotionIds);
-        $results = $this->connection->fetchAllAssociative(
-            $sql,
-            [
-                'versionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
-                'type' => PromotionProcessor::LINE_ITEM_TYPE,
-                'promotionIds' => $promotionIdsBytes,
-            ],
-            [
-                'promotionIds' => ArrayParameterType::BINARY,
-            ]
-        );
-
-        $counts = [];
-        foreach ($results as $result) {
-            $counts[$result['promotion_id']] = (int) $result['count'];
-        }
-
-        return $counts;
-    }
-
-    private function processOrder(?OrderLineItemCollection $promotions, ?OrderCustomerEntity $customer): void
-    {
-        if (!$promotions || !$customer) {
-            return;
-        }
-
-        $promotionIds = [];
-        foreach ($promotions as $promotion) {
-            $promotionId = $promotion->getPromotionId();
-            if ($promotionId === null) {
-                continue;
-            }
-
-            $promotionIds[] = $promotionId;
-        }
-
-        if (!$promotionIds) {
-            return;
-        }
-
-        $allPromotions = $this->fetchPromotionCounts($promotionIds);
-        $allCustomerCounts = $this->getAllCustomerCounts($promotionIds);
-
-        $update = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('UPDATE promotion SET order_count = :count, orders_per_customer_count = :customerCount WHERE id = :id')
-        );
-
-        foreach ($promotionIds as $promotionId) {
-            $customerId = $customer->getCustomerId();
-            if ($customerId !== null) {
-                $allCustomerCounts[$promotionId][$customerId] = 1 + ($allCustomerCounts[$promotionId][$customerId] ?? 0);
-            }
-
-            if (!isset($this->processedPromotions[$promotionId])) {
-                $update->execute([
-                    'id' => Uuid::fromHexToBytes($promotionId),
-                    'customerCount' => json_encode($allCustomerCounts[$promotionId], \JSON_THROW_ON_ERROR),
-                    'count' => $allPromotions[$promotionId] ?? 0,
-                ]);
-            }
-        }
     }
 }

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -65,15 +65,17 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
 
         $sql = <<<'SQL'
             SELECT LOWER(HEX(`promotion_id`)) FROM `order_line_item`
-            WHERE `promotion_id` IS NOT NULL AND `type` = :type AND `id` IN (:ids);
+            WHERE `promotion_id` IS NOT NULL AND `type` = :type AND `id` IN (:ids) AND `version_id` = :versionId;
         SQL;
 
         $this->promotionIds = $this->connection->fetchFirstColumn(
             $sql,
             [
                 'type' => PromotionProcessor::LINE_ITEM_TYPE,
-                'ids' => Uuid::fromHexToBytesList($lineItemsIds)],
-            ['ids' => ArrayParameterType::BINARY]
+                'ids' => Uuid::fromHexToBytesList($lineItemsIds),
+                'versionId' => Uuid::fromHexToBytes($event->getContext()->getVersionId()),
+            ],
+            ['ids' => ArrayParameterType::BINARY],
         );
     }
 
@@ -89,10 +91,14 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
 
     public function lineItemCreated(EntityWrittenEvent $event): void
     {
+        if ($event->getContext()->getVersionId() !== Defaults::LIVE_VERSION) {
+            return;
+        }
+
         $promotionIds = [];
         foreach ($event->getWriteResults() as $writeResult) {
             $type = $writeResult->getPayload()['type'] ?? null;
-            if ($writeResult->getOperation() === EntityWriteResult::OPERATION_INSERT && $type === PromotionProcessor::LINE_ITEM_TYPE) {
+            if ($writeResult->getOperation() !== EntityWriteResult::OPERATION_DELETE && $type === PromotionProcessor::LINE_ITEM_TYPE) {
                 $promotionIds[] = $writeResult->getPayload()['promotionId'] ?? null;
             }
         }
@@ -112,30 +118,23 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
         }
 
         $sql = <<<'SQL'
-            SELECT LOWER(HEX(promotion.id)) as promotion_id,
+            SELECT LOWER(HEX(order_line_item.promotion_id)) as promotion_id,
                    COUNT(DISTINCT order_line_item.order_id) as total,
                    LOWER(HEX(order_customer.customer_id)) as customer_id
-            FROM promotion
-                     LEFT JOIN order_line_item
-                               ON (promotion.id = order_line_item.promotion_id AND order_line_item.type = :type AND
-                                   order_line_item.version_id = :versionId)
+            FROM order_line_item
                      LEFT JOIN order_customer
                                ON (order_customer.order_id = order_line_item.order_id
                                    AND order_customer.version_id = order_line_item.version_id)
-            WHERE promotion.id IN (:ids)
+            WHERE order_line_item.promotion_id IN (:ids) AND order_line_item.version_id = :versionId AND order_line_item.type = :type
             GROUP BY order_line_item.promotion_id, order_customer.customer_id
         SQL;
 
-        /** @var list<array{promotion_id: string, total: int, customer_id: ?string}> $promotions */
+        /** @var list<array{promotion_id: string, total: numeric-string, customer_id: ?string}> $promotions */
         $promotions = $this->connection->fetchAllAssociative(
             $sql,
             ['type' => PromotionProcessor::LINE_ITEM_TYPE, 'ids' => Uuid::fromHexToBytesList($ids), 'versionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)],
             ['ids' => ArrayParameterType::BINARY]
         );
-
-        if (empty($promotions)) {
-            return;
-        }
 
         $update = new RetryableQuery(
             $this->connection,
@@ -143,9 +142,9 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
         );
 
         // group the promotions to update each promotion with a single update statement
-        $promotions = $this->groupByPromotion($promotions);
+        $promotionsGrouped = array_merge(array_fill_keys($ids, []), $this->groupByPromotion($promotions));
 
-        foreach ($promotions as $id => $totals) {
+        foreach ($promotionsGrouped as $id => $totals) {
             $update->execute([
                 'id' => Uuid::fromHexToBytes($id),
                 'count' => (int) array_sum($totals),
@@ -155,7 +154,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
     }
 
     /**
-     * @param non-empty-list<array{promotion_id: string, total: int, customer_id: ?string}> $promotions
+     * @param list<array{promotion_id: string, total: numeric-string, customer_id: ?string}> $promotions
      *
      * @return array<string, array<string, int>>
      */
@@ -163,11 +162,10 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
     {
         $grouped = [];
         foreach ($promotions as $promotion) {
-            $customerId = $promotion['customer_id'];
-            if (!$customerId) {
-                $grouped[$promotion['promotion_id']] ??= [];
-            } else {
-                $grouped[$promotion['promotion_id']][$customerId] = (int) $promotion['total'];
+            $grouped[$promotion['promotion_id']] ??= [];
+
+            if ($promotion['customer_id']) {
+                $grouped[$promotion['promotion_id']][$promotion['customer_id']] = (int) $promotion['total'];
             }
         }
 

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -63,7 +63,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
             return;
         }
 
-        $sql = <<<SQL
+        $sql = <<<'SQL'
             SELECT LOWER(HEX(`promotion_id`)) FROM `order_line_item`
             WHERE `promotion_id` IS NOT NULL AND `type` = :type AND `id` IN (:ids);
         SQL;

--- a/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
+++ b/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
@@ -71,6 +71,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
                 $this->ids->get('voucherA'),
                 $this->ids->get('voucherB'),
                 $this->ids->get('voucherD'),
+                Uuid::randomHex(), // Test an invalid promotionId
             ],
             Context::createDefaultContext()
         );

--- a/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
+++ b/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionIndividualCode\PromotionIndividualCodeCollection;
 use Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionRedemptionUpdater;
 use Shopware\Core\Checkout\Promotion\PromotionCollection;
+use Shopware\Core\Checkout\Promotion\PromotionEntity;
 use Shopware\Core\Checkout\Promotion\Subscriber\PromotionIndividualCodeRedeemer;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -101,51 +102,6 @@ class PromotionRedemptionUpdaterTest extends TestCase
         $this->assertUpdatedCounts();
     }
 
-    public function testItDoesNotFailWithZeroCustomerCount(): void
-    {
-        $this->createPromotionsAndOrder();
-
-        $voucherA = $this->ids->get('voucherA');
-
-        $connection = static::getContainer()->get(Connection::class);
-
-        // field is write protected - use plain sql here
-        $connection->executeStatement(
-            'UPDATE `promotion` SET `orders_per_customer_count` = "0" WHERE id = :id',
-            ['id' => Uuid::fromHexToBytes($voucherA)]
-        );
-
-        $criteria = new Criteria([$this->ids->create('order')]);
-        $criteria->addAssociation('lineItems');
-
-        /** @var OrderEntity|null $order */
-        $order = static::getContainer()
-            ->get('order.repository')
-            ->search($criteria, Context::createDefaultContext())
-            ->first();
-
-        static::assertNotNull($order);
-
-        $event = new EntityWrittenEvent(OrderDefinition::ENTITY_NAME, [new EntityWriteResult($order->getId(), [], OrderDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_UPDATE)], $this->salesChannelContext->getContext());
-
-        $updater = static::getContainer()->get(PromotionRedemptionUpdater::class);
-        $updater->orderUpdated($event);
-
-        $promotions = $connection->fetchAllAssociative(
-            'SELECT `id`, `orders_per_customer_count` FROM `promotion` WHERE `id` = :id',
-            ['id' => Uuid::fromHexToBytes($voucherA)]
-        );
-
-        $expected_json = json_encode([$this->ids->get('customer') => 1], \JSON_THROW_ON_ERROR);
-        static::assertIsString($expected_json);
-
-        static::assertCount(1, $promotions);
-        static::assertJsonStringEqualsJsonString(
-            $expected_json,
-            $promotions[0]['orders_per_customer_count']
-        );
-    }
-
     public function testIndividualCodeGotCustomerAssignment(): void
     {
         $this->createPromotionsAndOrder();
@@ -212,6 +168,111 @@ class PromotionRedemptionUpdaterTest extends TestCase
         );
     }
 
+    public function testRemoveItemMultipleOrders(): void
+    {
+        $this->createPromotionsAndOrder();
+        $firstCustomer = $this->ids->get('customer');
+
+        $this->ids->set('customer', $this->createCustomer('second@example.com'));
+
+        $secondCustomer = $this->ids->get('customer');
+        $secondOrderLineItemId = Uuid::randomHex();
+
+        // Create second order with different customer
+        static::getContainer()->get('order.repository')->create(
+            [[
+                'id' => Uuid::randomHex(),
+                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
+                'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                'orderCustomer' => [
+                    'customerId' => $secondCustomer,
+                    'email' => 'test@example.com',
+                    'salutationId' => $this->fetchFirstIdFromTable('salutation'),
+                    'firstName' => 'Max',
+                    'lastName' => 'Mustermann',
+                ],
+                'stateId' => $this->fetchFirstIdFromTable('state_machine_state'),
+                'paymentMethodId' => $this->fetchFirstIdFromTable('payment_method'),
+                'currencyId' => Defaults::CURRENCY,
+                'currencyFactor' => 1.0,
+                'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                'billingAddressId' => Uuid::randomHex(),
+                'addresses' => [
+                    [
+                        'id' => Uuid::randomHex(),
+                        'salutationId' => $this->fetchFirstIdFromTable('salutation'),
+                        'firstName' => 'Max',
+                        'lastName' => 'Mustermann',
+                        'street' => 'Ebbinghoff 10',
+                        'zipcode' => '48624',
+                        'city' => 'Schöppingen',
+                        'countryId' => $this->fetchFirstIdFromTable('country'),
+                    ],
+                ],
+                'lineItems' => [
+                    [
+                        'id' => $secondOrderLineItemId,
+                        'type' => LineItem::PROMOTION_LINE_ITEM_TYPE,
+                        'code' => '',
+                        'identifier' => $this->ids->get('voucherA'),
+                        'quantity' => 1,
+                        'payload' => [
+                            'promotionId' => $this->ids->get('voucherA'),
+                            'code' => '',
+                            'promotionCodeType' => 'global',
+                        ],
+                        'promotionId' => $this->ids->get('voucherA'),
+                        'label' => 'label',
+                        'price' => new CalculatedPrice(200, 200, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                        'priceDefinition' => new QuantityPriceDefinition(200, new TaxRuleCollection(), 2),
+                    ],
+                ],
+                'deliveries' => [],
+                'context' => '{}',
+                'payload' => '{}',
+            ]],
+            Context::createDefaultContext()
+        );
+
+        $promotionRepository = static::getContainer()->get('promotion.repository');
+
+        $promotionA = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->first();
+
+        static::assertInstanceOf(PromotionEntity::class, $promotionA);
+        static::assertIsArray($promotionA->getOrdersPerCustomerCount());
+        static::assertArrayHasKey($firstCustomer, $promotionA->getOrdersPerCustomerCount());
+        static::assertArrayHasKey($secondCustomer, $promotionA->getOrdersPerCustomerCount());
+        static::assertSame(2, $promotionA->getOrderCount());
+        static::assertSame(1, $promotionA->getOrdersPerCustomerCount()[$firstCustomer]);
+        static::assertSame(1, $promotionA->getOrdersPerCustomerCount()[$secondCustomer]);
+
+        static::getContainer()
+            ->get('order_line_item.repository')
+            ->delete([['id' => $this->ids->get('voucherA')]], Context::createDefaultContext());
+
+        $promotionALater = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->first();
+
+        static::assertInstanceOf(PromotionEntity::class, $promotionALater);
+        static::assertIsArray($promotionALater->getOrdersPerCustomerCount());
+        static::assertArrayNotHasKey($firstCustomer, $promotionALater->getOrdersPerCustomerCount());
+        static::assertArrayHasKey($secondCustomer, $promotionALater->getOrdersPerCustomerCount());
+        static::assertSame(1, $promotionALater->getOrdersPerCustomerCount()[$secondCustomer]);
+        static::assertSame(1, $promotionALater->getOrderCount());
+
+        static::getContainer()
+            ->get('order_line_item.repository')
+            ->delete([['id' => $secondOrderLineItemId]], Context::createDefaultContext());
+
+        $promotionAEvenLater = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->first();
+
+        static::assertInstanceOf(PromotionEntity::class, $promotionAEvenLater);
+        static::assertSame(0, $promotionAEvenLater->getOrderCount());
+        static::assertNull($promotionAEvenLater->getOrdersPerCustomerCount());
+    }
+
     private function createPromotionsAndOrder(): void
     {
         /** @var EntityRepository<PromotionCollection> $promotionRepository */
@@ -256,16 +317,15 @@ class PromotionRedemptionUpdaterTest extends TestCase
 
         $actualVoucherD = Uuid::fromBytesToHex($promotions[0]['id']) === $this->ids->get('voucherD') ? $promotions[0] : $promotions[1];
         static::assertNotEmpty($actualVoucherD);
-        static::assertSame('2', $actualVoucherD['order_count']);
+        static::assertSame('1', $actualVoucherD['order_count']);
         $customerCount = json_decode((string) $actualVoucherD['orders_per_customer_count'], true, 512, \JSON_THROW_ON_ERROR);
-        static::assertSame(2, $customerCount[$this->ids->get('customer')]);
+        static::assertSame(1, $customerCount[$this->ids->get('customer')]);
 
         $actualVoucherB = Uuid::fromBytesToHex($promotions[0]['id']) === $this->ids->get('voucherB') ? $promotions[0] : $promotions[1];
         static::assertNotEmpty($actualVoucherB);
-        // VoucherB is used twice, it's mean group by works
-        static::assertSame('2', $actualVoucherB['order_count']);
+        static::assertSame('1', $actualVoucherB['order_count']);
         $customerCount = json_decode((string) $actualVoucherB['orders_per_customer_count'], true, 512, \JSON_THROW_ON_ERROR);
-        static::assertSame(2, $customerCount[$this->ids->get('customer')]);
+        static::assertSame(1, $customerCount[$this->ids->get('customer')]);
     }
 
     private function assertNonUpdatedCounts(): void
@@ -282,16 +342,16 @@ class PromotionRedemptionUpdaterTest extends TestCase
 
         $actualVoucherD = Uuid::fromBytesToHex($promotions[0]['id']) === $this->ids->get('voucherD') ? $promotions[0] : $promotions[1];
         static::assertNotEmpty($actualVoucherD);
-        static::assertSame('2', $actualVoucherD['order_count']);
+        static::assertSame('1', $actualVoucherD['order_count']);
         $customerCount = json_decode((string) $actualVoucherD['orders_per_customer_count'], true, 512, \JSON_THROW_ON_ERROR);
-        static::assertSame(2, $customerCount[$this->ids->get('customer')]);
+        static::assertSame(1, $customerCount[$this->ids->get('customer')]);
 
         $actualVoucherB = Uuid::fromBytesToHex($promotions[0]['id']) === $this->ids->get('voucherB') ? $promotions[0] : $promotions[1];
         static::assertNotEmpty($actualVoucherB);
-        // VoucherB is used twice, it's mean group by works
-        static::assertSame('2', $actualVoucherB['order_count']);
+        // voucherB is used twice, it's mean group by works
+        static::assertSame('1', $actualVoucherB['order_count']);
         $customerCount = json_decode((string) $actualVoucherB['orders_per_customer_count'], true, 512, \JSON_THROW_ON_ERROR);
-        static::assertSame(2, $customerCount[$this->ids->get('customer')]);
+        static::assertSame(1, $customerCount[$this->ids->get('customer')]);
     }
 
     /**
@@ -357,10 +417,10 @@ class PromotionRedemptionUpdaterTest extends TestCase
                 ],
                 'lineItems' => [
                     [
-                        'id' => $this->ids->get('VoucherA'),
+                        'id' => $this->ids->get('voucherA'),
                         'type' => LineItem::PROMOTION_LINE_ITEM_TYPE,
                         'code' => '',
-                        'identifier' => $this->ids->get('VoucherA'),
+                        'identifier' => $this->ids->get('voucherA'),
                         'quantity' => 1,
                         'payload' => [
                             'promotionId' => $this->ids->get('voucherA'),
@@ -373,10 +433,10 @@ class PromotionRedemptionUpdaterTest extends TestCase
                         'priceDefinition' => new QuantityPriceDefinition(200, new TaxRuleCollection(), 2),
                     ],
                     [
-                        'id' => $this->ids->get('VoucherD'),
+                        'id' => $this->ids->get('voucherD'),
                         'type' => LineItem::PROMOTION_LINE_ITEM_TYPE,
                         'code' => null,
-                        'identifier' => $this->ids->get('VoucherD'),
+                        'identifier' => $this->ids->get('voucherD'),
                         'quantity' => 1,
                         'payload' => [
                             'promotionId' => $this->ids->get('voucherD'),
@@ -389,13 +449,13 @@ class PromotionRedemptionUpdaterTest extends TestCase
                         'priceDefinition' => new QuantityPriceDefinition(200, new TaxRuleCollection(), 2),
                     ],
                     [
-                        'id' => $this->ids->get('VoucherC'),
+                        'id' => $this->ids->get('voucherC'),
                         'type' => LineItem::PROMOTION_LINE_ITEM_TYPE,
-                        'code' => $this->ids->get('VoucherC'),
-                        'identifier' => $this->ids->get('VoucherC'),
+                        'code' => $this->ids->get('voucherC'),
+                        'identifier' => $this->ids->get('voucherC'),
                         'payload' => [
                             'promotionId' => $this->ids->get('voucherB'),
-                            'code' => $this->ids->get('VoucherC'),
+                            'code' => $this->ids->get('voucherC'),
                         ],
                         'promotionId' => $this->ids->get('voucherB'),
                         'quantity' => 1,
@@ -404,13 +464,13 @@ class PromotionRedemptionUpdaterTest extends TestCase
                         'priceDefinition' => new QuantityPriceDefinition(200, new TaxRuleCollection(), 2),
                     ],
                     [
-                        'id' => $this->ids->get('VoucherB'),
+                        'id' => $this->ids->get('voucherB'),
                         'type' => LineItem::PROMOTION_LINE_ITEM_TYPE,
-                        'code' => $this->ids->get('VoucherB'),
-                        'identifier' => $this->ids->get('VoucherB'),
+                        'code' => $this->ids->get('voucherB'),
+                        'identifier' => $this->ids->get('voucherB'),
                         'payload' => [
                             'promotionId' => $this->ids->get('voucherB'),
-                            'code' => $this->ids->get('VoucherB'),
+                            'code' => $this->ids->get('voucherB'),
                         ],
                         'promotionId' => $this->ids->get('voucherB'),
                         'quantity' => 1,

--- a/tests/unit/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
+++ b/tests/unit/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
@@ -5,34 +5,26 @@ namespace Shopware\Tests\Unit\Core\Checkout\Promotion\DataAbstractionLayer;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemDefinition;
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
-use Shopware\Core\Checkout\Order\OrderCollection;
-use Shopware\Core\Checkout\Order\OrderDefinition;
-use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionRedemptionUpdater;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeletedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWriteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -44,15 +36,15 @@ class PromotionRedemptionUpdaterTest extends TestCase
 {
     private Connection&MockObject $connectionMock;
 
-    private PromotionRedemptionUpdater $promotionRedemptionUpdater;
+    private MessageBusInterface&MockObject $messageBusMock;
 
-    private EntityRepository&MockObject $orderRepositoryMock;
+    private PromotionRedemptionUpdater $promotionRedemptionUpdater;
 
     protected function setUp(): void
     {
         $this->connectionMock = $this->createMock(Connection::class);
-        $this->orderRepositoryMock = $this->createMock(EntityRepository::class);
-        $this->promotionRedemptionUpdater = new PromotionRedemptionUpdater($this->connectionMock, $this->orderRepositoryMock);
+        $this->messageBusMock = $this->createMock(MessageBusInterface::class);
+        $this->promotionRedemptionUpdater = new PromotionRedemptionUpdater($this->connectionMock);
     }
 
     public function getDefinition(): OrderLineItemDefinition
@@ -68,8 +60,102 @@ class PromotionRedemptionUpdaterTest extends TestCase
 
     public function testUpdateEmptyIds(): void
     {
-        $this->connectionMock->expects($this->never())->method('fetchAllAssociative');
+        $this->connectionMock
+            ->expects($this->never())
+            ->method('fetchAllAssociative');
+
         $this->promotionRedemptionUpdater->update([], Context::createDefaultContext());
+    }
+
+    public function testNoLiveVersion(): void
+    {
+        $this->connectionMock
+            ->expects($this->never())
+            ->method('fetchAllAssociative');
+
+        $this->promotionRedemptionUpdater->update([Uuid::randomHex()], Context::createDefaultContext()->createWithVersionId(Uuid::randomHex()));
+    }
+
+    public function testInvalidPromotionIds(): void
+    {
+        $this->connectionMock
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
+
+        $this->messageBusMock
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->promotionRedemptionUpdater->update([Uuid::randomHex()], Context::createDefaultContext());
+    }
+
+    public function testItemDeleteNoLiveVersion(): void
+    {
+        $this->connectionMock
+            ->expects($this->never())
+            ->method('fetchFirstColumn');
+
+        $event = EntityWriteEvent::create(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            []
+        );
+
+        $this->promotionRedemptionUpdater->beforeDelete($event);
+    }
+
+    public function testItemDeleteEmptyCommands(): void
+    {
+        $this->connectionMock
+            ->expects($this->never())
+            ->method('fetchFirstColumn');
+
+        $event = EntityWriteEvent::create(
+            WriteContext::createFromContext(Context::createDefaultContext()->createWithVersionId(Uuid::randomHex())),
+            []
+        );
+
+        $this->promotionRedemptionUpdater->beforeDelete($event);
+    }
+
+    public function testItemDelete(): void
+    {
+        $this->connectionMock
+            ->expects($this->once())
+            ->method('fetchFirstColumn')
+            ->willReturn([Uuid::randomHex()]);
+
+        $this->connectionMock
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
+
+        $registry = new StaticDefinitionInstanceRegistry(
+            [OrderLineItemDefinition::class],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+
+        $validInsertCommand = new DeleteCommand(
+            $registry->get(OrderLineItemDefinition::class),
+            ['id' => Uuid::randomBytes()],
+            $this->createMock(EntityExistence::class),
+        );
+
+        $updateCommand = new UpdateCommand(
+            $registry->get(OrderLineItemDefinition::class),
+            ['promotionId' => Uuid::randomHex()],
+            ['id' => Uuid::randomBytes()],
+            $this->createMock(EntityExistence::class),
+            '/0'
+        );
+
+        $writeEvent = EntityWriteEvent::create(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [$validInsertCommand, $updateCommand]
+        );
+
+        $this->promotionRedemptionUpdater->beforeDelete($writeEvent);
+        $this->promotionRedemptionUpdater->lineItemDeleted(new EntityDeletedEvent('order_line_item', [], Context::createDefaultContext()));
     }
 
     public function testUpdateValidCase(): void
@@ -77,9 +163,15 @@ class PromotionRedemptionUpdaterTest extends TestCase
         $promotionId = Uuid::randomHex();
         $customerId = Uuid::randomHex();
 
-        $this->connectionMock->method('fetchAllAssociative')->willReturn([
-            ['promotion_id' => $promotionId, 'total' => 1, 'customer_id' => $customerId],
-        ]);
+        $this->connectionMock
+            ->method('fetchAllAssociative')
+            ->willReturn(
+                [
+                    ['promotion_id' => $promotionId, 'total' => 0, 'customer_id' => null],
+                    ['promotion_id' => $promotionId, 'total' => 1, 'customer_id' => $customerId],
+                    ['promotion_id' => $promotionId, 'total' => 0, 'customer_id' => null],
+                ]
+            );
 
         $statementMock = $this->createMock(Statement::class);
         $params = [
@@ -95,313 +187,60 @@ class PromotionRedemptionUpdaterTest extends TestCase
                 self::assertSame($params[$matcher->numberOfInvocations() - 1][1], $value);
             });
 
-        $statementMock->expects($this->once())
+        $statementMock
+            ->expects($this->once())
             ->method('executeStatement')
             ->willReturn(1);
-        $this->connectionMock->method('prepare')->willReturn($statementMock);
-
-        $this->promotionRedemptionUpdater->update([$promotionId], Context::createDefaultContext());
-    }
-
-    public function testOrderPlacedUpdatesPromotionsCorrectly(): void
-    {
-        $promotionId = Uuid::randomHex();
-        $customerId = Uuid::randomHex();
-
-        $event = $this->createOrderPlacedEvent($promotionId, $customerId);
-
-        $statementMock = $this->createMock(Statement::class);
-        $params = [
-            ['id', Uuid::fromHexToBytes($promotionId)],
-            ['customerCount', json_encode([$customerId => 1], \JSON_THROW_ON_ERROR)],
-            ['count', 0],
-        ];
-        $matcher = $this->exactly(\count($params));
-        $statementMock->expects($matcher)
-            ->method('bindValue')
-            ->willReturnCallback(function (string $key, $value) use ($matcher, $params): void {
-                self::assertSame($params[$matcher->numberOfInvocations() - 1][0], $key);
-                self::assertSame($params[$matcher->numberOfInvocations() - 1][1], $value);
-            });
-
-        $statementMock->expects($this->once())
-            ->method('executeStatement')
-            ->willReturn(1);
-
-        $this->connectionMock->method('prepare')->willReturn($statementMock);
-
-        $this->promotionRedemptionUpdater->orderUpdated($event);
-    }
-
-    public function testOrderPlacedNoLineItemsOrCustomer(): void
-    {
-        $event = $this->createOrderPlacedEvent(null, null);
-
-        $this->connectionMock->expects($this->never())->method('fetchAllAssociative');
-        $this->promotionRedemptionUpdater->orderUpdated($event);
-    }
-
-    public function testUpdateCalledBeforeOrderPlacedDoesNotRepeatUpdate(): void
-    {
-        $promotionId = Uuid::randomHex();
-        $customerId = Uuid::randomHex();
-
-        $this->connectionMock->method('fetchAllAssociative')->willReturnOnConsecutiveCalls(
-            [
-                [
-                    'promotion_id' => $promotionId,
-                    'total' => 1,
-                    'customer_id' => $customerId,
-                ],
-            ],
-            [
-                [
-                    'promotion_id' => $promotionId,
-                    'count' => 1,
-                ],
-            ],
-            [
-                [
-                    'id' => Uuid::fromHexToBytes($promotionId),
-                    'orders_per_customer_count' => json_encode([$customerId => 1]),
-                ],
-            ],
-        );
-
-        $statementMock = $this->createMock(Statement::class);
-        $params = [
-            ['id', Uuid::fromHexToBytes($promotionId)],
-            ['count', 1],
-            ['customerCount', json_encode([$customerId => 1], \JSON_THROW_ON_ERROR)],
-        ];
-        $matcher = $this->exactly(\count($params));
-        $statementMock->expects($matcher)
-            ->method('bindValue')
-            ->willReturnCallback(function (string $key, $value) use ($matcher, $params): void {
-                self::assertSame($params[$matcher->numberOfInvocations() - 1][0], $key);
-                self::assertSame($params[$matcher->numberOfInvocations() - 1][1], $value);
-            });
-
-        $statementMock->expects($this->once())->method('executeStatement')->willReturn(1);
-        $this->connectionMock->method('prepare')->willReturn($statementMock);
-
-        $this->promotionRedemptionUpdater->update([$promotionId], Context::createDefaultContext());
-
-        $event = $this->createOrderPlacedEvent($promotionId, $customerId);
-
-        // Expect no further update calls during orderPlaced
-        $statementMock = $this->createMock(Statement::class);
-        $statementMock->expects($this->never())->method('executeStatement');
-        $this->connectionMock->method('prepare')->willReturn($statementMock);
-
-        $this->promotionRedemptionUpdater->orderUpdated($event);
-    }
-
-    public function testBeforeDeletePromotionLineItems(): void
-    {
-        $customerId = Uuid::randomHex();
-        $promotionId = Uuid::randomHex();
-
-        $id = Uuid::randomBytes();
-        $command = new DeleteCommand(
-            $this->getDefinition(),
-            ['id' => $id],
-            $this->createMock(EntityExistence::class),
-        );
-
-        $event = EntityWriteEvent::create(
-            WriteContext::createFromContext(Context::createDefaultContext()),
-            [$command],
-        );
-
-        $this->connectionMock->method('fetchAllAssociative')->willReturnOnConsecutiveCalls(
-            [
-                [
-                    'promotion_id' => $promotionId,
-                    'payload' => '{"code": "F1D6Y0X2"}',
-                    'total' => 1,
-                    'customer_id' => $customerId,
-                ],
-            ],
-            [
-                [
-                    'id' => Uuid::fromHexToBytes($promotionId),
-                    'orders_per_customer_count' => json_encode([$customerId => 1]),
-                ],
-            ]
-        );
-
-        $statementMock = $this->createMock(Statement::class);
-        $params = [
-            ['id', Uuid::fromHexToBytes($promotionId)],
-            ['customerCount', json_encode([], \JSON_THROW_ON_ERROR)],
-            ['orderCount', 1],
-        ];
-        $matcher = $this->exactly(\count($params));
-        $statementMock->expects($matcher)
-            ->method('bindValue')
-            ->willReturnCallback(function (string $key, $value) use ($matcher, $params): void {
-                self::assertSame($params[$matcher->numberOfInvocations() - 1][0], $key);
-                self::assertSame($params[$matcher->numberOfInvocations() - 1][1], $value);
-            });
-
-        $statementMock->expects($this->once())
-            ->method('executeStatement')
-            ->willReturn(1);
-
-        $this->connectionMock->method('prepare')->willReturn($statementMock);
-        $this->connectionMock->expects($this->once())
-            ->method('executeStatement')
-            ->with(static::equalTo('UPDATE promotion_individual_code set payload = NULL WHERE code IN (:codes)'))
-            ->willReturnCallback(function ($query, $params): int {
-                static::assertSame(['codes' => ['F1D6Y0X2']], $params);
-
-                return 1;
-            });
-
-        $this->promotionRedemptionUpdater->beforeDeletePromotionLineItems($event);
-
-        $event->success();
-    }
-
-    public function testBeforeDeletePromotionLineItemsWithoutPromotion(): void
-    {
-        $id = Uuid::randomBytes();
-        $command = new DeleteCommand(
-            $this->getDefinition(),
-            ['id' => $id],
-            $this->createMock(EntityExistence::class),
-        );
-
-        $event = EntityWriteEvent::create(
-            WriteContext::createFromContext(Context::createDefaultContext()),
-            [$command],
-        );
-
-        $this->connectionMock->expects($this->once())->method('fetchAllAssociative')->willReturn([]);
-
-        $this->promotionRedemptionUpdater->beforeDeletePromotionLineItems($event);
-    }
-
-    public function testBeforeDeletePromotionLineItemsWithInsertCommand(): void
-    {
-        $command = new InsertCommand(
-            $this->getDefinition(),
-            ['order_id' => Uuid::randomBytes()],
-            ['id' => Uuid::randomBytes()],
-            $this->createMock(EntityExistence::class),
-            '/0'
-        );
-
-        $event = EntityWriteEvent::create(
-            WriteContext::createFromContext(Context::createDefaultContext()),
-            [$command],
-        );
-
-        $this->connectionMock->expects($this->never())->method('fetchAllAssociative');
-        $this->promotionRedemptionUpdater->beforeDeletePromotionLineItems($event);
-    }
-
-    public function testBeforeDeletePromotionLineItemsWithUpdateCommand(): void
-    {
-        $command = new UpdateCommand(
-            $this->getDefinition(),
-            ['order_id' => Uuid::randomBytes()],
-            ['id' => Uuid::randomBytes()],
-            $this->createMock(EntityExistence::class),
-            '/0'
-        );
-
-        $event = EntityWriteEvent::create(
-            WriteContext::createFromContext(Context::createDefaultContext()),
-            [$command],
-        );
-
-        $this->connectionMock->expects($this->never())->method('fetchAllAssociative');
-        $this->promotionRedemptionUpdater->beforeDeletePromotionLineItems($event);
-    }
-
-    public function testOrderUpdated(): void
-    {
-        $orderId = Uuid::randomHex();
-        $promotionId = Uuid::randomHex();
-        $customerId = Uuid::randomHex();
-
-        $orderLineItem = new OrderLineItemEntity();
-        $orderLineItem->setId(Uuid::randomHex());
-        $orderLineItem->setType(PromotionProcessor::LINE_ITEM_TYPE);
-        $orderLineItem->setPromotionId($promotionId);
-
-        $orderLineItems = new OrderLineItemCollection([$orderLineItem]);
-
-        $orderCustomer = new OrderCustomerEntity();
-        $orderCustomer->setCustomerId($customerId);
-
-        $order = new OrderEntity();
-        $order->setId($orderId);
-        $order->setLineItems($orderLineItems);
-        $order->setOrderCustomer($orderCustomer);
-
-        $entityWriteResult = new EntityWriteResult($orderId, [], 'order', EntityWriteResult::OPERATION_UPDATE);
-
-        $orderCollection = new OrderCollection([$order]);
-
-        $entitySearchResult = $this->createMock(EntitySearchResult::class);
-        $entitySearchResult->method('getEntities')->willReturn($orderCollection);
-
-        $this->orderRepositoryMock->method('search')->willReturn($entitySearchResult);
-
-        $event = new EntityWrittenEvent(
-            'order',
-            [$entityWriteResult],
-            Context::createDefaultContext()
-        );
-
-        $this->connectionMock->expects($this->once())
+        $this->connectionMock
             ->method('prepare')
-            ->with('UPDATE promotion SET order_count = :count, orders_per_customer_count = :customerCount WHERE id = :id')
-            ->willReturn($this->createMock(Statement::class));
+            ->willReturn($statementMock);
 
-        $this->promotionRedemptionUpdater->orderUpdated($event);
+        $this->promotionRedemptionUpdater->update([$promotionId], Context::createDefaultContext());
     }
 
-    private function createOrderPlacedEvent(?string $promotionId, ?string $customerId): EntityWrittenEvent
+    #[DataProvider('itemCreatedProvider')]
+    public function testLineItemCreated(EntityWriteResult $writeResult, bool $shouldCalled): void
     {
-        $lineItems = new OrderLineItemCollection();
-        $order = new OrderEntity();
-        $order->setId(Uuid::randomHex());
-        if ($promotionId !== null) {
-            $lineItem = new OrderLineItemEntity();
-            $lineItem->setId(Uuid::randomHex());
-            $lineItem->setType(PromotionProcessor::LINE_ITEM_TYPE);
-            $lineItem->setPromotionId($promotionId);
-            $lineItems->add($lineItem);
-            $order->setLineItems($lineItems);
-        }
+        $this->connectionMock
+            ->expects($shouldCalled ? $this->once() : $this->never())
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
 
-        if ($customerId !== null) {
-            $orderCustomer = new OrderCustomerEntity();
-            $orderCustomer->setId(Uuid::randomHex());
-            $orderCustomer->setCustomerId($customerId);
-            $order->setOrderCustomer($orderCustomer);
-        }
-
-        $context = Generator::generateSalesChannelContext();
-
-        $criteria = new Criteria([$order->getId()]);
-        $criteria->addAssociations(['lineItems', 'orderCustomer']);
-        $result = new EntitySearchResult(OrderDefinition::ENTITY_NAME, 1, new OrderCollection([$order]), null, $criteria, $context->getContext());
-
-        $this->orderRepositoryMock->expects($this->once())
-            ->method('search')
-            ->willReturn($result);
-
-        $entityWriteResult = new EntityWriteResult($order->getId(), [], OrderDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_UPDATE);
-
-        return new EntityWrittenEvent(
-            OrderDefinition::ENTITY_NAME,
-            [$entityWriteResult],
+        $this->promotionRedemptionUpdater->lineItemCreated(new EntityWrittenEvent(
+            'order_line_item',
+            [$writeResult],
             Context::createDefaultContext()
-        );
+        ));
+    }
+
+    /**
+     * @return non-empty-list<array{EntityWriteResult, bool}>
+     */
+    public static function itemCreatedProvider(): array
+    {
+        return [
+            [
+                new EntityWriteResult('id', ['some-field' => 'some-value'], 'order_line_item', EntityWriteResult::OPERATION_INSERT),
+                false,
+            ], [
+                new EntityWriteResult('id', ['promotionId' => null], 'order_line_item', EntityWriteResult::OPERATION_INSERT),
+                false,
+            ], [
+                new EntityWriteResult('id', ['promotionId' => null, 'type' => 'some-type'], 'order_line_item', EntityWriteResult::OPERATION_INSERT),
+                false,
+            ], [
+                new EntityWriteResult('id', ['promotionId' => null, 'type' => PromotionProcessor::LINE_ITEM_TYPE], 'order_line_item', EntityWriteResult::OPERATION_INSERT),
+                false,
+            ], [
+                new EntityWriteResult('id', ['type' => PromotionProcessor::LINE_ITEM_TYPE], 'order_line_item', EntityWriteResult::OPERATION_INSERT),
+                false,
+            ], [
+                new EntityWriteResult('id', ['promotionId' => Uuid::randomHex(), 'type' => PromotionProcessor::LINE_ITEM_TYPE], 'order_line_item', EntityWriteResult::OPERATION_INSERT),
+                true,
+            ], [
+                new EntityWriteResult('id', ['promotionId' => Uuid::randomHex()], 'order_line_item', EntityWriteResult::OPERATION_UPDATE),
+                false,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When a promotion applies a discount to both product line items and shipping costs, the promotion’s usage count (order_count) increases by more than one per order. This leads to incorrect tracking of promotion usage.

### 2. What does this change do, exactly?
The “index” update method is used to create and delete promotion items.
Before a promotion item is deleted, we search for the promotion ID. After deletion, all these promotions are updated.

**Administration**: Promotions will be grouped now on order detail page.

### 3. Describe each step to reproduce the issue or behaviour.

Create a promotion with:
Scope: Entire cart
Discounts: One for product(s), one for shipping
Global usage limit: e.g. 5
Place one order where both discounts are applied.
Observe that the usage counter increases by 2 instead of 1.


### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/10774

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
