### PR TITLE
chore: Remove unused `tecnickcom/tcpdf` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,7 +167,6 @@
         "symfony/validator": "~7.2.0",
         "symfony/var-exporter": "~7.2.0",
         "symfony/yaml": "~7.2.0",
-        "tecnickcom/tcpdf": "^6.8.0",
         "twig/intl-extra": "^3.10.0",
         "twig/string-extra": "^3.10.0",
         "twig/twig": "^3.19.0",

--- a/composer.json
+++ b/composer.json
@@ -167,7 +167,7 @@
         "symfony/validator": "~7.2.0",
         "symfony/var-exporter": "~7.2.0",
         "symfony/yaml": "~7.2.0",
-        "tecnickcom/tcpdf": "^6.7.7",
+        "tecnickcom/tcpdf": "^6.8.0",
         "twig/intl-extra": "^3.10.0",
         "twig/string-extra": "^3.10.0",
         "twig/twig": "^3.19.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -147,7 +147,6 @@
         "symfony/validator": "~7.2.0",
         "symfony/var-exporter": "~7.2.0",
         "symfony/yaml": "~7.2.0",
-        "tecnickcom/tcpdf": "^6.7.7",
         "twig/intl-extra": "^3.10.0",
         "twig/string-extra": "^3.10.0",
         "twig/twig": "^3.19.0",


### PR DESCRIPTION
### 1. Why is this change necessary?

~Versions below 6.8.0 of `tecnickcom/tcpdf` have CVEs. You will be effected by those, if you install composer with prefer-lowest setting~
The dependency is not used anymore since https://github.com/shopware/shopware/commit/4bf4b29e4255ecc951bc2c050599ceb3ce8f60f2 and was even deprecated to be removed with 6.7. This was not done yet

### 2. What does this change do, exactly?

Remove unused dependency

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
