### PR TITLE
feat: Add administration product number filter

### DIFF
--- a/changelog/_unreleased/2025-07-02-add-admin-product-number-filter.md
+++ b/changelog/_unreleased/2025-07-02-add-admin-product-number-filter.md
@@ -1,0 +1,8 @@
+---
+title: Add administration product number filter
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Added `product-number-filter` to `Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js` which allows you to filter by product number

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -42,6 +42,7 @@ export default {
             productEntityVariantModal: false,
             filterCriteria: [],
             defaultFilters: [
+                'product-number-filter',
                 'active-filter',
                 'product-without-images-filter',
                 'release-date-filter',
@@ -126,6 +127,15 @@ export default {
 
         listFilterOptions() {
             return {
+                'product-number-filter': {
+                    property: 'productNumber',
+                    type: 'string-filter',
+                    label: this.$tc('sw-product.filters.productNumberFilter.label'),
+                    placeholder: this.$tc('sw-product.filters.productNumberFilter.placeholder'),
+                    valueProperty: 'key',
+                    labelProperty: 'key',
+                    criteriaFilterType: 'equals',
+                },
                 'active-filter': {
                     property: 'active',
                     label: this.$tc('sw-product.filters.activeFilter.label'),

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
@@ -63,7 +63,7 @@ function mockCriteria() {
 }
 
 function getProductData(criteria) {
-    const products = [
+    let products = [
         {
             active: true,
             stock: 333,
@@ -120,7 +120,7 @@ function getProductData(criteria) {
     ];
 
     // check if grid is sorting for currency
-    const sortingForCurrency = criteria.sortings.some((sortAttr) => sortAttr.field.startsWith('price'));
+    const sortingForCurrency = criteria.sortings?.some((sortAttr) => sortAttr.field.startsWith('price'));
 
     if (sortingForCurrency) {
         const sortBy = criteria.sortings[0].field;
@@ -141,7 +141,7 @@ function getProductData(criteria) {
     }
 
     // check if grid is sorting for name
-    const sortingForName = criteria.sortings.some((sortAttr) => sortAttr.field.startsWith('name'));
+    const sortingForName = criteria.sortings?.some((sortAttr) => sortAttr.field.startsWith('name'));
 
     if (sortingForName) {
         const sortDirection = criteria.sortings[0].order;
@@ -158,7 +158,7 @@ function getProductData(criteria) {
     }
 
     // check if grid is sorting for manufacturer name
-    const sortingForManufacturer = criteria.sortings.some((sortAttr) => sortAttr.field.startsWith('manufacturer'));
+    const sortingForManufacturer = criteria.sortings?.some((sortAttr) => sortAttr.field.startsWith('manufacturer'));
 
     if (sortingForManufacturer) {
         const sortDirection = criteria.sortings[0].order;
@@ -172,6 +172,12 @@ function getProductData(criteria) {
 
             return nameA < nameB ? -1 : 1;
         });
+    }
+
+    const filterProductNumber = criteria.filters?.find((filter) => filter.field === 'productNumber');
+    if (filterProductNumber) {
+        const productNumber = filterProductNumber.value;
+        products = products.filter((product) => product.productNumber.includes(productNumber));
     }
 
     products.sortings = [];
@@ -704,5 +710,15 @@ describe('module/sw-product/page/sw-product-list', () => {
                 (association) => association.association === 'configuratorSettings',
             ),
         ).toBeFalsy();
+    });
+
+    it('should filter products by product number filter input', async () => {
+        wrapper.vm.filterCriteria.push(Criteria.equals('productNumber', 'SW10001'));
+
+        const productCriteria = wrapper.vm.productCriteria;
+        const products = getProductData(productCriteria);
+
+        expect(products).toHaveLength(1);
+        expect(products[0].productNumber).toBe('SW10001');
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -503,6 +503,10 @@
     "filters": {
       "fromPlaceholder": "Startwert eingeben ...",
       "toPlaceholder": "Endwert eingeben ...",
+      "productNumberFilter": {
+        "label": "Produktnummer",
+        "placeholder": "Gib eine Produktnummer ein ..."
+      },
       "activeFilter": {
         "label": "Aktiv",
         "placeholder": "Wähle einen Status ..."

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -503,6 +503,10 @@
     "filters": {
       "fromPlaceholder": "Enter start value...",
       "toPlaceholder": "Enter end value...",
+      "productNumberFilter": {
+        "label": "Product number",
+        "placeholder": "Enter a product number..."
+      },
       "activeFilter": {
         "label": "Active",
         "placeholder": "Select a status..."


### PR DESCRIPTION
### 1. Why is this change necessary?
- Similar to the customer view with customer number filter and order view with order number filter there should be a filter for the product number in the product view

### 2. What does this change do, exactly?
* Added `product-number-filter` to `Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js` which allows you to filter by product number

### 3. Describe each step to reproduce the issue or behaviour.
- Try to use the filter sidebar to filter by product number

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
