### PR TITLE
fix: fix tooltip formatting

### DIFF
--- a/changelog/_unreleased/2025-07-02-fix-tooltip-formatting.md
+++ b/changelog/_unreleased/2025-07-02-fix-tooltip-formatting.md
@@ -1,0 +1,16 @@
+---
+title: Fix tooltip formatting
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed following tooltip snippets to work with meteor tooltip component formatting:
+  - `sw-cms.elements.general.config.helpText.displayMode`
+  - `sw-cms-elements.imageGallery.config.helpText.displayMode`
+  - `sw-cms.elements.imageSlider.config.helpText.displayMode`
+  - `sw-cms.elements.productSlider.config.helpText.displayMode`
+  - `sw-product.packagingForm.referenceUnitHelpText`
+  - `sw-product.packagingForm.purchaseUnitHelpText`
+  - `sw-promotion-v2.detail.base.codes.individual.generateModal.helpTextCustomPattern`
+  - `sw-settings.detail.helpTextAdvancedPostalCodePattern`

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -218,7 +218,7 @@
           "helpText": {
             "autoplayTimeout": "Die Anzeigezeit eines einzelnen Bildes in Millisekunden.",
             "speed": "Die Dauer der Wechselanimation in Millisekunden.",
-            "displayMode": "<strong>Original:</strong> Das Bild wird in seiner ursprünglichen Auflösung erhalten oder auf die aktuelle Breite der CMS-Seite verkleinert.<br><br><strong>Skaliert:</strong> Das Bild wird ohne Höhenbeschränkungen auf die Breite der CMS-Seite skaliert.<br><br><strong>Zugeschnitten:</strong> Das Bild wird auf die aktuelle Breite der CMS-Seite skaliert. Jeglicher vertikaler Überlauf wird auf die konfigurierte maximale Höhe zugeschnitten."
+            "displayMode": "<ul><li><strong>Original:</strong> Das Bild wird in seiner ursprünglichen Auflösung erhalten oder auf die aktuelle Breite der CMS-Seite verkleinert.</li><li><strong>Skaliert:</strong> Das Bild wird ohne Höhenbeschränkungen auf die Breite der CMS-Seite skaliert.</li><li><strong>Zugeschnitten:</strong> Das Bild wird auf die aktuelle Breite der CMS-Seite skaliert. Jeglicher vertikaler Überlauf wird auf die konfigurierte maximale Höhe zugeschnitten.</li></ul>"
           },
           "caption": {
             "mediaUpload": "Lade ein Bild hoch"
@@ -272,7 +272,7 @@
             "magnifierOverGalleryHelpText": "Zeige die Lupe über der Galerie, anstatt daneben an."
           },
           "helpText": {
-            "displayMode": "<strong>Original:</strong> Die Bilder werden in ihrer ursprünglichen Auflösung erhalten oder auf die Höhe des Sliders verkleinert.<br><br><strong>Feste Höhe:</strong> Die Bilder werden in ihrer ursprünglichen Auflösung erhalten oder auf die konfigurierte Höhe verkleinert.<br><br><strong>Zugeschnitten:</strong> Die Bilder werden auf die aktuelle Breite der CMS-Seite skaliert. Jeglicher vertikaler Überlauf wird auf die konfigurierte Höhe zugeschnitten."
+            "displayMode": "<ul><li><strong>Original:</strong> Die Bilder werden in ihrer ursprünglichen Auflösung erhalten oder auf die Höhe des Sliders verkleinert.</li><li><strong>Feste Höhe:</strong> Die Bilder werden in ihrer ursprünglichen Auflösung erhalten oder auf die konfigurierte Höhe verkleinert.</li><li><strong>Zugeschnitten:</strong> Die Bilder werden auf die aktuelle Breite der CMS-Seite skaliert. Jeglicher vertikaler Überlauf wird auf die konfigurierte Höhe zugeschnitten.</li></ul>"
           }
         }
       },
@@ -287,7 +287,7 @@
             "navigationDots": "Punkt-Navigation"
           },
           "helpText": {
-            "displayMode": "<strong>Original:</strong> Die Bilder werden ohne Höhenbeschränkungen auf die Breite der CMS-Seite skaliert. Der Slider passt seine Höhe dynamisch an.<br><br><strong>Feste Höhe:</strong> Die Bilder werden ohne Höhenbeschränkungen auf die Breite der CMS-Seite skaliert. Der Slider behält die Höhe des höchsten Bildes bei.<br><br><strong>Zugeschnitten:</strong> Die Bilder werden auf die aktuelle Breite der CMS-Seite skaliert. Jeglicher vertikaler Überlauf wird auf die konfigurierte Höhe zugeschnitten."
+            "displayMode": "<ul><li><strong>Original:</strong> Die Bilder werden ohne Höhenbeschränkungen auf die Breite der CMS-Seite skaliert. Der Slider passt seine Höhe dynamisch an.</li><li><strong>Feste Höhe:</strong> Die Bilder werden ohne Höhenbeschränkungen auf die Breite der CMS-Seite skaliert. Der Slider behält die Höhe des höchsten Bildes bei.</li><li><strong>Zugeschnitten:</strong> Die Bilder werden auf die aktuelle Breite der CMS-Seite skaliert. Jeglicher vertikaler Überlauf wird auf die konfigurierte Höhe zugeschnitten.</li></ul>"
           }
         }
       },
@@ -388,7 +388,7 @@
           },
           "helpText": {
             "minWidth": "Gib die minimale Breite in der gewünschten Einheit an. Zum Beispiel: 200px",
-            "displayMode": "<strong>Original:</strong> Die Bilder werden auf Höhe oder Breite der Produktbox skaliert, so dass die Bilder immer komplett in den für sie vorgesehenen Bereich passen. Die Bilder werden nie hochskaliert.<br><br><strong>Feste Höhe:</strong> Die Bilder werden auf Höhe oder Breite der Produktbox skaliert, so dass die Bilder immer komplett in den für sie vorgesehenen Bereich passen. Die Bilder können hochskaliert werden.<br><br><strong>Zugeschnitten:</strong> Die Bilder werden auf die Höhe oder Breite der Produktbox skaliert. Jeglicher Überlauf wird entsprechend zugeschnitten."
+            "displayMode": "<ul><li><strong>Original:</strong> Die Bilder werden auf Höhe oder Breite der Produktbox skaliert, so dass die Bilder immer komplett in den für sie vorgesehenen Bereich passen. Die Bilder werden nie hochskaliert.</li><li><strong>Feste Höhe:</strong> Die Bilder werden auf Höhe oder Breite der Produktbox skaliert, so dass die Bilder immer komplett in den für sie vorgesehenen Bereich passen. Die Bilder können hochskaliert werden.</li><li><strong>Zugeschnitten:</strong> Die Bilder werden auf die Höhe oder Breite der Produktbox skaliert. Jeglicher Überlauf wird entsprechend zugeschnitten.</li></ul>"
           },
           "productAssignmentTypeOptions": {
             "manual": "Manuelle Zuweisung",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -221,7 +221,7 @@
           "helpText": {
             "autoplayTimeout": "The millisecond duration for how long the slide should stay still.",
             "speed": "The millisecond duration of the sliding animation.",
-            "displayMode": "<strong>Original:</strong> The image is displayed in its original resolution or shrunk down to current CMS page's width.<br><br><strong>Scaled:</strong> The image is scaled to the CMS page's width without any height restrictions.<br><br><strong>Cropped:</strong> The image is scaled to the current CMS page's width. Any vertical overflow is cropped to the configured maximum height."
+            "displayMode": "<ul><li><strong>Original:</strong> The image is displayed in its original resolution or shrunk down to current CMS page's width.</li><li><strong>Scaled:</strong> The image is scaled to the CMS page's width without any height restrictions.</li><li><strong>Cropped:</strong> The image is scaled to the current CMS page's width. Any vertical overflow is cropped to the configured maximum height.</li></ul>"
           },
           "tab": {
             "content": "Content",
@@ -272,7 +272,7 @@
             "magnifierOverGalleryHelpText": "Show the magnifier box on top of the gallery instead of showing it next to the gallery"
           },
           "helpText": {
-            "displayMode": "<strong>Original:</strong> The images are displayed in their original resolution or shrunk down to the slider's height.<br><br><strong>Fixed height:</strong> The images are displayed in their original resolution or shrunk down to the configured height.<br><br><strong>Cropped:</strong> The images are scaled to the current CMS page's width. Any vertical overflow is cropped to the configured height."
+            "displayMode": "<ul><li><strong>Original:</strong> The images are displayed in their original resolution or shrunk down to the slider's height.</li><li><strong>Fixed height:</strong> The images are displayed in their original resolution or shrunk down to the configured height.</li><li><strong>Cropped:</strong> The images are scaled to the current CMS page's width. Any vertical overflow is cropped to the configured height.</li></ul>"
           }
         }
       },
@@ -287,7 +287,7 @@
             "navigationDots": "Dots navigation"
           },
           "helpText": {
-            "displayMode": "<strong>Original:</strong> The images are scaled to the CMS page's width without any height restrictions. The slider's height is dynamically adjusted.<br><br><strong>Fixed height:</strong> The image is scaled to the CMS page's width without any height restrictions. The slider keeps the height of the tallest image.<br><br><strong>Cropped:</strong> The images are scaled to the current CMS page's width. Any vertical overflow is cropped to the configured height."
+            "displayMode": "<ul><li><strong>Original:</strong> The images are scaled to the CMS page's width without any height restrictions. The slider's height is dynamically adjusted.</li><li><strong>Fixed height:</strong> The image is scaled to the CMS page's width without any height restrictions. The slider keeps the height of the tallest image.</li><li><strong>Cropped:</strong> The images are scaled to the current CMS page's width. Any vertical overflow is cropped to the configured height.</li></ul>"
           }
         }
       },
@@ -388,7 +388,7 @@
           },
           "helpText": {
             "minWidth": "Enter the minimum width with your desired unit. For example: 200px",
-            "displayMode": "<strong>Original:</strong> The images are scaled to the height or width of the product box, so that they always fit into their designated area. The images are never scaled up.<br><br><strong>Fixed height:</strong> The images are scaled to the height or width of the product box, so that they always fit into their designated area. The images can be scaled up.<br><br><strong>Cropped:</strong> The images are scaled to the height or width of the product box. Any overflow is cropped."
+            "displayMode": "<ul><li><strong>Original:</strong> The images are scaled to the height or width of the product box, so that they always fit into their designated area. The images are never scaled up.</li><li><strong>Fixed height:</strong> The images are scaled to the height or width of the product box, so that they always fit into their designated area. The images can be scaled up.</li><li><strong>Cropped:</strong> The images are scaled to the height or width of the product box. Any overflow is cropped.</li></ul>"
           },
           "productAssignmentTypeOptions": {
             "manual": "Manual assignment",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -141,10 +141,10 @@
     "packagingForm": {
       "labelUnit": "Maßeinheit",
       "placeholderUnit": "Wähle aus ...",
-      "referenceUnitHelpText": "Notwendig für die Grundpreisberechnung. Der einzugebende Grundwert ist abhängig von der gewählten Maßeinheit.<br><br>Grundpreis = (Produktpreis * Grundeinheit) / Verkaufseinheit.<br><br>Der Grundpreis wird nicht angezeigt, wenn Verkaufseinheit und Grundeinheit den gleichen Wert haben.",
+      "referenceUnitHelpText": "Notwendig für die Grundpreisberechnung. Der einzugebende Grundwert ist abhängig von der gewählten Maßeinheit.<ul><li>Grundpreis = (Produktpreis * Grundeinheit) / Verkaufseinheit.</li></ul>Der Grundpreis wird nicht angezeigt, wenn Verkaufseinheit und Grundeinheit den gleichen Wert haben.",
       "packUnitHelpText": "Art der Verpackung: z.B. Flasche, Kiste, Tiegel ...",
       "packUnitPluralHelpText": "Art der Verpackung (Mehrzahl): z.B. Flaschen, Kisten, Tiegel ...",
-      "purchaseUnitHelpText": "Notwendig für die Grundpreisberechnung. Der einzugebende Wert ist abhängig von der gewählten Maßeinheit.<br><br>Grundpreis = (Produktpreis * Grundeinheit) / Verkaufseinheit.<br><br>Der Grundpreis wird nicht angezeigt, wenn Verkaufseinheit und Grundeinheit den gleichen Wert haben."
+      "purchaseUnitHelpText": "Notwendig für die Grundpreisberechnung. Der einzugebende Wert ist abhängig von der gewählten Maßeinheit.<ul><li>Grundpreis = (Produktpreis * Grundeinheit) / Verkaufseinheit.</li></ul>Der Grundpreis wird nicht angezeigt, wenn Verkaufseinheit und Grundeinheit den gleichen Wert haben."
     },
     "detailBase": {
       "cardTitleDeliverabilityInfo": "Lieferbarkeit",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -141,10 +141,10 @@
     "packagingForm": {
       "placeholderUnit": "Select...",
       "labelUnit": "Scale unit",
-      "referenceUnitHelpText": "Required to calculate the product's unit price. The base value to be entered depends on the selected scale unit.<br><br>Unit price = (product price * basic unit) / selling unit.<br><br>Unit price not displayed, if selling unit and basic unit have the same value.",
+      "referenceUnitHelpText": "Required to calculate the product's unit price. The base value to be entered depends on the selected scale unit.<ul><li>Unit price = (product price * basic unit) / selling unit.</li></ul>Unit price not displayed, if selling unit and basic unit have the same value.",
       "packUnitHelpText": "Type of packing: e.g. bottle, crate, tin...",
       "packUnitPluralHelpText": "Type of packing (plural): e.g. bottles, crates, tins...",
-      "purchaseUnitHelpText": "Required to calculate the product's unit price. The value to be entered depends on the selected scale unit.<br><br>Unit price = (product price * basic unit) / selling unit.<br><br>Unit price not displayed, if selling unit and basic unit have the same value."
+      "purchaseUnitHelpText": "Required to calculate the product's unit price. The value to be entered depends on the selected scale unit.<ul><li>Unit price = (product price * basic unit) / selling unit.</li></ul>Unit price not displayed, if selling unit and basic unit have the same value."
     },
     "detailBase": {
       "cardTitleDeliverabilityInfo": "Deliverability",

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/de-DE.json
@@ -94,7 +94,7 @@
                             "placeholderSuffix": "Gib einen Suffix an ...",
                             "labelCustomPattern": "Eigenes Muster",
                             "placeholderCustomPattern": "Gib ein eigenes Muster an",
-                            "helpTextCustomPattern": "Beachte, dass nur ein aufeinanderfolgender Satz an Variablen umgewandelt werden kann.<br><br>Mögliche Variablen:<br>- %d - Ziffern (0-9)<br>- %s - Buchstaben (A-Z)",
+                            "helpTextCustomPattern": "Beachte, dass nur ein aufeinanderfolgender Satz an Variablen umgewandelt werden kann. <strong>Mögliche Variablen:</strong><ul><li>%d - Ziffern (0-9)</li><li>%s - Buchstaben (A-Z)</li></ul>",
                             "labelUseCustomPattern": "Eigenes Muster nutzen",
                             "labelPreview": "Aktionscode-Vorschau",
                             "labelCodeAmount": "Anzahl der Aktionscodes",

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/en-GB.json
@@ -94,7 +94,7 @@
                             "placeholderSuffix": "Enter a suffix...",
                             "labelCustomPattern": "Custom pattern",
                             "placeholderCustomPattern": "Enter a custom pattern...",
-                            "helpTextCustomPattern": "Note, that there can only be one consecutive string of variables, which will be converted.<br><br>Possible variables to use:<br>- %d - Digits (0-9)<br>- %s - Letters (A-Z)",
+                            "helpTextCustomPattern": "Note, that there can only be one consecutive string of variables, which will be converted. <strong>Possible variables to use:</strong><ul><li>%d - Digits (0-9)</li><li>%s - Letters (A-Z)</li></ul>",
                             "labelUseCustomPattern": "Use custom pattern",
                             "labelPreview": "Promotion code preview",
                             "labelCodeAmount": "Number of promotion codes",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/snippet/de-DE.json
@@ -70,7 +70,7 @@
       "labelCheckPostalCodePattern": "Postleitzahl validieren",
       "labelCheckAdvancedPostalCodePattern": "Erweiterte Validierungsregeln",
       "placeholderAdvancedPostalCodePattern": "Gib ein Postleitzahl-Format an ...",
-      "helpTextAdvancedPostalCodePattern": "Mögliche Formate: <br><br> ^\\d{5}$ - Genau 5 Ziffern, z. B. 12345 <br>^(\\d{4})\\s*([A-Z]{2})$ - Genau 4 Ziffern und 2 Buchstaben, z. B. 1234 AB",
+      "helpTextAdvancedPostalCodePattern": "Mögliche Formate:<ul><li>^\\d{5}$ - Genau 5 Ziffern, z. B. 12345</li><li>^(\\d{4})\\s*([A-Z]{2})$ - Genau 4 Ziffern und 2 Buchstaben, z. B. 1234 AB</li></ul>",
       "labelCheckDefaultAddressFormat": "Benutzerdefiniertes Adressformat",
       "labelAddressFormatPlain": "Format",
       "titleFormatting": "Addressformat",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/snippet/en-GB.json
@@ -70,7 +70,7 @@
       "labelCheckPostalCodePattern": "Postal code validation",
       "labelCheckAdvancedPostalCodePattern": "Advanced validation rules",
       "placeholderAdvancedPostalCodePattern": "Enter postal code pattern...",
-      "helpTextAdvancedPostalCodePattern": "Possible formats to use:<br><br>^\\d{5}$ - Exact 5 Digits, e.g 12345<br><br>^(\\d{4})\\s*([A-Z]{2})$ - Exact 4 Digits and 2 Letters, e.g 1234 AB",
+      "helpTextAdvancedPostalCodePattern": "Possible formats to use:<ul><li>^\\d{5}$ - Exact 5 Digits, e.g 12345</li><li>^(\\d{4})\\s*([A-Z]{2})$ - Exact 4 Digits and 2 Letters, e.g 1234 AB</li></ul>",
       "labelCheckDefaultAddressFormat": "Custom address format",
       "labelAddressFormatPlain": "Format",
       "titleFormatting": "Address markup",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Some help text tooltips in the Administration are using the new Meteor tooltip component which does not support HTML tags like `strong` and `br`.

### 2. What does this change do, exactly?
Changed the help text/tooltip snippets to use allowed HTML tags like `b`, `ul` and `li`.

### 3. Describe each step to reproduce the issue or behaviour.
Go into Administration > edit CMS page > add image element > open config > hover help text of display mode setting

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
