### PR TITLE
feat: increase product weight precision

### DIFF
--- a/src/Core/Migration/V6_8/Migration1751522543IncreaseProductWeightPrecision.php
+++ b/src/Core/Migration/V6_8/Migration1751522543IncreaseProductWeightPrecision.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_8;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1751522543IncreaseProductWeightPrecision extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1751522543;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $sql = <<<'SQL'
+            ALTER TABLE `product`
+            MODIFY COLUMN `weight` DECIMAL(15,6) unsigned NULL;
+        SQL;
+
+        $connection->executeStatement($sql);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+} 

--- a/tests/migration/Core/V6_8/Migration1751522543IncreaseProductWeightPrecisionTest.php
+++ b/tests/migration/Core/V6_8/Migration1751522543IncreaseProductWeightPrecisionTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_8;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_8\Migration1751522543IncreaseProductWeightPrecision;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1751522543IncreaseProductWeightPrecision::class)]
+class Migration1751522543IncreaseProductWeightPrecisionTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Migration1751522543IncreaseProductWeightPrecision $migration;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->migration = new Migration1751522543IncreaseProductWeightPrecision();
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function rollbackTransaction(): void
+    {
+        $connection = KernelLifecycleManager::getConnection();
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+    }
+
+    public function testMigration(): void
+    {
+        $this->migration->update($this->connection);
+        $this->migration->update($this->connection);
+
+        $columnInfo = $this->getColumnInfo('product', 'weight');
+        
+        static::assertSame('decimal(15,6) unsigned', $columnInfo['Type']);
+        static::assertSame('YES', $columnInfo['Null']);
+    }
+
+    public function testWeightIsStoredCorrectlyAfterMigration(): void
+    {
+        $this->migration->update($this->connection);
+        
+        $productId = Uuid::randomBytes();
+        $versionId = Uuid::randomBytes();
+        $productNumber = Uuid::randomHex();
+        
+        // Test inserting data with higher precision after migration
+        $this->connection->executeStatement(
+            'INSERT INTO `product` (`id`, `version_id`, `product_number`, `weight`, `stock`, `created_at`) VALUES (?, ?, ?, ?, ?, ?)',
+            [
+                $productId,
+                $versionId,
+                $productNumber,
+                123.456789,
+                10,
+                '2024-01-01 00:00:00.000'
+            ]
+        );
+        
+        $result = $this->connection->fetchAssociative(
+            'SELECT weight FROM `product` WHERE `product_number` = ?',
+            [$productNumber]
+        );
+        
+        static::assertNotFalse($result);
+        static::assertSame('123.456789', $result['weight']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getColumnInfo(string $table, string $column): array
+    {
+        $result = $this->connection->fetchAssociative(
+            'SHOW COLUMNS FROM `' . $table . '` WHERE Field = ?',
+            [$column]
+        );
+        
+        static::assertNotFalse($result, "Column '$column' not found in table '$table'");
+        
+        return $result;
+    }
+} 


### PR DESCRIPTION
> Why only weight but not height, length and width?

Since the weight is stored in kg, the smallest value you can represent is 0.001, which is 1 gram. If you need to store a weight of 0.5 grams, you cannot do so accurately in the default field.

Other dimension fields are stored in `mm`, so you can have 0.005mm by default, which is small enough for an ecommerce platform.

By changing the DECIMAL(10,3) to DECIMAL(15,6), we increase the storage size from 6 bytes to 7 bytes, which is insignificant, but we can define weight in a more precise number.
