### PR TITLE
fix: Add missing dateTimeFormat property for sw-time-ago

### DIFF
--- a/changelog/_unreleased/2025-07-03-add-missing-date-time-format-prop-for-sw-time-ago.md
+++ b/changelog/_unreleased/2025-07-03-add-missing-date-time-format-prop-for-sw-time-ago.md
@@ -1,0 +1,8 @@
+---
+title: Add missing dateTimeFormat property for sw-time-ago
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Added missing `dateTimeFormat` property to `Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts` which gets passed to the `dateFilter`

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
@@ -22,6 +22,10 @@ export default Shopware.Component.wrapComponentConfig({
             ] as PropType<Date | string>,
             required: true,
         },
+        dateTimeFormat: {
+            type: Object as PropType<Intl.DateTimeFormatOptions>,
+            required: false,
+        }
     },
 
     data(): {
@@ -51,7 +55,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         fullDatetime(): string {
-            return this.dateFilter(this.dateObject.toString());
+            return this.dateFilter(this.dateObject.toString(), this.dateTimeFormat);
         },
 
         lessThanOneMinute(): boolean {
@@ -146,7 +150,7 @@ export default Shopware.Component.wrapComponentConfig({
                 });
             }
 
-            return this.dateFilter(this.dateObject.toString());
+            return this.dateFilter(this.dateObject.toString(), this.dateTimeFormat);
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
@@ -25,6 +25,7 @@ export default Shopware.Component.wrapComponentConfig({
         dateTimeFormat: {
             type: Object as PropType<Intl.DateTimeFormatOptions>,
             required: false,
+            default: {},
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
@@ -25,7 +25,7 @@ export default Shopware.Component.wrapComponentConfig({
         dateTimeFormat: {
             type: Object as PropType<Intl.DateTimeFormatOptions>,
             required: false,
-        }
+        },
     },
 
     data(): {


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently you can't set the format for the date time in the `sw-time-ago` component
- This PR adds the missing `dateTimeFormat` property for the component, which gets passed to the `dateFilter`

### 2. What does this change do, exactly?
* Added missing `dateTimeFormat` property to `Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts` which gets passed to the `dateFilter`

### 3. Describe each step to reproduce the issue or behaviour.
- Try to set the dateTimeFormat of the date time in the sw-time-ago component

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
