### PR TITLE
feat: Use single shared interval for sw-time-ago component

### DIFF
--- a/changelog/_unreleased/2025-07-03-use-single-shared-interval-for-sw-time-ago.md
+++ b/changelog/_unreleased/2025-07-03-use-single-shared-interval-for-sw-time-ago.md
@@ -1,0 +1,8 @@
+---
+title: Use single shared interval for sw-time-ago component
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Changed `Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts` to use the `useUpdateClock` function, which subscribes to a single shared time update interval

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
@@ -1,6 +1,6 @@
 import type { PropType } from 'vue';
 import template from './sw-time-ago.html.twig';
-import { useUpdateClock } from './updateClock';
+import useUpdateClock from './updateClock';
 
 /**
  * @private

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts
@@ -1,5 +1,6 @@
 import type { PropType } from 'vue';
 import template from './sw-time-ago.html.twig';
+import { useUpdateClock } from './updateClock';
 
 /**
  * @private
@@ -94,22 +95,14 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     mounted() {
-        this.formattedRelativeTime = this.formatRelativeTime();
-
-        // update the formatted date every 30 seconds
-        this.interval = setInterval(() => {
+        // subscriber to the updater, which updates the formatted date every 30 seconds
+        useUpdateClock(() => {
             // we have to set a new date, as vue does not react to changes in the date object
             // and does not invalidate the computed cache
             // this would lead to a wrong time string, if the component is active for more than 1 minute e.g.
             this.now = Date.now();
             this.formattedRelativeTime = this.formatRelativeTime();
-        }, 30000);
-    },
-
-    beforeUnmount() {
-        if (this.interval) {
-            clearInterval(this.interval);
-        }
+        });
     },
 
     methods: {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/sw-time-ago.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/sw-time-ago.spec.js
@@ -93,7 +93,7 @@ describe('src/app/component/utils/sw-time-ago', () => {
             date: '2025-06-24T15:00:00.000+00:00',
         });
 
-        const wrapper2 = await createWrapper({
+        await createWrapper({
             date: '2025-06-24T15:00:00.000+00:00',
         });
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/sw-time-ago.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/sw-time-ago.spec.js
@@ -60,7 +60,53 @@ describe('src/app/component/utils/sw-time-ago', () => {
         expect(wrapper.vm.now).toBe(1750777260000);
     });
 
-    it('should clear intervals', async () => {
+    it('should setup global interval, if a component is mounted', async () => {
+        jest.spyOn(global, 'setInterval');
+
+        await createWrapper({
+            date: '2025-06-24T15:00:00.000+00:00',
+        });
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+        expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 30_000);
+    });
+
+    it('should keep a single global interval, if multiple components are mounted', async () => {
+        jest.spyOn(global, 'setInterval');
+
+        await createWrapper({
+            date: '2025-06-24T15:00:00.000+00:00',
+        });
+
+        await createWrapper({
+            date: '2025-06-24T15:00:00.000+00:00',
+        });
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep the global interval, if not all components are unmounted', async () => {
+        jest.spyOn(global, 'setInterval');
+        jest.spyOn(global, 'clearInterval');
+
+        const wrapper1 = await createWrapper({
+            date: '2025-06-24T15:00:00.000+00:00',
+        });
+
+        const wrapper2 = await createWrapper({
+            date: '2025-06-24T15:00:00.000+00:00',
+        });
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+        expect(clearInterval).toHaveBeenCalledTimes(0);
+
+        wrapper1.unmount();
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+        expect(clearInterval).toHaveBeenCalledTimes(0);
+    });
+
+    it('should clear global interval, if all components are unmounted', async () => {
         jest.spyOn(global, 'clearInterval');
 
         const wrapper = await createWrapper({
@@ -73,22 +119,6 @@ describe('src/app/component/utils/sw-time-ago', () => {
 
         expect(clearInterval).toHaveBeenCalledTimes(1);
         expect(clearInterval).toHaveBeenCalledWith(expect.any(Number));
-    });
-
-    it('should not clear intervals if not set', async () => {
-        jest.spyOn(global, 'clearInterval');
-
-        const wrapper = await createWrapper({
-            date: '2025-06-24T15:00:00.000+00:00',
-        });
-
-        expect(clearInterval).toHaveBeenCalledTimes(0);
-
-        wrapper.vm.interval = null;
-
-        wrapper.unmount();
-
-        expect(clearInterval).toHaveBeenCalledTimes(0);
     });
 
     describe('date property as string', () => {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/updateClock.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/updateClock.ts
@@ -8,18 +8,18 @@ const subscribers = new Set<() => void>();
  * @private
  */
 export default function useUpdateClock(onTick: () => void) {
-  if (subscribers.size === 0) {
-    timer = setInterval(() => {
-      subscribers.forEach(cb => cb());
-    }, 30_000);
-  }
-  subscribers.add(onTick);
-  onTick();
-  onUnmounted(() => {
-    subscribers.delete(onTick);
-    if (timer && !subscribers.size) {
-      clearInterval(timer);
-      timer = null;
+    if (subscribers.size === 0) {
+        timer = setInterval(() => {
+            subscribers.forEach((cb) => cb());
+        }, 30_000);
     }
-  });
+    subscribers.add(onTick);
+    onTick();
+    onUnmounted(() => {
+        subscribers.delete(onTick);
+        if (timer && !subscribers.size) {
+            clearInterval(timer);
+            timer = null;
+        }
+    });
 }

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/updateClock.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/updateClock.ts
@@ -1,0 +1,21 @@
+import { onUnmounted } from 'vue';
+
+let timer: ReturnType<typeof setInterval> | null = null;
+const subscribers = new Set<() => void>();
+
+export function useUpdateClock(onTick: () => void) {
+  if (subscribers.size === 0) {
+    timer = setInterval(() => {
+      subscribers.forEach(cb => cb());
+    }, 30_000);
+  }
+  subscribers.add(onTick);
+  onTick();
+  onUnmounted(() => {
+    subscribers.delete(onTick);
+    if (timer && !subscribers.size) {
+      clearInterval(timer);
+      timer = null;
+    }
+  });
+}

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/updateClock.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-time-ago/updateClock.ts
@@ -3,7 +3,11 @@ import { onUnmounted } from 'vue';
 let timer: ReturnType<typeof setInterval> | null = null;
 const subscribers = new Set<() => void>();
 
-export function useUpdateClock(onTick: () => void) {
+/**
+ * @sw-package checkout
+ * @private
+ */
+export default function useUpdateClock(onTick: () => void) {
   if (subscribers.size === 0) {
     timer = setInterval(() => {
       subscribers.forEach(cb => cb());


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the sw-time-ago component uses a new interval for each instance of this component
- If you have a larger amount of this sw-time-ago components on your page then there are the same amount of intervals ticking behind the scenes, which just negatively impacts the page performance and memory usage

### 2. What does this change do, exactly?
* Changed `Resources/app/administration/src/app/component/utils/sw-time-ago/index.ts` to use the `useUpdateClock` function, which subscribes to a single shared time update interval

### 3. Describe each step to reproduce the issue or behaviour.
- Use a larger amount of sw-time-ago components on your page
- Each will register their own interval

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
