### PR TITLE
fix: wrong internal tagging

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
@@ -104,7 +104,6 @@ class QueryBuilder extends DBALQueryBuilder
     }
 
     /**
-     * @internal
      * {@inheritdoc}
      */
     public function select(string ...$expressions): self
@@ -115,7 +114,6 @@ class QueryBuilder extends DBALQueryBuilder
     }
 
     /**
-     * @internal
      * {@inheritdoc}
      */
     public function addSelect(string $expression, string ...$expressions): self
@@ -126,7 +124,6 @@ class QueryBuilder extends DBALQueryBuilder
     }
 
     /**
-     * @internal
      * {@inheritdoc}
      */
     public function orderBy(string $sort, ?string $order = null): self
@@ -137,7 +134,6 @@ class QueryBuilder extends DBALQueryBuilder
     }
 
     /**
-     * @internal
      * {@inheritdoc}
      */
     public function addOrderBy(string $sort, ?string $order = null): self


### PR DESCRIPTION
### 1. Why is this change necessary?

![CleanShot 2025-07-03 at 09 53 14@2x](https://github.com/user-attachments/assets/0d220f08-61a5-4846-a709-c1415bd44d9f)

You get in extensions phpstan errors as we marked that method internal, but it's not internal

### 2. What does this change do, exactly?

Just inherit the parent return type etc for overwrite

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
