### PR TITLE
fix(a11y): missing cookie off-canvas label

### DIFF
--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -793,6 +793,7 @@
     "save": "Speichern",
     "acceptAll": "Alle Cookies akzeptieren",
     "headline": "Cookie-Voreinstellungen",
+    "close": "Cookie-Voreinstellungen schließen",
     "groupRequired": "Technisch erforderlich",
     "groupRequiredDescription": "Für die Funktion des Shops erforderliche Cookies:",
     "groupRequiredSession": "Sitzung",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -793,6 +793,7 @@
     "save": "Save",
     "acceptAll": "Accept all cookies",
     "headline": "Cookie preferences",
+    "close": "Close cookie preferences",
     "groupRequired": "Technically required",
     "groupRequiredDescription": "Cookies required for this shop to function:",
     "groupRequiredSession": "Session",

--- a/src/Storefront/Resources/views/storefront/layout/cookie/cookie-configuration.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/cookie/cookie-configuration.html.twig
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block utilities_offcanvas_close_text %}
-    {{ 'cookie.headline'|trans|sw_sanitize }}
+    {{ 'cookie.close'|trans|sw_sanitize }}
 {% endblock %}
 
 {% block utilities_offcanvas_content %}
@@ -24,11 +24,9 @@
                 })|raw }}
             </p>
 
-            <div class="row align-items-center h6 offcanvas-cookie-header">
-                <div class="col">
-                    {{ 'cookie.configuration'|trans|sw_sanitize }}
-                </div>
-            </div>
+            <h2 class="offcanvas-cookie-header h5" data-id="off-canvas-headline">
+                {{ 'cookie.headline'|trans|sw_sanitize }}
+            </h2>
         </div>
 
         <div class="offcanvas-cookie-list">


### PR DESCRIPTION
closes #10934

### 1. Why is this change necessary?

Cookie OffCanvas is missing an `aria-labelledby` attribute to describe the dialog.

### 2. What does this change do, exactly?

* Add a `data-id` to the headline so the OffCanvas automatically adds the `aria-labelledby`.
* Change the headline from "Settings" to "Cookie preferences" to be more descriptive.
* Change the headline to a `h2` instead of `div`.
* Change the close button from "Cookie preferences" to "Close cookie preferences" so the button says what is actually does.
* Remove unneeded "col" and "row" elements.


