### PR TITLE
feat: include config in setupStagingEvent

### DIFF
--- a/changelog/_unreleased/2025-07-03-add-staging-config-to-event.md
+++ b/changelog/_unreleased/2025-07-03-add-staging-config-to-event.md
@@ -1,0 +1,5 @@
+---
+title: Add staging config to SetupStagingEvent
+---
+# Core
+* Changed `\Shopware\Core\Maintenance\Staging\Event\SetupStagingEvent` to include the staging configuration, this makes it easier to reuse the event in more dynamic cases where the config can not be hardcoded.

--- a/src/Core/Maintenance/DependencyInjection/services.xml
+++ b/src/Core/Maintenance/DependencyInjection/services.xml
@@ -132,6 +132,8 @@
         <service id="Shopware\Core\Maintenance\Staging\Command\SystemSetupStagingCommand">
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument>%shopware.staging.mailing.disable_delivery%</argument>
+            <argument>%shopware.staging.sales_channel.domain_rewrite%</argument>
 
             <tag name="console.command"/>
         </service>
@@ -144,14 +146,12 @@
         </service>
 
         <service id="Shopware\Core\Maintenance\Staging\Handler\StagingMailHandler">
-            <argument>%shopware.staging.mailing.disable_delivery%</argument>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
 
             <tag name="kernel.event_listener"/>
         </service>
 
         <service id="Shopware\Core\Maintenance\Staging\Handler\StagingSalesChannelHandler">
-            <argument>%shopware.staging.sales_channel.domain_rewrite%</argument>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
 
             <tag name="kernel.event_listener"/>

--- a/src/Core/Maintenance/Staging/Event/SetupStagingEvent.php
+++ b/src/Core/Maintenance/Staging/Event/SetupStagingEvent.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @internal
+ *
+ * @phpstan-type DomainRewriteRule = array{match: string, type: string, replace: string}
  */
 #[Package('framework')]
 class SetupStagingEvent
@@ -16,9 +18,14 @@ class SetupStagingEvent
 
     public bool $canceled = false;
 
+    /**
+     * @param list<DomainRewriteRule> $domainMappings
+     */
     public function __construct(
         public readonly Context $context,
         public readonly SymfonyStyle $io,
+        public readonly bool $disableMailDelivery,
+        public readonly array $domainMappings,
     ) {
     }
 }

--- a/src/Core/Maintenance/Staging/Handler/StagingMailHandler.php
+++ b/src/Core/Maintenance/Staging/Handler/StagingMailHandler.php
@@ -14,14 +14,13 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 readonly class StagingMailHandler
 {
     public function __construct(
-        private bool $disableMailDelivery,
         private SystemConfigService $systemConfigService
     ) {
     }
 
     public function __invoke(SetupStagingEvent $event): void
     {
-        if (!$this->disableMailDelivery) {
+        if (!$event->disableMailDelivery) {
             return;
         }
 

--- a/src/Core/Maintenance/Staging/Handler/StagingSalesChannelHandler.php
+++ b/src/Core/Maintenance/Staging/Handler/StagingSalesChannelHandler.php
@@ -9,17 +9,14 @@ use Shopware\Core\Maintenance\Staging\Event\SetupStagingEvent;
 /**
  * @internal
  *
- * @phpstan-type DomainRewriteRule = array{match: string, type: string, replace: string}
+ * @phpstan-import-type DomainRewriteRule from SetupStagingEvent
+ *
  * @phpstan-type DomainURL = array{id: string, url: string}
  */
 #[Package('framework')]
 readonly class StagingSalesChannelHandler
 {
-    /**
-     * @param DomainRewriteRule[] $rewrite
-     */
     public function __construct(
-        private array $rewrite,
         private Connection $connection
     ) {
     }
@@ -34,7 +31,7 @@ readonly class StagingSalesChannelHandler
         foreach ($urls as $urlRecord) {
             $beforeURl = $urlRecord['url'];
 
-            foreach ($this->rewrite as $rule) {
+            foreach ($event->domainMappings as $rule) {
                 switch ($rule['type']) {
                     case 'equal':
                         $urlRecord = $this->modifyByEqual($urlRecord, $rule);

--- a/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
@@ -23,7 +23,9 @@ class SystemSetupStagingCommandTest extends TestCase
     {
         $command = new SystemSetupStagingCommand(
             $this->createMock(EventDispatcherInterface::class),
-            $this->createMock(SystemConfigService::class)
+            $this->createMock(SystemConfigService::class),
+            true,
+            []
         );
 
         $tester = new CommandTester($command);
@@ -38,9 +40,15 @@ class SystemSetupStagingCommandTest extends TestCase
         $configService = new StaticSystemConfigService();
         $eventDispatcher = new CollectingEventDispatcher();
 
+        $routeMappings = [
+            ['match' => '/old-path', 'type' => 'prefix', 'replace' => '/new-path'],
+        ];
+
         $command = new SystemSetupStagingCommand(
             $eventDispatcher,
-            $configService
+            $configService,
+            true,
+            $routeMappings
         );
 
         $tester = new CommandTester($command);
@@ -54,6 +62,8 @@ class SystemSetupStagingCommandTest extends TestCase
         $event = $eventDispatcher->getEvents()[0];
 
         static::assertInstanceOf(SetupStagingEvent::class, $event);
+        static::assertSame($routeMappings, $event->domainMappings);
+        static::assertTrue($event->disableMailDelivery);
     }
 
     public function testRunNoInteractionWithForce(): void
@@ -63,7 +73,9 @@ class SystemSetupStagingCommandTest extends TestCase
 
         $command = new SystemSetupStagingCommand(
             $eventDispatcher,
-            $configService
+            $configService,
+            true,
+            []
         );
 
         $tester = new CommandTester($command);
@@ -82,7 +94,9 @@ class SystemSetupStagingCommandTest extends TestCase
     {
         $command = new SystemSetupStagingCommand(
             $this->createMock(EventDispatcherInterface::class),
-            $this->createMock(SystemConfigService::class)
+            $this->createMock(SystemConfigService::class),
+            true,
+            []
         );
 
         $tester = new CommandTester($command);

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingAppHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingAppHandlerTest.php
@@ -43,7 +43,12 @@ class StagingAppHandlerTest extends TestCase
         $configService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, 'test');
 
         $handler = new StagingAppHandler($connection, $configService);
-        $handler->__invoke(new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class)));
+        $handler->__invoke(new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            false,
+            []
+        ));
 
         static::assertNull($configService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
 

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingMailHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingMailHandlerTest.php
@@ -20,9 +20,14 @@ class StagingMailHandlerTest extends TestCase
     public function testDisabled(): void
     {
         $config = new StaticSystemConfigService();
-        $handler = new StagingMailHandler(false, $config);
+        $handler = new StagingMailHandler($config);
 
-        $handler(new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class)));
+        $handler(new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            false,
+            []
+        ));
 
         static::assertNull($config->get(MailSender::DISABLE_MAIL_DELIVERY));
     }
@@ -30,9 +35,14 @@ class StagingMailHandlerTest extends TestCase
     public function testEnabled(): void
     {
         $config = new StaticSystemConfigService();
-        $handler = new StagingMailHandler(true, $config);
+        $handler = new StagingMailHandler($config);
 
-        $handler(new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class)));
+        $handler(new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            true,
+            []
+        ));
 
         static::assertTrue($config->get(MailSender::DISABLE_MAIL_DELIVERY));
     }

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingSalesChannelHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingSalesChannelHandlerTest.php
@@ -33,14 +33,18 @@ class StagingSalesChannelHandlerTest extends TestCase
                 ['id' => 'id1']
             );
 
-        $handler = new StagingSalesChannelHandler(
-            [
-                ['match' => 'http://localhost', 'type' => 'equal', 'replace' => 'http://staging.local'],
-            ],
-            $connection
-        );
+        $handler = new StagingSalesChannelHandler($connection);
 
-        $event = new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class));
+        $domainMapping = [
+            ['match' => 'http://localhost', 'type' => 'equal', 'replace' => 'http://staging.local'],
+        ];
+
+        $event = new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            false,
+            $domainMapping
+        );
 
         $handler($event);
     }
@@ -58,14 +62,18 @@ class StagingSalesChannelHandlerTest extends TestCase
             ->expects($this->never())
             ->method('update');
 
-        $handler = new StagingSalesChannelHandler(
-            [
-                ['match' => 'http://fooo', 'type' => 'equal', 'replace' => 'http://staging.local'],
-            ],
-            $connection
-        );
+        $handler = new StagingSalesChannelHandler($connection);
 
-        $event = new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class));
+        $domainMapping = [
+            ['match' => 'http://fooo', 'type' => 'equal', 'replace' => 'http://staging.local'],
+        ];
+
+        $event = new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            false,
+            $domainMapping
+        );
 
         $handler($event);
     }
@@ -87,14 +95,18 @@ class StagingSalesChannelHandlerTest extends TestCase
                 ['id' => 'id1']
             );
 
-        $handler = new StagingSalesChannelHandler(
-            [
-                ['match' => '/https?:\/\/(\w+)\.(\w+)$/m', 'type' => 'regex', 'replace' => 'http://$1-$2.local'],
-            ],
-            $connection
-        );
+        $handler = new StagingSalesChannelHandler($connection);
 
-        $event = new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class));
+        $domainMapping = [
+            ['match' => '/https?:\/\/(\w+)\.(\w+)$/m', 'type' => 'regex', 'replace' => 'http://$1-$2.local'],
+        ];
+
+        $event = new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            false,
+            $domainMapping
+        );
 
         $handler($event);
     }
@@ -116,14 +128,18 @@ class StagingSalesChannelHandlerTest extends TestCase
                 ['id' => 'id1']
             );
 
-        $handler = new StagingSalesChannelHandler(
-            [
-                ['match' => 'https://pikachu.com', 'type' => 'prefix', 'replace' => 'http://localhost'],
-            ],
-            $connection
-        );
+        $handler = new StagingSalesChannelHandler($connection);
 
-        $event = new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class));
+        $domainMapping = [
+            ['match' => 'https://pikachu.com', 'type' => 'prefix', 'replace' => 'http://localhost'],
+        ];
+
+        $event = new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            false,
+            $domainMapping
+        );
 
         $handler($event);
     }

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchStagingHandlerTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchStagingHandlerTest.php
@@ -20,7 +20,12 @@ class ElasticsearchStagingHandlerTest extends TestCase
 {
     public function testCancel(): void
     {
-        $event = new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class));
+        $event = new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            false,
+            [],
+        );
 
         $helper = $this->createMock(ElasticsearchHelper::class);
         $helper->method('allowIndexing')->willReturn(true);
@@ -37,7 +42,12 @@ class ElasticsearchStagingHandlerTest extends TestCase
     #[DataProvider('disabledProvider')]
     public function testDisabled(bool $check, bool $indexing): void
     {
-        $event = new SetupStagingEvent(Context::createDefaultContext(), $this->createMock(SymfonyStyle::class));
+        $event = new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            false,
+            [],
+        );
 
         $helper = $this->createMock(ElasticsearchHelper::class);
         $helper->method('allowIndexing')->willReturn($indexing);


### PR DESCRIPTION
The staging event so far was pretty dump and the services relied on hard coded config

I moved the config to the event, the setup staging command still relies on the hardcoded symfony config, however this way we can reuse the logic in more dynamic cases, e.g. for snapshots in saas