### PR TITLE
fix: skip cart recalculation on esi sub-requests

### DIFF
--- a/changelog/_unreleased/2025-07-03-skip-cart-recalculation-on-esi-sub-requests.md
+++ b/changelog/_unreleased/2025-07-03-skip-cart-recalculation-on-esi-sub-requests.md
@@ -1,0 +1,10 @@
+---
+title: Skip cart recalculation on ESI sub requests
+issue: #8558
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `Shopware\Core\System\SalesChannel\Context\SalesChannelContextService` to skip cart recalculation on ESI sub requests
+* Added the method `Shopware\Core\Checkout\Cart\SalesChannel\CartService::hasCart` to check for memoized carts

--- a/src/Core/Checkout/Cart/SalesChannel/CartService.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartService.php
@@ -50,6 +50,11 @@ class CartService implements ResetInterface
         $this->cart[$cart->getToken()] = $cart;
     }
 
+    public function hasCart(string $token): bool
+    {
+        return isset($this->cart[$token]);
+    }
+
     public function createNew(string $token): Cart
     {
         $cart = $this->cartFactory->createNew($token);
@@ -63,7 +68,7 @@ class CartService implements ResetInterface
         bool $caching = true,
         bool $taxed = false
     ): Cart {
-        if ($caching && isset($this->cart[$token])) {
+        if ($caching && $this->hasCart($token)) {
             return $this->cart[$token];
         }
 

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -105,6 +105,7 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack"/>
         </service>
 
         <service id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextRestorer">

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -212,6 +212,6 @@ class SalesChannelContextServiceTest extends TestCase
         yield 'esi request with cart => false' => [new Request(attributes: ['_sw_esi' => true]), true, false];
         yield 'esi request without cart => true' => [new Request(attributes: ['_sw_esi' => true]), false, true];
         yield 'no esi request but cart => true' => [new Request(), true, true];
-        yield 'no esi request and cart => true' => [new Request(), false, true];
+        yield 'no esi request and no cart => true' => [new Request(), false, true];
     }
 }

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -3,10 +3,14 @@
 namespace Shopware\Tests\Unit\Core\System\SalesChannel\Context;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Checkout\Cart\RuleLoaderResult;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -15,9 +19,11 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @internal
@@ -26,27 +32,48 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(SalesChannelContextService::class)]
 class SalesChannelContextServiceTest extends TestCase
 {
+    private SalesChannelContextFactory&MockObject $factory;
+
+    private CartRuleLoader&MockObject $cartRuleLoader;
+
+    private SalesChannelContextPersister&MockObject $persister;
+
+    private CartService&MockObject $cartService;
+
+    private EventDispatcherInterface&MockObject $eventDispatcher;
+
+    private RequestStack $requestStack;
+
+    private SalesChannelContextService $service;
+
+    protected function setUp(): void
+    {
+        $this->factory = $this->createMock(SalesChannelContextFactory::class);
+        $this->cartRuleLoader = $this->createMock(CartRuleLoader::class);
+        $this->persister = $this->createMock(SalesChannelContextPersister::class);
+        $this->cartService = $this->createMock(CartService::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->requestStack = new RequestStack();
+
+        $this->service = new SalesChannelContextService(
+            $this->factory,
+            $this->cartRuleLoader,
+            $this->persister,
+            $this->cartService,
+            $this->eventDispatcher,
+            $this->requestStack,
+        );
+    }
+
     public function testTokenExpired(): void
     {
-        $factory = $this->createMock(SalesChannelContextFactory::class);
-        $persister = $this->createMock(SalesChannelContextPersister::class);
-
-        $service = new SalesChannelContextService(
-            $factory,
-            $this->createMock(CartRuleLoader::class),
-            $persister,
-            $this->createMock(CartService::class),
-            $this->createMock(EventDispatcherInterface::class),
-        );
-
-        $persister->method('load')->willReturn(['expired' => true]);
+        $this->persister->method('load')->willReturn(['expired' => true]);
 
         $expiredToken = Uuid::randomHex();
 
-        $context = $this->createMock(SalesChannelContext::class);
-        $context->method('withPermissions')->willReturn($this->createMock(RuleLoaderResult::class));
+        $context = Generator::generateSalesChannelContext();
 
-        $factory->expects($this->once())
+        $this->factory->expects($this->once())
             ->method('create')
             ->with(
                 static::logicalNot(static::equalTo($expiredToken)),
@@ -58,30 +85,32 @@ class SalesChannelContextServiceTest extends TestCase
             )
             ->willReturn($context);
 
-        $service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $expiredToken, Defaults::LANGUAGE_SYSTEM));
+        $result = new RuleLoaderResult(new Cart($expiredToken), new RuleCollection());
+
+        $this->cartRuleLoader
+            ->expects($this->once())
+            ->method('loadByToken')
+            ->with($context, static::logicalNot(static::equalTo($expiredToken)))
+            ->willReturn($result);
+
+        $this->cartService
+            ->expects($this->once())
+            ->method('setCart')
+            ->with($result->getCart());
+
+        $this->service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $expiredToken, Defaults::LANGUAGE_SYSTEM));
     }
 
     public function testTokenNotExpired(): void
     {
-        $factory = $this->createMock(SalesChannelContextFactory::class);
-        $persister = $this->createMock(SalesChannelContextPersister::class);
-
-        $service = new SalesChannelContextService(
-            $factory,
-            $this->createMock(CartRuleLoader::class),
-            $persister,
-            $this->createMock(CartService::class),
-            $this->createMock(EventDispatcherInterface::class)
-        );
-
         $customerId = Uuid::randomHex();
-        $persister->method('load')->willReturn(['expired' => false, SalesChannelContextService::CUSTOMER_ID => $customerId]);
         $noneExpiringToken = Uuid::randomHex();
 
-        $context = $this->createMock(SalesChannelContext::class);
-        $context->method('withPermissions')->willReturn($this->createMock(RuleLoaderResult::class));
+        $this->persister->method('load')->willReturn(['expired' => false, SalesChannelContextService::CUSTOMER_ID => $customerId]);
 
-        $factory->expects($this->once())
+        $context = Generator::generateSalesChannelContext();
+
+        $this->factory->expects($this->once())
             ->method('create')
             ->with(
                 $noneExpiringToken,
@@ -94,40 +123,95 @@ class SalesChannelContextServiceTest extends TestCase
             )
             ->willReturn($context);
 
-        $service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $noneExpiringToken, Defaults::LANGUAGE_SYSTEM));
+        $result = new RuleLoaderResult(new Cart($noneExpiringToken), new RuleCollection());
+
+        $this->cartRuleLoader
+            ->expects($this->once())
+            ->method('loadByToken')
+            ->with($context, $noneExpiringToken)
+            ->willReturn($result);
+
+        $this->cartService
+            ->expects($this->once())
+            ->method('setCart')
+            ->with($result->getCart());
+
+        $this->service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $noneExpiringToken, Defaults::LANGUAGE_SYSTEM));
     }
 
     public function testDispatchesSalesChannelContextCreatedEvent(): void
     {
         $token = 'test-token';
-        $context = $this->createMock(SalesChannelContext::class);
-        $context->method('withPermissions')->willReturn($this->createMock(RuleLoaderResult::class));
-        $session = [
-            'foo' => 'bar',
-        ];
+        $context = Generator::generateSalesChannelContext();
+        $session = ['foo' => 'bar'];
 
-        $persister = $this->createMock(SalesChannelContextPersister::class);
-        $persister->method('load')->willReturn($session);
+        $this->persister->method('load')->willReturn($session);
 
-        $factory = $this->createMock(SalesChannelContextFactory::class);
-        $factory->expects($this->once())
+        $this->factory->expects($this->once())
             ->method('create')
             ->with($token, TestDefaults::SALES_CHANNEL, $session)
             ->willReturn($context);
 
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $dispatcher->expects($this->once())
+        $this->eventDispatcher->expects($this->once())
             ->method('dispatch')
             ->with(new SalesChannelContextCreatedEvent($context, $token, $session));
 
-        $service = new SalesChannelContextService(
-            $factory,
-            $this->createMock(CartRuleLoader::class),
-            $persister,
-            $this->createMock(CartService::class),
-            $dispatcher,
-        );
+        $this->service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $token));
+    }
 
-        $service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $token));
+    #[DataProvider('skipCartCalculationIfAlreadyDoneAndESISubrequestProvider')]
+    public function testSkipCartCalculationIfAlreadyDoneAndESISubrequest(Request $request, bool $hasCart, bool $expectCalculation): void
+    {
+        $customerId = Uuid::randomHex();
+        $token = Uuid::randomHex();
+        $result = new RuleLoaderResult(new Cart($token), new RuleCollection());
+
+        $this->persister->method('load')->willReturn(['expired' => false, SalesChannelContextService::CUSTOMER_ID => $customerId]);
+
+        $context = Generator::generateSalesChannelContext();
+
+        $this->factory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($context);
+
+        $this->cartService
+            ->expects($this->once())
+            ->method('hasCart')
+            ->with($token)
+            ->willReturn($hasCart);
+
+        if ($expectCalculation) {
+            $this->cartRuleLoader
+                ->expects($this->once())
+                ->method('loadByToken')
+                ->with($context, $token)
+                ->willReturn($result);
+
+            $this->cartService
+                ->expects($this->once())
+                ->method('setCart')
+                ->with($result->getCart());
+        } else {
+            $this->cartRuleLoader
+                ->expects($this->never())
+                ->method(static::anything());
+
+            $this->cartService
+                ->expects($this->never())
+                ->method('setCart');
+        }
+
+        $this->requestStack->push($request);
+
+        $this->service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $token, Defaults::LANGUAGE_SYSTEM));
+    }
+
+    public static function skipCartCalculationIfAlreadyDoneAndESISubrequestProvider(): \Generator
+    {
+        yield 'esi request with cart => false' => [new Request(attributes: ['_sw_esi' => true]), true, false];
+        yield 'esi request without cart => true' => [new Request(attributes: ['_sw_esi' => true]), false, true];
+        yield 'no esi request but cart => true' => [new Request(), true, true];
+        yield 'no esi request and cart => true' => [new Request(), false, true];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
With the new ESI sub-requests for header and footer, the cart is recalculated three times as each request loads the `SalesChannelContext` via the `SalesChannelContextService`, which always triggers a cart calculated.

### 2. What does this change do, exactly?
We check for the existence of an already calculated and memoized cart and for the kind of request which is currently loading the `SalesChannelContext` to skip the recalculation for ESI sub-requests.

### 3. Describe each step to reproduce the issue or behaviour.
for more details, see #8558.

- Have a cart
- load any navigation page
- Have a look at the stack trace

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #8558 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
