### PR TITLE
feat: Add CanonicalRedirectExtension to CanonicalRedirectService

### DIFF
--- a/changelog/_unreleased/2025-07-03-add-canonical-redirect-extension.md
+++ b/changelog/_unreleased/2025-07-03-add-canonical-redirect-extension.md
@@ -1,0 +1,9 @@
+---
+title: Add CanonicalRedirectExtension to CanonicalRedirectService
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Added `Shopware\Core\Framework\Routing\Extension\CanonicalRedirectExtension`
+* Changed `Shopware\Core\Framework\Routing\CanonicalRedirectService` to publish `CanonicalRedirectExtension`

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -220,6 +220,7 @@ frame-ancestors 'none';
 
         <service id="Shopware\Core\Framework\Routing\CanonicalRedirectService" public="true">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
         </service>
 
         <service id="Shopware\Core\Framework\Routing\RouteEventSubscriber">

--- a/src/Core/Framework/Routing/CanonicalRedirectService.php
+++ b/src/Core/Framework/Routing/CanonicalRedirectService.php
@@ -2,7 +2,9 @@
 
 namespace Shopware\Core\Framework\Routing;
 
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\Extension\CanonicalRedirectExtension;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -15,8 +17,19 @@ class CanonicalRedirectService
     /**
      * @internal
      */
-    public function __construct(private readonly SystemConfigService $configService)
+    public function __construct(
+        private readonly SystemConfigService $configService,
+        private readonly ExtensionDispatcher $extensions,
+    ) {
+    }
+
+    public function getRedirect(Request $request): ?Response
     {
+        return $this->extensions->publish(
+            name: CanonicalRedirectExtension::NAME,
+            extension: new CanonicalRedirectExtension($request),
+            function: $this->_getRedirect(...),
+        );
     }
 
     /**
@@ -25,7 +38,7 @@ class CanonicalRedirectService
      * configuration option is active, it returns a redirect response to indicate, that
      * the request should be redirected to the canonical URL.
      */
-    public function getRedirect(Request $request): ?Response
+    private function _getRedirect(Request $request): ?Response
     {
         // This attribute has been set by the RequestTransformer if the requested URL was superseded.
         $canonical = $request->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK);

--- a/src/Core/Framework/Routing/CanonicalRedirectService.php
+++ b/src/Core/Framework/Routing/CanonicalRedirectService.php
@@ -23,6 +23,12 @@ class CanonicalRedirectService
     ) {
     }
 
+    /**
+     * getRedirect takes a request processed by the RequestTransformer and checks,
+     * whether it points to a SEO-URL which has been superseded. In case the corresponding
+     * configuration option is active, it returns a redirect response to indicate, that
+     * the request should be redirected to the canonical URL.
+     */
     public function getRedirect(Request $request): ?Response
     {
         return $this->extensions->publish(
@@ -32,12 +38,6 @@ class CanonicalRedirectService
         );
     }
 
-    /**
-     * getRedirect takes a request processed by the RequestTransformer and checks,
-     * whether it points to a SEO-URL which has been superseded. In case the corresponding
-     * configuration option is active, it returns a redirect response to indicate, that
-     * the request should be redirected to the canonical URL.
-     */
     private function _getRedirect(Request $request): ?Response
     {
         // This attribute has been set by the RequestTransformer if the requested URL was superseded.

--- a/src/Core/Framework/Routing/Extension/CanonicalRedirectExtension.php
+++ b/src/Core/Framework/Routing/Extension/CanonicalRedirectExtension.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Routing\Extension;
+
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @public this class is used as type-hint for all event listeners, so the class string is "public consumable" API
+ *
+ * @title Determination of a request redirect response
+ *
+ * @description This event allows interception of the request redirect check to modify the redirect response.
+ *
+ * @codeCoverageIgnore
+ *
+ * @extends Extension<?Response>
+ */
+#[Package('framework')]
+final class CanonicalRedirectExtension extends Extension
+{
+    public const NAME = 'canonical-redirect';
+
+    /**
+     * @internal shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(public readonly Request $request)
+    {
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently you can't intercept in the check for a redirect response
- This PR adds the `CanonicalRedirectExtension` which allows a interception of the request redirect check to modify the redirect response

### 2. What does this change do, exactly?
* Added `Shopware\Core\Framework\Routing\Extension\CanonicalRedirectExtension`
* Changed `Shopware\Core\Framework\Routing\CanonicalRedirectService` to publish `CanonicalRedirectExtension`

### 3. Describe each step to reproduce the issue or behaviour.
- Try to intercept in the redirect check

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
