### PR TITLE
fix: Removed EntityHydrator internal class tag

### DIFF
--- a/changelog/_unreleased/2025-07-03-removed-entity-hydrator-internal-class-tag.md
+++ b/changelog/_unreleased/2025-07-03-removed-entity-hydrator-internal-class-tag.md
@@ -1,0 +1,8 @@
+---
+title: Removed EntityHydrator internal class tag
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator` to remove the `internal` tag of the class

--- a/changelog/_unreleased/2025-07-03-removed-entity-hydrator-internal-class-tag.md
+++ b/changelog/_unreleased/2025-07-03-removed-entity-hydrator-internal-class-tag.md
@@ -5,4 +5,4 @@ author_email: Discord.Benjamin@web.de
 author_github: gecolay
 ---
 # Core
-* Changed `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator` to remove the `internal` tag of the class
+* Removed the `internal` tag of the class `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator`

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -31,8 +31,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Allows to hydrate database values into struct objects.
- *
- * @internal
  */
 #[Package('framework')]
 class EntityHydrator


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the `EntityHydrator` class has the `internal` tag, which flags it in log files with a `class is considered internal` warning if you use if for your custom entity hydrator classes
- This PR just removes the `internal` tag of the class, but keeps the `internal` tag on the constructor

![image](https://github.com/user-attachments/assets/b6581c41-959a-4888-9540-0b8f92b94a8b)

### 2. What does this change do, exactly?
* Changed `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator` to remove the `internal` tag of the class

### 3. Describe each step to reproduce the issue or behaviour.
- Create a custom entity hydrator which extends the shopware core EntityHydrator
- Take a look at the logs, there will be a `class is considered internal` warning

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
