### PR TITLE
fix: deprecate filesystem visibility configuration in the config array

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -36,6 +36,27 @@ New blocks have been added in `sw-settings-index.html.twig`:
 * You must pass the `confidential` parameter as the third parameter of the constructor.
 * You must pass the `name` parameter as the fourth parameter of the constructor.
 
+## Removed configuration of Filesystem visibility in config array
+
+The visibility of filesystems cannot be configured in the config array anymore. Instead, it should be set on the same level as `type`. For example, instead of:
+
+```yaml
+filesystems:
+  my_filesystem:
+    type: local
+    config:
+      visibility: public
+```
+
+You should now use:
+
+```yaml
+filesystems:
+  my_filesystem:
+    type: local
+    visibility: public
+```
+
 ## Storefront
 
 ### Deprecated DomAccess Helper

--- a/changelog/_unreleased/2025-07-03-deprecate-filesystem-visibility-in-config-array.md
+++ b/changelog/_unreleased/2025-07-03-deprecate-filesystem-visibility-in-config-array.md
@@ -1,0 +1,31 @@
+---
+title: Deprecate filesystem visibility in config array
+---
+
+# Core
+
+* Deprecated that filesystem visibility can be configured in the config array. It should be configured on the same level as `type`.
+
+___
+# Upgrade Information
+
+## Deprecated configuration of visibility in config array
+
+The visibility of filesystems should no longer be configured in the config array. Instead, it should be set on the same level as `type`. For example, instead of:
+
+```yaml
+filesystems:
+  my_filesystem:
+    type: local
+    config:
+      visibility: public
+```
+
+You should now use:
+
+```yaml
+filesystems:
+  my_filesystem:
+    type: local
+    visibility: public
+```

--- a/src/Core/Framework/Adapter/Filesystem/FilesystemFactory.php
+++ b/src/Core/Framework/Adapter/Filesystem/FilesystemFactory.php
@@ -10,6 +10,7 @@ use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AdapterFactoryInterface;
 use Shopware\Core\Framework\Adapter\Filesystem\Exception\AdapterFactoryNotFoundException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -45,7 +46,9 @@ class FilesystemFactory
         $config = $this->resolveFilesystemConfig($config);
         $factory = $this->findAdapterFactory($config['type']);
 
+        // @deprecated tag:v6.8.0 - the visibility option will be removed from the filesystem config, it should be set next to the type
         if (isset($config['config']['options']['visibility'])) {
+            Feature::triggerDeprecationOrThrow('v6.8.0.0', 'Setting visibility in the filesystem config level is deprecated. Set visibility next to type: amazon-s3 instead.');
             $config['visibility'] = $config['config']['options']['visibility'];
             unset($config['config']['options']['visibility']);
 

--- a/tests/unit/Core/Framework/Adapter/Filesystem/FilesystemFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/FilesystemFactoryTest.php
@@ -26,11 +26,9 @@ class FilesystemFactoryTest extends TestCase
         $factory = new FilesystemFactory([new LocalFactory()]);
         $adapter = $factory->factory([
             'type' => 'local',
+            'visibility' => Visibility::PUBLIC,
             'config' => [
                 'root' => __DIR__,
-                'options' => [
-                    'visibility' => Visibility::PUBLIC,
-                ],
             ],
         ]);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

It's weird that you can configure at two places the visibility


### 2. What does this change do, exactly?

Deprecate the other way of setting the visibility.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
