### PR TITLE
feat: add remove function to from submit loader plugin

### DIFF
--- a/changelog/_unreleased/2025-07-03-add-remove-function-to-form-submit-loader-plugin.md
+++ b/changelog/_unreleased/2025-07-03-add-remove-function-to-form-submit-loader-plugin.md
@@ -1,0 +1,6 @@
+---
+title: Add remove loader function to form submit loader plugin
+issue: #10978
+---
+# Storefront
+* Changed `form-submit-loader.plugin.js` and added a `removeLoadingIndicator` function to remove loading indicators from submitted buttons

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-submit-loader.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-submit-loader.plugin.js
@@ -28,6 +28,11 @@ export default class FormSubmitLoaderPlugin extends Plugin {
         skipLoadingIndicator: false,
     };
 
+    /**
+     * List of submitted button with loading indicators
+     */
+    _submittedButtonLoaders = [];
+
     init() {
         if (!this._getForm() || !this._getSubmitButtons()) {
             return;
@@ -35,6 +40,9 @@ export default class FormSubmitLoaderPlugin extends Plugin {
 
         // check if validation plugin is active for this form
         this._validationPluginActive = !!window.PluginManager.getPluginInstanceFromElement(this._form, 'FormValidation');
+
+        // Will hold the instances of loading indicators for each submit button.
+        this._submittedButtonLoaders = [];
 
         this._registerEvents();
     }
@@ -83,6 +91,7 @@ export default class FormSubmitLoaderPlugin extends Plugin {
     _registerEvents() {
         // the submit event will be triggered only if the HTML5 validation has been successful
         this._form.addEventListener('submit', this._onFormSubmit.bind(this));
+        this._form.addEventListener('removeLoader', this.removeLoadingIndicator.bind(this));
     }
 
     /**
@@ -108,8 +117,18 @@ export default class FormSubmitLoaderPlugin extends Plugin {
 
             const loader = new ButtonLoadingIndicator(submitButton, this.options.indicatorPosition);
             loader.create();
+            this._submittedButtonLoaders.push(loader);
         });
 
         this.$emitter.publish('beforeSubmit');
+    }
+
+    /**
+     * Will remove existing loading indicators from submit buttons
+     */
+    removeLoadingIndicator() {
+        this._submittedButtonLoaders.forEach(loader => loader.remove());
+
+        this._submittedButtonLoaders = [];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

![image](https://github.com/user-attachments/assets/a6c11acd-53f9-4e24-a8b4-259ddbee52ab)

When using the `FormSubmitLoaderPlugin`, a loading spinner is added to the submit button during form submission. However, if validation fails and the form is not submitted, the button text may disappear and the button can shrink (e.g. to 8px height), because the spinner remains and the original state is not restored.

There is currently no built-in method to remove the loading state on the client side. To address this, we need a function that removes all loading indicators and resets the button state.

### 2. What does this change do, exactly?
This change introduces a removeLoadingIndicator method to the FormSubmitLoaderPlugin. It removes all active loading indicators and restores the original button text and layout.


### 4. Please link to the relevant issues (if any).
- relates shopware/SwagPayPal#286


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
