### PR TITLE
feat: Improved XmlHttpRequest denied exception information

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -49,5 +49,8 @@ return [
 
         // The type has been extended and the old type is still accepted
         'CHANGED: The parameter \$context of Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\BuildBreadcrumbExtension#(getFullBreadcrumb|getFullBreadcrumbById)\(\) changed from Shopware\\\\Core\\\\Framework\\\\Context to Shopware\\\\Core\\\\Framework\\\\Context\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelContext',
+
+        // The parameters are optional, so this is not a BC break
+        'ADDED: Parameter .* was added to Method accessDeniedForXmlHttpRequest\(\) of class Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException',
     ],
 ];

--- a/changelog/_unreleased/2025-07-03-improved-xml-http-request-denied-exception-info.md
+++ b/changelog/_unreleased/2025-07-03-improved-xml-http-request-denied-exception-info.md
@@ -1,0 +1,8 @@
+---
+title: Improved XmlHttpRequest denied exception information
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `accessDeniedForXmlHttpRequest` in `Shopware\Core\Framework\Routing\RoutingException` to show more information about the request

--- a/src/Core/Framework/Routing/RoutingException.php
+++ b/src/Core/Framework/Routing/RoutingException.php
@@ -68,12 +68,18 @@ class RoutingException extends HttpException
         );
     }
 
-    public static function accessDeniedForXmlHttpRequest(): self
+    public static function accessDeniedForXmlHttpRequest(?string $route = null, ?string $url = null, ?string $referer = null): self
     {
+        $message = 'PageController ' . ($route ? '"{{ route }}" ' : '')
+            . ($url ? '("{{ url }}") ' : '')
+            . 'can\'t be requested via XmlHttpRequest.'
+            . ($referer ? ' Requested by "{{ referer }}".' : '');
+
         return new self(
             Response::HTTP_FORBIDDEN,
             self::ACCESS_DENIED_FOR_XML_HTTP_REQUEST,
-            'PageController can\'t be requested via XmlHttpRequest.'
+            $message,
+            ['route' => $route, 'url' => $url, 'referer' => $referer]
         );
     }
 }

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -183,22 +183,28 @@ class StorefrontSubscriber implements EventSubscriberInterface
 
     public function preventPageLoadingFromXmlHttpRequest(ControllerEvent $event): void
     {
-        if (!$event->getRequest()->isXmlHttpRequest()) {
+        $request = $event->getRequest();
+
+        if (!$request->isXmlHttpRequest()) {
             return;
         }
 
-        $scope = $event->getRequest()->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []);
+        $scope = $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []);
 
         if (!\in_array(StorefrontRouteScope::ID, $scope, true)) {
             return;
         }
 
-        $isAllowed = $event->getRequest()->attributes->getBoolean('XmlHttpRequest');
+        $isAllowed = $request->attributes->getBoolean('XmlHttpRequest');
         if ($isAllowed) {
             return;
         }
 
-        throw RoutingException::accessDeniedForXmlHttpRequest();
+        $route = $request->attributes->get('_route');
+        $url = $request->getUri();
+        $referer = $request->headers->get('referer');
+
+        throw RoutingException::accessDeniedForXmlHttpRequest($route, $url, $referer);
     }
 
     // used to switch session token - when the context token expired

--- a/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -207,7 +207,11 @@ class StorefrontSubscriberTest extends TestCase
         );
 
         if ($expected) {
-            $this->expectExceptionObject(RoutingException::accessDeniedForXmlHttpRequest());
+            $route = $request->attributes->get('_route');
+            $url = $request->getUri();
+            $referer = $request->headers->get('referer');
+
+            $this->expectExceptionObject(RoutingException::accessDeniedForXmlHttpRequest($route, $url, $referer));
         } else {
             static::assertTrue($event->isMainRequest());
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
-  Currently, if you find a `RoutingException` of type `ACCESS_DENIED_FOR_XML_HTTP_REQUEST` in your server logs, there's no meaningful information available about where the problem actually occurred. This makes it difficult to find the root cause of the problem.
- This PR adds more information to the `RoutingException` in the form of an improved message and exception parameters.

### 2. What does this change do, exactly?
* Changed `accessDeniedForXmlHttpRequest` in `Shopware\Core\Framework\Routing\RoutingException` to show more information about the request

### 3. Describe each step to reproduce the issue or behaviour.
- Access a page via XmlHttpRequest which doesn't support it
- There will be a error message without much detail

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
