### PR TITLE
chore: Use sw-time-ago for past date times

### DIFF
--- a/changelog/_unreleased/2025-07-03-use-sw-time-ago-for-past-date-times.md
+++ b/changelog/_unreleased/2025-07-03-use-sw-time-ago-for-past-date-times.md
@@ -1,0 +1,8 @@
+---
+title: Use sw-time-ago for past date times
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Changed several twig templates to use `sw-time-ago` for past date times instead of plain `dateFilter` function

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.spec.js
@@ -53,7 +53,6 @@ async function createWrapper(propsData = {}) {
                 'router-link': true,
                 'sw-button-group': true,
                 'sw-provide': true,
-                'sw-time-ago': await wrapTestComponent('sw-time-ago', { sync: true }),
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.spec.js
@@ -53,7 +53,7 @@ async function createWrapper(propsData = {}) {
                 'router-link': true,
                 'sw-button-group': true,
                 'sw-provide': true,
-                'sw-time-ago': true,
+                'sw-time-ago': await wrapTestComponent('sw-time-ago', { sync: true }),
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.spec.js
@@ -53,6 +53,7 @@ async function createWrapper(propsData = {}) {
                 'router-link': true,
                 'sw-button-group': true,
                 'sw-provide': true,
+                'sw-time-ago': true,
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/index.js
@@ -220,6 +220,9 @@ export default {
             return Shopware.Filter.getByName('currency');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/index.js
@@ -220,9 +220,6 @@ export default {
             return Shopware.Filter.getByName('currency');
         },
 
-        /**
-         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
-         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.html.twig
@@ -73,10 +73,7 @@
     <template #column-releaseDate="{ item }">
         {% block sw_advanced_selection_product_list_grid_columns_release_date_content %}
         <template v-if="item.releaseDate">
-            <sw-time-ago
-                :date="item.releaseDate"
-                :date-time-format="{ month: '2-digit', day: '2-digit' }"
-            />
+            {{ dateFilter(item.releaseDate, { month: '2-digit', day: '2-digit' }) }}
         </template>
         <template v-else>
             -

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.html.twig
@@ -73,7 +73,7 @@
     <template #column-releaseDate="{ item }">
         {% block sw_advanced_selection_product_list_grid_columns_release_date_content %}
         <template v-if="item.releaseDate">
-            {{ dateFilter(item.releaseDate) }}
+            <sw-time-ago :date="item.releaseDate" />
         </template>
         <template v-else>
             -

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.html.twig
@@ -73,7 +73,10 @@
     <template #column-releaseDate="{ item }">
         {% block sw_advanced_selection_product_list_grid_columns_release_date_content %}
         <template v-if="item.releaseDate">
-            <sw-time-ago :date="item.releaseDate" />
+            <sw-time-ago
+                :date="item.releaseDate"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
+            />
         </template>
         <template v-else>
             -

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.spec.js
@@ -331,6 +331,7 @@ async function createWrapper() {
                         'sw-context-menu': true,
                         'sw-entity-advanced-selection-modal-grid': true,
                         'sw-ai-copilot-badge': true,
+                        'sw-time-ago': true,
                     },
                 },
             },
@@ -412,7 +413,6 @@ describe('components/sw-advanced-selection-product', () => {
 
     it('should return filters from filter registry', () => {
         expect(wrapper.vm.currencyFilter).toEqual(expect.any(Function));
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
         expect(wrapper.vm.stockColorVariantFilter).toEqual(expect.any(Function));
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.spec.js
@@ -413,6 +413,10 @@ describe('components/sw-advanced-selection-product', () => {
 
     it('should return filters from filter registry', () => {
         expect(wrapper.vm.currencyFilter).toEqual(expect.any(Function));
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
         expect(wrapper.vm.stockColorVariantFilter).toEqual(expect.any(Function));
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.spec.js
@@ -331,7 +331,6 @@ async function createWrapper() {
                         'sw-context-menu': true,
                         'sw-entity-advanced-selection-modal-grid': true,
                         'sw-ai-copilot-badge': true,
-                        'sw-time-ago': true,
                     },
                 },
             },
@@ -413,10 +412,7 @@ describe('components/sw-advanced-selection-product', () => {
 
     it('should return filters from filter registry', () => {
         expect(wrapper.vm.currencyFilter).toEqual(expect.any(Function));
-        if (!Shopware.Feature.isActive('V6_8_0_0')) {
-            // eslint-disable-next-line jest/no-conditional-expect
-            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
-        }
+        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
         expect(wrapper.vm.stockColorVariantFilter).toEqual(expect.any(Function));
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/index.js
@@ -262,6 +262,9 @@ export default {
             return aggregations;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.html.twig
@@ -66,10 +66,16 @@
         {% block sw_advanced_selection_rule_list_grid_columns_create_date_content %}
         <span :class="getColumnClass(item)">
             <template v-if="item.updatedAt">
-                <sw-time-ago :date="item.updatedAt" />
+                <sw-time-ago
+                    :date="item.updatedAt"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
+                />
             </template>
             <template v-else>
-                <sw-time-ago :date="item.createdAt" />
+                <sw-time-ago
+                    :date="item.createdAt"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
+                />
             </template>
         </span>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.html.twig
@@ -66,10 +66,10 @@
         {% block sw_advanced_selection_rule_list_grid_columns_create_date_content %}
         <span :class="getColumnClass(item)">
             <template v-if="item.updatedAt">
-                {{ dateFilter(item.updatedAt) }}
+                <sw-time-ago :date="item.updatedAt" />
             </template>
             <template v-else>
-                {{ dateFilter(item.createdAt) }}
+                <sw-time-ago :date="item.createdAt" />
             </template>
         </span>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.spec.js
@@ -174,4 +174,14 @@ describe('components/sw-advanced-selection-rule', () => {
 
         expect(counts.productPrices).toBe(100);
     });
+
+    it('should return filters from filter registry', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.spec.js
@@ -58,6 +58,7 @@ async function createWrapper() {
                     'sw-empty-state': true,
                     'sw-extension-component-section': true,
                     'sw-ai-copilot-badge': true,
+                    'sw-time-ago': true,
                 },
                 provide: {
                     ruleConditionDataProviderService: {
@@ -172,12 +173,5 @@ describe('components/sw-advanced-selection-rule', () => {
         const counts = wrapper.vm.getCounts('1', aggregations);
 
         expect(counts.productPrices).toBe(100);
-    });
-
-    it('should return filters from filter registry', async () => {
-        const wrapper = await createWrapper();
-        await flushPromises();
-
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.spec.js
@@ -97,6 +97,7 @@ async function createWrapper(props) {
                     'mt-checkbox': true,
                     'sw-product-variant-info': true,
                     'sw-app-action-button': true,
+                    'sw-time-ago': true,
                 },
                 provide: {
                     repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.spec.js
@@ -119,6 +119,7 @@ async function createWrapper(buttonConfig) {
                 'mt-floating-ui': true,
                 'mt-url-field': MtUrlField,
                 'sw-app-action-button': true,
+                'sw-time-ago': true,
             },
         },
         props: {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/index.js
@@ -87,6 +87,9 @@ export default {
             return Shopware.Filter.getByName('asset');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.html.twig
@@ -75,7 +75,10 @@
     {% block sw_media_folder_meta_data %}
     <template #metadata="{ item }">
         <div class="sw-media-folder-item__metadata">
-            <sw-time-ago :date="item.createdAt" />
+            <sw-time-ago
+                :date="item.createdAt"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
+            />
         </div>
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.html.twig
@@ -75,7 +75,7 @@
     {% block sw_media_folder_meta_data %}
     <template #metadata="{ item }">
         <div class="sw-media-folder-item__metadata">
-            {{ dateFilter(item.createdAt) }}
+            <sw-time-ago :date="item.createdAt" />
         </div>
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
@@ -252,6 +252,10 @@ describe('components/media/sw-media-folder-item', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm.assetFilter).toEqual(expect.any(Function));
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
     });
 
     it('onBlur doesnt update the entity if the value did not change', async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
@@ -150,6 +150,7 @@ async function createWrapper(defaultFolderId, privileges = []) {
                 'sw-media-modal-folder-dissolve': true,
                 'sw-media-modal-move': true,
                 'sw-media-modal-delete': true,
+                'sw-time-ago': true,
             },
         },
     });
@@ -251,7 +252,6 @@ describe('components/media/sw-media-folder-item', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm.assetFilter).toEqual(expect.any(Function));
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
     });
 
     it('onBlur doesnt update the entity if the value did not change', async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/index.js
@@ -68,6 +68,9 @@ export default {
             return Shopware.Filter.getByName('mediaName');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.html.twig
@@ -48,7 +48,7 @@
     {% block sw_media_media_item_metadata %}
     <template #metadata="{ item }">
         <div class="sw-media-media-item__metadata">
-            {{ dateFilter(item.uploadedAt) }}, {{ fileSizeFilter(item.fileSize, locale) }}
+            <span v-if="item.uploadedAt"><sw-time-ago :date="item.uploadedAt" />, </span>{{ fileSizeFilter(item.fileSize, locale) }}
         </div>
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.html.twig
@@ -48,7 +48,10 @@
     {% block sw_media_media_item_metadata %}
     <template #metadata="{ item }">
         <div class="sw-media-media-item__metadata">
-            <span v-if="item.uploadedAt"><sw-time-ago :date="item.uploadedAt" />, </span>{{ fileSizeFilter(item.fileSize, locale) }}
+            <span v-if="item.uploadedAt"><sw-time-ago
+                :date="item.uploadedAt"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
+            />, </span>{{ fileSizeFilter(item.fileSize, locale) }}
         </div>
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.spec.js
@@ -49,6 +49,7 @@ async function createWrapper(mediaServiceFunctions = {}, props = {}) {
                 'sw-media-modal-delete': true,
                 'sw-media-modal-move': true,
                 'sw-app-action-button': true,
+                'sw-time-ago': true,
             },
         },
         props: {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/sw-notification-center-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/sw-notification-center-item.html.twig
@@ -12,7 +12,10 @@
         {% endblock %}
         {% block sw_notification_center_item_header_timestamp %}
         <p class="sw-notification-center-item__timestamp">
-            <sw-time-ago :date="notification.timestamp" />
+            <sw-time-ago
+                :date="notification.timestamp"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
+            />
         </p>
         {% endblock %}
         {% block sw_notification_center_item_header_delete %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/index.js
@@ -116,6 +116,9 @@ export default {
             return { [this.selectedPageObject.id]: this.selectedPageObject };
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.html.twig
@@ -164,13 +164,20 @@
 
             {% block sw_cms_list_listing_list_data_grid_column_created %}
             <template #column-createdAt="{ item }">
-                {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+                <sw-time-ago
+                    :date="item.createdAt"
+                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                />
             </template>
             {% endblock %}
 
             {% block sw_cms_list_listing_list_data_grid_column_updated %}
             <template #column-updatedAt="{ item }">
-                {{ dateFilter(item.updatedAt, { hour: '2-digit', minute: '2-digit' }) }}
+                <sw-time-ago
+                    v-if="item.updatedAt"
+                    :date="item.updatedAt"
+                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                />
             </template>
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.html.twig
@@ -166,7 +166,7 @@
             <template #column-createdAt="{ item }">
                 <sw-time-ago
                     :date="item.createdAt"
-                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
                 />
             </template>
             {% endblock %}
@@ -176,7 +176,7 @@
                 <sw-time-ago
                     v-if="item.updatedAt"
                     :date="item.updatedAt"
-                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
                 />
             </template>
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.spec.js
@@ -116,6 +116,7 @@ async function createWrapper() {
                     'sw-help-text': true,
                     'sw-ai-copilot-badge': true,
                     'sw-provide': { template: `<slot/>`, inheritAttrs: false },
+                    'sw-time-ago': true,
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
@@ -146,6 +146,9 @@ export default {
             ];
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
@@ -290,10 +290,7 @@
 
                                     {% block sw_cms_list_listing_list_data_grid_column_created %}
                                     <template #column-createdAt="{ item }">
-                                        <sw-time-ago
-                                            :date="item.createdAt"
-                                            :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
-                                        />
+                                        <sw-time-ago :date="item.createdAt" />
                                     </template>
                                     {% endblock %}
 
@@ -302,7 +299,6 @@
                                         <sw-time-ago
                                             v-if="item.updatedAt"
                                             :date="item.updatedAt"
-                                            :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
                                         />
                                     </template>
                                     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
@@ -290,13 +290,20 @@
 
                                     {% block sw_cms_list_listing_list_data_grid_column_created %}
                                     <template #column-createdAt="{ item }">
-                                        {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+                                        <sw-time-ago
+                                            :date="item.createdAt"
+                                            :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                                        />
                                     </template>
                                     {% endblock %}
 
                                     {% block sw_cms_list_listing_list_data_grid_column_updated %}
                                     <template #column-updatedAt="{ item }">
-                                        {{ dateFilter(item.updatedAt, { hour: '2-digit', minute: '2-digit' }) }}
+                                        <sw-time-ago
+                                            v-if="item.updatedAt"
+                                            :date="item.updatedAt"
+                                            :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                                        />
                                     </template>
                                     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
@@ -105,6 +105,7 @@ async function createWrapper(
                     'sw-data-grid-column-boolean': true,
                     'sw-data-grid-inline-edit': true,
                     'sw-provide': true,
+                    'sw-time-ago': true,
                 },
                 mocks: {
                     $route: { query: '' },

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -239,7 +239,10 @@
             </dt>
             <dd class="sw-customer-base__label-last-login">
                 <template v-if="customer.lastLogin">
-                    <sw-time-ago :date="customer.lastLogin" />
+                    <sw-time-ago
+                        :date="customer.lastLogin"
+                        :date-time-format="{ month: '2-digit', day: '2-digit' }"
+                    />
                 </template>
                 <template v-else>
                     {{ $tc('sw-customer.baseInfo.emptyTextLogin') }}
@@ -282,7 +285,7 @@
                 class="sw-customer-base__label-birthday"
             >
                 <template v-if="customer.birthday">
-                    {{ dateFilter(customer.birthday, { minute: undefined, hour: undefined }) }}
+                    {{ dateFilter(customer.birthday, { month: '2-digit', day: '2-digit', hour: undefined, minute: undefined }) }}
                 </template>
                 <template v-else>
                     {{ $tc('sw-customer.baseInfo.emptyTextBirthday') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -239,7 +239,7 @@
             </dt>
             <dd class="sw-customer-base__label-last-login">
                 <template v-if="customer.lastLogin">
-                    {{ dateFilter(customer.lastLogin) }}
+                    <sw-time-ago :date="customer.lastLogin" />
                 </template>
                 <template v-else>
                     {{ $tc('sw-customer.baseInfo.emptyTextLogin') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.spec.js
@@ -46,7 +46,7 @@ async function createWrapper() {
                 'sw-help-text': true,
                 'sw-datepicker': true,
                 'sw-text-field': true,
-                'sw-time-ago': true,
+                'sw-time-ago': await wrapTestComponent('sw-time-ago', { sync: true }),
             },
             provide: {
                 repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.spec.js
@@ -46,6 +46,7 @@ async function createWrapper() {
                 'sw-help-text': true,
                 'sw-datepicker': true,
                 'sw-text-field': true,
+                'sw-time-ago': true,
             },
             provide: {
                 repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.spec.js
@@ -92,7 +92,7 @@ describe('module/sw-customer/page/sw-customer-base-info', () => {
     });
 
     it('should display the birthday', async () => {
-        expect(wrapper.find('.sw-customer-base__label-birthday').text()).toBe('22 December 1992');
+        expect(wrapper.find('.sw-customer-base__label-birthday').text()).toBe('22/12/1992');
     });
 
     it('should display the empty birthday snippet placeholder', async () => {
@@ -108,7 +108,7 @@ describe('module/sw-customer/page/sw-customer-base-info', () => {
     });
 
     it('should display the last login date', async () => {
-        expect(wrapper.find('.sw-customer-base__label-last-login').text()).toBe('14 October 2021 at 11:23');
+        expect(wrapper.find('.sw-customer-base__label-last-login').text()).toBe('14/10/2021, 11:23');
     });
 
     it('should display the last login snippet placeholder', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
@@ -67,7 +67,10 @@
 
             {% block sw_customer_detail_order_card_grid_columns_order_date_time %}
             <template #column-orderDateTime="{ item }">
-                <sw-time-ago :date="item.orderDateTime" />
+                <sw-time-ago
+                    :date="item.orderDateTime"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
+                />
             </template>
             {% endblock %}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/index.ts
@@ -277,6 +277,9 @@ export default Shopware.Component.wrapComponentConfig({
             return Shopware.Filter.getByName('currency');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.html.twig
@@ -52,7 +52,7 @@
                         <template #column-orderDateTime="{ item }">
                             <sw-time-ago
                                 :date="item.orderDateTime"
-                                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                                :date-time-format="{ month: '2-digit', day: '2-digit' }"
                             />
                         </template>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.html.twig
@@ -49,16 +49,11 @@
                         :allow-column-edit="false"
                         :full-page="false"
                     >
-                        <template
-                            #column-orderDateTime="{ item }"
-                        >
-                            {{ dateFilter(item.orderDateTime, {
-                            hour: '2-digit',
-                            minute: '2-digit',
-                            year: undefined,
-                            month: undefined,
-                            day: undefined
-                            }) }}
+                        <template #column-orderDateTime="{ item }">
+                            <sw-time-ago
+                                :date="item.orderDateTime"
+                                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                            />
                         </template>
 
                         <template #column-orderCustomer.firstName="{ item }">

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.spec.js
@@ -38,6 +38,7 @@ async function createWrapper(privileges = [], repository = {}) {
                 'sw-ai-copilot-badge': true,
                 'sw-context-button': true,
                 'sw-inheritance-switch': true,
+                'sw-time-ago': true,
             },
             mocks: {
                 $tc: (...args) => JSON.stringify([...args]),

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
@@ -45,6 +45,9 @@ export default {
     },
 
     computed: {
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -64,12 +64,20 @@
 
         <span v-if="isInstalled">
             {{ $tc('sw-extension-store.component.sw-extension-card-base.installedLabel') }}
-            <sw-time-ago v-if="extension.installedAt.date" :date="extension.installedAt.date" />
+            <sw-time-ago
+                v-if="extension.installedAt.date"
+                :date="extension.installedAt.date"
+                :date-time-format="{ month: 'numeric', year: 'numeric', hour: undefined, minute: undefined }"
+            />
         </span>
 
         <span v-else-if="extension.storeLicense">
             {{ $tc('sw-extension-store.component.sw-extension-card-base.purchasedLabel') }}
-            <sw-time-ago v-if="extension.storeLicense.creationDate" :date="extension.storeLicense.creationDate" />
+            <sw-time-ago
+                v-if="extension.storeLicense.creationDate"
+                :date="extension.storeLicense.creationDate"
+                :date-time-format="{ month: 'numeric', year: 'numeric', hour: undefined, minute: undefined }"
+            />
         </span>
     </div>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -64,12 +64,12 @@
 
         <span v-if="isInstalled">
             {{ $tc('sw-extension-store.component.sw-extension-card-base.installedLabel') }}
-            {{ dateFilter(extension.installedAt.date, { month: 'numeric', year: 'numeric', hour: undefined, minute: undefined }) }}
+            <sw-time-ago v-if="extension.installedAt.date" :date="extension.installedAt.date" />
         </span>
 
         <span v-else-if="extension.storeLicense">
             {{ $tc('sw-extension-store.component.sw-extension-card-base.purchasedLabel') }}
-            {{ dateFilter(extension.storeLicense.creationDate, { month: 'numeric', year: 'numeric', hour: undefined, minute: undefined }) }}
+            <sw-time-ago v-if="extension.storeLicense.creationDate" :date="extension.storeLicense.creationDate" />
         </span>
     </div>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -67,7 +67,7 @@
             <sw-time-ago
                 v-if="extension.installedAt.date"
                 :date="extension.installedAt.date"
-                :date-time-format="{ month: 'numeric', year: 'numeric', hour: undefined, minute: undefined }"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
             />
         </span>
 
@@ -76,7 +76,7 @@
             <sw-time-ago
                 v-if="extension.storeLicense.creationDate"
                 :date="extension.storeLicense.creationDate"
-                :date-time-format="{ month: 'numeric', year: 'numeric', hour: undefined, minute: undefined }"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
             />
         </span>
     </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.spec.js
@@ -32,6 +32,7 @@ async function createWrapper(propsData = {}, provide = {}) {
                     template: '<div><slot></slot></div>',
                 },
                 'router-link': true,
+                'sw-time-ago': await wrapTestComponent('sw-time-ago'),
             },
         },
         props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
@@ -213,7 +213,7 @@ describe('src/module/sw-extension/component/sw-extension-card-bought', () => {
         expect(wrapper.find('.sw-extension-card-base__info-name').text()).toBe('Sample Extension Label');
         expect(wrapper.find('.sw-extension-icon img').attributes('src')).toBe('https://example.com');
         expect(wrapper.find('.sw-extension-card-base__meta-info').text().replace(/\s/g, '')).toBe(
-            'sw-extension-store.component.sw-extension-card-base.installedLabel01/02/2021',
+            'sw-extension-store.component.sw-extension-card-base.installedLabel01/02/2021,02:30',
         );
     });
 
@@ -255,7 +255,7 @@ describe('src/module/sw-extension/component/sw-extension-card-bought', () => {
             'administration/administration/static/img/theme/default_theme_preview.jpg',
         );
         expect(wrapper.find('.sw-extension-card-base__meta-info').text().replace(/\s/g, '')).toBe(
-            'sw-extension-store.component.sw-extension-card-base.installedLabel01/02/2021',
+            'sw-extension-store.component.sw-extension-card-base.installedLabel01/02/2021,02:30',
         );
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
@@ -104,6 +104,7 @@ async function createWrapper(extension) {
                 'sw-loader-deprecated': true,
                 'i18n-t': true,
                 'sw-label': true,
+                'sw-time-ago': await wrapTestComponent('sw-time-ago'),
             },
             provide: {
                 extensionStoreActionService: Shopware.Service('extensionStoreActionService'),

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
@@ -104,7 +104,7 @@ async function createWrapper(extension) {
                 'sw-loader-deprecated': true,
                 'i18n-t': true,
                 'sw-label': true,
-                'sw-time-ago': await wrapTestComponent('sw-time-ago'),
+                'sw-time-ago': await wrapTestComponent('sw-time-ago', { sync: true }),
             },
             provide: {
                 extensionStoreActionService: Shopware.Service('extensionStoreActionService'),

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-self-maintained-extension-card/sw-self-maintained-extension-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-self-maintained-extension-card/sw-self-maintained-extension-card.spec.js
@@ -21,6 +21,7 @@ async function createWrapper() {
                     'sw-extension-permissions-modal': true,
                     'sw-extension-privacy-policy-extensions-modal': true,
                     'sw-tabs': true,
+                    'sw-time-ago': true,
                 },
                 provide: {
                     repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/index.js
@@ -42,6 +42,9 @@ export default {
             };
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/sw-import-export-activity-log-info-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/sw-import-export-activity-log-info-modal.html.twig
@@ -36,7 +36,10 @@
         {% block sw_import_export_activity_log_info_modal_description_date %}
         <div class="sw-import-export-activity-log-info-modal__list-item sw-import-export-activity-log-info-modal__item-date">
             <dt>{{ $tc('sw-import-export.activity.logInfo.labelDate') }}</dt>
-            <dd>{{ dateFilter(logEntity.createdAt, { hour: '2-digit', minute: '2-digit' }) }}</dd>
+            <dd><sw-time-ago
+                :date="logEntity.createdAt"
+                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+            /></dd>
         </div>
         {% endblock %}
         {% block sw_import_export_activity_log_info_modal_description_user %}

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/sw-import-export-activity-log-info-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/sw-import-export-activity-log-info-modal.html.twig
@@ -38,7 +38,7 @@
             <dt>{{ $tc('sw-import-export.activity.logInfo.labelDate') }}</dt>
             <dd><sw-time-ago
                 :date="logEntity.createdAt"
-                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
             /></dd>
         </div>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/sw-import-export-activity-log-info-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/sw-import-export-activity-log-info-modal.spec.js
@@ -75,7 +75,7 @@ describe('module/sw-import-export/components/sw-import-export-activity-log-info-
         [
             'date',
             '.sw-import-export-activity-log-info-modal__item-date dd',
-            '5 November 2021 at 09:08',
+            '05/11/2021, 09:08',
         ],
         [
             'user',

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/sw-import-export-activity-log-info-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-log-info-modal/sw-import-export-activity-log-info-modal.spec.js
@@ -38,6 +38,7 @@ async function createWrapper(logEntity = getLogEntityMock()) {
                     </div>`,
                     },
                     'sw-color-badge': true,
+                    'sw-time-ago': await wrapTestComponent('sw-time-ago', { sync: true }),
                 },
             },
             props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/index.js
@@ -51,6 +51,9 @@ export default {
             return this.$tc(`sw-import-export.activity.detail.${this.logEntity.activity}Label`);
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.html.twig
@@ -97,7 +97,10 @@
                 {% block sw_import_export_activity_result_modal_info_log_list_date %}
                 <div class="sw-import-export-activity-result-modal__list-item sw-import-export-activity-result-modal__log-info-date">
                     <dt>{{ $tc('sw-import-export.activity.result.logInfo.labelDate') }}</dt>
-                    <dd>{{ dateFilter(logEntity.createdAt, { hour: '2-digit', minute: '2-digit' }) }}</dd>
+                    <dd><sw-time-ago
+                        :date="logEntity.createdAt"
+                        :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                    /></dd>
                 </div>
                 {% endblock %}
                 {% block sw_import_export_activity_result_modal_info_log_user %}

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.html.twig
@@ -99,7 +99,7 @@
                     <dt>{{ $tc('sw-import-export.activity.result.logInfo.labelDate') }}</dt>
                     <dd><sw-time-ago
                         :date="logEntity.createdAt"
-                        :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                        :date-time-format="{ month: '2-digit', day: '2-digit' }"
                     /></dd>
                 </div>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.spec.js
@@ -57,6 +57,7 @@ describe('module/sw-import-export/components/sw-import-export-activity-result-mo
                         'sw-color-badge': true,
                         'sw-grid': true,
                         'sw-grid-column': true,
+                        'sw-time-ago': true,
                     },
                 },
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.spec.js
@@ -82,7 +82,7 @@ describe('module/sw-import-export/components/sw-import-export-activity-result-mo
         ],
         [
             'Date / time',
-            '8 November 2021 at 14:50',
+            '08/11/2021, 14:50',
             'date',
         ],
         [

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity-result-modal/sw-import-export-activity-result-modal.spec.js
@@ -57,7 +57,7 @@ describe('module/sw-import-export/components/sw-import-export-activity-result-mo
                         'sw-color-badge': true,
                         'sw-grid': true,
                         'sw-grid-column': true,
-                        'sw-time-ago': true,
+                        'sw-time-ago': await wrapTestComponent('sw-time-ago', { sync: true }),
                     },
                 },
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/index.js
@@ -199,6 +199,9 @@ export default {
                 : this.$t('sw-import-export.activity.emptyState.titleImport');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.html.twig
@@ -55,7 +55,7 @@
             >
                 <sw-time-ago
                     :date="item.createdAt"
-                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
                 />
             </a>
         </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.html.twig
@@ -48,11 +48,15 @@
             >
                 {{ $t('sw-import-export.activity.dryrun') }}
             </sw-label>
+            <!-- eslint-disable-next-line vuejs-accessibility/anchor-has-content -->
             <a
                 href="#"
                 @click.prevent="onShowLog(item)"
             >
-                {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+                <sw-time-ago
+                    :date="item.createdAt"
+                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                />
             </a>
         </template>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
@@ -923,7 +923,7 @@ describe('module/sw-import-export/components/sw-import-export-activity', () => {
             type: 'import',
             username: 'username',
             records: 1,
-            createdAt: new Date('2020-04-03T12:23:02+00:00'),
+            createdAt: '2020-04-03T12:23:02+00:00',
             state: 'succeeded',
         };
 

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
@@ -60,6 +60,7 @@ const logDataExport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     empty: [],
@@ -115,6 +116,7 @@ const logDataExport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     failedWithLog: [
@@ -173,6 +175,7 @@ const logDataExport = {
                 activity: 'invalid_records_export',
                 state: 'succeeded',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     pending: [
@@ -227,6 +230,7 @@ const logDataExport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     progress: [
@@ -281,6 +285,7 @@ const logDataExport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     succeeded: [
@@ -335,6 +340,7 @@ const logDataExport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
 };
@@ -392,6 +398,7 @@ const logDataImport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     empty: [],
@@ -447,6 +454,7 @@ const logDataImport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     failedWithLog: [
@@ -505,6 +513,7 @@ const logDataImport = {
                 activity: 'invalid_records_export',
                 state: 'succeeded',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     pending: [
@@ -559,6 +568,7 @@ const logDataImport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     progress: [
@@ -613,6 +623,7 @@ const logDataImport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     succeeded: [
@@ -667,6 +678,7 @@ const logDataImport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
     succeededWithoutRecords: [
@@ -721,6 +733,7 @@ const logDataImport = {
                 apiAlias: null,
                 id: '645cfb7d036142c7b817ffefb89ac097',
             },
+            createdAt: '2021-09-20T10:22:47.000+00:00',
         },
     ],
 };
@@ -811,7 +824,7 @@ const createWrapper = async (options = {}) => {
                 'router-link': true,
                 'sw-ai-copilot-badge': true,
                 'sw-provide': { template: '<slot/>', inheritAttrs: false },
-                'sw-time-ago': await wrapTestComponent('sw-time-ago'),
+                'sw-time-ago': await wrapTestComponent('sw-time-ago', { sync: true }),
             },
             mocks: {
                 $tc: (key, _, pluralization) => {
@@ -859,7 +872,6 @@ const createWrapper = async (options = {}) => {
                         'sw-import-export.activity.status.aborted',
                     ].includes(key);
                 },
-                date: (date) => date,
             },
             provide: {
                 importExport: getImportExportServiceMock(),
@@ -911,7 +923,7 @@ describe('module/sw-import-export/components/sw-import-export-activity', () => {
             type: 'import',
             username: 'username',
             records: 1,
-            createdAt: '2020-04-03T12:23:02+00:00',
+            createdAt: new Date('2020-04-03T12:23:02+00:00'),
             state: 'succeeded',
         };
 

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
@@ -811,6 +811,7 @@ const createWrapper = async (options = {}) => {
                 'router-link': true,
                 'sw-ai-copilot-badge': true,
                 'sw-provide': { template: '<slot/>', inheritAttrs: false },
+                'sw-time-ago': await wrapTestComponent('sw-time-ago'),
             },
             mocks: {
                 $tc: (key, _, pluralization) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js
@@ -60,6 +60,9 @@ export default {
             return this.repositoryFactory.create('tag');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig
@@ -155,7 +155,10 @@
             <template
                 #column-updatedAt="{ item }"
             >
-                {{ dateFilter(item.updatedAt) }}
+                <sw-time-ago
+                    v-if="item.updatedAt"
+                    :date="item.updatedAt"
+                />
             </template>
             {% endblock %}
 
@@ -163,7 +166,7 @@
             <template
                 #column-createdAt="{ item }"
             >
-                {{ dateFilter(item.createdAt) }}
+                <sw-time-ago :date="item.createdAt" />
             </template>
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.spec.js
@@ -152,6 +152,7 @@ async function createWrapper() {
                 'sw-sidebar-collapse': true,
                 'sw-entity-multi-select': true,
                 'sw-sidebar': true,
+                'sw-time-ago': true,
             },
             provide: {
                 repositoryFactory: {
@@ -309,11 +310,5 @@ describe('src/module/sw-manufacturer/page/sw-manufacturer-list', () => {
         expect(wrapper.vm.entitySearchable).toBe(false);
 
         wrapper.vm.searchRankingService.getSearchFieldsByEntity.mockRestore();
-    });
-
-    it('should return filters from filter registry', async () => {
-        const wrapper = await createWrapper();
-
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.spec.js
@@ -311,4 +311,13 @@ describe('src/module/sw-manufacturer/page/sw-manufacturer-list', () => {
 
         wrapper.vm.searchRankingService.getSearchFieldsByEntity.mockRestore();
     });
+
+    it('should return filters from filter registry', async () => {
+        const wrapper = await createWrapper();
+
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-delivery-metadata/sw-order-delivery-metadata.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-delivery-metadata/sw-order-delivery-metadata.html.twig
@@ -19,7 +19,7 @@
 
             {% block sw_order_delivery_metadata_delivery_date %}
             <dt>{{ $tc('sw-order.detailDeliveries.labelDeliveryDate') }}</dt>
-            <dd>{{ dateFilter(delivery.shippingDateEarliest) }}</dd>
+            <dd>{{ dateFilter(delivery.shippingDateEarliest, { month: '2-digit', day: '2-digit' }) }}</dd>
             {% endblock %}
 
             {% block sw_order_delivery_metadata_shipping_costs %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.html.twig
@@ -43,7 +43,10 @@
                     scope="local"
                 >
                     <template #time>
-                        <sw-time-ago :date="lastStateChange.createdAt" />
+                        <sw-time-ago
+                            :date="lastStateChange.createdAt"
+                            :date-time-format="{ month: '2-digit', day: '2-digit' }"
+                        />
                     </template>
                     <template #author>
                         {{ lastChangeAuthorLabel }}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
@@ -221,6 +221,9 @@ export default {
             return Shopware.Filter.getByName('asset');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
@@ -71,7 +71,10 @@
             {% block sw_order_document_card_grid_column_date %}
             <template #column-createdAt="{ item }">
                 {% block sw_order_document_card_grid_column_date_label %}
-                {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+                <sw-time-ago
+                    :date="item.createdAt"
+                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                />
                 {% endblock %}
             </template>
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
@@ -73,7 +73,7 @@
                 {% block sw_order_document_card_grid_column_date_label %}
                 <sw-time-ago
                     :date="item.createdAt"
-                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
                 />
                 {% endblock %}
             </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
@@ -157,6 +157,7 @@ async function createWrapper() {
                 'sw-media-upload-v2': true,
                 'sw-media-modal-v2': true,
                 'sw-provide': { template: '<slot/>', inheritAttrs: false },
+                'sw-time-ago': true,
             },
             provide: {
                 documentService: {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
@@ -171,6 +171,9 @@ export default {
             return Shopware.Filter.getByName('currency');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
@@ -32,7 +32,7 @@
                 {{ $tc('sw-order.generalTab.info.summary.on') }}
                 <sw-time-ago
                     :date="order.orderDateTime"
-                    :date-time-format="{ hour: '2-digit', minute: '2-digit', day: '2-digit', month: '2-digit' }"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
                 />
                 <template v-if="transaction">
                     {{ $tc('sw-order.generalTab.info.summary.with') }}
@@ -54,7 +54,7 @@
                     {{ $tc('sw-order.generalTab.info.summary.lastChanged') }}:
                     <sw-time-ago
                         :date="lastChangedDateTime"
-                        :date-time-format="{ hour: '2-digit', minute: '2-digit', day: '2-digit', month: '2-digit' }"
+                        :date-time-format="{ month: '2-digit', day: '2-digit' }"
                     />
                 </div>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
@@ -30,13 +30,10 @@
             {% block sw_order_detail_base_general_info_summary_sub_description %}
             <div class="sw-order-general-info__summary-sub-description">
                 {{ $tc('sw-order.generalTab.info.summary.on') }}
-                {{ dateFilter(order.orderDateTime, {
-                hour: '2-digit',
-                minute: '2-digit',
-                day: '2-digit',
-                month: '2-digit',
-                year: 'numeric'
-                }) }}
+                <sw-time-ago
+                    :date="order.orderDateTime"
+                    :date-time-format="{ hour: '2-digit', minute: '2-digit', day: '2-digit', month: '2-digit' }"
+                />
                 <template v-if="transaction">
                     {{ $tc('sw-order.generalTab.info.summary.with') }}
                     {{ transaction.paymentMethod.translated.distinguishableName }}
@@ -55,13 +52,10 @@
                     class="sw-order-general-info__summary-sub-last-changed-time"
                 >
                     {{ $tc('sw-order.generalTab.info.summary.lastChanged') }}:
-                    {{ dateFilter(lastChangedDateTime, {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    day: '2-digit',
-                    month: '2-digit',
-                    year: 'numeric'
-                    }) }}
+                    <sw-time-ago
+                        :date="lastChangedDateTime"
+                        :date-time-format="{ hour: '2-digit', minute: '2-digit', day: '2-digit', month: '2-digit' }"
+                    />
                 </div>
                 {% endblock %}
                 {% block sw_order_detail_base_general_info_summary_sub_last_changed_user %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.spec.js
@@ -145,6 +145,7 @@ async function createWrapper() {
                     template: '<div><slot></slot></div>',
                 },
                 'sw-order-state-change-modal': true,
+                'sw-time-ago': true,
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
@@ -90,6 +90,9 @@ export default {
             return this.mailTemplateId === null || this.subject.length <= 0 || this.recipient.length <= 0;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.html.twig
@@ -29,7 +29,7 @@
             <dt>{{ $tc('sw-order.documentSendModal.labelDate') }}</dt>
             <dd><sw-time-ago
                 :date="document.createdAt"
-                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
             /></dd>
         </sw-description-list>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.html.twig
@@ -27,7 +27,10 @@
         {% block sw_order_send_document_modal_info_date %}
         <sw-description-list>
             <dt>{{ $tc('sw-order.documentSendModal.labelDate') }}</dt>
-            <dd>{{ dateFilter(document.createdAt, { hour: '2-digit', minute: '2-digit' }) }}</dd>
+            <dd><sw-time-ago
+                :date="document.createdAt"
+                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+            /></dd>
         </sw-description-list>
         {% endblock %}
     </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.spec.js
@@ -209,6 +209,7 @@ async function createWrapper(props = defaultProps, sendingSucceds = true, mailTe
                 'sw-ai-copilot-badge': true,
                 'sw-help-text': true,
                 'sw-field-error': true,
+                'sw-time-ago': await wrapTestComponent('sw-time-ago'),
             },
             provide: {
                 repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.spec.js
@@ -238,7 +238,7 @@ describe('src/module/sw-order/component/sw-order-send-document-modal', () => {
         const descriptionListElements = wrapper.findAll('.sw-description-list > dd');
         expect(descriptionListElements[0].text()).toBe(String(mockDocuments[0].documentNumber));
         expect(descriptionListElements[1].text()).toBe(String(mockDocuments[0].documentType.name));
-        expect(descriptionListElements[2].text()).toBe('23 January 2024 at 14:00');
+        expect(descriptionListElements[2].text()).toBe('23/01/2024, 14:00');
 
         expect(wrapper.find('.sw-entity-single-select__selection-text').text()).toBe(
             mockMailTemplates[0].mailTemplateType.name,

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/index.js
@@ -39,6 +39,9 @@ export default {
     },
 
     computed: {
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/sw-order-state-history-card-entry.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/sw-order-state-history-card-entry.html.twig
@@ -42,7 +42,7 @@
         >
             <sw-time-ago
                 :date="entry.createdAt"
-                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
             />
         </span>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/sw-order-state-history-card-entry.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/sw-order-state-history-card-entry.html.twig
@@ -40,7 +40,10 @@
             }"
             class="sw-order-state-card__date"
         >
-            {{ dateFilter(entry.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+            <sw-time-ago
+                :date="entry.createdAt"
+                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+            />
         </span>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.html.twig
@@ -17,7 +17,10 @@
 
         {% block sw_order_state_history_modal_content_columns_created_at %}
         <template #column-createdAt="{ item }">
-            <sw-time-ago :date="item.createdAt" />
+            <sw-time-ago
+                :date="item.createdAt"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
+            />
         </template>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -287,6 +287,9 @@ export default {
             return Shopware.Filter.getByName('currency');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -427,7 +427,10 @@
 
                         {% block sw_order_list_bulk_edit_grid_columns_order_date %}
                         <template #column-orderDateTime="{ item }">
-                            {{ dateFilter(item.orderDateTime, { hour: '2-digit', minute: '2-digit' }) }}
+                            <sw-time-ago
+                                :date="item.orderDateTime"
+                                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                            />
                         </template>
                         {% endblock %}
                     </sw-bulk-edit-modal>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -427,10 +427,7 @@
 
                         {% block sw_order_list_bulk_edit_grid_columns_order_date %}
                         <template #column-orderDateTime="{ item }">
-                            <sw-time-ago
-                                :date="item.orderDateTime"
-                                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
-                            />
+                            <sw-time-ago :date="item.orderDateTime" />
                         </template>
                         {% endblock %}
                     </sw-bulk-edit-modal>

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-list/index.js
@@ -46,6 +46,9 @@ export default {
             return this.repositoryFactory.create('product_stream');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-list/sw-product-stream-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-list/sw-product-stream-list.html.twig
@@ -107,11 +107,10 @@
                 {% block sw_product_stream_list_grid_colum_updated_at %}
                 <template #column-updatedAt="{item}">
                     <template v-if="item.updatedAt">
-                        {{ dateFilter(item.updatedAt) }}
+                        <sw-time-ago :date="item.updatedAt" />
                     </template>
-
                     <template v-else>
-                        {{ dateFilter(item.createdAt) }}
+                        <sw-time-ago :date="item.createdAt" />
                     </template>
                 </template>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -240,6 +240,9 @@ export default {
             return Shopware.Filter.getByName('currency');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
@@ -260,11 +260,14 @@
                 {% endblock %}
 
                 <template #column-createdAt="{ item }">
-                    {{ dateFilter(item.createdAt) }}
+                    <sw-time-ago :date="item.createdAt" />
                 </template>
 
                 <template #column-updatedAt="{ item }">
-                    {{ dateFilter(item.updatedAt) }}
+                    <sw-time-ago
+                        v-if="item.updatedAt"
+                        :date="item.updatedAt"
+                    />
                 </template>
 
                 {% block sw_product_list_grid_columns_actions %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
@@ -696,6 +696,10 @@ describe('module/sw-product/page/sw-product-list', () => {
     it('should return filters from filter registry', async () => {
         expect(wrapper.vm.assetFilter).toEqual(expect.any(Function));
         expect(wrapper.vm.currencyFilter).toEqual(expect.any(Function));
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
         expect(wrapper.vm.stockColorVariantFilter).toEqual(expect.any(Function));
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
@@ -353,6 +353,7 @@ async function createWrapper() {
                     'sw-data-grid-column-boolean': true,
                     'sw-data-grid-inline-edit': true,
                     'sw-provide': { template: '<slot/>', inheritAttrs: false },
+                    'sw-time-ago': true,
                 },
             },
         }),
@@ -695,7 +696,6 @@ describe('module/sw-product/page/sw-product-list', () => {
     it('should return filters from filter registry', async () => {
         expect(wrapper.vm.assetFilter).toEqual(expect.any(Function));
         expect(wrapper.vm.currencyFilter).toEqual(expect.any(Function));
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
         expect(wrapper.vm.stockColorVariantFilter).toEqual(expect.any(Function));
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/index.js
@@ -85,6 +85,9 @@ export default {
             return Shopware.Filter.getByName('asset');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.html.twig
@@ -45,7 +45,10 @@
 
                 {% block sw_product_detail_reviews_data_created_at %}
                 <template #column-createdAt="{ item }">
-                    {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit', second: '2-digit' }) }}
+                    <sw-time-ago
+                        :date="item.createdAt"
+                        :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                    />
                 </template>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.html.twig
@@ -47,7 +47,7 @@
                 <template #column-createdAt="{ item }">
                     <sw-time-ago
                         :date="item.createdAt"
-                        :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                        :date-time-format="{ month: '2-digit', day: '2-digit' }"
                     />
                 </template>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.spec.js
@@ -214,5 +214,9 @@ describe('src/module/sw-product/view/sw-product-detail-reviews', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm.assetFilter).toEqual(expect.any(Function));
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.spec.js
@@ -64,6 +64,7 @@ async function createWrapper(privileges = []) {
                 'sw-rating-stars': true,
                 'sw-data-grid-column-boolean': true,
                 'sw-pagination': true,
+                'sw-time-ago': true,
             },
         },
     });
@@ -213,6 +214,5 @@ describe('src/module/sw-product/view/sw-product-detail-reviews', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm.assetFilter).toEqual(expect.any(Function));
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/index.js
@@ -94,6 +94,9 @@ export default {
             return Shopware.Filter.getByName('asset');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.html.twig
@@ -111,7 +111,10 @@
 
                 {% block sw_promotion_v2_individual_codes_behavior_grid_created_at %}
                 <template #column-createdAt="{ item }">
-                    {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+                    <sw-time-ago
+                        :date="item.createdAt"
+                        :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                    />
                 </template>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.html.twig
@@ -113,7 +113,7 @@
                 <template #column-createdAt="{ item }">
                     <sw-time-ago
                         :date="item.createdAt"
-                        :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                        :date-time-format="{ month: '2-digit', day: '2-digit' }"
                     />
                 </template>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.spec.js
@@ -38,6 +38,7 @@ async function createWrapper(additionalPromotionData = {}) {
                         props: ['disabled'],
                     },
                     'sw-loader': true,
+                    'sw-time-ago': true,
                 },
                 provide: {
                     repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.html.twig
@@ -103,13 +103,13 @@
 
                 {% block sw_promotion_v2_list_grid_columns_valid_from %}
                 <template #column-validFrom="{ item }">
-                    {{ dateFilter(item.validFrom, { hour: '2-digit', minute: '2-digit' }) }}
+                    {{ dateFilter(item.validFrom) }}
                 </template>
                 {% endblock %}
 
                 {% block sw_promotion_v2_list_grid_columns_valid_until %}
                 <template #column-validUntil="{ item }">
-                    {{ dateFilter(item.validUntil, { hour: '2-digit', minute: '2-digit' }) }}
+                    {{ dateFilter(item.validUntil) }}
                 </template>
                 {% endblock %}
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/index.js
@@ -101,6 +101,9 @@ export default {
             return this.review && this.customFieldSets && this.customFieldSets.length > 0;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.html.twig
@@ -128,7 +128,10 @@
 
                                                 {% block sw_customer_base_metadata_created_at_content %}
                                                 <dd>
-                                                    {{ dateFilter(review.createdAt, { hour: '2-digit', minute: '2-digit', second: '2-digit' }) }}
+                                                    <sw-time-ago
+                                                        :date="review.createdAt"
+                                                        :date-time-format="{ hour: '2-digit', minute: '2-digit', second: '2-digit' }"
+                                                    />
                                                 </dd>
                                                 {% endblock %}
                                             </sw-description-list>

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.html.twig
@@ -130,7 +130,7 @@
                                                 <dd>
                                                     <sw-time-ago
                                                         :date="review.createdAt"
-                                                        :date-time-format="{ hour: '2-digit', minute: '2-digit', second: '2-digit' }"
+                                                        :date-time-format="{ month: '2-digit', day: '2-digit' }"
                                                     />
                                                 </dd>
                                                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.spec.js
@@ -150,4 +150,13 @@ describe('module/sw-review/page/sw-review-detail', () => {
         expect(activeField.attributes().disabled).toBeFalsy();
         expect(commentField.attributes().disabled).toBeFalsy();
     });
+
+    it('should return filters from filter registry', async () => {
+        const wrapper = await createWrapper();
+
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.spec.js
@@ -81,6 +81,7 @@ async function createWrapper() {
                 'sw-rating-stars': true,
                 'sw-custom-field-set-renderer': true,
                 'sw-error-summary': true,
+                'sw-time-ago': true,
             },
         },
     });
@@ -148,11 +149,5 @@ describe('module/sw-review/page/sw-review-detail', () => {
         expect(languageField.attributes().disabled).toBeFalsy();
         expect(activeField.attributes().disabled).toBeFalsy();
         expect(commentField.attributes().disabled).toBeFalsy();
-    });
-
-    it('should return filters from filter registry', async () => {
-        const wrapper = await createWrapper();
-
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/index.js
@@ -97,6 +97,9 @@ export default {
             return criteria;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.html.twig
@@ -79,7 +79,10 @@
 
             {% block sw_review_list_content_list_created_at %}
             <template #column-createdAt="{ item }">
-                {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit', second: '2-digit' }) }}
+                <sw-time-ago
+                    :date="item.createdAt"
+                    :date-time-format="{ hour: '2-digit', minute: '2-digit', second: '2-digit' }"
+                />
             </template>
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.html.twig
@@ -79,10 +79,7 @@
 
             {% block sw_review_list_content_list_created_at %}
             <template #column-createdAt="{ item }">
-                <sw-time-ago
-                    :date="item.createdAt"
-                    :date-time-format="{ hour: '2-digit', minute: '2-digit', second: '2-digit' }"
-                />
+                <sw-time-ago :date="item.createdAt" />
             </template>
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.spec.js
@@ -63,6 +63,7 @@ async function createWrapper() {
                 'sw-rating-stars': true,
                 'sw-sidebar-item': true,
                 'sw-sidebar': true,
+                'sw-time-ago': true,
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/index.js
@@ -102,6 +102,9 @@ export default {
             return Shopware.Service('salesChannelFavorites');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/sw-sales-channel-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/sw-sales-channel-list.html.twig
@@ -117,7 +117,10 @@
 
                         {% block sw_sales_channel_list_grid_column_created_at %}
                         <template #column-createdAt="{ item }">
-                            {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+                            <sw-time-ago
+                                :date="item.createdAt"
+                                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                            />
                         </template>
                         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/sw-sales-channel-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-list/sw-sales-channel-list.html.twig
@@ -117,10 +117,7 @@
 
                         {% block sw_sales_channel_list_grid_column_created_at %}
                         <template #column-createdAt="{ item }">
-                            <sw-time-ago
-                                :date="item.createdAt"
-                                :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
-                            />
+                            <sw-time-ago :date="item.createdAt" />
                         </template>
                         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -489,6 +489,9 @@ export default {
             return criteria;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -503,7 +503,10 @@
                 v-if="productExport.generatedAt"
                 class="sw-sales-channel-detail-base_general__last-generation-text"
             >
-                {{ $tc('sw-sales-channel.detail.productComparison.lastGenerationLabel') }}{{ dateFilter(productExport.generatedAt, { hour: '2-digit', minute: '2-digit' }) }}
+                {{ $tc('sw-sales-channel.detail.productComparison.lastGenerationLabel') }}<sw-time-ago
+                    :date="productExport.generatedAt"
+                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                />
             </div>
             <div
                 v-else

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -505,7 +505,7 @@
             >
                 {{ $tc('sw-sales-channel.detail.productComparison.lastGenerationLabel') }}<sw-time-ago
                     :date="productExport.generatedAt"
-                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                    :date-time-format="{ month: '2-digit', day: '2-digit' }"
                 />
             </div>
             <div

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
@@ -1004,6 +1004,15 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-base', () => 
         );
     });
 
+    it('should return filters from filter registry', async () => {
+        const wrapper = await createWrapper();
+
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
+    });
+
     it('"changeInterval" also updates cronjob config', async () => {
         const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
@@ -47,6 +47,7 @@ async function createWrapper() {
                 'sw-custom-field-set-renderer': true,
                 'mt-banner': true,
                 'sw-sales-channel-measurement': true,
+                'sw-time-ago': true,
             },
             provide: {
                 salesChannelService: {},
@@ -1001,12 +1002,6 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-base', () => 
                 ]),
             }),
         );
-    });
-
-    it('should return filters from filter registry', async () => {
-        const wrapper = await createWrapper();
-
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
     });
 
     it('"changeInterval" also updates cronjob config', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/index.js
@@ -66,6 +66,9 @@ export default {
             return 'sw-settings-logging-entry-info';
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig
@@ -55,7 +55,10 @@
                 #column-createdAt="{ item }"
             >
                 {% block sw_settings_logging_list_column_created_at %}
-                {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+                <sw-time-ago
+                    :date="item.createdAt"
+                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
+                />
                 {% endblock %}
             </template>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig
@@ -55,10 +55,7 @@
                 #column-createdAt="{ item }"
             >
                 {% block sw_settings_logging_list_column_created_at %}
-                <sw-time-ago
-                    :date="item.createdAt"
-                    :date-time-format="{ hour: '2-digit', minute: '2-digit' }"
-                />
+                <sw-time-ago :date="item.createdAt" />
                 {% endblock %}
             </template>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.spec.js
@@ -42,6 +42,7 @@ async function createWrapper() {
                 },
                 'sw-extension-component-section': await wrapTestComponent('sw-extension-component-section', { sync: true }),
                 'sw-textarea-field': true,
+                'sw-time-ago': true,
             },
             provide: {
                 searchRankingService: {},

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/index.js
@@ -173,6 +173,9 @@ export default {
             return properties;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.html.twig
@@ -115,11 +115,14 @@
                 </template>
 
                 <template #column-updatedAt="{item}">
-                    {{ dateFilter(item.updatedAt) }}
+                    <sw-time-ago
+                        v-if="item.updatedAt"
+                        :date="item.updatedAt"
+                    />
                 </template>
 
                 <template #column-createdAt="{item}">
-                    {{ dateFilter(item.createdAt) }}
+                    <sw-time-ago :date="item.createdAt" />
                 </template>
 
                 {% block sw_settings_rule_list_grid_columns_actions %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.spec.js
@@ -211,6 +211,16 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-list', () => {
         expect(Object.keys(listFilters)).toContain('tags');
     });
 
+    it('should return filters from filter registry', async () => {
+        const { wrapper } = await createWrapper();
+        await flushPromises();
+
+        if (!Shopware.Feature.isActive('V6_8_0_0')) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
+        }
+    });
+
     it('should consider criteria filters via updateCriteria (triggered by sw-sidebar-filter-panel)', async () => {
         const { wrapper } = await createWrapper();
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.spec.js
@@ -35,6 +35,7 @@ async function createWrapper(privileges = []) {
                 'sw-sidebar-filter-panel': true,
                 'sw-sidebar': true,
                 'router-link': true,
+                'sw-time-ago': true,
             },
             provide: {
                 repositoryFactory: {
@@ -208,13 +209,6 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-list', () => {
         expect(Object.keys(listFilters)).toContain('conditions');
         expect(Object.keys(listFilters)).toContain('assignments');
         expect(Object.keys(listFilters)).toContain('tags');
-    });
-
-    it('should return filters from filter registry', async () => {
-        const { wrapper } = await createWrapper();
-        await flushPromises();
-
-        expect(wrapper.vm.dateFilter).toEqual(expect.any(Function));
     });
 
     it('should consider criteria filters via updateCriteria (triggered by sw-sidebar-filter-panel)', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.html.twig
@@ -42,7 +42,13 @@
     {% block sw_settings_search_search_index_lastest_build %}
     <span class="sw-settings-search__search-index-latest-build">
         <template v-if="latestIndex">
-            {{ $tc('sw-settings-search.generalTab.textLastedBuild') }} <sw-time-ago :date="latestIndex.firstDate" /> &dash; <sw-time-ago :date="latestIndex.lastDate" />
+            {{ $tc('sw-settings-search.generalTab.textLastedBuild') }} <sw-time-ago
+                :date="latestIndex.firstDate"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
+            /> &dash; <sw-time-ago
+                :date="latestIndex.lastDate"
+                :date-time-format="{ month: '2-digit', day: '2-digit' }"
+            />
         </template>
         <template v-else>
             {{ $tc('sw-settings-search.generalTab.textSearchNotIndexedYet') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/index.js
@@ -67,6 +67,9 @@ export default {
             return this.acl.can('snippet.editor') ? this.$t('global.default.edit') : this.$t('global.default.view');
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, because the filter is unused
+         */
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.html.twig
@@ -139,10 +139,10 @@
 
                             <template #column-updatedAt="{ item }">
                                 <template v-if="item.updatedAt">
-                                    {{ dateFilter(item.updatedAt) }}
+                                    <sw-time-ago :date="item.updatedAt" />
                                 </template>
                                 <template v-else>
-                                    {{ dateFilter(item.createdAt) }}
+                                    <sw-time-ago :date="item.createdAt" />
                                 </template>
                             </template>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.spec.js
@@ -116,6 +116,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-set-list', () => {
                         'mt-select': true,
                         'mt-text-field': true,
                         'router-link': true,
+                        'sw-time-ago': true,
                     },
                 },
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/sw-tax-rule-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/sw-tax-rule-card.html.twig
@@ -98,13 +98,7 @@
 
                 {% block sw_settings_tax_rule_grid_column_tax_rule_active_from %}
                 <template #column-activeFrom="{ item }">
-                    {{ dateFilter(item.activeFrom, {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    day: '2-digit',
-                    month: '2-digit',
-                    year: 'numeric'
-                    }) }}
+                    {{ dateFilter(item.activeFrom, { month: '2-digit', day: '2-digit' }) }}
                 </template>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.spec.js
@@ -86,6 +86,7 @@ async function createWrapper(defaultValues = {}) {
                 'sw-media-modal-move': true,
                 'mt-url-field': MtUrlField,
                 'sw-app-action-button': true,
+                'sw-time-ago': true,
             },
             provide: {
                 systemConfigApiService: {


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently there are several places with dateFilter usages for date times past now
- In most cases, date times that lie in the past are better displayed using sw-time-ago, as this displays the relative time to the event where the time was set
- This is particularly helpful for createdAt, updatedAt or order time, for example, as a relative time is much easier to read than an absolute one in this places
- However, I haven't replaced all dateFilters with sw-time-ago. For example, in the promotions module, the validFrom and validTo date times are still using dateFilters, as a sw-time-ago wouldn't make much sense here

### 2. What does this change do, exactly?
* Changed several twig templates to use `sw-time-ago` for past date times instead of plain `dateFilter` function

### 3. Describe each step to reproduce the issue or behaviour.
- Take a look at e.g. createdAt & updatedAt date times in a list view

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
