### PR TITLE
fix: delete correct expired store session

### DIFF
--- a/changelog/_unreleased/2025-07-04-delete-correct-expired-store-session.md
+++ b/changelog/_unreleased/2025-07-04-delete-correct-expired-store-session.md
@@ -1,0 +1,12 @@
+---
+title: Delete correct expired store session
+issue: #10919
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `Shopware\Core\Framework\Store\Services\StoreSessionExpiredMiddleware` to delete the user token that the request was sent with, rather than the one from the context.
+* Changed `Shopware\Core\Framework\Store\Services\MiddlewareInterface` to include the `RequestInterface` the request was sent with.
+* Changed `Shopware\Core\Framework\Store\Subscriber\LicenseHostChangedSubscriber` to offload everything regarding In-App Purchases into `InAppPurchaseConfigSubscriber`.
+* Added `Shopware\Core\Framework\Store\InAppPurchase\Subscriber\InAppPurchaseConfigSubscriber` for In-App Purchase JWT invalidations and updates.

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -214,7 +214,6 @@
         <service id="Shopware\Core\Framework\Store\Subscriber\LicenseHostChangedSubscriber">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
-            <argument type="service" id="Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>
@@ -294,6 +293,14 @@
             <argument type="service" id="Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="logger"/>
+        </service>
+
+
+        <service id="Shopware\Core\Framework\Store\InAppPurchase\Subscriber\InAppPurchaseConfigSubscriber">
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater"/>
+
+            <tag name="kernel.event_subscriber"/>
         </service>
 
         <service id="Shopware\Core\Framework\JWT\JWTDecoder"/>

--- a/src/Core/Framework/Store/Authentication/StoreRequestOptionsProvider.php
+++ b/src/Core/Framework/Store/Authentication/StoreRequestOptionsProvider.php
@@ -23,8 +23,8 @@ class StoreRequestOptionsProvider extends AbstractStoreRequestOptionsProvider
     final public const CONFIG_KEY_STORE_LICENSE_DOMAIN = 'core.store.licenseHost';
     final public const CONFIG_KEY_STORE_SHOP_SECRET = 'core.store.shopSecret';
 
-    private const SHOPWARE_PLATFORM_TOKEN_HEADER = 'X-Shopware-Platform-Token';
-    private const SHOPWARE_SHOP_SECRET_HEADER = 'X-Shopware-Shop-Secret';
+    final public const SHOPWARE_PLATFORM_TOKEN_HEADER = 'X-Shopware-Platform-Token';
+    final public const SHOPWARE_SHOP_SECRET_HEADER = 'X-Shopware-Shop-Secret';
 
     /**
      * @param EntityRepository<UserCollection> $userRepository

--- a/src/Core/Framework/Store/InAppPurchase/Subscriber/InAppPurchaseConfigSubscriber.php
+++ b/src/Core/Framework/Store/InAppPurchase/Subscriber/InAppPurchaseConfigSubscriber.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Store\InAppPurchase\Subscriber;
+
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
+use Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseProvider;
+use Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SystemConfig\Event\SystemConfigChangedEvent;
+use Shopware\Core\System\SystemConfig\Event\SystemConfigDomainLoadedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class InAppPurchaseConfigSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly InAppPurchaseUpdater $inAppPurchaseUpdater,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SystemConfigChangedEvent::class => 'updateIapKey',
+            SystemConfigDomainLoadedEvent::class => 'removeIapInformationFromDomain',
+        ];
+    }
+
+    public function updateIapKey(SystemConfigChangedEvent $event): void
+    {
+        if ($event->getKey() === StoreRequestOptionsProvider::CONFIG_KEY_STORE_SHOP_SECRET && $event->getValue() !== null) {
+            $this->inAppPurchaseUpdater->update($this->getAdminContext() ?? Context::createDefaultContext());
+        }
+    }
+
+    /**
+     * We have to remove the IAP key from the system config domain,
+     * otherwise it is exposed in the admin and the admin will overwrite it automatically,
+     * thus circumventing our reset logic on license host change.
+     */
+    public function removeIapInformationFromDomain(SystemConfigDomainLoadedEvent $event): void
+    {
+        if ($event->getDomain() !== 'core.store.') {
+            return;
+        }
+
+        $config = $event->getConfig();
+        unset($config[InAppPurchaseProvider::CONFIG_STORE_IAP_KEY]);
+
+        $event->setConfig($config);
+    }
+
+    private function getAdminContext(): ?Context
+    {
+        $context = $this->requestStack->getCurrentRequest()?->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
+
+        if ($context instanceof Context && $context->getSource() instanceof AdminApiSource) {
+            return $context;
+        }
+
+        return null;
+    }
+}

--- a/src/Core/Framework/Store/Services/MiddlewareInterface.php
+++ b/src/Core/Framework/Store/Services/MiddlewareInterface.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Store\Services;
 
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Shopware\Core\Framework\Log\Package;
 
@@ -11,5 +12,11 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('checkout')]
 interface MiddlewareInterface
 {
-    public function __invoke(ResponseInterface $response): ResponseInterface;
+    /**
+     * Will be called after the request.
+     *
+     * @param ResponseInterface $response - Response we got.
+     * @param RequestInterface $request - Request that was sent.
+     */
+    public function __invoke(ResponseInterface $response, RequestInterface $request): ResponseInterface;
 }

--- a/src/Core/Framework/Store/Services/ShopSecretInvalidMiddleware.php
+++ b/src/Core/Framework/Store/Services/ShopSecretInvalidMiddleware.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Store\Services;
 
 use Doctrine\DBAL\Connection;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
@@ -26,7 +27,7 @@ class ShopSecretInvalidMiddleware implements MiddlewareInterface
     ) {
     }
 
-    public function __invoke(ResponseInterface $response): ResponseInterface
+    public function __invoke(ResponseInterface $response, RequestInterface $request): ResponseInterface
     {
         if ($response->getStatusCode() !== 401) {
             return $response;

--- a/src/Core/Framework/Store/Services/StoreClientFactory.php
+++ b/src/Core/Framework/Store/Services/StoreClientFactory.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Store\Services;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
@@ -30,7 +30,7 @@ class StoreClientFactory
         $stack = HandlerStack::create();
 
         foreach ($middlewares as $middleware) {
-            $stack->push(Middleware::mapResponse($middleware));
+            $stack->push(self::mapResponse($middleware));
         }
 
         $config = $this->getClientBaseConfig();
@@ -51,5 +51,17 @@ class StoreClientFactory
                 'Accept' => 'application/vnd.api+json,application/json',
             ],
         ];
+    }
+
+    /**
+     * Similar to {@see Middleware::mapResponse} but does also include the request.
+     */
+    private static function mapResponse(callable $fn): callable
+    {
+        return static function (callable $handler) use ($fn): callable {
+            return static function (RequestInterface $request, array $options) use ($handler, $fn) {
+                return $handler($request, $options)->then(fn ($response) => $fn($response, $request));
+            };
+        };
     }
 }

--- a/src/Core/Framework/Store/Services/StoreClientFactory.php
+++ b/src/Core/Framework/Store/Services/StoreClientFactory.php
@@ -5,7 +5,9 @@ namespace Shopware\Core\Framework\Store\Services;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
@@ -55,10 +57,13 @@ class StoreClientFactory
 
     /**
      * Similar to {@see Middleware::mapResponse} but does also include the request.
+     *
+     * @param callable(ResponseInterface, RequestInterface): ResponseInterface $fn
      */
     private static function mapResponse(callable $fn): callable
     {
         return static function (callable $handler) use ($fn): callable {
+            /** @var callable(RequestInterface, array<mixed>): Promise $handler */
             return static function (RequestInterface $request, array $options) use ($handler, $fn) {
                 return $handler($request, $options)->then(fn ($response) => $fn($response, $request));
             };

--- a/tests/integration/Core/Framework/Store/Services/ShopSecretInvalidMiddlewareTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ShopSecretInvalidMiddlewareTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Store\Services;
 
 use Doctrine\DBAL\Connection;
+use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
@@ -35,10 +36,11 @@ class ShopSecretInvalidMiddlewareTest extends TestCase
         $this->systemConfigService->set('core.store.shopSecret', 'shop-s3cr3t-token');
 
         $response = new Response(200, [], '{"payload":"data"}');
+        $request = new Psr7Request('GET', '/');
 
         $middleware = new ShopSecretInvalidMiddleware($this->connection, $this->systemConfigService);
 
-        $handledResponse = $middleware($response);
+        $handledResponse = $middleware($response, $request);
 
         static::assertSame($response, $handledResponse);
 
@@ -55,10 +57,11 @@ class ShopSecretInvalidMiddlewareTest extends TestCase
         $this->systemConfigService->set('core.store.shopSecret', 'shop-s3cr3t-token');
 
         $response = new Response(401, [], '{"payload":"data"}');
+        $request = new Psr7Request('GET', '/');
 
         $middleware = new ShopSecretInvalidMiddleware($this->connection, $this->systemConfigService);
 
-        $handledResponse = $middleware($response);
+        $handledResponse = $middleware($response, $request);
 
         static::assertSame($response, $handledResponse);
 
@@ -74,11 +77,12 @@ class ShopSecretInvalidMiddlewareTest extends TestCase
         $this->setAllUserStoreTokens('secret_token');
 
         $response = new Response(401, [], '{"code":"ShopwarePlatformException-68"}');
+        $request = new Psr7Request('GET', '/');
 
         $middleware = new ShopSecretInvalidMiddleware($this->connection, $this->systemConfigService);
 
         $this->expectException(ShopSecretInvalidException::class);
-        $middleware($response);
+        $middleware($response, $request);
 
         foreach ($this->fetchAllUserStoreTokens() as $token) {
             static::assertNull($token['store_token']);

--- a/tests/integration/Core/Framework/Store/Services/StoreSessionExpiredMiddlewareTest.php
+++ b/tests/integration/Core/Framework/Store/Services/StoreSessionExpiredMiddlewareTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Store\Services;
 
 use Doctrine\DBAL\Connection;
+use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -11,9 +12,11 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
 use Shopware\Core\Framework\Store\Exception\StoreSessionExpiredException;
 use Shopware\Core\Framework\Store\Services\StoreSessionExpiredMiddleware;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\User\UserCollection;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -26,16 +29,27 @@ class StoreSessionExpiredMiddlewareTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<UserCollection>
+     */
+    private EntityRepository $userRepository;
+
+    protected function setUp(): void
+    {
+        $this->userRepository = static::getContainer()->get('user.repository');
+    }
+
     public function testReturnsResponseIfStatusCodeIsNotUnauthorized(): void
     {
         $response = new Response(200, [], '{"payload":"data"}');
+        $request = new Psr7Request('GET', '/');
 
         $middleware = new StoreSessionExpiredMiddleware(
             static::getContainer()->get(Connection::class),
             new RequestStack()
         );
 
-        $handledResponse = $middleware($response);
+        $handledResponse = $middleware($response, $request);
 
         static::assertSame($response, $handledResponse);
     }
@@ -43,13 +57,14 @@ class StoreSessionExpiredMiddlewareTest extends TestCase
     public function testReturnsResponseWithRewoundBodyIfCodeIsNotMatched(): void
     {
         $response = new Response(401, [], '{"payload":"data"}');
+        $request = new Psr7Request('GET', '/');
 
         $middleware = new StoreSessionExpiredMiddleware(
             static::getContainer()->get(Connection::class),
             new RequestStack()
         );
 
-        $handledResponse = $middleware($response);
+        $handledResponse = $middleware($response, $request);
 
         static::assertSame($response, $handledResponse);
     }
@@ -58,6 +73,7 @@ class StoreSessionExpiredMiddlewareTest extends TestCase
     public function testThrowsIfApiRespondsWithTokenExpiredException(RequestStack $requestStack): void
     {
         $response = new Response(401, [], '{"code":"ShopwarePlatformException-1"}');
+        $request = new Psr7Request('GET', '/');
 
         $middleware = new StoreSessionExpiredMiddleware(
             static::getContainer()->get(Connection::class),
@@ -65,18 +81,16 @@ class StoreSessionExpiredMiddlewareTest extends TestCase
         );
 
         $this->expectException(StoreSessionExpiredException::class);
-        $middleware($response);
+        $middleware($response, $request);
     }
 
     public function testLogsOutUserAndThrowsIfApiRespondsWithTokenExpiredException(): void
     {
         $response = new Response(401, [], '{"code":"ShopwarePlatformException-1"}');
 
-        /** @var EntityRepository<UserCollection> $userRepository */
-        $userRepository = static::getContainer()->get('user.repository');
-        $adminUser = $userRepository->search(new Criteria(), Context::createDefaultContext())->getEntities()->first();
+        $adminUser = $this->userRepository->search(new Criteria(), Context::createDefaultContext())->getEntities()->first();
         static::assertNotNull($adminUser);
-        $userRepository->update([[
+        $this->userRepository->update([[
             'id' => $adminUser->getId(),
             'store_token' => 's3cr3t',
         ]], Context::createDefaultContext());
@@ -99,12 +113,48 @@ class StoreSessionExpiredMiddlewareTest extends TestCase
             $requestStack
         );
 
-        $this->expectException(StoreSessionExpiredException::class);
-        $middleware($response);
+        $request = new Psr7Request('GET', '/');
 
-        $adminUser = $userRepository->search(new Criteria([$adminUser->getId()]), Context::createDefaultContext())->getEntities()->first();
+        $this->expectException(StoreSessionExpiredException::class);
+        $middleware($response, $request);
+
+        $adminUser = $this->userRepository->search(new Criteria([$adminUser->getId()]), Context::createDefaultContext())->getEntities()->first();
         static::assertNotNull($adminUser);
         static::assertNull($adminUser->getStoreToken());
+    }
+
+    public function testLogsOutUserByTokenAndThrowsIfApiRespondsWithTokenExpiredException(): void
+    {
+        $response = new Response(401, [], '{"code":"ShopwarePlatformException-1"}');
+
+        $expiredSessionUserId = Uuid::randomHex();
+        $loginSessionUserId = Uuid::randomHex();
+
+        $this->createAdminUser($expiredSessionUserId, 'some-invalid-token');
+        $this->createAdminUser($loginSessionUserId, 'some-valid-token');
+
+        $request = new Request(attributes: ['sw-context' => new Context(new AdminApiSource($loginSessionUserId))]);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $middleware = new StoreSessionExpiredMiddleware(
+            static::getContainer()->get(Connection::class),
+            $requestStack
+        );
+
+        $request = new Psr7Request('GET', '/', [StoreRequestOptionsProvider::SHOPWARE_PLATFORM_TOKEN_HEADER => 'some-invalid-token']);
+
+        $this->expectException(StoreSessionExpiredException::class);
+        $middleware($response, $request);
+
+        $adminUsers = $this->userRepository->search(new Criteria([$expiredSessionUserId, $loginSessionUserId]), Context::createDefaultContext())->getEntities();
+        $expiredSessionUser = $adminUsers->get($expiredSessionUserId);
+        $loginSessionUser = $adminUsers->get($loginSessionUserId);
+        static::assertNotNull($expiredSessionUser);
+        static::assertNotNull($loginSessionUser);
+        static::assertNull($expiredSessionUser->getStoreToken());
+        static::assertSame('some-valid-token', $loginSessionUser->getStoreToken());
     }
 
     public static function provideRequestStacks(): \Generator
@@ -125,5 +175,23 @@ class StoreSessionExpiredMiddlewareTest extends TestCase
         $requestStackWithMissingUserId->push(new Request([], [], ['sw-context' => new Context(new AdminApiSource(null))]));
 
         yield 'request stack with missing user id' => [$requestStackWithMissingUserId];
+    }
+
+    private function createAdminUser(string $userId, string $storeToken): void
+    {
+        $data = [
+            [
+                'id' => $userId,
+                'localeId' => $this->getLocaleIdOfSystemLanguage(),
+                'username' => Uuid::randomHex() . 'foobar',
+                'password' => 'asdasdasdasd',
+                'firstName' => 'Foo',
+                'lastName' => 'Bar',
+                'email' => Uuid::randomHex() . '@bar.com',
+                'storeToken' => $storeToken,
+            ],
+        ];
+
+        $this->userRepository->create($data, Context::createDefaultContext());
     }
 }

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Subscriber/InAppPurchaseConfigSubscriberTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Subscriber/InAppPurchaseConfigSubscriberTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\InAppPurchases\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater;
+use Shopware\Core\Framework\Store\InAppPurchase\Subscriber\InAppPurchaseConfigSubscriber;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SystemConfig\Event\SystemConfigChangedEvent;
+use Shopware\Core\System\SystemConfig\Event\SystemConfigDomainLoadedEvent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(InAppPurchaseConfigSubscriber::class)]
+class InAppPurchaseConfigSubscriberTest extends TestCase
+{
+    private RequestStack $requestStack;
+
+    private InAppPurchaseUpdater&MockObject $iapUpdater;
+
+    private InAppPurchaseConfigSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->requestStack = new RequestStack();
+        $this->iapUpdater = $this->createMock(InAppPurchaseUpdater::class);
+
+        $this->subscriber = new InAppPurchaseConfigSubscriber(
+            $this->requestStack,
+            $this->iapUpdater,
+        );
+    }
+
+    public function testIsSubscribedToSystemConfigChangedEvents(): void
+    {
+        static::assertSame([
+            SystemConfigChangedEvent::class => 'updateIapKey',
+            SystemConfigDomainLoadedEvent::class => 'removeIapInformationFromDomain',
+        ], InAppPurchaseConfigSubscriber::getSubscribedEvents());
+    }
+
+    public function testUpdateIapKeyOnlyUsesStoreToken(): void
+    {
+        $this->iapUpdater->expects($this->never())->method('update');
+
+        $event = new SystemConfigChangedEvent('random.config.key', 'whatever', null);
+        $this->subscriber->updateIapKey($event);
+    }
+
+    public function testUpdateIapKeyOnlyUsesActualToken(): void
+    {
+        $this->iapUpdater->expects($this->never())->method('update');
+
+        $event = new SystemConfigChangedEvent('core.store.shopSecret', null, null);
+        $this->subscriber->updateIapKey($event);
+    }
+
+    public function testUpdateIapKeyUpdatesOnStoreSecretSet(): void
+    {
+        $this->iapUpdater->expects($this->once())->method('update');
+
+        $event = new SystemConfigChangedEvent('core.store.shopSecret', 'secret', null);
+        $this->subscriber->updateIapKey($event);
+    }
+
+    public function testUpdateIapKeyUsesAdminContext(): void
+    {
+        $context = Context::createDefaultContext(new AdminApiSource(null));
+        $this->requestStack->push(new Request(attributes: [PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT => $context]));
+
+        $this->iapUpdater
+            ->expects($this->once())
+            ->method('update')
+            ->with($context);
+
+        $event = new SystemConfigChangedEvent('core.store.shopSecret', 'secret', null);
+        $this->subscriber->updateIapKey($event);
+    }
+
+    public function testRemoveIapInformationFromDomainOnlyActsOnStoreDomain(): void
+    {
+        $event = new SystemConfigDomainLoadedEvent('some.domain.', ['core.store.iapKey' => 'key'], false, null);
+        $this->subscriber->removeIapInformationFromDomain($event);
+
+        static::assertSame(['core.store.iapKey' => 'key'], $event->getConfig());
+    }
+
+    public function testRemoveIapInformationCleansDomain(): void
+    {
+        $event = new SystemConfigDomainLoadedEvent('core.store.', ['core.store.iapKey' => 'key'], false, null);
+        $this->subscriber->removeIapInformationFromDomain($event);
+
+        static::assertSame([], $event->getConfig());
+    }
+}

--- a/tests/unit/Core/Framework/Store/Services/ShopSecretInvalidMiddlewareTest.php
+++ b/tests/unit/Core/Framework/Store/Services/ShopSecretInvalidMiddlewareTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Framework\Store\Services;
 
 use Doctrine\DBAL\Connection;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -22,13 +23,14 @@ class ShopSecretInvalidMiddlewareTest extends TestCase
     public function testKeepsStoreTokensAndReturnsResponse(): void
     {
         $response = new Response(200, [], '{"payload":"data"}');
+        $request = new Request('GET', '/');
 
         $middleware = new ShopSecretInvalidMiddleware(
             $this->createMock(Connection::class),
             $this->createMock(SystemConfigService::class)
         );
 
-        $handledResponse = $middleware($response);
+        $handledResponse = $middleware($response, $request);
 
         static::assertSame($response, $handledResponse);
     }
@@ -36,13 +38,14 @@ class ShopSecretInvalidMiddlewareTest extends TestCase
     public function testKeepsStoreTokensAndReturnsResponseWithRewoundBody(): void
     {
         $response = new Response(401, [], '{"payload":"data"}');
+        $request = new Request('GET', '/');
 
         $middleware = new ShopSecretInvalidMiddleware(
             $this->createMock(Connection::class),
             $this->createMock(SystemConfigService::class)
         );
 
-        $handledResponse = $middleware($response);
+        $handledResponse = $middleware($response, $request);
 
         static::assertSame($response, $handledResponse);
     }
@@ -50,6 +53,7 @@ class ShopSecretInvalidMiddlewareTest extends TestCase
     public function testThrowsAndDeletesStoreTokensIfApiRespondsWithTokenExpiredException(): void
     {
         $response = new Response(401, [], '{"code":"ShopwarePlatformException-68"}');
+        $request = new Request('GET', '/');
 
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())
@@ -66,6 +70,6 @@ class ShopSecretInvalidMiddlewareTest extends TestCase
         );
 
         $this->expectException(ShopSecretInvalidException::class);
-        $middleware($response);
+        $middleware($response, $request);
     }
 }

--- a/tests/unit/Core/Framework/Store/Subscriber/LicenseHostChangedSubscriberTest.php
+++ b/tests/unit/Core/Framework/Store/Subscriber/LicenseHostChangedSubscriberTest.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater;
 use Shopware\Core\Framework\Store\Subscriber\LicenseHostChangedSubscriber;
 use Shopware\Core\System\SystemConfig\Event\BeforeSystemConfigChangedEvent;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
@@ -69,7 +68,7 @@ class LicenseHostChangedSubscriberTest extends TestCase
         $connection = $this->createMock(Connection::class);
         $connection->expects($this->once())->method('executeStatement')->with('UPDATE user SET store_token = NULL');
 
-        $subscriber = new LicenseHostChangedSubscriber($config, $connection, $this->createMock(InAppPurchaseUpdater::class));
+        $subscriber = new LicenseHostChangedSubscriber($config, $connection);
 
         $event = new BeforeSystemConfigChangedEvent('core.store.licenseHost', 'otherhost', null);
         $subscriber->onLicenseHostChanged($event);

--- a/tests/unit/Core/Framework/Store/Subscriber/LicenseHostChangedSubscriberTest.php
+++ b/tests/unit/Core/Framework/Store/Subscriber/LicenseHostChangedSubscriberTest.php
@@ -9,8 +9,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater;
 use Shopware\Core\Framework\Store\Subscriber\LicenseHostChangedSubscriber;
 use Shopware\Core\System\SystemConfig\Event\BeforeSystemConfigChangedEvent;
-use Shopware\Core\System\SystemConfig\Event\SystemConfigChangedEvent;
-use Shopware\Core\System\SystemConfig\Event\SystemConfigDomainLoadedEvent;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 
 /**
@@ -24,8 +22,6 @@ class LicenseHostChangedSubscriberTest extends TestCase
     {
         static::assertSame([
             BeforeSystemConfigChangedEvent::class => 'onLicenseHostChanged',
-            SystemConfigChangedEvent::class => 'updateIapKey',
-            SystemConfigDomainLoadedEvent::class => 'removeIapInformationFromDomain',
         ], LicenseHostChangedSubscriber::getSubscribedEvents());
     }
 
@@ -37,7 +33,6 @@ class LicenseHostChangedSubscriberTest extends TestCase
         $subscriber = new LicenseHostChangedSubscriber(
             $config,
             $this->createMock(Connection::class),
-            $this->createMock(InAppPurchaseUpdater::class),
         );
 
         $event = new BeforeSystemConfigChangedEvent('random.config.key', null, null);
@@ -55,7 +50,6 @@ class LicenseHostChangedSubscriberTest extends TestCase
         $subscriber = new LicenseHostChangedSubscriber(
             $config,
             $this->createMock(Connection::class),
-            $this->createMock(InAppPurchaseUpdater::class),
         );
 
         $event = new BeforeSystemConfigChangedEvent('core.store.licenseHost', 'host', null);
@@ -69,6 +63,7 @@ class LicenseHostChangedSubscriberTest extends TestCase
         $config = new StaticSystemConfigService([
             'core.store.shopSecret' => 'shop-s3cr3t',
             'core.store.licenseHost' => 'host',
+            'core.store.iapKey' => 'iap-key',
         ]);
 
         $connection = $this->createMock(Connection::class);
@@ -81,78 +76,5 @@ class LicenseHostChangedSubscriberTest extends TestCase
 
         static::assertNull($config->get('core.store.shopSecret'));
         static::assertNull($config->get('core.store.iapKey'));
-    }
-
-    public function testUpdateIapKeyOnlyUsesStoreToken(): void
-    {
-        $iapUpdater = $this->createMock(InAppPurchaseUpdater::class);
-        $iapUpdater->expects($this->never())->method('update');
-
-        $subscriber = new LicenseHostChangedSubscriber(
-            new StaticSystemConfigService(),
-            $this->createMock(Connection::class),
-            $iapUpdater,
-        );
-
-        $event = new SystemConfigChangedEvent('random.config.key', 'whatever', null);
-        $subscriber->updateIapKey($event);
-    }
-
-    public function testUpdateIapKeyOnlyUsesActualToken(): void
-    {
-        $iapUpdater = $this->createMock(InAppPurchaseUpdater::class);
-        $iapUpdater->expects($this->never())->method('update');
-
-        $subscriber = new LicenseHostChangedSubscriber(
-            new StaticSystemConfigService(),
-            $this->createMock(Connection::class),
-            $iapUpdater,
-        );
-
-        $event = new SystemConfigChangedEvent('core.store.shopSecret', null, null);
-        $subscriber->updateIapKey($event);
-    }
-
-    public function testUpdateIapKeyUpdatesOnStoreSecretSet(): void
-    {
-        $iapUpdater = $this->createMock(InAppPurchaseUpdater::class);
-        $iapUpdater->expects($this->once())->method('update');
-
-        $subscriber = new LicenseHostChangedSubscriber(
-            new StaticSystemConfigService(),
-            $this->createMock(Connection::class),
-            $iapUpdater,
-        );
-
-        $event = new SystemConfigChangedEvent('core.store.shopSecret', 'secret', null);
-        $subscriber->updateIapKey($event);
-    }
-
-    public function testRemoveIapInformationFromDomainOnlyActsOnStoreDomain(): void
-    {
-        $subscriber = new LicenseHostChangedSubscriber(
-            new StaticSystemConfigService(),
-            $this->createMock(Connection::class),
-            $this->createMock(InAppPurchaseUpdater::class),
-        );
-
-        $event = new SystemConfigDomainLoadedEvent('some.domain.', ['core.store.iapKey' => 'key'], false, null);
-        $subscriber->removeIapInformationFromDomain($event);
-
-        static::assertSame(['core.store.iapKey' => 'key'], $event->getConfig());
-    }
-
-    public function testRemoveIapInformationCleansDomain(): void
-    {
-        $subscriber = new LicenseHostChangedSubscriber(
-            new StaticSystemConfigService(),
-            $this->createMock(Connection::class),
-            $this->createMock(InAppPurchaseUpdater::class),
-        );
-
-        $event = new SystemConfigDomainLoadedEvent('core.store.', ['core.store.iapKey' => 'key'], false, null);
-        $subscriber->removeIapInformationFromDomain($event);
-
-        static::assertSame([], $event->getConfig());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The following could happen while logging in with a Shopware Account:
1. Some user logs in his Shopware Account in the administration.
2. The change of `core.store.shopSecret` will trigger an IAP Update via the `InAppPurchaseUpdater` with a `Context` containing a `SystemSource`.
3. The IAP Updater uses the `StoreRequestOptionsProvider`.
4. The `StoreRequestOptionsProvider` sees the `SystemSource` and fetches the first non-null `storeToken` from the `user` table.
5. **The first best token could be invalid and the IAP update request fails**
6. The `StoreSessionExpiredMiddleware` tries to delete the invalid `storeToken` by **fetching the context from the request stack**, which is an `AdminApiSource`.
7. As the IAP update request was made with a `SystemSource` and therefore a random `storeToken`, deleting the token from the just logged in admin user is wrong.

### 2. What does this change do, exactly?
- The IAP Updater tries to fetch the current context from the request stack.
- The  `StoreSessionExpiredMiddleware` deletes the correct `storeToken` by the token used in the request instead by the user id.

### 3. Describe each step to reproduce the issue or behaviour.
- Create two admin users
- Give the first user an invalid `storeToken`
- Login into the admin as the second user and try to log in with a Shopware Account 

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #10919 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
