### PR TITLE
fix(services): missing snippets

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-grant-permissions-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-grant-permissions-modal/index.ts
@@ -58,8 +58,6 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         grantPermissions(done: () => void) {
-            console.log('Grant permissions');
-
             done();
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/index.ts
@@ -7,8 +7,6 @@ import type { ServiceDescription } from '../../service/shopware-services.service
 import template from './sw-settings-services-service-card.html.twig';
 import './sw-settings-services-service-card.scss';
 import extractErrorMessage from '../../composables/extract-error';
-// eslint-disable-next-line import/no-unresolved
-import iconPlaceholder from './assets/extension-icon-placeholder.svg?no-inline';
 
 /**
  * @private

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.html.twig
@@ -49,7 +49,9 @@
             </mt-popover>
         </div>
 
-        <div class="sw-settings-services-service-card__description" v-html="service.description"></div>
+        <div class="sw-settings-services-service-card__description"
+             v-html="service.description"
+        ></div>
 
         <div class="sw-settings-services-service-card__footer">
             {{  $t('sw-settings-services.service-card.updated-at-label', { updatedAt: updatedAt }) }}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
@@ -29,8 +29,6 @@
             <div class="sw-settings-services__listing-section">
                 <h3>
                     {{ $t('sw-settings-services.index.available-services') }}
-
-                    <sw-help-text :text="$t('sw-settings-services.index.available-services-tooltip')" />
                 </h3>
 
                 <mt-banner

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
@@ -42,7 +42,7 @@
                     <p>{{ loadingError }}</p>
                 </mt-banner>
 
-                   <mt-banner
+                <mt-banner
                     v-if="config.disabled"
                     class="sw-settings-services-index__services-deactivated-banner"
                     variant="attention"
@@ -52,9 +52,9 @@
                     <p>{{ $t('sw-settings-services.index.services-are-disabled-cta') }}</p>
 
                     <mt-button
-                            variant="primary"
-                            size="small"
-                            @click="activateServices"
+                        variant="primary"
+                        size="small"
+                        @click="activateServices"
                     >
                         {{ $t('sw-settings-services.index.services-are-disabled-button-label') }}
                     </mt-button>
@@ -68,9 +68,9 @@
                         <mt-loader size="var(--scale-size-32)" />
                     </div>
 
-                    <p class="sw-settings-services-index__installing-card-title">Installing Shopware Services</p>
+                    <p class="sw-settings-services-index__installing-card-title">{{ $t('sw-settings-services.index.installing-services-title') }}</p>
 
-                    <p>This might take a while. You will get a notification when all installations are finished. You can use your Shopware Administration freely in the meantime.</p>
+                    <p>{{ $t('sw-settings-services.index.installing-services-description') }}</p>
                 </div>
 
                 <ul

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/de-DE.json
@@ -21,7 +21,6 @@
     },
     "index": {
       "available-services": "Verfügbare Services",
-      "available-services-tooltip": "Zusätzliche Funktionen, die über den Kern hinausgehen, um erweiterte Anwendungsfälle wie künstliche Intelligenz zu ermöglichen und eine Vielzahl von Geschäftsanforderungen zu unterstützen.",
       "services-are-disabled": "Shopware Services sind deaktiviert",
       "services-are-disabled-cta": "Dir entgehen derzeit alle Shopware Services, einschließlich fortschrittlicher KI-Tools und vielem mehr. Aktiviere Shopware Services, um alle aktuellen und zukünftigen Services nutzen zu können.",
       "services-are-disabled-button-label": "Services aktivieren",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/de-DE.json
@@ -28,7 +28,9 @@
       "services-enabled": "Services aktiviert",
       "services-scheduled": "Services sind zur Installation und Aktivierung eingeplant. Dies kann einen Moment dauern.",
       "label-documentation-link": "Dokumentation",
-      "label-tos-link": "AGB"
+      "label-tos-link": "AGB",
+      "installing-services-title": "Shopware Services werden installiert",
+      "installing-services-description": "Dies kann eine Weile dauern. Du wirst benachrichtigt, sobald die Installationen abgeschlossen sind. In der Zwischenzeit kannst Du Deine Shopware Administration frei nutzen."
     },
     "service-card": {
       "status-active": "Aktiv",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/en-GB.json
@@ -21,7 +21,6 @@
     },
     "index": {
       "available-services": "Available services",
-      "available-services-tooltip": "Additional features that go beyond the core to enable advanced use cases, such as artificial intelligence, while supporting a wide range of business needs.",
       "services-are-disabled": "Shopware Services are deactivated",
       "services-are-disabled-cta": "You are currently missing out on all Shopware Services, including advanced AI tools and much more. Activate Shopware Services to take advantage of all the current and future Services we have to offer.",
       "services-are-disabled-button-label": "Activate Services",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/en-GB.json
@@ -28,7 +28,9 @@
       "services-enabled": "Services enabled",
       "services-scheduled": "Services are scheduled to be installed and activated. This can take a moment.",
       "label-documentation-link": "Documentation",
-      "label-tos-link": "Terms & Conditions"
+      "label-tos-link": "Terms & Conditions",
+      "installing-services-title": "Installing Shopware Services",
+      "installing-services-description": "This might take a while. You will be notified as soon as the installations are complete. In the meantime you can freely use your Shopware administration."
     },
     "service-card": {
       "status-active": "Active",


### PR DESCRIPTION
Adding missing translation snippets.

### EN-GB
![Screenshot 2025-07-04 at 08 45 10](https://github.com/user-attachments/assets/33b2d762-8544-4f98-a322-6e524bdb601f)

### DE-DE
![Screenshot 2025-07-04 at 08 44 19](https://github.com/user-attachments/assets/5b4c77b9-5e16-45dd-9810-baa0511f8d52)

