### PR TITLE
test: fix flaky SearchKeywordUpdaterTest::testItUpdatesKeywordsForAvailableLanguagesOnly

### DIFF
--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -68,6 +68,8 @@ class SearchKeywordUpdaterTest extends TestCase
     #[DataProvider('productKeywordProvider')]
     public function testItUpdatesKeywordsForAvailableLanguagesOnly(array $productData, IdsCollection $ids, array $englishKeywords, array $germanKeywords, array $additionalDictionaries = []): void
     {
+        $this->connection->executeStatement('DELETE FROM product');
+
         $context = Context::createDefaultContext();
 
         $criteria = new Criteria();


### PR DESCRIPTION
### 1. Why is this change necessary?
see https://github.com/shopware/shopware/issues/10994

### 2. What does this change do, exactly?
It enforces a clean state as we expect a determined set of products only

### 3. Describe each step to reproduce the issue or behaviour.
 -  run Nightly
 -  check for integration / PHP update 6.6 -> 6.7 (no failure)

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/10994

