### PR TITLE
fix: Order line items label display & add type column

### DIFF
--- a/changelog/_unreleased/2025-07-04-fix-order-line-items-label-display-and-add-type-column.md
+++ b/changelog/_unreleased/2025-07-04-fix-order-line-items-label-display-and-add-type-column.md
@@ -1,0 +1,9 @@
+---
+title: Fix order line items label display & add type column
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Changed `Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss` to improve the label display of the order line items with better line breaks
+* Added `type` column to `Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig` & `Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js`

--- a/src/Administration/Resources/app/administration/blocks-list.json
+++ b/src/Administration/Resources/app/administration/blocks-list.json
@@ -3865,6 +3865,8 @@
  "sw_order_line_items_grid_grid_columns_tax_inline_edit",
  "sw_order_line_items_grid_grid_columns_total_price",
  "sw_order_line_items_grid_grid_columns_total_price_content",
+ "sw_order_line_items_grid_grid_columns_type",
+ "sw_order_line_items_grid_grid_columns_type_content",
  "sw_order_line_items_grid_grid_columns_unit_price",
  "sw_order_line_items_grid_grid_columns_unit_price_content",
  "sw_order_line_items_grid_grid_columns_unit_price_inline_edit",

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
@@ -166,6 +166,12 @@ export default {
                     align: 'right',
                     width: '120px',
                 },
+                {
+                    property: 'type',
+                    dataIndex: 'type',
+                    label: 'sw-order.detailBase.columnType',
+                    allowResize: false,
+                },
             ];
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
@@ -124,6 +124,13 @@ export default {
                     multiLine: true,
                 },
                 {
+                    property: 'type',
+                    dataIndex: 'type',
+                    label: 'sw-order.detailBase.columnType',
+                    allowResize: false,
+                    visible: false,
+                },
+                {
                     property: 'payload.productNumber',
                     dataIndex: 'payload.productNumber',
                     label: 'sw-order.detailBase.columnProductNumber',
@@ -165,12 +172,6 @@ export default {
                     allowResize: false,
                     align: 'right',
                     width: '120px',
-                },
-                {
-                    property: 'type',
-                    dataIndex: 'type',
-                    label: 'sw-order.detailBase.columnType',
-                    allowResize: false,
                 },
             ];
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
@@ -292,6 +292,18 @@
         </template>
         {% endblock %}
 
+        {% block sw_order_line_items_grid_grid_columns_type %}
+        <template #column-type="{ item }">
+
+            {% block sw_order_line_items_grid_grid_columns_type_content %}
+            <span>
+                {{ $t('sw-order.lineItemType.' + item.type) }}
+            </span>
+            {% endblock %}
+
+        </template>
+        {% endblock %}
+
         {% block sw_order_line_items_grid_grid_actions %}
         <template #actions="{ item, itemIndex }">
             {% block sw_order_line_items_grid_grid_actions_show %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss
@@ -50,7 +50,14 @@ $sw-order-line-item-border: $color-gray-300;
     .sw-order-line-items-grid__item-payload-options {
         .sw-product-variant-info {
             text-overflow: unset;
+            white-space: normal;
+            min-width: 192px;
         }
+    }
+
+    .sw-order-detail-general__line-item-grid-card .sw-order-line-items-grid__item-label {
+        white-space: normal;
+        min-width: 192px;
     }
 
     .sw-entity-single-select__selection-text .sw-product-variant-info {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
@@ -481,10 +481,10 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         });
 
         const header = wrapper.find('.sw-data-grid__header');
-        const columnVat = header.find('.sw-data-grid__cell--4');
-        const columnPrice = header.find('.sw-data-grid__cell--1');
+        const firstRow = wrapper.find('.sw-data-grid__row--0');
+        const columnVat = firstRow.find('.sw-data-grid__cell--price-taxRules\\[0\\]');
         expect(columnVat.exists()).toBe(true);
-        expect(columnPrice.text()).not.toBe('sw-order.createBase.columnPriceTaxFree');
+        expect(header.text()).not.toContain('sw-order.createBase.columnPriceTaxFree');
     });
 
     it('should not have vat column and price label is tax free when tax status is tax free', async () => {
@@ -499,10 +499,10 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         });
 
         const header = wrapper.find('.sw-data-grid__header');
-        const columnVat = header.find('.sw-data-grid__cell--5');
-        const columnPrice = header.find('.sw-data-grid__cell--3');
+        const firstRow = wrapper.find('.sw-data-grid__row--0');
+        const columnVat = firstRow.find('.sw-data-grid__cell--price-taxRules\\[0\\]');
         expect(columnVat.exists()).toBe(false);
-        expect(columnPrice.text()).toBe('sw-order.detailBase.columnPriceTaxFree');
+        expect(header.text()).toContain('sw-order.detailBase.columnPriceTaxFree');
     });
 
     // eslint-disable-next-line max-len
@@ -534,7 +534,6 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         const wrapper = await createWrapper();
 
         let header;
-        let columnTotal;
 
         await wrapper.setProps({
             order: {
@@ -545,8 +544,7 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         });
 
         header = wrapper.find('.sw-data-grid__header');
-        columnTotal = header.find('.sw-data-grid__cell--4');
-        expect(columnTotal.text()).toBe('sw-order.detailBase.columnTotalPriceNet');
+        expect(header.text()).toContain('sw-order.detailBase.columnTotalPriceNet');
 
         await wrapper.setProps({
             order: {
@@ -557,8 +555,7 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         });
 
         header = wrapper.find('.sw-data-grid__header');
-        columnTotal = header.find('.sw-data-grid__cell--5');
-        expect(columnTotal.text()).toBe('sw-order.detailBase.columnTotalPriceGross');
+        expect(header.text()).toContain('sw-order.detailBase.columnTotalPriceGross');
 
         await wrapper.setProps({
             order: {
@@ -569,8 +566,7 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         });
 
         header = wrapper.find('.sw-data-grid__header');
-        columnTotal = header.find('.sw-data-grid__cell--5');
-        expect(columnTotal.text()).toBe('sw-order.detailBase.columnTotalPriceNet');
+        expect(header.text()).toContain('sw-order.detailBase.columnTotalPriceNet');
     });
 
     it('should able to create new empty line item', async () => {
@@ -875,9 +871,7 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         });
 
         const header = wrapper.find('.sw-data-grid__header');
-        const columnProductNumber = header.find('.sw-data-grid__cell--2');
-
-        expect(columnProductNumber.text()).toBe('sw-order.detailBase.columnProductNumber');
+        expect(header.text()).toContain('sw-order.detailBase.columnProductNumber');
     });
 
     it('should show items correctly when search by product number', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de-DE.json
@@ -203,6 +203,7 @@
       "columnPriceNet": "Nettopreis",
       "columnTotalPriceNet": "Gesamt",
       "columnProductNumber": "Produktnummer",
+      "columnType": "Typ",
       "contextMenuShowProduct": "Produkt anzeigen",
       "contextMenuDelete": "Aus Bestellung entfernen",
       "summaryLabelAmount": "Summe",
@@ -265,6 +266,14 @@
       "textDeleteLineItemConfirm": "Möchten Sie die Position ({label}) wirklich löschen?",
       "helpTextCustomerComment": "Dieser Kommentar wird von Kunden hinterlassen und Änderungen sind für sie sichtbar.",
       "helpTextInternalComment": "Dieser Kommentar ist nur für interne Zwecke und wird Kunden nicht angezeigt."
+    },
+    "lineItemType": {
+      "credit": "Gutschrift",
+      "product": "Produkt",
+      "custom": "Individuell",
+      "promotion": "Rabattaktion",
+      "discount": "Rabatt",
+      "container": "Container"
     },
     "nestedLineItemsModal": {
       "titlePrefix": "Position: {lineItemLabel} - {price}",

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en-GB.json
@@ -203,6 +203,7 @@
       "columnTotalPriceGross": "Subtotal",
       "columnTax": "VAT",
       "columnProductNumber": "Product number",
+      "columnType": "Type",
       "contextMenuShowProduct": "Show product",
       "contextMenuDelete": "Remove from order",
       "summaryLabelAmount": "Subtotal",
@@ -265,6 +266,14 @@
       "textDeleteLineItemConfirm": "Are you sure you want to delete the position ({label})?",
       "helpTextCustomerComment": "Customers can submit this comment, and any changes will be visible to them.",
       "helpTextInternalComment": "This comment is for internal use only and will not be presented to customers."
+    },
+    "lineItemType": {
+      "credit": "Credit",
+      "product": "Product",
+      "custom": "Custom",
+      "promotion": "Promotion",
+      "discount": "Discount",
+      "container": "Container"
     },
     "nestedLineItemsModal": {
       "titlePrefix": "Item: {lineItemLabel} - {price}",


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the display of the label in the order line items grid is broken, as the line break is not applied correctly, as it gets overriden by another css property
- The property `multiLine` is set for the label, but is not applied because of the css property of the used component
- With this PR we correctly override the css white-space property of the used component to restore the mutliline display
- With this PR I also added the `type` column, which is currently missing but can be really helpfull, if you have multiple different line item types in a single order

Before:
![image](https://github.com/user-attachments/assets/021a99ae-0ea8-46d8-950a-61962328f058)

After:
![image](https://github.com/user-attachments/assets/4cdf0fd3-ba6f-4ab5-9a0d-db974306b3f4)

### 2. What does this change do, exactly?
* Changed `Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss` to improve the label display of the order line items with better line breaks
* Added `type` column to `Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig` & `Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js`

### 3. Describe each step to reproduce the issue or behaviour.
- Display a order with a fairly long label of a order line item

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
