### PR TITLE
fix: Change deprecated `&&` in sql accessor builder

### DIFF
--- a/changelog/_unreleased/2025-07-04-change-deprecated-and-in-sql-accessor-builder.md
+++ b/changelog/_unreleased/2025-07-04-change-deprecated-and-in-sql-accessor-builder.md
@@ -1,0 +1,8 @@
+---
+title: Change deprecated `&&` in sql accessor builder
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `Framework\DataAbstractionLayer\Dbal\FieldAccessorBuilder\JsonFieldAccessorBuilder` to use `AND` instead of the deprecated `&&`

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilder.php
@@ -112,7 +112,7 @@ class JsonFieldAccessorBuilder implements FieldAccessorBuilderInterface
 
         if ($field instanceof BoolField) {
             return \sprintf(
-                'IF(JSON_UNQUOTE(%s) != "true" && JSON_UNQUOTE(%s) = 0, 0, 1)',
+                'IF(JSON_UNQUOTE(%s) != "true" AND JSON_UNQUOTE(%s) = 0, 0, 1)',
                 $jsonValueExpr,
                 $jsonValueExpr
             );


### PR DESCRIPTION
### 1. Why is this change necessary?
- The `&&` in mysql is deprecated and should be replaced by `AND`

### 2. What does this change do, exactly?
* Changed `Framework\DataAbstractionLayer\Dbal\FieldAccessorBuilder\JsonFieldAccessorBuilder` to use `AND` instead of the deprecated `&&`

### 3. Describe each step to reproduce the issue or behaviour.
- Run a query with a json field filter
- Deprecation log will show `'&&' is deprecated and will be removed in a future release. Please use AND instead`

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
