### PR TITLE
fix: Flaky test suites integration RateLimiterTest ControllerRateLimiter FeatureTest

### DIFF
--- a/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
@@ -7,8 +7,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\Extension\FeatureFlagExtension;
 use Shopware\Core\Framework\Feature;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -20,8 +18,6 @@ use Twig\Loader\FilesystemLoader;
 #[Group('skip-paratest')]
 class FeatureTest extends TestCase
 {
-    use KernelTestBehaviour;
-
     /**
      * @var array<string, FeatureFlagConfig>
      */
@@ -46,7 +42,6 @@ class FeatureTest extends TestCase
         self::$featureAllValue = $_SERVER['FEATURE_ALL'] ?? 'false';
         self::$appEnvValue = $_ENV['APP_ENV'] ?? $_SERVER['APP_ENV'];
         self::$features = Feature::getRegisteredFeatures();
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
     }
 
     protected function setUp(): void
@@ -72,8 +67,6 @@ class FeatureTest extends TestCase
 
         Feature::resetRegisteredFeatures();
         Feature::registerFeatures(self::$features);
-
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
     }
 
     public function testABoolGetsReturned(): void
@@ -166,7 +159,6 @@ class FeatureTest extends TestCase
 
         $_SERVER['APP_ENV'] = 'test';
         $_ENV['APP_ENV'] = 'test';
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
 
         $loader = new FilesystemLoader(__DIR__ . '/_fixture/');
         $twig = new Environment($loader, [
@@ -186,7 +178,6 @@ class FeatureTest extends TestCase
     {
         $_SERVER['APP_ENV'] = 'prod';
         $_ENV['APP_ENV'] = 'prod';
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
 
         $loader = new FilesystemLoader(__DIR__ . '/_fixture/');
         $twig = new Environment($loader, [
@@ -585,8 +576,6 @@ class FeatureTest extends TestCase
     {
         $_SERVER['APP_ENV'] = 'prod';
         $_ENV['APP_ENV'] = 'prod';
-
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
 
         foreach ($env as $key => $value) {
             $_SERVER[$key] = $value;

--- a/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
+++ b/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
@@ -50,6 +50,8 @@ class RateLimiterTest extends TestCase
     use OrderFixture;
     use RateLimiterTestTrait;
 
+    public static string $customCacheId;
+
     private Context $context;
 
     private IdsCollection $ids;
@@ -60,18 +62,14 @@ class RateLimiterTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        DisableRateLimiterCompilerPass::disableNoLimit();
-        KernelLifecycleManager::bootKernel(true, Uuid::randomHex());
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        DisableRateLimiterCompilerPass::enableNoLimit();
-        KernelLifecycleManager::bootKernel(true, Uuid::randomHex());
+        self::$customCacheId = Uuid::randomHex();
     }
 
     protected function setUp(): void
     {
+        DisableRateLimiterCompilerPass::disableNoLimit();
+        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
+
         $this->context = Context::createDefaultContext();
         $this->ids = new IdsCollection();
 
@@ -88,6 +86,7 @@ class RateLimiterTest extends TestCase
     protected function tearDown(): void
     {
         DisableRateLimiterCompilerPass::enableNoLimit();
+        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
     }
 
     public function testRateLimitLoginRoute(): void

--- a/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
+++ b/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
@@ -64,6 +64,8 @@ class ControllerRateLimiterTest extends TestCase
     use RateLimiterTestTrait;
     use StorefrontControllerTestBehaviour;
 
+    public static string $customCacheId;
+
     private Context $context;
 
     private IdsCollection $ids;
@@ -76,18 +78,14 @@ class ControllerRateLimiterTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        DisableRateLimiterCompilerPass::disableNoLimit();
-        KernelLifecycleManager::bootKernel(true, Uuid::randomHex());
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        DisableRateLimiterCompilerPass::enableNoLimit();
-        KernelLifecycleManager::bootKernel(true, Uuid::randomHex());
+        self::$customCacheId = Uuid::randomHex();
     }
 
     protected function setUp(): void
     {
+        DisableRateLimiterCompilerPass::disableNoLimit();
+        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
+
         $this->context = Context::createDefaultContext();
         $this->ids = new IdsCollection();
 
@@ -106,6 +104,12 @@ class ControllerRateLimiterTest extends TestCase
         $session->getFlashBag()->clear();
 
         $this->translator = static::getContainer()->get('translator');
+    }
+
+    protected function tearDown(): void
+    {
+        DisableRateLimiterCompilerPass::enableNoLimit();
+        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
     }
 
     public function testGenerateAccountRecoveryRateLimit(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Without backport to 6.6 can end up in failing pipeline, would the order of test make ControllerRateLimiterTest, RateLimiterTest, FeatureTest match  odd number of calls for KernelLifecycleManager::bootKernel()

As before this change, bootKernel is invoked only 1 time before the test suite starts, and 1 time when it ends in 
- RateLimiterTest
- ControllerRateLimiter

While in FeatureTest 1 time before the suite starts and at every teardown


### 2. What does this change do, exactly?
- Ensure we don't end up with odd number of calls for KernelLifecycleManager::bootKernel(): call bootKernel with setup / teardown
- Remove bootKernel from FeatureTest (backport of https://github.com/shopware/shopware/pull/7667)

### 3. Describe each step to reproduce the issue or behaviour.
- run `composer run phpunit --  --testsuite integration --filter 'RateLimiterTest|FeatureTest' --testdox --random-order-seed 1751632365` (before change: error)
- run again (after change: passes)


### 4. Please link to the relevant issues (if any).

- closes  #10938
- relates https://github.com/shopware/shopware/pull/11007

### 5. Checklist

- run Nightly
