### PR TITLE
fix: cms image gallery position value

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
@@ -135,7 +135,7 @@ export default {
                     label: this.$tc('sw-cms.elements.imageGallery.config.label.navigationPreviewPositionLeft'),
                 },
                 {
-                    value: 'right',
+                    value: 'underneath',
                     label: this.$tc('sw-cms.elements.imageGallery.config.label.navigationPreviewPositionUnderneath'),
                 },
             ];


### PR DESCRIPTION
### 1. Why is this change necessary?
Storefront expects the value to be 'underneath' like in 6.6

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
