### PR TITLE
feat: Change ApiAware visibility for products association in CustomerWishlist

### DIFF
--- a/changelog/_unreleased/2025-07-07-change-api-aware-visibility-products-customer-wishlist.md
+++ b/changelog/_unreleased/2025-07-07-change-api-aware-visibility-products-customer-wishlist.md
@@ -1,0 +1,8 @@
+---
+title: Change ApiAware visibility for products association in CustomerWishlist
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `products` association ApiAware visibility in `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlist\CustomerWishlistDefinition`

--- a/src/Core/Checkout/Customer/Aggregate/CustomerWishlist/CustomerWishlistDefinition.php
+++ b/src/Core/Checkout/Customer/Aggregate/CustomerWishlist/CustomerWishlistDefinition.php
@@ -56,7 +56,7 @@ class CustomerWishlistDefinition extends EntityDefinition
             (new FkField('sales_channel_id', 'salesChannelId', SalesChannelDefinition::class))->addFlags(new Required()),
             (new CustomFields())->addFlags(new ApiAware()),
 
-            (new OneToManyAssociationField('products', CustomerWishlistProductDefinition::class, 'customer_wishlist_id'))->addFlags(new CascadeDelete()),
+            (new OneToManyAssociationField('products', CustomerWishlistProductDefinition::class, 'customer_wishlist_id'))->addFlags(new ApiAware(), new CascadeDelete()),
             new ManyToOneAssociationField('customer', 'customer_id', CustomerDefinition::class, 'id', false),
             new ManyToOneAssociationField('salesChannel', 'sales_channel_id', SalesChannelDefinition::class, 'id', false),
         ]);

--- a/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
+++ b/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
@@ -1165,6 +1165,7 @@
     "customer_wishlist.id",
     "customer_wishlist.customerId",
     "customer_wishlist.customFields",
+    "customer_wishlist.products",
     "customer_wishlist.createdAt",
     "customer_wishlist.updatedAt",
     "customer_wishlist_product.id",


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently, it is not possible to access the `customer_wishlist_product` entity through the store api, although it contains ApiAware fields and could contain custom extensions of plugins.

### 2. What does this change do, exactly?
* Changed `products` association ApiAware visibility in `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlist\CustomerWishlistDefinition`

### 3. Describe each step to reproduce the issue or behaviour.
- Try to access the `customer_wishlist_product` entity via the store api

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
