### PR TITLE
fix: theme config inheritance for database child themes

### DIFF
--- a/changelog/_unreleased/2025-07-07-fixed-theme-config-inheritance.md
+++ b/changelog/_unreleased/2025-07-07-fixed-theme-config-inheritance.md
@@ -1,0 +1,6 @@
+---
+title: Fixed theme config inheritance for database child themes
+issue: #8591
+---
+# Storefront
+* Changed method `getConfigInheritance` in `\Shopware\Storefront\Theme\ConfigLoader\DatabaseConfigLoader` and `\Shopware\Storefront\Theme\ThemeMergedConfigBuilder` to properly resolve original parent theme config inheritance.

--- a/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
+++ b/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
@@ -300,16 +300,18 @@ class DatabaseConfigLoader extends AbstractConfigLoader
      */
     private function getConfigInheritance(ThemeEntity $mainTheme): array
     {
-        if (\is_array($mainTheme->getBaseConfig())
-            && \array_key_exists('configInheritance', $mainTheme->getBaseConfig())
-            && \is_array($mainTheme->getBaseConfig()['configInheritance'])
-            && !empty($mainTheme->getBaseConfig()['configInheritance'])
+        $baseConfig = $mainTheme->getBaseConfig();
+
+        if (\is_array($baseConfig)
+            && \array_key_exists('configInheritance', $baseConfig)
+            && \is_array($baseConfig['configInheritance'])
+            && !empty($baseConfig['configInheritance'])
         ) {
-            return $mainTheme->getBaseConfig()['configInheritance'];
+            return $baseConfig['configInheritance'];
         }
 
         // For database copies (child themes), inherit config from parent theme.
-        if ($mainTheme->getBaseConfig() === null
+        if ($baseConfig === null
             && $mainTheme->getTechnicalName() === null
             && $mainTheme->getParentThemeId() !== null) {
             $criteria = new Criteria();

--- a/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
+++ b/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
@@ -300,22 +300,39 @@ class DatabaseConfigLoader extends AbstractConfigLoader
      */
     private function getConfigInheritance(ThemeEntity $mainTheme): array
     {
-        if (!\is_array($mainTheme->getBaseConfig())) {
-            return [];
+        if (\is_array($mainTheme->getBaseConfig())
+            && \array_key_exists('configInheritance', $mainTheme->getBaseConfig())
+            && \is_array($mainTheme->getBaseConfig()['configInheritance'])
+            && !empty($mainTheme->getBaseConfig()['configInheritance'])
+        ) {
+            return $mainTheme->getBaseConfig()['configInheritance'];
         }
 
-        if (!\array_key_exists('configInheritance', $mainTheme->getBaseConfig())) {
-            return [];
+        // For database copies (child themes), inherit config from parent theme.
+        if ($mainTheme->getBaseConfig() === null && 
+            $mainTheme->getTechnicalName() === null && 
+            $mainTheme->getParentThemeId() !== null) {
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('id', $mainTheme->getParentThemeId()));
+
+            $parentTheme = $this->themeRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
+
+            if ($parentTheme instanceof ThemeEntity) {
+                $parentConfigInheritance = $this->getConfigInheritance($parentTheme);
+                if (!empty($parentConfigInheritance)) {
+                    return $parentConfigInheritance;
+                }
+            }
         }
 
-        if (!\is_array($mainTheme->getBaseConfig()['configInheritance'])) {
-            return [];
+        // Fallback: ensure every theme (except base theme) inherits from Storefront by default
+        if ($mainTheme->getTechnicalName() !== StorefrontPluginRegistry::BASE_THEME_NAME) {
+            return [
+                '@' . StorefrontPluginRegistry::BASE_THEME_NAME,
+            ];
         }
 
-        if (empty($mainTheme->getBaseConfig()['configInheritance'])) {
-            return [];
-        }
-
-        return $mainTheme->getBaseConfig()['configInheritance'];
+        return [];
     }
 }

--- a/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
+++ b/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
@@ -309,9 +309,9 @@ class DatabaseConfigLoader extends AbstractConfigLoader
         }
 
         // For database copies (child themes), inherit config from parent theme.
-        if ($mainTheme->getBaseConfig() === null && 
-            $mainTheme->getTechnicalName() === null && 
-            $mainTheme->getParentThemeId() !== null) {
+        if ($mainTheme->getBaseConfig() === null
+            && $mainTheme->getTechnicalName() === null
+            && $mainTheme->getParentThemeId() !== null) {
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('id', $mainTheme->getParentThemeId()));
 

--- a/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
+++ b/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
@@ -312,7 +312,6 @@ class DatabaseConfigLoader extends AbstractConfigLoader
         if ($mainTheme->getBaseConfig() === null && 
             $mainTheme->getTechnicalName() === null && 
             $mainTheme->getParentThemeId() !== null) {
-
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('id', $mainTheme->getParentThemeId()));
 

--- a/src/Storefront/Theme/ThemeMergedConfigBuilder.php
+++ b/src/Storefront/Theme/ThemeMergedConfigBuilder.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\Exception\InvalidThemeConfigException;
 use Shopware\Storefront\Theme\Exception\ThemeException;
-use Shopware\Storefront\Theme\ThemeEntity;
 
 use function Symfony\Component\String\u;
 

--- a/src/Storefront/Theme/ThemeMergedConfigBuilder.php
+++ b/src/Storefront/Theme/ThemeMergedConfigBuilder.php
@@ -6,10 +6,12 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\Exception\InvalidThemeConfigException;
 use Shopware\Storefront\Theme\Exception\ThemeException;
+use Shopware\Storefront\Theme\ThemeEntity;
 
 use function Symfony\Component\String\u;
 
@@ -279,6 +281,25 @@ class ThemeMergedConfigBuilder
             return $mainTheme->getBaseConfig()['configInheritance'];
         }
 
+        // For database copies (child themes), inherit config from parent theme.
+        if ($mainTheme->getBaseConfig() === null && 
+            $mainTheme->getTechnicalName() === null && 
+            $mainTheme->getParentThemeId() !== null) {
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('id', $mainTheme->getParentThemeId()));
+
+            $parentTheme = $this->themeRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
+
+            if ($parentTheme instanceof ThemeEntity) {
+                $parentConfigInheritance = $this->getConfigInheritance($parentTheme);
+                if (!empty($parentConfigInheritance)) {
+                    return $parentConfigInheritance;
+                }
+            }
+        }
+
+        // Fallback: ensure every theme (except base theme) inherits from Storefront by default
         if ($mainTheme->getTechnicalName() !== StorefrontPluginRegistry::BASE_THEME_NAME) {
             return [
                 '@' . StorefrontPluginRegistry::BASE_THEME_NAME,
@@ -496,7 +517,7 @@ class ThemeMergedConfigBuilder
     {
         $custom = $custom ?? null;
 
-        if ($custom && \is_array($custom['options'])) {
+        if ($custom && isset($custom['options']) && \is_array($custom['options'])) {
             foreach ($custom['options'] as $optionIndex => &$option) {
                 $option['labelSnippetKey'] = $this->buildSnippetKey(
                     $themeTechnicalName,

--- a/src/Storefront/Theme/ThemeMergedConfigBuilder.php
+++ b/src/Storefront/Theme/ThemeMergedConfigBuilder.php
@@ -273,16 +273,18 @@ class ThemeMergedConfigBuilder
      */
     private function getConfigInheritance(ThemeEntity $mainTheme): array
     {
-        if (\is_array($mainTheme->getBaseConfig())
-            && \array_key_exists('configInheritance', $mainTheme->getBaseConfig())
-            && \is_array($mainTheme->getBaseConfig()['configInheritance'])
-            && !empty($mainTheme->getBaseConfig()['configInheritance'])
+        $baseConfig = $mainTheme->getBaseConfig();
+
+        if (\is_array($baseConfig)
+            && \array_key_exists('configInheritance', $baseConfig)
+            && \is_array($baseConfig['configInheritance'])
+            && !empty($baseConfig['configInheritance'])
         ) {
-            return $mainTheme->getBaseConfig()['configInheritance'];
+            return $baseConfig['configInheritance'];
         }
 
         // For database copies (child themes), inherit config from parent theme.
-        if ($mainTheme->getBaseConfig() === null
+        if ($baseConfig === null
             && $mainTheme->getTechnicalName() === null
             && $mainTheme->getParentThemeId() !== null) {
             $criteria = new Criteria();

--- a/src/Storefront/Theme/ThemeMergedConfigBuilder.php
+++ b/src/Storefront/Theme/ThemeMergedConfigBuilder.php
@@ -282,9 +282,9 @@ class ThemeMergedConfigBuilder
         }
 
         // For database copies (child themes), inherit config from parent theme.
-        if ($mainTheme->getBaseConfig() === null && 
-            $mainTheme->getTechnicalName() === null && 
-            $mainTheme->getParentThemeId() !== null) {
+        if ($mainTheme->getBaseConfig() === null
+            && $mainTheme->getTechnicalName() === null
+            && $mainTheme->getParentThemeId() !== null) {
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('id', $mainTheme->getParentThemeId()));
 

--- a/src/Storefront/Theme/ThemeMergedConfigBuilder.php
+++ b/src/Storefront/Theme/ThemeMergedConfigBuilder.php
@@ -285,7 +285,6 @@ class ThemeMergedConfigBuilder
         if ($mainTheme->getBaseConfig() === null && 
             $mainTheme->getTechnicalName() === null && 
             $mainTheme->getParentThemeId() !== null) {
-
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('id', $mainTheme->getParentThemeId()));
 

--- a/src/Storefront/Theme/ThemeMergedConfigBuilder.php
+++ b/src/Storefront/Theme/ThemeMergedConfigBuilder.php
@@ -110,7 +110,18 @@ class ThemeMergedConfigBuilder
             }
         }
 
-        $themeConfig['themeTechnicalName'] = $theme->getTechnicalName();
+        // Check if the theme is a database copy of a physical theme.
+        // If so, use the technical name of the parent theme.
+        if ($theme->getTechnicalName() === null && $theme->getParentThemeId() !== null) {
+            $parentTheme = $themes->filter(fn (ThemeEntity $themeEntry) => $themeEntry->getId() === $theme->getParentThemeId())->first();
+
+            if ($parentTheme instanceof ThemeEntity) {
+                $themeConfig['themeTechnicalName'] = $parentTheme->getTechnicalName();
+            }
+        } else {
+            $themeConfig['themeTechnicalName'] = $theme->getTechnicalName();
+        }
+
         $themeConfig['fields'] = $configFields;
         $themeConfig['currentFields'] = [];
         $themeConfig['baseThemeFields'] = [];

--- a/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -300,7 +300,7 @@ class DatabaseConfigLoaderTest extends TestCase
             ],
         ];
 
-        yield 'Test overwrite' => [
+        yield 'Test override' => [
             'child',
             [
                 'base' => [
@@ -337,6 +337,30 @@ class DatabaseConfigLoaderTest extends TestCase
             ],
             [
                 'base-field-1' => '#000',
+            ],
+        ];
+
+        yield 'Test multiple inheritance' => [
+            'child',
+            [
+                'base' => [
+                    'base-field-1' => self::field('#000'),
+                ],
+                'parent' => [
+                    'base-field-1' => self::field('#fff'),
+                    'parent-field-1' => self::field('#000'),
+                    'parent-field-2' => self::fieldUntyped(900),
+                ],
+                'child' => [
+                    'parent-field-2' => self::fieldUntyped(500),
+                    'child-field-1' => self::field('#000'),
+                ],
+            ],
+            [
+                'base-field-1' => '#fff',
+                'parent-field-1' => '#000',
+                'parent-field-2' => 500,
+                'child-field-1' => '#000',
             ],
         ];
     }

--- a/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
+++ b/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
@@ -147,7 +147,6 @@ class ThemeMergedConfigBuilderTest extends TestCase
             }
         );
 
-
         $storefrontPlugin = new StorefrontPluginConfiguration('Test');
         $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
 

--- a/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
+++ b/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
@@ -111,41 +111,7 @@ class ThemeMergedConfigBuilderTest extends TestCase
         ?array $expected = null,
         ?array $expectedStructured = null,
     ): void {
-        // Set up the mock to handle both the main search and the parent theme search
-        $this->themeRepositoryMock->method('search')->willReturnCallback(
-            function (Criteria $criteria) use ($themeCollection) {
-                // If the criteria has a filter for a specific ID, find that theme
-                $filters = $criteria->getFilters();
-                foreach ($filters as $filter) {
-                    if ($filter instanceof \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter
-                        && $filter->getField() === 'id') {
-                        $searchId = (string) $filter->getValue();
-                        $foundTheme = $themeCollection->get($searchId);
-
-                        if ($foundTheme) {
-                            return new EntitySearchResult(
-                                'theme',
-                                1,
-                                new ThemeCollection([$foundTheme]),
-                                null,
-                                $criteria,
-                                $this->context
-                            );
-                        }
-                    }
-                }
-
-                // Default: return the full collection for the main search
-                return new EntitySearchResult(
-                    'theme',
-                    $themeCollection->count(),
-                    $themeCollection,
-                    null,
-                    $criteria,
-                    $this->context
-                );
-            }
-        );
+        $this->mockThemeRepositorySearch($themeCollection);
 
         $storefrontPlugin = new StorefrontPluginConfiguration('Test');
         $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
@@ -196,6 +162,32 @@ class ThemeMergedConfigBuilderTest extends TestCase
         ?array $expected = null,
         ?array $expectedStructured = null,
     ): void {
+        $this->mockThemeRepositorySearch($themeCollection);
+
+        $storefrontPlugin = new StorefrontPluginConfiguration('Test');
+        $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
+
+        $this->storefrontPluginRegistryMock->method('getConfigurations')->willReturn(
+            new StorefrontPluginConfigurationCollection(
+                [
+                    $storefrontPlugin,
+                ]
+            )
+        );
+
+        $config = $this->mergedConfigBuilder->getThemeConfigurationFieldStructure($ids['themeId'], $this->context, true);
+
+        static::assertArrayHasKey('tabs', $config);
+        static::assertArrayHasKey('default', $config['tabs']);
+        static::assertArrayHasKey('blocks', $config['tabs']['default']);
+        static::assertEquals($expectedStructured, $config);
+    }
+
+    /**
+     * @param ThemeCollection $themeCollection
+     */
+    private function mockThemeRepositorySearch(ThemeCollection $themeCollection): void
+    {
         // Set up the mock to handle both the main search and the parent theme search
         $this->themeRepositoryMock->method('search')->willReturnCallback(
             function (Criteria $criteria) use ($themeCollection) {
@@ -231,23 +223,5 @@ class ThemeMergedConfigBuilderTest extends TestCase
                 );
             }
         );
-
-        $storefrontPlugin = new StorefrontPluginConfiguration('Test');
-        $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
-
-        $this->storefrontPluginRegistryMock->method('getConfigurations')->willReturn(
-            new StorefrontPluginConfigurationCollection(
-                [
-                    $storefrontPlugin,
-                ]
-            )
-        );
-
-        $config = $this->mergedConfigBuilder->getThemeConfigurationFieldStructure($ids['themeId'], $this->context, true);
-
-        static::assertArrayHasKey('tabs', $config);
-        static::assertArrayHasKey('default', $config['tabs']);
-        static::assertArrayHasKey('blocks', $config['tabs']['default']);
-        static::assertEquals($expectedStructured, $config);
     }
 }

--- a/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
+++ b/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
@@ -183,9 +183,6 @@ class ThemeMergedConfigBuilderTest extends TestCase
         static::assertEquals($expectedStructured, $config);
     }
 
-    /**
-     * @param ThemeCollection $themeCollection
-     */
     private function mockThemeRepositorySearch(ThemeCollection $themeCollection): void
     {
         // Set up the mock to handle both the main search and the parent theme search

--- a/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
+++ b/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
@@ -111,16 +111,42 @@ class ThemeMergedConfigBuilderTest extends TestCase
         ?array $expected = null,
         ?array $expectedStructured = null,
     ): void {
-        $this->themeRepositoryMock->method('search')->willReturn(
-            new EntitySearchResult(
-                'theme',
-                1,
-                $themeCollection,
-                null,
-                new Criteria(),
-                $this->context
-            )
+        // Set up the mock to handle both the main search and the parent theme search
+        $this->themeRepositoryMock->method('search')->willReturnCallback(
+            function (Criteria $criteria) use ($themeCollection) {
+                // If the criteria has a filter for a specific ID, find that theme
+                $filters = $criteria->getFilters();
+                foreach ($filters as $filter) {
+                    if ($filter instanceof \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter
+                        && $filter->getField() === 'id') {
+                        $searchId = (string) $filter->getValue();
+                        $foundTheme = $themeCollection->get($searchId);
+
+                        if ($foundTheme) {
+                            return new EntitySearchResult(
+                                'theme',
+                                1,
+                                new ThemeCollection([$foundTheme]),
+                                null,
+                                $criteria,
+                                $this->context
+                            );
+                        }
+                    }
+                }
+
+                // Default: return the full collection for the main search
+                return new EntitySearchResult(
+                    'theme',
+                    $themeCollection->count(),
+                    $themeCollection,
+                    null,
+                    $criteria,
+                    $this->context
+                );
+            }
         );
+
 
         $storefrontPlugin = new StorefrontPluginConfiguration('Test');
         $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
@@ -171,15 +197,40 @@ class ThemeMergedConfigBuilderTest extends TestCase
         ?array $expected = null,
         ?array $expectedStructured = null,
     ): void {
-        $this->themeRepositoryMock->method('search')->willReturn(
-            new EntitySearchResult(
-                'theme',
-                1,
-                $themeCollection,
-                null,
-                new Criteria(),
-                $this->context
-            )
+        // Set up the mock to handle both the main search and the parent theme search
+        $this->themeRepositoryMock->method('search')->willReturnCallback(
+            function (Criteria $criteria) use ($themeCollection) {
+                // If the criteria has a filter for a specific ID, find that theme
+                $filters = $criteria->getFilters();
+                foreach ($filters as $filter) {
+                    if ($filter instanceof \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter
+                        && $filter->getField() === 'id') {
+                        $searchId = (string) $filter->getValue();
+                        $foundTheme = $themeCollection->get($searchId);
+
+                        if ($foundTheme) {
+                            return new EntitySearchResult(
+                                'theme',
+                                1,
+                                new ThemeCollection([$foundTheme]),
+                                null,
+                                $criteria,
+                                $this->context
+                            );
+                        }
+                    }
+                }
+
+                // Default: return the full collection for the main search
+                return new EntitySearchResult(
+                    'theme',
+                    $themeCollection->count(),
+                    $themeCollection,
+                    null,
+                    $criteria,
+                    $this->context
+                );
+            }
         );
 
         $storefrontPlugin = new StorefrontPluginConfiguration('Test');

--- a/tests/unit/Storefront/Theme/fixtures/ThemeFixtures.php
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeFixtures.php
@@ -816,10 +816,10 @@ class ThemeFixtures
                 'currentFields' => self::getExtractedCurrentFields9(),
                 'baseThemeFields' => self::getExtractedBaseThemeFields9(),
                 'name' => 'test',
-                'themeTechnicalName' => null,
+                'themeTechnicalName' => 'Test',
             ],
             'expectedStructured' => [
-                'tabs' => self::getExtractedTabs10(),
+                'tabs' => self::getExtractedTabs11(),
             ],
         ];
     }
@@ -2809,6 +2809,64 @@ class ThemeFixtures
                                         'custom' => null,
                                         'fullWidth' => null,
                                     ],
+                                    'parent-custom-config' => [
+                                        'labelSnippetKey' => 'sw-theme.test.default.default.default.parent-custom-config.label',
+                                        'helpTextSnippetKey' => 'sw-theme.test.default.default.default.parent-custom-config.helpText',
+                                        'type' => 'int',
+                                        'custom' => null,
+                                        'fullWidth' => null,
+                                    ],
+                                    'extend-parent-custom-config' => [
+                                        'labelSnippetKey' => 'sw-theme.test.default.default.default.extend-parent-custom-config.label',
+                                        'helpTextSnippetKey' => 'sw-theme.test.default.default.default.extend-parent-custom-config.helpText',
+                                        'type' => 'int',
+                                        'custom' => null,
+                                        'fullWidth' => null,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function getExtractedTabs11(): array
+    {
+        return [
+            'default' => [
+                'labelSnippetKey' => 'sw-theme.test.default.label',
+                'blocks' => [
+                    'themeColors' => [
+                        'labelSnippetKey' => 'sw-theme.test.default.themeColors.label',
+                        'sections' => self::getExtractedSectionsThemeColors(),
+                    ],
+                    'statusColors' => [
+                        'labelSnippetKey' => 'sw-theme.test.default.statusColors.label',
+                        'sections' => self::getExtractedSectionsStatusColors(),
+                    ],
+                    'typography' => [
+                        'labelSnippetKey' => 'sw-theme.test.default.typography.label',
+                        'sections' => self::getExtractedSectionsTypography(),
+                    ],
+                    'eCommerce' => [
+                        'labelSnippetKey' => 'sw-theme.test.default.eCommerce.label',
+                        'sections' => self::getExtractedSectionsECommerce(),
+                    ],
+                    'media' => [
+                        'labelSnippetKey' => 'sw-theme.test.default.media.label',
+                        'sections' => self::getExtractedSectionsMediaNoHelpTexts(),
+                    ],
+                    'default' => [
+                        'labelSnippetKey' => 'sw-theme.test.default.default.label',
+                        'sections' => [
+                            'default' => [
+                                'labelSnippetKey' => 'sw-theme.test.default.default.default.label',
+                                'fields' => [
                                     'parent-custom-config' => [
                                         'labelSnippetKey' => 'sw-theme.test.default.default.default.parent-custom-config.label',
                                         'helpTextSnippetKey' => 'sw-theme.test.default.default.default.parent-custom-config.helpText',

--- a/tests/unit/Storefront/Theme/fixtures/ThemeFixtures.php
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeFixtures.php
@@ -204,7 +204,10 @@ class ThemeFixtures
         $themeId = Uuid::randomHex();
         $parentThemeId = Uuid::randomHex();
         $baseThemeId = Uuid::randomHex();
+        $databaseThemeId = Uuid::randomHex();
 
+        // Test Case 1: Theme with parent theme inheritance and custom field extensions
+        // Tests: Theme inherits from parent theme, has custom field extensions with labels and help texts.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -293,6 +296,8 @@ class ThemeFixtures
             ],
         ];
 
+        // Test Case 2: Theme with parent theme inheritance and basic configuration
+        // Tests: Theme inherits from parent theme with basic config, has labels and help texts.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -356,6 +361,8 @@ class ThemeFixtures
             ],
         ];
 
+        // Test Case 3: Theme with custom fields and help texts
+        // Tests: Theme with custom fields defined in baseConfig and help texts.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -420,6 +427,8 @@ class ThemeFixtures
             ],
         ];
 
+        // Test Case 4: Theme with minimal configuration
+        // Tests: Theme with only basic configuration and configValues, no baseConfig.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -468,6 +477,8 @@ class ThemeFixtures
             ],
         ];
 
+        // Test Case 5: Theme with parent theme having false fields configuration
+        // Tests: Parent theme with baseConfig.fields set to false.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -519,6 +530,8 @@ class ThemeFixtures
             ],
         ];
 
+        // Test Case 6: Theme with parent theme having empty fields configuration
+        // Tests: Parent theme with baseConfig.fields set to empty array.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -570,6 +583,8 @@ class ThemeFixtures
             ],
         ];
 
+        // Test Case 7: Theme without parent theme
+        // Tests: Theme directly inheriting from base theme without parent theme.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -610,6 +625,8 @@ class ThemeFixtures
             ],
         ];
 
+        // Test Case 8: Theme with configValues in base theme
+        // Tests: Theme with empty configValues but base theme has configValues.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -651,6 +668,8 @@ class ThemeFixtures
             ],
         ];
 
+        // Test Case 9: Theme with custom field overrides and select options
+        // Tests: Theme with custom field overrides including select component with options.
         yield [
             'ids' => [
                 'themeId' => $themeId,
@@ -711,6 +730,96 @@ class ThemeFixtures
             ],
             'expectedStructured' => [
                 'tabs' => self::getExtractedTabsNameTheme(),
+            ],
+        ];
+
+        // Test Case 10: Database child theme
+        // Tests: Database child theme with parent theme inheritance and custom field extensions.
+        yield [
+            'ids' => [
+                'themeId' => $databaseThemeId,
+                'physicalThemeId' => $themeId,
+                'parentThemeId' => $parentThemeId,
+                'baseThemeId' => $baseThemeId,
+            ],
+            'themeCollection' => new ThemeCollection(
+                [
+                    (new ThemeEntity())->assign(
+                        [
+                            'id' => $databaseThemeId,
+                            '_uniqueIdentifier' => $databaseThemeId,
+                            'technicalName' => null, // Database child themes don't have a technical name.
+                            'parentThemeId' => $themeId,
+                            'salesChannels' => new SalesChannelCollection(),
+                            'configValues' => [
+                                'sw-color-brand-primary' => ['value' => '#db0f80'],
+                            ],
+                        ]
+                    ),
+                    (new ThemeEntity())->assign(
+                        [
+                            'id' => $themeId,
+                            '_uniqueIdentifier' => $themeId,
+                            'technicalName' => 'Test',
+                            'parentThemeId' => $parentThemeId,
+                            'baseConfig' => [
+                                'configInheritance' => [
+                                    '@ParentTheme',
+                                ],
+                                'config' => self::getThemeJsonConfig(),
+                                'fields' => [
+                                    'extend-parent-custom-config' => [
+                                        'type' => 'int',
+                                        'value' => '20',
+                                        'editable' => true,
+                                    ],
+                                ],
+                            ],
+                            'configValues' => [
+                                'parent-custom-config' => ['value' => '40'],
+                            ],
+                        ]
+                    ),
+                    (new ThemeEntity())->assign(
+                        [
+                            'id' => $parentThemeId,
+                            'technicalName' => 'ParentTheme',
+                            'parentThemeId' => $baseThemeId,
+                            '_uniqueIdentifier' => $parentThemeId,
+                            'baseConfig' => [
+                                'configInheritance' => [
+                                    '@Storefront',
+                                ],
+                                'fields' => [
+                                    'parent-custom-config' => [
+                                        'type' => 'int',
+                                        'value' => '20',
+                                        'editable' => true,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ),
+                    (new ThemeEntity())->assign(
+                        [
+                            'id' => $baseThemeId,
+                            'technicalName' => StorefrontPluginRegistry::BASE_THEME_NAME,
+                            '_uniqueIdentifier' => $baseThemeId,
+                        ]
+                    ),
+                ]
+            ),
+            'expected' => [
+                'fields' => self::getExtractedFields11(),
+                'configInheritance' => self::getExtractedConfigInheritance(),
+                'config' => self::getExtractedConfig1(),
+                'currentFields' => self::getExtractedCurrentFields9(),
+                'baseThemeFields' => self::getExtractedBaseThemeFields9(),
+                'name' => 'test',
+                'themeTechnicalName' => null,
+            ],
+            'expectedStructured' => [
+                'tabs' => self::getExtractedTabs10(),
             ],
         ];
     }
@@ -2263,6 +2372,22 @@ class ThemeFixtures
     /**
      * @return array<string, mixed>
      */
+    private static function getExtractedFields11(): array
+    {
+        $fields = self::getExtractedFields7();
+
+        $fields['parent-custom-config']['value'] = '40';
+        $fields['sw-color-brand-primary']['value'] = '#db0f80';
+
+        unset($fields['test']);
+        unset($fields['test-something-with-options']);
+
+        return $fields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     private static function getExtractedCurrentFields5(): array
     {
         return [...self::getExtractedCurrentFields1(), ...[
@@ -2397,6 +2522,105 @@ class ThemeFixtures
     /**
      * @return array<string, mixed>
      */
+    private static function getExtractedCurrentFields9(): array
+    {
+        $currentFields = [
+            'sw-color-brand-primary' => [
+                'isInherited' => false,
+                'value' => '#db0f80',
+            ],
+            'sw-color-brand-secondary' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-border-color' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-background-color' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-success' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-info' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-warning' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-danger' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-font-family-base' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-text-color' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-font-family-headline' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-headline-color' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-price' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-buy-button' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-buy-button-text' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-desktop' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-tablet' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-mobile' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-share' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-favicon' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'parent-custom-config' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'extend-parent-custom-config' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+        ];
+
+        return $currentFields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     private static function getExtractedBaseThemeFields5(): array
     {
         return [...self::getExtractedBaseThemeFields1(), ...[
@@ -2514,6 +2738,28 @@ class ThemeFixtures
         $baseThemeFields['test'] = [
             'isInherited' => true,
             'value' => null,
+        ];
+
+        unset($baseThemeFields['test-something-with-options']);
+
+        return $baseThemeFields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function getExtractedBaseThemeFields9(): array
+    {
+        $baseThemeFields = self::getExtractedBaseThemeFields6();
+
+        $baseThemeFields['parent-custom-config'] = [
+            'isInherited' => false,
+            'value' => '40',
+        ];
+
+        $baseThemeFields['extend-parent-custom-config'] = [
+            'isInherited' => false,
+            'value' => '20',
         ];
 
         unset($baseThemeFields['test-something-with-options']);


### PR DESCRIPTION
Fixes: #8591

### 1. Why is this change necessary?
The theme config inheritance setting is not resolved correctly for database child themes, resulting in a broken theme config.

### 2. What does this change do, exactly?
Fix the corresponding config inheritance resolution to iterate recursively through parent themes to apply the correct theme config settings. 

### 3. Describe each step to reproduce the issue or behaviour.

Test app themes and the description to reproduce this behaviour can be found in the issue: [#8591](https://github.com/shopware/shopware/issues/8591)
