### PR TITLE
fix: Router generates routes based on current request

### DIFF
--- a/changelog/_unreleased/2025-07-07-generate-routes-base-on-current-request.md
+++ b/changelog/_unreleased/2025-07-07-generate-routes-base-on-current-request.md
@@ -1,0 +1,5 @@
+---
+title: Generate routes based on current request
+---
+# Storefront
+* Changed `\Shopware\Storefront\Framework\Routing\Router` to generate routes based on the current request, instead of main request, thus solving issues when the domain changes between sub requests. 

--- a/src/Storefront/Framework/Routing/Router.php
+++ b/src/Storefront/Framework/Routing/Router.php
@@ -168,7 +168,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     private function getSalesChannelBaseUrl(): string
     {
-        $request = $this->requestStack->getMainRequest();
+        $request = $this->requestStack->getCurrentRequest();
         if (!$request) {
             return '';
         }
@@ -184,7 +184,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     private function getBasePath(): string
     {
-        $request = $this->requestStack->getMainRequest();
+        $request = $this->requestStack->getCurrentRequest();
         if (!$request) {
             return '';
         }


### PR DESCRIPTION
When you have sub requests that change the domain the router might generate the wrong URLs.

the case we observed was the following:

SystemCheckApiRequest: -> Api domain
Homepage Sub-Request: -> on sales channel specific (sub) domain
ESI header and footer requests: -> here the URL/path was generated based on the first API request, however it needs to be based on the homepage request
