### PR TITLE
feat: Add `buildConfig` method to `sw-flow-mail-send-modal`

### DIFF
--- a/changelog/_unreleased/2025-07-07-add-mail-modal-build-config.md
+++ b/changelog/_unreleased/2025-07-07-add-mail-modal-build-config.md
@@ -1,0 +1,8 @@
+---
+title: Add `buildConfig` method to `sw-flow-mail-send-modal`
+author: Fayti1703
+author_email: fayti1703@protonmail.com
+author_github: @Fayti1703
+---
+# Administration
+*  Added new `buildConfig` method to `sw-flow-mail-send-modal` component to allow easier and more compatible overriding.

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-mail-send-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-mail-send-modal/index.js
@@ -313,6 +313,18 @@ export default {
             return invalidItemIndex >= 0;
         },
 
+        buildConfig() {
+            return {
+                mailTemplateId: this.mailTemplateId,
+                documentTypeIds: this.documentTypeIds,
+                recipient: {
+                    type: this.mailRecipient,
+                    data: this.getRecipientData(),
+                },
+                replyTo: this.replyTo,
+            }
+        },
+
         onAddAction() {
             this.mailTemplateIdError = this.mailTemplateError(this.mailTemplateId);
             if (this.showReplyToField) {
@@ -328,15 +340,7 @@ export default {
 
             const sequence = {
                 ...this.sequence,
-                config: {
-                    mailTemplateId: this.mailTemplateId,
-                    documentTypeIds: this.documentTypeIds,
-                    recipient: {
-                        type: this.mailRecipient,
-                        data: this.getRecipientData(),
-                    },
-                    replyTo: this.replyTo,
-                },
+                config: this.buildConfig(),
             };
 
             this.$nextTick(() => {


### PR DESCRIPTION
### 1. Why is this change necessary?

Plugins that add new functionality to the "Send Mail" flow action (e.g. by listening to the `FlowSendMailActionEvent`) that requires additional configuration currently cannot be made compatible with each other.
This is because the only way to modify the action's configuration is to duplicate the entire `onAddAction` method and modify the object literal assigned to `config`.

### 2. What does this change do, exactly?

This change moves the `config` object literal into a new `buildConfig` method, which can be easily and stackably overridden using the existing `$super` pattern.

### 3. Describe each step to reproduce the issue or behaviour.

N/A

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them


I'd like to request a backport of this change to 6.6.x.x, if possible.