### PR TITLE
fix: theme config inheritance for database child themes (6.6.x)

### DIFF
--- a/changelog/_unreleased/2025-07-08-fix-theme-config-inheritance.md
+++ b/changelog/_unreleased/2025-07-08-fix-theme-config-inheritance.md
@@ -1,0 +1,6 @@
+---
+title: Fixed theme config inheritance for database child themes
+issue: #8591
+---
+# Storefront
+* Changed method `getConfigInheritance` in `\Shopware\Storefront\Theme\ConfigLoader\DatabaseConfigLoader` and `\Shopware\Storefront\Theme\ThemeService` to properly resolve original parent theme config inheritance.

--- a/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
+++ b/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
@@ -301,22 +301,40 @@ class DatabaseConfigLoader extends AbstractConfigLoader
      */
     private function getConfigInheritance(ThemeEntity $mainTheme): array
     {
-        if (!\is_array($mainTheme->getBaseConfig())) {
-            return [];
+        $baseConfig = $mainTheme->getBaseConfig();
+
+        if (\is_array($baseConfig)
+            && \array_key_exists('configInheritance', $baseConfig)
+            && \is_array($baseConfig['configInheritance'])
+            && !empty($baseConfig['configInheritance'])
+        ) {
+            return $baseConfig['configInheritance'];
         }
 
-        if (!\array_key_exists('configInheritance', $mainTheme->getBaseConfig())) {
-            return [];
+        // For database copies (child themes), inherit config from parent theme.
+        if ($baseConfig === null
+            && $mainTheme->getTechnicalName() === null
+            && $mainTheme->getParentThemeId() !== null) {
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('id', $mainTheme->getParentThemeId()));
+
+            $parentTheme = $this->themeRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
+
+            if ($parentTheme instanceof ThemeEntity) {
+                $parentConfigInheritance = $this->getConfigInheritance($parentTheme);
+                if (!empty($parentConfigInheritance)) {
+                    return $parentConfigInheritance;
+                }
+            }
         }
 
-        if (!\is_array($mainTheme->getBaseConfig()['configInheritance'])) {
-            return [];
+        // Fallback: ensure every theme (except base theme) inherits from Storefront by default
+        if ($mainTheme->getTechnicalName() !== StorefrontPluginRegistry::BASE_THEME_NAME) {
+            return [
+                '@' . StorefrontPluginRegistry::BASE_THEME_NAME,
+            ];
         }
 
-        if (empty($mainTheme->getBaseConfig()['configInheritance'])) {
-            return [];
-        }
-
-        return $mainTheme->getBaseConfig()['configInheritance'];
+        return [];
     }
 }

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -424,14 +425,34 @@ class ThemeService implements ResetInterface
      */
     private function getConfigInheritance(ThemeEntity $mainTheme): array
     {
-        if (\is_array($mainTheme->getBaseConfig())
-            && \array_key_exists('configInheritance', $mainTheme->getBaseConfig())
-            && \is_array($mainTheme->getBaseConfig()['configInheritance'])
-            && !empty($mainTheme->getBaseConfig()['configInheritance'])
+        $baseConfig = $mainTheme->getBaseConfig();
+
+        if (\is_array($baseConfig)
+            && \array_key_exists('configInheritance', $baseConfig)
+            && \is_array($baseConfig['configInheritance'])
+            && !empty($baseConfig['configInheritance'])
         ) {
-            return $mainTheme->getBaseConfig()['configInheritance'];
+            return $baseConfig['configInheritance'];
         }
 
+        // For database copies (child themes), inherit config from parent theme.
+        if ($baseConfig === null
+            && $mainTheme->getTechnicalName() === null
+            && $mainTheme->getParentThemeId() !== null) {
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('id', $mainTheme->getParentThemeId()));
+
+            $parentTheme = $this->themeRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
+
+            if ($parentTheme instanceof ThemeEntity) {
+                $parentConfigInheritance = $this->getConfigInheritance($parentTheme);
+                if (!empty($parentConfigInheritance)) {
+                    return $parentConfigInheritance;
+                }
+            }
+        }
+
+        // Fallback: ensure every theme (except base theme) inherits from Storefront by default
         if ($mainTheme->getTechnicalName() !== StorefrontPluginRegistry::BASE_THEME_NAME) {
             return [
                 '@' . StorefrontPluginRegistry::BASE_THEME_NAME,

--- a/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -300,7 +300,7 @@ class DatabaseConfigLoaderTest extends TestCase
             ],
         ];
 
-        yield 'Test overwrite' => [
+        yield 'Test override' => [
             'child',
             [
                 'base' => [
@@ -337,6 +337,30 @@ class DatabaseConfigLoaderTest extends TestCase
             ],
             [
                 'base-field-1' => '#000',
+            ],
+        ];
+
+        yield 'Test multiple inheritance' => [
+            'child',
+            [
+                'base' => [
+                    'base-field-1' => self::field('#000'),
+                ],
+                'parent' => [
+                    'base-field-1' => self::field('#fff'),
+                    'parent-field-1' => self::field('#000'),
+                    'parent-field-2' => self::fieldUntyped(900),
+                ],
+                'child' => [
+                    'parent-field-2' => self::fieldUntyped(500),
+                    'child-field-1' => self::field('#000'),
+                ],
+            ],
+            [
+                'base-field-1' => '#fff',
+                'parent-field-1' => '#000',
+                'parent-field-2' => 500,
+                'child-field-1' => '#000',
             ],
         ];
     }

--- a/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -253,7 +253,7 @@ class DatabaseConfigLoaderTest extends TestCase
                 'active' => true,
                 'technicalName' => null,
                 'baseConfig' => null,
-            ]
+            ],
         ];
 
         $this->themeRepository->create($themes, Context::createDefaultContext());

--- a/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -238,8 +238,22 @@ class DatabaseConfigLoaderTest extends TestCase
                 'technicalName' => 'child',
                 'baseConfig' => [
                     'fields' => $config['child'] ?? [],
+                    'configInheritance' => [
+                        '@base',
+                        '@parent',
+                        '@child',
+                    ],
                 ],
             ],
+            [
+                'id' => $this->ids->get('database-copy'),
+                'parentThemeId' => $this->ids->get('child'),
+                'name' => 'database-copy',
+                'author' => 'test',
+                'active' => true,
+                'technicalName' => null,
+                'baseConfig' => null,
+            ]
         ];
 
         $this->themeRepository->create($themes, Context::createDefaultContext());
@@ -340,8 +354,8 @@ class DatabaseConfigLoaderTest extends TestCase
             ],
         ];
 
-        yield 'Test multiple inheritance' => [
-            'child',
+        yield 'Test multiple inheritance with database child' => [
+            'database-copy',
             [
                 'base' => [
                     'base-field-1' => self::field('#000'),

--- a/tests/unit/Storefront/Theme/ThemeServiceTest.php
+++ b/tests/unit/Storefront/Theme/ThemeServiceTest.php
@@ -535,16 +535,7 @@ class ThemeServiceTest extends TestCase
         ?array $expectedStructured = null,
         ?array $expectedStructuredNotTranslated = null
     ): void {
-        $this->themeRepositoryMock->method('search')->willReturn(
-            new EntitySearchResult(
-                'theme',
-                1,
-                $themeCollection,
-                null,
-                new Criteria(),
-                $this->context
-            )
-        );
+        $this->mockThemeRepositorySearch($themeCollection);
 
         $storefrontPlugin = new StorefrontPluginConfiguration('Test');
         $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
@@ -585,16 +576,7 @@ class ThemeServiceTest extends TestCase
             $expected = $expectedNotTranslated;
         }
 
-        $this->themeRepositoryMock->method('search')->willReturn(
-            new EntitySearchResult(
-                'theme',
-                1,
-                $themeCollection,
-                null,
-                new Criteria(),
-                $this->context
-            )
-        );
+        $this->mockThemeRepositorySearch($themeCollection);
 
         $storefrontPlugin = new StorefrontPluginConfiguration('Test');
         $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
@@ -631,16 +613,7 @@ class ThemeServiceTest extends TestCase
         ?array $expectedStructured = null,
         ?array $expectedStructuredNotTranslated = null
     ): void {
-        $this->themeRepositoryMock->method('search')->willReturn(
-            new EntitySearchResult(
-                'theme',
-                1,
-                $themeCollection,
-                null,
-                new Criteria(),
-                $this->context
-            )
-        );
+        $this->mockThemeRepositorySearch($themeCollection);
 
         $storefrontPlugin = new StorefrontPluginConfiguration('Test');
         $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
@@ -681,16 +654,7 @@ class ThemeServiceTest extends TestCase
             $expectedStructured = $expectedStructuredNotTranslated;
         }
 
-        $this->themeRepositoryMock->method('search')->willReturn(
-            new EntitySearchResult(
-                'theme',
-                1,
-                $themeCollection,
-                null,
-                new Criteria(),
-                $this->context
-            )
-        );
+        $this->mockThemeRepositorySearch($themeCollection);
 
         $storefrontPlugin = new StorefrontPluginConfiguration('Test');
         $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
@@ -1483,5 +1447,44 @@ class ThemeServiceTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    private function mockThemeRepositorySearch(ThemeCollection $themeCollection): void
+    {
+        // Set up the mock to handle both the main search and the parent theme search
+        $this->themeRepositoryMock->method('search')->willReturnCallback(
+            function (Criteria $criteria) use ($themeCollection) {
+                // If the criteria has a filter for a specific ID, find that theme
+                $filters = $criteria->getFilters();
+                foreach ($filters as $filter) {
+                    if ($filter instanceof \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter
+                        && $filter->getField() === 'id') {
+                        $searchId = (string) $filter->getValue();
+                        $foundTheme = $themeCollection->get($searchId);
+
+                        if ($foundTheme) {
+                            return new EntitySearchResult(
+                                'theme',
+                                1,
+                                new ThemeCollection([$foundTheme]),
+                                null,
+                                $criteria,
+                                $this->context
+                            );
+                        }
+                    }
+                }
+
+                // Default: return the full collection for the main search
+                return new EntitySearchResult(
+                    'theme',
+                    $themeCollection->count(),
+                    $themeCollection,
+                    null,
+                    $criteria,
+                    $this->context
+                );
+            }
+        );
     }
 }

--- a/tests/unit/Storefront/Theme/ThemeServiceTest.php
+++ b/tests/unit/Storefront/Theme/ThemeServiceTest.php
@@ -721,6 +721,7 @@ class ThemeServiceTest extends TestCase
         $themeId = Uuid::randomHex();
         $parentThemeId = Uuid::randomHex();
         $baseThemeId = Uuid::randomHex();
+        $databaseThemeId = Uuid::randomHex();
 
         return [
             [
@@ -1444,6 +1445,119 @@ class ThemeServiceTest extends TestCase
                 ],
                 'expectedStructuredNotTranslated' => [
                     'tabs' => ThemeFixtures::getExtractedTabs13(),
+                ],
+            ],
+            [
+                'ids' => [
+                    'themeId' => $databaseThemeId,
+                    'physicalThemeId' => $themeId,
+                    'parentThemeId' => $parentThemeId,
+                    'baseThemeId' => $baseThemeId,
+                ],
+                'themeCollection' => new ThemeCollection(
+                    [
+                        (new ThemeEntity())->assign(
+                            [
+                                'id' => $databaseThemeId,
+                                '_uniqueIdentifier' => $databaseThemeId,
+                                'technicalName' => null, // Database child themes don't have a technical name.
+                                'parentThemeId' => $themeId,
+                                'salesChannels' => new SalesChannelCollection(),
+                                'configValues' => [
+                                    'sw-color-brand-primary' => ['value' => '#db0f80'],
+                                ],
+                            ]
+                        ),
+                        (new ThemeEntity())->assign(
+                            [
+                                'id' => $themeId,
+                                '_uniqueIdentifier' => $themeId,
+                                'technicalName' => 'Test',
+                                'parentThemeId' => $parentThemeId,
+                                'baseConfig' => [
+                                    'configInheritance' => [
+                                        '@ParentTheme',
+                                    ],
+                                    'config' => ThemeFixtures::getThemeJsonConfig(),
+                                    'fields' => [
+                                        'extend-parent-custom-config' => [
+                                            'type' => 'int',
+                                            'value' => '20',
+                                            'editable' => true,
+                                            'label' => [
+                                                'de-DE' => 'DE',
+                                                'en-GB' => 'EN',
+                                            ],
+                                            'helpText' => [
+                                                'de-DE' => 'De Helptext',
+                                                'en-GB' => 'EN Helptext',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                'configValues' => [
+                                    'parent-custom-config' => ['value' => '40'],
+                                ],
+                            ]
+                        ),
+                        (new ThemeEntity())->assign(
+                            [
+                                'id' => $parentThemeId,
+                                'technicalName' => 'ParentTheme',
+                                'parentThemeId' => $baseThemeId,
+                                '_uniqueIdentifier' => $parentThemeId,
+                                'baseConfig' => [
+                                    'configInheritance' => [
+                                        '@Storefront',
+                                    ],
+                                    'fields' => [
+                                        'parent-custom-config' => [
+                                            'type' => 'int',
+                                            'value' => '20',
+                                            'editable' => true,
+                                            'label' => [
+                                                'de-DE' => 'DE',
+                                                'en-GB' => 'EN',
+                                            ],
+                                            'helpText' => [
+                                                'de-DE' => 'De Helptext',
+                                                'en-GB' => 'EN Helptext',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ),
+                        (new ThemeEntity())->assign(
+                            [
+                                'id' => $baseThemeId,
+                                'technicalName' => StorefrontPluginRegistry::BASE_THEME_NAME,
+                                '_uniqueIdentifier' => $baseThemeId,
+                            ]
+                        ),
+                    ]
+                ),
+                'expected' => [
+                    'fields' => ThemeFixtures::getExtractedFields13(),
+                    'configInheritance' => ThemeFixtures::getExtractedConfigInheritance(),
+                    'config' => ThemeFixtures::getExtractedConfig1(),
+                    'currentFields' => ThemeFixtures::getExtractedCurrentFields9(),
+                    'baseThemeFields' => ThemeFixtures::getExtractedBaseThemeFields9(),
+                    'blocks' => ThemeFixtures::getExtractedBlock1(),
+                ],
+                'expectedNotTranslated' => [
+                    'fields' => ThemeFixtures::getExtractedFields13(),
+                    'configInheritance' => ThemeFixtures::getExtractedConfigInheritance(),
+                    'config' => ThemeFixtures::getExtractedConfig1(),
+                    'currentFields' => ThemeFixtures::getExtractedCurrentFields9(),
+                    'baseThemeFields' => ThemeFixtures::getExtractedBaseThemeFields9(),
+                    'blocks' => ThemeFixtures::getExtractedBlock1(),
+                ],
+                'expectedStructured' => [
+                    'tabs' => ThemeFixtures::getExtractedTabs15(),
+                ],
+                'expectedStructuredNotTranslated' => [
+                    'tabs' => ThemeFixtures::getExtractedTabs14(),
                 ],
             ],
         ];

--- a/tests/unit/Storefront/Theme/fixtures/ThemeFixtures.php
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeFixtures.php
@@ -4554,7 +4554,7 @@ class ThemeFixtures
      */
     public static function getExtractedFields13(): array
     {
-        $fields = [ ...self::getExtractedFieldsSub1(), ...[
+        $fields = [...self::getExtractedFieldsSub1(), ...[
             'parent-custom-config' => [
                 'extensions' => [
                 ],

--- a/tests/unit/Storefront/Theme/fixtures/ThemeFixtures.php
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeFixtures.php
@@ -1008,7 +1008,6 @@ class ThemeFixtures
                         'en-GB' => 'Primary colour',
                         'de-DE' => 'Primärfarbe',
                     ],
-
                     'type' => 'color',
                     'value' => '#008490',
                     'editable' => true,
@@ -1021,7 +1020,6 @@ class ThemeFixtures
                         'en-GB' => 'Secondary colour',
                         'de-DE' => 'Sekundärfarbe',
                     ],
-
                     'type' => 'color',
                     'value' => '#526e7f',
                     'editable' => true,
@@ -1034,7 +1032,6 @@ class ThemeFixtures
                         'en-GB' => 'Border',
                         'de-DE' => 'Rahmen',
                     ],
-
                     'type' => 'color',
                     'value' => '#bcc1c7',
                     'editable' => true,
@@ -1047,7 +1044,6 @@ class ThemeFixtures
                         'en-GB' => 'Background',
                         'de-DE' => 'Hintergrund',
                     ],
-
                     'type' => 'color',
                     'value' => '#fff',
                     'editable' => true,
@@ -1060,7 +1056,6 @@ class ThemeFixtures
                         'en-GB' => 'Success',
                         'de-DE' => 'Erfolg',
                     ],
-
                     'type' => 'color',
                     'value' => '#3cc261',
                     'editable' => true,
@@ -1073,7 +1068,6 @@ class ThemeFixtures
                         'en-GB' => 'Information',
                         'de-DE' => 'Information',
                     ],
-
                     'type' => 'color',
                     'value' => '#26b6cf',
                     'editable' => true,
@@ -1086,7 +1080,6 @@ class ThemeFixtures
                         'en-GB' => 'Notice',
                         'de-DE' => 'Hinweis',
                     ],
-
                     'type' => 'color',
                     'value' => '#ffbd5d',
                     'editable' => true,
@@ -1099,7 +1092,6 @@ class ThemeFixtures
                         'en-GB' => 'Error',
                         'de-DE' => 'Fehler',
                     ],
-
                     'type' => 'color',
                     'value' => '#e52427',
                     'editable' => true,
@@ -1112,7 +1104,6 @@ class ThemeFixtures
                         'en-GB' => 'Fonttype text',
                         'de-DE' => 'Schriftart Text',
                     ],
-
                     'type' => 'fontFamily',
                     'value' => '\'Inter\', sans-serif',
                     'editable' => true,
@@ -1125,7 +1116,6 @@ class ThemeFixtures
                         'en-GB' => 'Text colour',
                         'de-DE' => 'Textfarbe',
                     ],
-
                     'type' => 'color',
                     'value' => '#4a545b',
                     'editable' => true,
@@ -1138,7 +1128,6 @@ class ThemeFixtures
                         'en-GB' => 'Fonttype headline',
                         'de-DE' => 'Schriftart Überschrift',
                     ],
-
                     'type' => 'fontFamily',
                     'value' => '\'Inter\', sans-serif',
                     'editable' => true,
@@ -1151,7 +1140,6 @@ class ThemeFixtures
                         'en-GB' => 'Headline colour',
                         'de-DE' => 'Überschriftfarbe',
                     ],
-
                     'type' => 'color',
                     'value' => '#4a545b',
                     'editable' => true,
@@ -1164,7 +1152,6 @@ class ThemeFixtures
                         'en-GB' => 'Price',
                         'de-DE' => 'Preis',
                     ],
-
                     'type' => 'color',
                     'value' => '#4a545b',
                     'editable' => true,
@@ -1177,7 +1164,6 @@ class ThemeFixtures
                         'en-GB' => 'Buy button',
                         'de-DE' => 'Kaufen-Button',
                     ],
-
                     'type' => 'color',
                     'value' => '#008490',
                     'editable' => true,
@@ -1190,7 +1176,6 @@ class ThemeFixtures
                         'en-GB' => 'Buy button text',
                         'de-DE' => 'Kaufen-Button Text',
                     ],
-
                     'type' => 'color',
                     'value' => '#fff',
                     'editable' => true,
@@ -1203,12 +1188,10 @@ class ThemeFixtures
                         'en-GB' => 'Desktop',
                         'de-DE' => 'Desktop',
                     ],
-
                     'helpText' => [
                         'en-GB' => 'Displayed on viewport sizes above 991px and as a fallback on smaller viewports, if no other logo is set.',
                         'de-DE' => 'Wird bei Ansichten über 991px angezeigt und als Alternative bei kleineren Auflösungen, für die kein anderes Logo eingestellt ist.',
                     ],
-
                     'type' => 'media',
                     'value' => 'app/storefront/dist/assets/logo/demostore-logo.png',
                     'editable' => true,
@@ -1222,12 +1205,10 @@ class ThemeFixtures
                         'en-GB' => 'Tablet',
                         'de-DE' => 'Tablet',
                     ],
-
                     'helpText' => [
                         'en-GB' => 'Displayed between a viewport of 767px to 991px',
                         'de-DE' => 'Wird zwischen einem viewport von 767px bis 991px angezeigt',
                     ],
-
                     'type' => 'media',
                     'value' => 'app/storefront/dist/assets/logo/demostore-logo.png',
                     'editable' => true,
@@ -1241,12 +1222,10 @@ class ThemeFixtures
                         'en-GB' => 'Mobile',
                         'de-DE' => 'Mobil',
                     ],
-
                     'helpText' => [
                         'en-GB' => 'Displayed up to a viewport of 767px',
                         'de-DE' => 'Wird bis zu einem Viewport von 767px angezeigt',
                     ],
-
                     'type' => 'media',
                     'value' => 'app/storefront/dist/assets/logo/demostore-logo.png',
                     'editable' => true,
@@ -1260,7 +1239,6 @@ class ThemeFixtures
                         'en-GB' => 'App & share icon',
                         'de-DE' => 'App- & Share-Icon',
                     ],
-
                     'type' => 'media',
                     'value' => '',
                     'editable' => true,
@@ -1273,7 +1251,6 @@ class ThemeFixtures
                         'en-GB' => 'Favicon',
                         'de-DE' => 'Favicon',
                     ],
-
                     'type' => 'media',
                     'value' => 'app/storefront/dist/assets/logo/favicon.png',
                     'editable' => true,
@@ -4570,6 +4547,286 @@ class ThemeFixtures
         }
 
         return $fields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getExtractedFields13(): array
+    {
+        $fields = [ ...self::getExtractedFieldsSub1(), ...[
+            'parent-custom-config' => [
+                'extensions' => [
+                ],
+                'name' => 'parent-custom-config',
+                'label' => [
+                    'de-DE' => 'DE',
+                    'en-GB' => 'EN',
+                ],
+                'helpText' => [
+                    'de-DE' => 'De Helptext',
+                    'en-GB' => 'EN Helptext',
+                ],
+                'type' => 'int',
+                'value' => '40',
+                'editable' => true,
+                'block' => null,
+                'section' => null,
+                'tab' => null,
+                'order' => null,
+                'sectionOrder' => null,
+                'blockOrder' => null,
+                'tabOrder' => null,
+                'custom' => null,
+                'scss' => null,
+                'fullWidth' => null,
+            ],
+            'extend-parent-custom-config' => [
+                'extensions' => [
+                ],
+                'name' => 'extend-parent-custom-config',
+                'label' => [
+                    'de-DE' => 'DE',
+                    'en-GB' => 'EN',
+                ],
+                'helpText' => [
+                    'de-DE' => 'De Helptext',
+                    'en-GB' => 'EN Helptext',
+                ],
+                'type' => 'int',
+                'value' => '20',
+                'editable' => true,
+                'block' => null,
+                'section' => null,
+                'tab' => null,
+                'order' => null,
+                'sectionOrder' => null,
+                'blockOrder' => null,
+                'tabOrder' => null,
+                'custom' => null,
+                'scss' => null,
+                'fullWidth' => null,
+            ],
+        ]];
+
+        $fields['sw-color-brand-primary']['value'] = '#db0f80';
+
+        unset($fields['test']);
+        unset($fields['test-something-with-options']);
+
+        return $fields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getExtractedCurrentFields9(): array
+    {
+        $currentFields = [
+            'sw-color-brand-primary' => [
+                'isInherited' => false,
+                'value' => '#db0f80',
+            ],
+            'sw-color-brand-secondary' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-border-color' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-background-color' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-success' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-info' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-warning' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-danger' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-font-family-base' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-text-color' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-font-family-headline' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-headline-color' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-price' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-buy-button' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-color-buy-button-text' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-desktop' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-tablet' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-mobile' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-share' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'sw-logo-favicon' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'parent-custom-config' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+            'extend-parent-custom-config' => [
+                'isInherited' => true,
+                'value' => null,
+            ],
+        ];
+
+        return $currentFields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getExtractedBaseThemeFields9(): array
+    {
+        $baseThemeFields = self::getExtractedBaseThemeFields6();
+
+        $baseThemeFields['parent-custom-config'] = [
+            'isInherited' => false,
+            'value' => '40',
+        ];
+
+        $baseThemeFields['extend-parent-custom-config'] = [
+            'isInherited' => false,
+            'value' => '20',
+        ];
+
+        unset($baseThemeFields['test-something-with-options']);
+
+        return $baseThemeFields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getExtractedTabs14(): array
+    {
+        $tabs = self::getExtractedTabs11();
+
+        unset($tabs['default']['blocks']['default']['sections']['default']['fields']['test']);
+
+        return $tabs;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getExtractedTabs15(): array
+    {
+        $tabs = self::getExtractedTabs10();
+
+        $tabs['default']['blocks']['media'] = [
+            'label' => 'media',
+            'sections' => [
+                'default' => [
+                    'label' => '',
+                    'fields' => [
+                        'sw-logo-desktop' => [
+                            'label' => 'sw-logo-desktop',
+                            'helpText' => [
+                                'en-GB' => 'Displayed on viewport sizes above 991px and as a fallback on smaller viewports, if no other logo is set.',
+                                'de-DE' => 'Wird bei Ansichten über 991px angezeigt und als Alternative bei kleineren Auflösungen, für die kein anderes Logo eingestellt ist.',
+                            ],
+                            'type' => 'media',
+                            'custom' => null,
+                            'fullWidth' => true,
+                        ],
+                        'sw-logo-tablet' => [
+                            'label' => 'sw-logo-tablet',
+                            'helpText' => [
+                                'en-GB' => 'Displayed between a viewport of 767px to 991px',
+                                'de-DE' => 'Wird zwischen einem viewport von 767px bis 991px angezeigt',
+                            ],
+                            'type' => 'media',
+                            'custom' => null,
+                            'fullWidth' => true,
+                        ],
+                        'sw-logo-mobile' => [
+                            'label' => 'sw-logo-mobile',
+                            'helpText' => [
+                                'en-GB' => 'Displayed up to a viewport of 767px',
+                                'de-DE' => 'Wird bis zu einem Viewport von 767px angezeigt',
+                            ],
+                            'type' => 'media',
+                            'custom' => null,
+                            'fullWidth' => true,
+                        ],
+                        'sw-logo-share' => [
+                            'label' => 'sw-logo-share',
+                            'helpText' => null,
+                            'type' => 'media',
+                            'custom' => null,
+                            'fullWidth' => null,
+                        ],
+                        'sw-logo-favicon' => [
+                            'label' => 'sw-logo-favicon',
+                            'helpText' => null,
+                            'type' => 'media',
+                            'custom' => null,
+                            'fullWidth' => null,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $tabs['default']['blocks']['default']['sections']['default']['fields']['parent-custom-config']['label'] = 'parent-custom-config';
+        $tabs['default']['blocks']['default']['sections']['default']['fields']['extend-parent-custom-config']['label'] = 'extend-parent-custom-config';
+
+        $tabs['default']['blocks']['default']['sections']['default']['fields']['parent-custom-config']['helpText'] = [
+            'de-DE' => 'De Helptext',
+            'en-GB' => 'EN Helptext',
+        ];
+        $tabs['default']['blocks']['default']['sections']['default']['fields']['extend-parent-custom-config']['helpText'] = [
+            'de-DE' => 'De Helptext',
+            'en-GB' => 'EN Helptext',
+        ];
+
+        unset($tabs['default']['blocks']['default']['sections']['default']['fields']['test']);
+
+        return $tabs;
     }
 
     /**


### PR DESCRIPTION
fixes #8591

This is a manual backport of #11036

### 1. Why is this change necessary?
The theme config inheritance setting is not resolved correctly for database child themes, resulting in a broken theme config.

### 2. What does this change do, exactly?
Fix the corresponding config inheritance resolution to iterate recursively through parent themes to apply the correct theme config settings. 

### 3. Describe each step to reproduce the issue or behaviour.

Test app themes and the description to reproduce this behaviour can be found in the issue: [#8591](https://github.com/shopware/shopware/issues/8591)
