### PR TITLE
Using localhost to access the docker container from the host since co…

### DIFF
--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -34,7 +34,7 @@ const isDev = VITE_MODE === 'development';
 
 // This env variable is provided by the symfony recipes
 const hasAdminRootEnv = !!process.env.ADMIN_ROOT;
-const host = process.env.VITE_HOST || (isInsideDockerContainer() ? getContainerIP() : undefined) || 'localhost';
+const host = process.env.HOST || process.env.VITE_HOST || (isInsideDockerContainer() ? getContainerIP() : undefined) || 'localhost';
 
 const extensionEntries = loadExtensions();
 
@@ -167,7 +167,7 @@ const main = async () => {
     if (isDev) {
         const availablePorts = await findAvailablePorts(5333, extensionEntries.length);
         const extensionsServerScheme = process.env.VITE_EXTENSIONS_SERVER_SCHEME || 'http';
-        const extensionsServerHost = process.env.VITE_EXTENSIONS_SERVER_HOST || host || 'localhost';
+        const extensionsServerHost = process.env.VITE_EXTENSIONS_SERVER_HOST || (isInsideDockerContainer() ? 'localhost' : undefined) || host || 'localhost';
 
         // Create sw-plugin-dev.json for development mode
         const swPluginDevJsonData = {


### PR DESCRIPTION
### 1. Why is this change necessary?
Reason for this is that the admin watcher does not work when running shopware inside a docker container (e.g. using "dockware"), the container ip on the host machine will not resolve to the shopware instance inside the container.

Therefore the vite ports (5333 and 5334) have to be forwarded from the container to the host and the vite host has to be set to "0.0.0.0".

This allows the host machine to use "localhost:5333" and "localhost:5334" in order to access at least the following file:
- /@vite/client

### 2. What does this change do, exactly?
It allows the environmental variables used by for instance dockware `HOST` to overwrite the vite host and also makes sure the host machine will try to access the script under `/@vite/client` using `locahost` and not using the container ip since that does not work

### 3. Describe each step to reproduce the issue or behaviour.
Try to access the admin watcher on e.g. windows using a docker container with shopware 6.7.0.1 inside or use dockware.

### 4. Please link to the relevant issues (if any).
- closes the issue #9393 when the PR is merged

### 5. Checklist
Does not really apply as far as I can tell. If anything is missing tell me and I will add it!
