### PR TITLE
feat: Upgrade php-cs-fixer to `3.82.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,7 +178,7 @@
         "bamarni/composer-bin-plugin": "^1.8.2",
         "dominikb/composer-license-checker": "^2.5",
         "ergebnis/phpunit-slow-test-detector": "^2.4",
-        "friendsofphp/php-cs-fixer": "3.72.0",
+        "friendsofphp/php-cs-fixer": "3.82.1",
         "jdorn/sql-formatter": "^1.2.17",
         "league/construct-finder": "^1.1",
         "league/flysystem-async-aws-s3": "^3.29.0",
@@ -343,14 +343,8 @@
             "@php bin/console assets:install"
         ],
         "check:license": "bash -c \"vendor/bin/composer-license-checker check -a $(sed -z 's/\\n/ -a /g' .allowed-licenses)\"",
-        "ecs": [
-            "@putenv PHP_CS_FIXER_IGNORE_ENV=true",
-            "php-cs-fixer fix --dry-run --diff"
-        ],
-        "ecs-fix": [
-            "@putenv PHP_CS_FIXER_IGNORE_ENV=true",
-            "php-cs-fixer fix"
-        ],
+        "ecs": "php-cs-fixer fix --dry-run --diff",
+        "ecs-fix": "php-cs-fixer fix",
         "eslint": [
             "@eslint:admin",
             "@eslint:storefront"

--- a/src/Core/Framework/App/InAppPurchases/Gateway/InAppPurchasesGateway.php
+++ b/src/Core/Framework/App/InAppPurchases/Gateway/InAppPurchasesGateway.php
@@ -18,8 +18,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class InAppPurchasesGateway
 {
     public function __construct(
-        readonly private InAppPurchasesPayloadService $payloadService,
-        readonly private EventDispatcherInterface $eventDispatcher,
+        private readonly InAppPurchasesPayloadService $payloadService,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 

--- a/src/Core/Framework/Telemetry/Metrics/Transport/TransportCollection.php
+++ b/src/Core/Framework/Telemetry/Metrics/Transport/TransportCollection.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Framework\Telemetry\Metrics\Transport;
 
-use IteratorAggregate;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Telemetry\Metrics\Config\TransportConfigProvider;
 use Shopware\Core\Framework\Telemetry\Metrics\Factory\MetricTransportFactoryInterface;
@@ -11,7 +10,7 @@ use Shopware\Core\Framework\Telemetry\Metrics\MetricTransportInterface;
 /**
  * @template MetricTransport of MetricTransportInterface
  *
- * @implements IteratorAggregate<int, MetricTransport>
+ * @implements \IteratorAggregate<int, MetricTransport>
  *
  * @internal
  */

--- a/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
+++ b/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
@@ -30,10 +30,10 @@ class SystemSetupStagingCommand extends Command
      * @param list<DomainRewriteRule> $domainMappings
      */
     public function __construct(
-        readonly private EventDispatcherInterface $eventDispatcher,
-        readonly private SystemConfigService $systemConfigService,
-        readonly bool $disableMailDelivery,
-        readonly array $domainMappings,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly SystemConfigService $systemConfigService,
+        public readonly bool $disableMailDelivery,
+        public readonly array $domainMappings,
     ) {
         parent::__construct();
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
- php-cs-fixer version `3.82.1` was released with complete PHP 8.4 support
- We can remove the `PHP_CS_FIXER_IGNORE_ENV=true` as it is no longer required

### 2. What does this change do, exactly?
- Upgrade php-cs-fixer to version `3.82.1`

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/10805

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
