### PR TITLE
fix: flaky timing test issue

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -52,5 +52,7 @@ return [
 
         // The parameters are optional, so this is not a BC break
         'ADDED: Parameter .* was added to Method accessDeniedForXmlHttpRequest\(\) of class Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException',
+
+        'ADDED: Parameter clock was added to Method __construct\(\) of class Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Gateway\\\\Template\\\\ActiveDateRange'
     ],
 ];

--- a/src/Core/Checkout/Promotion/Gateway/Template/ActiveDateRange.php
+++ b/src/Core/Checkout/Promotion/Gateway/Template/ActiveDateRange.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Promotion\Gateway\Template;
 
+use Psr\Clock\ClockInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
@@ -19,10 +20,10 @@ class ActiveDateRange extends MultiFilter
      * This means either no date ranges set at all, either no starting
      * or ending date, or a valid and active date range.
      */
-    public function __construct()
+    public function __construct(?ClockInterface $clock = null)
     {
-        $today = new \DateTime();
-        $today = $today->setTimezone(new \DateTimeZone('UTC'));
+        $dateTime = $clock?->now() ?? new \DateTime();
+        $today = $dateTime->setTimezone(new \DateTimeZone('UTC'));
 
         $todayStart = $today->format('Y-m-d H:i:s');
         $todayEnd = $today->format('Y-m-d H:i:s');

--- a/tests/unit/Core/Checkout/Cart/Promotion/Gateway/Template/ActiveDateRangeTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Gateway/Template/ActiveDateRangeTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Clock\MockClock;
 
 /**
  * @internal
@@ -25,19 +26,18 @@ class ActiveDateRangeTest extends TestCase
     #[Group('promotions')]
     public function testCriteria(): void
     {
-        $template = new ActiveDateRange();
+        $clock = new MockClock(new \DateTimeImmutable());
 
-        static::assertEquals($this->getExpectedDateRangeFilter()->getQueries(), $template->getQueries());
+        $template = new ActiveDateRange(clock: $clock);
+
+        static::assertEquals($this->getExpectedDateRangeFilter($clock->now())->getQueries(), $template->getQueries());
     }
 
     /**
      * @throws \Exception
      */
-    private function getExpectedDateRangeFilter(): MultiFilter
+    private function getExpectedDateRangeFilter(\DateTimeImmutable $today): MultiFilter
     {
-        $today = new \DateTime();
-        $today = $today->setTimezone(new \DateTimeZone('UTC'));
-
         $todayStart = $today->format('Y-m-d H:i:s');
         $todayEnd = $today->format('Y-m-d H:i:s');
 


### PR DESCRIPTION
### 1. Why is this change necessary?

```
1) Shopware\Tests\Unit\Core\Checkout\Cart\Promotion\Gateway\Template\ActiveDateRangeTest::testCriteria
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
                 'resolved' => null
                 'field' => 'validUntil'
                 'parameters' => Array (
-                    'gt' => '2025-07-09 06:53:47'
+                    'gt' => '2025-07-09 06:53:46'
                 )
             )
         )
```

### 2. What does this change do, exactly?

Use the same date time for expecting 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
