### PR TITLE
fix: Use Symfony routing attribute instead of annotation

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/ImitateCustomerRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ImitateCustomerRoute.php
@@ -17,7 +17,7 @@ use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\ContextTokenResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 

--- a/src/Core/Framework/Api/Controller/FeatureFlagController.php
+++ b/src/Core/Framework/Api/Controller/FeatureFlagController.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Feature\FeatureFlagRegistry;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route(defaults: ['_routeScope' => ['api']])]
 #[Package('framework')]

--- a/tests/integration/Core/Content/Seo/SalesChannel/FixturesPhp/StoreApiSeoResolverTestRoute.php
+++ b/tests/integration/Core/Content/Seo/SalesChannel/FixturesPhp/StoreApiSeoResolverTestRoute.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/Api/EventListener/FixturesPhp/SalesChannelAuthenticationListenerTestRoute.php
+++ b/tests/integration/Core/Framework/Api/EventListener/FixturesPhp/SalesChannelAuthenticationListenerTestRoute.php
@@ -7,7 +7,7 @@ use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @internal

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApi/_fixtures/StoreApiTestOtherRoute.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApi/_fixtures/StoreApiTestOtherRoute.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Routing\Annotation\Entity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @internal


### PR DESCRIPTION
### 1. Why is this change necessary?
Deprecated code.

### 2. What does this change do, exactly?
Replace it with the attribute.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
