### PR TITLE
fix: Display of the from text as soon as the inheritance of the price in variants is disabled

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
@@ -16,6 +16,7 @@
         {% set real = cheapest %}
         {% set totalVariants = product.cheapestPriceContainer.value %}
         {% set hasDifferentPrice = totalVariants|filter(variant => variant.default != null)|length > 0 %}
+        {% set hasRange = product.cheapestPrice.hasRange %}
     {% endif %}
 
     <div class="product-price-info">
@@ -78,7 +79,7 @@
                     The product is not directly buy-able from the listing.
                     Example: "From $120.00"
                 #}
-                {% if displayFrom or (displayParent and hasDifferentPrice and totalVariants|length > 1) %}
+                {% if displayFrom or (displayParent and hasDifferentPrice and hasRange and totalVariants|length > 1) %}
                     {{ 'listing.listingTextFrom'|trans|sw_sanitize }}
                 {% endif %}
 


### PR DESCRIPTION
### Solution 

1. Disable inherited but keep the same price.
![image](https://github.com/user-attachments/assets/569a1b8e-186b-407b-8b1d-f7fb7fc4b4d7)

2. In the storefront. No "From" text display before price number anymore.
![image](https://github.com/user-attachments/assets/e7a0a9f7-4611-4e86-862c-8fa6ba44ffd4)
