### PR TITLE
fix: properly parsing mysql replica parameters provided as dsn

### DIFF
--- a/changelog/_unreleased/2025-07-09-fix-mysql-replica-parameters-parsing.md
+++ b/changelog/_unreleased/2025-07-09-fix-mysql-replica-parameters-parsing.md
@@ -1,0 +1,6 @@
+---
+title: Fix mysql replica parameters parsing
+issue: https://github.com/shopware/shopware/issues/11085
+---
+# Core
+* Changed `Shopware\Core\Framework\Adapter\Database\MySQLFactory` to properly initialize replica parameters provided in the dsn format

--- a/src/Core/Framework/Adapter/Database/MySQLFactory.php
+++ b/src/Core/Framework/Adapter/Database/MySQLFactory.php
@@ -82,7 +82,14 @@ class MySQLFactory
             $parameters['replica'] = [];
 
             for ($i = 0; $replicaUrl = (string) EnvironmentHelper::getVariable('DATABASE_REPLICA_' . $i . '_URL'); ++$i) {
-                $parameters['replica'][] = ['url' => $replicaUrl, 'charset' => $parameters['charset'], 'driverOptions' => $parameters['driverOptions']];
+                $replicaParams = $dsnParser->parse($replicaUrl);
+
+                $replicaParams = array_merge([
+                    'charset' => $parameters['charset'],
+                    'driverOptions' => $parameters['driverOptions'],
+                ], $replicaParams);
+
+                $parameters['replica'][$i] = $replicaParams;
             }
         }
 

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 
 /**
  * @internal
@@ -15,11 +16,72 @@ use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 #[CoversClass(MySQLFactory::class)]
 class MySQLFactoryTest extends TestCase
 {
+    use EnvTestBehaviour;
+
     public function testMiddlewaresAreUsed(): void
     {
         $conn = MySQLFactory::create([new MyMiddleware()]);
 
         static::assertInstanceOf(MyDriver::class, $conn->getDriver());
+    }
+
+    public function testReplicaConfigurationParsesDsnParameters(): void
+    {
+        $this->setEnvVars([
+            'DATABASE_URL' => 'mysql://user:pass@localhost:3306/shopware',
+            'DATABASE_REPLICA_0_URL' => 'mysql://replica_user:replica_pass@replica_host:3307/replica_db',
+            'DATABASE_REPLICA_1_URL' => 'mysql://replica_user2:replica_pass2@replica_host2:3308/replica_db2',
+        ]);
+
+        $connection = MySQLFactory::create();
+        $params = $connection->getParams();
+
+        // Assert connection is not created - we don't want to connect to a real database in unit tests
+        static::assertFalse($connection->isConnected());
+
+        // If we get here, the connection was successful and we can test the parameters
+        static::assertArrayHasKey('wrapperClass', $params);
+        static::assertArrayHasKey('primary', $params);
+        static::assertArrayHasKey('replica', $params);
+        static::assertCount(2, $params['replica']);
+
+        // Check first replica parameters
+        $replica0 = $params['replica'][0];
+        static::assertArrayHasKey('host', $replica0);
+        static::assertSame('replica_host', $replica0['host']);
+        static::assertArrayHasKey('port', $replica0);
+        static::assertSame(3307, $replica0['port']);
+        static::assertArrayHasKey('user', $replica0);
+        static::assertSame('replica_user', $replica0['user']);
+        static::assertArrayHasKey('password', $replica0);
+        static::assertSame('replica_pass', $replica0['password']);
+        static::assertArrayHasKey('dbname', $replica0);
+        static::assertSame('replica_db', $replica0['dbname']);
+        static::assertArrayHasKey('charset', $replica0);
+        static::assertSame('utf8mb4', $replica0['charset']);
+        static::assertArrayHasKey('driverOptions', $replica0);
+
+        // Check second replica parameters
+        $replica1 = $params['replica'][1];
+        static::assertArrayHasKey('host', $replica1);
+        static::assertSame('replica_host2', $replica1['host']);
+        static::assertArrayHasKey('port', $replica1);
+        static::assertSame(3308, $replica1['port']);
+        static::assertArrayHasKey('user', $replica1);
+        static::assertSame('replica_user2', $replica1['user']);
+        static::assertArrayHasKey('password', $replica1);
+        static::assertSame('replica_pass2', $replica1['password']);
+        static::assertArrayHasKey('dbname', $replica1);
+        static::assertSame('replica_db2', $replica1['dbname']);
+        static::assertArrayHasKey('charset', $replica1);
+        static::assertSame('utf8mb4', $replica1['charset']);
+        static::assertArrayHasKey('driverOptions', $replica1);
+
+        // Verify that default parameters are merged correctly
+        static::assertArrayHasKey('driver', $replica0);
+        static::assertSame('pdo_mysql', $replica0['driver']);
+        static::assertArrayHasKey('driver', $replica1);
+        static::assertSame('pdo_mysql', $replica1['driver']);
     }
 }
 

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -59,7 +59,6 @@ class MySQLFactoryTest extends TestCase
         static::assertSame('replica_db', $replica0['dbname']);
         static::assertArrayHasKey('charset', $replica0);
         static::assertSame('utf8mb4', $replica0['charset']);
-        static::assertArrayHasKey('driverOptions', $replica0);
 
         // Check second replica parameters
         $replica1 = $params['replica'][1];
@@ -75,13 +74,17 @@ class MySQLFactoryTest extends TestCase
         static::assertSame('replica_db2', $replica1['dbname']);
         static::assertArrayHasKey('charset', $replica1);
         static::assertSame('utf8mb4', $replica1['charset']);
-        static::assertArrayHasKey('driverOptions', $replica1);
 
-        // Verify that default parameters are merged correctly
+        // Verify that parameters are merged correctly
         static::assertArrayHasKey('driver', $replica0);
         static::assertSame('pdo_mysql', $replica0['driver']);
+        static::assertArrayHasKey('driverOptions', $replica0);
+        static::assertSame($replica0['driverOptions'], $params['driverOptions']);
+
         static::assertArrayHasKey('driver', $replica1);
         static::assertSame('pdo_mysql', $replica1['driver']);
+        static::assertArrayHasKey('driverOptions', $replica1);
+        static::assertSame($replica1['driverOptions'], $params['driverOptions']);
     }
 }
 

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -78,6 +78,7 @@ class MySQLFactoryTest extends TestCase
         // Verify that parameters are merged correctly
         static::assertArrayHasKey('driver', $replica0);
         static::assertSame('pdo_mysql', $replica0['driver']);
+        static::assertArrayHasKey('driverOptions', $params);
         static::assertArrayHasKey('driverOptions', $replica0);
         static::assertSame($replica0['driverOptions'], $params['driverOptions']);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`doctrine/dbal` removed [url connection parameter](https://github.com/doctrine/dbal/blob/4.2.x/UPGRADE.md#bc-break-removed-the-url-connection-parameter) in version 4.0.

### 2. What does this change do, exactly?

This change adapts parameters preparation in MySQLFactory to the mentioned change.

### 3. Describe each step to reproduce the issue or behaviour.

See original issue.

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/11085

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
