### PR TITLE
fix: click-areas-for-cms-slot-selection

### DIFF
--- a/changelog/_unreleased/2025-07-09-improve-cms-slot-selection.md
+++ b/changelog/_unreleased/2025-07-09-improve-cms-slot-selection.md
@@ -1,0 +1,15 @@
+---
+title: Improve CMS slot selection and prevent misclicks
+issue: 
+author: Marvin Rewer
+author_email: marvin.rewer@trendpet.de
+author_github: @marvn_r3
+---
+
+## Administration
+* Updated SCSS properties in `Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss`
+
+### Improved
+* Enhanced the user experience when selecting CMS elements by improving the overlay interaction areas
+* Favorite Icon Positioning: Moved the favorite icon for CMS elements to the top-right corner
+* Prevents misclicks between CMS slot selection and favorite functionality by prioritizing selection action over favoriting. Reduces accidental favoriting.

--- a/changelog/_unreleased/2025-07-09-improve-cms-slot-selection.md
+++ b/changelog/_unreleased/2025-07-09-improve-cms-slot-selection.md
@@ -1,10 +1,9 @@
 ---
 title: Improve CMS slot selection and prevent misclicks
-issue: 
+issue: ""
 author: Marvin Rewer
 author_email: marvin.rewer@trendpet.de
 author_github: @marvn_r3
 ---
-
 ## Administration
-* changed SCSS properties in `Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss`
+* Changed SCSS properties in `Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss`

--- a/changelog/_unreleased/2025-07-09-improve-cms-slot-selection.md
+++ b/changelog/_unreleased/2025-07-09-improve-cms-slot-selection.md
@@ -7,9 +7,4 @@ author_github: @marvn_r3
 ---
 
 ## Administration
-* Updated SCSS properties in `Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss`
-
-### Improved
-* Enhanced the user experience when selecting CMS elements by improving the overlay interaction areas
-* Favorite Icon Positioning: Moved the favorite icon for CMS elements to the top-right corner
-* Prevents misclicks between CMS slot selection and favorite functionality by prioritizing selection action over favoriting. Reduces accidental favoriting.
+* changed SCSS properties in `Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss`

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -195,6 +195,17 @@ export default Shopware.Component.wrapComponentConfig({
             this.cmsElementFavorites.update(!this.cmsElementFavorites.isFavorite(elementName), elementName);
         },
 
+        toggleHoverElement(element: CmsElementConfig, targetState: boolean) {
+            element.hover = targetState;
+        },
+
+        getFavoriteIconToggleState(element: CmsElementConfig): boolean {
+            return (
+                (this.cmsElementFavorites.isFavorite(element.name) && !element?.hover) ||
+                (!this.cmsElementFavorites.isFavorite(element.name) && !!element?.hover)
+            );
+        },
+
         elementInElementGroup(element: CmsElementConfig, elementGroup: string) {
             if (elementGroup === 'favorite') {
                 return this.cmsElementFavorites.isFavorite(element.name);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
@@ -196,14 +196,18 @@
                                         tabindex="0"
                                         @click="onToggleElementFavorite(element.name)"
                                         @keydown.enter="onToggleElementFavorite(element.name)"
+                                        @mouseenter="toggleHoverElement(element, true)"
+                                        @mouseleave="toggleHoverElement(element, false)"
+                                        @focusin="toggleHoverElement(element, true)"
+                                        @focusout="toggleHoverElement(element, false)"
                                     >
                                         <mt-icon
-                                            v-if="cmsElementFavorites.isFavorite(element.name)"
+                                            v-show="getFavoriteIconToggleState(element)"
                                             name="solid-heart"
                                             size="28"
                                         />
                                         <mt-icon
-                                            v-else
+                                            v-show="!getFavoriteIconToggleState(element)"
                                             name="regular-heart"
                                             size="28"
                                         />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss
@@ -134,13 +134,13 @@
         }
 
         .element-selection__overlay {
-          display: none;
-          align-content: center;
-          align-items: center;
-          justify-content: center;
-          justify-items: center;
-          position: absolute;
-          border-radius: 5px;
+            display: none;
+            align-content: center;
+            align-items: center;
+            justify-content: center;
+            justify-items: center;
+            position: absolute;
+            border-radius: 5px;
 
             &.element-selection__overlay-action-select {
                 width: 100%;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss
@@ -134,26 +134,29 @@
         }
 
         .element-selection__overlay {
-            width: 50%;
-            height: 100%;
-            display: none;
-            align-content: center;
-            align-items: center;
-            justify-content: center;
-            justify-items: center;
-            margin: auto;
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            background: rgba(255, 255, 255, 80%);
-            border-radius: 5px;
+          display: none;
+          align-content: center;
+          align-items: center;
+          justify-content: center;
+          justify-items: center;
+          position: absolute;
+          border-radius: 5px;
 
             &.element-selection__overlay-action-select {
+                width: 100%;
+                height: 100%;
+                background: rgba(255, 255, 255, 80%);
+                top: 0;
+                bottom: 0;
+                right: 0;
                 left: 0;
+                margin: auto;
             }
 
             &.element-selection__overlay-action-favorite {
-                right: 0;
+                top: 2px;
+                right: 2px;
+                padding: 4px;
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/html/preview/sw-cms-el-preview-html.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/html/preview/sw-cms-el-preview-html.scss
@@ -5,7 +5,8 @@
                 height: 112px;
 
                 /* stylelint-disable max-nesting-depth */
-                .ace_gutter {
+                .ace_gutter,
+                .ace_scrollbar {
                     z-index: 0;
                 }
                 /* stylelint-enable max-nesting-depth */

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
@@ -57,6 +57,7 @@ type CmsElementConfig = {
     appData?: {
         baseUrl: string;
     };
+    hover?: boolean;
 };
 
 type CmsBlockConfig = {


### PR DESCRIPTION
### 1. Why is this change necessary?
Users frequently misclick between selecting CMS elements and favoriting them due to equal sized interaction areas, disrupting editing workflow.

### 2. What does this change do, exactly?
- Moves the favorite icon to the top-right corner of CMS elements
- Updates SCSS for overlay selection components to prevent misclicks
- Prioritizes selection actions over favoriting


before:
![image](https://github.com/user-attachments/assets/cf3e3bbb-b73a-4823-b3a9-74e6ff8c9ccb)

after: 
![image](https://github.com/user-attachments/assets/30b1d0d0-0b18-483b-bdf4-a4c2acc1602c)


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Administration → Content → Shopping Experiences
2. Edit/create a CMS page
3. Try selecting CMS elements from the library
4. Notice accidental favoriting when trying to select elements

### 4. Please link to the relevant issues (if any).
No related issues.

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them