### PR TITLE
feat: add env variables for Opensearch min_ngram and max_ngram

### DIFF
--- a/changelog/_unreleased/2025-07-10-add-env-variables-for-opensearch-min_ngram-and-max_ngram.md
+++ b/changelog/_unreleased/2025-07-10-add-env-variables-for-opensearch-min_ngram-and-max_ngram.md
@@ -1,0 +1,6 @@
+---
+title: add env variables for Opensearch min_ngram and max_ngram
+issue: 11131
+---
+# Core
+* Changed `src/Elasticsearch/Resources/config/packages/elasticsearch.yaml` to allow setting `min_ngram` and `max_ngram` for Opensearch via environment variables `SHOPWARE_ES_NGRAM_MIN_GRAM` (default as 4) and `SHOPWARE_ES_NGRAM_MAX_GRAM` (default as 5).

--- a/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
@@ -76,8 +76,8 @@ elasticsearch:
         filter:
             sw_ngram_filter:
                 type: ngram
-                min_gram: 4
-                max_gram: 5
+                min_gram: "%env(int:SHOPWARE_ES_NGRAM_MIN_GRAM)%"
+                max_gram: "%env(int:SHOPWARE_ES_NGRAM_MAX_GRAM)%"
             sw_english_stop_filter:
                 type: 'stop'
                 stopwords: '_english_'
@@ -113,3 +113,5 @@ parameters:
     env(SHOPWARE_ADMIN_ES_REFRESH_INDICES): ""
     env(SHOPWARE_ES_INDEXING_BATCH_SIZE): "100"
     env(SHOPWARE_ES_EXCLUDE_SOURCE): "0"
+    env(SHOPWARE_ES_NGRAM_MIN_GRAM): "4"
+    env(SHOPWARE_ES_NGRAM_MAX_GRAM): "5"


### PR DESCRIPTION
Currently, elasticsearch.analysis.filter.ngram_filter.min_ngram and elasticsearch.analysis.filter.ngram_filter.max_ngram are fixed as 4 and 5, respectively. We want to have this value configurable using an environment variable, so we can toggle it

Hint: When changing this values, you have to re-index the data to make the new filter option applied

