### PR TITLE
ci: update gh-project-automation

### DIFF
--- a/.github/bin/js/package-lock.json
+++ b/.github/bin/js/package-lock.json
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@shopware-ag/gh-project-automation": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.9.0.tgz",
-      "integrity": "sha512-tEqFraV/m0dj64/7d/obZ3mj7ynSlxiq8shrwlnveE2bvshWgOxLskWU6O4hEjWF4SHhP4ZvcPFI6z1KB3SsnA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.9.1.tgz",
+      "integrity": "sha512-0LmWglM0rqb6+g6NbcRJnfBt8dqKayhtMPeUVgdO9ev5kCzIeDz6g3LtD3UhARIcFw4Ig49cgDRiso9GQjVYnA==",
       "dependencies": {
         "@slack/web-api": "^7.9.2"
       },
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@slack/types": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.14.0.tgz",
-      "integrity": "sha512-n0EGm7ENQRxlXbgKSrQZL69grzg1gHLAVd+GlRVQJ1NSORo0FrApR7wql/gaKdu2n4TO83Sq/AmeUOqD60aXUA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.15.0.tgz",
+      "integrity": "sha512-livb1gyG3J8ATLBJ3KjZfjHpTRz9btY1m5cgNuXxWJbhwRB1Gwb8Ly6XLJm2Sy1W6h+vLgqIHg7IwKrF1C1Szg==",
       "engines": {
         "node": ">= 12.13.0",
         "npm": ">= 6.12.0"


### PR DESCRIPTION
### 1. Why is this change necessary?
We renamed the close labels, so we need to update the `gh-project-automation`.

### 2. What does this change do, exactly?
Update `gh-project-automation` to `1.9.1`.