### PR TITLE
fix: refresh measurement units

### DIFF
--- a/changelog/_unreleased/2025-07-11-refresh-measurement-units.md
+++ b/changelog/_unreleased/2025-07-11-refresh-measurement-units.md
@@ -1,0 +1,6 @@
+---
+title: refresh measurement units
+issue: #11139
+---
+# Administration
+* Changed `onChangeLanguage` method in `sw-settings-measurement` to refresh the measurement units after the content language changed

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/index.js
@@ -171,6 +171,7 @@ export default {
 
         onChangeLanguage(languageId) {
             Shopware.Store.get('context').setApiLanguageId(languageId);
+            this.createdComponent();
         },
 
         async onChangeMeasurementSystem(technicalName) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/sw-settings-measurement.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/sw-settings-measurement.spec.js
@@ -278,4 +278,36 @@ describe('src/module/sw-settings-measurement/page/sw-settings-measurement', () =
             weight: 'g',
         });
     });
+
+    it('should refresh measurement units when language changes', async () => {
+        const setApiLanguageIdSpy = jest.fn();
+
+        Shopware.Store.unregister('context');
+        Shopware.Store.register({
+            id: 'context',
+            actions: {
+                setApiLanguageId: setApiLanguageIdSpy,
+            },
+        });
+
+        const initialMeasurementUnits = { ...wrapper.vm.measurementUnits };
+
+        const mockGermanMeasurementSystem = {
+            'core.measurementUnits.system': 'metric',
+            'core.measurementUnits.length': 'cm',
+            'core.measurementUnits.weight': 'g',
+        };
+
+        wrapper.vm.systemConfigApiService.getValues.mockResolvedValueOnce(mockGermanMeasurementSystem);
+
+        await wrapper.vm.onChangeLanguage('de-DE');
+
+        expect(setApiLanguageIdSpy).toHaveBeenCalledWith('de-DE');
+        expect(wrapper.vm.measurementUnits).toEqual({
+            system: 'metric',
+            length: 'cm',
+            weight: 'g',
+        });
+        expect(wrapper.vm.measurementUnits).not.toEqual(initialMeasurementUnits);
+    });
 });

--- a/src/Core/Migration/V6_7/Migration1742199550MeasurementDisplayUnitTable.php
+++ b/src/Core/Migration/V6_7/Migration1742199550MeasurementDisplayUnitTable.php
@@ -72,7 +72,7 @@ class Migration1742199550MeasurementDisplayUnitTable extends MigrationStep
         $imperialId = $connection->fetchOne('SELECT `id` FROM `measurement_system` WHERE `technical_name` = :technicalName', ['technicalName' => 'imperial']);
 
         $units = [
-            ['id' => Uuid::randomBytes(), 'measurement_system_id' => $metricId, 'default' => 0, 'type' => 'length', 'short_name' => 'm', 'factor' => 1000, 'precision' => 2, 'name_en' => 'Meter', 'name_de' => 'Zähler'],
+            ['id' => Uuid::randomBytes(), 'measurement_system_id' => $metricId, 'default' => 0, 'type' => 'length', 'short_name' => 'm', 'factor' => 1000, 'precision' => 2, 'name_en' => 'Meter', 'name_de' => 'Meter'],
             ['id' => Uuid::randomBytes(), 'measurement_system_id' => $metricId, 'default' => 0, 'type' => 'length', 'short_name' => 'cm', 'factor' => 10, 'precision' => 2, 'name_en' => 'Centimeter', 'name_de' => 'Zentimeter'],
             ['id' => Uuid::randomBytes(), 'measurement_system_id' => $metricId, 'default' => 1, 'type' => 'length', 'short_name' => 'mm', 'factor' => 1, 'precision' => 2, 'name_en' => 'Millimeter', 'name_de' => 'Millimeter'],
             ['id' => Uuid::randomBytes(), 'measurement_system_id' => $metricId, 'default' => 1, 'type' => 'weight', 'short_name' => 'kg', 'factor' => 1, 'precision' => 2, 'name_en' => 'Kilogram', 'name_de' => 'Kilogramm'],

--- a/src/Core/Migration/V6_7/Migration1752229050ChangeDESnippetOfMeterUnit.php
+++ b/src/Core/Migration/V6_7/Migration1752229050ChangeDESnippetOfMeterUnit.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class Migration1752229050ChangeDESnippetOfMeterUnit extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1752229050;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $deLanguageId = $this->getDeDeId($connection);
+
+        if (!$deLanguageId) {
+            return;
+        }
+
+        $meterUnitId = $connection->fetchOne(
+            'SELECT id FROM measurement_display_unit WHERE short_name = "m"'
+        );
+
+        if (!$meterUnitId) {
+            return;
+        }
+
+        $connection->executeStatement('
+            UPDATE `measurement_display_unit_translation` SET `name` = :name
+            WHERE `measurement_display_unit_id` = :unitId AND `language_id` = :languageId AND `updated_at` IS NULL
+        ', [
+            'name' => 'Meter',
+            'unitId' => $meterUnitId,
+            'languageId' => $deLanguageId,
+        ]);
+    }
+
+    private function getDeDeId(Connection $connection): ?string
+    {
+        $result = $connection->fetchOne(
+            '
+            SELECT lang.id
+            FROM language lang
+            INNER JOIN locale loc ON lang.translation_code_id = loc.id
+            AND loc.code = "de-DE"'
+        );
+
+        if ($result === false || Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM) === $result) {
+            return null;
+        }
+
+        return (string) $result;
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1752229050ChangeDESnippetOfMeterUnitTest.php
+++ b/tests/migration/Core/V6_7/Migration1752229050ChangeDESnippetOfMeterUnitTest.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1742199549MeasurementSystemTable;
+use Shopware\Core\Migration\V6_7\Migration1742199550MeasurementDisplayUnitTable;
+use Shopware\Core\Migration\V6_7\Migration1752229050ChangeDESnippetOfMeterUnit;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(Migration1752229050ChangeDESnippetOfMeterUnit::class)]
+class Migration1752229050ChangeDESnippetOfMeterUnitTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `measurement_display_unit_translation`');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `measurement_display_unit`');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `measurement_system_translation`');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `measurement_system`');
+
+        $systemMigration = new Migration1742199549MeasurementSystemTable();
+        $systemMigration->update($this->connection);
+
+        $unitMigration = new Migration1742199550MeasurementDisplayUnitTable();
+        $unitMigration->update($this->connection);
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1752229050, (new Migration1752229050ChangeDESnippetOfMeterUnit())->getCreationTimestamp());
+    }
+
+    public function testMigrationUpdatesGermanTranslation(): void
+    {
+        $deLanguageId = $this->getDeLanguageId();
+        $meterUnitId = $this->getMeterUnitId();
+
+        if (!$deLanguageId || !$meterUnitId) {
+            static::markTestSkipped('German language or meter unit not found');
+        }
+
+        $this->connection->executeStatement('
+            UPDATE `measurement_display_unit_translation`
+            SET `name` = :name, `updated_at` = NULL
+            WHERE `measurement_display_unit_id` = :unitId AND `language_id` = :languageId
+        ', [
+            'name' => 'Zähler',
+            'unitId' => $meterUnitId,
+            'languageId' => $deLanguageId,
+        ]);
+
+        $translationBefore = $this->connection->fetchOne('
+            SELECT `name` FROM `measurement_display_unit_translation`
+            WHERE `measurement_display_unit_id` = :unitId AND `language_id` = :languageId
+        ', [
+            'unitId' => $meterUnitId,
+            'languageId' => $deLanguageId,
+        ]);
+
+        static::assertSame('Zähler', $translationBefore);
+
+        $migration = new Migration1752229050ChangeDESnippetOfMeterUnit();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        // Verify the translation was updated
+        $translationAfter = $this->connection->fetchOne('
+            SELECT `name` FROM `measurement_display_unit_translation`
+            WHERE `measurement_display_unit_id` = :unitId AND `language_id` = :languageId
+        ', [
+            'unitId' => $meterUnitId,
+            'languageId' => $deLanguageId,
+        ]);
+
+        static::assertSame('Meter', $translationAfter);
+    }
+
+    public function testMigrationDoesNotUpdateModifiedTranslation(): void
+    {
+        $deLanguageId = $this->getDeLanguageId();
+        $meterUnitId = $this->getMeterUnitId();
+
+        if (!$deLanguageId || !$meterUnitId) {
+            static::markTestSkipped('German language or meter unit not found');
+        }
+
+        // Set a different German translation with updated_at (simulating manual modification)
+        $this->connection->executeStatement('
+            UPDATE `measurement_display_unit_translation`
+            SET `name` = :name, `updated_at` = :updatedAt
+            WHERE `measurement_display_unit_id` = :unitId AND `language_id` = :languageId
+        ', [
+            'name' => 'Manuell bearbeitet',
+            'unitId' => $meterUnitId,
+            'languageId' => $deLanguageId,
+            'updatedAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $migration = new Migration1752229050ChangeDESnippetOfMeterUnit();
+        $migration->update($this->connection);
+
+        $translationAfter = $this->connection->fetchOne('
+            SELECT `name` FROM `measurement_display_unit_translation`
+            WHERE `measurement_display_unit_id` = :unitId AND `language_id` = :languageId
+        ', [
+            'unitId' => $meterUnitId,
+            'languageId' => $deLanguageId,
+        ]);
+
+        static::assertSame('Manuell bearbeitet', $translationAfter);
+    }
+
+    private function getDeLanguageId(): ?string
+    {
+        $result = $this->connection->fetchOne('
+            SELECT lang.id
+            FROM language lang
+            INNER JOIN locale loc ON lang.translation_code_id = loc.id
+            AND loc.code = "de-DE"
+        ');
+
+        if ($result === false || Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM) === $result) {
+            return null;
+        }
+
+        return (string) $result;
+    }
+
+    private function getMeterUnitId(): ?string
+    {
+        $result = $this->connection->fetchOne('SELECT id FROM measurement_display_unit WHERE short_name = "m"');
+
+        return $result ?: null;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/11139

### 2. What does this change do, exactly?

Refreshes the measurement units after the content languages have changed.

### 3. Describe each step to reproduce the issue or behaviour.

_

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
_

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
