### PR TITLE
refactor: Initialize properties directly instead of setting them in the constructor

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/CartPromotionsDataDefinition.php
+++ b/src/Core/Checkout/Promotion/Cart/CartPromotionsDataDefinition.php
@@ -12,17 +12,15 @@ class CartPromotionsDataDefinition extends Struct
     /**
      * @var array<string, array<PromotionEntity>>
      */
-    private array $codePromotions;
+    private array $codePromotions = [];
 
     /**
      * @var array<PromotionEntity>
      */
-    private array $automaticPromotions;
+    private array $automaticPromotions = [];
 
     public function __construct()
     {
-        $this->codePromotions = [];
-        $this->automaticPromotions = [];
     }
 
     /**

--- a/src/Core/Checkout/Promotion/Cart/Discount/DiscountPackage.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/DiscountPackage.php
@@ -18,12 +18,11 @@ class DiscountPackage
     /**
      * @var array<string, LineItem>|null
      */
-    private ?array $hashMap;
+    private ?array $hashMap = null;
 
     public function __construct(private LineItemQuantityCollection $metaItems)
     {
         $this->cartItems = new LineItemFlatCollection();
-        $this->hashMap = null;
     }
 
     public function getMetaData(): LineItemQuantityCollection

--- a/src/Core/Framework/Api/Context/AdminApiSource.php
+++ b/src/Core/Framework/Api/Context/AdminApiSource.php
@@ -12,7 +12,7 @@ class AdminApiSource implements ContextSource, \JsonSerializable
 
     public string $type = 'admin-api';
 
-    private bool $isAdmin;
+    private bool $isAdmin = false;
 
     /**
      * @var array<string>
@@ -21,9 +21,8 @@ class AdminApiSource implements ContextSource, \JsonSerializable
 
     public function __construct(
         private readonly ?string $userId,
-        private readonly ?string $integrationId = null
+        private readonly ?string $integrationId = null,
     ) {
-        $this->isAdmin = false;
     }
 
     public function getUserId(): ?string

--- a/src/Core/Framework/RateLimiter/Policy/TimeBackoff.php
+++ b/src/Core/Framework/RateLimiter/Policy/TimeBackoff.php
@@ -14,7 +14,7 @@ use Symfony\Component\RateLimiter\Util\TimeUtil;
 #[Package('framework')]
 class TimeBackoff implements LimiterStateInterface
 {
-    private int $attempts;
+    private int $attempts = 0;
 
     private int $timer;
 
@@ -32,7 +32,6 @@ class TimeBackoff implements LimiterStateInterface
         private array $limits,
         ?int $timer = null
     ) {
-        $this->attempts = 0;
         $this->timer = $timer ?? time();
         $this->unthrottledAttempts = min(array_column($this->limits, 'limit')) ?: 0;
     }

--- a/src/Core/System/UsageData/Services/EntityDeleteEventHelper.php
+++ b/src/Core/System/UsageData/Services/EntityDeleteEventHelper.php
@@ -20,12 +20,12 @@ class EntityDeleteEventHelper
     /**
      * @var EntityDefinition[]
      */
-    private array $includedEntityDefinitions;
+    private array $includedEntityDefinitions = [];
 
     /**
      * @var string[]
      */
-    private array $excludedFields;
+    private array $excludedFields = [];
 
     /**
      * @var array<string, list<array<string, string>>>
@@ -34,8 +34,6 @@ class EntityDeleteEventHelper
 
     public function __construct(private readonly EntityDeleteEvent $event)
     {
-        $this->includedEntityDefinitions = [];
-        $this->excludedFields = [];
     }
 
     /**

--- a/src/Core/Test/Integration/Builder/Customer/CustomerBuilder.php
+++ b/src/Core/Test/Integration/Builder/Customer/CustomerBuilder.php
@@ -27,11 +27,11 @@ class CustomerBuilder
 
     public string $id;
 
-    protected string $firstName;
+    protected string $firstName = 'Max';
 
-    protected string $lastName;
+    protected string $lastName = 'Mustermann';
 
-    protected string $email;
+    protected string $email = 'max@mustermann.com';
 
     protected string $customerGroupId;
 
@@ -69,9 +69,6 @@ class CustomerBuilder
     ) {
         $this->ids = $ids;
         $this->id = $ids->create($customerNumber);
-        $this->firstName = 'Max';
-        $this->lastName = 'Mustermann';
-        $this->email = 'max@mustermann.com';
         $this->salutation = self::salutation($ids);
 
         $this->customerGroup($customerGroup);

--- a/src/Core/Test/Integration/Builder/Order/OrderBuilder.php
+++ b/src/Core/Test/Integration/Builder/Order/OrderBuilder.php
@@ -30,9 +30,9 @@ class OrderBuilder
 
     protected string $orderNumber;
 
-    protected string $currencyId;
+    protected string $currencyId = Defaults::CURRENCY;
 
-    protected float $currencyFactor;
+    protected float $currencyFactor = 1.0;
 
     protected string $billingAddressId;
 
@@ -72,11 +72,9 @@ class OrderBuilder
         $this->ids = $ids;
         $this->id = $ids->get($orderNumber);
         $this->billingAddressId = $ids->get('billing_address');
-        $this->currencyId = Defaults::CURRENCY;
         $this->stateId = $this->getStateMachineState();
         $this->orderNumber = $orderNumber;
         $this->orderDateTime = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
-        $this->currencyFactor = 1.0;
 
         $this->price(420.69);
         $this->shippingCosts(0);

--- a/src/Core/Test/Integration/Builder/Promotion/PromotionFixtureBuilder.php
+++ b/src/Core/Test/Integration/Builder/Promotion/PromotionFixtureBuilder.php
@@ -22,12 +22,12 @@ class PromotionFixtureBuilder
     /**
      * @var list<array<string, mixed>>
      */
-    private array $dataSetGroups;
+    private array $dataSetGroups = [];
 
     /**
      * @var list<array<string, mixed>>
      */
-    private array $dataDiscounts;
+    private array $dataDiscounts = [];
 
     public function __construct(
         private readonly string $promotionId,
@@ -36,9 +36,6 @@ class PromotionFixtureBuilder
         private readonly EntityRepository $promotionSetgroupRepository,
         private readonly EntityRepository $promotionDiscountRepository
     ) {
-        $this->dataSetGroups = [];
-        $this->dataDiscounts = [];
-
         $this->context = $salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
There is no need to set properties in the constructor, if they can already be set in the declaration.

### 2. What does this change do, exactly?
Directly set the property default values instead of setting them in the constructors.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
