### PR TITLE
refactor: Make final classes readonly instead of properties

### DIFF
--- a/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
+++ b/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
@@ -15,12 +15,12 @@ use Shopware\Core\Framework\Uuid\Uuid;
  * @internal - Fetch the $referenceDocumentId if set, otherwise fetch the latest document
  */
 #[Package('after-sales')]
-final class ReferenceInvoiceLoader
+final readonly class ReferenceInvoiceLoader
 {
     /**
      * @internal
      */
-    public function __construct(private readonly Connection $connection)
+    public function __construct(private Connection $connection)
     {
     }
 

--- a/src/Core/Checkout/Gateway/Command/Executor/CheckoutGatewayCommandExecutor.php
+++ b/src/Core/Checkout/Gateway/Command/Executor/CheckoutGatewayCommandExecutor.php
@@ -11,14 +11,14 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('checkout')]
-final class CheckoutGatewayCommandExecutor
+final readonly class CheckoutGatewayCommandExecutor
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly CheckoutGatewayCommandRegistry $registry,
-        private readonly ExceptionLogger $logger,
+        private CheckoutGatewayCommandRegistry $registry,
+        private ExceptionLogger $logger,
     ) {
     }
 

--- a/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodValidator.php
+++ b/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodValidator.php
@@ -14,12 +14,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @internal
  */
 #[Package('checkout')]
-final class PaymentMethodValidator implements EventSubscriberInterface
+final readonly class PaymentMethodValidator implements EventSubscriberInterface
 {
     /**
      * @internal
      */
-    public function __construct(private readonly Connection $connection)
+    public function __construct(private Connection $connection)
     {
     }
 

--- a/src/Core/Content/ImportExport/Message/DeleteFileHandler.php
+++ b/src/Core/Content/ImportExport/Message/DeleteFileHandler.php
@@ -12,12 +12,12 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler]
 #[Package('fundamentals@after-sales')]
-final class DeleteFileHandler
+final readonly class DeleteFileHandler
 {
     /**
      * @internal
      */
-    public function __construct(private readonly FilesystemOperator $filesystem)
+    public function __construct(private FilesystemOperator $filesystem)
     {
     }
 

--- a/src/Core/Content/ImportExport/Message/ImportExportHandler.php
+++ b/src/Core/Content/ImportExport/Message/ImportExportHandler.php
@@ -20,15 +20,15 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 #[AsMessageHandler]
 #[Package('fundamentals@after-sales')]
-final class ImportExportHandler
+final readonly class ImportExportHandler
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly MessageBusInterface $messageBus,
-        private readonly ImportExportFactory $importExportFactory,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private MessageBusInterface $messageBus,
+        private ImportExportFactory $importExportFactory,
+        private EventDispatcherInterface $eventDispatcher
     ) {
     }
 

--- a/src/Core/Content/Mail/Message/SendMailHandler.php
+++ b/src/Core/Content/Mail/Message/SendMailHandler.php
@@ -16,15 +16,15 @@ use Symfony\Component\Mime\Email;
  */
 #[AsMessageHandler(handles: SendMailMessage::class)]
 #[Package('after-sales')]
-final class SendMailHandler
+final readonly class SendMailHandler
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly TransportInterface $transport,
-        private readonly FilesystemOperator $filesystem,
-        private readonly LoggerInterface $logger
+        private TransportInterface $transport,
+        private FilesystemOperator $filesystem,
+        private LoggerInterface $logger
     ) {
     }
 

--- a/src/Core/Content/Media/Message/DeleteFileHandler.php
+++ b/src/Core/Content/Media/Message/DeleteFileHandler.php
@@ -14,14 +14,14 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler]
 #[Package('discovery')]
-final class DeleteFileHandler
+final readonly class DeleteFileHandler
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly FilesystemOperator $filesystemPublic,
-        private readonly FilesystemOperator $filesystemPrivate
+        private FilesystemOperator $filesystemPublic,
+        private FilesystemOperator $filesystemPrivate
     ) {
     }
 

--- a/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
+++ b/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
@@ -15,15 +15,15 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler]
 #[Package('discovery')]
-final class GenerateThumbnailsHandler
+final readonly class GenerateThumbnailsHandler
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly ThumbnailService $thumbnailService,
-        private readonly EntityRepository $mediaRepository,
-        private readonly bool $remoteThumbnailsEnable = false
+        private ThumbnailService $thumbnailService,
+        private EntityRepository $mediaRepository,
+        private bool $remoteThumbnailsEnable = false
     ) {
     }
 

--- a/src/Core/Content/Product/DataAbstractionLayer/StockUpdate/StockUpdateFilterProvider.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/StockUpdate/StockUpdateFilterProvider.php
@@ -9,14 +9,14 @@ use Shopware\Core\Framework\Log\Package;
  * @internal In order to manipulate the filter process, provide your own tagged AbstractStockUpdateFilter
  */
 #[Package('framework')]
-final class StockUpdateFilterProvider
+final readonly class StockUpdateFilterProvider
 {
     /**
      * @internal
      *
      * @param AbstractStockUpdateFilter[] $filters
      */
-    public function __construct(private readonly iterable $filters)
+    public function __construct(private iterable $filters)
     {
     }
 

--- a/src/Core/Content/Product/SalesChannel/Listing/Processor/CompositeListingProcessor.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Processor/CompositeListingProcessor.php
@@ -10,14 +10,14 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
 #[Package('inventory')]
-final class CompositeListingProcessor
+final readonly class CompositeListingProcessor
 {
     /**
      * @param iterable<AbstractListingProcessor> $processors
      *
      * @internal
      */
-    public function __construct(private readonly iterable $processors)
+    public function __construct(private iterable $processors)
     {
     }
 

--- a/src/Core/Content/Product/Stock/OrderStockSubscriber.php
+++ b/src/Core/Content/Product/Stock/OrderStockSubscriber.php
@@ -21,15 +21,15 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @internal
  */
 #[Package('inventory')]
-final class OrderStockSubscriber implements EventSubscriberInterface
+final readonly class OrderStockSubscriber implements EventSubscriberInterface
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly Connection $connection,
-        private readonly AbstractStockStorage $stockStorage,
-        private readonly bool $enableStockManagement,
+        private Connection $connection,
+        private AbstractStockStorage $stockStorage,
+        private bool $enableStockManagement,
     ) {
     }
 

--- a/src/Core/Content/Product/Stock/StockAlteration.php
+++ b/src/Core/Content/Product/Stock/StockAlteration.php
@@ -5,13 +5,13 @@ namespace Shopware\Core\Content\Product\Stock;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('inventory')]
-final class StockAlteration
+final readonly class StockAlteration
 {
     public function __construct(
-        public readonly string $lineItemId,
-        public readonly string $productId,
-        public readonly int $quantityBefore,
-        public readonly int $newQuantity
+        public string $lineItemId,
+        public string $productId,
+        public int $quantityBefore,
+        public int $newQuantity
     ) {
     }
 

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
@@ -32,24 +32,24 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 #[AsMessageHandler]
 #[Package('inventory')]
-final class ProductExportPartialGenerationHandler
+final readonly class ProductExportPartialGenerationHandler
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly ProductExportGeneratorInterface $productExportGenerator,
-        private readonly AbstractSalesChannelContextFactory $salesChannelContextFactory,
-        private readonly EntityRepository $productExportRepository,
-        private readonly ProductExportFileHandlerInterface $productExportFileHandler,
-        private readonly MessageBusInterface $messageBus,
-        private readonly ProductExportRendererInterface $productExportRender,
-        private readonly AbstractTranslator $translator,
-        private readonly SalesChannelContextServiceInterface $salesChannelContextService,
-        private readonly SalesChannelContextPersister $contextPersister,
-        private readonly Connection $connection,
-        private readonly int $readBufferSize,
-        private readonly LanguageLocaleCodeProvider $languageLocaleProvider
+        private ProductExportGeneratorInterface $productExportGenerator,
+        private AbstractSalesChannelContextFactory $salesChannelContextFactory,
+        private EntityRepository $productExportRepository,
+        private ProductExportFileHandlerInterface $productExportFileHandler,
+        private MessageBusInterface $messageBus,
+        private ProductExportRendererInterface $productExportRender,
+        private AbstractTranslator $translator,
+        private SalesChannelContextServiceInterface $salesChannelContextService,
+        private SalesChannelContextPersister $contextPersister,
+        private Connection $connection,
+        private int $readBufferSize,
+        private LanguageLocaleCodeProvider $languageLocaleProvider
     ) {
     }
 

--- a/src/Core/Content/Sitemap/ScheduledTask/SitemapMessageHandler.php
+++ b/src/Core/Content/Sitemap/ScheduledTask/SitemapMessageHandler.php
@@ -16,16 +16,16 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler]
 #[Package('discovery')]
-final class SitemapMessageHandler
+final readonly class SitemapMessageHandler
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly AbstractSalesChannelContextFactory $salesChannelContextFactory,
-        private readonly SitemapExporterInterface $sitemapExporter,
-        private readonly LoggerInterface $logger,
-        private readonly SystemConfigService $systemConfigService,
+        private AbstractSalesChannelContextFactory $salesChannelContextFactory,
+        private SitemapExporterInterface $sitemapExporter,
+        private LoggerInterface $logger,
+        private SystemConfigService $systemConfigService,
     ) {
     }
 

--- a/src/Core/Framework/Adapter/Cache/Message/CleanupOldCacheFoldersHandler.php
+++ b/src/Core/Framework/Adapter/Cache/Message/CleanupOldCacheFoldersHandler.php
@@ -11,9 +11,9 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler]
 #[Package('framework')]
-final class CleanupOldCacheFoldersHandler
+final readonly class CleanupOldCacheFoldersHandler
 {
-    public function __construct(private readonly CacheClearer $cacheClearer)
+    public function __construct(private CacheClearer $cacheClearer)
     {
     }
 

--- a/src/Core/Framework/App/Lifecycle/Parameters/AppInstallParameters.php
+++ b/src/Core/Framework/App/Lifecycle/Parameters/AppInstallParameters.php
@@ -10,11 +10,11 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore This is a simple DTO and does not require tests
  */
 #[Package('framework')]
-final class AppInstallParameters
+final readonly class AppInstallParameters
 {
     public function __construct(
-        public readonly bool $activate = true,
-        public readonly bool $acceptPermissions = true
+        public bool $activate = true,
+        public bool $acceptPermissions = true
     ) {
     }
 }

--- a/src/Core/Framework/App/Lifecycle/Parameters/AppUpdateParameters.php
+++ b/src/Core/Framework/App/Lifecycle/Parameters/AppUpdateParameters.php
@@ -10,10 +10,10 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore This is a simple DTO and does not require tests
  */
 #[Package('framework')]
-final class AppUpdateParameters
+final readonly class AppUpdateParameters
 {
     public function __construct(
-        public readonly bool $acceptPermissions = true
+        public bool $acceptPermissions = true
     ) {
     }
 }

--- a/src/Core/Framework/Extensions/ExtensionDispatcher.php
+++ b/src/Core/Framework/Extensions/ExtensionDispatcher.php
@@ -6,13 +6,13 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 #[Package('framework')]
-final class ExtensionDispatcher
+final readonly class ExtensionDispatcher
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly EventDispatcherInterface $dispatcher
+        private EventDispatcherInterface $dispatcher
     ) {
     }
 

--- a/src/Core/Framework/MessageQueue/Subscriber/PluginLifecycleSubscriber.php
+++ b/src/Core/Framework/MessageQueue/Subscriber/PluginLifecycleSubscriber.php
@@ -15,14 +15,14 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
  * @internal
  */
 #[Package('framework')]
-final class PluginLifecycleSubscriber implements EventSubscriberInterface
+final readonly class PluginLifecycleSubscriber implements EventSubscriberInterface
 {
     /**
      * @internal
      */
     public function __construct(
-        private readonly TaskRegistry $registry,
-        private readonly CacheItemPoolInterface $restartSignalCachePool
+        private TaskRegistry $registry,
+        private CacheItemPoolInterface $restartSignalCachePool,
     ) {
     }
 

--- a/src/Core/Framework/MessageQueue/Subscriber/UpdatePostFinishSubscriber.php
+++ b/src/Core/Framework/MessageQueue/Subscriber/UpdatePostFinishSubscriber.php
@@ -11,12 +11,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @internal
  */
 #[Package('framework')]
-final class UpdatePostFinishSubscriber implements EventSubscriberInterface
+final readonly class UpdatePostFinishSubscriber implements EventSubscriberInterface
 {
     /**
      * @internal
      */
-    public function __construct(private readonly TaskRegistry $registry)
+    public function __construct(private TaskRegistry $registry)
     {
     }
 

--- a/src/Core/Framework/Routing/Facade/RequestFacade.php
+++ b/src/Core/Framework/Routing/Facade/RequestFacade.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @example scripts/store-api-request-test/store-api-request-test.twig Use request to determine method and return all json body back
  */
 #[Package('framework')]
-final class RequestFacade
+final readonly class RequestFacade
 {
     private const ALLOWED_PARAMETERS = [
         'content-type',
@@ -43,7 +43,7 @@ final class RequestFacade
     /**
      * @internal
      */
-    public function __construct(private readonly Request $request)
+    public function __construct(private Request $request)
     {
     }
 

--- a/src/Core/Framework/Store/InAppPurchase/Services/DecodedPurchaseStruct.php
+++ b/src/Core/Framework/Store/InAppPurchase/Services/DecodedPurchaseStruct.php
@@ -10,19 +10,19 @@ use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
 
 #[Package('checkout')]
-final class DecodedPurchaseStruct
+final readonly class DecodedPurchaseStruct
 {
     #[NotNull, NotBlank, Type('string')]
-    public readonly string $identifier;
+    public string $identifier;
 
     #[Type('string')]
-    public readonly ?string $nextBookingDate;
+    public ?string $nextBookingDate;
 
     #[NotNull, Type('integer')]
-    public readonly int $quantity;
+    public int $quantity;
 
     #[NotNull, NotBlank, Type('string')]
-    public readonly string $sub;
+    public string $sub;
 
     /**
      * @param array{identifier: string, nextBookingDate: string|null, quantity: int, sub: string} $data

--- a/src/Core/Framework/Store/InAppPurchase/Services/InAppPurchaseProvider.php
+++ b/src/Core/Framework/Store/InAppPurchase/Services/InAppPurchaseProvider.php
@@ -20,15 +20,15 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
  * @phpstan-import-type JSONWebKey from JWKStruct
  */
 #[Package('checkout')]
-final class InAppPurchaseProvider
+final readonly class InAppPurchaseProvider
 {
     public const CONFIG_STORE_IAP_KEY = 'core.store.iapKey';
 
     public function __construct(
-        private readonly SystemConfigService $systemConfig,
-        private readonly JWTDecoder $decoder,
-        private readonly KeyFetcher $keyFetcher,
-        private readonly LoggerInterface $logger,
+        private SystemConfigService $systemConfig,
+        private JWTDecoder $decoder,
+        private KeyFetcher $keyFetcher,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/src/Core/Framework/Store/InAppPurchase/Services/KeyFetcher.php
+++ b/src/Core/Framework/Store/InAppPurchase/Services/KeyFetcher.php
@@ -21,15 +21,15 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
  * @phpstan-import-type JSONWebKey from JWKStruct
  */
 #[Package('checkout')]
-final class KeyFetcher
+final readonly class KeyFetcher
 {
     final public const CORE_STORE_JWKS = 'core.store.jwks';
 
     public function __construct(
-        private readonly ClientInterface $client,
-        private readonly AbstractStoreRequestOptionsProvider $storeRequestOptionsProvider,
-        private readonly SystemConfigService $systemConfigService,
-        private readonly LoggerInterface $logger
+        private ClientInterface $client,
+        private AbstractStoreRequestOptionsProvider $storeRequestOptionsProvider,
+        private SystemConfigService $systemConfigService,
+        private LoggerInterface $logger
     ) {
     }
 

--- a/src/Core/Framework/Store/Struct/FrwState.php
+++ b/src/Core/Framework/Store/Struct/FrwState.php
@@ -8,12 +8,12 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore
  */
 #[Package('checkout')]
-final class FrwState
+final readonly class FrwState
 {
     private function __construct(
-        private readonly ?\DateTimeImmutable $completedAt = null,
-        private readonly ?\DateTimeImmutable $failedAt = null,
-        private readonly int $failureCount = 0
+        private ?\DateTimeImmutable $completedAt = null,
+        private ?\DateTimeImmutable $failedAt = null,
+        private int $failureCount = 0
     ) {
     }
 

--- a/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
+++ b/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
@@ -22,7 +22,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler]
 #[Package('framework')]
-final class WebhookEventMessageHandler
+final readonly class WebhookEventMessageHandler
 {
     private const TIMEOUT = 20;
     private const CONNECT_TIMEOUT = 10;
@@ -31,9 +31,9 @@ final class WebhookEventMessageHandler
      * @internal
      */
     public function __construct(
-        private readonly Client $client,
-        private readonly EntityRepository $webhookEventLogRepository,
-        private readonly RelatedWebhooks $relatedWebhooks,
+        private Client $client,
+        private EntityRepository $webhookEventLogRepository,
+        private RelatedWebhooks $relatedWebhooks,
     ) {
     }
 

--- a/src/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchema.php
+++ b/src/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchema.php
@@ -11,14 +11,14 @@ use Symfony\Component\Config\Util\XmlUtils;
  * @internal
  */
 #[Package('framework')]
-final class AdminUiXmlSchema
+final readonly class AdminUiXmlSchema
 {
     public const FILENAME = 'admin-ui.xml';
 
     public const XSD_FILEPATH = __DIR__ . '/admin-ui-1.0.xsd';
 
     private function __construct(
-        private readonly AdminUi $adminUi
+        private AdminUi $adminUi
     ) {
     }
 

--- a/src/Core/System/UsageData/EntitySync/CollectEntityDataMessageHandler.php
+++ b/src/Core/System/UsageData/EntitySync/CollectEntityDataMessageHandler.php
@@ -11,10 +11,10 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler(handles: CollectEntityDataMessage::class)]
 #[Package('data-services')]
-final class CollectEntityDataMessageHandler
+final readonly class CollectEntityDataMessageHandler
 {
     public function __construct(
-        private readonly EntityDispatchService $entityDispatchService,
+        private EntityDispatchService $entityDispatchService,
     ) {
     }
 

--- a/src/Core/System/UsageData/EntitySync/DispatchEntityMessageHandler.php
+++ b/src/Core/System/UsageData/EntitySync/DispatchEntityMessageHandler.php
@@ -26,16 +26,16 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
  */
 #[AsMessageHandler(handles: DispatchEntityMessage::class)]
 #[Package('data-services')]
-final class DispatchEntityMessageHandler
+final readonly class DispatchEntityMessageHandler
 {
     public function __construct(
-        private readonly EntityDefinitionService $entityDefinitionService,
-        private readonly ManyToManyAssociationService $manyToManyAssociationService,
-        private readonly UsageDataAllowListService $usageDataAllowListService,
-        private readonly Connection $connection,
-        private readonly EntityDispatcher $entityDispatcher,
-        private readonly ConsentService $consentService,
-        private readonly ShopIdProvider $shopIdProvider
+        private EntityDefinitionService $entityDefinitionService,
+        private ManyToManyAssociationService $manyToManyAssociationService,
+        private UsageDataAllowListService $usageDataAllowListService,
+        private Connection $connection,
+        private EntityDispatcher $entityDispatcher,
+        private ConsentService $consentService,
+        private ShopIdProvider $shopIdProvider
     ) {
     }
 

--- a/src/Core/System/UsageData/EntitySync/IterateEntityMessageHandler.php
+++ b/src/Core/System/UsageData/EntitySync/IterateEntityMessageHandler.php
@@ -16,14 +16,14 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 #[AsMessageHandler(handles: IterateEntityMessage::class)]
 #[Package('data-services')]
-final class IterateEntityMessageHandler
+final readonly class IterateEntityMessageHandler
 {
     public function __construct(
-        private readonly MessageBusInterface $bus,
-        private readonly IterateEntitiesQueryBuilder $iteratorFactory,
-        private readonly ConsentService $consentService,
-        private readonly EntityDefinitionService $entityDefinitionService,
-        private readonly LoggerInterface $logger,
+        private MessageBusInterface $bus,
+        private IterateEntitiesQueryBuilder $iteratorFactory,
+        private ConsentService $consentService,
+        private EntityDefinitionService $entityDefinitionService,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/src/Elasticsearch/Admin/AdminSearchController.php
+++ b/src/Elasticsearch/Admin/AdminSearchController.php
@@ -18,13 +18,13 @@ use Symfony\Component\Routing\Attribute\Route;
  * @internal
  */
 #[Package('inventory')]
-final class AdminSearchController
+final readonly class AdminSearchController
 {
     public function __construct(
-        private readonly AdminSearcher $searcher,
-        private readonly DefinitionInstanceRegistry $definitionRegistry,
-        private readonly JsonEntityEncoder $entityEncoder,
-        private readonly AdminElasticsearchHelper $adminEsHelper
+        private AdminSearcher $searcher,
+        private DefinitionInstanceRegistry $definitionRegistry,
+        private JsonEntityEncoder $entityEncoder,
+        private AdminElasticsearchHelper $adminEsHelper
     ) {
     }
 

--- a/src/Elasticsearch/Admin/AdminSearchIndexingMessage.php
+++ b/src/Elasticsearch/Admin/AdminSearchIndexingMessage.php
@@ -11,17 +11,17 @@ use Shopware\Core\Framework\Util\Hasher;
  * @internal
  */
 #[Package('inventory')]
-final class AdminSearchIndexingMessage implements AsyncMessageInterface, DeduplicatableMessageInterface
+final readonly class AdminSearchIndexingMessage implements AsyncMessageInterface, DeduplicatableMessageInterface
 {
     /**
      * @param array<string, string> $indices
      * @param array<string> $ids
      */
     public function __construct(
-        private readonly string $entity,
-        private readonly string $indexer,
-        private readonly array $indices,
-        private readonly array $ids
+        private string $entity,
+        private string $indexer,
+        private array $indices,
+        private array $ids
     ) {
     }
 

--- a/src/Elasticsearch/Admin/Subscriber/RefreshIndexSubscriber.php
+++ b/src/Elasticsearch/Admin/Subscriber/RefreshIndexSubscriber.php
@@ -12,9 +12,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @internal
  */
 #[Package('inventory')]
-final class RefreshIndexSubscriber implements EventSubscriberInterface
+final readonly class RefreshIndexSubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly AdminSearchRegistry $registry)
+    public function __construct(private AdminSearchRegistry $registry)
     {
     }
 

--- a/src/Storefront/Controller/AppController.php
+++ b/src/Storefront/Controller/AppController.php
@@ -15,9 +15,9 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 #[Route(defaults: ['_routeScope' => ['storefront']])]
 #[Package('framework')]
-final class AppController
+final readonly class AppController
 {
-    public function __construct(private readonly AppJWTGenerateRoute $appJWTGenerateRoute)
+    public function __construct(private AppJWTGenerateRoute $appJWTGenerateRoute)
     {
     }
 

--- a/src/Storefront/Theme/Message/CompileThemeHandler.php
+++ b/src/Storefront/Theme/Message/CompileThemeHandler.php
@@ -22,18 +22,18 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler]
 #[Package('framework')]
-final class CompileThemeHandler
+final readonly class CompileThemeHandler
 {
     /**
      * @param EntityRepository<SalesChannelCollection> $saleschannelRepository
      */
     public function __construct(
-        private readonly ThemeCompilerInterface $themeCompiler,
-        private readonly AbstractConfigLoader $configLoader,
-        private readonly StorefrontPluginRegistry $extensionRegistry,
-        private readonly NotificationService $notificationService,
-        private readonly EntityRepository $saleschannelRepository,
-        private readonly ThemeRuntimeConfigService $runtimeConfigService,
+        private ThemeCompilerInterface $themeCompiler,
+        private AbstractConfigLoader $configLoader,
+        private StorefrontPluginRegistry $extensionRegistry,
+        private NotificationService $notificationService,
+        private EntityRepository $saleschannelRepository,
+        private ThemeRuntimeConfigService $runtimeConfigService,
     ) {
     }
 

--- a/src/Storefront/Theme/Message/DeleteThemeFilesHandler.php
+++ b/src/Storefront/Theme/Message/DeleteThemeFilesHandler.php
@@ -17,11 +17,11 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  */
 #[AsMessageHandler]
 #[Package('framework')]
-final class DeleteThemeFilesHandler
+final readonly class DeleteThemeFilesHandler
 {
     public function __construct(
-        private readonly FilesystemOperator $filesystem,
-        private readonly AbstractThemePathBuilder $pathBuilder,
+        private FilesystemOperator $filesystem,
+        private AbstractThemePathBuilder $pathBuilder,
     ) {
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It is advantageous to directly declare classes as readonly, instead of each property, as future added properties will directly be readonly.

Also it indicates more clearly that the classes should be immutable.

However this can only be done safely on `final` classes.

### 2. What does this change do, exactly?
Convert readonly properties of classes to readonly classes.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
