### PR TITLE
fix: Expose docker db port

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,8 @@ services:
 
     database:
         image: mariadb:latest
+        ports:
+            - 3306:3306
         environment:
             MARIADB_ROOT_PASSWORD: root
             MARIADB_DATABASE: shopware


### PR DESCRIPTION
### 1. Why is this change necessary?
To connect to the DB using the delivered docker setup.

### 2. What does this change do, exactly?
Expose port 3306 of the db container to port 3306 of the host machine.


### 3. Describe each step to reproduce the issue or behaviour.
Spin up the docker setup and try to connect via your host machine e.g PHPStorm.

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
