### PR TITLE
feat: introduce user delete command

### DIFF
--- a/changelog/_unreleased/2025-07-12-introduce-user-delete-command.md
+++ b/changelog/_unreleased/2025-07-12-introduce-user-delete-command.md
@@ -2,4 +2,4 @@
 title: Introduce user delete command
 ---
 # Core
-* Introduces the new CLI command: `user:delete` for deleting a user by the given user ID
+* Added the new CLI command `user:delete` for deleting a user by the given user ID

--- a/changelog/_unreleased/2025-07-12-introduce-user-delete-command.md
+++ b/changelog/_unreleased/2025-07-12-introduce-user-delete-command.md
@@ -1,0 +1,5 @@
+---
+title: Introduce user delete command
+---
+# Core
+* Introduces the new CLI command: `user:delete` for deleting a user by the given user ID

--- a/src/Core/Maintenance/User/Command/UserDeleteCommand.php
+++ b/src/Core/Maintenance/User/Command/UserDeleteCommand.php
@@ -41,7 +41,7 @@ class UserDeleteCommand extends Command
 
         $userId = $input->getArgument('user_id');
 
-        $findUserById = $this->userRepository->search(new Criteria(['id' => $userId]), $context)->first();
+        $findUserById = $this->userRepository->search(new Criteria([$userId]), $context)->first();
         if (!$findUserById) {
             $io->error(sprintf('User with the ID: "%s" does not exist.', $userId));
             return self::INVALID;

--- a/src/Core/Maintenance/User/Command/UserDeleteCommand.php
+++ b/src/Core/Maintenance/User/Command/UserDeleteCommand.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Maintenance\User\Command;
+
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * @internal should be used over the CLI only
+ */
+#[AsCommand(
+    name: 'user:delete',
+    description: 'Deletes a user by the given user id',
+)]
+#[Package('framework')]
+class UserDeleteCommand extends Command
+{
+    public function __construct(private readonly EntityRepository $userRepository)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('user_id', InputArgument::REQUIRED, 'User ID for the user');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+        $context = Context::createCLIContext();
+
+        $userId = $input->getArgument('user_id');
+
+        $findUserById = $this->userRepository->search(new Criteria(['id' => $userId]), $context)->first();
+        if (!$findUserById) {
+            $io->error(sprintf('User with the ID: "%s" does not exist.', $userId));
+            return self::INVALID;
+        }
+
+        $askConfirmationQuestion = new ConfirmationQuestion(sprintf('Would you like to delete the user with the ID: "%s" ?', $userId), false);
+        $askConfirmation = $io->askQuestion($askConfirmationQuestion);
+        if ($askConfirmation) {
+            $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($userId): void {
+                $this->userRepository->delete([['id' => $userId]], $context);
+            });
+
+            $message = \sprintf('User with the ID: "%s" successfully deleted.', $userId);
+            $io->success($message);
+        } else {
+            $io->info('The process was canceled and the user was not deleted');
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

This pull request enhances the user cli commands. It adds a new command: `user:delete` which adds the possibility to delete a user by the given ID.

### 2. What does this change do, exactly?
adds a new CLI command: `user:delete`

### 3. Describe each step to reproduce the issue or behaviour.

Run:

```bash
bin/shopware user:delete user-id
```
and accept the confirmation.


### 4. Please link to the relevant issues (if any).
_None_

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
