### PR TITLE
feat: Add NumberRangeValueGeneratorExtension to NumberRangeValueGenerator

### DIFF
--- a/changelog/_unreleased/2025-07-14-add-number-range-value-generator-extension.md
+++ b/changelog/_unreleased/2025-07-14-add-number-range-value-generator-extension.md
@@ -1,0 +1,9 @@
+---
+title: Add NumberRangeValueGeneratorExtension to NumberRangeValueGenerator
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Added `Shopware\Core\System\NumberRange\Extension\NumberRangeValueGeneratorExtension`
+* Changed `Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGenerator` to publish `NumberRangeValueGeneratorExtension`

--- a/src/Core/System/DependencyInjection/number_range.xml
+++ b/src/Core/System/DependencyInjection/number_range.xml
@@ -70,6 +70,7 @@
                  public="true">
             <argument type="service" id="Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternRegistry" />
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>
 

--- a/src/Core/System/NumberRange/Extension/NumberRangeValueGeneratorExtension.php
+++ b/src/Core/System/NumberRange/Extension/NumberRangeValueGeneratorExtension.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\NumberRange\Extension;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @public this class is used as type-hint for all event listeners, so the class string is "public consumable" API
+ *
+ * @title Determination of a number range value
+ *
+ * @description This event allows interception of the number range value generation to modify the generated value.
+ *
+ * @codeCoverageIgnore
+ *
+ * @extends Extension<string>
+ */
+#[Package('framework')]
+final class NumberRangeValueGeneratorExtension extends Extension
+{
+    public const NAME = 'number-range-value-generator';
+
+    /**
+     * @internal shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(
+        public readonly string $type,
+        public readonly Context $context,
+        public readonly ?string $salesChannelId,
+        public readonly bool $preview,
+    ) {
+    }
+}

--- a/src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
+++ b/src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
@@ -4,9 +4,11 @@ namespace Shopware\Core\System\NumberRange\ValueGenerator;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\Exception\NoConfigurationException;
+use Shopware\Core\System\NumberRange\Extension\NumberRangeValueGeneratorExtension;
 use Shopware\Core\System\NumberRange\NumberRangeEvents;
 use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -20,17 +22,18 @@ class NumberRangeValueGenerator implements NumberRangeValueGeneratorInterface
     public function __construct(
         private readonly ValueGeneratorPatternRegistry $valueGeneratorPatternRegistry,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ExtensionDispatcher $extensions,
         private readonly Connection $connection
     ) {
     }
 
     public function getValue(string $type, Context $context, ?string $salesChannelId, bool $preview = false): string
     {
-        $config = $this->getConfiguration($type, $salesChannelId);
-
-        $parsedPattern = $this->parsePattern($config['pattern']);
-
-        $generatedValue = \is_array($parsedPattern) ? $this->generate($parsedPattern, $config, $preview) : '';
+        $generatedValue = $this->extensions->publish(
+            name: NumberRangeValueGeneratorExtension::NAME,
+            extension: new NumberRangeValueGeneratorExtension($type, $context, $salesChannelId, $preview),
+            function: $this->_getValue(...),
+        );
 
         return $this->endEvent($generatedValue, $type, $context, $salesChannelId, $preview);
     }
@@ -47,6 +50,15 @@ class NumberRangeValueGenerator implements NumberRangeValueGeneratorInterface
         $parsedPattern = $this->parsePattern($pattern);
 
         return \is_array($parsedPattern) ? $this->generate($parsedPattern, $config, true) : '';
+    }
+
+    private function _getValue(string $type, Context $context, ?string $salesChannelId, bool $preview = false): string
+    {
+        $config = $this->getConfiguration($type, $salesChannelId);
+
+        $parsedPattern = $this->parsePattern($config['pattern']);
+
+        return \is_array($parsedPattern) ? $this->generate($parsedPattern, $config, $preview) : '';
     }
 
     /**

--- a/tests/integration/Core/System/NumberRange/NumberRangeValueGeneratorTest.php
+++ b/tests/integration/Core/System/NumberRange/NumberRangeValueGeneratorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeCollection;
@@ -19,6 +20,7 @@ use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInt
 use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternDate;
 use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternIncrement;
 use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternRegistry;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * @internal
@@ -149,9 +151,12 @@ class NumberRangeValueGeneratorTest extends TestCase
             ->method('fetchAssociative')
             ->willReturn(['id' => Uuid::randomHex(), 'pattern' => $pattern, 'start' => 1]);
 
+        $dispatcher = new EventDispatcher();
+
         return new NumberRangeValueGenerator(
             $patternReg,
-            static::getContainer()->get('event_dispatcher'),
+            $dispatcher,
+            new ExtensionDispatcher($dispatcher),
             $connection,
         );
     }

--- a/tests/unit/Core/System/NumberRange/ValueGenerator/NumberRangeValueGeneratorTest.php
+++ b/tests/unit/Core/System/NumberRange/ValueGenerator/NumberRangeValueGeneratorTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\NumberRange\ValueGenerator;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\NumberRange\Extension\NumberRangeValueGeneratorExtension;
+use Shopware\Core\System\NumberRange\NumberRangeEvents;
+use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGenerator;
+use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\IncrementStorage\IncrementSqlStorage;
+use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternIncrement;
+use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternRegistry;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ */
+#[CoversClass(NumberRangeValueGenerator::class)]
+class NumberRangeValueGeneratorTest extends TestCase
+{
+    public function testGeneratedNumberValue(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'id' => Uuid::randomHex(),
+                'pattern' => 'ABC{n}',
+                'start' => 0,
+            ]);
+
+        $result = $this->createMock(Result::class);
+        $result->expects($this->once())
+            ->method('fetchOne')
+            ->willReturn('1');
+
+        $connection->expects($this->once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        $numberRangeValueGenerator = new NumberRangeValueGenerator(
+            new ValueGeneratorPatternRegistry([
+                new ValueGeneratorPatternIncrement(
+                    new IncrementSqlStorage($connection),
+                ),
+            ]),
+            $dispatcher,
+            new ExtensionDispatcher($dispatcher),
+            $connection,
+        );
+
+        $value = $numberRangeValueGenerator->getValue(OrderDefinition::ENTITY_NAME, Context::createDefaultContext(), null, false);
+        static::assertSame('ABC1', $value);
+    }
+
+    public function testGeneratedEventIsDispatched(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'id' => Uuid::randomHex(),
+                'pattern' => '{n}',
+                'start' => 0,
+            ]);
+
+        $numberRangeValueGenerator = new NumberRangeValueGenerator(
+            new ValueGeneratorPatternRegistry([]),
+            $dispatcher,
+            new ExtensionDispatcher($dispatcher),
+            $connection,
+        );
+
+        $post = $this->createMock(CallableClass::class);
+        $post->expects($this->exactly(1))->method('__invoke');
+        $dispatcher->addListener(NumberRangeEvents::NUMBER_RANGE_GENERATED, $post);
+
+        $numberRangeValueGenerator->getValue(OrderDefinition::ENTITY_NAME, Context::createDefaultContext(), null, false);
+    }
+
+    public function testExtensionIsDispatched(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        $numberRangeValueGenerator = new NumberRangeValueGenerator(
+            new ValueGeneratorPatternRegistry([]),
+            $dispatcher,
+            new ExtensionDispatcher($dispatcher),
+            $this->createMock(Connection::class),
+        );
+
+        $post = $this->createMock(CallableClass::class);
+        $post->expects($this->exactly(1))->method('__invoke');
+        $dispatcher->addListener(ExtensionDispatcher::post(NumberRangeValueGeneratorExtension::NAME), $post);
+
+        $dispatcher->addListener(
+            ExtensionDispatcher::pre(NumberRangeValueGeneratorExtension::NAME),
+            function (NumberRangeValueGeneratorExtension $extension): void {
+                $extension->stopPropagation();
+
+                $extension->result = 'new-number-range-value';
+            }
+        );
+
+        $value = $numberRangeValueGenerator->getValue(OrderDefinition::ENTITY_NAME, Context::createDefaultContext(), null, false);
+
+        static::assertSame('new-number-range-value', $value);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently you can't really intercept in the generation process of a number range value
- This PR adds the NumberRangeValueGeneratorExtension which allows a interception of the generation process of a number range value to add custom logic to it

### 2. What does this change do, exactly?
* Added `Shopware\Core\System\NumberRange\Extension\NumberRangeValueGeneratorExtension`
* Changed `Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGenerator` to publish `NumberRangeValueGeneratorExtension`

### 3. Describe each step to reproduce the issue or behaviour.
- Try to intercept in the generation process of a number range value

### 4. Please link to the relevant issues (if any).
- #10969

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
