### PR TITLE
fix: scope RenamePaidTransitionActions migration

### DIFF
--- a/changelog/_unreleased/2025-07-15-scope-renamepaidtransitionactions-migration-to-ordertransactions.md
+++ b/changelog/_unreleased/2025-07-15-scope-renamepaidtransitionactions-migration-to-ordertransactions.md
@@ -1,0 +1,9 @@
+---
+title: Scope RenamePaidTransitionActions migration to order transaction state transitions
+issue: #11157
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `Shopware\Core\Migration\V6_7\Migration1742302302RenamePaidTransitionActions` to only change state transitions belonging to order transactions

--- a/src/Core/Migration/V6_7/Migration1742302302RenamePaidTransitionActions.php
+++ b/src/Core/Migration/V6_7/Migration1742302302RenamePaidTransitionActions.php
@@ -31,7 +31,7 @@ class Migration1742302302RenamePaidTransitionActions extends MigrationStep
         // pay -> paid
         // pay_partially -> paid_partially
         // do_pay -> process
-        $query = <<<SQL
+        $query = <<<'SQL'
             INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, custom_fields, created_at)
                 SELECT UNHEX(REPLACE(UUID(), "-", "")), t.state_machine_id, t.from_state_id, t.to_state_id, :newActionName, t.custom_fields, :createdAt
                 FROM `state_machine_transition` t

--- a/src/Core/Migration/V6_7/Migration1742302302RenamePaidTransitionActions.php
+++ b/src/Core/Migration/V6_7/Migration1742302302RenamePaidTransitionActions.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Migration\V6_7;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -21,6 +22,11 @@ class Migration1742302302RenamePaidTransitionActions extends MigrationStep
 
     public function update(Connection $connection): void
     {
+        $stateMachineId = $connection->fetchOne(
+            'SELECT id FROM state_machine WHERE technical_name = :technicalName',
+            ['technicalName' => OrderTransactionStates::STATE_MACHINE],
+        );
+
         // create duplicate transitions, if they do not exist for:
         // pay -> paid
         // pay_partially -> paid_partially
@@ -36,6 +42,7 @@ class Migration1742302302RenamePaidTransitionActions extends MigrationStep
                     AND existing.action_name = :newActionName
                 WHERE t.action_name = :oldActionName
                     AND existing.id IS NULL
+                    AND t.state_machine_id = :stateMachineId
             SQL;
 
         $connection->executeStatement($query, [
@@ -43,6 +50,7 @@ class Migration1742302302RenamePaidTransitionActions extends MigrationStep
             'newActionName' => 'paid',
             'oldActionName' => 'pay',
             'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'stateMachineId' => $stateMachineId,
         ]);
 
         $connection->executeStatement($query, [
@@ -50,6 +58,7 @@ class Migration1742302302RenamePaidTransitionActions extends MigrationStep
             'newActionName' => 'paid_partially',
             'oldActionName' => 'pay_partially',
             'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'stateMachineId' => $stateMachineId,
         ]);
 
         $connection->executeStatement($query, [
@@ -57,14 +66,20 @@ class Migration1742302302RenamePaidTransitionActions extends MigrationStep
             'newActionName' => 'process',
             'oldActionName' => 'do_pay',
             'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'stateMachineId' => $stateMachineId,
         ]);
     }
 
     public function updateDestructive(Connection $connection): void
     {
+        $stateMachineId = $connection->fetchOne(
+            'SELECT id FROM state_machine WHERE technical_name = :technicalName',
+            ['technicalName' => OrderTransactionStates::STATE_MACHINE],
+        );
+
         // remove old transition names
-        $connection->delete('state_machine_transition', ['action_name' => 'pay']);
-        $connection->delete('state_machine_transition', ['action_name' => 'pay_partially']);
-        $connection->delete('state_machine_transition', ['action_name' => 'do_pay']);
+        $connection->delete('state_machine_transition', ['action_name' => 'pay', 'state_machine_id' => $stateMachineId]);
+        $connection->delete('state_machine_transition', ['action_name' => 'pay_partially', 'state_machine_id' => $stateMachineId]);
+        $connection->delete('state_machine_transition', ['action_name' => 'do_pay', 'state_machine_id' => $stateMachineId]);
     }
 }

--- a/tests/migration/Core/V6_7/Migration1742302302RenamePaidTransitionActionsTest.php
+++ b/tests/migration/Core/V6_7/Migration1742302302RenamePaidTransitionActionsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -31,16 +32,18 @@ class Migration1742302302RenamePaidTransitionActionsTest extends TestCase
 
     public function testMigrationUpdate(): void
     {
-        $stateMachineId = Uuid::randomBytes();
+        $stateMachineId = $this->connection->fetchOne(
+            'SELECT id FROM state_machine WHERE technical_name = :technicalName',
+            ['technicalName' => OrderTransactionStates::STATE_MACHINE],
+        );
         $fromStateId = Uuid::randomBytes();
         $toStateId = Uuid::randomBytes();
 
         $duplicateTransition1 = Uuid::randomBytes();
         $duplicateTransition2 = Uuid::randomBytes();
         $duplicateTransition3 = Uuid::randomBytes();
+        $duplicateTransition4 = Uuid::randomBytes();
         $validTransition = Uuid::randomBytes();
-
-        $this->connection->executeStatement('INSERT INTO `state_machine` (id, technical_name, created_at) VALUES (?, ?, ?)', [$stateMachineId, 'state_machine', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
 
         $this->connection->executeStatement('INSERT INTO `state_machine_state` (id, state_machine_id, technical_name, created_at) VALUES (?, ?, ?, ?)', [$fromStateId, $stateMachineId, 'from_state', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
         $this->connection->executeStatement('INSERT INTO `state_machine_state` (id, state_machine_id, technical_name, created_at) VALUES (?, ?, ?, ?)', [$toStateId, $stateMachineId, 'to_state', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
@@ -48,7 +51,8 @@ class Migration1742302302RenamePaidTransitionActionsTest extends TestCase
         // Insert duplicate transitions
         $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition1, $stateMachineId, $fromStateId, $toStateId, 'pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
         $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition2, $stateMachineId, $fromStateId, $toStateId, 'do_pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
-        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition3, $stateMachineId, $fromStateId, $toStateId, 'paid', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition3, $stateMachineId, $fromStateId, $toStateId, 'pay_partially', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition4, $stateMachineId, $fromStateId, $toStateId, 'paid', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
 
         // Insert a random transition
         $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$validTransition, $stateMachineId, $fromStateId, $toStateId, 'other_action', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
@@ -57,16 +61,71 @@ class Migration1742302302RenamePaidTransitionActionsTest extends TestCase
         $migration->update($this->connection);
         $migration->update($this->connection);
 
-        $remainingTransitions = $this->connection->fetchFirstColumn('SELECT id FROM `state_machine_transition` WHERE from_state_id = ? AND to_state_id = ?', [$fromStateId, $toStateId]);
+        $remainingTransitions = $this->connection->fetchAllKeyValue('SELECT id, action_name FROM `state_machine_transition` WHERE from_state_id = ? AND to_state_id = ? AND state_machine_id = ?', [$fromStateId, $toStateId, $stateMachineId]);
 
-        static::assertContains($duplicateTransition1, $remainingTransitions);
-        static::assertContains($duplicateTransition2, $remainingTransitions);
-        static::assertContains($duplicateTransition3, $remainingTransitions);
+        static::assertArrayHasKey($duplicateTransition1, $remainingTransitions);
+        static::assertSame('pay', $remainingTransitions[$duplicateTransition1]);
+        static::assertArrayHasKey($duplicateTransition2, $remainingTransitions);
+        static::assertSame('do_pay', $remainingTransitions[$duplicateTransition2]);
+        static::assertArrayHasKey($duplicateTransition3, $remainingTransitions);
+        static::assertSame('pay_partially', $remainingTransitions[$duplicateTransition3]);
+        static::assertArrayHasKey($duplicateTransition4, $remainingTransitions);
+        static::assertSame('paid', $remainingTransitions[$duplicateTransition4]);
+        static::assertArrayHasKey($validTransition, $remainingTransitions);
 
-        static::assertContains($validTransition, $remainingTransitions);
+        // assert new transitions
+        static::assertContains('paid_partially', $remainingTransitions);
+        static::assertContains('process', $remainingTransitions);
     }
 
     public function testMigrationUpdateDestructive(): void
+    {
+        $stateMachineId = $this->connection->fetchOne(
+            'SELECT id FROM state_machine WHERE technical_name = :technicalName',
+            ['technicalName' => OrderTransactionStates::STATE_MACHINE],
+        );
+        $fromStateId = Uuid::randomBytes();
+        $toStateId = Uuid::randomBytes();
+
+        $duplicateTransition1 = Uuid::randomBytes();
+        $duplicateTransition2 = Uuid::randomBytes();
+        $duplicateTransition3 = Uuid::randomBytes();
+        $duplicateTransition4 = Uuid::randomBytes();
+        $validTransition = Uuid::randomBytes();
+
+        $this->connection->executeStatement('INSERT INTO `state_machine_state` (id, state_machine_id, technical_name, created_at) VALUES (?, ?, ?, ?)', [$fromStateId, $stateMachineId, 'from_state', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_state` (id, state_machine_id, technical_name, created_at) VALUES (?, ?, ?, ?)', [$toStateId, $stateMachineId, 'to_state', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // Insert duplicate transitions
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition1, $stateMachineId, $fromStateId, $toStateId, 'pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition2, $stateMachineId, $fromStateId, $toStateId, 'do_pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition3, $stateMachineId, $fromStateId, $toStateId, 'pay_partially', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition4, $stateMachineId, $fromStateId, $toStateId, 'paid', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // Insert a random transition
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$validTransition, $stateMachineId, $fromStateId, $toStateId, 'other_action', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        $migration = new Migration1742302302RenamePaidTransitionActions();
+        $migration->update($this->connection);
+        $migration->updateDestructive($this->connection);
+        $migration->updateDestructive($this->connection);
+
+        $remainingTransitions = $this->connection->fetchAllKeyValue('SELECT id, action_name FROM `state_machine_transition` WHERE from_state_id = ? AND to_state_id = ? AND state_machine_id = ?', [$fromStateId, $toStateId, $stateMachineId]);
+
+        static::assertNotContains($duplicateTransition1, $remainingTransitions);
+        static::assertNotContains($duplicateTransition2, $remainingTransitions);
+        static::assertNotContains($duplicateTransition3, $remainingTransitions);
+
+        static::assertArrayHasKey($duplicateTransition4, $remainingTransitions);
+        static::assertSame('paid', $remainingTransitions[$duplicateTransition4]);
+        static::assertArrayHasKey($validTransition, $remainingTransitions);
+
+        // assert new transitions
+        static::assertContains('paid_partially', $remainingTransitions);
+        static::assertContains('process', $remainingTransitions);
+    }
+
+    public function testMigrationUpdateOnlyOrderTransactionStateMachine(): void
     {
         $stateMachineId = Uuid::randomBytes();
         $fromStateId = Uuid::randomBytes();
@@ -85,20 +144,37 @@ class Migration1742302302RenamePaidTransitionActionsTest extends TestCase
         // Insert duplicate transitions
         $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition1, $stateMachineId, $fromStateId, $toStateId, 'pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
         $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition2, $stateMachineId, $fromStateId, $toStateId, 'do_pay', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
-        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition3, $stateMachineId, $fromStateId, $toStateId, 'paid', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$duplicateTransition3, $stateMachineId, $fromStateId, $toStateId, 'pay_partially', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
 
         // Insert a random transition
         $this->connection->executeStatement('INSERT INTO `state_machine_transition` (id, state_machine_id, from_state_id, to_state_id, action_name, created_at) VALUES (?, ?, ?, ?, ?, ?)', [$validTransition, $stateMachineId, $fromStateId, $toStateId, 'other_action', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
 
         $migration = new Migration1742302302RenamePaidTransitionActions();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $remainingTransitions = $this->connection->fetchAllKeyValue('SELECT id, action_name FROM `state_machine_transition` WHERE from_state_id = ? AND to_state_id = ? AND state_machine_id = ?', [$fromStateId, $toStateId, $stateMachineId]);
+
+        static::assertArrayHasKey($duplicateTransition1, $remainingTransitions);
+        static::assertSame('pay', $remainingTransitions[$duplicateTransition1]);
+        static::assertArrayHasKey($duplicateTransition2, $remainingTransitions);
+        static::assertSame('do_pay', $remainingTransitions[$duplicateTransition2]);
+        static::assertArrayHasKey($duplicateTransition3, $remainingTransitions);
+        static::assertSame('pay_partially', $remainingTransitions[$duplicateTransition3]);
+        static::assertArrayHasKey($validTransition, $remainingTransitions);
+
+        // assert no new transitions
+        static::assertNotContains('paid_partially', $remainingTransitions);
+        static::assertNotContains('process', $remainingTransitions);
+
         $migration->updateDestructive($this->connection);
         $migration->updateDestructive($this->connection);
 
-        $remainingTransitions = $this->connection->fetchFirstColumn('SELECT id FROM `state_machine_transition` WHERE from_state_id = ? AND to_state_id = ?', [$fromStateId, $toStateId]);
+        $remainingTransitions = $this->connection->fetchFirstColumn('SELECT id FROM `state_machine_transition` WHERE from_state_id = ? AND to_state_id = ? AND state_machine_id = ?', [$fromStateId, $toStateId, $stateMachineId]);
 
-        static::assertNotContains($duplicateTransition1, $remainingTransitions);
-        static::assertNotContains($duplicateTransition2, $remainingTransitions);
-
+        // random state machine, will not be deleted
+        static::assertContains($duplicateTransition1, $remainingTransitions);
+        static::assertContains($duplicateTransition2, $remainingTransitions);
         static::assertContains($duplicateTransition3, $remainingTransitions);
         static::assertContains($validTransition, $remainingTransitions);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We're also changing transition names of state machines that aren't ours.

### 2. What does this change do, exactly?
Only change state transitions belonging to our order transaction state machine.

### 3. Describe each step to reproduce the issue or behaviour.
See #11157

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #11157

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
