### PR TITLE
fix: sync the services after running system install

### DIFF
--- a/src/Core/Service/DependencyInjection/services.xml
+++ b/src/Core/Service/DependencyInjection/services.xml
@@ -115,6 +115,13 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Shopware\Core\Service\Subscriber\SystemUpdateSubscriber">
+            <argument type="service" id="Shopware\Core\Service\LifecycleManager"/>
+            <argument type="service" id="logger"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Service\TemporaryDirectoryFactory">
             <argument>%kernel.project_dir%</argument>
         </service>
@@ -144,6 +151,7 @@
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle"/>
             <argument type="service" id="Shopware\Core\Service\AllServiceInstaller"/>
             <argument type="service" id="Shopware\Core\Service\Permission\PermissionsService"/>
+            <argument type="service" id="Shopware\Core\Service\ServiceRegistry\Client"/>
         </service>
 
         <service id="Shopware\Core\Service\Subscriber\ServiceLifecycleSubscriber">

--- a/src/Core/Service/LifecycleManager.php
+++ b/src/Core/Service/LifecycleManager.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Service\Permission\PermissionsService;
+use Shopware\Core\Service\ServiceRegistry\Client;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
@@ -45,6 +46,7 @@ class LifecycleManager
         private readonly AbstractAppLifecycle $appLifecycle,
         private readonly AllServiceInstaller $serviceInstaller,
         private readonly PermissionsService $permissionsService,
+        private readonly Client $client,
     ) {
     }
 
@@ -60,6 +62,12 @@ class LifecycleManager
         }
 
         return $this->serviceInstaller->install($context);
+    }
+
+    public function sync(Context $context): void
+    {
+        $services = $this->getAllServices($context);
+        $this->removeOrphanedServices($services, $context);
     }
 
     public function syncState(string $service, Context $context): void
@@ -134,6 +142,28 @@ class LifecycleManager
     public function enabled(): bool
     {
         return !$this->areDisabledFromEnv() && !$this->areDisabledFromConfig();
+    }
+
+    private function removeOrphanedServices(AppCollection $services, Context $context): void
+    {
+        $registryServices = $this->client->getAll();
+
+        if (\count($registryServices) === 0) {
+            // this is not safe to do if there are zero services.
+            // it could e a transient error or a misconfiguration.
+            return;
+        }
+
+        $registryServiceNames = [];
+        foreach ($registryServices as $registryService) {
+            $registryServiceNames[$registryService->name] = true;
+        }
+
+        foreach ($services as $service) {
+            if (!isset($registryServiceNames[$service->getName()])) {
+                $this->appLifecycle->delete($service->getName(), ['id' => $service->getId()], $context);
+            }
+        }
     }
 
     private function areDisabledFromEnv(): bool

--- a/src/Core/Service/LifecycleManager.php
+++ b/src/Core/Service/LifecycleManager.php
@@ -150,7 +150,7 @@ class LifecycleManager
 
         if (\count($registryServices) === 0) {
             // this is not safe to do if there are zero services.
-            // it could e a transient error or a misconfiguration.
+            // it could be a transient error or a misconfiguration.
             return;
         }
 

--- a/src/Core/Service/ServiceSourceResolver.php
+++ b/src/Core/Service/ServiceSourceResolver.php
@@ -84,7 +84,13 @@ class ServiceSourceResolver implements Source
      */
     private function checkVersionAndDownloadAppZip(string $serviceName, array $sourceConfig): string
     {
-        $client = $this->serviceClientFactory->fromName($serviceName);
+        try {
+            $client = $this->serviceClientFactory->fromName($serviceName);
+        } catch (ServiceException) {
+            // the service is not available, so we cannot download it.
+            // this can happen if the service is not installed or the service client is misconfigured. or the service has been removed.
+            return Path::join($this->temporaryDirectoryFactory->path(), $serviceName);
+        }
 
         $latestAppInfo = $client->latestAppInfo();
 

--- a/src/Core/Service/Subscriber/SystemUpdateSubscriber.php
+++ b/src/Core/Service/Subscriber/SystemUpdateSubscriber.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Service\Subscriber;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
+use Shopware\Core\Service\LifecycleManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class SystemUpdateSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly LifecycleManager $lifecycleManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            UpdatePostFinishEvent::class => 'sync',
+        ];
+    }
+
+    public function sync(UpdatePostFinishEvent $event): void
+    {
+        try {
+            $this->lifecycleManager->sync($event->getContext());
+        } catch (\Throwable $exception) {
+            // this should not fail the update process, no matter what.
+            $this->logger->error('Failed to sync lifecycle manager', ['exception' => $exception]);
+        }
+    }
+}

--- a/tests/unit/Core/Service/Subscriber/SystemUpdateSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/SystemUpdateSubscriberTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Service\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
+use Shopware\Core\Service\LifecycleManager;
+use Shopware\Core\Service\Subscriber\SystemUpdateSubscriber;
+
+/**
+ * @internal
+ */
+#[CoversClass(SystemUpdateSubscriber::class)]
+class SystemUpdateSubscriberTest extends TestCase
+{
+    public function testSyncDelegatesToLifecycleManager(): void
+    {
+        $context = new Context(new SystemSource());
+        $lifecycleManager = $this->createMock(LifecycleManager::class);
+        $lifecycleManager->expects($this->once())
+            ->method('sync')
+            ->with($context);
+
+        $subscriber = new SystemUpdateSubscriber($lifecycleManager, $this->createMock(LoggerInterface::class));
+        $subscriber->sync(new UpdatePostFinishEvent($context, '6.7.0.0', '6.7.1.0'));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new synchronization mechanism for managing services and ensures that orphaned services are removed during system updates. It also adds a new event subscriber to trigger the synchronization process after updates.