### PR TITLE
fix: rename measurementUnits property to measurements

### DIFF
--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductEntity.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductEntity.php
@@ -38,7 +38,7 @@ class SalesChannelProductEntity extends ProductEntity
 
     protected ?CheapestPriceContainer $cheapestPriceContainer = null;
 
-    protected ?ConvertedUnitSet $measurementUnits = null;
+    protected ?ConvertedUnitSet $measurements = null;
 
     public function setCalculatedPrices(PriceCollection $prices): void
     {
@@ -130,13 +130,13 @@ class SalesChannelProductEntity extends ProductEntity
         return $this->cheapestPriceContainer;
     }
 
-    public function getMeasurementUnits(): ?ConvertedUnitSet
+    public function getMeasurements(): ?ConvertedUnitSet
     {
-        return $this->measurementUnits;
+        return $this->measurements;
     }
 
-    public function setMeasurementUnits(?ConvertedUnitSet $measurementUnits): void
+    public function setMeasurements(ConvertedUnitSet $measurements): void
     {
-        $this->measurementUnits = $measurementUnits;
+        $this->measurements = $measurements;
     }
 }


### PR DESCRIPTION
In the definition src/Core/Content/Product/SalesChannel/SalesChannelProductDefinition.php, we renamed the property from `measurementUnits` to `measurements` but not yet in the Entity