### PR TITLE
fix: clear object cache before shopware installation

### DIFF
--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -47,9 +47,7 @@ class CacheClearer
 
     public function clear(bool $clearHttp = true): void
     {
-        foreach ($this->adapters as $adapter) {
-            $adapter->clear();
-        }
+        $this->clearObjectCache();
 
         if ($clearHttp && $this->reverseHttpCacheEnabled) {
             $this->reverseProxyCache?->banAll();
@@ -112,6 +110,13 @@ class CacheClearer
     {
         foreach ($this->adapters as $adapter) {
             $adapter->deleteItems($keys);
+        }
+    }
+
+    public function clearObjectCache(): void
+    {
+        foreach ($this->adapters as $adapter) {
+            $adapter->clear();
         }
     }
 

--- a/src/Core/Maintenance/DependencyInjection/services.xml
+++ b/src/Core/Maintenance/DependencyInjection/services.xml
@@ -13,6 +13,7 @@
             <argument>%kernel.project_dir%</argument>
             <argument type="service" id="Shopware\Core\Maintenance\System\Service\SetupDatabaseAdapter"/>
             <argument type="service" id="Shopware\Core\Maintenance\System\Service\DatabaseConnectionFactory"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheClearer"/>
             <tag name="console.command"/>
         </service>
 

--- a/src/Core/Maintenance/System/Command/SystemInstallCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemInstallCommand.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Maintenance\System\Command;
 
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Maintenance\MaintenanceException;
@@ -30,7 +31,8 @@ class SystemInstallCommand extends Command
     public function __construct(
         private readonly string $projectDir,
         private readonly SetupDatabaseAdapter $setupDatabaseAdapter,
-        private readonly DatabaseConnectionFactory $databaseConnectionFactory
+        private readonly DatabaseConnectionFactory $databaseConnectionFactory,
+        private readonly CacheClearer $cacheClearer,
     ) {
         parent::__construct();
     }
@@ -66,6 +68,9 @@ class SystemInstallCommand extends Command
 
             return self::FAILURE;
         }
+
+        // Delete old object cache, which can lead to wrong assumptions
+        $this->cacheClearer->clearObjectCache();
 
         $this->initializeDatabase($output, $input);
 

--- a/tests/unit/Core/Maintenance/System/Command/SystemInstallCommandTest.php
+++ b/tests/unit/Core/Maintenance/System/Command/SystemInstallCommandTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
 use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
 use Shopware\Core\Maintenance\System\Command\SystemInstallCommand;
 use Shopware\Core\Maintenance\System\Service\DatabaseConnectionFactory;
@@ -183,7 +184,12 @@ class SystemInstallCommandTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->add(
-            new SystemInstallCommand(__DIR__, $setupDatabaseAdapterMock, $connectionFactory)
+            new SystemInstallCommand(
+                __DIR__,
+                $setupDatabaseAdapterMock,
+                $connectionFactory,
+                $this->createMock(CacheClearer::class)
+            )
         );
         $application->setDispatcher($dispatcher);
 
@@ -205,7 +211,12 @@ class SystemInstallCommandTest extends TestCase
         $connectionFactory->method('getConnection')->willReturn($connection);
 
         $setupDatabaseAdapterMock = $this->createMock(SetupDatabaseAdapter::class);
-        $systemInstallCmd = new SystemInstallCommand(__DIR__, $setupDatabaseAdapterMock, $connectionFactory);
+        $systemInstallCmd = new SystemInstallCommand(
+            __DIR__,
+            $setupDatabaseAdapterMock,
+            $connectionFactory,
+            $this->createMock(CacheClearer::class)
+        );
 
         $application = $this->createMock(Application::class);
         $application->method('has')


### PR DESCRIPTION
### 1. Why is this change necessary?

- Install Shopware with Redis
- Reinstall Shopware, crashes because of weird translation insert errors

The DAL fetches language mapping and stores it in cache, as we don't clear explictly the cache, the old uuids are getting reused


### 2. What does this change do, exactly?

Clear explictly the cache


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
