### PR TITLE
fix: use correct field name on hidden accountType fields

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -7,6 +7,8 @@
 #}
 {% block component_address_personal_fields %}
     {% block component_address_personal_account_type %}
+        {% set accountTypeFieldName = prefix ? prefix ~ '[accountType]' : 'accountType' %}
+
         {% if (onlyCompanyRegistration or (config('core.loginRegistration.showAccountTypeSelection') and not hideCustomerTypeSelect)) and not hasSelectedBusiness %}
             <div class="row g-2">
                 {% set toggleTarget = ".js-field-toggle-contact-type-company" %}
@@ -59,7 +61,7 @@
                     {% sw_include '@Storefront/storefront/component/form/form-select.html.twig' with {
                         label: 'account.personalTypeLabel'|trans|sw_sanitize,
                         id: idPrefix ~ prefix ~ '-accountType',
-                        name: prefix ? prefix ~ '[accountType]' : 'accountType',
+                        name: accountTypeFieldName,
                         options: accountTypeOptions,
                         validationRules: 'required',
                         disabled: (onlyCompanyRegistration) ? 'true',
@@ -79,14 +81,14 @@
                     {# This is rendered on the profile edit page if the customer registered via a custom commercial registration form. #}
                     {# The selection field is then disabled and the account type is set to "business". #}
                     <input type="hidden"
-                           name="accountType"
+                           name="{{ accountTypeFieldName }}"
                            value="{{ constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS') }}">
                 {% endif %}
             </div>
         {% elseif not hideCustomerTypeSelect %}
             {# This case applies to custom registration forms with the "Company signup form" config enabled. #}
             {# The registration is always of type "commercial" then. #}
-            <input type="hidden" name="accountType">
+            <input type="hidden" name="{{ accountTypeFieldName }}">
         {% endif %}
     {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When using custom forms for business type account registration, multiple inputs using the same name (`accountType`) are used within the registration template due to the reuse of the address template - overriding each other when submitted. The last non-disabled input field with the same name will be sent to the server. In this case, it has no value.

<img width="572" height="237" alt="image" src="https://github.com/user-attachments/assets/626234f9-77c1-4013-862c-659d5f4def59" />

This leads to the accountType being lost in the controller action, which results in a loss of company-related account data.

### 2. What does this change do, exactly?
Fix the hidden inputs to use a prefixed name (`accountType`, `billingAddress[accountType]`, `shippingAddress[accountType`). This prefix already exists for the accountType select, but wasn't used when only allowing company accounts.

### 3. Describe each step to reproduce the issue or behaviour.
see #8955 

### 4. Please link to the relevant issues (if any).
- closes #8955 
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
