### PR TITLE
fix: flaky SearchKeywordUpdaterTest::testItUpdatesKeywordsForAvailableLanguagesOnly

### DIFF
--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -69,6 +69,8 @@ class SearchKeywordUpdaterTest extends TestCase
     public function testItUpdatesKeywordsForAvailableLanguagesOnly(array $productData, IdsCollection $ids, array $englishKeywords, array $germanKeywords, array $additionalDictionaries = []): void
     {
         $this->connection->executeStatement('DELETE FROM product');
+        $this->connection->executeStatement('DELETE FROM product_search_keyword');
+        $this->connection->executeStatement('DELETE FROM product_keyword_dictionary');
 
         $context = Context::createDefaultContext();
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Follow up of https://github.com/shopware/shopware/pull/10996, still failing nightly: https://github.com/shopware/shopware/actions/runs/16308203973/job/46058550467

### 2. What does this change do, exactly?
Clean state of tables `product_search_keyword`, `product_keyword_dictionary` (only `products` was considered previously)

### 3. Describe each step to reproduce the issue or behaviour.
- Run the nightly
- or run`php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure` with `1752629809` seed

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/10994

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
