### PR TITLE
fix(snippets): Snippet validate command now checks pluralization

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2598,87 +2598,11 @@ parameters:
 			count: 1
 			path: src/Core/System/SalesChannel/SalesChannel/StoreApiInfoController.php
 
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\Command\\ValidateSnippetsCommand\:\:hydrateMissingSnippets\(\) has parameter \$missingSnippetsArray with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
 
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:findAdministrationSnippetFiles\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
 
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:findSnippetFilesByPath\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
 
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:findStorefrontSnippetFiles\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
 
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:openJsonFile\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
 
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:writeJsonFile\(\) has parameter \$content with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
-
-		-
-			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
-
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFixer\:\:addTranslationUsingSnippetKey\(\) has parameter \$json with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/SnippetFixer.php
-
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFixer\:\:addTranslationUsingSnippetKey\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/SnippetFixer.php
-
-		-
-			message: '#^Parameter \#2 \$translation of method Shopware\\Core\\System\\Snippet\\SnippetFixer\:\:addTranslationUsingSnippetKey\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Core/System/Snippet/SnippetFixer.php
-
-		-
-			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetValidatorInterface\:\:validate\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/Snippet/SnippetValidatorInterface.php
-
-		-
-			message: '#^Method Shopware\\Core\\System\\StateMachine\\Loader\\InitialStateIdLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/System/StateMachine/Loader/InitialStateIdLoader.php
-
-		-
-			message: '#^Property Shopware\\Core\\System\\StateMachine\\Loader\\InitialStateIdLoader\:\:\$ids type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/StateMachine/Loader/InitialStateIdLoader.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2598,11 +2598,15 @@ parameters:
 			count: 1
 			path: src/Core/System/SalesChannel/SalesChannel/StoreApiInfoController.php
 
+		-
+			message: '#^Method Shopware\\Core\\System\\StateMachine\\Loader\\InitialStateIdLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Core/System/StateMachine/Loader/InitialStateIdLoader.php
 
-
-
-
-
+		-
+			message: '#^Property Shopware\\Core\\System\\StateMachine\\Loader\\InitialStateIdLoader\:\:\$ids type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/StateMachine/Loader/InitialStateIdLoader.php
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/snippet/de-DE.json
@@ -25,7 +25,7 @@
         "googleReCaptchaV3DescriptionThresholdScore": "reCAPTCHA v3 vergibt für jede Nutzeranfrage eine Punktzahl, ohne den Nutzer zu behelligen. Die Punktzahl errechnet sich aus den Interaktionen mit Deiner Seite und versetzt Dich in die Lage, eine für Deine Seite angemessene Aktion auszuführen. Die Grenzwertpunktzahl kann Werte zwischen 0.0 und 1.0 annehmen."
       },
       "basicCaptchaNoticeTitle": "Hinweis",
-      "basicCaptchaNotice": "Die Basic Captcha Lösung wird nicht als barrierefrei betrachtet. Wir empfehlen, eine Lösung zu verwenden, die keine Benutzerinteraktion benötigt."
+      "basicCaptchaNotice": "Die Basic-Captcha-Lösung wird nicht als barrierefrei betrachtet. Wir empfehlen, eine Lösung zu verwenden, die keine Benutzerinteraktion benötigt."
     }
   }
 }

--- a/src/Core/System/DependencyInjection/snippet.xml
+++ b/src/Core/System/DependencyInjection/snippet.xml
@@ -60,7 +60,9 @@
             <argument type="service" id="Shopware\Core\System\Snippet\Struct\TranslationConfig"/>
         </service>
 
-        <service id="Shopware\Core\System\Snippet\SnippetFileHandler" />
+        <service id="Shopware\Core\System\Snippet\SnippetFileHandler">
+            <argument type="service" id="filesystem"/>
+        </service>
 
         <service id="Shopware\Core\System\Snippet\Subscriber\CustomFieldSubscriber">
             <argument type="service" id="Doctrine\DBAL\Connection"/>

--- a/src/Core/System/DependencyInjection/snippet.xml
+++ b/src/Core/System/DependencyInjection/snippet.xml
@@ -19,12 +19,18 @@
             <argument>%kernel.project_dir%/</argument>
         </service>
 
+        <service id="Shopware\Core\System\Snippet\SnippetValidator">
+            <argument type="service" id="Shopware\Core\System\Snippet\Files\SnippetFileCollection" />
+            <argument type="service" id="Shopware\Core\System\Snippet\SnippetFileHandler" />
+            <argument>%kernel.project_dir%/</argument>
+        </service>
+
         <service id="Shopware\Core\System\Snippet\SnippetFixer">
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetFileHandler" />
         </service>
 
         <service id="Shopware\Core\System\Snippet\Command\ValidateSnippetsCommand">
-            <argument type="service" id="Shopware\Core\System\Snippet\SnippetValidatorInterface" />
+            <argument type="service" id="Shopware\Core\System\Snippet\SnippetValidator" />
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetFixer" />
 
             <tag name="console.command"/>

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\SnippetFixer;
 use Shopware\Core\System\Snippet\SnippetValidator;
+use Shopware\Core\System\Snippet\Struct\InvalidPluralizationCollection;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetStruct;
 use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
@@ -20,7 +21,6 @@ use Symfony\Component\Console\Question\Question;
 /**
  * @phpstan-type Snippets array<string, string|array<string, mixed>>
  *
- * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  * @phpstan-import-type MissingSnippets from SnippetValidationStruct
  */
 #[AsCommand(
@@ -53,7 +53,7 @@ class ValidateSnippetsCommand extends Command
         $hasMissingSnippets = $missingSnippetsCollection->count() > 0;
 
         $invalidPluralization = $invalidSnippetsStruct->invalidPluralization;
-        $hasInvalidPluralization = \count($invalidPluralization) > 0;
+        $hasInvalidPluralization = $invalidPluralization->count() > 0;
 
         $io = new ShopwareStyle($input, $output);
 
@@ -127,23 +127,23 @@ class ValidateSnippetsCommand extends Command
         return $missingSnippetsCollection;
     }
 
-    /**
-     * @param InvalidPluralization $invalidPluralization
-     */
-    private function renderPluralizationErrors(ShopwareStyle $io, OutputInterface $output, array $invalidPluralization): void
-    {
+    private function renderPluralizationErrors(
+        ShopwareStyle $io,
+        OutputInterface $output,
+        InvalidPluralizationCollection $invalidPluralization
+    ): void {
         $io->error('Invalid pluralization found! Please always contain cases from 0 to Inf');
         $table = new Table($output);
         $table->setHeaders([
             'Snippet', 'Value', 'Automatically fixable', 'File Path',
         ]);
 
-        foreach ($invalidPluralization as $invalidPluralizationEntry) {
+        foreach ($invalidPluralization->getIterator() as $invalidPluralizationEntry) {
             $table->addRow([
-                $invalidPluralizationEntry['snippetKey'],
-                $invalidPluralizationEntry['snippetValue'],
-                $invalidPluralizationEntry['isFixable'] ? 'Yes' : 'No',
-                $invalidPluralizationEntry['path'],
+                $invalidPluralizationEntry->snippetKey,
+                $invalidPluralizationEntry->snippetValue,
+                $invalidPluralizationEntry->isFixable ? 'Yes' : 'No',
+                $invalidPluralizationEntry->path,
             ]);
         }
 

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -8,6 +8,7 @@ use Shopware\Core\System\Snippet\SnippetFixer;
 use Shopware\Core\System\Snippet\SnippetValidatorInterface;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetStruct;
+use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -18,6 +19,7 @@ use Symfony\Component\Console\Question\Question;
 
 /**
  * @phpstan-type Snippets array<string, string|array<string, mixed>>
+ * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[AsCommand(
     name: 'snippets:validate',
@@ -109,7 +111,7 @@ class ValidateSnippetsCommand extends Command
     }
 
     /**
-     * @param Snippets $missingSnippetsArray
+     * @param array<String, Snippets> $missingSnippetsArray
      */
     private function hydrateMissingSnippets(array $missingSnippetsArray): MissingSnippetCollection
     {
@@ -124,12 +126,7 @@ class ValidateSnippetsCommand extends Command
     }
 
     /**
-     * @param array<string, array{
-     *     snippetKey: string,
-     *     snippetValue: string,
-     *     isFixable: bool,
-     *     path: string
-     * }> $invalidPluralization
+     * @param InvalidPluralization $invalidPluralization
      */
     private function renderPluralizationErrors(ShopwareStyle $io, OutputInterface $output, array $invalidPluralization): void
     {

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -7,9 +7,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\SnippetFixer;
 use Shopware\Core\System\Snippet\SnippetValidator;
 use Shopware\Core\System\Snippet\Struct\InvalidPluralizationCollection;
-use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
-use Shopware\Core\System\Snippet\Struct\MissingSnippetStruct;
-use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -20,8 +17,6 @@ use Symfony\Component\Console\Question\Question;
 
 /**
  * @phpstan-type Snippets array<string, string|array<string, mixed>>
- *
- * @phpstan-import-type MissingSnippets from SnippetValidationStruct
  */
 #[AsCommand(
     name: 'snippets:validate',
@@ -49,7 +44,7 @@ class ValidateSnippetsCommand extends Command
     {
         $invalidSnippetsStruct = $this->snippetValidator->getValidation();
 
-        $missingSnippetsCollection = $this->hydrateMissingSnippets($invalidSnippetsStruct->missingSnippets);
+        $missingSnippetsCollection = $invalidSnippetsStruct->missingSnippets;
         $hasMissingSnippets = $missingSnippetsCollection->count() > 0;
 
         $invalidPluralization = $invalidSnippetsStruct->invalidPluralization;
@@ -110,21 +105,6 @@ class ValidateSnippetsCommand extends Command
         }
 
         return self::SUCCESS;
-    }
-
-    /**
-     * @param MissingSnippets $missingSnippetsArray
-     */
-    private function hydrateMissingSnippets(array $missingSnippetsArray): MissingSnippetCollection
-    {
-        $missingSnippetsCollection = new MissingSnippetCollection();
-        foreach ($missingSnippetsArray as $locale => $missingSnippets) {
-            foreach ($missingSnippets as $key => $missingSnippet) {
-                $missingSnippetsCollection->add(new MissingSnippetStruct($key, $missingSnippet['path'], $missingSnippet['availableISO'], $missingSnippet['availableValue'], $locale));
-            }
-        }
-
-        return $missingSnippetsCollection;
     }
 
     private function renderPluralizationErrors(

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
 /**
- * @phpstan-type Snippets array<string, string|mixed>
+ * @phpstan-type Snippets array<string, string|array<string, mixed>>
  */
 #[AsCommand(
     name: 'snippets:validate',
@@ -43,12 +43,12 @@ class ValidateSnippetsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $invalidSnippets = $this->snippetValidator->validate();
+        $invalidSnippetsStruct = $this->snippetValidator->getValidation();
 
-        $missingSnippetsCollection = $this->hydrateMissingSnippets($invalidSnippets['missingSnippets']);
+        $missingSnippetsCollection = $this->hydrateMissingSnippets($invalidSnippetsStruct->missingSnippets);
         $hasMissingSnippets = $missingSnippetsCollection->count() > 0;
 
-        $invalidPluralization = $invalidSnippets['invalidPluralization'];
+        $invalidPluralization = $invalidSnippetsStruct->invalidPluralization;
         $hasInvalidPluralization = \count($invalidPluralization) > 0;
 
         $io = new ShopwareStyle($input, $output);
@@ -79,7 +79,7 @@ class ValidateSnippetsCommand extends Command
             }
 
             if ($hasInvalidPluralization) {
-                $this->renderPluralizationErrors($io, $output, $invalidSnippets['invalidPluralization']);
+                $this->renderPluralizationErrors($io, $output, $invalidPluralization);
             }
 
             return -1;
@@ -101,7 +101,7 @@ class ValidateSnippetsCommand extends Command
         $this->snippetFixer->fix($missingSnippetsCollection, $invalidPluralization);
 
         if ($hasInvalidPluralization) {
-            $this->renderPluralizationErrors($io, $output, $invalidSnippets['invalidPluralization']);
+            $this->renderPluralizationErrors($io, $output, $invalidPluralization);
             $io->warning('Only invalid pluralization range can be fixed automatically. Please review carefully.');
         }
 

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
 /**
- * @phpstan-type Snippets array<string, string|Snippets>
+ * @phpstan-type Snippets array<string, string|mixed>
  */
 #[AsCommand(
     name: 'snippets:validate',
@@ -79,21 +79,7 @@ class ValidateSnippetsCommand extends Command
             }
 
             if ($hasInvalidPluralization) {
-                $io->error('Invalid pluralization found!');
-                $table = new Table($output);
-                $table->setHeaders([
-                    'Snippet', 'Value', 'File Path',
-                ]);
-
-                foreach ($invalidSnippets['invalidPluralization'] as $invalidPluralization) {
-                    $table->addRow([
-                        $invalidPluralization['snippetKey'],
-                        $invalidPluralization['availableValue'],
-                        $invalidPluralization['path'],
-                    ]);
-                }
-
-                $table->render();
+                $this->renderPluralizationErrors($io, $output, $invalidSnippets['invalidPluralization']);
             }
 
             return -1;
@@ -114,6 +100,11 @@ class ValidateSnippetsCommand extends Command
 
         $this->snippetFixer->fix($missingSnippetsCollection, $invalidPluralization);
 
+        if ($hasInvalidPluralization) {
+            $this->renderPluralizationErrors($io, $output, $invalidSnippets['invalidPluralization']);
+            $io->warning('Only invalid pluralization range can be fixed automatically. Please review carefully.');
+        }
+
         return self::SUCCESS;
     }
 
@@ -130,5 +121,33 @@ class ValidateSnippetsCommand extends Command
         }
 
         return $missingSnippetsCollection;
+    }
+
+    /**
+     * @param array<string, array{
+     *     snippetKey: string,
+     *     snippetValue: string,
+     *     isFixable: bool,
+     *     path: string
+     * }> $invalidPluralization
+     */
+    private function renderPluralizationErrors(ShopwareStyle $io, OutputInterface $output, array $invalidPluralization): void
+    {
+        $io->error('Invalid pluralization found! Please always contain cases from 0 to Inf');
+        $table = new Table($output);
+        $table->setHeaders([
+            'Snippet', 'Value', 'Automatically fixable', 'File Path',
+        ]);
+
+        foreach ($invalidPluralization as $invalidPluralizationEntry) {
+            $table->addRow([
+                $invalidPluralizationEntry['snippetKey'],
+                $invalidPluralizationEntry['snippetValue'],
+                $invalidPluralizationEntry['isFixable'] ? 'Yes' : 'No',
+                $invalidPluralizationEntry['path'],
+            ]);
+        }
+
+        $table->render();
     }
 }

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -127,7 +127,7 @@ class ValidateSnippetsCommand extends Command
     }
 
     /**
-     * @param InvalidPluralization $invalidPluralization
+     * @param array<string, InvalidPluralization> $invalidPluralization
      */
     private function renderPluralizationErrors(ShopwareStyle $io, OutputInterface $output, array $invalidPluralization): void
     {

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Question\Question;
  * @phpstan-type Snippets array<string, string|array<string, mixed>>
  *
  * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
+ * @phpstan-import-type MissingSnippets from SnippetValidationStruct
  */
 #[AsCommand(
     name: 'snippets:validate',
@@ -112,7 +113,7 @@ class ValidateSnippetsCommand extends Command
     }
 
     /**
-     * @param array<string, array<string, Snippets>> $missingSnippetsArray
+     * @param MissingSnippets $missingSnippetsArray
      */
     private function hydrateMissingSnippets(array $missingSnippetsArray): MissingSnippetCollection
     {
@@ -127,7 +128,7 @@ class ValidateSnippetsCommand extends Command
     }
 
     /**
-     * @param array<string, InvalidPluralization> $invalidPluralization
+     * @param InvalidPluralization $invalidPluralization
      */
     private function renderPluralizationErrors(ShopwareStyle $io, OutputInterface $output, array $invalidPluralization): void
     {

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -66,7 +66,7 @@ class ValidateSnippetsCommand extends Command
                     'Snippet', 'Missing for ISO', 'Found in file',
                 ]);
 
-                foreach ($missingSnippetsCollection->getIterator() as $missingSnippetStruct) {
+                foreach ($missingSnippetsCollection as $missingSnippetStruct) {
                     $table->addRow([
                         $missingSnippetStruct->getKeyPath(),
                         $missingSnippetStruct->getMissingForISO(),

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -112,7 +112,7 @@ class ValidateSnippetsCommand extends Command
     }
 
     /**
-     * @param array<string, Snippets> $missingSnippetsArray
+     * @param array<string, array<string, Snippets>> $missingSnippetsArray
      */
     private function hydrateMissingSnippets(array $missingSnippetsArray): MissingSnippetCollection
     {

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\System\Snippet\Command;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\SnippetFixer;
-use Shopware\Core\System\Snippet\SnippetValidatorInterface;
+use Shopware\Core\System\Snippet\SnippetValidator;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetStruct;
 use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
@@ -32,7 +32,7 @@ class ValidateSnippetsCommand extends Command
      * @internal
      */
     public function __construct(
-        private readonly SnippetValidatorInterface $snippetValidator,
+        private readonly SnippetValidator $snippetValidator,
         private readonly SnippetFixer $snippetFixer
     ) {
         parent::__construct();

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -16,6 +16,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
+/**
+ * @phpstan-type Snippets array<string, string|Snippets>
+ */
 #[AsCommand(
     name: 'snippets:validate',
     description: 'Validates snippets',
@@ -40,33 +43,58 @@ class ValidateSnippetsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $missingSnippetsArray = $this->snippetValidator->validate();
-        $missingSnippetsCollection = $this->hydrateMissingSnippets($missingSnippetsArray);
+        $invalidSnippets = $this->snippetValidator->validate();
+
+        $missingSnippetsCollection = $this->hydrateMissingSnippets($invalidSnippets['missingSnippets']);
+        $hasMissingSnippets = $missingSnippetsCollection->count() > 0;
+
+        $invalidPluralization = $invalidSnippets['invalidPluralization'];
+        $hasInvalidPluralization = \count($invalidPluralization) > 0;
 
         $io = new ShopwareStyle($input, $output);
 
-        if ($missingSnippetsCollection->count() === 0) {
+        if (!$hasMissingSnippets && !$hasInvalidPluralization) {
             $io->success('Snippets are valid!');
 
             return self::SUCCESS;
         }
 
         if (!$input->getOption('fix')) {
-            $io->error('Invalid snippets found!');
-            $table = new Table($output);
-            $table->setHeaders([
-                'Snippet', 'Missing for ISO', 'Found in file',
-            ]);
-
-            foreach ($missingSnippetsCollection->getIterator() as $missingSnippetStruct) {
-                $table->addRow([
-                    $missingSnippetStruct->getKeyPath(),
-                    $missingSnippetStruct->getMissingForISO(),
-                    $missingSnippetStruct->getFilePath(),
+            if ($hasMissingSnippets) {
+                $io->error('Invalid snippets found!');
+                $table = new Table($output);
+                $table->setHeaders([
+                    'Snippet', 'Missing for ISO', 'Found in file',
                 ]);
+
+                foreach ($missingSnippetsCollection->getIterator() as $missingSnippetStruct) {
+                    $table->addRow([
+                        $missingSnippetStruct->getKeyPath(),
+                        $missingSnippetStruct->getMissingForISO(),
+                        $missingSnippetStruct->getFilePath(),
+                    ]);
+                }
+
+                $table->render();
             }
 
-            $table->render();
+            if ($hasInvalidPluralization) {
+                $io->error('Invalid pluralization found!');
+                $table = new Table($output);
+                $table->setHeaders([
+                    'Snippet', 'Value', 'File Path',
+                ]);
+
+                foreach ($invalidSnippets['invalidPluralization'] as $invalidPluralization) {
+                    $table->addRow([
+                        $invalidPluralization['snippetKey'],
+                        $invalidPluralization['availableValue'],
+                        $invalidPluralization['path'],
+                    ]);
+                }
+
+                $table->render();
+            }
 
             return -1;
         }
@@ -84,11 +112,14 @@ class ValidateSnippetsCommand extends Command
             $missingSnippetStruct->setTranslation($questionHelper->ask($input, $output, new Question($question)) ?? '');
         }
 
-        $this->snippetFixer->fix($missingSnippetsCollection);
+        $this->snippetFixer->fix($missingSnippetsCollection, $invalidPluralization);
 
         return self::SUCCESS;
     }
 
+    /**
+     * @param Snippets $missingSnippetsArray
+     */
     private function hydrateMissingSnippets(array $missingSnippetsArray): MissingSnippetCollection
     {
         $missingSnippetsCollection = new MissingSnippetCollection();

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Question\Question;
 
 /**
  * @phpstan-type Snippets array<string, string|array<string, mixed>>
+ *
  * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[AsCommand(
@@ -111,7 +112,7 @@ class ValidateSnippetsCommand extends Command
     }
 
     /**
-     * @param array<String, Snippets> $missingSnippetsArray
+     * @param array<string, Snippets> $missingSnippetsArray
      */
     private function hydrateMissingSnippets(array $missingSnippetsArray): MissingSnippetCollection
     {

--- a/src/Core/System/Snippet/SnippetException.php
+++ b/src/Core/System/Snippet/SnippetException.php
@@ -24,6 +24,8 @@ class SnippetException extends HttpException
 
     final public const INVALID_SNIPPET_FILE = 'SYSTEM__INVALID_SNIPPET_FILE';
 
+    final public const JSON_NOT_FOUND = 'SYSTEM__JSON_NOT_FOUND';
+
     final public const SNIPPET_NO_ARGUMENTS_PROVIDED = 'SYSTEM__NO_ARGUMENTS_PROVIDED';
 
     final public const SNIPPET_NO_LOCALES_ARGUMENT_PROVIDED = 'SYSTEM__NO_LOCALES_ARGUMENT_PROVIDED';
@@ -95,6 +97,15 @@ class SnippetException extends HttpException
             self::SNIPPET_SET_NOT_FOUND,
             'Snippet set with ID "{{ snippetSetId }}" not found.',
             ['snippetSetId' => $snippetSetId]
+        );
+    }
+
+    public static function jsonNotFound(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::JSON_NOT_FOUND,
+            'Snippet JSON file not found. Please check the path and ensure the file exists.'
         );
     }
 

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -17,6 +17,9 @@ class SnippetFileHandler
 {
     private readonly Filesystem $filesystem;
 
+    /**
+     * @internal
+     */
     public function __construct()
     {
         $this->filesystem = new Filesystem();
@@ -27,9 +30,9 @@ class SnippetFileHandler
      */
     public function openJsonFile(string $path): array
     {
-        $fileContents = $this->filesystem->readFile($path);
-
-        if ($fileContents === false) {
+        try {
+            $fileContents = $this->filesystem->readFile($path);
+        } catch (\Throwable) {
             throw SnippetException::jsonNotFound();
         }
 

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -7,9 +7,15 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Storefront;
 use Symfony\Component\Finder\Finder;
 
+/**
+ * @phpstan-type Snippets array<string, string|Snippets>
+ */
 #[Package('discovery')]
 class SnippetFileHandler
 {
+    /**
+     * @return Snippets
+     */
     public function openJsonFile(string $path): array
     {
         $json = json_decode(file_get_contents($path), true);
@@ -22,13 +28,19 @@ class SnippetFileHandler
         return $json;
     }
 
+    /**
+     * @param Snippets $content
+     */
     public function writeJsonFile(string $path, array $content): void
     {
         $json = json_encode($content, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
-
+        $json = str_replace('    ', '  ', $json); // Workaround because of wrong indentation
         file_put_contents($path, $json);
     }
 
+    /**
+     * @return string[]
+     */
     public function findAdministrationSnippetFiles(): array
     {
         if (!($bundleDir = $this->getBundleDir(Administration::class))) {
@@ -38,6 +50,9 @@ class SnippetFileHandler
         return $this->findSnippetFilesByPath($bundleDir . '/Resources/app/*/src/');
     }
 
+    /**
+     * @return string[]
+     */
     public function findStorefrontSnippetFiles(): array
     {
         if (!($bundleDir = $this->getBundleDir(Storefront::class))) {
@@ -56,6 +71,9 @@ class SnippetFileHandler
         return \dirname((string) (new \ReflectionClass($bundleClass))->getFileName());
     }
 
+    /**
+     * @return string[]
+     */
     private function findSnippetFilesByPath(string $path): array
     {
         $finder = (new Finder())

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -4,11 +4,12 @@ namespace Shopware\Core\System\Snippet;
 
 use Shopware\Administration\Administration;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\Command\ValidateSnippetsCommand;
 use Shopware\Storefront\Storefront;
 use Symfony\Component\Finder\Finder;
 
 /**
- * @phpstan-type Snippets array<string, string|mixed>
+ * @phpstan-import-type Snippets from ValidateSnippetsCommand
  */
 #[Package('discovery')]
 class SnippetFileHandler
@@ -24,11 +25,10 @@ class SnippetFileHandler
             throw SnippetException::jsonNotFound();
         }
 
-        $json = json_decode($fileContents, true, 512, \JSON_THROW_ON_ERROR);
-
-        $jsonError = json_last_error();
-        if ($jsonError !== 0) {
-            throw SnippetException::invalidSnippetFile($path, new \RuntimeException(json_last_error_msg(), $jsonError));
+        try {
+            $json = json_decode($fileContents, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            throw SnippetException::invalidSnippetFile($path, $e);
         }
 
         return $json;
@@ -39,16 +39,18 @@ class SnippetFileHandler
      */
     public function writeJsonFile(string $path, array $content): void
     {
-        $json = \json_encode(
-            $content,
-            \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES
-        ) ?: '';
+        try {
+            $json = \json_encode($content, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+        } catch (\Throwable $e) {
+            throw SnippetException::invalidSnippetFile($path, $e);
+        }
+
         $json = str_replace('    ', '  ', $json); // Workaround because of wrong indentation
         file_put_contents($path, $json);
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function findAdministrationSnippetFiles(): array
     {
@@ -60,7 +62,7 @@ class SnippetFileHandler
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function findStorefrontSnippetFiles(): array
     {
@@ -81,7 +83,7 @@ class SnippetFileHandler
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     private function findSnippetFilesByPath(string $path): array
     {

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -15,14 +15,11 @@ use Symfony\Component\Finder\Finder;
 #[Package('discovery')]
 class SnippetFileHandler
 {
-    private readonly Filesystem $filesystem;
-
     /**
      * @internal
      */
-    public function __construct()
+    public function __construct(private readonly Filesystem $filesystem)
     {
-        $this->filesystem = new Filesystem();
     }
 
     /**

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -6,6 +6,7 @@ use Shopware\Administration\Administration;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Command\ValidateSnippetsCommand;
 use Shopware\Storefront\Storefront;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -14,12 +15,19 @@ use Symfony\Component\Finder\Finder;
 #[Package('discovery')]
 class SnippetFileHandler
 {
+    private readonly Filesystem $filesystem;
+
+    public function __construct()
+    {
+        $this->filesystem = new Filesystem();
+    }
+
     /**
      * @return Snippets
      */
     public function openJsonFile(string $path): array
     {
-        $fileContents = file_get_contents($path);
+        $fileContents = $this->filesystem->readFile($path);
 
         if ($fileContents === false) {
             throw SnippetException::jsonNotFound();
@@ -46,7 +54,7 @@ class SnippetFileHandler
         }
 
         $json = str_replace('    ', '  ', $json); // Workaround because of wrong indentation
-        file_put_contents($path, $json);
+        $this->filesystem->dumpFile($path, $json);
     }
 
     /**

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -8,7 +8,7 @@ use Shopware\Storefront\Storefront;
 use Symfony\Component\Finder\Finder;
 
 /**
- * @phpstan-type Snippets array<string, string|Snippets>
+ * @phpstan-type Snippets array<string, string|mixed>
  */
 #[Package('discovery')]
 class SnippetFileHandler
@@ -18,11 +18,17 @@ class SnippetFileHandler
      */
     public function openJsonFile(string $path): array
     {
-        $json = json_decode(file_get_contents($path), true);
+        $fileContents = file_get_contents($path);
+
+        if ($fileContents === false) {
+            throw SnippetException::jsonNotFound();
+        }
+
+        $json = json_decode($fileContents, true, 512, \JSON_THROW_ON_ERROR);
 
         $jsonError = json_last_error();
         if ($jsonError !== 0) {
-            throw new \RuntimeException(\sprintf('Invalid JSON in snippet file at path \'%s\' with code \'%d\'', $path, $jsonError));
+            throw SnippetException::invalidSnippetFile($path, new \RuntimeException(json_last_error_msg(), $jsonError));
         }
 
         return $json;
@@ -33,7 +39,10 @@ class SnippetFileHandler
      */
     public function writeJsonFile(string $path, array $content): void
     {
-        $json = json_encode($content, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+        $json = \json_encode(
+            $content,
+            \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES
+        ) ?: '';
         $json = str_replace('    ', '  ', $json); // Workaround because of wrong indentation
         file_put_contents($path, $json);
     }

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -10,7 +10,6 @@ use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
  * @phpstan-import-type Snippets from ValidateSnippetsCommand
- *
  * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[Package('discovery')]

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Snippet;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
 
+/**
+ * @phpstan-type Snippets array<string, string|Snippets>
+ */
 #[Package('discovery')]
 class SnippetFixer
 {
@@ -15,7 +18,16 @@ class SnippetFixer
     {
     }
 
-    public function fix(MissingSnippetCollection $missingSnippetCollection): void
+    /**
+     * @param Snippets $invalidPluralization
+     */
+    public function fix(MissingSnippetCollection $missingSnippetCollection, array $invalidPluralization): void
+    {
+        $this->fixMissingSnippets($missingSnippetCollection);
+        $this->fixInvalidPluralization($invalidPluralization);
+    }
+
+    private function fixMissingSnippets(MissingSnippetCollection $missingSnippetCollection): void
     {
         foreach ($missingSnippetCollection->getIterator() as $missingSnippetStruct) {
             // Replace e.g. en-GB to de-DE and en_GB to de_DE
@@ -42,6 +54,11 @@ class SnippetFixer
         }
     }
 
+    /**
+     * @param Snippets $json
+     *
+     * @return Snippets
+     */
     private function addTranslationUsingSnippetKey(array $json, string $translation, string $key): array
     {
         $keyParts = explode('.', $key);
@@ -52,6 +69,48 @@ class SnippetFixer
         foreach ($keyParts as $keyPart) {
             if ($keyPart === $lastKey) {
                 $currentJson[$keyPart] = $translation;
+
+                continue;
+            }
+
+            $currentJson = &$currentJson[$keyPart];
+        }
+
+        return $json;
+    }
+
+    /**
+     * @param Snippets $invalidPluralization
+     */
+    private function fixInvalidPluralization(array $invalidPluralization): void
+    {
+        foreach ($invalidPluralization as $invalidSnippet) {
+            $json = $this->snippetFileHandler->openJsonFile($invalidSnippet['path']);
+
+            $json = $this->replaceInvalidPluralization(
+                $json,
+                $invalidSnippet['snippetKey'],
+            );
+
+            $this->snippetFileHandler->writeJsonFile($invalidSnippet['path'], $json);
+        }
+    }
+
+    /**
+     * @param Snippets $json
+     *
+     * @return Snippets
+     */
+    private function replaceInvalidPluralization(array $json, string $key): array
+    {
+        $keyParts = explode('.', $key);
+
+        $currentJson = &$json;
+        $lastKey = end($keyParts);
+        reset($keyParts);
+        foreach ($keyParts as $keyPart) {
+            if ($keyPart === $lastKey) {
+                $currentJson[$keyPart] = preg_replace('/\]\s*1\s*,\s*Inf\s*\[/i', '[0,Inf[', $currentJson[$keyPart]);
 
                 continue;
             }

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -10,6 +10,7 @@ use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
  * @phpstan-import-type Snippets from ValidateSnippetsCommand
+ *
  * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[Package('discovery')]
@@ -27,7 +28,7 @@ class SnippetFixer
      *
      * @param InvalidPluralization $invalidPluralization
      */
-    public function fix(MissingSnippetCollection $missingSnippetCollection /*, array $invalidPluralization */): void
+    public function fix(MissingSnippetCollection $missingSnippetCollection /* , array $invalidPluralization */): void
     {
         /** @var Snippets $invalidPluralization */
         $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : [];

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -2,11 +2,13 @@
 
 namespace Shopware\Core\System\Snippet;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\Command\ValidateSnippetsCommand;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
 
 /**
- * @phpstan-type Snippets array<string, string|mixed>
+ * @phpstan-import-type Snippets from ValidateSnippetsCommand
  */
 #[Package('discovery')]
 class SnippetFixer
@@ -21,10 +23,14 @@ class SnippetFixer
     /**
      * @deprecated tag:v6.8.0 reason:new-optional-parameter - Will get a second parameter `$invalidPluralization`
      */
-    public function fix(MissingSnippetCollection $missingSnippetCollection): void
+    public function fix(MissingSnippetCollection $missingSnippetCollection /*, array $invalidPluralization*/): void
     {
         /** @var Snippets $invalidPluralization */
         $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : [];
+
+        if (!Feature::isActive('v6.8.0.0') && \func_num_args() < 2) {
+            Feature::triggerDeprecationOrThrow('v6.8.0.0', 'New required parameter `$invalidPluralization` missing');
+        }
 
         $this->fixMissingSnippets($missingSnippetCollection);
         $this->fixInvalidPluralization($invalidPluralization);

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -25,11 +25,11 @@ class SnippetFixer
     /**
      * @deprecated tag:v6.8.0 reason:new-optional-parameter - Will get a second parameter `$invalidPluralization`
      *
-     * @param InvalidPluralization $invalidPluralization
+     * @toDo: Add `@param InvalidPluralization $invalidPluralization`
      */
     public function fix(MissingSnippetCollection $missingSnippetCollection /* , array $invalidPluralization */): void
     {
-        /** @var Snippets $invalidPluralization */
+        /** @var InvalidPluralization $invalidPluralization */
         $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : [];
 
         if (!Feature::isActive('v6.8.0.0') && \func_num_args() < 2) {

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
 
 /**
- * @phpstan-type Snippets array<string, string|Snippets>
+ * @phpstan-type Snippets array<string, string|mixed>
  */
 #[Package('discovery')]
 class SnippetFixer
@@ -19,10 +19,13 @@ class SnippetFixer
     }
 
     /**
-     * @param Snippets $invalidPluralization
+     * @deprecated tag:v6.8.0 reason:new-optional-parameter - Will get a second parameter `$invalidPluralization`
      */
-    public function fix(MissingSnippetCollection $missingSnippetCollection, array $invalidPluralization): void
+    public function fix(MissingSnippetCollection $missingSnippetCollection): void
     {
+        /** @var Snippets $invalidPluralization */
+        $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : [];
+
         $this->fixMissingSnippets($missingSnippetCollection);
         $this->fixInvalidPluralization($invalidPluralization);
     }
@@ -55,12 +58,33 @@ class SnippetFixer
     }
 
     /**
+     * @param Snippets $invalidPluralization
+     */
+    private function fixInvalidPluralization(array $invalidPluralization): void
+    {
+        foreach ($invalidPluralization as $invalidSnippet) {
+            $json = $this->snippetFileHandler->openJsonFile($invalidSnippet['path']);
+
+            $json = $this->replaceInvalidPluralization(
+                $json,
+                $invalidSnippet['snippetKey'],
+            );
+
+            $this->snippetFileHandler->writeJsonFile($invalidSnippet['path'], $json);
+        }
+    }
+
+    /**
      * @param Snippets $json
      *
      * @return Snippets
      */
-    private function addTranslationUsingSnippetKey(array $json, string $translation, string $key): array
+    private function addTranslationUsingSnippetKey(array $json, ?string $translation, string $key): array
     {
+        if ($translation === null) {
+            return $json;
+        }
+
         $keyParts = explode('.', $key);
 
         $currentJson = &$json;
@@ -77,23 +101,6 @@ class SnippetFixer
         }
 
         return $json;
-    }
-
-    /**
-     * @param Snippets $invalidPluralization
-     */
-    private function fixInvalidPluralization(array $invalidPluralization): void
-    {
-        foreach ($invalidPluralization as $invalidSnippet) {
-            $json = $this->snippetFileHandler->openJsonFile($invalidSnippet['path']);
-
-            $json = $this->replaceInvalidPluralization(
-                $json,
-                $invalidSnippet['snippetKey'],
-            );
-
-            $this->snippetFileHandler->writeJsonFile($invalidSnippet['path'], $json);
-        }
     }
 
     /**

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -33,7 +33,10 @@ class SnippetFixer
         $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : [];
 
         if (!Feature::isActive('v6.8.0.0') && \func_num_args() < 2) {
-            Feature::triggerDeprecationOrThrow('v6.8.0.0', 'New required parameter `$invalidPluralization` missing');
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                'New required parameter `$invalidPluralization` missing'
+            );
         }
 
         $this->fixMissingSnippets($missingSnippetCollection);

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -6,9 +6,11 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Command\ValidateSnippetsCommand;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
+use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
  * @phpstan-import-type Snippets from ValidateSnippetsCommand
+ * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[Package('discovery')]
 class SnippetFixer
@@ -64,7 +66,7 @@ class SnippetFixer
     }
 
     /**
-     * @param Snippets $invalidPluralization
+     * @param InvalidPluralization $invalidPluralization
      */
     private function fixInvalidPluralization(array $invalidPluralization): void
     {

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -27,7 +27,7 @@ class SnippetFixer
     public function fix(MissingSnippetCollection $missingSnippetCollection /* , InvalidPluralizationCollection $invalidPluralization */): void
     {
         /** @var InvalidPluralizationCollection $invalidPluralization */
-        $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : [];
+        $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : new InvalidPluralizationCollection();
 
         if (!Feature::isActive('v6.8.0.0') && \func_num_args() < 2) {
             Feature::triggerDeprecationOrThrow(

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -24,8 +24,10 @@ class SnippetFixer
 
     /**
      * @deprecated tag:v6.8.0 reason:new-optional-parameter - Will get a second parameter `$invalidPluralization`
+     *
+     * @param InvalidPluralization $invalidPluralization
      */
-    public function fix(MissingSnippetCollection $missingSnippetCollection /*, array $invalidPluralization*/): void
+    public function fix(MissingSnippetCollection $missingSnippetCollection /*, array $invalidPluralization */): void
     {
         /** @var Snippets $invalidPluralization */
         $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : [];

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -5,12 +5,11 @@ namespace Shopware\Core\System\Snippet;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Command\ValidateSnippetsCommand;
+use Shopware\Core\System\Snippet\Struct\InvalidPluralizationCollection;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
-use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
  * @phpstan-import-type Snippets from ValidateSnippetsCommand
- * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[Package('discovery')]
 class SnippetFixer
@@ -24,12 +23,10 @@ class SnippetFixer
 
     /**
      * @deprecated tag:v6.8.0 reason:new-optional-parameter - Will get a second parameter `$invalidPluralization`
-     *
-     * @toDo: Add `@param InvalidPluralization $invalidPluralization`
      */
-    public function fix(MissingSnippetCollection $missingSnippetCollection /* , array $invalidPluralization */): void
+    public function fix(MissingSnippetCollection $missingSnippetCollection /* , InvalidPluralizationCollection $invalidPluralization */): void
     {
-        /** @var InvalidPluralization $invalidPluralization */
+        /** @var InvalidPluralizationCollection $invalidPluralization */
         $invalidPluralization = \func_num_args() === 2 ? func_get_arg(1) : [];
 
         if (!Feature::isActive('v6.8.0.0') && \func_num_args() < 2) {
@@ -40,6 +37,11 @@ class SnippetFixer
         }
 
         $this->fixMissingSnippets($missingSnippetCollection);
+
+        if ($invalidPluralization->count() < 1) {
+            return;
+        }
+
         $this->fixInvalidPluralization($invalidPluralization);
     }
 
@@ -70,20 +72,17 @@ class SnippetFixer
         }
     }
 
-    /**
-     * @param InvalidPluralization $invalidPluralization
-     */
-    private function fixInvalidPluralization(array $invalidPluralization): void
+    private function fixInvalidPluralization(InvalidPluralizationCollection $invalidPluralization): void
     {
-        foreach ($invalidPluralization as $invalidSnippet) {
-            $json = $this->snippetFileHandler->openJsonFile($invalidSnippet['path']);
+        foreach ($invalidPluralization->getIterator() as $invalidSnippet) {
+            $json = $this->snippetFileHandler->openJsonFile($invalidSnippet->path);
 
             $json = $this->replaceInvalidPluralization(
                 $json,
-                $invalidSnippet['snippetKey'],
+                $invalidSnippet->snippetKey,
             );
 
-            $this->snippetFileHandler->writeJsonFile($invalidSnippet['path'], $json);
+            $this->snippetFileHandler->writeJsonFile($invalidSnippet->path, $json);
         }
     }
 

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -46,7 +46,7 @@ class SnippetValidator implements SnippetValidatorInterface
         );
 
         $missingSnippetsArray = [];
-        foreach ($this->getValidation()->missingSnippets->getIterator() as $entry) {
+        foreach ($this->getValidation()->missingSnippets as $entry) {
             $key = $entry->getKeyPath();
             $missingSnippetsArray[$entry->getMissingForISO()][$key] = [
                 'path' => $entry->getFilePath(),

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -5,7 +5,12 @@ namespace Shopware\Core\System\Snippet;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
+use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
+/**
+ * @phpstan-import-type MissingSnippets from SnippetValidationStruct
+ * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
+ */
 #[Package('discovery')]
 class SnippetValidator implements SnippetValidatorInterface
 {
@@ -20,9 +25,19 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @return array<string, array<string, mixed>>
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return SnippetValidationStruct
+     *
+     * @return MissingSnippets
      */
     public function validate(): array
+    {
+        return $this->getValidation()->missingSnippets;
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed, use validate() instead
+     */
+    public function getValidation(): SnippetValidationStruct
     {
         $files = $this->getAllFiles();
 
@@ -61,10 +76,10 @@ class SnippetValidator implements SnippetValidatorInterface
             }
         }
 
-        return [
-            'missingSnippets' => $this->findMissingSnippets($snippetFileMappings, $availableISOs),
-            'invalidPluralization' => $invalidPluralization,
-        ];
+        return new SnippetValidationStruct(
+            $this->findMissingSnippets($snippetFileMappings, $availableISOs),
+            $invalidPluralization,
+        );
     }
 
     protected function getAllFiles(): SnippetFileCollection
@@ -140,7 +155,7 @@ class SnippetValidator implements SnippetValidatorInterface
      * @param array<string, array<string, array<string, mixed>>> $snippetFileMappings
      * @param array<int, string> $availableISOs
      *
-     * @return array<string, mixed>
+     * @return MissingSnippets
      */
     private function findMissingSnippets(array $snippetFileMappings, array $availableISOs): array
     {
@@ -178,7 +193,7 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @return array{isInvalid: bool, isFixable: bool}
+     * @return InvalidPluralization
      */
     private function hasInvalidPluralization(string $snippetContent, string $filePath): array
     {

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -13,7 +13,7 @@ use Shopware\Core\System\Snippet\Struct\MissingSnippetStruct;
 use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
- * @phpstan-type MissingSnippets array<string, array<string, array{
+ * @phpstan-type MissingSnippetsArray array<string, array<string, array{
  *      path: string,
  *      availableISO: string,
  *      availableValue: string,
@@ -36,7 +36,7 @@ class SnippetValidator implements SnippetValidatorInterface
     /**
      * @deprecated tag:v6.8.0 - Will be removed, use `getValidation()` instead
      *
-     * @return MissingSnippets
+     * @return MissingSnippetsArray
      */
     public function validate(): array
     {
@@ -118,7 +118,7 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @param MissingSnippets $missingSnippetsArray
+     * @param MissingSnippetsArray $missingSnippetsArray
      */
     private function hydrateMissingSnippets(array $missingSnippetsArray): MissingSnippetCollection
     {

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -8,10 +8,17 @@ use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\Struct\InvalidPluralizationCollection;
 use Shopware\Core\System\Snippet\Struct\InvalidPluralizationStruct;
+use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
+use Shopware\Core\System\Snippet\Struct\MissingSnippetStruct;
 use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
- * @phpstan-import-type MissingSnippets from SnippetValidationStruct
+ * @phpstan-type MissingSnippets array<string, array<string, array{
+ *      path: string,
+ *      availableISO: string,
+ *      availableValue: string,
+ *      keyPath: string
+ * }>>
  */
 #[Package('discovery')]
 class SnippetValidator implements SnippetValidatorInterface
@@ -38,7 +45,18 @@ class SnippetValidator implements SnippetValidatorInterface
             'The method  Will be removed, use `getValidation()` instead.'
         );
 
-        return $this->getValidation()->missingSnippets;
+        $missingSnippetsArray = [];
+        foreach ($this->getValidation()->missingSnippets->getIterator() as $entry) {
+            $key = $entry->getKeyPath();
+            $missingSnippetsArray[$entry->getMissingForISO()][$key] = [
+                'path' => $entry->getFilePath(),
+                'availableISO' => $entry->getAvailableISO(),
+                'availableValue' => $entry->getAvailableTranslation(),
+                'keyPath' => $key,
+            ];
+        }
+
+        return $missingSnippetsArray;
     }
 
     public function getValidation(): SnippetValidationStruct
@@ -97,6 +115,21 @@ class SnippetValidator implements SnippetValidatorInterface
         $storefrontSnippetFiles = $this->snippetFileHandler->findStorefrontSnippetFiles();
 
         return $this->hydrateFiles(array_merge($deprecatedFiles, $administrationFiles, $storefrontSnippetFiles));
+    }
+
+    /**
+     * @param MissingSnippets $missingSnippetsArray
+     */
+    private function hydrateMissingSnippets(array $missingSnippetsArray): MissingSnippetCollection
+    {
+        $missingSnippetsCollection = new MissingSnippetCollection();
+        foreach ($missingSnippetsArray as $locale => $missingSnippets) {
+            foreach ($missingSnippets as $key => $missingSnippet) {
+                $missingSnippetsCollection->add(new MissingSnippetStruct($key, $missingSnippet['path'], $missingSnippet['availableISO'], $missingSnippet['availableValue'], $locale));
+            }
+        }
+
+        return $missingSnippetsCollection;
     }
 
     /**
@@ -162,10 +195,8 @@ class SnippetValidator implements SnippetValidatorInterface
     /**
      * @param array<string, array<string, array<string, mixed>>> $snippetFileMappings
      * @param array<int, string> $availableISOs
-     *
-     * @return MissingSnippets
      */
-    private function findMissingSnippets(array $snippetFileMappings, array $availableISOs): array
+    private function findMissingSnippets(array $snippetFileMappings, array $availableISOs): MissingSnippetCollection
     {
         $availableISOs = array_keys(array_flip($availableISOs));
 
@@ -189,7 +220,7 @@ class SnippetValidator implements SnippetValidatorInterface
             }
         }
 
-        return $missingSnippetsArray;
+        return $this->hydrateMissingSnippets($missingSnippetsArray);
     }
 
     /**

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -12,7 +12,7 @@ use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
  * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[Package('discovery')]
-class SnippetValidator implements SnippetValidatorInterface
+class SnippetValidator
 {
     /**
      * @internal
@@ -25,7 +25,7 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return SnippetValidationStruct
+     * @deprecated tag:v6.8.0 - Will be removed, use `getValidation()` instead
      *
      * @return MissingSnippets
      */
@@ -34,9 +34,6 @@ class SnippetValidator implements SnippetValidatorInterface
         return $this->getValidation()->missingSnippets;
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - Will be removed, use validate() instead
-     */
     public function getValidation(): SnippetValidationStruct
     {
         $files = $this->getAllFiles();

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -12,7 +12,7 @@ use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
  * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[Package('discovery')]
-class SnippetValidator
+class SnippetValidator implements SnippetValidatorInterface
 {
     /**
      * @internal

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
+use Shopware\Core\System\Snippet\Struct\InvalidPluralizationCollection;
+use Shopware\Core\System\Snippet\Struct\InvalidPluralizationStruct;
 use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
@@ -43,7 +45,7 @@ class SnippetValidator implements SnippetValidatorInterface
     {
         $files = $this->getAllFiles();
 
-        $invalidPluralization = [];
+        $invalidPluralization = new InvalidPluralizationCollection();
         $snippetFileMappings = [];
         $availableISOs = [];
         foreach ($files as $snippetFile) {
@@ -72,12 +74,12 @@ class SnippetValidator implements SnippetValidatorInterface
                 $validationData = $this->hasInvalidPluralization($value, $path);
 
                 if ($validationData['isInvalid']) {
-                    $invalidPluralization[$key] = [
-                        'snippetKey' => $key,
-                        'snippetValue' => $value,
-                        'isFixable' => $validationData['isFixable'],
-                        'path' => $path,
-                    ];
+                    $invalidPluralization->set($key, new InvalidPluralizationStruct(
+                        $key,
+                        $value,
+                        $validationData['isFixable'],
+                        $path,
+                    ));
                 }
             }
         }

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -20,12 +20,13 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, array<string, mixed>>
      */
     public function validate(): array
     {
         $files = $this->getAllFiles();
 
+        $invalidPluralization = [];
         $snippetFileMappings = [];
         $availableISOs = [];
         foreach ($files as $snippetFile) {
@@ -38,14 +39,28 @@ class SnippetValidator implements SnippetValidatorInterface
             $json = $this->snippetFileHandler->openJsonFile($snippetFile->getPath());
 
             foreach ($this->getRecursiveArrayKeys($json) as $keyValue) {
-                $snippetFileMappings[$snippetFile->getIso()][key($keyValue)] = [
+                $key = key($keyValue);
+                $value = array_shift($keyValue);
+
+                $snippetFileMappings[$snippetFile->getIso()][$key] = [
                     'path' => str_ireplace($this->projectDir, '', $snippetFile->getPath()),
-                    'availableValue' => array_shift($keyValue),
+                    'availableValue' => $value,
                 ];
+
+                if (str_contains(preg_replace('/\s+/', '', $value), ']1,Inf[')) {
+                    $invalidPluralization['key'] = [
+                        'snippetKey' => $key,
+                        'availableValue' => $value,
+                        'path' => str_ireplace($this->projectDir, '', $snippetFile->getPath()),
+                    ];
+                }
             }
         }
 
-        return $this->findMissingSnippets($snippetFileMappings, $availableISOs);
+        return [
+            'missingSnippets' => $this->findMissingSnippets($snippetFileMappings, $availableISOs),
+            'invalidPluralization' => $invalidPluralization,
+        ];
     }
 
     protected function getAllFiles(): SnippetFileCollection
@@ -92,7 +107,7 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @param array<mixed> $dataSet
+     * @param array<string, mixed> $dataSet
      *
      * @return array<int, array<string, mixed>>
      */
@@ -151,7 +166,7 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @return array<string>
+     * @return list<string>
      */
     private function findDeprecatedSnippetFiles(): array
     {

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -41,17 +41,21 @@ class SnippetValidator implements SnippetValidatorInterface
             foreach ($this->getRecursiveArrayKeys($json) as $keyValue) {
                 $key = key($keyValue);
                 $value = array_shift($keyValue);
+                $path = str_ireplace($this->projectDir, '', $snippetFile->getPath());
 
                 $snippetFileMappings[$snippetFile->getIso()][$key] = [
-                    'path' => str_ireplace($this->projectDir, '', $snippetFile->getPath()),
+                    'path' => $path,
                     'availableValue' => $value,
                 ];
 
-                if (str_contains(preg_replace('/\s+/', '', $value), ']1,Inf[')) {
-                    $invalidPluralization['key'] = [
+                $validationData = $this->hasInvalidPluralization($value, $path);
+
+                if ($validationData['isInvalid']) {
+                    $invalidPluralization[$key] = [
                         'snippetKey' => $key,
-                        'availableValue' => $value,
-                        'path' => str_ireplace($this->projectDir, '', $snippetFile->getPath()),
+                        'snippetValue' => $value,
+                        'isFixable' => $validationData['isFixable'],
+                        'path' => $path,
                     ];
                 }
             }
@@ -171,5 +175,31 @@ class SnippetValidator implements SnippetValidatorInterface
     private function findDeprecatedSnippetFiles(): array
     {
         return array_column($this->deprecatedSnippetFiles->toArray(), 'path');
+    }
+
+    /**
+     * @return array{isInvalid: bool, isFixable: bool}
+     */
+    private function hasInvalidPluralization(string $snippetContent, string $filePath): array
+    {
+        $unformattedSnippet = strtolower(preg_replace('/\s+/', '', $snippetContent) ?: '');
+
+        $isSymfonyTranslationFile = preg_match('/storefront|messages/i', $filePath);
+        $hasPluralization = str_contains($snippetContent, '|');
+
+        if (!$isSymfonyTranslationFile || !$hasPluralization) {
+            return [
+                'isInvalid' => false,
+                'isFixable' => false,
+            ];
+        }
+
+        $hasInvalidPluralization = !preg_match('/^(\{0\}.+\|)?(\{1\}.+\|)(\[0,inf\[.+)/i', $unformattedSnippet);
+        $hasInvalidPluralizationRange = str_contains($unformattedSnippet, ']1,inf[');
+
+        return [
+            'isInvalid' => $hasInvalidPluralization || $hasInvalidPluralizationRange,
+            'isFixable' => $hasInvalidPluralizationRange,
+        ];
     }
 }

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\Snippet;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
@@ -9,7 +10,6 @@ use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
  * @phpstan-import-type MissingSnippets from SnippetValidationStruct
- * @phpstan-import-type InvalidPluralization from SnippetValidationStruct
  */
 #[Package('discovery')]
 class SnippetValidator implements SnippetValidatorInterface
@@ -31,6 +31,11 @@ class SnippetValidator implements SnippetValidatorInterface
      */
     public function validate(): array
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'The method  Will be removed, use `getValidation()` instead.'
+        );
+
         return $this->getValidation()->missingSnippets;
     }
 
@@ -52,7 +57,11 @@ class SnippetValidator implements SnippetValidatorInterface
 
             foreach ($this->getRecursiveArrayKeys($json) as $keyValue) {
                 $key = key($keyValue);
+                \assert(\is_string($key));
+
                 $value = array_shift($keyValue);
+                \assert(\is_string($value));
+
                 $path = str_ireplace($this->projectDir, '', $snippetFile->getPath());
 
                 $snippetFileMappings[$snippetFile->getIso()][$key] = [
@@ -190,7 +199,7 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @return InvalidPluralization
+     * @return array{isInvalid: bool, isFixable: bool}
      */
     private function hasInvalidPluralization(string $snippetContent, string $filePath): array
     {

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Snippet;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
+/**
+ * @deprecated tag:v6.8.0 - Will be removed, use SnippetValidator directly instead
+ */
 #[Package('discovery')]
 interface SnippetValidatorInterface
 {
@@ -12,9 +15,4 @@ interface SnippetValidatorInterface
      * @return array<string, array<string, mixed>>
      */
     public function validate(): array;
-
-    /**
-     * @deprecated tag:v6.8.0 - Will be removed, use validate() instead
-     */
-    public function getValidation(): SnippetValidationStruct;
 }

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\System\Snippet;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 /**
  * @deprecated tag:v6.8.0 - Will be removed, use SnippetValidator directly instead

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\System\Snippet;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\Struct\SnippetValidationStruct;
 
 #[Package('discovery')]
 interface SnippetValidatorInterface
@@ -11,4 +12,9 @@ interface SnippetValidatorInterface
      * @return array<string, array<string, mixed>>
      */
     public function validate(): array;
+
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed, use validate() instead
+     */
+    public function getValidation(): SnippetValidationStruct;
 }

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -15,6 +15,4 @@ interface SnippetValidatorInterface
      * @return array<string, array<string, mixed>>
      */
     public function validate(): array;
-
-    public function getValidation(): SnippetValidationStruct;
 }

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -7,5 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 interface SnippetValidatorInterface
 {
+    /**
+     * @return array<string, array<string, mixed>>
+     */
     public function validate(): array;
 }

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -15,4 +15,6 @@ interface SnippetValidatorInterface
      * @return array<string, array<string, mixed>>
      */
     public function validate(): array;
+
+    public function getValidation(): SnippetValidationStruct;
 }

--- a/src/Core/System/Snippet/Struct/InvalidPluralizationCollection.php
+++ b/src/Core/System/Snippet/Struct/InvalidPluralizationCollection.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Snippet\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Collection;
+
+/**
+ * @extends Collection<InvalidPluralizationStruct>
+ */
+#[Package('discovery')]
+class InvalidPluralizationCollection extends Collection
+{
+}

--- a/src/Core/System/Snippet/Struct/InvalidPluralizationCollection.php
+++ b/src/Core/System/Snippet/Struct/InvalidPluralizationCollection.php
@@ -11,4 +11,8 @@ use Shopware\Core\Framework\Struct\Collection;
 #[Package('discovery')]
 class InvalidPluralizationCollection extends Collection
 {
+    protected function getExpectedClass(): string
+    {
+        return InvalidPluralizationStruct::class;
+    }
 }

--- a/src/Core/System/Snippet/Struct/InvalidPluralizationStruct.php
+++ b/src/Core/System/Snippet/Struct/InvalidPluralizationStruct.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Snippet\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+#[Package('discovery')]
+class InvalidPluralizationStruct extends Struct
+{
+    public function __construct(
+        public readonly string $snippetKey,
+        public readonly string $snippetValue,
+        public readonly bool $isFixable,
+        public readonly string $path,
+    ) {
+    }
+}

--- a/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
+++ b/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
@@ -5,22 +5,11 @@ namespace Shopware\Core\System\Snippet\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @phpstan-type MissingSnippets array<string, array<string, array{
- *      path: string,
- *      availableISO: string,
- *      availableValue: string,
- *      keyPath: string
- * }>>
- */
 #[Package('discovery')]
 class SnippetValidationStruct extends Struct
 {
-    /**
-     * @param MissingSnippets $missingSnippets
-     */
     public function __construct(
-        public readonly array $missingSnippets,
+        public readonly MissingSnippetCollection $missingSnippets,
         public readonly InvalidPluralizationCollection $invalidPluralization,
     ) {
     }

--- a/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
+++ b/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
@@ -12,17 +12,19 @@ use Shopware\Core\Framework\Struct\Struct;
  *      availableValue: string,
  *      keyPath: string
  * }>>
- * @phpstan-type InvalidPluralization array{
- *      isInvalid: bool,
- *      isFixable: bool
- * }
+ * @phpstan-type InvalidPluralization array<string, array{
+ *      snippetKey: string,
+ *      snippetValue: string,
+ *      isFixable: bool,
+ *      path: string,
+ * }>
  */
 #[Package('discovery')]
 class SnippetValidationStruct extends Struct
 {
     /**
      * @param MissingSnippets $missingSnippets
-     * @param array<string, InvalidPluralization> $invalidPluralization
+     * @param InvalidPluralization $invalidPluralization
      */
     public function __construct(
         public readonly array $missingSnippets,

--- a/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
+++ b/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Snippet\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+/**
+ * @phpstan-type MissingSnippets array<string, array<string, array{
+ *      path: string,
+ *      availableISO: string,
+ *      availableValue: string,
+ *      keyPath: string
+ * }>>
+ * @phpstan-type InvalidPluralization array{
+ *      isInvalid: bool,
+ *      isFixable: bool
+ * }
+ */
+#[Package('discovery')]
+class SnippetValidationStruct extends Struct
+{
+    /**
+     * @param MissingSnippets $missingSnippets
+     * @param array<string, InvalidPluralization> $invalidPluralization
+     */
+    public function __construct(
+        public readonly array $missingSnippets,
+        public readonly array $invalidPluralization,
+    ) {
+    }
+}

--- a/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
+++ b/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
@@ -12,23 +12,16 @@ use Shopware\Core\Framework\Struct\Struct;
  *      availableValue: string,
  *      keyPath: string
  * }>>
- * @phpstan-type InvalidPluralization array<string, array{
- *      snippetKey: string,
- *      snippetValue: string,
- *      isFixable: bool,
- *      path: string,
- * }>
  */
 #[Package('discovery')]
 class SnippetValidationStruct extends Struct
 {
     /**
      * @param MissingSnippets $missingSnippets
-     * @param InvalidPluralization $invalidPluralization
      */
     public function __construct(
         public readonly array $missingSnippets,
-        public readonly array $invalidPluralization,
+        public readonly InvalidPluralizationCollection $invalidPluralization,
     ) {
     }
 }

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -77,7 +77,7 @@
     "searchButton": "Suchen",
     "searchPlaceholder": "Suchbegriff eingeben ...",
     "searchAllResults": "Alle Suchergebnisse anzeigen",
-    "searchResults": "{1} 1 Ergebnis|]1,Inf[ %count% Ergebnisse",
+    "searchResults": "{1} 1 Ergebnis|[0,Inf[ %count% Ergebnisse",
     "searchDropdownTitle": "Die Dropdown-Suche",
     "searchCloseButton": "Die Dropdown-Suche schließen",
     "supportInfo": "<strong>Fragen zu Ihrer Bestellung?</strong><br /><strong><a href=\"tel:+4912345-123456789\">12345-123456789</a></strong> <small>Täglich 7:30 bis 22:00 Uhr</small>",
@@ -422,7 +422,7 @@
     "companyVatPlaceholder": "Umsatzsteuer-ID"
   },
   "checkout": {
-    "itemCounter": "{1} 1 Position|]1,Inf[ %count% Positionen",
+    "itemCounter": "{1} 1 Position|[0,Inf[ %count% Positionen",
     "addressHeader": "Versandinformationen",
     "addressLoginToggle": "Sie sind bereits Kunde? Klicken Sie hier, um sich einzuloggen.",
     "addressRegisterCardTitle": "Persönliche Informationen",
@@ -433,7 +433,7 @@
     "cartMetaTitle": "Warenkorb",
     "cartHeader": "Warenkorb",
     "cartUpdateSuccess": "Warenkorb aktualisiert.",
-    "cartScreenReaderUpdate": "Warenkorb enthält eine Position. Der Gesamtwert beträgt %total%.|Warenkorb enthält %count% Positionen. Der Gesamtwert beträgt %total%.",
+    "cartScreenReaderUpdate": "{1}Warenkorb enthält eine Position. Der Gesamtwert beträgt %total%.|[0,Inf[Warenkorb enthält %count% Positionen. Der Gesamtwert beträgt %total%.",
     "continueShopping": "Weiter einkaufen",
     "emptyCart": "Ihr Warenkorb ist leer.",
     "proceedToCart": "Warenkorb anzeigen",
@@ -512,7 +512,7 @@
     "finishChangePayment": "Zahlungsart ändern",
     "finishPaymentFailed": "Leider ist der Zahlungsprozess fehlgeschlagen. Bitte ändern Sie die Zahlungsart um Ihre Bestellung abzuschließen. <a href=\"%editOrderUrl%\">Zahlung ändern</a>",
     "codeAddedSuccessful": "Gutscheincode erfolgreich hinzugefügt.",
-    "addToCartSuccess": "{1} 1 Produkt zum Warenkorb hinzugefügt.|]1,Inf[ %count% Produkte zum Warenkorb hinzugefügt.",
+    "addToCartSuccess": "{1} 1 Produkt zum Warenkorb hinzugefügt.|[0,Inf[ %count% Produkte zum Warenkorb hinzugefügt.",
     "shippingCosts": "Versanddetails öffnen",
     "shippingCountry": "Lieferland",
     "paymentMethod": "Zahlungsart",
@@ -640,7 +640,7 @@
     "success": "Wir haben Ihre Kontaktanfrage erhalten und werden sie schnellstmöglich bearbeiten."
   },
   "search": {
-    "headline": "{0} Zu \"%searchTerm%\" wurde kein Produkt gefunden | {1} Zu \"%searchTerm%\" wurde 1 Produkt gefunden | ]1,Inf[ Zu \"%searchTerm%\" wurden %count% Produkte gefunden",
+    "headline": "{0} Zu \"%searchTerm%\" wurde kein Produkt gefunden | {1} Zu \"%searchTerm%\" wurde 1 Produkt gefunden | [0,Inf[ Zu \"%searchTerm%\" wurden %count% Produkte gefunden",
     "metaTitle": "Suchergebnis"
   },
   "detail": {
@@ -658,13 +658,13 @@
     "dataColumnPrice": "Stückpreis",
     "dataColumnReferencePrice": "Grundpreis",
     "deliveryTimeAvailable": "Sofort verfügbar, Lieferzeit: %name%",
-    "deliveryTimeRestock": "{1} Versandfertig in 1 Tag, Lieferzeit %name% |]1,Inf[ Versandfertig in %restockTime% Tagen, Lieferzeit %name% ",
+    "deliveryTimeRestock": "{1} Versandfertig in 1 Tag, Lieferzeit %name% |[0,Inf[ Versandfertig in %restockTime% Tagen, Lieferzeit %name% ",
     "soldOut": "Nicht mehr verfügbar",
     "tabsReview": "Bewertungen",
     "reviewTitle": "%count% von %total% Bewertungen",
     "reviewVerifiedItemTooltip": "Verifizierter Käufer",
     "reviewCommentLabel": "Unser Kommentar: ",
-    "reviewLinkText": "{1} Bewertung|]1,Inf[ Bewertungen",
+    "reviewLinkText": "{1} Bewertung|[0,Inf[ Bewertungen",
     "reviewFormRatingLabel": "Ihre Bewertung",
     "reviewFormTitleLabel": "Titel",
     "reviewFormTitlePlaceholder": "Titel eingeben ...",
@@ -691,7 +691,7 @@
     "reviewSortLabel": "Sortiert nach",
     "reviewSortTopRatedLabel": "Am besten bewertet",
     "reviewSortNewLabel": "Neueste Bewertung",
-    "reviewCountAfter": "{1} Bewertung|]1,Inf[ Bewertungen",
+    "reviewCountAfter": "{1} Bewertung|[0,Inf[ Bewertungen",
     "reviewCountBefore": "von",
     "reviewListEmpty": "Keine Bewertungen gefunden. Teilen Sie Ihre Erfahrungen mit anderen.",
     "reviewLoginHeader": "Anmelden",
@@ -758,7 +758,7 @@
     "wishlistMergeHint": "Ihr Merkzettel kann Produkte enthalten, die bei einem vorhergehenden Besuch hinzugefügt und gespeichert wurden.",
     "wishlistEmptyHeader": "Ihr Merkzettel ist leer",
     "wishlistEmptyDescription": "Behalten Sie interessante Produkte im Auge, indem Sie sie zu Ihrem Merkzettel hinzufügen.",
-    "deliveryTimeRestock": "{1} Versandfertig in 1 Tag, Lieferzeit %name% |]1,Inf[ Versandfertig in %restockTime% Tagen, Lieferzeit %name% ",
+    "deliveryTimeRestock": "{1} Versandfertig in 1 Tag, Lieferzeit %name% |[0,Inf[ Versandfertig in %restockTime% Tagen, Lieferzeit %name% ",
     "deliveryShipping": "Dieses Produkt erscheint am",
     "remove": "%product_name% vom Merkzettel entfernen"
   },

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -77,7 +77,7 @@
     "searchButton": "Search",
     "searchPlaceholder": "Enter search term...",
     "searchAllResults": "Show all search results",
-    "searchResults": "{1} 1 Result|]1,Inf[ %count% Results",
+    "searchResults": "{1} 1 Result|[0,Inf[ %count% Results",
     "searchDropdownTitle": "The dropdown search",
     "searchCloseButton": "Close the dropdown search",
     "supportInfo": "<strong>Questions regarding your order?</strong><br /><strong><a href=\"tel:+4912345-123456789\">12345-123456789</a></strong> <small>Daily from 7:30 am to 10:00 pm</small>",
@@ -422,7 +422,7 @@
     "companyVatPlaceholder": "VAT Reg.No."
   },
   "checkout": {
-    "itemCounter": "{1} 1 item|]1,Inf[ %count% items",
+    "itemCounter": "{1} 1 item|[0,Inf[ %count% items",
     "addressHeader": "Shipping information",
     "addressLoginToggle": "You already have an account? Click here to login.",
     "addressRegisterCardTitle": "Your personal details",
@@ -433,7 +433,7 @@
     "cartMetaTitle": "Shopping cart",
     "cartHeader": "Shopping cart",
     "cartUpdateSuccess": "Shopping cart updated.",
-    "cartScreenReaderUpdate": "Shopping cart contains one item. The cart total value is %total%.|Shopping cart contains %count% items. The cart total value is %total%.",
+    "cartScreenReaderUpdate": "{1}Shopping cart contains one item. The cart total value is %total%.|[0,Inf[Shopping cart contains %count% items. The cart total value is %total%.",
     "continueShopping": "Continue shopping",
     "emptyCart": "Your shopping cart is empty.",
     "proceedToCart": "Display shopping cart",
@@ -512,7 +512,7 @@
     "finishChangePayment": "Change payment method",
     "finishPaymentFailed": "Unfortunately, the payment process went wrong. Please change your payment method to finish your order. <a href=\"%editOrderUrl%\">Change payment method</a>",
     "codeAddedSuccessful": "Promo code added successfully.",
-    "addToCartSuccess": "{1} 1 product added to your shopping cart.|]1,Inf[ %count% products added to your shopping cart.",
+    "addToCartSuccess": "{1} 1 product added to your shopping cart.|[0,Inf[ %count% products added to your shopping cart.",
     "shippingCosts": "Open shipping details",
     "shippingCountry": "Shipping country",
     "paymentMethod": "Payment method",
@@ -640,7 +640,7 @@
     "success": "We have received your contact request and will process it as soon as possible."
   },
   "search": {
-    "headline": "{0} 0 products found for \"%searchTerm%\" | {1} One product found for \"%searchTerm%\" | ]1,Inf[ %count% products found for \"%searchTerm%\"",
+    "headline": "{0} 0 products found for \"%searchTerm%\" | {1} One product found for \"%searchTerm%\" | [0,Inf[ %count% products found for \"%searchTerm%\"",
     "metaTitle": "Search results"
   },
   "detail": {
@@ -658,13 +658,13 @@
     "dataColumnPrice": "Unit price",
     "dataColumnReferencePrice": "Base price",
     "deliveryTimeAvailable": "Available, delivery time: %name%",
-    "deliveryTimeRestock": "{1} Available in 1 day, delivery time %name%|]1,Inf[ Available in %restockTime% days, delivery time %name%",
+    "deliveryTimeRestock": "{1} Available in 1 day, delivery time %name%|[0,Inf[ Available in %restockTime% days, delivery time %name%",
     "soldOut": "No longer available",
     "tabsReview": "Reviews",
     "reviewTitle": "%count% of %total% reviews",
     "reviewVerifiedItemTooltip": "Verified buyer",
     "reviewCommentLabel": "Our feedback: ",
-    "reviewLinkText": "{1} Review|]1,Inf[ Reviews",
+    "reviewLinkText": "{1} Review|[0,Inf[ Reviews",
     "reviewFormRatingLabel": "Your rating",
     "reviewFormTitleLabel": "Title",
     "reviewFormTitlePlaceholder": "Enter title...",
@@ -691,7 +691,7 @@
     "reviewSortLabel": "Sort by",
     "reviewSortTopRatedLabel": "Top rated",
     "reviewSortNewLabel": "Most recent",
-    "reviewCountAfter": "{1} review|]1,Inf[ reviews",
+    "reviewCountAfter": "{1} review|[0,Inf[ reviews",
     "reviewCountBefore": "of",
     "reviewListEmpty": "No reviews found. Share your insights with others.",
     "reviewLoginHeader": "Login",
@@ -758,7 +758,7 @@
     "wishlistMergeHint": "Your wishlist might contain products that have been added and saved during a previous visit.",
     "wishlistEmptyHeader": "Your wishlist is empty",
     "wishlistEmptyDescription": "Keep an eye on products you like by adding them to your wishlist.",
-    "deliveryTimeRestock": "{1} Available in 1 day, delivery time %name%|]1,Inf[ Available in %restockTime% days, delivery time %name%",
+    "deliveryTimeRestock": "{1} Available in 1 day, delivery time %name%|[0,Inf[ Available in %restockTime% days, delivery time %name%",
     "deliveryShipping": "This product will be released on",
     "remove": "Remove %product_name% from wishlist"
   },

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -22,8 +22,8 @@ class SnippetValidatorTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $firstPath = 'irrelevant.de-DE.json';
-        $secondPath = 'irrelevant.en-GB.json';
+        $firstPath = 'storefront.de-DE.json';
+        $secondPath = 'storefront.en-GB.json';
         $snippetFileHandler->method('findAdministrationSnippetFiles')
             ->willReturn([$firstPath]);
         $snippetFileHandler->method('findStorefrontSnippetFiles')
@@ -39,7 +39,8 @@ class SnippetValidatorTest extends TestCase
             });
 
         $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
-        $missingSnippets = $snippetValidator->validate();
+        $invalidData = $snippetValidator->validate();
+        $missingSnippets = $invalidData['missingSnippets'];
 
         static::assertCount(2, $missingSnippets);
         static::assertArrayHasKey('german', $missingSnippets['en-GB']);
@@ -49,6 +50,9 @@ class SnippetValidatorTest extends TestCase
         static::assertArrayHasKey('english', $missingSnippets['de-DE']);
         static::assertSame('english', $missingSnippets['de-DE']['english']['keyPath']);
         static::assertSame('exampleEnglish', $missingSnippets['de-DE']['english']['availableValue']);
+
+        $invalidPluralization = $invalidData['invalidPluralization'];
+        static::assertCount(0, $invalidPluralization);
     }
 
     public function testValidateShouldNotFindAnyMissingSnippets(): void
@@ -57,8 +61,8 @@ class SnippetValidatorTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $firstPath = 'irrelevant.de-DE.json';
-        $secondPath = 'irrelevant.en-GB.json';
+        $firstPath = 'storefront.de-DE.json';
+        $secondPath = 'storefront.en-GB.json';
         $snippetFileHandler->method('findAdministrationSnippetFiles')
             ->willReturn([$firstPath]);
         $snippetFileHandler->method('findStorefrontSnippetFiles')
@@ -68,8 +72,54 @@ class SnippetValidatorTest extends TestCase
             ->willReturnCallback(fn () => ['foo' => 'bar']);
 
         $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
-        $missingSnippets = $snippetValidator->validate();
+        $invalidData = $snippetValidator->validate();
 
-        static::assertCount(0, $missingSnippets);
+        static::assertCount(0, $invalidData['missingSnippets']);
+    }
+
+    public function testValidateShouldFindInvalidPluralization(): void
+    {
+        $snippetFileHandler = $this->getMockBuilder(SnippetFileHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $path = 'storefront.en-GB.json';
+        $snippetFileHandler->method('findStorefrontSnippetFiles')
+            ->willReturn([$path]);
+
+        $expectedInvalidSnippets = [
+            'noIndexes' => 'Singular | Plural',
+            'noFallbackRange' => '{1}Singular | Plural',
+            'noOneIndex' => '{0} Singular | [0,Inf[ Plural',
+            'wrongPluralRangeSnippet' => '{1} Singular |]1,Inf[ Plural',
+            'wrongPluralRangeSnippetDupe' => '{1} Singular DUPE |]1,Inf[ Plural DUPE',
+        ];
+
+        $actualSnippets = [
+            'noPluralization' => 'Something',
+            'somethingValid' => '{1} Singular |[0,Inf[ Plural',
+            'somethingValidWith0' => '{0} Zero case | {1} Singular |[0,Inf[ Plural',
+            ...$expectedInvalidSnippets,
+        ];
+
+        $snippetFileHandler->method('openJsonFile')
+            ->willReturnCallback(fn () => $actualSnippets);
+
+        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
+        $invalidData = $snippetValidator->validate();
+        $invalidPluralization = $invalidData['invalidPluralization'];
+
+        static::assertCount(5, $invalidPluralization);
+        static::assertArrayNotHasKey('somethingValid', $invalidPluralization);
+        static::assertArrayNotHasKey('somethingValidWith0', $invalidPluralization);
+
+        foreach ($expectedInvalidSnippets as $expectedKey => $expectedValue) {
+            static::assertArrayHasKey($expectedKey, $invalidPluralization, "Missing expected key: $expectedKey");
+
+            $invalidSnippet = $invalidPluralization[$expectedKey];
+            static::assertCount(4, $invalidSnippet);
+            static::assertSame($expectedValue, $invalidSnippet['snippetValue'], "Invalid pluralization for key: $expectedKey");
+            static::assertSame($path, $invalidSnippet['path'], "Invalid path for key: $expectedKey");
+        }
     }
 }

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -40,16 +40,16 @@ class SnippetValidatorTest extends TestCase
 
         $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
         $invalidData = $snippetValidator->getValidation();
-        $missingSnippets = $invalidData->missingSnippets;
-
+        $missingSnippets = $invalidData->missingSnippets->getElements();
         static::assertCount(2, $missingSnippets);
-        static::assertArrayHasKey('german', $missingSnippets['en-GB']);
-        static::assertSame('german', $missingSnippets['en-GB']['german']['keyPath']);
-        static::assertSame('exampleGerman', $missingSnippets['en-GB']['german']['availableValue']);
 
-        static::assertArrayHasKey('english', $missingSnippets['de-DE']);
-        static::assertSame('english', $missingSnippets['de-DE']['english']['keyPath']);
-        static::assertSame('exampleEnglish', $missingSnippets['de-DE']['english']['availableValue']);
+        $missingSnippetEnGB = $missingSnippets[0];
+        static::assertSame('german', $missingSnippetEnGB->getKeyPath());
+        static::assertSame('exampleGerman', $missingSnippetEnGB->getAvailableTranslation());
+
+        $missingSnippetdeDE = $missingSnippets[1];
+        static::assertSame('english', $missingSnippetdeDE->getKeyPath());
+        static::assertSame('exampleEnglish', $missingSnippetdeDE->getAvailableTranslation());
 
         $invalidPluralization = $invalidData->invalidPluralization;
         static::assertCount(0, $invalidPluralization);

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -91,8 +91,8 @@ class SnippetValidatorTest extends TestCase
             'noIndexes' => 'Singular | Plural',
             'noFallbackRange' => '{1}Singular | Plural',
             'noOneIndex' => '{0} Singular | [0,Inf[ Plural',
-            'wrongPluralRangeSnippet' => '{1} Singular |]1,Inf[ Plural',
-            'wrongPluralRangeSnippetDupe' => '{1} Singular DUPE |]1,Inf[ Plural DUPE',
+            'wrongPluralRangeSnippetFixable' => '{1} Singular |]1,Inf[ Plural',
+            'wrongPluralRangeSnippetDupeFixable' => '{1} Singular DUPE |]1,Inf[ Plural DUPE',
         ];
 
         $actualSnippets = [
@@ -110,16 +110,16 @@ class SnippetValidatorTest extends TestCase
         $invalidPluralization = $invalidData->invalidPluralization;
 
         static::assertCount(5, $invalidPluralization);
-        static::assertArrayNotHasKey('somethingValid', $invalidPluralization);
-        static::assertArrayNotHasKey('somethingValidWith0', $invalidPluralization);
+        static::assertFalse($invalidPluralization->has('somethingValid'));
+        static::assertFalse($invalidPluralization->has('somethingValidWith0'));
 
         foreach ($expectedInvalidSnippets as $expectedKey => $expectedValue) {
-            static::assertArrayHasKey($expectedKey, $invalidPluralization, "Missing expected key: $expectedKey");
+            static::assertTrue($invalidPluralization->has($expectedKey), "Missing expected key: $expectedKey");
 
-            $invalidSnippet = $invalidPluralization[$expectedKey];
-            static::assertCount(4, $invalidSnippet);
-            static::assertSame($expectedValue, $invalidSnippet['snippetValue'], "Invalid pluralization for key: $expectedKey");
-            static::assertSame($path, $invalidSnippet['path'], "Invalid path for key: $expectedKey");
+            $invalidSnippet = $invalidPluralization->get($expectedKey);
+            static::assertSame($expectedValue, $invalidSnippet->snippetValue, "Invalid pluralization for key: $expectedKey");
+            static::assertSame($path, $invalidSnippet->path, "Invalid path for key: $expectedKey");
+            static::assertSame(\str_contains($expectedKey, 'Fixable'), $invalidSnippet->isFixable);
         }
     }
 }

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -39,8 +39,8 @@ class SnippetValidatorTest extends TestCase
             });
 
         $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
-        $invalidData = $snippetValidator->validate();
-        $missingSnippets = $invalidData['missingSnippets'];
+        $invalidData = $snippetValidator->getValidation();
+        $missingSnippets = $invalidData->missingSnippets;
 
         static::assertCount(2, $missingSnippets);
         static::assertArrayHasKey('german', $missingSnippets['en-GB']);
@@ -51,7 +51,7 @@ class SnippetValidatorTest extends TestCase
         static::assertSame('english', $missingSnippets['de-DE']['english']['keyPath']);
         static::assertSame('exampleEnglish', $missingSnippets['de-DE']['english']['availableValue']);
 
-        $invalidPluralization = $invalidData['invalidPluralization'];
+        $invalidPluralization = $invalidData->invalidPluralization;
         static::assertCount(0, $invalidPluralization);
     }
 
@@ -72,9 +72,9 @@ class SnippetValidatorTest extends TestCase
             ->willReturnCallback(fn () => ['foo' => 'bar']);
 
         $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
-        $invalidData = $snippetValidator->validate();
+        $invalidData = $snippetValidator->getValidation();
 
-        static::assertCount(0, $invalidData['missingSnippets']);
+        static::assertCount(0, $invalidData->missingSnippets);
     }
 
     public function testValidateShouldFindInvalidPluralization(): void
@@ -106,8 +106,8 @@ class SnippetValidatorTest extends TestCase
             ->willReturnCallback(fn () => $actualSnippets);
 
         $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
-        $invalidData = $snippetValidator->validate();
-        $invalidPluralization = $invalidData['invalidPluralization'];
+        $invalidData = $snippetValidator->getValidation();
+        $invalidPluralization = $invalidData->invalidPluralization;
 
         static::assertCount(5, $invalidPluralization);
         static::assertArrayNotHasKey('somethingValid', $invalidPluralization);


### PR DESCRIPTION
fixes: #11299

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We noticed, some languages have multiple pluralization cases, confusing symfony, when providing exact 2 pluralization options.

### 2. What does this change do, exactly?
This fixes the pluralization ranges and adds tests to prevent further issues
<img width="2074" height="397" alt="image" src="https://github.com/user-attachments/assets/be039edd-962d-4bf8-bfa4-7b9c254a73b6" />


### 3. Describe each step to reproduce the issue or behaviour.
- Have a snippet with ]1, Inf[ but no 0 case in Polish or Czech
- Render this snippet in Storefront
- Error


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
