### PR TITLE
fix: address not shown in digital order

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
@@ -91,7 +91,7 @@
 
                             {% block page_checkout_confirm_address_billing_data %}
                                 <div class="confirm-address-billing mb-3">
-                                    {% if billingAddress.id is same as(shippingAddress.id) %}
+                                    {% if billingAddress.id is same as(shippingAddress.id) and not page.isHideShippingAddress()%}
                                         {% block page_checkout_confirm_address_billing_data_equal %}
                                             <p>
                                                 {{ 'checkout.addressEqualText'|trans|sw_sanitize }}


### PR DESCRIPTION
## 1. Why is this change necessary?
<img width="1030" height="655" alt="image" src="https://github.com/user-attachments/assets/36975f43-5f49-41e6-a003-c5993909c61d" />

The billing adress is not shown for ditital orders

### 2. What does this change do, exactly?

Change the if condition 

<img width="551" height="707" alt="image" src="https://github.com/user-attachments/assets/9939827c-5ae5-435e-b5af-146a186efe63" />


### 4. Please link to the relevant issues (if any).
fixes #6366
