### PR TITLE
fix: Add missing context config setting access optional chaining

### DIFF
--- a/changelog/_unreleased/2025-07-17-add-missing-context-setting-optional-chaining.md
+++ b/changelog/_unreleased/2025-07-17-add-missing-context-setting-optional-chaining.md
@@ -1,0 +1,8 @@
+---
+title: Add missing context config setting access optional chaining
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Changed several places where config settings were accessed without the optional chaining operator

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-wrong-app-url-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-wrong-app-url-modal/index.js
@@ -40,7 +40,7 @@ export default {
         },
 
         hasAppsThatRequireAppUrl() {
-            return Shopware.Store.get('context').app.config.settings.appsRequireAppUrl;
+            return Shopware.Store.get('context').app.config.settings?.appsRequireAppUrl;
         },
 
         display() {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/index.js
@@ -37,7 +37,7 @@ export default {
         },
 
         isStaging() {
-            return Shopware.Store.get('context').app.config.settings.enableStagingMode === true;
+            return Shopware.Store.get('context').app.config.settings?.enableStagingMode === true;
         },
     },
 
@@ -77,7 +77,7 @@ export default {
         },
 
         updateShowUrlChangedModal() {
-            if (!Shopware.Store.get('context').app.config.settings.appsRequireAppUrl) {
+            if (!Shopware.Store.get('context').app.config.settings?.appsRequireAppUrl) {
                 this.urlDiff = null;
                 return;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
@@ -201,7 +201,7 @@ export default {
         },
 
         extensionManagementDisabled() {
-            return Shopware.Store.get('context').app.config.settings.disableExtensionManagement;
+            return Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
         },
 
         showContextMenu() {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/index.js
@@ -29,7 +29,7 @@ export default {
         },
 
         extensionManagementDisabled() {
-            return Shopware.Store.get('context').app.config.settings.disableExtensionManagement;
+            return Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/index.js
@@ -119,7 +119,7 @@ export default {
         },
 
         extensionManagementDisabled() {
-            return Shopware.Store.get('context').app.config.settings.disableExtensionManagement;
+            return Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/component/sw-first-run-wizard-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/component/sw-first-run-wizard-modal/index.js
@@ -93,7 +93,7 @@ export default {
         },
 
         extensionManagementDisabled() {
-            return Shopware.Store.get('context').app.config.settings.disableExtensionManagement;
+            return Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
         },
 
         isClosable() {
@@ -101,7 +101,7 @@ export default {
         },
 
         stepper() {
-            if (Shopware.Store.get('context').app.config.settings.disableExtensionManagement) {
+            if (Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
                 return {
                     welcome: {
                         name: 'sw.first.run.wizard.index.welcome',

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-defaults/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-defaults/index.js
@@ -49,7 +49,7 @@ export default {
                 },
             ];
 
-            if (!Shopware.Store.get('context').app.config.settings.disableExtensionManagement) {
+            if (!Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
                 buttons.unshift({
                     key: 'back',
                     label: this.$tc('sw-first-run-wizard.general.buttonBack'),

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-finish/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-finish/index.js
@@ -48,7 +48,7 @@ export default {
         },
 
         buttonConfig() {
-            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings.disableExtensionManagement;
+            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
             const prevRoute = disabledExtensionManagement ? 'shopware.account' : 'store';
 
             return [

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-finish/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-finish/index.js
@@ -48,7 +48,8 @@ export default {
         },
 
         buttonConfig() {
-            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
+            const disabledExtensionManagement =
+                Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
             const prevRoute = disabledExtensionManagement ? 'shopware.account' : 'store';
 
             return [

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-local/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-local/index.js
@@ -46,7 +46,7 @@ export default {
         },
 
         nextAction() {
-            if (Shopware.Store.get('context').app.config.settings.disableExtensionManagement) {
+            if (Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
                 return 'sw.first.run.wizard.index.shopware.account';
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/index.js
@@ -30,7 +30,8 @@ export default {
         },
 
         buttonConfig() {
-            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
+            const disabledExtensionManagement =
+                Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
             const nextRoute = disabledExtensionManagement ? 'shopware.account' : 'paypal.info';
 
             return [

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/index.js
@@ -30,7 +30,7 @@ export default {
         },
 
         buttonConfig() {
-            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings.disableExtensionManagement;
+            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
             const nextRoute = disabledExtensionManagement ? 'shopware.account' : 'paypal.info';
 
             return [

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-account/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-account/index.js
@@ -45,7 +45,7 @@ export default {
         },
 
         updateButtons() {
-            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings.disableExtensionManagement;
+            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
             const prevRoute = disabledExtensionManagement ? 'mailer.selection' : 'plugins';
             const skipRoute = disabledExtensionManagement ? 'finish' : 'store';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-account/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-account/index.js
@@ -45,7 +45,8 @@ export default {
         },
 
         updateButtons() {
-            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
+            const disabledExtensionManagement =
+                Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
             const prevRoute = disabledExtensionManagement ? 'mailer.selection' : 'plugins';
             const skipRoute = disabledExtensionManagement ? 'finish' : 'store';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-domain/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-shopware-domain/index.js
@@ -38,7 +38,7 @@ export default {
         },
 
         nextAction() {
-            if (Shopware.Store.get('context').app.config.settings.disableExtensionManagement) {
+            if (Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
                 return 'sw.first.run.wizard.index.finish';
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/index.js
@@ -114,7 +114,7 @@ export default {
         },
 
         updateButtons() {
-            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings.disableExtensionManagement;
+            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
             const nextRoute = disabledExtensionManagement ? 'defaults' : 'data-import';
 
             const buttonConfig = [
@@ -139,7 +139,7 @@ export default {
         },
 
         getLanguagePlugins() {
-            if (Shopware.Store.get('context').app.config.settings.disableExtensionManagement) {
+            if (Shopware.Store.get('context').app.config.settings?.disableExtensionManagement) {
                 this.languagePlugins = [];
                 return;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/index.js
@@ -114,7 +114,8 @@ export default {
         },
 
         updateButtons() {
-            const disabledExtensionManagement = Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
+            const disabledExtensionManagement =
+                Shopware.Store.get('context').app.config.settings?.disableExtensionManagement;
             const nextRoute = disabledExtensionManagement ? 'defaults' : 'data-import';
 
             const buttonConfig = [


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the optional chaining operator is missing in a few places where the config settings can be undefined/null which would result in a error if you access the object

### 2. What does this change do, exactly?
* Changed several places where config settings were accessed without the optional chaining operator

### 3. Describe each step to reproduce the issue or behaviour.
- Empty app context config settings

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
