### PR TITLE
fix: Correctly delete bearerAuth cookie from base path in administration

### DIFF
--- a/changelog/_unreleased/2025-07-17-correctly-delete-bearer-auth-cookie-from-base-path.md
+++ b/changelog/_unreleased/2025-07-17-correctly-delete-bearer-auth-cookie-from-base-path.md
@@ -1,0 +1,8 @@
+---
+title: Correctly delete bearerAuth cookie from base path in administration
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Changed `Resources/app/administration/src/core/service/login.service.ts` to correctly delete the `bearerAuth` cookie also from the `context.basePath` if the logout function is called

--- a/src/Administration/Resources/app/administration/src/core/service/login.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/login.service.ts
@@ -371,6 +371,7 @@ export default function createLoginService(
      */
     function logout(isInactivityLogout = false, shouldRedirect = true): boolean {
         if (typeof document !== 'undefined' && typeof document.cookie !== 'undefined') {
+            cookieStorage.removeItem(storageKey, { path: context.basePath });
             cookieStorage.removeItem(storageKey);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
- If you work from the administration from different paths there can be a page loading issue, which prevents you from loading the administration
- See `3. Describe each step to reproduce the issue or behaviour`

#### Optional other fix:
- Change [this](https://github.com/shopware/shopware/pull/11341/files#diff-1aa037d400a774eb23af11a1a995a0e3bca65e69b03a286c775f4d991d6b9950R490) to just `const path = context.basePath!;`

### 2. What does this change do, exactly?
* Changed `Resources/app/administration/src/core/service/login.service.ts` to correctly delete the `bearerAuth` cookie also from the `context.basePath` if the logout function is called

### 3. Describe each step to reproduce the issue or behaviour.
- Login to the administration from a path with empty a pathInfo e.g. from the administration watch script
- Wait for the bearerAuth token to get invalid or set the token invalid by yourself
- Try to load the normal administration from '/admin'
- You will end up in a page refresh loop as the browser accesses the cookie from path '/' but tries to delete it on path '/admin'

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
