### PR TITLE
feat: enhance opensearch performance on searching and sorting

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -39,6 +39,7 @@ return [
         preg_quote('ADDED: Parameter response was added to Method __construct() of class Shopware\Elasticsearch\Framework\DataAbstractionLayer\Event\ElasticsearchEntitySearcherSearchedEvent', '/'),
         preg_quote('ADDED: Parameter clock was added to Method __construct() of class Shopware\Core\Checkout\Promotion\Gateway\Template\ActiveDateRange', '/'),
         preg_quote('ADDED: Parameter visibility was added to Method __construct() of class Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput', '/'),
+        preg_quote('ADDED: Parameter useForSorting was added to Method __construct() of class Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField', '/'),
 
         // Fix to make promotions work with order recalculation
         'Value of constant Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\OrderConverter::ADMIN_EDIT_ORDER_PERMISSIONS changed from array \((\n.*)*skipPromotion.*(\n.*)*to array \((\n.*)*pinAutomaticPromotions',

--- a/changelog/_unreleased/2025-08-12-optimize-storefront-elasticsearch.md
+++ b/changelog/_unreleased/2025-08-12-optimize-storefront-elasticsearch.md
@@ -1,0 +1,32 @@
+---
+title: Optimize storefront elasticsearch
+issue: 11130
+---
+# Core
+* Added new bool property `useForSorting` (default as `false`) in `\Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField` to indicate this field could be used for sorting when querying against Elasticsearch.
+* Changed `\Shopware\Core\Content\Product\ProductDefinition` to mark `name` field as `useForSorting = true`.
+* Added new getter for `salesChannelId` and `visibility` in `\Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter`
+* Added new getter for `value` and `field` in `\Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter`
+* Added a new bool property `lastMessage` in `\Shopware\ElasticSearch\Framework\Indexing\ElasticsearchIndexingMessage` to indicate whether the message is the last one in the queue.
+* Added a new event `\Shopware\ElasticSearch\Framework\Indexing\Event\ElasticsearchIndexingFinishedEvent` to signal the end of the indexing process.
+* Changed `\Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer::handleIndexingMessage` to dispatch `ElasticsearchIndexingFinishedEvent` when the last message is processed. 
+* Changed `\Shopware\Elasticsearch\Product\ElasticsearchProductDefinition` to define new mapping `visibility_<sales_channel_id>` field to optimize for reading performance.
+* Added `Shopware\Elasticsearch\Product\ProductCriteriaParser` to optimize search query performance when searching against products index.
+* Changed `\Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser` to use keyword field whenever possible to optimize search query performance
+* Added a new listener `\Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch` to switch the flag that indicates we should use the optimized search query parser.
+___
+# Upgrade Information
+## New Elasticsearch enhancement for optimized storefront searching and sorting
+
+This change introduces a new Elasticsearch enhancement that optimizes storefront searching and sorting. It includes the following key features:
+
+- A new boolean property `useForSorting` in `TranslatedField` to indicate if a field can be used for sorting in Elasticsearch queries.
+- Avoid using nested query when searching against Elasticsearch because its performance is not optimal.
+
+These changes require a full re-index, you need to update your Elasticsearch index's mapping by running the following command:
+
+```bash
+bin/console es:index
+```
+
+And the new implementation will be switched and ready to use after the re-indexing is completed.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1149,12 +1149,6 @@ parameters:
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
-			count: 12
-			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
 			count: 6
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
 

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -197,7 +197,7 @@ class ProductDefinition extends EntityDefinition
             (new TranslatedField('metaTitle'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('packUnit'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('packUnitPlural'))->addFlags(new ApiAware(), new Inherited()),
-            (new TranslatedField('customFields', true))->addFlags(new ApiAware(), new Inherited()),
+            (new TranslatedField('customFields'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('slotConfig'))->addFlags(new Inherited()),
             (new TranslatedField('customSearchKeywords'))->addFlags(new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
 

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -191,13 +191,13 @@ class ProductDefinition extends EntityDefinition
             (new OneToManyAssociationField('downloads', ProductDownloadDefinition::class, 'product_id'))->addFlags(new ApiAware(), new CascadeDelete()),
 
             (new TranslatedField('metaDescription'))->addFlags(new ApiAware(), new Inherited()),
-            (new TranslatedField('name'))->addFlags(new ApiAware(), new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new TranslatedField('name', true))->addFlags(new ApiAware(), new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new TranslatedField('keywords'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('description'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('metaTitle'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('packUnit'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('packUnitPlural'))->addFlags(new ApiAware(), new Inherited()),
-            (new TranslatedField('customFields'))->addFlags(new ApiAware(), new Inherited()),
+            (new TranslatedField('customFields', true))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('slotConfig'))->addFlags(new Inherited()),
             (new TranslatedField('customSearchKeywords'))->addFlags(new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
 

--- a/src/Core/Content/Product/SalesChannel/ProductAvailableFilter.php
+++ b/src/Core/Content/Product/SalesChannel/ProductAvailableFilter.php
@@ -15,8 +15,8 @@ use Shopware\Core\Framework\Log\Package;
 class ProductAvailableFilter extends MultiFilter
 {
     public function __construct(
-        string $salesChannelId,
-        int $visibility = ProductVisibilityDefinition::VISIBILITY_ALL
+        private readonly string $salesChannelId,
+        private readonly int $visibility = ProductVisibilityDefinition::VISIBILITY_ALL
     ) {
         parent::__construct(
             self::CONNECTION_AND,
@@ -26,5 +26,15 @@ class ProductAvailableFilter extends MultiFilter
                 new EqualsFilter('product.active', true),
             ]
         );
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelId;
+    }
+
+    public function getVisibility(): int
+    {
+        return $this->visibility;
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Field/TranslatedField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/TranslatedField.php
@@ -17,9 +17,9 @@ class TranslatedField extends Field
     private readonly string $foreignFieldName;
 
     /**
-     * @param bool $prefilledFallback - only relevant in OpenSearch context, if true, the translated field is filled with fallback value if no translation is available.
+     * @param bool $useForSorting - only relevant in OpenSearch context, if true, the translated field is filled with fallback value if no translation is available.
      */
-    public function __construct(string $propertyName, private readonly bool $prefilledFallback = false)
+    public function __construct(string $propertyName, private readonly bool $useForSorting = false)
     {
         $this->foreignClassName = LanguageDefinition::class;
         $this->foreignFieldName = 'id';
@@ -42,9 +42,9 @@ class TranslatedField extends Field
         return $this->foreignFieldName;
     }
 
-    public function isPrefilledFallback(): bool
+    public function useForSorting(): bool
     {
-        return $this->prefilledFallback;
+        return $this->useForSorting;
     }
 
     protected function getSerializerClass(): string

--- a/src/Core/Framework/DataAbstractionLayer/Field/TranslatedField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/TranslatedField.php
@@ -16,7 +16,10 @@ class TranslatedField extends Field
 
     private readonly string $foreignFieldName;
 
-    public function __construct(string $propertyName)
+    /**
+     * @param bool $prefilledFallback - only relevant in OpenSearch context, if true, the translated field is filled with fallback value if no translation is available.
+     */
+    public function __construct(string $propertyName, private readonly bool $prefilledFallback = false)
     {
         $this->foreignClassName = LanguageDefinition::class;
         $this->foreignFieldName = 'id';
@@ -37,6 +40,11 @@ class TranslatedField extends Field
     public function getForeignFieldName(): string
     {
         return $this->foreignFieldName;
+    }
+
+    public function isPrefilledFallback(): bool
+    {
+        return $this->prefilledFallback;
     }
 
     protected function getSerializerClass(): string

--- a/src/Core/Framework/DataAbstractionLayer/Search/Filter/NotEqualsFilter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Filter/NotEqualsFilter.php
@@ -18,4 +18,14 @@ class NotEqualsFilter extends NotFilter
             new EqualsFilter($field, $value),
         ]);
     }
+
+    public function getValue(): float|bool|int|string|null
+    {
+        return $this->value;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
 }

--- a/src/Core/Migration/V6_8/Migration1743256470RemoveElasticsearchAppConfigFlag.php
+++ b/src/Core/Migration/V6_8/Migration1743256470RemoveElasticsearchAppConfigFlag.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_8;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Adapter\Storage\MySQLKeyValueStorage;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class Migration1743256470RemoveElasticsearchAppConfigFlag extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1743256470;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $storage = new MySQLKeyValueStorage($connection);
+
+        $storage->remove('ELASTIC_OPTIMIZE_FLAG');
+    }
+}

--- a/src/Elasticsearch/Framework/Command/ElasticsearchIndexingCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchIndexingCommand.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Command\ConsoleProgressTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Elasticsearch\Framework\Indexing\CreateAliasTaskHandler;
 use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer;
+use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexingMessage;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -65,9 +66,25 @@ class ElasticsearchIndexingCommand extends Command
 
         $entities = $input->getOption('only') ? explode(',', $input->getOption('only')) : [];
         $offset = null;
+        $messagesToDispatch = [];
+
         while ($message = $this->indexer->iterate($offset, $entities)) {
             $offset = $message->getOffset();
 
+            $messagesToDispatch[] = $message;
+        }
+
+        $lastMessage = end($messagesToDispatch);
+
+        if (!$lastMessage instanceof ElasticsearchIndexingMessage) {
+            $this->io->error('No messages found for indexing.');
+
+            return self::SUCCESS;
+        }
+
+        $lastMessage->markAsLastMessage();
+
+        foreach ($messagesToDispatch as $message) {
             $step = \count($message->getData()->getIds());
 
             if ($input->getOption('no-queue')) {
@@ -79,10 +96,6 @@ class ElasticsearchIndexingCommand extends Command
             }
 
             $this->messageBus->dispatch($message);
-
-            if ($message->isLastMessage()) {
-                break;
-            }
 
             $progressBar->advance($step);
         }

--- a/src/Elasticsearch/Framework/Command/ElasticsearchIndexingCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchIndexingCommand.php
@@ -80,6 +80,10 @@ class ElasticsearchIndexingCommand extends Command
 
             $this->messageBus->dispatch($message);
 
+            if ($message->isLastMessage()) {
+                break;
+            }
+
             $progressBar->advance($step);
         }
 

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -24,6 +24,7 @@ use OpenSearchDSL\Query\TermLevel\WildcardQuery;
 use OpenSearchDSL\Sort\FieldSort;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -70,6 +71,7 @@ use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\ElasticsearchDateHistogramAggregation;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Sort\CountSort;
 
 #[Package('framework')]
@@ -80,7 +82,8 @@ class CriteriaParser
      */
     public function __construct(
         private readonly EntityDefinitionQueryHelper $helper,
-        private readonly CustomFieldService $customFieldService
+        private readonly CustomFieldService $customFieldService,
+        private readonly AbstractKeyValueStorage $storage
     ) {
     }
 
@@ -556,7 +559,7 @@ class CriteriaParser
             $query = new BoolQuery();
 
             if ($field instanceof TranslatedField) {
-                if ($field->useForSorting()) {
+                if ($this->isSortableTranslatedField($field)) {
                     $query->add(new ExistsQuery($contextLanguageFieldName), BoolQuery::MUST_NOT);
                 }
 
@@ -574,7 +577,7 @@ class CriteriaParser
         $query = new TermQuery($fieldName, $value);
 
         if ($field instanceof TranslatedField) {
-            if ($field->useForSorting()) {
+            if ($this->isSortableTranslatedField($field)) {
                 $query = new TermQuery($contextLanguageFieldName, $value);
             } else {
                 $multiMatchFields = [];
@@ -603,7 +606,7 @@ class CriteriaParser
         $query = $this->prepareTermsQueryWithNullSupport($fieldName, $value);
 
         if ($field instanceof TranslatedField) {
-            if ($field->useForSorting()) {
+            if ($this->isSortableTranslatedField($field)) {
                 $fieldName = $this->getTranslatedFieldName($fieldName, $context->getLanguageId());
                 $query = $this->prepareTermsQueryWithNullSupport($fieldName, $value);
             } else {
@@ -658,7 +661,7 @@ class CriteriaParser
         $query = new WildcardQuery($accessor, '*' . $value . '*');
 
         if ($field instanceof TranslatedField) {
-            if ($field->useForSorting()) {
+            if ($this->isSortableTranslatedField($field)) {
                 $query = new WildcardQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), '*' . $value . '*');
             } else {
                 $query = new DisMaxQuery();
@@ -687,7 +690,7 @@ class CriteriaParser
         $query = new PrefixQuery($accessor, $value);
 
         if ($field instanceof TranslatedField) {
-            if ($field->useForSorting()) {
+            if ($this->isSortableTranslatedField($field)) {
                 $query = new PrefixQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), $value);
             } else {
                 $query = new DisMaxQuery();
@@ -716,7 +719,7 @@ class CriteriaParser
         $query = new WildcardQuery($accessor, '*' . $value);
 
         if ($field instanceof TranslatedField) {
-            if ($field->useForSorting()) {
+            if ($this->isSortableTranslatedField($field)) {
                 $query = new WildcardQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), '*' . $value);
             } else {
                 $query = new DisMaxQuery();
@@ -768,7 +771,7 @@ class CriteriaParser
         $query = new RangeQuery($accessor, $value);
 
         if ($field instanceof TranslatedField) {
-            if ($field->useForSorting()) {
+            if ($this->isSortableTranslatedField($field)) {
                 $query = new RangeQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), $value);
             } else {
                 $query = new DisMaxQuery();
@@ -822,7 +825,6 @@ class CriteriaParser
                 $this->buildAccessor($definition, $filter->getField(), $context)
             );
         }
-
 
         if (\count($filter->getQueries()) === 1) {
             $bool->add(
@@ -1153,7 +1155,7 @@ class CriteriaParser
         $accessor = $this->buildAccessor($definition, $sorting->getField(), $context);
 
         if ($field instanceof TranslatedField) {
-            if (!$field->useForSorting()) {
+            if (!$this->isSortableTranslatedField($field)) {
                 return $this->createTranslatedSorting($definition->getEntityName(), $sorting, $context);
             }
 
@@ -1165,5 +1167,10 @@ class CriteriaParser
         }
 
         return new FieldSort($accessor, $sorting->getDirection());
+    }
+
+    private function isSortableTranslatedField(TranslatedField $field): bool
+    {
+        return $field->useForSorting() && $this->storage->has(ElasticsearchOptimizeSwitch::FLAG);
     }
 }

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -151,12 +151,15 @@ class CriteriaParser
         }
 
         $field = $this->helper->getField($sorting->getField(), $definition, $definition->getEntityName(), false);
+        $accessor = $this->buildAccessor($definition, $sorting->getField(), $context);
 
         if ($field instanceof TranslatedField) {
-            return $this->createTranslatedSorting($definition->getEntityName(), $sorting, $context);
-        }
+            if (!$field->isPrefilledFallback()) {
+                return $this->createTranslatedSorting($definition->getEntityName(), $sorting, $context);
+            }
 
-        $accessor = $this->buildAccessor($definition, $sorting->getField(), $context);
+            $accessor = $this->getTranslatedFieldName($accessor, $context->getLanguageId());
+        }
 
         if ($sorting instanceof CountSorting) {
             return new CountSort($accessor, $sorting->getDirection());
@@ -1030,8 +1033,9 @@ class CriteriaParser
         if ($parts[0] === 'customFields') {
             $customField = $this->customFieldService->getCustomField($parts[1]);
 
-            $numericTranslatedFieldSortingScript = $this->getScript('numeric_translated_field_sorting');
             if ($customField instanceof IntField || $customField instanceof FloatField) {
+                $numericTranslatedFieldSortingScript = $this->getScript('numeric_translated_field_sorting');
+
                 return new FieldSort('_script', $sorting->getDirection(), null, [
                     'type' => 'number',
                     'script' => array_merge($numericTranslatedFieldSortingScript, [

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -65,6 +65,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\XOrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\CountSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\CustomFieldService;
@@ -559,7 +560,7 @@ class CriteriaParser
             $query = new BoolQuery();
 
             if ($field instanceof TranslatedField) {
-                if ($this->isSortableTranslatedField($field)) {
+                if ($this->shouldUseMainContextLanguage($field, $context)) {
                     $query->add(new ExistsQuery($contextLanguageFieldName), BoolQuery::MUST_NOT);
                 }
 
@@ -577,7 +578,7 @@ class CriteriaParser
         $query = new TermQuery($fieldName, $value);
 
         if ($field instanceof TranslatedField) {
-            if ($this->isSortableTranslatedField($field)) {
+            if ($this->shouldUseMainContextLanguage($field, $context)) {
                 $query = new TermQuery($contextLanguageFieldName, $value);
             } else {
                 $multiMatchFields = [];
@@ -606,7 +607,7 @@ class CriteriaParser
         $query = $this->prepareTermsQueryWithNullSupport($fieldName, $value);
 
         if ($field instanceof TranslatedField) {
-            if ($this->isSortableTranslatedField($field)) {
+            if ($this->shouldUseMainContextLanguage($field, $context)) {
                 $fieldName = $this->getTranslatedFieldName($fieldName, $context->getLanguageId());
                 $query = $this->prepareTermsQueryWithNullSupport($fieldName, $value);
             } else {
@@ -661,7 +662,7 @@ class CriteriaParser
         $query = new WildcardQuery($accessor, '*' . $value . '*');
 
         if ($field instanceof TranslatedField) {
-            if ($this->isSortableTranslatedField($field)) {
+            if ($this->shouldUseMainContextLanguage($field, $context)) {
                 $query = new WildcardQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), '*' . $value . '*');
             } else {
                 $query = new DisMaxQuery();
@@ -690,7 +691,7 @@ class CriteriaParser
         $query = new PrefixQuery($accessor, $value);
 
         if ($field instanceof TranslatedField) {
-            if ($this->isSortableTranslatedField($field)) {
+            if ($this->shouldUseMainContextLanguage($field, $context)) {
                 $query = new PrefixQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), $value);
             } else {
                 $query = new DisMaxQuery();
@@ -719,7 +720,7 @@ class CriteriaParser
         $query = new WildcardQuery($accessor, '*' . $value);
 
         if ($field instanceof TranslatedField) {
-            if ($this->isSortableTranslatedField($field)) {
+            if ($this->shouldUseMainContextLanguage($field, $context)) {
                 $query = new WildcardQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), '*' . $value);
             } else {
                 $query = new DisMaxQuery();
@@ -771,7 +772,7 @@ class CriteriaParser
         $query = new RangeQuery($accessor, $value);
 
         if ($field instanceof TranslatedField) {
-            if ($this->isSortableTranslatedField($field)) {
+            if ($this->shouldUseMainContextLanguage($field, $context)) {
                 $query = new RangeQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), $value);
             } else {
                 $query = new DisMaxQuery();
@@ -1155,7 +1156,7 @@ class CriteriaParser
         $accessor = $this->buildAccessor($definition, $sorting->getField(), $context);
 
         if ($field instanceof TranslatedField) {
-            if (!$this->isSortableTranslatedField($field)) {
+            if (!$this->shouldUseMainContextLanguage($field, $context)) {
                 return $this->createTranslatedSorting($definition->getEntityName(), $sorting, $context);
             }
 
@@ -1169,8 +1170,15 @@ class CriteriaParser
         return new FieldSort($accessor, $sorting->getDirection());
     }
 
-    private function isSortableTranslatedField(TranslatedField $field): bool
+    private function shouldUseMainContextLanguage(TranslatedField $field, Context $context): bool
     {
-        return $field->useForSorting() && $this->storage->has(ElasticsearchOptimizeSwitch::FLAG);
+        if (\count($context->getLanguageIdChain()) === 1) {
+            return true;
+        }
+
+        /**
+         * @deprecated tag:v6.8.0 - remove (Feature::isActive('v6.8.0.0') || $this->storage->has(ElasticsearchOptimizeSwitch::FLAG)) part as it will be always true
+         */
+        return $field->useForSorting() && (Feature::isActive('v6.8.0.0') || $this->storage->has(ElasticsearchOptimizeSwitch::FLAG));
     }
 }

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -54,6 +54,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
@@ -815,6 +816,13 @@ class CriteriaParser
         if (\count($filter->getQueries()) === 0) {
             return $bool;
         }
+
+        if ($filter instanceof NotEqualsFilter && $filter->getValue() === null) {
+            return new ExistsQuery(
+                $this->buildAccessor($definition, $filter->getField(), $context)
+            );
+        }
+
 
         if (\count($filter->getQueries()) === 1) {
             $bool->add(

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -128,50 +128,15 @@ class CriteriaParser
 
     public function parseSorting(FieldSorting $sorting, EntityDefinition $definition, Context $context): FieldSort
     {
-        if ($this->isCheapestPriceField($sorting->getField())) {
-            $scriptContent = $this->getScript('cheapest_price');
-
-            return new FieldSort('_script', $sorting->getDirection(), null, [
-                'type' => 'number',
-                'script' => array_merge($scriptContent, [
-                    'params' => $this->getCheapestPriceParameters($context),
-                ]),
-            ]);
-        }
-
-        if ($this->isCheapestPriceField($sorting->getField(), true)) {
-            $scriptContent = $this->getScript('cheapest_price_percentage');
-
-            return new FieldSort('_script', $sorting->getDirection(), null, [
-                'type' => 'number',
-                'script' => array_merge($scriptContent, [
-                    'params' => ['accessors' => $this->getCheapestPriceAccessors($context, true)],
-                ]),
-            ]);
-        }
-
-        $field = $this->helper->getField($sorting->getField(), $definition, $definition->getEntityName(), false);
-        $accessor = $this->buildAccessor($definition, $sorting->getField(), $context);
-
-        if ($field instanceof TranslatedField) {
-            if (!$field->isPrefilledFallback()) {
-                return $this->createTranslatedSorting($definition->getEntityName(), $sorting, $context);
-            }
-
-            $accessor = $this->getTranslatedFieldName($accessor, $context->getLanguageId());
-        }
-
-        if ($sorting instanceof CountSorting) {
-            return new CountSort($accessor, $sorting->getDirection());
-        }
+        $fieldSort = $this->buildFieldSort($sorting, $definition, $context);
 
         $path = $this->getNestedPath($definition, $sorting->getField());
 
         if ($path) {
-            return new FieldSort($accessor, $sorting->getDirection(), null, ['nested' => ['path' => $path]]);
+            $fieldSort->addParameter('nested', ['path' => $path]);
         }
 
-        return new FieldSort($accessor, $sorting->getDirection());
+        return $fieldSort;
     }
 
     public function parseAggregation(Aggregation $aggregation, EntityDefinition $definition, Context $context): ?AbstractAggregation
@@ -582,6 +547,7 @@ class CriteriaParser
         }
 
         $fieldName = $this->buildAccessor($definition, $filter->getField(), $context);
+        $contextLanguageFieldName = $this->getTranslatedFieldName($fieldName, $context->getLanguageId());
 
         $field = $this->getField($definition, $fieldName);
 
@@ -589,6 +555,10 @@ class CriteriaParser
             $query = new BoolQuery();
 
             if ($field instanceof TranslatedField) {
+                if ($field->useForSorting()) {
+                    $query->add(new ExistsQuery($contextLanguageFieldName), BoolQuery::MUST_NOT);
+                }
+
                 foreach ($context->getLanguageIdChain() as $languageId) {
                     $query->add(new ExistsQuery($this->getTranslatedFieldName($fieldName, $languageId)), BoolQuery::MUST_NOT);
                 }
@@ -603,15 +573,19 @@ class CriteriaParser
         $query = new TermQuery($fieldName, $value);
 
         if ($field instanceof TranslatedField) {
-            $multiMatchFields = [];
+            if ($field->useForSorting()) {
+                $query = new TermQuery($contextLanguageFieldName, $value);
+            } else {
+                $multiMatchFields = [];
 
-            foreach ($context->getLanguageIdChain() as $languageId) {
-                $multiMatchFields[] = $this->getTranslatedFieldName($fieldName, $languageId);
+                foreach ($context->getLanguageIdChain() as $languageId) {
+                    $multiMatchFields[] = $this->getTranslatedFieldName($fieldName, $languageId);
+                }
+
+                $query = new MultiMatchQuery($multiMatchFields, $value, [
+                    'type' => 'best_fields',
+                ]);
             }
-
-            $query = new MultiMatchQuery($multiMatchFields, $value, [
-                'type' => 'best_fields',
-            ]);
         }
 
         return $this->createNestedQuery($query, $definition, $filter->getField());
@@ -628,10 +602,15 @@ class CriteriaParser
         $query = $this->prepareTermsQueryWithNullSupport($fieldName, $value);
 
         if ($field instanceof TranslatedField) {
-            $query = new DisMaxQuery();
-            foreach ($context->getLanguageIdChain() as $languageId) {
-                $accessor = $this->getTranslatedFieldName($fieldName, $languageId);
-                $query->addQuery($this->prepareTermsQueryWithNullSupport($accessor, $value));
+            if ($field->useForSorting()) {
+                $fieldName = $this->getTranslatedFieldName($fieldName, $context->getLanguageId());
+                $query = $this->prepareTermsQueryWithNullSupport($fieldName, $value);
+            } else {
+                $query = new DisMaxQuery();
+                foreach ($context->getLanguageIdChain() as $languageId) {
+                    $accessor = $this->getTranslatedFieldName($fieldName, $languageId);
+                    $query->addQuery($this->prepareTermsQueryWithNullSupport($accessor, $value));
+                }
             }
         }
 
@@ -678,10 +657,14 @@ class CriteriaParser
         $query = new WildcardQuery($accessor, '*' . $value . '*');
 
         if ($field instanceof TranslatedField) {
-            $query = new DisMaxQuery();
-            foreach ($context->getLanguageIdChain() as $languageId) {
-                $fieldName = $this->getTranslatedFieldName($accessor, $languageId);
-                $query->addQuery(new WildcardQuery($fieldName, '*' . $value . '*'));
+            if ($field->useForSorting()) {
+                $query = new WildcardQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), '*' . $value . '*');
+            } else {
+                $query = new DisMaxQuery();
+                foreach ($context->getLanguageIdChain() as $languageId) {
+                    $fieldName = $this->getTranslatedFieldName($accessor, $languageId);
+                    $query->addQuery(new WildcardQuery($fieldName, '*' . $value . '*'));
+                }
             }
         }
 
@@ -703,10 +686,14 @@ class CriteriaParser
         $query = new PrefixQuery($accessor, $value);
 
         if ($field instanceof TranslatedField) {
-            $query = new DisMaxQuery();
+            if ($field->useForSorting()) {
+                $query = new PrefixQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), $value);
+            } else {
+                $query = new DisMaxQuery();
 
-            foreach ($context->getLanguageIdChain() as $languageId) {
-                $query->addQuery(new WildcardQuery($this->getTranslatedFieldName($accessor, $languageId), $value . '*'));
+                foreach ($context->getLanguageIdChain() as $languageId) {
+                    $query->addQuery(new WildcardQuery($this->getTranslatedFieldName($accessor, $languageId), $value . '*'));
+                }
             }
         }
 
@@ -728,10 +715,14 @@ class CriteriaParser
         $query = new WildcardQuery($accessor, '*' . $value);
 
         if ($field instanceof TranslatedField) {
-            $query = new DisMaxQuery();
-            foreach ($context->getLanguageIdChain() as $languageId) {
-                $fieldName = $this->getTranslatedFieldName($accessor, $languageId);
-                $query->addQuery(new WildcardQuery($fieldName, '*' . $value));
+            if ($field->useForSorting()) {
+                $query = new WildcardQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), '*' . $value);
+            } else {
+                $query = new DisMaxQuery();
+                foreach ($context->getLanguageIdChain() as $languageId) {
+                    $fieldName = $this->getTranslatedFieldName($accessor, $languageId);
+                    $query->addQuery(new WildcardQuery($fieldName, '*' . $value));
+                }
             }
         }
 
@@ -776,10 +767,14 @@ class CriteriaParser
         $query = new RangeQuery($accessor, $value);
 
         if ($field instanceof TranslatedField) {
-            $query = new DisMaxQuery();
-            foreach ($context->getLanguageIdChain() as $languageId) {
-                $fieldName = $this->getTranslatedFieldName($accessor, $languageId);
-                $query->addQuery(new RangeQuery($fieldName, $value));
+            if ($field->useForSorting()) {
+                $query = new RangeQuery($this->getTranslatedFieldName($accessor, $context->getLanguageId()), $value);
+            } else {
+                $query = new DisMaxQuery();
+                foreach ($context->getLanguageIdChain() as $languageId) {
+                    $fieldName = $this->getTranslatedFieldName($accessor, $languageId);
+                    $query->addQuery(new RangeQuery($fieldName, $value));
+                }
             }
         }
 
@@ -1120,5 +1115,47 @@ class CriteriaParser
     private function constructScriptQuery(array $script, array $parameters): ScriptQuery
     {
         return new ScriptQuery($script['source'], $parameters);
+    }
+
+    private function buildFieldSort(FieldSorting $sorting, EntityDefinition $definition, Context $context): FieldSort
+    {
+        if ($this->isCheapestPriceField($sorting->getField())) {
+            $scriptContent = $this->getScript('cheapest_price');
+
+            return new FieldSort('_script', $sorting->getDirection(), null, [
+                'type' => 'number',
+                'script' => array_merge($scriptContent, [
+                    'params' => $this->getCheapestPriceParameters($context),
+                ]),
+            ]);
+        }
+
+        if ($this->isCheapestPriceField($sorting->getField(), true)) {
+            $scriptContent = $this->getScript('cheapest_price_percentage');
+
+            return new FieldSort('_script', $sorting->getDirection(), null, [
+                'type' => 'number',
+                'script' => array_merge($scriptContent, [
+                    'params' => ['accessors' => $this->getCheapestPriceAccessors($context, true)],
+                ]),
+            ]);
+        }
+
+        $field = $this->helper->getField($sorting->getField(), $definition, $definition->getEntityName(), false);
+        $accessor = $this->buildAccessor($definition, $sorting->getField(), $context);
+
+        if ($field instanceof TranslatedField) {
+            if (!$field->useForSorting()) {
+                return $this->createTranslatedSorting($definition->getEntityName(), $sorting, $context);
+            }
+
+            $accessor = $this->getTranslatedFieldName($accessor, $context->getLanguageId());
+        }
+
+        if ($sorting instanceof CountSorting) {
+            return new CountSort($accessor, $sorting->getDirection());
+        }
+
+        return new FieldSort($accessor, $sorting->getDirection());
     }
 }

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\ElasticsearchRegistry;
-use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexingFinished;
+use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexingFinishedEvent;
 use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexIteratorEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -100,7 +100,7 @@ class ElasticsearchIndexer
         return new ElasticsearchIndexingMessage($indexing, null, $context);
     }
 
-    private function createIndexingMessage(IndexerOffset $offset): ElasticsearchIndexingMessage
+    private function createIndexingMessage(IndexerOffset $offset): ?ElasticsearchIndexingMessage
     {
         $definition = $this->registry->get((string) $offset->getDefinition());
 
@@ -117,17 +117,9 @@ class ElasticsearchIndexer
 
         $ids = $event->iterator->fetch();
 
-        $alias = $this->helper->getIndexName($definition->getEntityDefinition());
-
-        $index = $alias . '_' . $offset->getTimestamp();
-
-        if (\count($ids) < $this->indexingBatchSize) {
-            return new ElasticsearchIndexingMessage(new IndexingDto(array_values($ids), $index, $entity), null, Context::createDefaultContext(), true);
-        }
-
         if (empty($ids)) {
             if (!$offset->hasNextDefinition()) {
-                return new ElasticsearchIndexingMessage(new IndexingDto([], $index, $entity), null, Context::createDefaultContext(), true);
+                return null;
             }
             // increment definition offset
             $offset->selectNextDefinition();
@@ -137,6 +129,10 @@ class ElasticsearchIndexer
 
             return $this->createIndexingMessage($offset);
         }
+
+        $alias = $this->helper->getIndexName($definition->getEntityDefinition());
+
+        $index = $alias . '_' . $offset->getTimestamp();
 
         // increment last id with iterator offset
         $offset->setLastId($iterator->getOffset());
@@ -230,17 +226,9 @@ class ElasticsearchIndexer
 
     private function handleIndexingMessage(ElasticsearchIndexingMessage $message): void
     {
-        if ($message->isLastMessage()) {
-            $event = new ElasticsearchIndexingFinished();
-            $this->eventDispatcher->dispatch($event);
-        }
         $task = $message->getData();
 
         $ids = $task->getIds();
-
-        if (\count($ids) === 0) {
-            return;
-        }
 
         $index = $task->getIndex();
 
@@ -289,12 +277,20 @@ class ElasticsearchIndexer
 
         $result = $this->client->bulk($arguments);
 
+        $exception = null;
+
         if (\is_array($result) && isset($result['errors']) && $result['errors']) {
             $errors = $this->parseErrors($result);
+            $exception = ElasticsearchException::indexingError($errors);
+        }
 
-            $this->helper->logAndThrowException(
-                ElasticsearchException::indexingError($errors)
-            );
+        if ($message->isLastMessage()) {
+            $event = new ElasticsearchIndexingFinishedEvent();
+            $this->eventDispatcher->dispatch($event);
+        }
+
+        if ($exception) {
+            $this->helper->logAndThrowException($exception);
         }
     }
 

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\ElasticsearchRegistry;
+use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexingFinished;
 use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexIteratorEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -99,7 +100,7 @@ class ElasticsearchIndexer
         return new ElasticsearchIndexingMessage($indexing, null, $context);
     }
 
-    private function createIndexingMessage(IndexerOffset $offset): ?ElasticsearchIndexingMessage
+    private function createIndexingMessage(IndexerOffset $offset): ElasticsearchIndexingMessage
     {
         $definition = $this->registry->get((string) $offset->getDefinition());
 
@@ -116,9 +117,17 @@ class ElasticsearchIndexer
 
         $ids = $event->iterator->fetch();
 
+        $alias = $this->helper->getIndexName($definition->getEntityDefinition());
+
+        $index = $alias . '_' . $offset->getTimestamp();
+
+        if (\count($ids) < $this->indexingBatchSize) {
+            return new ElasticsearchIndexingMessage(new IndexingDto(array_values($ids), $index, $entity), null, Context::createDefaultContext(), true);
+        }
+
         if (empty($ids)) {
             if (!$offset->hasNextDefinition()) {
-                return null;
+                return new ElasticsearchIndexingMessage(new IndexingDto([], $index, $entity), null, Context::createDefaultContext(), true);
             }
             // increment definition offset
             $offset->selectNextDefinition();
@@ -131,10 +140,6 @@ class ElasticsearchIndexer
 
         // increment last id with iterator offset
         $offset->setLastId($iterator->getOffset());
-
-        $alias = $this->helper->getIndexName($definition->getEntityDefinition());
-
-        $index = $alias . '_' . $offset->getTimestamp();
 
         // return indexing message for current offset
         return new ElasticsearchIndexingMessage(new IndexingDto(array_values($ids), $index, $entity), $offset, Context::createDefaultContext());
@@ -225,9 +230,17 @@ class ElasticsearchIndexer
 
     private function handleIndexingMessage(ElasticsearchIndexingMessage $message): void
     {
+        if ($message->isLastMessage()) {
+            $event = new ElasticsearchIndexingFinished();
+            $this->eventDispatcher->dispatch($event);
+        }
         $task = $message->getData();
 
         $ids = $task->getIds();
+
+        if (\count($ids) === 0) {
+            return;
+        }
 
         $index = $task->getIndex();
 

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexingMessage.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexingMessage.php
@@ -18,7 +18,7 @@ class ElasticsearchIndexingMessage implements AsyncMessageInterface, Deduplicata
         private readonly IndexingDto $data,
         private readonly ?IndexerOffset $offset,
         private readonly Context $context,
-        private readonly bool $lastMessage = false
+        private bool $lastMessage = false
     ) {
     }
 
@@ -59,5 +59,10 @@ class ElasticsearchIndexingMessage implements AsyncMessageInterface, Deduplicata
     public function isLastMessage(): bool
     {
         return $this->lastMessage;
+    }
+
+    public function markAsLastMessage(): bool
+    {
+        return $this->lastMessage = true;
     }
 }

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexingMessage.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexingMessage.php
@@ -17,7 +17,8 @@ class ElasticsearchIndexingMessage implements AsyncMessageInterface, Deduplicata
     public function __construct(
         private readonly IndexingDto $data,
         private readonly ?IndexerOffset $offset,
-        private readonly Context $context
+        private readonly Context $context,
+        private readonly bool $lastMessage = false
     ) {
     }
 
@@ -53,5 +54,10 @@ class ElasticsearchIndexingMessage implements AsyncMessageInterface, Deduplicata
         ]);
 
         return Hasher::hash($data);
+    }
+
+    public function isLastMessage(): bool
+    {
+        return $this->lastMessage;
     }
 }

--- a/src/Elasticsearch/Framework/Indexing/Event/ElasticsearchIndexingFinished.php
+++ b/src/Elasticsearch/Framework/Indexing/Event/ElasticsearchIndexingFinished.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Framework\Indexing\Event;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[Package('framework')]
+class ElasticsearchIndexingFinished
+{
+}

--- a/src/Elasticsearch/Framework/Indexing/Event/ElasticsearchIndexingFinishedEvent.php
+++ b/src/Elasticsearch/Framework/Indexing/Event/ElasticsearchIndexingFinishedEvent.php
@@ -8,6 +8,6 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore
  */
 #[Package('framework')]
-class ElasticsearchIndexingFinished
+class ElasticsearchIndexingFinishedEvent
 {
 }

--- a/src/Elasticsearch/Framework/SystemUpdateListener.php
+++ b/src/Elasticsearch/Framework/SystemUpdateListener.php
@@ -45,6 +45,10 @@ class SystemUpdateListener
             $offset = $message->getOffset();
 
             $this->messageBus->dispatch($message);
+
+            if ($message->isLastMessage()) {
+                break;
+            }
         }
 
         $this->storage->remove(self::CONFIG_KEY);

--- a/src/Elasticsearch/Framework/SystemUpdateListener.php
+++ b/src/Elasticsearch/Framework/SystemUpdateListener.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
 use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer;
+use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexingMessage;
 use Shopware\Elasticsearch\Framework\Indexing\IndexMappingUpdater;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -40,15 +41,24 @@ class SystemUpdateListener
             return;
         }
 
+        $messagesToDispatch = [];
         $offset = null;
         while ($message = $this->indexer->iterate($offset)) {
             $offset = $message->getOffset();
 
-            $this->messageBus->dispatch($message);
+            $messagesToDispatch[] = $message;
+        }
 
-            if ($message->isLastMessage()) {
-                break;
-            }
+        $lastMessage = end($messagesToDispatch);
+
+        if (!$lastMessage instanceof ElasticsearchIndexingMessage) {
+            return;
+        }
+
+        $lastMessage->markAsLastMessage();
+
+        foreach ($messagesToDispatch as $message) {
+            $this->messageBus->dispatch($message);
         }
 
         $this->storage->remove(self::CONFIG_KEY);

--- a/src/Elasticsearch/Product/ElasticsearchOptimizeSwitch.php
+++ b/src/Elasticsearch/Product/ElasticsearchOptimizeSwitch.php
@@ -4,7 +4,7 @@ namespace Shopware\Elasticsearch\Product;
 
 use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexingFinished;
+use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexingFinishedEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -33,14 +33,14 @@ class ElasticsearchOptimizeSwitch implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ElasticsearchIndexingFinished::class => 'onIndexingFinished',
+            ElasticsearchIndexingFinishedEvent::class => 'onIndexingFinished',
         ];
     }
 
     /**
      * @deprecated tag:v6.8.0 - reason:remove-subscriber - will be removed without alternative
      */
-    public function onIndexingFinished(ElasticsearchIndexingFinished $event): void
+    public function onIndexingFinished(ElasticsearchIndexingFinishedEvent $event): void
     {
         $this->storage->set(self::FLAG, true);
     }

--- a/src/Elasticsearch/Product/ElasticsearchOptimizeSwitch.php
+++ b/src/Elasticsearch/Product/ElasticsearchOptimizeSwitch.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Product;
+
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexingFinished;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ *
+ * @deprecated tag:v6.8.0 - reason:remove-subscriber - will be removed without alternative
+ */
+#[Package('inventory')]
+class ElasticsearchOptimizeSwitch implements EventSubscriberInterface
+{
+    /**
+     * @deprecated tag:v6.8.0 - reason:remove-subscriber - will be removed, this app_config value will be always true
+     */
+    public const FLAG = 'ELASTIC_OPTIMIZE_FLAG';
+
+    /**
+     * @internal
+     */
+    public function __construct(private readonly AbstractKeyValueStorage $storage)
+    {
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:remove-subscriber - will be removed without alternative
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ElasticsearchIndexingFinished::class => 'onIndexingFinished',
+        ];
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:remove-subscriber - will be removed without alternative
+     */
+    public function onIndexingFinished(ElasticsearchIndexingFinished $event): void
+    {
+        $this->storage->set(self::FLAG, true);
+    }
+}

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -6,12 +6,14 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use OpenSearchDSL\BuilderInterface;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\SqlHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageLoaderInterface;
 use Shopware\Core\System\Language\SalesChannelLanguageLoader;
 use Shopware\Elasticsearch\Framework\AbstractElasticsearchDefinition;
 use Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder;
@@ -33,9 +35,10 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
         private readonly AbstractProductSearchQueryBuilder $searchQueryBuilder,
         private readonly ElasticsearchFieldBuilder $fieldBuilder,
         private readonly ElasticsearchFieldMapper $fieldMapper,
-        private readonly SalesChannelLanguageLoader $languageLoader,
+        private readonly SalesChannelLanguageLoader $salesChannelLanguageLoader,
         private readonly bool $excludeSource,
-        private readonly string $environment
+        private readonly string $environment,
+        private readonly LanguageLoaderInterface $languageLoader
     ) {
     }
 
@@ -188,12 +191,25 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
 
         $groups = $this->fetchProperties(\array_keys($groupIds));
 
+        $languageMapping = $this->getLanguageMapping();
+
         /** @var array<string, string> $item */
         foreach ($data as $id => $item) {
             /** @var array<int|string, array<string, string|null>> $translation */
             $translation = $item['translation'] ?? [];
             /** @var array<int, array{id: string, languageId?: string}> $categories */
             $categories = $item['categories'] ?? [];
+
+            $names = ElasticsearchFieldMapper::translated(field: 'name', items: $translation);
+            $names = $this->fillFallbackTranslation($languageMapping, $names);
+
+            $customFields = $this->mapCustomFields(
+                variantCustomFields: ElasticsearchFieldMapper::translated(field: 'customFields', items: $translation, stripText: false),
+                parentCustomFields: ElasticsearchFieldMapper::translated(field: 'parentCustomFields', items: $translation, stripText: false),
+                context: $context
+            );
+
+            $customFields = $this->fillFallbackTranslation($languageMapping, $customFields);
 
             $documents[$id] = [
                 'id' => $id,
@@ -265,12 +281,8 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 'propertyIds' => ElasticsearchIndexingUtils::parseJson($item, 'propertyIds'),
                 'tagIds' => ElasticsearchIndexingUtils::parseJson($item, 'tagIds'),
                 'states' => ElasticsearchIndexingUtils::parseJson($item, 'states'),
-                'customFields' => $this->mapCustomFields(
-                    variantCustomFields: ElasticsearchFieldMapper::translated(field: 'customFields', items: $translation, stripText: false),
-                    parentCustomFields: ElasticsearchFieldMapper::translated(field: 'parentCustomFields', items: $translation, stripText: false),
-                    context: $context
-                ),
-                'name' => ElasticsearchFieldMapper::translated(field: 'name', items: $translation),
+                'customFields' => $customFields,
+                'name' => $names,
                 'description' => ElasticsearchFieldMapper::translated(field: 'description', items: $translation),
                 'metaTitle' => ElasticsearchFieldMapper::translated(field: 'metaTitle', items: $translation),
                 'metaDescription' => ElasticsearchFieldMapper::translated(field: 'metaDescription', items: $translation),
@@ -289,7 +301,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
      */
     private function fetchProducts(array $ids, Context $context): array
     {
-        $languages = \array_keys($this->languageLoader->loadLanguages());
+        $languages = \array_keys($this->salesChannelLanguageLoader->loadLanguages());
 
         $baseSql = <<<'SQL'
 SELECT
@@ -571,5 +583,53 @@ SQL;
         }
 
         return $this->fieldMapper->customFields(ProductDefinition::ENTITY_NAME, $customFields, $context);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getLanguageMapping(): array
+    {
+        $languages = $this->languageLoader->loadLanguages();
+        $salesChannelLanguages = $this->salesChannelLanguageLoader->loadLanguages();
+
+        $mapping = [];
+
+        foreach ($languages as $languageId => $language) {
+            if (!isset($salesChannelLanguages[$languageId])) {
+                continue;
+            }
+            // If the has parent language, we add the parent language into the mapping
+            if (isset($language['parentId'])) {
+                $mapping[$language['parentId']] = Defaults::LANGUAGE_SYSTEM;
+            }
+
+            $mapping[$languageId] = $language['parentId'] ?? Defaults::LANGUAGE_SYSTEM;
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * @param array<string, string> $languageMapping
+     * @param array<string, mixed> $value
+     *
+     * @return array<string, mixed>
+     */
+    private function fillFallbackTranslation(array $languageMapping, array $value): array
+    {
+        foreach ($languageMapping as $languageId => $fallback) {
+            if ($languageId === Defaults::LANGUAGE_SYSTEM) {
+                continue;
+            }
+
+            if (isset($value[$languageId])) {
+                continue;
+            }
+
+            $value[$languageId] = $value[$fallback] ?? $value[Defaults::LANGUAGE_SYSTEM];
+        }
+
+        return $value;
     }
 }

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\SqlHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageLoaderInterface;
@@ -133,6 +134,11 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
             'customFields' => $this->fieldBuilder->customFields($this->getEntityDefinition()->getEntityName(), $context),
             ...$visibilities,
         ];
+
+        if (Feature::isActive('v6.8.0.0')) {
+            unset($properties['categoriesRo']);
+            unset($properties['visibilities']);
+        }
 
         $mapping = [
             'dynamic_templates' => [
@@ -317,6 +323,11 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 ...$this->mapCheapestPrice(ElasticsearchIndexingUtils::parseJson($item, 'cheapest_price_accessor')),
                 ...$visibilitiesFlatten,
             ];
+
+            if (Feature::isActive('v6.8.0.0')) {
+                unset($documents[$id]['categoriesRo']);
+                unset($documents[$id]['visibilities']);
+            }
         }
 
         return $documents;

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -53,6 +53,16 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
     public function getMapping(Context $context): array
     {
         $languageFields = $this->fieldBuilder->translated(self::getTextFieldConfig());
+        $salesChannelByLanguage = $this->languageLoader->loadLanguages();
+        $allSalesChannels = array_values(array_unique(array_merge(...array_values($salesChannelByLanguage))));
+
+        $visibilities = [];
+
+        foreach ($allSalesChannels as $salesChannelId) {
+            $visibilities['visibility_' . $salesChannelId] = [
+                'type' => 'integer',
+            ];
+        }
 
         $debug = $this->environment !== 'prod';
 
@@ -121,6 +131,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
             'width' => self::FLOAT_FIELD,
             'states' => self::KEYWORD_FIELD,
             'customFields' => $this->fieldBuilder->customFields($this->getEntityDefinition()->getEntityName(), $context),
+            ...$visibilities,
         ];
 
         $mapping = [
@@ -209,7 +220,23 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 context: $context
             );
 
-            $customFields = $this->fillFallbackTranslation($languageMapping, $customFields);
+            $visibilities = ElasticsearchIndexingUtils::parseJson($item, 'visibilities');
+
+            $visibilitiesFlatten = [];
+
+            foreach ($visibilities as $key => $visibility) {
+                if (!isset($visibility['salesChannelId'])) {
+                    unset($visibilities[$key]);
+                    continue;
+                }
+
+                $visibilitiesFlatten['visibility_' . $visibility['salesChannelId']] = $visibility['visibility'] ?? 0;
+            }
+
+            // no visibilities found, skip this product
+            if (empty($visibilitiesFlatten)) {
+                continue;
+            }
 
             $documents[$id] = [
                 'id' => $id,
@@ -224,7 +251,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                     return array_merge([
                         '_count' => 1,
                     ], $visibility);
-                }, ElasticsearchIndexingUtils::parseJson($item, 'visibilities')),
+                }, $visibilities),
                 'availableStock' => (int) $item['availableStock'],
                 'productNumber' => $item['productNumber'],
                 'ean' => $item['ean'],
@@ -288,6 +315,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 'metaDescription' => ElasticsearchFieldMapper::translated(field: 'metaDescription', items: $translation),
                 'customSearchKeywords' => ElasticsearchFieldMapper::translated(field: 'customSearchKeywords', items: $translation),
                 ...$this->mapCheapestPrice(ElasticsearchIndexingUtils::parseJson($item, 'cheapest_price_accessor')),
+                ...$visibilitiesFlatten,
             ];
         }
 

--- a/src/Elasticsearch/Product/ProductCriteriaParser.php
+++ b/src/Elasticsearch/Product/ProductCriteriaParser.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Product;
+
+use OpenSearchDSL\BuilderInterface;
+use OpenSearchDSL\Query\Compound\BoolQuery;
+use OpenSearchDSL\Query\TermLevel\RangeQuery;
+use OpenSearchDSL\Query\TermLevel\TermQuery;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
+
+/**
+ * @internal - This class is part of the internal API, optimized for read and should not be used directly.
+ */
+#[Package('inventory')]
+class ProductCriteriaParser extends CriteriaParser
+{
+
+    public function parseFilter(Filter $filter, EntityDefinition $definition, string $root, Context $context): BuilderInterface
+    {
+        if (!$definition instanceof ProductDefinition) {
+            return parent::parseFilter($filter, $definition, $root, $context);
+        }
+
+        if ($filter instanceof ProductAvailableFilter) {
+            $query = new BoolQuery();
+
+            $query->add(
+                new TermQuery('active', true),
+                BoolQuery::MUST
+            );
+
+            $query->add(
+                new RangeQuery('visibility_' . $filter->getSalesChannelId(), [RangeFilter::GTE => $filter->getVisibility()]),
+                BoolQuery::MUST
+            );
+
+            return $query;
+        }
+
+        if ($filter instanceof EqualsFilter && \str_contains($filter->getField(), 'categoriesRo.id')) {
+            return new TermQuery('categoryTree', $filter->getValue());
+        }
+
+        return parent::parseFilter($filter, $definition, $root, $context);
+    }
+}

--- a/src/Elasticsearch/Product/ProductCriteriaParser.php
+++ b/src/Elasticsearch/Product/ProductCriteriaParser.php
@@ -4,6 +4,7 @@ namespace Shopware\Elasticsearch\Product;
 
 use OpenSearchDSL\BuilderInterface;
 use OpenSearchDSL\Query\Compound\BoolQuery;
+use OpenSearchDSL\Query\TermLevel\ExistsQuery;
 use OpenSearchDSL\Query\TermLevel\RangeQuery;
 use OpenSearchDSL\Query\TermLevel\TermQuery;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -15,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
@@ -36,31 +38,45 @@ class ProductCriteriaParser extends CriteriaParser
 
     public function parseFilter(Filter $filter, EntityDefinition $definition, string $root, Context $context): BuilderInterface
     {
-        if (!$this->storage->has(ElasticsearchOptimizeSwitch::FLAG)) {
-            return $this->decorated->parseFilter($filter, $definition, $root, $context);
-        }
-
         if (!$definition instanceof ProductDefinition) {
             return parent::parseFilter($filter, $definition, $root, $context);
         }
 
         if ($filter instanceof ProductAvailableFilter) {
+            /**
+             * @deprecated tag:v6.8.0 - this if statement will be always true
+             */
+            if (!Feature::isActive('v6.8.0.0') && !$this->storage->has(ElasticsearchOptimizeSwitch::FLAG)) {
+                return $this->decorated->parseFilter($filter, $definition, $root, $context);
+            }
+
             $query = new BoolQuery();
 
             $query->add(
                 new TermQuery('active', true),
-                BoolQuery::MUST
             );
 
             $query->add(
                 new RangeQuery('visibility_' . $filter->getSalesChannelId(), [RangeFilter::GTE => $filter->getVisibility()]),
-                BoolQuery::MUST
             );
 
             return $query;
         }
 
-        if ($filter instanceof EqualsFilter && \str_contains($filter->getField(), 'categoriesRo.id') && $filter->getValue() !== null) {
+        if ($filter instanceof EqualsFilter && \str_contains($filter->getField(), 'categoriesRo.id')) {
+            /**
+             * @deprecated tag:v6.8.0 - this if statement will be always true
+             */
+            if (!Feature::isActive('v6.8.0.0') && !$this->storage->has(ElasticsearchOptimizeSwitch::FLAG)) {
+                return $this->decorated->parseFilter($filter, $definition, $root, $context);
+            }
+
+            if ($filter->getValue() === null) {
+                return new BoolQuery([
+                    BoolQuery::MUST_NOT => new ExistsQuery('categoryTree'),
+                ]);
+            }
+
             return new TermQuery('categoryTree', $filter->getValue());
         }
 

--- a/src/Elasticsearch/Product/ProductCriteriaParser.php
+++ b/src/Elasticsearch/Product/ProductCriteriaParser.php
@@ -8,12 +8,15 @@ use OpenSearchDSL\Query\TermLevel\RangeQuery;
 use OpenSearchDSL\Query\TermLevel\TermQuery;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
 
 /**
@@ -22,9 +25,21 @@ use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
 #[Package('inventory')]
 class ProductCriteriaParser extends CriteriaParser
 {
+    public function __construct(
+        EntityDefinitionQueryHelper $helper,
+        CustomFieldService $customFieldService,
+        private readonly AbstractKeyValueStorage $storage,
+        private readonly CriteriaParser $decorated
+    ) {
+        parent::__construct($helper, $customFieldService, $storage);
+    }
 
     public function parseFilter(Filter $filter, EntityDefinition $definition, string $root, Context $context): BuilderInterface
     {
+        if (!$this->storage->has(ElasticsearchOptimizeSwitch::FLAG)) {
+            return $this->decorated->parseFilter($filter, $definition, $root, $context);
+        }
+
         if (!$definition instanceof ProductDefinition) {
             return parent::parseFilter($filter, $definition, $root, $context);
         }
@@ -45,7 +60,7 @@ class ProductCriteriaParser extends CriteriaParser
             return $query;
         }
 
-        if ($filter instanceof EqualsFilter && \str_contains($filter->getField(), 'categoriesRo.id')) {
+        if ($filter instanceof EqualsFilter && \str_contains($filter->getField(), 'categoriesRo.id') && $filter->getValue() !== null) {
             return new TermQuery('categoryTree', $filter->getValue());
         }
 

--- a/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
@@ -24,7 +24,7 @@ elasticsearch:
             'mapping.total_fields.limit': 50000
             'mapping.nested_fields.limit': 500
             'mapping.nested_objects.limit': 1000000
-            max_result_window: 10000
+            max_result_window: 500000
         analysis:
             normalizer:
                 sw_lowercase_normalizer:

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -230,6 +230,7 @@
             <argument type="service" id="Shopware\Core\System\Language\SalesChannelLanguageLoader" />
             <argument>%elasticsearch.product.exclude_source%</argument>
             <argument>%kernel.environment%</argument>
+            <argument type="service" id="Shopware\Core\System\Language\LanguageLoader" />
 
             <tag name="shopware.es.definition"/>
         </service>

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -552,5 +552,11 @@
             <tag name="shopware.elastic.admin-searcher-index" key="product_stream"/>
         </service>
 
+        <service id="Shopware\Elasticsearch\Product\ProductCriteriaParser"
+                 decorates="Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser"
+        >
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper"/>
+            <argument type="service" id="Shopware\Core\System\CustomField\CustomFieldService"/>
+        </service>
     </services>
 </container>

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -32,6 +32,7 @@
         <service id="Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser">
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper"/>
             <argument type="service" id="Shopware\Core\System\CustomField\CustomFieldService"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage" />
         </service>
 
         <service id="Shopware\Elasticsearch\Framework\ElasticsearchHelper" public="true">
@@ -254,6 +255,7 @@
         <service id="Shopware\Elasticsearch\TokenQueryBuilder">
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Shopware\Core\System\CustomField\CustomFieldService"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage" />
         </service>
 
         <service id="Shopware\Elasticsearch\Product\CustomFieldUpdater">
@@ -552,11 +554,17 @@
             <tag name="shopware.elastic.admin-searcher-index" key="product_stream"/>
         </service>
 
-        <service id="Shopware\Elasticsearch\Product\ProductCriteriaParser"
-                 decorates="Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser"
-        >
+        <service id="Shopware\Elasticsearch\Product\ProductCriteriaParser" decorates="Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser">
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper"/>
             <argument type="service" id="Shopware\Core\System\CustomField\CustomFieldService"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage" />
+            <argument type="service" id=".inner"/>
         </service>
+
+        <service id="Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch">
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage" />
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
     </services>
 </container>

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -9,6 +9,7 @@ use OpenSearchDSL\Query\FullText\MatchPhrasePrefixQuery;
 use OpenSearchDSL\Query\FullText\MatchQuery;
 use OpenSearchDSL\Query\Joining\NestedQuery;
 use OpenSearchDSL\Query\TermLevel\TermQuery;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
@@ -23,6 +24,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Product\SearchFieldConfig;
 
 /**
@@ -38,7 +40,8 @@ class TokenQueryBuilder
      */
     public function __construct(
         private readonly DefinitionInstanceRegistry $definitionRegistry,
-        private readonly CustomFieldService $customFieldService
+        private readonly CustomFieldService $customFieldService,
+        private readonly AbstractKeyValueStorage $storage
     ) {
     }
 
@@ -73,7 +76,7 @@ class TokenQueryBuilder
                 // If the field is a TranslatedField, we need to build a translated query
                 // translated query will use the languageIdChain to find the correct translation with fallback
                 // and if the field is prefilled fallback, we can use the current languageId as every languageId is filled with the fallback when indexing
-                $this->translatedQuery($real, $token, $config, $field->useForSorting() ? [$context->getLanguageId()] : $languageIdChain) :
+                $this->translatedQuery($real, $token, $config, $this->isSortableTranslatedField($field) ? [$context->getLanguageId()] : $languageIdChain) :
                 $this->matchQuery($real, $token, $config);
 
             if (!$fieldQuery) {
@@ -236,5 +239,10 @@ class TokenQueryBuilder
         $fieldQuery->addParameter('_name', $explainPayload);
 
         return $fieldQuery;
+    }
+
+    private function isSortableTranslatedField(TranslatedField $field): bool
+    {
+        return $field->useForSorting() && $this->storage->has(ElasticsearchOptimizeSwitch::FLAG);
     }
 }

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -70,7 +70,10 @@ class TokenQueryBuilder
             $root = EntityDefinitionQueryHelper::getRoot($config->getField(), $definition);
 
             $fieldQuery = $field instanceof TranslatedField ?
-                $this->translatedQuery($real, $token, $config, $languageIdChain) :
+                // If the field is a TranslatedField, we need to build a translated query
+                // translated query will use the languageIdChain to find the correct translation with fallback
+                // and if the field is prefilled fallback, we can use the current languageId as every languageId is filled with the fallback when indexing
+                $this->translatedQuery($real, $token, $config, $field->isPrefilledFallback() ? [$context->getLanguageId()] : $languageIdChain) :
                 $this->matchQuery($real, $token, $config);
 
             if (!$fieldQuery) {

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -73,7 +73,7 @@ class TokenQueryBuilder
                 // If the field is a TranslatedField, we need to build a translated query
                 // translated query will use the languageIdChain to find the correct translation with fallback
                 // and if the field is prefilled fallback, we can use the current languageId as every languageId is filled with the fallback when indexing
-                $this->translatedQuery($real, $token, $config, $field->isPrefilledFallback() ? [$context->getLanguageId()] : $languageIdChain) :
+                $this->translatedQuery($real, $token, $config, $field->useForSorting() ? [$context->getLanguageId()] : $languageIdChain) :
                 $this->matchQuery($real, $token, $config);
 
             if (!$fieldQuery) {

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
@@ -243,6 +244,6 @@ class TokenQueryBuilder
 
     private function isSortableTranslatedField(TranslatedField $field): bool
     {
-        return $field->useForSorting() && $this->storage->has(ElasticsearchOptimizeSwitch::FLAG);
+        return $field->useForSorting() && (Feature::isActive('v6.8.0.0') || $this->storage->has(ElasticsearchOptimizeSwitch::FLAG));
     }
 }

--- a/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
+++ b/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
 use Shopware\Core\Content\Product\State;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -85,6 +86,7 @@ use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntityAgg
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\ElasticsearchIndexingUtils;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Product\ElasticsearchProductDefinition;
 use Shopware\Elasticsearch\Test\ElasticsearchTestTestBehaviour;
 use Shopware\Tests\Integration\Elasticsearch\Product\Fixture\ProductsFixture;
@@ -146,6 +148,8 @@ class ElasticsearchProductTest extends TestCase
         $this->client = static::getContainer()->get(Client::class);
         $this->productDefinition = static::getContainer()->get(ProductDefinition::class);
         $this->languageRepository = static::getContainer()->get('language.repository');
+
+        static::getContainer()->get(AbstractKeyValueStorage::class)->set(ElasticsearchOptimizeSwitch::FLAG, true);
 
         static::getContainer()->get(SalesChannelLanguageLoader::class)->reset();
         $this->connection = static::getContainer()->get(Connection::class);
@@ -277,6 +281,7 @@ class ElasticsearchProductTest extends TestCase
             $this->productRepository->upsert([
                 (new ProductBuilder($this->ids, 'u7', 300))
                     ->price(100)
+                    ->visibility()
                     ->build(),
             ], $context);
 

--- a/tests/integration/Elasticsearch/Product/Fixture/ProductsFixture.php
+++ b/tests/integration/Elasticsearch/Product/Fixture/ProductsFixture.php
@@ -32,6 +32,7 @@ class ProductsFixture
                 ->releaseDate('2019-01-01 10:11:00')
                 ->purchasePrice(0)
                 ->stock(2)
+                ->visibility()
                 ->createdAt('2019-01-01 10:11:00')
                 ->category('c1')
                 ->category('c2')
@@ -74,6 +75,7 @@ class ProductsFixture
                 ->releaseDate('2019-06-15 13:00:00')
                 ->purchasePrice(100)
                 ->stock(100)
+                ->visibility()
                 ->category('c1')
                 ->category('c3')
                 ->property('red', 'color')
@@ -84,6 +86,7 @@ class ProductsFixture
                 ->price(100, 100, 'default', 100, 100)
                 ->purchasePrice(100)
                 ->stock(100)
+                ->visibility()
                 ->property('silver', 'color')
                 ->build(),
             (new ProductBuilder($ids, 'product-4'))
@@ -98,6 +101,7 @@ class ProductsFixture
                 ->releaseDate('2020-09-30 15:00:00')
                 ->purchasePrice(100)
                 ->stock(300)
+                ->visibility()
                 ->property('green', 'color')
                 ->build(),
             (new ProductBuilder($ids, 'product-5'))

--- a/tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -31,6 +32,7 @@ use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Elasticsearch\Event\ElasticsearchCustomFieldsMappingEvent;
 use Shopware\Elasticsearch\Framework\ElasticsearchIndexingUtils;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Product\ProductSearchQueryBuilder;
 use Shopware\Elasticsearch\Test\ElasticsearchTestTestBehaviour;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -94,6 +96,8 @@ class ProductSearchQueryBuilderTest extends TestCase
     public function testIndexing(): IdsCollection
     {
         $this->connection->executeStatement('DELETE FROM product');
+
+        static::getContainer()->get(AbstractKeyValueStorage::class)->set(ElasticsearchOptimizeSwitch::FLAG, true);
 
         $this->clearElasticsearch();
         $this->registerCustomFieldsMapping();
@@ -384,26 +388,31 @@ class ProductSearchQueryBuilderTest extends TestCase
                 ->tax('t1')
                 ->price(50, 50)
                 ->category('Shoes')
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-2'))
                 ->name('Aerodynamic Leather Portaline')
                 ->price(50, 50)
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-3'))
                 ->name('Aerodynamic Leather Wordlobster')
                 ->price(50, 50)
                 ->add('customSearchKeywords', ['Activity'])
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-4'))
                 ->name('Leather Red')
                 ->add('description', 'Aerodynamic Fooo')
                 ->manufacturer('Shopware')
                 ->price(50, 50)
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-5'))
                 ->name('Cycle Suave')
                 ->price(50, 50)
                 ->tag('Smarthome')
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-6'))
                 ->name('T-Shirt')
@@ -413,36 +422,43 @@ class ProductSearchQueryBuilderTest extends TestCase
                         ->option('green', 'color')
                         ->build()
                 )
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-7'))
                 ->name('Keyboard')
                 ->price(50, 50)
                 ->property('Wireless', 'Connectivity')
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'SW5686779889'))
                 ->name('SW Product')
                 ->price(50, 50)
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-8'))
                 ->name('Super cool Pikachu Pokemon')
                 ->add('description', 'A cool pokemon is traveling around the world')
                 ->price(50, 50)
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-9'))
                 ->name('Super Pokemon')
                 ->add('description', 'A cool raichu is traveling around the world')
                 ->add('customSearchKeywords', ['Raichu'])
                 ->price(50, 50)
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-10'))
                 ->name('Eevee')
                 ->customField('evolvesTo', ['Vaporeon', 'Jolteon', 'Flareon'])
                 ->price(50, 50)
+                ->visibility()
                 ->build(),
             (new ProductBuilder($ids, 'product-11'))
                 ->name('EeveeCfText')
                 ->customField('evolvesText', 'Jolteon')
                 ->price(50, 50)
+                ->visibility()
                 ->build(),
         ];
 

--- a/tests/migration/Core/V6_8/Migration1743256470RemoveElasticsearchAppConfigFlagTest.php
+++ b/tests/migration/Core/V6_8/Migration1743256470RemoveElasticsearchAppConfigFlagTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_8;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Storage\MySQLKeyValueStorage;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_8\Migration1743256470RemoveElasticsearchAppConfigFlag;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(Migration1743256470RemoveElasticsearchAppConfigFlag::class)]
+class Migration1743256470RemoveElasticsearchAppConfigFlagTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testMigration(): void
+    {
+        $storage = new MySQLKeyValueStorage($this->connection);
+
+        $storage->set('ELASTIC_OPTIMIZE_FLAG', true);
+
+        static::assertTrue($storage->has('ELASTIC_OPTIMIZE_FLAG'));
+        $migration = new Migration1743256470RemoveElasticsearchAppConfigFlag();
+        static::assertSame(1743256470, $migration->getCreationTimestamp());
+
+        // make sure a migration can run multiple times without failing
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $storage->reset();
+        static::assertFalse($storage->has('ELASTIC_OPTIMIZE_FLAG'));
+    }
+}

--- a/tests/unit/Core/Content/Product/SalesChannel/ProductAvailableFilterTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/ProductAvailableFilterTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ProductAvailableFilter::class)]
+class ProductAvailableFilterTest extends TestCase
+{
+    public function testCreatesProductAvailableFilter(): void
+    {
+        $salesChannelId = TestDefaults::SALES_CHANNEL;
+        $visibility = ProductVisibilityDefinition::VISIBILITY_ALL;
+
+        $filter = new ProductAvailableFilter($salesChannelId, $visibility);
+
+        static::assertSame($salesChannelId, $filter->getSalesChannelId());
+        static::assertSame($visibility, $filter->getVisibility());
+        static::assertCount(3, $filter->getQueries());
+        static::assertSame([
+            (new RangeFilter('product.visibilities.visibility', [RangeFilter::GTE => $visibility]))->jsonSerialize(),
+            (new EqualsFilter('product.visibilities.salesChannelId', $salesChannelId))->jsonSerialize(),
+            (new EqualsFilter('product.active', true))->jsonSerialize(),
+        ], array_map(
+            static fn (Filter $filter): array => $filter->jsonSerialize(),
+            $filter->getQueries()
+        ));
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/TranslatedFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/TranslatedFieldTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+
+/**
+ * @internal
+ */
+#[CoversClass(TranslatedField::class)]
+class TranslatedFieldTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $field = new TranslatedField(
+            'name',
+            true,
+        );
+
+        static::assertSame('name', $field->getPropertyName());
+        static::assertTrue($field->isPrefilledFallback());
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/TranslatedFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/TranslatedFieldTest.php
@@ -14,12 +14,16 @@ class TranslatedFieldTest extends TestCase
 {
     public function testInstantiate(): void
     {
+        $field = new TranslatedField('name');
+
+        static::assertFalse($field->useForSorting());
+
         $field = new TranslatedField(
             'name',
             true,
         );
 
         static::assertSame('name', $field->getPropertyName());
-        static::assertTrue($field->isPrefilledFallback());
+        static::assertTrue($field->useForSorting());
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/NotEqualsFilterTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Filter/NotEqualsFilterTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Search\Filter;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(NotEqualsFilter::class)]
+class NotEqualsFilterTest extends TestCase
+{
+    public function testCreatesNotEqualsFilterTest(): void
+    {
+        $filter = new NotEqualsFilter('product.name', 'test');
+
+        static::assertSame('product.name', $filter->getField());
+        static::assertSame('test', $filter->getValue());
+        static::assertCount(1, $filter->getQueries());
+        static::assertSame(
+            [
+                (new EqualsFilter('product.name', 'test'))->jsonSerialize(),
+            ],
+            array_map(
+                static fn (Filter $filter): array => $filter->jsonSerialize(),
+                $filter->getQueries()
+            )
+        );
+    }
+}

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -39,8 +39,10 @@ use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Core\System\Unit\Aggregate\UnitTranslation\UnitTranslationDefinition;
 use Shopware\Core\System\Unit\UnitDefinition;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Shopware\Core\Test\Stub\Framework\Adapter\Storage\ArrayKeyValueStorage;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -60,7 +62,8 @@ class CriteriaParserTest extends TestCase
         /** @var CompositeAggregation $esAgg */
         $esAgg = (new CriteriaParser(
             new EntityDefinitionQueryHelper(),
-            $this->createMock(CustomFieldService::class)
+            $this->createMock(CustomFieldService::class),
+            new ArrayKeyValueStorage([]),
         ))->parseAggregation($aggs, $definition, Context::createDefaultContext());
 
         static::assertInstanceOf(CompositeAggregation::class, $esAgg);
@@ -105,6 +108,7 @@ class CriteriaParserTest extends TestCase
         $parser = new CriteriaParser(
             new EntityDefinitionQueryHelper(),
             $this->createMock(CustomFieldService::class),
+            new ArrayKeyValueStorage([]),
         );
 
         $esAgg = $parser->parseAggregation($aggs, $definition, Context::createDefaultContext());
@@ -131,6 +135,7 @@ class CriteriaParserTest extends TestCase
         $parser = new CriteriaParser(
             new EntityDefinitionQueryHelper(),
             $this->createMock(CustomFieldService::class),
+            new ArrayKeyValueStorage([]),
         );
 
         $esAgg = $parser->parseAggregation($aggs, $definition, Context::createDefaultContext());
@@ -150,6 +155,9 @@ class CriteriaParserTest extends TestCase
         $parser = new CriteriaParser(
             new EntityDefinitionQueryHelper(),
             $this->createMock(CustomFieldService::class),
+            new ArrayKeyValueStorage([
+                ElasticsearchOptimizeSwitch::FLAG => true,
+            ]),
         );
 
         $context = new Context(
@@ -167,7 +175,7 @@ class CriteriaParserTest extends TestCase
     {
         $definition = $this->getDefinition();
 
-        $parser = new CriteriaParser(new EntityDefinitionQueryHelper(), $this->createMock(CustomFieldService::class));
+        $parser = new CriteriaParser(new EntityDefinitionQueryHelper(), $this->createMock(CustomFieldService::class), new ArrayKeyValueStorage([]));
 
         static::expectException(ElasticsearchException::class);
         static::expectExceptionMessage(\sprintf('Provided filter of class %s is not supported', CustomFilter::class));
@@ -179,7 +187,7 @@ class CriteriaParserTest extends TestCase
     {
         $definition = $this->getDefinition();
 
-        $accessor = (new CriteriaParser(new EntityDefinitionQueryHelper(), $this->createMock(CustomFieldService::class)))->buildAccessor($definition, $field, $context);
+        $accessor = (new CriteriaParser(new EntityDefinitionQueryHelper(), $this->createMock(CustomFieldService::class), new ArrayKeyValueStorage([])))->buildAccessor($definition, $field, $context);
 
         static::assertSame($expectedAccessor, $accessor);
     }
@@ -770,10 +778,21 @@ EOT,
             $customFieldService->method('getCustomField')->willReturn($customField);
         }
 
+        $context = Context::createDefaultContext();
+        $context->assign([
+            'languageIdChain' => [
+                Defaults::LANGUAGE_SYSTEM,
+                self::SECOND_LANGUAGE,
+            ],
+        ]);
+
         $fieldSort = (new CriteriaParser(
             new EntityDefinitionQueryHelper(),
             $customFieldService,
-        ))->parseSorting($sorting, $definition, Context::createDefaultContext());
+            new ArrayKeyValueStorage([
+                ElasticsearchOptimizeSwitch::FLAG => true,
+            ]),
+        ))->parseSorting($sorting, $definition, $context);
 
         static::assertSame($expectedFieldSort->getField(), $fieldSort->getField());
         static::assertNotNull($expectedFieldSort->getOrder());
@@ -936,6 +955,7 @@ EOT,
                         'field' => 'customFields',
                         'languages' => [
                             Defaults::LANGUAGE_SYSTEM,
+                            self::SECOND_LANGUAGE,
                         ],
                         'suffix' => 'foo',
                     ],
@@ -955,6 +975,7 @@ EOT,
                         'field' => 'customFields',
                         'languages' => [
                             Defaults::LANGUAGE_SYSTEM,
+                            self::SECOND_LANGUAGE,
                         ],
                         'suffix' => 'foo',
                         'order' => FieldSort::ASC,
@@ -975,6 +996,7 @@ EOT,
                         'field' => 'customFields',
                         'languages' => [
                             Defaults::LANGUAGE_SYSTEM,
+                            self::SECOND_LANGUAGE,
                         ],
                         'suffix' => 'foo',
                         'order' => FieldSort::ASC,
@@ -995,6 +1017,7 @@ EOT,
                         'field' => 'name',
                         'languages' => [
                             Defaults::LANGUAGE_SYSTEM,
+                            self::SECOND_LANGUAGE,
                         ],
                     ],
                 ],
@@ -1013,6 +1036,7 @@ EOT,
                         'field' => 'name',
                         'languages' => [
                             Defaults::LANGUAGE_SYSTEM,
+                            self::SECOND_LANGUAGE,
                         ],
                     ],
                 ],
@@ -1043,6 +1067,7 @@ EOT,
                         'field' => 'customFields',
                         'languages' => [
                             Defaults::LANGUAGE_SYSTEM,
+                            self::SECOND_LANGUAGE,
                         ],
                         'suffix' => 'bar',
                     ],
@@ -1062,6 +1087,7 @@ EOT,
                         'field' => 'customFields',
                         'languages' => [
                             Defaults::LANGUAGE_SYSTEM,
+                            self::SECOND_LANGUAGE,
                         ],
                         'suffix' => 'boolField',
                     ],
@@ -1083,6 +1109,7 @@ EOT,
         $sortedFilter = (new CriteriaParser(
             new EntityDefinitionQueryHelper(),
             $this->createMock(CustomFieldService::class),
+            new ArrayKeyValueStorage([]),
         ))->parseFilter($filter, $definition, '', $context);
 
         $sortedFilterArray = $sortedFilter->toArray();
@@ -1261,12 +1288,8 @@ EOT,
                 'nested' => [
                     'path' => 'unit',
                     'query' => [
-                        'multi_match' => [
-                            'query' => 'value',
-                            'fields' => [
-                                'unit.shortCode.2fbb5fe2e29a4d70aa5854ce7ce3e20b',
-                            ],
-                            'type' => 'best_fields',
+                        'term' => [
+                            'unit.shortCode.2fbb5fe2e29a4d70aa5854ce7ce3e20b' => 'value',
                         ],
                     ],
                 ],
@@ -1306,6 +1329,7 @@ EOT,
         $sorting = (new CriteriaParser(
             new EntityDefinitionQueryHelper(),
             $this->createMock(CustomFieldService::class),
+            new ArrayKeyValueStorage([]),
         ))->parseSorting($sorting, $definition, $context);
 
         $script = $sorting->getParameter('script');
@@ -1499,6 +1523,7 @@ return Double.MIN_VALUE;
         $parsedSorting = (new CriteriaParser(
             new EntityDefinitionQueryHelper(),
             $this->createMock(CustomFieldService::class),
+            new ArrayKeyValueStorage([]),
         ))->parseSorting($sorting, $definition, $context);
 
         $script = $parsedSorting->getParameter('script');

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -3,11 +3,13 @@
 namespace Shopware\Tests\Unit\Elasticsearch\Framework\DataAbstractionLayer;
 
 use OpenSearchDSL\Aggregation\Bucketing\CompositeAggregation;
+use OpenSearchDSL\Sort\FieldSort;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductManufacturerTranslation\ProductManufacturerTranslationDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
@@ -320,13 +322,8 @@ EOT,
                             'bool' => [
                                 'must' => [
                                     [
-                                        'multi_match' => [
-                                            'query' => 'foo',
-                                            'fields' => [
-                                                'name.' . self::SECOND_LANGUAGE,
-                                                'name.' . Defaults::LANGUAGE_SYSTEM,
-                                            ],
-                                            'type' => 'best_fields',
+                                        'term' => [
+                                            'name.' . self::SECOND_LANGUAGE => 'foo',
                                         ],
                                     ],
                                     [
@@ -377,13 +374,8 @@ EOT,
                 'bool' => [
                     'must' => [
                         [
-                            'multi_match' => [
-                                'query' => 'foo',
-                                'fields' => [
-                                    'name.' . self::SECOND_LANGUAGE,
-                                    'name.' . Defaults::LANGUAGE_SYSTEM,
-                                ],
-                                'type' => 'best_fields',
+                            'term' => [
+                                'name.' . self::SECOND_LANGUAGE => 'foo',
                             ],
                         ],
                         [
@@ -400,6 +392,7 @@ EOT,
                 ],
             ],
         ];
+
         yield 'EqualsFilter field' => [
             new EqualsFilter('productNumber', 'bar'),
             [
@@ -408,19 +401,29 @@ EOT,
                 ],
             ],
         ];
-        yield 'EqualsFilter translated field' => [
+        yield 'EqualsFilter name translated field' => [
             new EqualsFilter('name', 'foo'),
+            [
+                'term' => [
+                    'name.' . self::SECOND_LANGUAGE => 'foo',
+                ],
+            ],
+        ];
+
+        yield 'EqualsFilter description translated field' => [
+            new EqualsFilter('description', 'foo'),
             [
                 'multi_match' => [
                     'query' => 'foo',
                     'fields' => [
-                        'name.' . self::SECOND_LANGUAGE,
-                        'name.' . Defaults::LANGUAGE_SYSTEM,
+                        'description.' . self::SECOND_LANGUAGE,
+                        'description.' . Defaults::LANGUAGE_SYSTEM,
                     ],
                     'type' => 'best_fields',
                 ],
             ],
         ];
+
         yield 'EqualsAnyFilter field' => [
             new EqualsAnyFilter('productNumber', ['foo', 'bar']),
             [
@@ -429,19 +432,29 @@ EOT,
                 ],
             ],
         ];
-        yield 'EqualsAnyFilter translated field' => [
+
+        yield 'EqualsAnyFilter name translated field' => [
             new EqualsAnyFilter('name', ['foo', 'bar']),
+            [
+                'terms' => [
+                    'name.' . self::SECOND_LANGUAGE => ['foo', 'bar'],
+                ],
+            ],
+        ];
+
+        yield 'EqualsAnyFilter description translated field' => [
+            new EqualsAnyFilter('description', ['foo', 'bar']),
             [
                 'dis_max' => [
                     'queries' => [
                         [
                             'terms' => [
-                                'name.' . self::SECOND_LANGUAGE => ['foo', 'bar'],
+                                'description.' . self::SECOND_LANGUAGE => ['foo', 'bar'],
                             ],
                         ],
                         [
                             'terms' => [
-                                'name.' . Defaults::LANGUAGE_SYSTEM => ['foo', 'bar'],
+                                'description.' . Defaults::LANGUAGE_SYSTEM => ['foo', 'bar'],
                             ],
                         ],
                     ],
@@ -473,50 +486,22 @@ EOT,
                 ],
             ],
         ];
-        yield 'EqualsAnyFilter translated field with null' => [
+        yield 'EqualsAnyFilter name translated field with null' => [
             new EqualsAnyFilter('name', ['foo', 'bar', null]),
             [
-                'dis_max' => [
-                    'queries' => [
+                'bool' => [
+                    'should' => [
                         [
-                            'bool' => [
-                                'should' => [
-                                    [
-                                        'terms' => [
-                                            'name.' . self::SECOND_LANGUAGE => ['foo', 'bar'],
-                                        ],
-                                    ],
-                                    [
-                                        'bool' => [
-                                            'must_not' => [
-                                                [
-                                                    'exists' => [
-                                                        'field' => 'name.' . self::SECOND_LANGUAGE,
-                                                    ],
-                                                ],
-                                            ],
-                                        ],
-                                    ],
-                                ],
+                            'terms' => [
+                                'name.' . self::SECOND_LANGUAGE => ['foo', 'bar'],
                             ],
                         ],
                         [
                             'bool' => [
-                                'should' => [
+                                'must_not' => [
                                     [
-                                        'terms' => [
-                                            'name.' . Defaults::LANGUAGE_SYSTEM => ['foo', 'bar'],
-                                        ],
-                                    ],
-                                    [
-                                        'bool' => [
-                                            'must_not' => [
-                                                [
-                                                    'exists' => [
-                                                        'field' => 'name.' . Defaults::LANGUAGE_SYSTEM,
-                                                    ],
-                                                ],
-                                            ],
+                                        'exists' => [
+                                            'field' => 'name.' . self::SECOND_LANGUAGE,
                                         ],
                                     ],
                                 ],
@@ -536,25 +521,12 @@ EOT,
                 ],
             ],
         ];
-        yield 'ContainsFilter translated field' => [
+        yield 'ContainsFilter name translated field' => [
             new ContainsFilter('name', 'foo'),
             [
-                'dis_max' => [
-                    'queries' => [
-                        [
-                            'wildcard' => [
-                                'name.' . self::SECOND_LANGUAGE => [
-                                    'value' => '*foo*',
-                                ],
-                            ],
-                        ],
-                        [
-                            'wildcard' => [
-                                'name.' . Defaults::LANGUAGE_SYSTEM => [
-                                    'value' => '*foo*',
-                                ],
-                            ],
-                        ],
+                'wildcard' => [
+                    'name.' . self::SECOND_LANGUAGE => [
+                        'value' => '*foo*',
                     ],
                 ],
             ],
@@ -569,25 +541,12 @@ EOT,
                 ],
             ],
         ];
-        yield 'PrefixFilter translated field' => [
+        yield 'PrefixFilter name translated field' => [
             new PrefixFilter('name', 'foo'),
             [
-                'dis_max' => [
-                    'queries' => [
-                        [
-                            'wildcard' => [
-                                'name.' . self::SECOND_LANGUAGE => [
-                                    'value' => 'foo*',
-                                ],
-                            ],
-                        ],
-                        [
-                            'wildcard' => [
-                                'name.' . Defaults::LANGUAGE_SYSTEM => [
-                                    'value' => 'foo*',
-                                ],
-                            ],
-                        ],
+                'prefix' => [
+                    'name.' . self::SECOND_LANGUAGE => [
+                        'value' => 'foo',
                     ],
                 ],
             ],
@@ -602,25 +561,12 @@ EOT,
                 ],
             ],
         ];
-        yield 'SuffixFilter translated field' => [
+        yield 'SuffixFilter name translated field' => [
             new SuffixFilter('name', 'foo'),
             [
-                'dis_max' => [
-                    'queries' => [
-                        [
-                            'wildcard' => [
-                                'name.' . self::SECOND_LANGUAGE => [
-                                    'value' => '*foo',
-                                ],
-                            ],
-                        ],
-                        [
-                            'wildcard' => [
-                                'name.' . Defaults::LANGUAGE_SYSTEM => [
-                                    'value' => '*foo',
-                                ],
-                            ],
-                        ],
+                'wildcard' => [
+                    'name.' . self::SECOND_LANGUAGE => [
+                        'value' => '*foo',
                     ],
                 ],
             ],
@@ -637,27 +583,14 @@ EOT,
                 ],
             ],
         ];
-        yield 'RangeFilter translated field' => [
+        yield 'RangeFilter name translated field' => [
             new RangeFilter('name', [
                 RangeFilter::GT => $now,
             ]),
             [
-                'dis_max' => [
-                    'queries' => [
-                        [
-                            'range' => [
-                                'name.' . self::SECOND_LANGUAGE => [
-                                    RangeFilter::GT => $now,
-                                ],
-                            ],
-                        ],
-                        [
-                            'range' => [
-                                'name.' . Defaults::LANGUAGE_SYSTEM => [
-                                    RangeFilter::GT => $now,
-                                ],
-                            ],
-                        ],
+                'range' => [
+                    'name.' . self::SECOND_LANGUAGE => [
+                        RangeFilter::GT => $now,
                     ],
                 ],
             ],
@@ -826,18 +759,15 @@ EOT,
         $this->executeCheapestPriceTest($sorting, $expectedQuery, $context, true);
     }
 
-    /**
-     * @param array<mixed> $expectedQuery
-     */
     #[DataProvider('providerTranslatedField')]
-    public function testTranslatedFieldSorting(FieldSorting $sorting, array $expectedQuery, bool $scriptSorting = true, ?Field $customField = null): void
+    public function testTranslatedFieldSorting(FieldSorting $sorting, FieldSort $expectedFieldSort, ?Field $customField = null): void
     {
-        $definition = $this->getDefinition();
+        $definition = $this->getDefinition(ProductManufacturerDefinition::ENTITY_NAME);
 
         $customFieldService = $this->createMock(CustomFieldService::class);
 
         if ($customField instanceof Field) {
-            $customFieldService->expects($this->once())->method('getCustomField')->willReturn($customField);
+            $customFieldService->method('getCustomField')->willReturn($customField);
         }
 
         $fieldSort = (new CriteriaParser(
@@ -845,21 +775,11 @@ EOT,
             $customFieldService,
         ))->parseSorting($sorting, $definition, Context::createDefaultContext());
 
-        if ($scriptSorting) {
-            static::assertTrue($fieldSort->hasParameter('script'));
-            $script = $fieldSort->getParameter('script');
-            static::assertIsArray($script);
-
-            // Unset the 'source' key before comparison.
-            unset($script['source']);
-            static::assertSame($expectedQuery, $script);
-
-            return;
-        }
-
-        static::assertSame($sorting->getField(), $fieldSort->getField());
-        static::assertSame($sorting->getDirection(), $fieldSort->getOrder());
-        static::assertSame([], $fieldSort->getParameters());
+        static::assertSame($expectedFieldSort->getField(), $fieldSort->getField());
+        static::assertNotNull($expectedFieldSort->getOrder());
+        static::assertNotNull($fieldSort->getOrder());
+        static::assertSame(strtolower($expectedFieldSort->getOrder()), strtolower($fieldSort->getOrder()));
+        static::assertSame($expectedFieldSort->getParameters(), $fieldSort->getParameters());
     }
 
     /**
@@ -995,164 +915,158 @@ EOT,
     }
 
     /**
-     * @return iterable<string, array{FieldSorting, array{lang: string, params: array{field: string, languages: list<string>}}, bool, ?Field}>
+     * @return iterable<string, array{FieldSorting, FieldSort, ?Field}>
      */
     public static function providerTranslatedField(): iterable
     {
         yield 'non translated field' => [
             new FieldSorting('productNumber', FieldSorting::ASCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'name',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
-                    ],
-                ],
-            ],
-            false,
+            new FieldSort('productNumber', FieldSorting::ASCENDING, null, []),
             null,
         ];
 
         yield 'customFields translated field' => [
-            new FieldSorting('customFields.foo', FieldSorting::ASCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'customFields',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
+            new FieldSorting('customFields.foo', FieldSorting::DESCENDING),
+            new FieldSort('_script', FieldSorting::DESCENDING, null, [
+                'type' => 'string',
+                'script' => [
+                    'source' => static::getScriptStringSortingSource(),
+                    'lang' => 'painless',
+                    'params' => [
+                        'field' => 'customFields',
+                        'languages' => [
+                            Defaults::LANGUAGE_SYSTEM,
+                        ],
+                        'suffix' => 'foo',
                     ],
-                    'suffix' => 'foo',
                 ],
-            ],
-            true,
+            ]),
             new StringField('foo', 'foo'),
         ];
 
         yield 'customFields int translated field' => [
             new FieldSorting('customFields.foo', FieldSorting::ASCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'customFields',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
+            new FieldSort('_script', FieldSorting::ASCENDING, null, [
+                'type' => 'number',
+                'script' => [
+                    'source' => static::getScriptIntSortingSource(),
+                    'lang' => 'painless',
+                    'params' => [
+                        'field' => 'customFields',
+                        'languages' => [
+                            Defaults::LANGUAGE_SYSTEM,
+                        ],
+                        'suffix' => 'foo',
+                        'order' => FieldSort::ASC,
                     ],
-                    'suffix' => 'foo',
-                    'order' => 'asc',
                 ],
-            ],
-            true,
+            ]),
             new IntField('foo', 'foo'),
         ];
 
         yield 'customFields float translated field' => [
             new FieldSorting('customFields.foo', FieldSorting::ASCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'customFields',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
+            new FieldSort('_script', FieldSort::ASC, null, [
+                'type' => 'number',
+                'script' => [
+                    'source' => static::getScriptIntSortingSource(),
+                    'lang' => 'painless',
+                    'params' => [
+                        'field' => 'customFields',
+                        'languages' => [
+                            Defaults::LANGUAGE_SYSTEM,
+                        ],
+                        'suffix' => 'foo',
+                        'order' => FieldSort::ASC,
                     ],
-                    'suffix' => 'foo',
-                    'order' => 'asc',
                 ],
-            ],
-            true,
+            ]),
             new FloatField('foo', 'foo'),
         ];
 
         yield 'non nested translated field' => [
-            new FieldSorting('product.name', FieldSorting::ASCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'name',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
+            new FieldSorting('name', FieldSorting::ASCENDING),
+            new FieldSort('_script', FieldSort::ASC, null, [
+                'type' => 'string',
+                'script' => [
+                    'source' => static::getScriptStringSortingSource(),
+                    'lang' => 'painless',
+                    'params' => [
+                        'field' => 'name',
+                        'languages' => [
+                            Defaults::LANGUAGE_SYSTEM,
+                        ],
                     ],
                 ],
-            ],
-            true,
+            ]),
             null,
         ];
 
         yield 'non translated field with root prefix' => [
-            new FieldSorting('product.name', FieldSorting::ASCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'name',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
+            new FieldSorting('product_manufacturer.name', FieldSorting::ASCENDING),
+            new FieldSort('_script', FieldSort::ASC, null, [
+                'type' => 'string',
+                'script' => [
+                    'source' => static::getScriptStringSortingSource(),
+                    'lang' => 'painless',
+                    'params' => [
+                        'field' => 'name',
+                        'languages' => [
+                            Defaults::LANGUAGE_SYSTEM,
+                        ],
                     ],
                 ],
-            ],
-            true,
+            ]),
             null,
         ];
 
         yield 'nested translated field' => [
-            new FieldSorting('manufacturer.name', FieldSorting::ASCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'manufacturer.name',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
-                    ],
-                ],
-            ],
-            true,
+            new FieldSorting('product_manufacturer.products.name', FieldSorting::ASCENDING),
+            new FieldSort('products.name.' . Defaults::LANGUAGE_SYSTEM, FieldSorting::ASCENDING, null, ['nested' => ['path' => 'products']]),
             null,
         ];
 
         yield 'nested translated field with root prefix' => [
-            new FieldSorting('manufacturer.name', FieldSorting::ASCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'manufacturer.name',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
-                    ],
-                ],
-            ],
-            true,
+            new FieldSorting('products.name', FieldSorting::ASCENDING),
+            new FieldSort('products.name.' . Defaults::LANGUAGE_SYSTEM, FieldSorting::ASCENDING, null, ['nested' => ['path' => 'products']]),
             null,
         ];
 
         yield 'customFields string translated field in descending order' => [
             new FieldSorting('customFields.bar', FieldSorting::DESCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'customFields',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
+            new FieldSort('_script', FieldSort::DESC, null, [
+                'type' => 'string',
+                'script' => [
+                    'source' => static::getScriptStringSortingSource(),
+                    'lang' => 'painless',
+                    'params' => [
+                        'field' => 'customFields',
+                        'languages' => [
+                            Defaults::LANGUAGE_SYSTEM,
+                        ],
+                        'suffix' => 'bar',
                     ],
-                    'suffix' => 'bar',
                 ],
-            ],
-            true,
+            ]),
             new StringField('bar', 'bar'),
         ];
 
         yield 'customFields bool translated field' => [
             new FieldSorting('customFields.boolField', FieldSorting::DESCENDING),
-            [
-                'lang' => 'painless',
-                'params' => [
-                    'field' => 'customFields',
-                    'languages' => [
-                        Defaults::LANGUAGE_SYSTEM,
+            new FieldSort('_script', FieldSort::DESC, null, [
+                'type' => 'string',
+                'script' => [
+                    'source' => static::getScriptStringSortingSource(),
+                    'lang' => 'painless',
+                    'params' => [
+                        'field' => 'customFields',
+                        'languages' => [
+                            Defaults::LANGUAGE_SYSTEM,
+                        ],
+                        'suffix' => 'boolField',
                     ],
-                    'suffix' => 'boolField',
                 ],
-            ],
-            true,
+            ]),
             new BoolField('boolField', 'boolField'),
         ];
     }
@@ -1360,12 +1274,13 @@ EOT,
         ];
     }
 
-    public function getDefinition(): EntityDefinition
+    public function getDefinition(string $entityName = 'product'): EntityDefinition
     {
         $instanceRegistry = new StaticDefinitionInstanceRegistry(
             [
                 ProductDefinition::class,
                 ProductManufacturerDefinition::class,
+                ProductManufacturerTranslationDefinition::class,
                 UnitDefinition::class,
                 ProductTranslationDefinition::class,
                 UnitTranslationDefinition::class,
@@ -1374,7 +1289,7 @@ EOT,
             $this->createMock(EntityWriteGatewayInterface::class)
         );
 
-        return $instanceRegistry->getByEntityName('product');
+        return $instanceRegistry->getByEntityName($entityName);
     }
 
     /**
@@ -1530,6 +1445,48 @@ EOT,
             ],
             $context,
         ];
+    }
+
+    public static function getScriptStringSortingSource(): string
+    {
+        return 'def languages = params[\'languages\'];
+def suffix = params.containsKey(\'suffix\') ? \'.\' + params[\'suffix\'] : \'\';
+
+for (int i = 0; i < languages.length; i++) {
+    def field_name = params[\'field\'] + \'.\' + languages[i] + suffix;
+
+    if (doc[field_name].size() > 0 && doc[field_name].value != null && doc[field_name].value.toString().length() > 0) {
+        def fieldValue = doc[field_name].value;
+
+        return fieldValue.toString();
+    }
+}
+
+return \'\';
+';
+    }
+
+    public static function getScriptIntSortingSource(): string
+    {
+        return 'def languages = params[\'languages\'];
+def suffix = params.containsKey(\'suffix\') ? \'.\' + params[\'suffix\'] : \'\';
+
+for (int i = 0; i < languages.length; i++) {
+    def field_name = params[\'field\'] + \'.\' + languages[i] + suffix;
+
+    if (doc[field_name].size() > 0 && doc[field_name].value != null && doc[field_name].value.toString().length() > 0) {
+        def fieldValue = doc[field_name].value;
+
+        return fieldValue;
+    }
+}
+
+if (params[\'order\'] == \'asc\') {
+    return Double.MAX_VALUE;
+}
+
+return Double.MIN_VALUE;
+';
     }
 
     /**

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcherTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcherTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelpe
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\System\CustomField\CustomFieldService;
+use Shopware\Core\Test\Stub\Framework\Adapter\Storage\ArrayKeyValueStorage;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\AbstractElasticsearchSearchHydrator;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
@@ -336,7 +337,7 @@ class ElasticsearchEntitySearcherTest extends TestCase
             $client,
             $this->createMock(EntitySearcherInterface::class),
             $helper,
-            new CriteriaParser(new EntityDefinitionQueryHelper(), $this->createMock(CustomFieldService::class)),
+            new CriteriaParser(new EntityDefinitionQueryHelper(), $this->createMock(CustomFieldService::class), new ArrayKeyValueStorage([])),
             $this->createMock(AbstractElasticsearchSearchHydrator::class),
             new EventDispatcher(),
             '5s',

--- a/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -77,7 +77,7 @@ class ElasticsearchIndexerTest extends TestCase
         static::assertNull($indexer->iterate(), 'Iterate should return null if es is disabled');
     }
 
-    public function testIterateNullCreatesIndices(): void
+    public function testIterateTillLastMsgCreatesIndices(): void
     {
         $indexer = $this->getIndexer();
 
@@ -90,7 +90,7 @@ class ElasticsearchIndexerTest extends TestCase
         static::assertNull($msg);
     }
 
-    public function testIterateNullCreatesIndicesAndIndexTaskInDB(): void
+    public function testIterateTillLastMsgCreatesIndicesAndIndexTaskInDB(): void
     {
         $indexer = $this->getIndexer();
         $this->connection

--- a/tests/unit/Elasticsearch/Product/ElasticsearchOptimizeSwitchTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchOptimizeSwitchTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Product;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\Framework\Adapter\Storage\ArrayKeyValueStorage;
+use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexingFinishedEvent;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ElasticsearchOptimizeSwitch::class)]
+class ElasticsearchOptimizeSwitchTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+    }
+
+    public function testGetSubscribers(): void
+    {
+        $subscribers = ElasticsearchOptimizeSwitch::getSubscribedEvents();
+
+        static::assertSame([
+            ElasticsearchIndexingFinishedEvent::class => 'onIndexingFinished',
+        ], $subscribers);
+    }
+
+    public function testOnIndexingFinished(): void
+    {
+        $storage = new ArrayKeyValueStorage([]);
+
+        static::assertFalse($storage->has(ElasticsearchOptimizeSwitch::FLAG));
+
+        $event = new ElasticsearchIndexingFinishedEvent();
+        $subscriber = new ElasticsearchOptimizeSwitch($storage);
+        $subscriber->onIndexingFinished($event);
+
+        static::assertTrue($storage->get(ElasticsearchOptimizeSwitch::FLAG));
+    }
+}

--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Core\System\Language\LanguageLoaderInterface;
 use Shopware\Core\System\Language\SalesChannelLanguageLoader;
@@ -356,6 +357,10 @@ class ElasticsearchProductDefinitionTest extends TestCase
             ],
         ];
 
+        if (Feature::isActive('v6.8.0.0')) {
+            unset($expectedMapping['properties']['visibilities']);
+            unset($expectedMapping['properties']['categoriesRo']);
+        }
         static::assertEquals($expectedMapping, $definition->getMapping(Context::createDefaultContext()));
     }
 
@@ -607,42 +612,50 @@ class ElasticsearchProductDefinitionTest extends TestCase
             $document['propertyIds']
         );
 
-        static::assertArrayHasKey('visibilities', $document);
-        static::assertSame(
-            [
+        if (Feature::isActive('v6.8.0.0')) {
+            static::assertArrayHasKey('visibility_sc-1', $document);
+            static::assertArrayHasKey('visibility_sc-2', $document);
+            static::assertSame(30, $document['visibility_sc-1']);
+            static::assertSame(20, $document['visibility_sc-2']);
+        } else {
+            static::assertArrayHasKey('visibilities', $document);
+
+            static::assertSame(
                 [
-                    '_count' => 1,
-                    'visibility' => 20,
-                    'salesChannelId' => 'sc-2',
+                    [
+                        '_count' => 1,
+                        'visibility' => 20,
+                        'salesChannelId' => 'sc-2',
+                    ],
+                    [
+                        '_count' => 1,
+                        'visibility' => 20,
+                        'salesChannelId' => 'sc-2',
+                    ],
+                    [
+                        '_count' => 1,
+                        'visibility' => 20,
+                        'salesChannelId' => 'sc-2',
+                    ],
+                    [
+                        '_count' => 1,
+                        'visibility' => 30,
+                        'salesChannelId' => 'sc-1',
+                    ],
+                    [
+                        '_count' => 1,
+                        'visibility' => 30,
+                        'salesChannelId' => 'sc-1',
+                    ],
+                    [
+                        '_count' => 1,
+                        'visibility' => 20,
+                        'salesChannelId' => 'sc-2',
+                    ],
                 ],
-                [
-                    '_count' => 1,
-                    'visibility' => 20,
-                    'salesChannelId' => 'sc-2',
-                ],
-                [
-                    '_count' => 1,
-                    'visibility' => 20,
-                    'salesChannelId' => 'sc-2',
-                ],
-                [
-                    '_count' => 1,
-                    'visibility' => 30,
-                    'salesChannelId' => 'sc-1',
-                ],
-                [
-                    '_count' => 1,
-                    'visibility' => 30,
-                    'salesChannelId' => 'sc-1',
-                ],
-                [
-                    '_count' => 1,
-                    'visibility' => 20,
-                    'salesChannelId' => 'sc-2',
-                ],
-            ],
-            $document['visibilities']
-        );
+                $document['visibilities']
+            );
+        }
 
         static::assertSame(
             [

--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
+use Shopware\Core\System\Language\LanguageLoaderInterface;
 use Shopware\Core\System\Language\SalesChannelLanguageLoader;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -140,7 +141,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
             $fieldMapper,
             $salesChannelLanguageLoader,
             false,
-            'dev'
+            'dev',
+            $this->createMock(LanguageLoaderInterface::class)
         );
 
         $expectedMapping = [
@@ -402,7 +404,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
             $fieldMapper,
             $salesChannelLoader,
             false,
-            'dev'
+            'dev',
+            $this->createMock(LanguageLoaderInterface::class)
         );
 
         $mapping = $definition->getMapping(Context::createDefaultContext());
@@ -496,7 +499,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
             $this->createMock(ElasticsearchFieldMapper::class),
             $this->createMock(SalesChannelLanguageLoader::class),
             false,
-            'dev'
+            'dev',
+            $this->createMock(LanguageLoaderInterface::class)
         );
 
         static::assertSame($definition, $esDefinition->getEntityDefinition());
@@ -527,7 +531,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
             $fieldMapper,
             $this->createMock(SalesChannelLanguageLoader::class),
             false,
-            'dev'
+            'dev',
+            $this->createMock(LanguageLoaderInterface::class)
         );
 
         $criteria = new Criteria();
@@ -564,7 +569,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
             $this->createMock(ElasticsearchFieldMapper::class),
             $salesChannelLanguageLoader,
             false,
-            'dev'
+            'dev',
+            $this->createMock(LanguageLoaderInterface::class)
         );
 
         $uuid = $this->ids->get('product-1');
@@ -703,7 +709,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
             $fieldMapper,
             $salesChannelLanguageLoader,
             false,
-            'dev'
+            'dev',
+            $this->createMock(LanguageLoaderInterface::class)
         );
 
         $uuid = $this->ids->get('product-1');

--- a/tests/unit/Elasticsearch/Product/ProductCriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductCriteriaParserTest.php
@@ -1,0 +1,249 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Product;
+
+use OpenSearchDSL\BuilderInterface;
+use OpenSearchDSL\Query\Compound\BoolQuery;
+use OpenSearchDSL\Query\TermLevel\TermQuery;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationDefinition;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\CustomField\CustomFieldService;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Shopware\Core\Test\Stub\Framework\Adapter\Storage\ArrayKeyValueStorage;
+use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
+use Shopware\Elasticsearch\Product\ProductCriteriaParser;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProductCriteriaParser::class)]
+class ProductCriteriaParserTest extends TestCase
+{
+    private EntityDefinitionQueryHelper $helper;
+
+    private CustomFieldService&MockObject $customFieldService;
+
+    private CriteriaParser&MockObject $decoratedParser;
+
+    private EntityDefinition $productDefinition;
+
+    private EntityDefinition $categoryDefinition;
+
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        $registry = $this->getRegistry();
+
+        $this->helper = new EntityDefinitionQueryHelper();
+        $this->customFieldService = $this->createMock(CustomFieldService::class);
+        $this->decoratedParser = $this->createMock(CriteriaParser::class);
+        $this->productDefinition = $registry->getByEntityName(ProductDefinition::ENTITY_NAME);
+        $this->categoryDefinition = $registry->getByEntityName(CategoryDefinition::ENTITY_NAME);
+        $this->context = new Context(new SystemSource());
+    }
+
+    public function testParseFilterWithNonProductDefinition(): void
+    {
+        $storage = new ArrayKeyValueStorage();
+        $parser = new ProductCriteriaParser(
+            $this->helper,
+            $this->customFieldService,
+            $storage,
+            $this->decoratedParser
+        );
+
+        $filter = new EqualsFilter('name', 'test');
+
+        $this->decoratedParser
+            ->expects($this->never())
+            ->method('parseFilter');
+
+        $result = $parser->parseFilter($filter, $this->categoryDefinition, 'root', $this->context);
+
+        static::assertInstanceOf(TermQuery::class, $result);
+        static::assertSame([
+            'term' => [
+                'name.2fbb5fe2e29a4d70aa5854ce7ce3e20b' => 'test',
+            ],
+        ], $result->toArray());
+    }
+
+    public function testParseFilterShouldCallsParent(): void
+    {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
+        $storage = new ArrayKeyValueStorage();
+        $parser = new ProductCriteriaParser(
+            $this->helper,
+            $this->customFieldService,
+            $storage,
+            $this->decoratedParser
+        );
+
+        $filter = new NotFilter(NotFilter::CONNECTION_AND, [new EqualsFilter('active', true)]);
+        $expectedBuilder = $this->createMock(BuilderInterface::class);
+
+        $this->decoratedParser
+            ->expects($this->once())
+            ->method('parseFilter')
+            ->with($filter, $this->productDefinition, 'root', $this->context)
+            ->willReturn($expectedBuilder);
+
+        $result = $parser->parseFilter($filter, $this->productDefinition, 'root', $this->context);
+
+        static::assertSame($expectedBuilder, $result);
+    }
+
+    public function testParseProductAvailableFilterWithOptimizationDisabled(): void
+    {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
+        $storage = new ArrayKeyValueStorage();
+        $parser = new ProductCriteriaParser(
+            $this->helper,
+            $this->customFieldService,
+            $storage,
+            $this->decoratedParser
+        );
+
+        $salesChannelId = Uuid::randomHex();
+        $filter = new ProductAvailableFilter($salesChannelId, 30);
+        $expectedBuilder = $this->createMock(BuilderInterface::class);
+
+        $this->decoratedParser
+            ->expects($this->once())
+            ->method('parseFilter')
+            ->with($filter, $this->productDefinition, 'root', $this->context)
+            ->willReturn($expectedBuilder);
+
+        $result = $parser->parseFilter($filter, $this->productDefinition, 'root', $this->context);
+
+        static::assertSame($expectedBuilder->toArray(), $result->toArray());
+    }
+
+    public function testParseProductAvailableFilterWithOptimizationEnabled(): void
+    {
+        $storage = new ArrayKeyValueStorage([
+            ElasticsearchOptimizeSwitch::FLAG => true,
+        ]);
+        $parser = new ProductCriteriaParser(
+            $this->helper,
+            $this->customFieldService,
+            $storage,
+            $this->decoratedParser
+        );
+
+        $salesChannelId = Uuid::randomHex();
+        $visibility = 30;
+        $filter = new ProductAvailableFilter($salesChannelId, $visibility);
+
+        $result = $parser->parseFilter($filter, $this->productDefinition, 'root', $this->context);
+
+        static::assertInstanceOf(BoolQuery::class, $result);
+
+        $queryArray = $result->toArray();
+
+        static::assertArrayHasKey('bool', $queryArray);
+        static::assertArrayHasKey('must', $queryArray['bool']);
+        static::assertCount(2, $queryArray['bool']['must']);
+
+        $activeQuery = $queryArray['bool']['must'][0];
+        static::assertArrayHasKey('term', $activeQuery);
+        static::assertArrayHasKey('active', $activeQuery['term']);
+        static::assertTrue($activeQuery['term']['active']);
+
+        $visibilityQuery = $queryArray['bool']['must'][1];
+        static::assertArrayHasKey('range', $visibilityQuery);
+        static::assertArrayHasKey('visibility_' . $salesChannelId, $visibilityQuery['range']);
+        static::assertArrayHasKey('gte', $visibilityQuery['range']['visibility_' . $salesChannelId]);
+        static::assertSame($visibility, $visibilityQuery['range']['visibility_' . $salesChannelId]['gte']);
+    }
+
+    public function testParseCategoriesRoIdEqualsFilter(): void
+    {
+        $storage = new ArrayKeyValueStorage();
+        $parser = new ProductCriteriaParser(
+            $this->helper,
+            $this->customFieldService,
+            $storage,
+            $this->decoratedParser
+        );
+
+        $categoryId = Uuid::randomHex();
+        $filter = new EqualsFilter('categoriesRo.id', $categoryId);
+
+        $result = $parser->parseFilter($filter, $this->productDefinition, 'root', $this->context);
+
+        static::assertInstanceOf(TermQuery::class, $result);
+
+        $queryArray = $result->toArray();
+        static::assertArrayHasKey('term', $queryArray);
+        static::assertArrayHasKey('categoryTree', $queryArray['term']);
+        static::assertSame($categoryId, $queryArray['term']['categoryTree']);
+    }
+
+    public function testParseCategoriesRoIdEqualsFilterWithNullValue(): void
+    {
+        $storage = new ArrayKeyValueStorage([
+            ElasticsearchOptimizeSwitch::FLAG => true,
+        ]);
+
+        $parser = new ProductCriteriaParser(
+            $this->helper,
+            $this->customFieldService,
+            $storage,
+            $this->decoratedParser
+        );
+
+        $filter = new EqualsFilter('categoriesRo.id', null);
+
+        $this->decoratedParser
+            ->expects($this->never())
+            ->method('parseFilter');
+
+        $result = $parser->parseFilter($filter, $this->productDefinition, 'root', $this->context);
+
+        static::assertInstanceOf(BoolQuery::class, $result);
+        $queryArray = $result->toArray();
+        static::assertArrayHasKey('bool', $queryArray);
+        static::assertArrayHasKey('must_not', $queryArray['bool']);
+        static::assertIsArray($queryArray['bool']['must_not']);
+        static::assertNotEmpty($queryArray['bool']['must_not'][0]);
+        static::assertSame([
+            'exists' => [
+                'field' => 'categoryTree',
+            ],
+        ], $queryArray['bool']['must_not'][0]);
+    }
+
+    private function getRegistry(): DefinitionInstanceRegistry
+    {
+        return new StaticDefinitionInstanceRegistry(
+            [
+                ProductDefinition::class,
+                CategoryDefinition::class,
+                CategoryTranslationDefinition::class,
+            ],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+    }
+}

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -33,8 +33,10 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Shopware\Core\Test\Stub\Framework\Adapter\Storage\ArrayKeyValueStorage;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Product\AbstractProductSearchQueryBuilder;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Product\ProductSearchQueryBuilder;
 use Shopware\Elasticsearch\TokenQueryBuilder;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -58,7 +60,10 @@ class ProductSearchQueryBuilderTest extends TestCase
                 'evolvesInt' => new IntField('evolvesInt', 'evolvesInt'),
                 'evolvesFloat' => new FloatField('evolvesFloat', 'evolvesFloat'),
                 'evolvesText' => new StringField('evolvesText', 'evolvesText'),
-            ])
+            ]),
+            new ArrayKeyValueStorage([
+                ElasticsearchOptimizeSwitch::FLAG => true,
+            ]),
         );
     }
 

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -296,15 +296,30 @@ class ProductSearchQueryBuilderTest extends TestCase
             'term' => 'foo 2023',
             'expected' => self::disMax([
                 self::bool([
-                    self::textMatch($prefixCfLang1 . 'evolvesText', 'foo', 500, null, false),
+                    self::disMax([
+                        self::textMatch($prefixCfLang1 . 'evolvesText', 'foo', 500, null, false),
+                        self::textMatch($prefixCfLang2 . 'evolvesText', 'foo', 400, null, false),
+                    ]),
                     self::bool([
-                        self::textMatch($prefixCfLang1 . 'evolvesText', '2023', 500, null, false),
-                        self::term($prefixCfLang1 . 'evolvesInt', 2023, 400),
-                        self::term($prefixCfLang1 . 'evolvesFloat', 2023, 500),
+                        self::disMax([
+                            self::textMatch($prefixCfLang1 . 'evolvesText', '2023', 500, null, false),
+                            self::textMatch($prefixCfLang2 . 'evolvesText', '2023', 400, null, false),
+                        ]),
+                        self::disMax([
+                            self::term($prefixCfLang1 . 'evolvesInt', 2023, 400),
+                            self::term($prefixCfLang2 . 'evolvesInt', 2023, 320),
+                        ]),
+                        self::disMax([
+                            self::term($prefixCfLang1 . 'evolvesFloat', 2023, 500),
+                            self::term($prefixCfLang2 . 'evolvesFloat', 2023, 400),
+                        ]),
                         self::nested('categories', self::term('categories.childCount', 2023, 500)),
                     ]),
                 ], BoolQuery::MUST),
-                self::textMatch($prefixCfLang1 . 'evolvesText', 'foo 2023', 500, null, false),
+                self::disMax([
+                    self::textMatch($prefixCfLang1 . 'evolvesText', 'foo 2023', 500, null, false),
+                    self::textMatch($prefixCfLang2 . 'evolvesText', 'foo 2023', 400, null, false),
+                ]),
             ]),
         ];
     }

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -247,10 +247,7 @@ class ProductSearchQueryBuilderTest extends TestCase
             ],
             'term' => 'foo',
             'expected' => self::bool([
-                self::disMax([
-                    self::textMatch('name', 'foo', 1000, Defaults::LANGUAGE_SYSTEM, andSearch: false),
-                    self::textMatch('name', 'foo', 800, self::SECOND_LANGUAGE_ID, andSearch: false),
-                ]),
+                self::textMatch('name', 'foo', 1000, Defaults::LANGUAGE_SYSTEM, andSearch: false),
                 self::nested('tags', self::textMatch('tags.name', 'foo', 500, andSearch: false)),
                 self::nested('categories', self::disMax([
                     self::textMatch('categories.name', 'foo', 200, Defaults::LANGUAGE_SYSTEM, andSearch: false),
@@ -270,28 +267,19 @@ class ProductSearchQueryBuilderTest extends TestCase
             'expected' => self::disMax([
                 self::bool([
                     self::bool([
-                        self::disMax([
-                            self::textMatch('name', 'foo', 1000, Defaults::LANGUAGE_SYSTEM, false),
-                            self::textMatch('name', 'foo', 800, self::SECOND_LANGUAGE_ID, false),
-                        ]),
+                        self::textMatch('name', 'foo', 1000, Defaults::LANGUAGE_SYSTEM, false),
                         self::textMatch('ean', 'foo', 2000, null, false),
                         self::nested('tags', self::textMatch('tags.name', 'foo', 500, null, false)),
                     ]),
                     self::bool([
-                        self::disMax([
-                            self::textMatch('name', '2023', 1000, Defaults::LANGUAGE_SYSTEM, false),
-                            self::textMatch('name', '2023', 800, self::SECOND_LANGUAGE_ID, false),
-                        ]),
+                        self::textMatch('name', '2023', 1000, Defaults::LANGUAGE_SYSTEM, false),
                         self::textMatch('ean', '2023', 2000, null, false),
                         self::term('restockTime', 2023, 1500),
                         self::nested('tags', self::textMatch('tags.name', '2023', 500, null, false)),
                     ]),
                 ], BoolQuery::MUST),
                 self::bool([
-                    self::disMax([
-                        self::textMatch('name', 'foo 2023', 1000, Defaults::LANGUAGE_SYSTEM, false),
-                        self::textMatch('name', 'foo 2023', 800, self::SECOND_LANGUAGE_ID, false),
-                    ]),
+                    self::textMatch('name', 'foo 2023', 1000, Defaults::LANGUAGE_SYSTEM, false),
                     self::textMatch('ean', 'foo 2023', 2000, null, false),
                     self::nested('tags', self::textMatch('tags.name', 'foo 2023', 500, null, false)),
                 ]),
@@ -308,30 +296,15 @@ class ProductSearchQueryBuilderTest extends TestCase
             'term' => 'foo 2023',
             'expected' => self::disMax([
                 self::bool([
-                    self::disMax([
-                        self::textMatch($prefixCfLang1 . 'evolvesText', 'foo', 500, null, false),
-                        self::textMatch($prefixCfLang2 . 'evolvesText', 'foo', 400, null, false),
-                    ]),
+                    self::textMatch($prefixCfLang1 . 'evolvesText', 'foo', 500, null, false),
                     self::bool([
-                        self::disMax([
-                            self::textMatch($prefixCfLang1 . 'evolvesText', '2023', 500, null, false),
-                            self::textMatch($prefixCfLang2 . 'evolvesText', '2023', 400, null, false),
-                        ]),
-                        self::disMax([
-                            self::term($prefixCfLang1 . 'evolvesInt', 2023, 400),
-                            self::term($prefixCfLang2 . 'evolvesInt', 2023, 320),
-                        ]),
-                        self::disMax([
-                            self::term($prefixCfLang1 . 'evolvesFloat', 2023, 500),
-                            self::term($prefixCfLang2 . 'evolvesFloat', 2023, 400),
-                        ]),
+                        self::textMatch($prefixCfLang1 . 'evolvesText', '2023', 500, null, false),
+                        self::term($prefixCfLang1 . 'evolvesInt', 2023, 400),
+                        self::term($prefixCfLang1 . 'evolvesFloat', 2023, 500),
                         self::nested('categories', self::term('categories.childCount', 2023, 500)),
                     ]),
                 ], BoolQuery::MUST),
-                self::disMax([
-                    self::textMatch($prefixCfLang1 . 'evolvesText', 'foo 2023', 500, null, false),
-                    self::textMatch($prefixCfLang2 . 'evolvesText', 'foo 2023', 400, null, false),
-                ]),
+                self::textMatch($prefixCfLang1 . 'evolvesText', 'foo 2023', 500, null, false),
             ]),
         ];
     }

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -30,7 +30,9 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Shopware\Core\Test\Stub\Framework\Adapter\Storage\ArrayKeyValueStorage;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
+use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Product\ProductSearchQueryBuilder;
 use Shopware\Elasticsearch\Product\SearchFieldConfig;
 use Shopware\Elasticsearch\TokenQueryBuilder;
@@ -48,13 +50,16 @@ class TokenQueryBuilderTest extends TestCase
 
     protected function setUp(): void
     {
+        $storage = new ArrayKeyValueStorage([ElasticsearchOptimizeSwitch::FLAG => true]);
+
         $this->tokenQueryBuilder = new TokenQueryBuilder(
             $this->getRegistry(),
             new CustomFieldServiceMock([
                 'evolvesInt' => new IntField('evolvesInt', 'evolvesInt'),
                 'evolvesFloat' => new FloatField('evolvesFloat', 'evolvesFloat'),
                 'evolvesText' => new StringField('evolvesText', 'evolvesText'),
-            ])
+            ]),
+            $storage
         );
     }
 

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -277,9 +277,18 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => '2023',
             'expected' => self::bool([
-                self::textMatch($prefixCfLang1 . 'evolvesText', '2023', 500, null, false),
-                self::term($prefixCfLang1 . 'evolvesInt', 2023, 400),
-                self::term($prefixCfLang1 . 'evolvesFloat', 2023.0, 500),
+                self::disMax([
+                    self::textMatch($prefixCfLang1 . 'evolvesText', '2023', 500, null, false),
+                    self::textMatch($prefixCfLang2 . 'evolvesText', '2023', 400, null, false),
+                ]),
+                self::disMax([
+                    self::term($prefixCfLang1 . 'evolvesInt', 2023, 400),
+                    self::term($prefixCfLang2 . 'evolvesInt', 2023, 320),
+                ]),
+                self::disMax([
+                    self::term($prefixCfLang1 . 'evolvesFloat', 2023.0, 500),
+                    self::term($prefixCfLang2 . 'evolvesFloat', 2023.0, 400),
+                ]),
                 self::nested('categories', self::term('categories.childCount', 2023, 500)),
             ]),
         ];
@@ -292,7 +301,10 @@ class TokenQueryBuilderTest extends TestCase
                 self::config(field: 'categories.childCount', ranking: 500),
             ],
             'term' => 'foo',
-            'expected' => self::textMatch($prefixCfLang1 . 'evolvesText', 'foo', 500, null, false),
+            'expected' => self::disMax([
+                self::textMatch($prefixCfLang1 . 'evolvesText', 'foo', 500, null, false),
+                self::textMatch($prefixCfLang2 . 'evolvesText', 'foo', 400, null, false),
+            ]),
         ];
     }
 

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -244,10 +244,7 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => 'foo',
             'expected' => self::bool([
-                self::disMax([
-                    self::textMatch(field: 'name', query: 'foo', boost: 1000, languageId: Defaults::LANGUAGE_SYSTEM, andSearch: false),
-                    self::textMatch('name', 'foo', 800, self::SECOND_LANGUAGE_ID, andSearch: false),
-                ]),
+                self::textMatch(field: 'name', query: 'foo', boost: 1000, languageId: Defaults::LANGUAGE_SYSTEM, andSearch: false),
                 self::nested('tags', self::textMatch('tags.name', 'foo', 500, andSearch: false)),
                 self::nested('categories', self::disMax([
                     self::textMatch('categories.name', 'foo', 200, Defaults::LANGUAGE_SYSTEM, andSearch: false),
@@ -265,10 +262,7 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => 'foo 2023',
             'expected' => self::bool([
-                self::disMax([
-                    self::textMatch('name', 'foo 2023', 1000, Defaults::LANGUAGE_SYSTEM, false),
-                    self::textMatch('name', 'foo 2023', 800, self::SECOND_LANGUAGE_ID, false),
-                ]),
+                self::textMatch('name', 'foo 2023', 1000, Defaults::LANGUAGE_SYSTEM, false),
                 self::textMatch('ean', 'foo 2023', 2000, null, false),
                 self::nested('tags', self::textMatch('tags.name', 'foo 2023', 500, null, false)),
             ]),
@@ -283,18 +277,9 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => '2023',
             'expected' => self::bool([
-                self::disMax([
-                    self::textMatch($prefixCfLang1 . 'evolvesText', '2023', 500, null, false),
-                    self::textMatch($prefixCfLang2 . 'evolvesText', '2023', 400, null, false),
-                ]),
-                self::disMax([
-                    self::term($prefixCfLang1 . 'evolvesInt', 2023, 400),
-                    self::term($prefixCfLang2 . 'evolvesInt', 2023, 320),
-                ]),
-                self::disMax([
-                    self::term($prefixCfLang1 . 'evolvesFloat', 2023.0, 500),
-                    self::term($prefixCfLang2 . 'evolvesFloat', 2023.0, 400),
-                ]),
+                self::textMatch($prefixCfLang1 . 'evolvesText', '2023', 500, null, false),
+                self::term($prefixCfLang1 . 'evolvesInt', 2023, 400),
+                self::term($prefixCfLang1 . 'evolvesFloat', 2023.0, 500),
                 self::nested('categories', self::term('categories.childCount', 2023, 500)),
             ]),
         ];
@@ -307,10 +292,7 @@ class TokenQueryBuilderTest extends TestCase
                 self::config(field: 'categories.childCount', ranking: 500),
             ],
             'term' => 'foo',
-            'expected' => self::disMax([
-                self::textMatch($prefixCfLang1 . 'evolvesText', 'foo', 500, null, false),
-                self::textMatch($prefixCfLang2 . 'evolvesText', 'foo', 400, null, false),
-            ]),
+            'expected' => self::textMatch($prefixCfLang1 . 'evolvesText', 'foo', 500, null, false),
         ];
     }
 


### PR DESCRIPTION
### Prerequisites

Number of documents: 2580421
Number of sales channel languages: 5
Endpoint: /sw_product/_search?request_cache=false

Queries using for testing

1. With a sort script

```
{
  "profile": true,
  "_source": false,
  "sort": [
    {
      "_script": {
        "type": "string",
        "script": {
          "source": "def languages = params['languages'];\ndef suffix = params.containsKey('suffix') ? '.' + params['suffix'] : '';\n\nfor (int i = 0; i < languages.length; i++) {\n    def field_name = params['field'] + '.' + languages[i] + suffix;\n\n    if (doc[field_name].size() > 0 && doc[field_name].value != null && doc[field_name].value.toString().length() > 0) {\n        def fieldValue = doc[field_name].value;\n\n        return fieldValue.toString();\n    }\n}\n\nreturn '';\n",
          "lang": "painless",
          "params": {
            "field": "name",
            "languages": [
              "0198187d773b7833806c564766c15e4c",
              "2fbb5fe2e29a4d70aa5854ce7ce3e20b"
            ]
          }
        },
        "order": "DESC"
      }
    },
    {
      "id": {
        "order": "ASC"
      }
    }
  ],
  "aggregations": {
    "total-count": {
      "cardinality": {
        "field": "displayGroup"
      }
    }
  },
  "from": 0,
  "size": 24,
  "collapse": {
    "field": "displayGroup"
  },
  "timeout": "5s"
}
```

2. Without sort script

```
{
  "profile": true,
  "_source": false,
  "sort": [
    {
      "name.0198187d773b7833806c564766c15e4c": {
        "order": "DESC"
      }
    },
    {
      "id": {
        "order": "ASC"
      }
    }
  ],
  "aggregations": {
    "total-count": {
      "cardinality": {
        "field": "displayGroup"
      }
    }
  },
  "from": 0,
  "size": 24,
  "collapse": {
    "field": "displayGroup"
  },
  "timeout": "5s"
}
```

### Benchmark result:

|Criteria|Before (with script sort)|After (without script sort)|
| -------- | ------- |------- |
|Index time (no-queue) | 2 mins, 56 secs | 2 mins, 57 secs |
|Disk space | 366 MB | 433 MB |
|Search time | ~150-300ms | ~20-30ms |
|Cost for sorting(from the profile result)|~130ms (85%)|~6.5ms (22%)|

### Conclusion

- Search time dropped from ~150–300ms to ~20–30ms, a 5–10x improvement, despite identical data size, indexing time and index structure.

- The collector time related to sorting, as reported in the query profile, decreased from ~130ms (85% of total query time) to just ~6.5ms (22%). This confirms that the script-based sort was the dominant bottleneck.

- An increase in disk usage (366MB → 433MB) is the result of storing sortable content in 5 different languages

So, for large-scale catalogs (2M+ products), avoid script sort and use pre-indexed sortable fields wherever possible. This is a highly recommended best practice. The trade-off in storage is minimal and well worth the massive gains in query responsiveness.