### PR TITLE
fix: Adjust path of favicon-32x32.png asset

### DIFF
--- a/src/Administration/Resources/views/administration/layout/base.html.twig
+++ b/src/Administration/Resources/views/administration/layout/base.html.twig
@@ -13,7 +13,7 @@
     {% block administration_favicons %}
         <link rel="apple-touch-icon" href="{{ asset('administration/static/img/favicon/apple-touch-icon.png', '@Administration') }}">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('administration/static/img/favicon/favicon-16x16.png', '@Administration') }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('sadministration/static/img/favicon/favicon-32x32.png', '@Administration') }}" id="dynamic-favicon">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('administration/static/img/favicon/favicon-32x32.png', '@Administration') }}" id="dynamic-favicon">
         <link rel="icon" type="image/png" sizes="192x192" href="{{ asset('administration/static/img/favicon/android-chrome-192x192.png', '@Administration') }}">
         <link rel="icon" type="image/png" sizes="256x256" href="{{ asset('administration/static/img/favicon/android-chrome-256x256.png', '@Administration') }}">
         <meta name="msapplication-TileImage" content="{{ asset('administration/static/img/favicon/mstile-150x150.png', '@Administration') }}">


### PR DESCRIPTION
Fixes Issue in Administration:
/bundles/administration/sadministration/static/img/favicon/favicon-32x32.png 404 (Not Found)

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Fixes a issue in administration because link is incorrect.

### 2. What does this change do, exactly?

Fixes the link.

### 3. Describe each step to reproduce the issue or behaviour.

Open administration anywhere.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
