### PR TITLE
fix: sidebar sdk handlers sw meteor page

### DIFF
--- a/changelog/_unreleased/2025-07-21-fix-sidebar-sdk-handlers-sw-meteor-page.md
+++ b/changelog/_unreleased/2025-07-21-fix-sidebar-sdk-handlers-sw-meteor-page.md
@@ -1,0 +1,8 @@
+---
+title: Fix sidebar SDK handlers in Meteor page
+author: Dennis Höllmann
+author_email: d.hoellmann@shopware.com
+author_github: @Deristes
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.html.twig` to display sidebar extension buttons correctly.

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/index.ts
@@ -1,0 +1,23 @@
+import template from './sw-app-topbar-sidebar.html.twig';
+import './sw-app-topbar-sidebar.scss';
+
+/**
+ * @sw-package framework
+ *
+ * @private
+ */
+export default {
+    template,
+
+    computed: {
+        sidebars() {
+            return Shopware.Store.get('sidebar').sidebars;
+        },
+    },
+
+    methods: {
+        setActiveSidebar(locationId: string) {
+            Shopware.Store.get('sidebar').setActiveSidebar(locationId);
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.html.twig
@@ -1,0 +1,33 @@
+<template v-if="sidebars && sidebars.length === 1">
+    <button
+        v-tooltip="{ message: sidebars[0].title, placement: 'right' }"
+        class="sw-app-topbar-sidebar__icon"
+        :class="{ 'sw-app-topbar-sidebar__icon-active': sidebars[0].active }"
+        :aria-label="$tc('sidebar.ariaLabelButtonOpen')"
+        @click="setActiveSidebar(sidebars[0].locationId)"
+    >
+        <mt-icon
+            :name="sidebars[0].icon"
+            :size="20"
+        />
+    </button>
+</template>
+
+<template v-if="sidebars.length && sidebars.length > 1">
+    <sw-context-button>
+        <template
+            v-for="sidebar in sidebars"
+            :key="sidebar.title"
+        >
+            <sw-context-menu-item
+                @click="setActiveSidebar(sidebar.locationId)"
+            >
+                <mt-icon
+                    :name="sidebar.icon"
+                    :size="14"
+                />
+                {{ $t(sidebar.title) }}
+            </sw-context-menu-item>
+        </template>
+    </sw-context-button>
+</template>

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.scss
@@ -1,0 +1,14 @@
+.sw-app-topbar-sidebar__icon {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--border-radius-button);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: background-color 0.2s ease-in-out;
+
+    &-active,
+    &:hover {
+        background: var(--color-interaction-secondary-hover);
+    }
+}

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.spec.js
@@ -1,0 +1,43 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+
+async function createWrapper() {
+    return mount(await wrapTestComponent('sw-app-topbar-sidebar', { sync: true }), {
+        global: {
+            stubs: {
+                'sw-context-menu-item': true,
+                'sw-context-button': true,
+            },
+        },
+    });
+}
+
+const sidebar = {
+    locationId: 'example-location-id',
+    title: 'Example Sidebar',
+    icon: 'regular-file',
+    baseUrl: 'https://example.com',
+    active: false,
+};
+
+describe('sw-app-topbar-sidebar', () => {
+    let wrapper = null;
+
+    it('should be a Vue.js component', async () => {
+        wrapper = await createWrapper();
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('should render button correctly', async () => {
+        const store = Shopware.Store.get('sidebar');
+        store.sidebars.push(sidebar);
+
+        wrapper = await createWrapper();
+
+        const button = wrapper.find('button');
+        expect(button.classes()).toContain('sw-app-topbar-sidebar__icon');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/component/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/index.ts
@@ -445,6 +445,7 @@ export default () => {
         () => import('src/app/component/app/sw-app-wrong-app-url-modal/index'),
     );
     Shopware.Component.register('sw-app-topbar-button', () => import('src/app/component/app/sw-app-topbar-button/index'));
+    Shopware.Component.register('sw-app-topbar-sidebar', () => import('src/app/component/app/sw-app-topbar-sidebar/index'));
     Shopware.Component.register(
         'sw-app-app-url-changed-modal',
         () => import('src/app/component/app/sw-app-app-url-changed-modal/index'),

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.html.twig
@@ -26,6 +26,8 @@
                 {% endblock %}
 
                 <sw-help-center-v2 />
+
+                <sw-app-topbar-sidebar />
             </div>
 
             <div class="sw-meteor-page__smart-bar">

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.spec.js
@@ -28,6 +28,7 @@ async function createWrapper(slotsData = {}) {
                 'mt-tabs': true,
                 'sw-extension-component-section': true,
                 'sw-app-topbar-button': true,
+                'sw-app-topbar-sidebar': true,
             },
             mocks: {
                 $route: {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/index.js
@@ -173,10 +173,6 @@ export default {
                 'grid-row': rowNumber,
             };
         },
-
-        sidebars() {
-            return Shopware.Store.get('sidebar').sidebars;
-        },
     },
 
     created() {
@@ -253,10 +249,6 @@ export default {
             if (this.previousPath) {
                 this.previousRoute = this.$router.resolve({ path: this.previousPath }).name;
             }
-        },
-
-        setActiveSidebar(locationId) {
-            Shopware.Store.get('sidebar').setActiveSidebar(locationId);
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.html.twig
@@ -37,44 +37,7 @@
                 <sw-help-center-v2 />
             </div>
 
-            <template v-if="sidebars && sidebars.length === 1">
-                <div class="sw-page__sidebar-container">
-                    <button
-                        v-tooltip="{ message: sidebars[0].title, placement: 'right' }"
-                        class="sw-page__sidebar-icon"
-                        :class="{ 'sw-page__sidebar-icon-active': sidebars[0].active }"
-                        :aria-label="$tc('sidebar.ariaLabelButtonOpen')"
-                        @click="setActiveSidebar(sidebars[0].locationId)"
-                    >
-                        <mt-icon
-                            :name="sidebars[0].icon"
-                            :size="20"
-                        />
-                    </button>
-                </div>
-            </template>
-
-            <template v-if="sidebars.length && sidebars.length > 1">
-                <div class="sw-page__sidebar-container">
-                    <sw-context-button>
-                        <template
-                            v-for="sidebar in sidebars"
-                            :key="sidebar.title"
-                        >
-                            <sw-context-menu-item
-                                @click="setActiveSidebar(sidebar.locationId)"
-                            >
-                                <mt-icon
-                                    :name="sidebar.icon"
-                                    :size="14"
-                                />
-
-                                {{ $t(sidebar.title) }}
-                            </sw-context-menu-item>
-                        </template>
-                    </sw-context-button>
-                </div>
-            </template>
+            <sw-app-topbar-sidebar />
         </div>
         {% endblock %}
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
@@ -213,22 +213,4 @@ $sw-page-search-bar-z-index: $z-index-sw-page-search-bar;
             }
         }
     }
-
-    .sw-page__sidebar-icon {
-        width: 40px;
-        height: 40px;
-        border-radius: var(--border-radius-button);
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        transition: background-color 0.2s ease-in-out;
-
-        &:hover {
-            background: var(--color-interaction-secondary-hover);
-        }
-
-        &-active {
-            background: var(--color-interaction-secondary-hover);
-        }
-    }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.spec.js
@@ -53,6 +53,7 @@ async function createWrapper(route = productDetailRoute) {
                 'sw-context-button': true,
                 'sw-context-menu-item': true,
                 'sw-app-topbar-button': true,
+                'sw-app-topbar-sidebar': true,
             },
             plugins: [router],
             mocks: {

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.spec.js
@@ -86,6 +86,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-customer', () => {
                     }),
                     'sw-bulk-edit-save-modal': await wrapTestComponent('sw-bulk-edit-save-modal', { sync: true }),
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                     'sw-help-center-v2': true,
                     'mt-loader': true,
                     'sw-loader-deprecated': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
@@ -89,6 +89,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-order', () => {
                     'sw-inherit-wrapper': await wrapTestComponent('sw-inherit-wrapper'),
                     'sw-error-summary': true,
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                     'sw-help-center-v2': true,
                     'sw-context-button': true,
                     'sw-inheritance-switch': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
@@ -203,6 +203,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
                     'mt-loader': true,
                     'sw-loader-deprecated': true,
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                     'sw-error-summary': true,
                     'sw-ai-copilot-badge': true,
                     'sw-context-button': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.spec.js
@@ -16,6 +16,7 @@ async function createWrapper(privileges = []) {
                 'sw-extension-component-section': true,
                 'sw-search-bar': true,
                 'sw-app-topbar-button': true,
+                'sw-app-topbar-sidebar': true,
                 'sw-notification-center': true,
                 'sw-help-center-v2': true,
                 'router-link': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
@@ -41,6 +41,7 @@ async function createWrapper(back = null, push = jest.fn()) {
                 },
                 'sw-search-bar': true,
                 'sw-app-topbar-button': true,
+                'sw-app-topbar-sidebar': true,
                 'sw-notification-center': true,
                 'sw-help-center-v2': true,
                 'sw-app-actions': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-app-module-page/sw-extension-app-module-page.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-app-module-page/sw-extension-app-module-page.spec.js
@@ -23,6 +23,7 @@ async function createWrapper(props) {
                 'sw-app-actions': true,
                 'sw-loader': true,
                 'sw-app-topbar-button': true,
+                'sw-app-topbar-sidebar': true,
                 'sw-help-center-v2': true,
                 'sw-context-menu-item': true,
                 'sw-context-button': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/sw-extension-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/sw-extension-config.spec.js
@@ -35,6 +35,7 @@ describe('src/module/sw-extension/page/sw-extension-config.spec', () => {
                     'sw-form-field-renderer': true,
                     'sw-inherit-wrapper': true,
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                     'sw-ai-copilot-badge': true,
                 },
                 provide: {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
@@ -24,6 +24,7 @@ async function createWrapper() {
                     'sw-meteor-navigation': true,
                     'sw-tabs': true,
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                 },
                 mocks: {
                     $route: {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.spec.js
@@ -98,6 +98,7 @@ describe('src/module/sw-order/page/sw-order-create', () => {
             },
             'sw-order-create-invalid-promotion-modal': true,
             'sw-app-topbar-button': true,
+            'sw-app-topbar-sidebar': true,
             'sw-help-center-v2': true,
             'router-link': true,
             'sw-error-summary': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-create/sw-settings-customer-group-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-create/sw-settings-customer-group-create.spec.js
@@ -89,6 +89,7 @@ async function createWrapper() {
                     'sw-highlight-text': true,
                     'sw-skeleton': true,
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                     'router-link': true,
                     'sw-context-menu-item': true,
                     'sw-notification-center-item': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.spec.js
@@ -37,6 +37,7 @@ async function createWrapper() {
                     'sw-error-summary': true,
                     'mt-slider': true,
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                     'sw-notification-center': true,
                     'sw-help-center-v2': true,
                     'router-link': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-list/sw-settings-product-feature-sets-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-list/sw-settings-product-feature-sets-list.spec.js
@@ -47,6 +47,7 @@ async function createWrapper(additionalOptions = {}, privileges = []) {
                     i18n: true,
                     'sw-app-actions': true,
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                     'sw-help-center-v2': true,
                     'sw-bulk-edit-modal': true,
                     'sw-data-grid-column-boolean': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/page/sw-settings-seo/sw-settings-seo.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/page/sw-settings-seo/sw-settings-seo.spec.js
@@ -35,6 +35,7 @@ async function createWrapper() {
                     'sw-skeleton': true,
                     'sw-error-summary': true,
                     'sw-app-topbar-button': true,
+                    'sw-app-topbar-sidebar': true,
                     'sw-help-center-v2': true,
                     'router-link': true,
                     'sw-sales-channel-switch': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.spec.js
@@ -166,6 +166,7 @@ describe('module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-
                         'sw-field-error': true,
                         'sw-base-field': true,
                         'sw-app-topbar-button': true,
+                        'sw-app-topbar-sidebar': true,
                         'sw-help-center-v2': true,
                         'sw-empty-state': true,
                         'sw-data-grid-column-boolean': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/sw-settings-snippet-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/sw-settings-snippet-detail.spec.js
@@ -168,6 +168,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-detail', () => {
                         'sw-loader': true,
                         'sw-error-summary': true,
                         'sw-app-topbar-button': true,
+                        'sw-app-topbar-sidebar': true,
                         'sw-notification-center': true,
                         'sw-help-center-v2': true,
                         'sw-context-menu-item': true,


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the buttons that are added for SDK sidebars are only added on the `sw-page` component, and not on the `sw-meteor-page`. This results to the situation, that the button is not added in the extensions module.

### 2. What does this change do, exactly?
The code for displaying the buttons was factored out of the `sw-page` component into the `sw-app-topbar-sidebar`. This component now gets used by `sw-page` and `sw-meteor-page`.

### 3. Describe each step to reproduce the issue or behaviour.
Open the admin and go to the My extensions module.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
