### PR TITLE
fix: infinity loop in migration when order without delivery or transa…

### DIFF
--- a/src/Core/Migration/V6_7/Migration1728040169AddPrimaryOrderDelivery.php
+++ b/src/Core/Migration/V6_7/Migration1728040169AddPrimaryOrderDelivery.php
@@ -37,7 +37,12 @@ class Migration1728040169AddPrimaryOrderDelivery extends MigrationStep
 
         do {
             $ids = $connection->fetchFirstColumn(
-                'SELECT `id` FROM `order` WHERE `primary_order_delivery_id` IS NULL LIMIT :limit',
+                'SELECT `id` FROM `order` WHERE `primary_order_delivery_id` IS NULL AND EXISTS (
+                 SELECT 1
+                 FROM `order_delivery`
+                 WHERE `order_delivery`.`order_id` = `order`.`id`
+                   AND `order_delivery`.`order_version_id` = `order`.`version_id`
+             ) LIMIT :limit',
                 ['limit' => $updateLimit],
                 ['limit' => ParameterType::INTEGER]
             );

--- a/src/Core/Migration/V6_7/Migration1728040170AddPrimaryOrderTransaction.php
+++ b/src/Core/Migration/V6_7/Migration1728040170AddPrimaryOrderTransaction.php
@@ -37,7 +37,12 @@ class Migration1728040170AddPrimaryOrderTransaction extends MigrationStep
 
         do {
             $ids = $connection->fetchFirstColumn(
-                'SELECT `id` FROM `order` WHERE `primary_order_transaction_id` IS NULL LIMIT :limit',
+                'SELECT `id` FROM `order` WHERE `primary_order_transaction_id` IS NULL AND EXISTS (
+                 SELECT 1
+                 FROM `order_transaction`
+                 WHERE `order_transaction`.`order_id` = `order`.`id`
+                   AND `order_transaction`.`order_version_id` = `order`.`version_id`
+             ) LIMIT :limit',
                 ['limit' => $updateLimit],
                 ['limit' => ParameterType::INTEGER]
             );

--- a/tests/migration/Core/V6_7/Migration1728040169AddPrimaryOrderDeliveryTest.php
+++ b/tests/migration/Core/V6_7/Migration1728040169AddPrimaryOrderDeliveryTest.php
@@ -66,7 +66,32 @@ class Migration1728040169AddPrimaryOrderDeliveryTest extends TestCase
         }
     }
 
-    private function prepareOldDatabaseEntry(): void
+    public function testMigrationWithoutDelivery(): void
+    {
+        $this->rollback();
+        $this->prepareOldDatabaseEntry(false);
+
+        $this->migrate();
+        $this->migrate();
+
+        $manager = $this->connection->createSchemaManager();
+        $columns = $manager->listTableColumns(OrderDefinition::ENTITY_NAME);
+
+        static::assertArrayHasKey('primary_order_delivery_id', $columns);
+        static::assertArrayHasKey('primary_order_delivery_version_id', $columns);
+
+        $query = $this->connection->createQueryBuilder();
+        $query->select('*');
+        $query->from('`order`');
+        $result = $query->executeQuery()->fetchAllAssociative();
+
+        foreach ($result as $row) {
+            static::assertNull($row['primary_order_delivery_id']);
+            static::assertNull($row['primary_order_delivery_version_id']);
+        }
+    }
+
+    private function prepareOldDatabaseEntry(bool $withDelivery = true): void
     {
         $orderId = Uuid::fromHexToBytes(Uuid::randomHex());
         $defaultShippingMethodId = $this->connection->executeQuery('SELECT id FROM shipping_method WHERE active = 1')->fetchOne();
@@ -101,22 +126,24 @@ class Migration1728040169AddPrimaryOrderDeliveryTest extends TestCase
             ]
         );
 
-        $this->connection->insert(
-            '`order_delivery`',
-            [
-                'id' => Uuid::fromHexToBytes(Uuid::randomHex()),
-                'version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
-                'order_id' => $orderId,
-                'order_version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
-                'state_id' => $stateId,
-                'shipping_method_id' => $defaultShippingMethodId,
-                'tracking_codes' => '["code"]',
-                'shipping_date_earliest' => '2020-01-01',
-                'shipping_date_latest' => '2025-01-01',
-                'shipping_costs' => '{}',
-                'created_at' => '2020-01-01',
-            ]
-        );
+        if ($withDelivery) {
+            $this->connection->insert(
+                '`order_delivery`',
+                [
+                    'id' => Uuid::fromHexToBytes(Uuid::randomHex()),
+                    'version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                    'order_id' => $orderId,
+                    'order_version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                    'state_id' => $stateId,
+                    'shipping_method_id' => $defaultShippingMethodId,
+                    'tracking_codes' => '["code"]',
+                    'shipping_date_earliest' => '2020-01-01',
+                    'shipping_date_latest' => '2025-01-01',
+                    'shipping_costs' => '{}',
+                    'created_at' => '2020-01-01',
+                ]
+            );
+        }
     }
 
     private function migrate(): void


### PR DESCRIPTION
Fix the issue from this https://github.com/shopware/shopware/pull/6864

If there are at least 1000 orders that don’t have order_delivery, then at least 1000 order.primary_order_delivery_id is never updated, and so the loop will run forever (same for order without transactions)