### PR TITLE
test: experiment event dispatcher, profiler enabled for symfony 7.3 in integration tests

### DIFF
--- a/tests/integration/Core/Content/ImportExport/ImportExportTest.php
+++ b/tests/integration/Core/Content/ImportExport/ImportExportTest.php
@@ -136,7 +136,7 @@ class ImportExportTest extends AbstractImportExportTestCase
 
     public function testExportEvents(): void
     {
-        $this->getKernel()->getContainer()->get('test.client')->enableProfiler();
+        $this->getContainer()->get('profiler')->enable();
         $this->listener->addSubscriber(new StockSubscriber());
 
         $productId = Uuid::randomHex();
@@ -157,6 +157,7 @@ class ImportExportTest extends AbstractImportExportTestCase
 
     public function testImportEvents(): void
     {
+        $this->getContainer()->get('profiler')->enable();
         $this->listener->addSubscriber(new TestSubscriber());
         $this->importCategoryCsv();
         $events = array_column($this->listener->getCalledListeners(), 'event');
@@ -168,7 +169,6 @@ class ImportExportTest extends AbstractImportExportTestCase
 
     public function testImportExport(): void
     {
-        $this->getKernel()->getContainer()->get('test.client')->enableProfiler();
         $filesystem = static::getContainer()->get('shopware.filesystem.private');
 
         $productId = Uuid::randomHex();

--- a/tests/integration/Core/Service/PermissionsServiceTest.php
+++ b/tests/integration/Core/Service/PermissionsServiceTest.php
@@ -43,7 +43,7 @@ class PermissionsServiceTest extends TestCase
 
     public function testGrantPermissionsIntegration(): void
     {
-        $this->getKernel()->getContainer()->get('test.client')->enableProfiler();
+        $this->getContainer()->get('profiler')->enable();
 
         $revision = '2025-06-13';
 
@@ -70,7 +70,7 @@ class PermissionsServiceTest extends TestCase
 
     public function testRevokePermissionsIntegration(): void
     {
-        $this->getKernel()->getContainer()->get('test.client')->enableProfiler();
+        $this->getContainer()->get('profiler')->enable();
 
         $revision = '2025-06-13';
         $this->permissionsService->grant($revision, $this->context);


### PR DESCRIPTION
### 1. Why is this change necessary?
Experiment about https://github.com/shopware/shopware/pull/11024  

Trying to verify https://github.com/shopware/shopware/pull/11024#discussion_r2219615862

### 2. What does this change do, exactly?

Forces profiler on kernel browser to be active

### 3. Describe each step to reproduce the issue or behaviour.


Do not merge this