### PR TITLE
fix: add deliveryTime to product elasticsearch mapping

### DIFF
--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -316,6 +316,17 @@ class ElasticsearchProductDefinitionTest extends TestCase
                 'customSearchKeywords' => self::TRANSLATABLE_SEARCHABLE_MAPPING,
                 'states' => AbstractElasticsearchDefinition::KEYWORD_FIELD,
                 'manufacturerId' => AbstractElasticsearchDefinition::KEYWORD_FIELD,
+                'deliveryTimeId' => AbstractElasticsearchDefinition::KEYWORD_FIELD,
+                'deliveryTime' => [
+                    'type' => 'nested',
+                    'properties' => [
+                        'id' => AbstractElasticsearchDefinition::KEYWORD_FIELD,
+                        'name' => self::TRANSLATABLE_SEARCHABLE_MAPPING,
+                        '_count' => [
+                            'type' => 'long',
+                        ],
+                    ],
+                ],
             ],
             'dynamic_templates' => [
                 ['cheapest_price' => [
@@ -737,6 +748,7 @@ class ElasticsearchProductDefinitionTest extends TestCase
                         'height' => 4,
                         'length' => 4,
                         'productManufacturerId' => null,
+                        'deliveryTimeId' => null,
                         'manufacturerNumber' => null,
                         'taxId' => 'tax',
                         'displayGroup' => '1',


### PR DESCRIPTION
### 1. Why is this change necessary?

currently the ElasticsearchProductDefinition is missing the deliveryTime which breaks the corresponding filter in product streams. 

### 2. What does this change do, exactly?

Add deliveryTime to ES Definition

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
