### PR TITLE
feat: recursively serialize structs

### DIFF
--- a/changelog/_unreleased/2025-07-22-recursive-serialize-structs.md
+++ b/changelog/_unreleased/2025-07-22-recursive-serialize-structs.md
@@ -1,0 +1,14 @@
+---
+title: Recursively serialize structs
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `Shopware\Core\Framework\Struct\JsonSerializableTrait` and `Shopware\Core\Framework\Struct\Collection` to recursively `jsonSerialize` with 6.8.0.
+___
+# Next Major Version Changes
+## Structs and Collections will recursively serialize
+Structs, entities and collections will be serialized recursively.
+This means that any call to `jsonSerialize()` will result in a nested array, rather than an array that may contain objects that have not yet been serialized.
+To revert to the previous behaviour, use the `getVars()` function for structs and the `getElements()` function for collections.

--- a/src/Core/Checkout/Document/DocumentConfigurationFactory.php
+++ b/src/Core/Checkout/Document/DocumentConfigurationFactory.php
@@ -38,7 +38,7 @@ class DocumentConfigurationFactory
         if (\is_array($additionalConfig)) {
             $additionalConfigArray = $additionalConfig;
         } elseif (\is_object($additionalConfig)) {
-            $additionalConfigArray = $additionalConfig->jsonSerialize();
+            $additionalConfigArray = $additionalConfig->getVars();
         }
 
         $additionalConfigArray = self::cleanConfig($additionalConfigArray);

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/OrderSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/OrderSerializer.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
@@ -33,11 +34,53 @@ class OrderSerializer extends EntitySerializer
 
         yield from parent::serialize($config, $definition, $entity);
 
-        if (isset($entity['lineItems']) && $entity['lineItems'] instanceof OrderLineItemCollection) {
-            $lineItems = $entity['lineItems']->getElements();
-            $modifiedLineItems = [];
+        if (!Feature::isActive('v6.8.0.0')) {
+            if (isset($entity['lineItems']) && $entity['lineItems'] instanceof OrderLineItemCollection) {
+                $lineItems = $entity['lineItems']->getElements();
+                $modifiedLineItems = [];
 
-            foreach ($lineItems as $lineItem) {
+                foreach ($lineItems as $lineItem) {
+                    $lineItem = $lineItem->jsonSerialize();
+
+                    $modifiedLineItems[] = $lineItem['quantity'] . 'x ' . $lineItem['productId'];
+                }
+
+                $entity['lineItems'] = implode('|', $modifiedLineItems);
+            }
+
+            if (isset($entity['deliveries']) && $entity['deliveries'] instanceof OrderDeliveryCollection && $entity['deliveries']->count() > 0) {
+                $entity['deliveries'] = $entity['deliveries']->first()?->jsonSerialize();
+
+                if (!empty($entity['deliveries']['trackingCodes'])) {
+                    $entity['deliveries']['trackingCodes'] = implode('|', $entity['deliveries']['trackingCodes']);
+                }
+            }
+
+            if (isset($entity['transactions']) && $entity['transactions'] instanceof OrderTransactionCollection && $entity['transactions']->count() > 0) {
+                $entity['transactions'] = $entity['transactions']->first()?->jsonSerialize();
+
+                if (!empty($entity['transactions']['stateMachineState']) && $entity['transactions']['stateMachineState'] instanceof StateMachineStateEntity) {
+                    $entity['transactions']['stateMachineState'] = $entity['transactions']['stateMachineState']->jsonSerialize();
+                }
+            }
+
+            if (isset($entity['itemRounding']) && $entity['itemRounding'] instanceof CashRoundingConfig) {
+                $entity['itemRounding'] = $entity['itemRounding']->jsonSerialize();
+            }
+
+            if (isset($entity['totalRounding']) && $entity['totalRounding'] instanceof CashRoundingConfig) {
+                $entity['totalRounding'] = $entity['totalRounding']->jsonSerialize();
+            }
+
+            yield from $entity;
+
+            return;
+        }
+
+
+        if (isset($entity['lineItems']) && \is_array($entity['lineItems'])) {
+            $modifiedLineItems = [];
+            foreach ($entity['lineItems'] as $lineItem) {
                 $lineItem = $lineItem->jsonSerialize();
 
                 $modifiedLineItems[] = $lineItem['quantity'] . 'x ' . $lineItem['productId'];
@@ -46,28 +89,21 @@ class OrderSerializer extends EntitySerializer
             $entity['lineItems'] = implode('|', $modifiedLineItems);
         }
 
-        if (isset($entity['deliveries']) && $entity['deliveries'] instanceof OrderDeliveryCollection && $entity['deliveries']->count() > 0) {
-            $entity['deliveries'] = $entity['deliveries']->first()?->jsonSerialize();
+
+        if (isset($entity['deliveries']) && \is_array($entity['deliveries']) && \count($entity['deliveries']) > 0) {
+            $entity['deliveries'] = $entity['deliveries'][0];
 
             if (!empty($entity['deliveries']['trackingCodes'])) {
                 $entity['deliveries']['trackingCodes'] = implode('|', $entity['deliveries']['trackingCodes']);
             }
         }
 
-        if (isset($entity['transactions']) && $entity['transactions'] instanceof OrderTransactionCollection && $entity['transactions']->count() > 0) {
-            $entity['transactions'] = $entity['transactions']->first()?->jsonSerialize();
+        if (isset($entity['transactions']) && \is_array($entity['transactions']) && \count($entity['transactions']) > 0) {
+            $entity['transactions'] = $entity['transactions'][0];
 
             if (!empty($entity['transactions']['stateMachineState']) && $entity['transactions']['stateMachineState'] instanceof StateMachineStateEntity) {
                 $entity['transactions']['stateMachineState'] = $entity['transactions']['stateMachineState']->jsonSerialize();
             }
-        }
-
-        if (isset($entity['itemRounding']) && $entity['itemRounding'] instanceof CashRoundingConfig) {
-            $entity['itemRounding'] = $entity['itemRounding']->jsonSerialize();
-        }
-
-        if (isset($entity['totalRounding']) && $entity['totalRounding'] instanceof CashRoundingConfig) {
-            $entity['totalRounding'] = $entity['totalRounding']->jsonSerialize();
         }
 
         yield from $entity;

--- a/src/Core/Content/ImportExport/ImportExport.php
+++ b/src/Core/Content/ImportExport/ImportExport.php
@@ -447,7 +447,7 @@ class ImportExport
         $offset = $progress->getOffset();
         foreach ($records as $originalRecord) {
             $originalRecord = $originalRecord instanceof Entity
-                ? $originalRecord->jsonSerialize()
+                ? $originalRecord->getVars()
                 : $originalRecord;
 
             $mappedRecord = [];

--- a/src/Core/Framework/Api/Serializer/Record.php
+++ b/src/Core/Framework/Api/Serializer/Record.php
@@ -179,7 +179,7 @@ class Record implements \JsonSerializable
     {
         $this->id = $entity->getUniqueIdentifier();
 
-        $data = $entity->jsonSerialize();
+        $data = $entity->getVars();
 
         foreach ($this->attributes as $key => $_relationship) {
             $this->attributes[$key] = $data[$key] ?? null;

--- a/src/Core/Framework/Struct/ArrayStruct.php
+++ b/src/Core/Framework/Struct/ArrayStruct.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Struct;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -85,9 +86,13 @@ class ArrayStruct extends Struct implements \ArrayAccess, \IteratorAggregate, \C
         // The key-values pairs from the property $data are now serialized in the JSON property "data".
         // But the key-value pairs from data should appear in the serialization as they were properties of the ArrayStruct itself.
         // Therefore, the key-values moved one level up.
+        $data = $jsonArray['data'];
         unset($jsonArray['data']);
-        $data = $this->data;
-        $this->convertDateTimePropertiesToJsonStringRepresentation($data);
+
+        if (!Feature::isActive('v6.8.0.0')) {
+            $data = $this->data;
+            $this->convertDateTimePropertiesToJsonStringRepresentation($data);
+        }
 
         return array_merge($jsonArray, $data);
     }

--- a/src/Core/Framework/Struct/Collection.php
+++ b/src/Core/Framework/Struct/Collection.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Struct;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 
@@ -157,7 +158,19 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
 
     public function jsonSerialize(): array
     {
-        return array_values($this->elements);
+        $values = array_values($this->elements);
+
+        if (!Feature::isActive('v6.8.0.0')) {
+            return $values;
+        }
+
+        foreach ($values as &$value) {
+            if ($value instanceof \JsonSerializable) {
+                $value = $value->jsonSerialize();
+            }
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Core/Framework/Struct/JsonSerializableTrait.php
+++ b/src/Core/Framework/Struct/JsonSerializableTrait.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Struct;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('framework')]
@@ -14,6 +15,16 @@ trait JsonSerializableTrait
     {
         $vars = get_object_vars($this);
         $this->convertDateTimePropertiesToJsonStringRepresentation($vars);
+
+        if (!Feature::isActive('v6.8.0.0')) {
+            return $vars;
+        }
+
+        foreach ($vars as &$value) {
+            if ($value instanceof \JsonSerializable) {
+                $value = $value->jsonSerialize();
+            }
+        }
 
         return $vars;
     }

--- a/tests/integration/Core/Checkout/Customer/Command/DeleteUnusedGuestCustomersCommandTest.php
+++ b/tests/integration/Core/Checkout/Customer/Command/DeleteUnusedGuestCustomersCommandTest.php
@@ -189,8 +189,8 @@ class DeleteUnusedGuestCustomersCommandTest extends TestCase
         $order = [
             'id' => $orderId,
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),
             'stateId' => static::getContainer()->get(InitialStateIdLoader::class)->get(OrderStates::STATE_MACHINE),

--- a/tests/integration/Core/Checkout/Customer/DeleteUnusedGuestCustomerServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/DeleteUnusedGuestCustomerServiceTest.php
@@ -269,8 +269,8 @@ class DeleteUnusedGuestCustomerServiceTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
@@ -504,8 +504,8 @@ class DocumentControllerTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/Checkout/Document/DocumentGeneratorControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentGeneratorControllerTest.php
@@ -400,8 +400,8 @@ class DocumentGeneratorControllerTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandlerTest.php
+++ b/tests/integration/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandlerTest.php
@@ -186,8 +186,8 @@ class OrderTransactionStateHandlerTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/Checkout/Order/Listener/OrderStateChangeEventListenerTest.php
+++ b/tests/integration/Core/Checkout/Order/Listener/OrderStateChangeEventListenerTest.php
@@ -131,8 +131,8 @@ class OrderStateChangeEventListenerTest extends TestCase
             'stateId' => $this->getStateId('open', 'order.state'),
             'price' => new CartPrice(200, 200, 200, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_GROSS),
             'shippingCosts' => new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()),
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'ruleIds' => [$ids->get('rule')],
             'orderCustomer' => [
                 'id' => $ids->get('order_customer'),

--- a/tests/integration/Core/Checkout/Order/OrderRepositoryTest.php
+++ b/tests/integration/Core/Checkout/Order/OrderRepositoryTest.php
@@ -254,8 +254,8 @@ class OrderRepositoryTest extends TestCase
         $order = [
             [
                 'id' => $orderId,
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
                 'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Checkout/Order/SalesChannel/CancelOrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/CancelOrderRouteTest.php
@@ -163,8 +163,8 @@ class CancelOrderRouteTest extends TestCase
         static::getContainer()->get('order.repository')->create(
             [[
                 'id' => $id,
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
                 'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -606,8 +606,8 @@ class OrderRouteTest extends TestCase
         $order = [
             [
                 'id' => $orderId,
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 'orderNumber' => Uuid::randomHex(),
                 'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/Checkout/Order/SalesChannel/SetPaymentOrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/SetPaymentOrderRouteTest.php
@@ -333,8 +333,8 @@ class SetPaymentOrderRouteTest extends TestCase
         static::getContainer()->get('order.repository')->create(
             [[
                 'id' => $id,
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
                 'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Checkout/Payment/SalesChannel/HandlePaymentMethodRouteResponseTest.php
+++ b/tests/integration/Core/Checkout/Payment/SalesChannel/HandlePaymentMethodRouteResponseTest.php
@@ -156,8 +156,8 @@ class HandlePaymentMethodRouteResponseTest extends TestCase
         $order = [
             'id' => $orderId,
             'orderNumber' => Uuid::randomHex(),
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
+++ b/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
@@ -183,8 +183,8 @@ class PromotionRedemptionUpdaterTest extends TestCase
         static::getContainer()->get('order.repository')->create(
             [[
                 'id' => Uuid::randomHex(),
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
                 'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),
@@ -386,8 +386,8 @@ class PromotionRedemptionUpdaterTest extends TestCase
         static::getContainer()->get('order.repository')->create(
             [[
                 'id' => $this->ids->create('order'),
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
                 'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Content/Flow/GenerateDocumentActionTest.php
+++ b/tests/integration/Core/Content/Flow/GenerateDocumentActionTest.php
@@ -360,8 +360,8 @@ class GenerateDocumentActionTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/Content/Flow/RemoveOrderTagActionTest.php
+++ b/tests/integration/Core/Content/Flow/RemoveOrderTagActionTest.php
@@ -160,8 +160,8 @@ class RemoveOrderTagActionTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -787,8 +787,8 @@ class SendMailActionTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/Content/MailTemplate/Api/MailActionControllerTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Api/MailActionControllerTest.php
@@ -167,8 +167,8 @@ class MailActionControllerTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
@@ -599,8 +599,8 @@ class MediaRepositoryTest extends TestCase
 
         return [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceTest.php
@@ -95,8 +95,8 @@ class CheapestPriceTest extends TestCase
                 'symbol' => 'T',
                 'isoCode' => 'TTT',
                 'position' => 3,
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 'shortName' => 'TE',
                 'name' => 'Test',
             ];

--- a/tests/integration/Core/Content/Product/Repository/ProductRepositoryTest.php
+++ b/tests/integration/Core/Content/Product/Repository/ProductRepositoryTest.php
@@ -124,8 +124,8 @@ class ProductRepositoryTest extends TestCase
                     'symbol' => 'A',
                     'isoCode' => 'XX',
                     'decimalPrecision' => 2,
-                    'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                    'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                    'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                    'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 ],
             ],
             $this->context
@@ -2634,8 +2634,8 @@ class ProductRepositoryTest extends TestCase
                     'symbol' => 'DM',
                     'isoCode' => $isoCode,
                     'decimalPrecision' => 2,
-                    'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                    'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                    'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                    'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 ],
             ],
             Context::createDefaultContext()

--- a/tests/integration/Core/Framework/Api/Sync/SyncServiceTest.php
+++ b/tests/integration/Core/Framework/Api/Sync/SyncServiceTest.php
@@ -123,8 +123,8 @@ class SyncServiceTest extends TestCase
             'name' => 'test',
             'factor' => 2,
             'symbol' => '€',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'shortName' => 'TEST',
         ];
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -918,8 +918,8 @@ class AttributeEntityIntegrationTest extends TestCase
             'symbol' => '€',
             'isoCode' => $iso,
             'shortName' => 'Euro',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
         ];
     }
 
@@ -932,8 +932,8 @@ class AttributeEntityIntegrationTest extends TestCase
 
         return [
             'id' => $id,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => '2024-05-06 12:34:56',
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
@@ -237,8 +237,8 @@ class EntityForeignKeyResolverTest extends TestCase
         $data = [
             'id' => $ids->create('order' . $i),
             'billingAddressId' => $ids->create('billing-address' . $i),
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'currencyId' => Defaults::CURRENCY,
             'languageId' => Defaults::LANGUAGE_SYSTEM,
             'salesChannelId' => TestDefaults::SALES_CHANNEL,

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
@@ -141,8 +141,8 @@ class CreatedByFieldTest extends TestCase
 
         return [
             'id' => Uuid::randomHex(),
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/PriceFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/PriceFieldTest.php
@@ -261,8 +261,8 @@ EOF;
             'symbol' => 'A',
             'shortName' => 'A',
             'isoCode' => 'A',
-            'itemRounding' => json_decode(json_encode($rounding, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode($rounding, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => $rounding->jsonSerialize(),
+            'totalRounding' => $rounding->jsonSerialize(),
         ];
 
         static::getContainer()
@@ -495,8 +495,8 @@ EOF;
             'symbol' => 'A',
             'shortName' => 'A',
             'isoCode' => 'A',
-            'itemRounding' => json_decode(json_encode($rounding, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode($rounding, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => $rounding->jsonSerialize(),
+            'totalRounding' => $rounding->jsonSerialize(),
         ];
 
         static::getContainer()

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/RemoteAddressFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/RemoteAddressFieldTest.php
@@ -149,8 +149,8 @@ class RemoteAddressFieldTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
@@ -139,8 +139,8 @@ class UpdatedByFieldTest extends TestCase
 
         return [
             'id' => Uuid::randomHex(),
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/StateMachineSateFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/StateMachineSateFieldSerializerTest.php
@@ -108,8 +108,8 @@ class StateMachineSateFieldSerializerTest extends TestCase
 
         return [
             'id' => Uuid::randomHex(),
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningCustomFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningCustomFieldTest.php
@@ -108,8 +108,8 @@ class VersioningCustomFieldTest extends TestCase
         return [
             'id' => $orderId,
             'versionId' => $orderVersionId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'customerId' => Uuid::randomHex(),
             'billingAddressId' => Uuid::randomHex(),
             'currencyId' => Defaults::CURRENCY,

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/TranslationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/TranslationTest.php
@@ -90,8 +90,8 @@ class TranslationTest extends TestCase
             'symbol' => '$',
             'decimalPrecision' => 2,
             'isoCode' => 'FOO',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'translations' => [
                 'en-GB' => [
                     'name' => 'US Dollar',
@@ -129,8 +129,8 @@ class TranslationTest extends TestCase
             'decimalPrecision' => 2,
             'symbol' => '$',
             'isoCode' => 'FOO',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'translations' => [
                 [
                     'languageId' => Defaults::LANGUAGE_SYSTEM,
@@ -171,8 +171,8 @@ class TranslationTest extends TestCase
             'decimalPrecision' => 2,
             'symbol' => '$',
             'isoCode' => 'FOO',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'translations' => [
                 'en-GB' => [
                     'name' => $name,
@@ -214,8 +214,8 @@ class TranslationTest extends TestCase
             'decimalPrecision' => 2,
             'symbol' => '$',
             'isoCode' => 'FOO',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'translations' => [
                 'en-GB' => [
                     'shortName' => $shortName,
@@ -279,8 +279,8 @@ class TranslationTest extends TestCase
             'factor' => 1,
             'decimalPrecision' => 2,
             'symbol' => '$',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'isoCode' => 'FOO',
             'translations' => [
                 'en-GB' => [
@@ -332,8 +332,8 @@ class TranslationTest extends TestCase
             'symbol' => '$',
             'decimalPrecision' => 2,
             'isoCode' => 'FOO',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'translations' => [
                 'en-GB' => [
                     'name' => $englishName,
@@ -382,8 +382,8 @@ class TranslationTest extends TestCase
             'symbol' => '$',
             'decimalPrecision' => 2,
             'isoCode' => 'BAR',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'translations' => [
                 Defaults::LANGUAGE_SYSTEM => [
                     'name' => 'default',
@@ -428,8 +428,8 @@ class TranslationTest extends TestCase
             'symbol' => '$',
             'decimalPrecision' => 2,
             'isoCode' => 'TST',
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'translations' => [
                 Defaults::LANGUAGE_SYSTEM => [
                     'name' => 'US Dollar',

--- a/tests/integration/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommandTest.php
+++ b/tests/integration/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommandTest.php
@@ -230,8 +230,8 @@ class CleanPersonalDataCommandTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/tests/integration/Core/System/Currency/Repository/CurrencyRepositoryTest.php
+++ b/tests/integration/Core/System/Currency/Repository/CurrencyRepositoryTest.php
@@ -49,8 +49,8 @@ class CurrencyRepositoryTest extends TestCase
                 'shortName' => 'test',
                 'factor' => 1,
                 'symbol' => 'A',
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             ],
             [
                 'id' => $recordB,
@@ -60,8 +60,8 @@ class CurrencyRepositoryTest extends TestCase
                 'shortName' => 'match',
                 'factor' => 1,
                 'symbol' => 'A',
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             ],
         ];
 
@@ -109,8 +109,8 @@ class CurrencyRepositoryTest extends TestCase
                 'shortName' => 'test',
                 'factor' => 1,
                 'symbol' => 'A',
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             ],
         ];
 

--- a/tests/integration/Core/System/Currency/SalesChannel/CurrencyRouteTest.php
+++ b/tests/integration/Core/System/Currency/SalesChannel/CurrencyRouteTest.php
@@ -104,8 +104,8 @@ class CurrencyRouteTest extends TestCase
                 'shortName' => 'test',
                 'factor' => 1,
                 'symbol' => 'A',
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             ],
             [
                 'id' => $this->ids->create('currency2'),
@@ -115,8 +115,8 @@ class CurrencyRouteTest extends TestCase
                 'shortName' => 'yay',
                 'factor' => 1,
                 'symbol' => 'B',
-                'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             ],
         ];
 

--- a/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextRestorerTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextRestorerTest.php
@@ -163,8 +163,8 @@ class SalesChannelContextRestorerTest extends TestCase
 
         $data = [
             'id' => $ids->create('order'),
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'billingAddressId' => $ids->create('billing-address'),
             'currencyId' => Defaults::CURRENCY,

--- a/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
+++ b/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
@@ -335,8 +335,8 @@ class StateMachineActionControllerTest extends TestCase
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderNumber' => Uuid::randomHex(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -236,8 +236,8 @@ EOF;
 
         $order = [
             'id' => $orderId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(
                 10,

--- a/tests/integration/Core/System/Tag/Service/FilterTagIdsServiceTest.php
+++ b/tests/integration/Core/System/Tag/Service/FilterTagIdsServiceTest.php
@@ -347,8 +347,8 @@ class FilterTagIdsServiceTest extends TestCase
         return [
             'id' => $orderId,
             'versionId' => $orderVersionId,
-            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+            'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
             'customerId' => Uuid::randomHex(),
             'billingAddressId' => Uuid::randomHex(),
             'currencyId' => Defaults::CURRENCY,

--- a/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
+++ b/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
@@ -225,8 +225,8 @@ class ElasticsearchProductTest extends TestCase
                     'decimalPrecision' => 2,
                     'shortName' => 'A',
                     'isoCode' => 'A',
-                    'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.05, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                    'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.05, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                    'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                    'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 ],
                 [
                     'id' => $this->anotherCurrencyId,
@@ -236,8 +236,8 @@ class ElasticsearchProductTest extends TestCase
                     'decimalPrecision' => 2,
                     'shortName' => 'B',
                     'isoCode' => 'B',
-                    'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.05, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
-                    'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.05, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+                    'itemRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
+                    'totalRounding' => (new CashRoundingConfig(2, 0.01, true))->jsonSerialize(),
                 ],
             ];
 

--- a/tests/unit/Core/Content/Property/PropertySortTest.php
+++ b/tests/unit/Core/Content/Property/PropertySortTest.php
@@ -37,7 +37,7 @@ class PropertySortTest extends TestCase
         $propertyGroups->sortByConfig();
         $propertyGroup = $propertyGroups->first();
         static::assertNotNull($propertyGroup);
-        $propertyOptionsArray = json_decode(json_encode($propertyGroup->getOptions(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+        $propertyOptionsArray = $propertyGroup->getOptions()->jsonSerialize();
 
         $equalsArray = [];
         for ($x = 0; $x < 50; ++$x) {
@@ -59,7 +59,7 @@ class PropertySortTest extends TestCase
         $propertyGroups->sortByConfig();
         $propertyGroup = $propertyGroups->first();
         static::assertNotNull($propertyGroup);
-        $propertyOptionsArray = json_decode(json_encode($propertyGroup->getOptions(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+        $propertyOptionsArray = $propertyGroup->getOptions()->jsonSerialize();
 
         $equalsArray = [];
         $letterArray = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
@@ -82,7 +82,7 @@ class PropertySortTest extends TestCase
         $propertyGroups->sortByConfig();
         $propertyGroup = $propertyGroups->first();
         static::assertNotNull($propertyGroup);
-        $propertyOptionsArray = json_decode(json_encode($propertyGroup->getOptions(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+        $propertyOptionsArray = $propertyGroup->getOptions()->jsonSerialize();
 
         $equalsArray = [];
         for ($x = 10; $x < 20; ++$x) {
@@ -104,7 +104,7 @@ class PropertySortTest extends TestCase
         $propertyGroups->sortByConfig();
         $propertyGroup = $propertyGroups->first();
         static::assertNotNull($propertyGroup);
-        $propertyOptionsArray = json_decode(json_encode($propertyGroup->getOptions(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+        $propertyOptionsArray = $propertyGroup->getOptions()->jsonSerialize();
 
         static::assertSame(
             $this->notShuffledPosition,
@@ -121,7 +121,7 @@ class PropertySortTest extends TestCase
         $propertyGroups->sortByConfig();
         $propertyGroup = $propertyGroups->first();
         static::assertNotNull($propertyGroup);
-        $propertyOptionsArray = json_decode(json_encode($propertyGroup->getOptions(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+        $propertyOptionsArray = $propertyGroup->getOptions()->jsonSerialize();
 
         static::assertSame(
             $this->notShuffledName,
@@ -279,7 +279,7 @@ class PropertySortTest extends TestCase
             $propertyOptions[] = $propertyOption;
         }
         $this->notShuffledName = ['1a', '2aa', '3-x$e', '3d', '3e', '20aa', '44f', '55g', 'h6', 'i7', 'j2'];
-        $this->notShuffledPosition = array_column(json_decode(json_encode($propertyOptions, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR), 'position');
+        $this->notShuffledPosition = array_column(\array_map(fn ($option) => $option->jsonSerialize(), $propertyOptions), 'position');
         shuffle($propertyOptions);
 
         return new PropertyGroupOptionCollection($propertyOptions);

--- a/tests/unit/Core/Framework/App/Payload/AppPayloadServiceHelperTest.php
+++ b/tests/unit/Core/Framework/App/Payload/AppPayloadServiceHelperTest.php
@@ -98,7 +98,7 @@ class AppPayloadServiceHelperTest extends TestCase
 
         $array = $appPayloadServiceHelper->encode($payload);
 
-        static::assertSame(['source' => $source, 'cart' => $cart, 'context' => []], $array);
+        static::assertSame(['source' => $source->jsonSerialize(), 'cart' => $cart->jsonSerialize(), 'context' => []], $array);
     }
 
     public function testCreateRequestOptionsWithNoParams(): void
@@ -136,7 +136,7 @@ class AppPayloadServiceHelperTest extends TestCase
 
         $jsonPayload = $appPayloadServiceHelper->createRequestOptions($payload, $app, $context)->jsonSerialize();
 
-        static::assertSame($context, $jsonPayload[AuthMiddleware::APP_REQUEST_CONTEXT]);
+        static::assertSame($context->jsonSerialize(), $jsonPayload[AuthMiddleware::APP_REQUEST_CONTEXT]);
         static::assertSame('top-secret', $jsonPayload[AuthMiddleware::APP_REQUEST_TYPE][AuthMiddleware::APP_SECRET]);
         static::assertSame(['Content-Type' => 'application/json'], $jsonPayload['headers']);
         static::assertJsonStringEqualsJsonString('{"key":"value"}', $jsonPayload['body']);
@@ -177,7 +177,7 @@ class AppPayloadServiceHelperTest extends TestCase
 
         $jsonPayload = $appPayloadServiceHelper->createRequestOptions($payload, $app, $context, ['timeout' => 50])->jsonSerialize();
 
-        static::assertSame($context, $jsonPayload[AuthMiddleware::APP_REQUEST_CONTEXT]);
+        static::assertSame($context->jsonSerialize(), $jsonPayload[AuthMiddleware::APP_REQUEST_CONTEXT]);
         static::assertSame('top-secret', $jsonPayload[AuthMiddleware::APP_REQUEST_TYPE][AuthMiddleware::APP_SECRET]);
         static::assertSame(['Content-Type' => 'application/json'], $jsonPayload['headers']);
         static::assertArrayHasKey('timeout', $jsonPayload);

--- a/tests/unit/Core/Framework/App/Payment/Payload/PaymentPayloadServiceTest.php
+++ b/tests/unit/Core/Framework/App/Payment/Payload/PaymentPayloadServiceTest.php
@@ -129,7 +129,7 @@ class PaymentPayloadServiceTest extends TestCase
             ->expects($this->once())
             ->method('request')
             ->with('POST', 'http://example.com', [
-                AuthMiddleware::APP_REQUEST_CONTEXT => $context,
+                AuthMiddleware::APP_REQUEST_CONTEXT => $context->jsonSerialize(),
                 AuthMiddleware::APP_REQUEST_TYPE => [
                     AuthMiddleware::APP_SECRET => 'secret',
                     AuthMiddleware::VALIDATED_RESPONSE => true,

--- a/tests/unit/Core/Framework/Struct/CollectionTest.php
+++ b/tests/unit/Core/Framework/Struct/CollectionTest.php
@@ -239,8 +239,8 @@ class CollectionTest extends TestCase
     public function testJsonSerializeWithObjects(): void
     {
         $collection = new TestCollection();
-        $collection->add(new TestEntity('name-1', 'value-1'));
-        $collection->add(new TestEntity('name-2', 'value-2'));
+        $collection->add(new CollectionTestEntity('name-1', 'value-1'));
+        $collection->add(new CollectionTestEntity('name-2', 'value-2'));
 
         static::assertEquals(
             [
@@ -264,7 +264,7 @@ class TestCollection extends Collection
 /**
  * @internal
  */
-class TestEntity extends Struct
+class CollectionTestEntity extends Struct
 {
     public function __construct(
         protected string $name,

--- a/tests/unit/Core/Framework/Struct/CollectionTest.php
+++ b/tests/unit/Core/Framework/Struct/CollectionTest.php
@@ -235,6 +235,21 @@ class CollectionTest extends TestCase
         $collection->add('a3');
         static::assertSame('a1', $collection->firstWhere(fn ($element) => str_starts_with($element, 'a')));
     }
+
+    public function testJsonSerializeWithObjects(): void
+    {
+        $collection = new TestCollection();
+        $collection->add(new TestEntity('name-1', 'value-1'));
+        $collection->add(new TestEntity('name-2', 'value-2'));
+
+        static::assertEquals(
+            [
+                ['name' => 'name-1', 'value' => 'value-1', 'extensions' => []],
+                ['name' => 'name-2', 'value' => 'value-2', 'extensions' => []],
+            ],
+            $collection->jsonSerialize(),
+        );
+    }
 }
 
 /**
@@ -244,4 +259,16 @@ class CollectionTest extends TestCase
  */
 class TestCollection extends Collection
 {
+}
+
+/**
+ * @internal
+ */
+class TestEntity extends Struct
+{
+    public function __construct(
+        protected string $name,
+        protected string $value,
+    ) {
+    }
 }

--- a/tests/unit/Core/Framework/Struct/JsonSerializableTraitTest.php
+++ b/tests/unit/Core/Framework/Struct/JsonSerializableTraitTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct;
+
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\JsonSerializableTrait;
+use Shopware\Core\Framework\Struct\Struct;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversTrait(JsonSerializableTrait::class)]
+class JsonSerializableTraitTest extends TestCase
+{
+    public function test(): void
+    {
+        static::assertEquals(
+            [
+                'value' => 1,
+                'testEntity' => [
+                    'name' => 'example-name',
+                    'nonStruct' => ['non-struct-key' => 'non-struct-value'],
+                    'createdAt' => '2025-01-01T00:00:00.000+00:00',
+                    'extensions' => [],
+                ],
+            ],
+            (new SerializableClass())->jsonSerialize(),
+        );
+    }
+}
+
+/**
+ * @internal
+ */
+class NonStruct implements \JsonSerializable
+{
+    public function jsonSerialize(): array
+    {
+        return ['non-struct-key' => 'non-struct-value'];
+    }
+}
+
+/**
+ * @internal
+ */
+class TestEntity extends Struct
+{
+    public function __construct(
+        private string $state = 'unprocessed',
+        protected string $name = 'example-name',
+        protected NonStruct $nonStruct = new NonStruct(),
+        public \DateTimeInterface $createdAt = new \DateTimeImmutable('2025-01-01T00:00:00.000+00:00'),
+    ) {
+    }
+}
+
+/**
+ * @internal
+ */
+class SerializableClass implements \JsonSerializable
+{
+    use JsonSerializableTrait;
+
+    public function __construct(
+        protected int $value = 1,
+        protected TestEntity $testEntity = new TestEntity()
+    ) {
+    }
+}

--- a/tests/unit/Core/Framework/Struct/JsonSerializableTraitTest.php
+++ b/tests/unit/Core/Framework/Struct/JsonSerializableTraitTest.php
@@ -27,7 +27,7 @@ class JsonSerializableTraitTest extends TestCase
                     'extensions' => [],
                 ],
             ],
-            (new SerializableClass())->jsonSerialize(),
+            (new JsonSerializableTraitTestSerializableClass())->jsonSerialize(),
         );
     }
 }
@@ -35,7 +35,7 @@ class JsonSerializableTraitTest extends TestCase
 /**
  * @internal
  */
-class NonStruct implements \JsonSerializable
+class JsonSerializableTraitTestNonStruct implements \JsonSerializable
 {
     public function jsonSerialize(): array
     {
@@ -46,13 +46,13 @@ class NonStruct implements \JsonSerializable
 /**
  * @internal
  */
-class TestEntity extends Struct
+class JsonSerializableTraitTestEntity extends Struct
 {
     public function __construct(
         private string $state = 'unprocessed',
         protected string $name = 'example-name',
-        protected NonStruct $nonStruct = new NonStruct(),
-        public \DateTimeInterface $createdAt = new \DateTimeImmutable('2025-01-01T00:00:00.000+00:00'),
+        protected JsonSerializableTraitTestNonStruct $nonStruct = new JsonSerializableTraitTestNonStruct(),
+        public \DateTimeInterface $createdAt = new \DateTimeImmutable('2025-01-01'),
     ) {
     }
 }
@@ -60,13 +60,13 @@ class TestEntity extends Struct
 /**
  * @internal
  */
-class SerializableClass implements \JsonSerializable
+class JsonSerializableTraitTestSerializableClass implements \JsonSerializable
 {
     use JsonSerializableTrait;
 
     public function __construct(
         protected int $value = 1,
-        protected TestEntity $testEntity = new TestEntity()
+        protected JsonSerializableTraitTestEntity $testEntity = new JsonSerializableTraitTestEntity()
     ) {
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When calling `jsonSerialize` you would expect that the object including any nested ones are serialized into an array.
This is currently not the case, instead `jsonSerialize` behaves like `get_object_vars`, `Struct::getVars()` or `Collection::getElements()`. The changed behaviour is desired to get a pure array of data.

Additionally, we could eliminate some calls to the function `json_decode(json_encode())`, which were used to overcome the issue of missing serialized objects. There are also cases where you want to pass an entity or collection to `EntityRepository::upsert()` but cannot because of the objects that are not serialized.

### 2. What does this change do, exactly?
Iterate over values and serialize objects too, if they implement `jsonSerialize`.

### 3. Describe each step to reproduce the issue or behaviour.
See tests

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
