### PR TITLE
fix: Media thumbnail sizes with mediaThumbnailSizeId

### DIFF
--- a/changelog/_unreleased/2025-07-22-fix-media-thumbnail-sizes-with-media-thumbnail-size-id.md
+++ b/changelog/_unreleased/2025-07-22-fix-media-thumbnail-sizes-with-media-thumbnail-size-id.md
@@ -1,0 +1,9 @@
+---
+title: Fix media thumbnail sizes with mediaThumbnailSizeId
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Added `mediaThumbnailSizeId` field to `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailDefinition`
+* Changed `Shopware\Core\Content\Media\Thumbnail\ThumbnailService` to correctly check thumbnail existing by size id & insert correct media with and height into database

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Media\Aggregate\MediaThumbnail;
 
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeDefinition;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -55,12 +56,14 @@ class MediaThumbnailDefinition extends EntityDefinition
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
 
             (new FkField('media_id', 'mediaId', MediaDefinition::class))->addFlags(new ApiAware(), new Required()),
+            (new FkField('media_thumbnail_size_id', 'mediaThumbnailSizeId', MediaThumbnailSizeDefinition::class))->addFlags(new Required()),
 
             (new IntField('width', 'width'))->addFlags(new ApiAware(), new Required(), new WriteProtected(Context::SYSTEM_SCOPE)),
             (new IntField('height', 'height'))->addFlags(new ApiAware(), new Required(), new WriteProtected(Context::SYSTEM_SCOPE)),
             (new StringField('url', 'url'))->addFlags(new ApiAware(), new Runtime(['path', 'updatedAt'])),
             (new StringField('path', 'path'))->addFlags(new ApiAware()),
             new ManyToOneAssociationField('media', 'media_id', MediaDefinition::class, 'id', false),
+            new ManyToOneAssociationField('mediaThumbnailSize', 'media_thumbnail_size_id', MediaThumbnailSizeDefinition::class, 'id', false),
             (new CustomFields())->addFlags(new ApiAware()),
         ]);
     }

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Media\Aggregate\MediaThumbnail;
 
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeEntity;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
@@ -29,6 +30,10 @@ class MediaThumbnailEntity extends Entity
     protected ?string $mediaId;
 
     protected ?MediaEntity $media = null;
+
+    protected string $mediaThumbnailSizeId;
+
+    protected ?MediaThumbnailSizeEntity $mediaThumbnailSize = null;
 
     public function assign(array $options)
     {
@@ -105,6 +110,26 @@ class MediaThumbnailEntity extends Entity
     public function setMedia(MediaEntity $media): void
     {
         $this->media = $media;
+    }
+
+    public function getMediaThumbnailSizeId(): string
+    {
+        return $this->mediaThumbnailSizeId;
+    }
+
+    public function setMediaThumbnailSizeId(string $mediaThumbnailSizeId): void
+    {
+        $this->mediaThumbnailSizeId = $mediaThumbnailSizeId;
+    }
+
+    public function getMediaThumbnailSize(): ?MediaThumbnailSizeEntity
+    {
+        return $this->mediaThumbnailSize;
+    }
+
+    public function setMediaThumbnailSize(MediaThumbnailSizeEntity $mediaThumbnailSize): void
+    {
+        $this->mediaThumbnailSize = $mediaThumbnailSize;
     }
 
     public function getIdentifier(): string

--- a/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeDefinition.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize;
 
 use Shopware\Core\Content\Media\Aggregate\MediaFolderConfiguration\MediaFolderConfigurationDefinition;
 use Shopware\Core\Content\Media\Aggregate\MediaFolderConfigurationMediaThumbnailSize\MediaFolderConfigurationMediaThumbnailSizeDefinition;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
@@ -12,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
@@ -47,6 +49,7 @@ class MediaThumbnailSizeDefinition extends EntityDefinition
             (new IntField('width', 'width', 1))->addFlags(new ApiAware(), new Required()),
             (new IntField('height', 'height', 1))->addFlags(new ApiAware(), new Required()),
             new ManyToManyAssociationField('mediaFolderConfigurations', MediaFolderConfigurationDefinition::class, MediaFolderConfigurationMediaThumbnailSizeDefinition::class, 'media_thumbnail_size_id', 'media_folder_configuration_id'),
+            new OneToManyAssociationField('mediaThumbnails', MediaThumbnailDefinition::class, 'media_thumbnail_size_id', 'id'),
             (new CustomFields())->addFlags(new ApiAware()),
         ]);
     }

--- a/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeEntity.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize;
 
 use Shopware\Core\Content\Media\Aggregate\MediaFolderConfiguration\MediaFolderConfigurationCollection;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
@@ -25,6 +26,8 @@ class MediaThumbnailSizeEntity extends Entity
     protected int $height;
 
     protected ?MediaFolderConfigurationCollection $mediaFolderConfigurations = null;
+
+    protected ?MediaThumbnailCollection $mediaThumbnails = null;
 
     /**
      * @return int<1, max>
@@ -66,5 +69,15 @@ class MediaThumbnailSizeEntity extends Entity
     public function setMediaFolderConfigurations(MediaFolderConfigurationCollection $mediaFolderConfigurations): void
     {
         $this->mediaFolderConfigurations = $mediaFolderConfigurations;
+    }
+
+    public function getMediaThumbnails(): ?MediaThumbnailCollection
+    {
+        return $this->mediaThumbnails;
+    }
+
+    public function setMediaThumbnails(MediaThumbnailCollection $mediaThumbnails): void
+    {
+        $this->mediaThumbnails = $mediaThumbnails;
     }
 }

--- a/src/Core/Content/Test/Media/MediaFixtures.php
+++ b/src/Core/Content/Test/Media/MediaFixtures.php
@@ -3,11 +3,15 @@
 namespace Shopware\Core\Content\Test\Media;
 
 use PHPUnit\Framework\Attributes\Before;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeCollection;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeEntity;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaType\BinaryType;
 use Shopware\Core\Content\Media\MediaType\DocumentType;
 use Shopware\Core\Content\Media\MediaType\ImageType;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Integration\Traits\EntityFixturesBase;
 
@@ -23,11 +27,25 @@ trait MediaFixtures
      */
     public array $mediaFixtures;
 
+    public string $thumbnailSize150Id;
+
+    public string $thumbnailSize200Id;
+
+    public string $thumbnailSize300Id;
+
     #[Before]
     public function initializeMediaFixtures(): void
     {
-        $thumbnailSize150Id = Uuid::randomHex();
-        $thumbnailSize300Id = Uuid::randomHex();
+        $this->thumbnailSize150Id = Uuid::randomHex();
+        $this->thumbnailSize300Id = Uuid::randomHex();
+
+        // Media thumbnail size 200 is a default size which already exists in the database, to prevent duplicate entries we use the existing one.
+        /** @var EntityRepository<MediaThumbnailSizeCollection> */
+        $mediaThumbnailSizeRepository = static::getFixtureRepository('media_thumbnail_size');
+        $mediaThumbnailSizes = $mediaThumbnailSizeRepository->search(new Criteria(), $this->entityFixtureContext)->getEntities();
+        $this->thumbnailSize200Id = $mediaThumbnailSizes->filter(
+            static fn (MediaThumbnailSizeEntity $size) => $size->getWidth() === 200 && $size->getHeight() === 200
+        )->first()?->getId() ?? Uuid::randomHex();
 
         $this->mediaFixtures = [
             'NamedEmpty' => [
@@ -85,6 +103,7 @@ trait MediaFixtures
                         'width' => 200,
                         'height' => 200,
                         'highDpi' => false,
+                        'mediaThumbnailSizeId' => $this->thumbnailSize200Id,
                     ],
                 ],
             ],
@@ -143,12 +162,12 @@ trait MediaFixtures
                         'thumbnailQuality' => 80,
                         'mediaThumbnailSizes' => [
                             [
-                                'id' => $thumbnailSize150Id,
+                                'id' => $this->thumbnailSize150Id,
                                 'width' => 150,
                                 'height' => 150,
                             ],
                             [
-                                'id' => $thumbnailSize300Id,
+                                'id' => $this->thumbnailSize300Id,
                                 'width' => 300,
                                 'height' => 300,
                             ],
@@ -173,12 +192,12 @@ trait MediaFixtures
                         'thumbnailQuality' => 80,
                         'mediaThumbnailSizes' => [
                             [
-                                'id' => $thumbnailSize150Id,
+                                'id' => $this->thumbnailSize150Id,
                                 'width' => 150,
                                 'height' => 150,
                             ],
                             [
-                                'id' => $thumbnailSize300Id,
+                                'id' => $this->thumbnailSize300Id,
                                 'width' => 300,
                                 'height' => 300,
                             ],
@@ -202,7 +221,6 @@ trait MediaFixtures
                     ],
                 ],
             ],
-
             'NamedMimePngEtxPngWithFolderHugeThumbnails' => [
                 'id' => Uuid::randomHex(),
                 'mimeType' => 'image/png',
@@ -221,12 +239,12 @@ trait MediaFixtures
                         'thumbnailQuality' => 80,
                         'mediaThumbnailSizes' => [
                             [
-                                'id' => $thumbnailSize150Id,
+                                'id' => $this->thumbnailSize150Id,
                                 'width' => 1500,
                                 'height' => 1500,
                             ],
                             [
-                                'id' => $thumbnailSize300Id,
+                                'id' => $this->thumbnailSize300Id,
                                 'width' => 3000,
                                 'height' => 3000,
                             ],

--- a/src/Core/Migration/V6_7/Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnail.php
+++ b/src/Core/Migration/V6_7/Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnail.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+class Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnail extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1753191228;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if (!$this->columnExists($connection, 'media_thumbnail', 'media_thumbnail_size_id')) {
+            $this->addColumn($connection, 'media_thumbnail', 'media_thumbnail_size_id', 'BINARY(16)');
+        }
+
+        $this->migrateMediaThumbnailRows($connection);
+
+        $connection->executeStatement('
+            ALTER TABLE `media_thumbnail`
+            MODIFY COLUMN `media_thumbnail_size_id` BINARY(16) NOT NULL
+        ');
+
+        if ($this->indexExists($connection, 'media_thumbnail', 'fk.media_thumbnail.media_thumbnail_size_id')) {
+            return;
+        }
+
+        $connection->executeStatement('
+            ALTER TABLE `media_thumbnail`
+            ADD CONSTRAINT `fk.media_thumbnail.media_thumbnail_size_id`
+            FOREIGN KEY (`media_thumbnail_size_id`)
+            REFERENCES `media_thumbnail_size` (`id`)
+            ON DELETE RESTRICT ON UPDATE CASCADE
+        ');
+
+        $this->registerIndexer($connection, 'media.indexer');
+    }
+
+    private function migrateMediaThumbnailRows(Connection $connection): void
+    {
+        $batchSize = 10000;
+
+        do {
+            $affected = $connection->executeStatement('
+                UPDATE `media_thumbnail`
+                SET media_thumbnail_size_id = (
+                    SELECT size.id
+                    FROM `media_thumbnail_size` AS size
+                    WHERE size.width = media_thumbnail.width
+                    AND size.height = media_thumbnail.height
+                    LIMIT 1
+                )
+                WHERE media_thumbnail_size_id IS NULL
+                AND EXISTS (
+                    SELECT 1
+                    FROM `media_thumbnail_size` AS size
+                    WHERE size.width = media_thumbnail.width
+                    AND size.height = media_thumbnail.height
+                )
+                LIMIT ' . $batchSize);
+        } while ($affected > 0);
+
+        /** @var int */
+        $invalidCount = $connection->fetchOne('
+            SELECT COUNT(*)
+            FROM `media_thumbnail`
+            WHERE media_thumbnail_size_id IS NULL
+        ');
+
+        if (!$invalidCount) {
+            return;
+        }
+
+        /** @var ?string */
+        $fallbackId = $connection->fetchOne('SELECT id FROM media_thumbnail_size WHERE width = 0 AND height = 0');
+        if (!$fallbackId) {
+            $fallbackId = Uuid::randomBytes();
+
+            $connection->executeStatement('
+                INSERT INTO `media_thumbnail_size` (`id`, `width`, `height`, `created_at`)
+                VALUES (:id, 0, 0, NOW())
+            ', ['id' => $fallbackId]);
+        }
+
+        do {
+            $affected = $connection->executeStatement('
+                UPDATE `media_thumbnail`
+                SET media_thumbnail_size_id = :id
+                WHERE media_thumbnail_size_id IS NULL
+                LIMIT ' . $batchSize, [
+                'id' => $fallbackId,
+            ]);
+        } while ($affected > 0);
+    }
+}

--- a/src/Core/Test/Integration/Traits/EntityFixturesBase.php
+++ b/src/Core/Test/Integration/Traits/EntityFixturesBase.php
@@ -33,8 +33,6 @@ trait EntityFixturesBase
 
     public static function getFixtureRepository(string $fixtureName): EntityRepository
     {
-        self::ensureATransactionIsActive();
-
         $container = KernelLifecycleManager::getKernel()->getContainer();
 
         if ($container->has('test.service_container')) {

--- a/tests/integration/Core/Content/Media/Core/Application/MediaPathUpdaterTest.php
+++ b/tests/integration/Core/Content/Media/Core/Application/MediaPathUpdaterTest.php
@@ -64,6 +64,20 @@ class MediaPathUpdaterTest extends TestCase
 
         $inserts = new MultiInsertQueryQueue(static::getContainer()->get(Connection::class));
 
+        $inserts->addInsert('media_thumbnail_size', [
+            'id' => $ids->getBytes('thumbnail-size-1'),
+            'width' => 100,
+            'height' => 100,
+            'created_at' => '2022-01-01',
+        ]);
+
+        $inserts->addInsert('media_thumbnail_size', [
+            'id' => $ids->getBytes('thumbnail-size-2'),
+            'width' => 240,
+            'height' => 240,
+            'created_at' => '2022-01-01',
+        ]);
+
         $inserts->addInsert('media', [
             'id' => $ids->getBytes('media-1'),
             'file_name' => 'test-file-1',
@@ -76,6 +90,7 @@ class MediaPathUpdaterTest extends TestCase
             'media_id' => $ids->getBytes('media-1'),
             'width' => 100,
             'height' => 100,
+            'media_thumbnail_size_id' => $ids->getBytes('thumbnail-size-1'),
             'created_at' => '2022-01-01',
         ]);
         $inserts->addInsert('media_thumbnail', [
@@ -83,6 +98,7 @@ class MediaPathUpdaterTest extends TestCase
             'media_id' => $ids->getBytes('media-1'),
             'width' => 240,
             'height' => 240,
+            'media_thumbnail_size_id' => $ids->getBytes('thumbnail-size-2'),
             'created_at' => '2022-01-01',
         ]);
 

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
@@ -117,6 +117,10 @@ class MediaRepositoryTest extends TestCase
                             'width' => 100,
                             'height' => 200,
                             'highDpi' => false,
+                            'mediaThumbnailSize' => [
+                                'width' => 100,
+                                'height' => 200,
+                            ],
                         ],
                     ],
                 ],
@@ -178,6 +182,10 @@ class MediaRepositoryTest extends TestCase
                                 'width' => 100,
                                 'height' => 200,
                                 'highDpi' => true,
+                                'mediaThumbnailSize' => [
+                                    'width' => 100,
+                                    'height' => 200,
+                                ],
                             ],
                         ],
                         'mediaFolder' => [
@@ -302,6 +310,10 @@ class MediaRepositoryTest extends TestCase
                             'width' => 100,
                             'height' => 200,
                             'highDpi' => true,
+                            'mediaThumbnailSize' => [
+                                'width' => 100,
+                                'height' => 200,
+                            ],
                         ],
                     ],
                 ],

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaThumbnailRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaThumbnailRepositoryTest.php
@@ -19,6 +19,22 @@ class MediaThumbnailRepositoryTest extends TestCase
     use IntegrationTestBehaviour;
     use QueueTestBehaviour;
 
+    private string $mediaThumbnailSizeId;
+
+    protected function setUp(): void
+    {
+        $this->mediaThumbnailSizeId = Uuid::randomHex();
+
+        $sizeData = [
+            'id' => $this->mediaThumbnailSizeId,
+            'width' => 100,
+            'height' => 200,
+        ];
+
+        static::getContainer()->get('media_thumbnail_size.repository')
+            ->create([$sizeData], Context::createDefaultContext());
+    }
+
     #[DataProvider('deleteThumbnailProvider')]
     public function testDeleteThumbnail(bool $private): void
     {
@@ -62,6 +78,7 @@ class MediaThumbnailRepositoryTest extends TestCase
                         'width' => 100,
                         'height' => 200,
                         'highDpi' => false,
+                        'mediaThumbnailSizeId' => $this->mediaThumbnailSizeId,
                     ],
                 ],
             ],
@@ -83,6 +100,7 @@ class MediaThumbnailRepositoryTest extends TestCase
             'width' => 100,
             'height' => 200,
             'path' => 'foo/bar.png',
+            'mediaThumbnailSizeId' => $this->mediaThumbnailSizeId,
         ];
 
         static::getContainer()->get('media_thumbnail.repository')

--- a/tests/integration/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/integration/Core/Content/Media/File/FileSaverTest.php
@@ -532,6 +532,10 @@ class FileSaverTest extends TestCase
                     'width' => 100,
                     'height' => 100,
                     'highDpi' => false,
+                    'mediaThumbnailSize' => [
+                        'width' => 100,
+                        'height' => 100,
+                    ],
                 ],
             ],
         ]], $context);

--- a/tests/integration/Core/Content/Media/Infrastructure/Command/UpdatePathTest.php
+++ b/tests/integration/Core/Content/Media/Infrastructure/Command/UpdatePathTest.php
@@ -32,10 +32,11 @@ class UpdatePathTest extends TestCase
     /**
      * @param array<mixed> $media
      * @param array<mixed> $thumbnail
+     * @param array<mixed> $mediaThumbnailSize
      * @param array<string, string> $expected
      */
     #[DataProvider('commandProvider')]
-    public function testCommand(array $media, array $thumbnail, ArrayInput $input, array $expected): void
+    public function testCommand(array $media, array $thumbnail, array $mediaThumbnailSize, ArrayInput $input, array $expected): void
     {
         $ids = new IdsCollection();
 
@@ -44,8 +45,12 @@ class UpdatePathTest extends TestCase
         $media['id'] = $ids->getBytes('media');
         $queue->addInsert('media', $media);
 
+        $mediaThumbnailSize['id'] = $ids->getBytes('media_thumbnail_size');
+        $queue->addInsert('media_thumbnail_size', $mediaThumbnailSize);
+
         $thumbnail['id'] = $ids->getBytes('media_thumbnail');
         $thumbnail['media_id'] = $ids->getBytes('media');
+        $thumbnail['media_thumbnail_size_id'] = $ids->getBytes('media_thumbnail_size');
         $queue->addInsert('media_thumbnail', $thumbnail);
 
         $queue->execute();
@@ -97,6 +102,11 @@ class UpdatePathTest extends TestCase
                 'height' => 100,
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             ],
+            [
+                'width' => 100,
+                'height' => 100,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ],
             new ArrayInput([]),
             [
                 'media' => 'media/test.png',
@@ -117,6 +127,11 @@ class UpdatePathTest extends TestCase
                 'path' => 'foo/test_100x100.png',
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             ],
+            [
+                'width' => 100,
+                'height' => 100,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ],
             new ArrayInput([]),
             [
                 'media' => 'foo/test.png',
@@ -135,6 +150,11 @@ class UpdatePathTest extends TestCase
                 'width' => 100,
                 'height' => 100,
                 'path' => 'foo/test_100x100.png',
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ],
+            [
+                'width' => 100,
+                'height' => 100,
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             ],
             new ArrayInput(['--force' => true]),

--- a/tests/integration/Core/Content/Media/Infrastructure/Path/MediaPathStorageTest.php
+++ b/tests/integration/Core/Content/Media/Infrastructure/Path/MediaPathStorageTest.php
@@ -62,11 +62,19 @@ class MediaPathStorageTest extends TestCase
             'created_at' => '2022-01-01',
         ]);
 
+        $inserts->addInsert('media_thumbnail_size', [
+            'id' => $ids->getBytes('thumbnail-size-1'),
+            'width' => 100,
+            'height' => 100,
+            'created_at' => '2022-01-01',
+        ]);
+
         $inserts->addInsert('media_thumbnail', [
             'id' => $ids->getBytes('media_thumbnail'),
             'media_id' => $ids->getBytes('media'),
             'width' => 100,
             'height' => 100,
+            'media_thumbnail_size_id' => $ids->getBytes('thumbnail-size-1'),
             'created_at' => '2022-01-01',
         ]);
 

--- a/tests/integration/Core/Content/Media/Message/GenerateThumbnailsHandlerTest.php
+++ b/tests/integration/Core/Content/Media/Message/GenerateThumbnailsHandlerTest.php
@@ -65,11 +65,16 @@ class GenerateThumbnailsHandlerTest extends TestCase
                 'mediaId' => $media->getId(),
                 'width' => 987,
                 'height' => 987,
+                'mediaThumbnailSize' => [
+                    'width' => 987,
+                    'height' => 987,
+                ],
             ],
             [
                 'mediaId' => $media->getId(),
                 'width' => 150,
                 'height' => 150,
+                'mediaThumbnailSizeId' => $this->thumbnailSize150Id,
             ],
         ], $this->context);
 
@@ -97,9 +102,10 @@ class GenerateThumbnailsHandlerTest extends TestCase
         static::assertCount(2, $mediaThumbnailCollection);
 
         foreach ($mediaThumbnailCollection as $thumbnail) {
+            // Keep aspect ratio is true so the width and height can differ from the media thumbnail size configuration
             static::assertTrue(
-                ($thumbnail->getWidth() === 300 && $thumbnail->getHeight() === 300)
-                || ($thumbnail->getWidth() === 150 && $thumbnail->getHeight() === 150)
+                ($thumbnail->getWidth() === 300 && $thumbnail->getHeight() === 160)
+                || ($thumbnail->getWidth() === 150 && $thumbnail->getHeight() === 80)
             );
 
             $path = $thumbnail->getPath();
@@ -124,6 +130,10 @@ class GenerateThumbnailsHandlerTest extends TestCase
                 'mediaId' => $media->getId(),
                 'width' => 987,
                 'height' => 987,
+                'mediaThumbnailSize' => [
+                    'width' => 987,
+                    'height' => 987,
+                ],
             ],
         ], $this->context);
 
@@ -154,9 +164,10 @@ class GenerateThumbnailsHandlerTest extends TestCase
         static::assertCount(2, $mediaThumbnailCollection);
 
         foreach ($mediaThumbnailCollection as $thumbnail) {
+            // Keep aspect ratio is true so the width and height can differ from the media thumbnail size configuration
             static::assertTrue(
-                ($thumbnail->getWidth() === 300 && $thumbnail->getHeight() === 300)
-                || ($thumbnail->getWidth() === 150 && $thumbnail->getHeight() === 150)
+                ($thumbnail->getWidth() === 300 && $thumbnail->getHeight() === 160)
+                || ($thumbnail->getWidth() === 150 && $thumbnail->getHeight() === 80)
             );
 
             $path = $thumbnail->getPath();

--- a/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -111,7 +111,7 @@ class ThumbnailServiceTest extends TestCase
             static::assertInstanceOf(MediaThumbnailSizeCollection::class, $sizes);
 
             $filtered = $sizes->filter(
-                fn (MediaThumbnailSizeEntity $size) => $size->getWidth() === $thumbnail->getWidth() && $size->getHeight() === $thumbnail->getHeight()
+                fn (MediaThumbnailSizeEntity $size) => $size->getId() === $thumbnail->getMediaThumbnailSizeId()
             );
 
             static::assertCount(1, $filtered);
@@ -178,7 +178,8 @@ class ThumbnailServiceTest extends TestCase
         $media->getMediaFolder()->getConfiguration()->setMediaThumbnailSizes(
             new MediaThumbnailSizeCollection([
                 (new MediaThumbnailSizeEntity())->assign([
-                    'id' => Uuid::randomHex(),
+                    // Use a dummy existing thumbnail size ID to prevent foreign key constraint violation
+                    'id' => $this->thumbnailSize200Id,
                     'width' => 1530,
                     'height' => 1530,
                 ]),
@@ -267,12 +268,20 @@ class ThumbnailServiceTest extends TestCase
                             'height' => 100,
                             'path' => 'foo/thumb_100x100.png',
                             'highDpi' => false,
+                            'mediaThumbnailSize' => [
+                                'width' => 100,
+                                'height' => 100,
+                            ],
                         ],
                         [
                             'width' => 300,
                             'height' => 300,
                             'path' => 'foo/thumb_300x300.png',
                             'highDpi' => true,
+                            'mediaThumbnailSize' => [
+                                'width' => 300,
+                                'height' => 300,
+                            ],
                         ],
                     ],
                 ],
@@ -373,11 +382,16 @@ class ThumbnailServiceTest extends TestCase
                 'mediaId' => $media->getId(),
                 'width' => 987,
                 'height' => 987,
+                'mediaThumbnailSize' => [
+                    'width' => 987,
+                    'height' => 987,
+                ],
             ],
             [
                 'mediaId' => $media->getId(),
                 'width' => 150,
                 'height' => 150,
+                'mediaThumbnailSizeId' => $this->thumbnailSize150Id,
             ],
         ], $this->context);
 
@@ -411,8 +425,9 @@ class ThumbnailServiceTest extends TestCase
         static::assertInstanceOf(MediaThumbnailCollection::class, $thumbnails);
         static::assertCount(2, $thumbnails);
 
-        $filteredThumbnails = $thumbnails->filter(fn (MediaThumbnailEntity $thumbnail) => ($thumbnail->getWidth() === 300 && $thumbnail->getHeight() === 300)
-            || ($thumbnail->getWidth() === 150 && $thumbnail->getHeight() === 150));
+        // Keep aspect ratio is true so the width and height can differ from the media thumbnail size configuration
+        $filteredThumbnails = $thumbnails->filter(fn (MediaThumbnailEntity $thumbnail) => ($thumbnail->getWidth() === 300 && $thumbnail->getHeight() === 160)
+            || ($thumbnail->getWidth() === 150 && $thumbnail->getHeight() === 80));
 
         static::assertCount(2, $filteredThumbnails);
 
@@ -439,11 +454,19 @@ class ThumbnailServiceTest extends TestCase
                 'mediaId' => $media->getId(),
                 'width' => 150,
                 'height' => 150,
+                'mediaThumbnailSize' => [
+                    'width' => 150,
+                    'height' => 150,
+                ],
             ],
             [
                 'mediaId' => $media->getId(),
                 'width' => 300,
                 'height' => 300,
+                'mediaThumbnailSize' => [
+                    'width' => 300,
+                    'height' => 300,
+                ],
             ],
         ], $this->context);
 
@@ -507,11 +530,16 @@ class ThumbnailServiceTest extends TestCase
                 'mediaId' => $media->getId(),
                 'width' => 987,
                 'height' => 987,
+                'mediaThumbnailSize' => [
+                    'width' => 987,
+                    'height' => 987,
+                ],
             ],
             [
                 'mediaId' => $media->getId(),
                 'width' => 150,
                 'height' => 150,
+                'mediaThumbnailSizeId' => $this->thumbnailSize150Id,
             ],
         ], $this->context);
 
@@ -548,8 +576,9 @@ class ThumbnailServiceTest extends TestCase
         static::assertInstanceOf(MediaThumbnailCollection::class, $thumbnails);
         static::assertCount(2, $thumbnails);
 
-        $filteredThumbnails = $thumbnails->filter(fn (MediaThumbnailEntity $thumbnail) => ($thumbnail->getWidth() === 300 && $thumbnail->getHeight() === 300)
-            || ($thumbnail->getWidth() === 150 && $thumbnail->getHeight() === 150));
+        // Keep aspect ratio is true so the width and height can differ from the media thumbnail size configuration
+        $filteredThumbnails = $thumbnails->filter(fn (MediaThumbnailEntity $thumbnail) => ($thumbnail->getWidth() === 300 && $thumbnail->getHeight() === 160)
+            || ($thumbnail->getWidth() === 150 && $thumbnail->getHeight() === 80));
 
         static::assertCount(2, $filteredThumbnails);
 
@@ -586,6 +615,7 @@ class ThumbnailServiceTest extends TestCase
                 'mediaId' => $media->getId(),
                 'width' => 200,
                 'height' => 200,
+                'mediaThumbnailSizeId' => $this->thumbnailSize200Id,
             ],
         ], $this->context);
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -2024,9 +2024,9 @@ class EntityReaderTest extends TestCase
                     'id' => $ids->get('media'),
                     'name' => 'test-image',
                     'thumbnails' => [
-                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 10, 'height' => 10, 'highDpi' => true],
-                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 20, 'height' => 20, 'highDpi' => true],
-                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 30, 'height' => 30, 'highDpi' => true],
+                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 10, 'height' => 10, 'highDpi' => true, 'mediaThumbnailSize' => ['width' => 10, 'height' => 10]],
+                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 20, 'height' => 20, 'highDpi' => true, 'mediaThumbnailSize' => ['width' => 20, 'height' => 20]],
+                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 30, 'height' => 30, 'highDpi' => true, 'mediaThumbnailSize' => ['width' => 30, 'height' => 30]],
                     ],
                 ],
             ],

--- a/tests/migration/Core/V6_7/Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnailTest.php
+++ b/tests/migration/Core/V6_7/Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnailTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_7\Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnail;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnail::class)]
+class Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnailTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testMigration(): void
+    {
+        $connection = $this->getContainer()->get(Connection::class);
+
+        $this->revertMigration($connection);
+
+        $migration = new Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnail();
+        $migration->update($connection);
+        $migration->update($connection);
+
+        $manager = $connection->createSchemaManager();
+        $columns = $manager->listTableColumns('media_thumbnail');
+
+        static::assertArrayHasKey('media_thumbnail_size_id', $columns);
+        static::assertTrue($columns['media_thumbnail_size_id']->getNotnull());
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1753191228, (new Migration1753191228AddMediaThumbnailSizeIdToMediaThumbnail())->getCreationTimestamp());
+    }
+
+    private function revertMigration(Connection $connection): void
+    {
+        $connection->executeStatement('ALTER TABLE `media_thumbnail` DROP FOREIGN KEY `fk.media_thumbnail.media_thumbnail_size_id`');
+        $connection->executeStatement('ALTER TABLE `media_thumbnail` DROP COLUMN `media_thumbnail_size_id`');
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently, if you generate thumbnails with the keepAspectRatio flag the width & height of the thumbnail is not correctly saved to the database
- Currently the existing and to-generate thumbnails in the thumbnail service are compared by the width & height, which doesn't allow for a match check, if the final sizes doesn't match the configuration if the keepAspectRatio flag was used

### 2. What does this change do, exactly?
* Added `mediaThumbnailSizeId` field to `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailDefinition`
* Changed `Shopware\Core\Content\Media\Thumbnail\ThumbnailService` to correctly check thumbnail existing by size id & insert correct media with and height into database

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
