### PR TITLE
fix: Customer logout process will lose all sessions

### DIFF
--- a/changelog/_unreleased/2025-07-23-fix-customer-logout-lose-sessions.md
+++ b/changelog/_unreleased/2025-07-23-fix-customer-logout-lose-sessions.md
@@ -1,0 +1,9 @@
+---
+title: Fix customer logout process will lose all sessions
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute` to no longer replace the current `sales_channel_api_context` in the database (This will prevent multiple session logouts)
+* Changed `Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute` to correctly dispatch the `SalesChannelContextTokenChangeEvent` for the context token switch

--- a/src/Core/Checkout/Customer/SalesChannel/LogoutRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LogoutRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\ContextTokenResponse;
+use Shopware\Core\System\SalesChannel\Event\SalesChannelContextTokenChangeEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Routing\Attribute\Route;
@@ -44,13 +45,16 @@ class LogoutRoute extends AbstractLogoutRoute
         if ($this->shouldDelete($context)) {
             $this->cartService->deleteCart($context);
             $this->contextPersister->delete($context->getToken(), $context->getSalesChannelId());
-        } else {
-            $this->contextPersister->replace($context->getToken(), $context);
         }
 
+        $oldToken = $context->getToken();
+        $newToken = Random::getAlphanumericString(32);
+
         $context->assign([
-            'token' => Random::getAlphanumericString(32),
+            'token' => $newToken,
         ]);
+
+        $this->eventDispatcher->dispatch(new SalesChannelContextTokenChangeEvent($context, $oldToken, $newToken));
 
         $event = new CustomerLogoutEvent($context, $customer);
         $this->eventDispatcher->dispatch($event);


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently if you login with one account on multiple devices and logout on one of them later you will lose your session on all devices, as the token in the database will be rewritten to a new token, while the old one no longer exists
- Also currently the SalesChannelContextTokenChangeEvent is not dispatched if the context is completely deleted

### 2. What does this change do, exactly?
* Changed `Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute` to no longer replace the current `sales_channel_api_context` in the database (This will prevent multiple session logouts)
* Changed `Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute` to correctly dispatch the `SalesChannelContextTokenChangeEvent` for the context token switch

### 3. Describe each step to reproduce the issue or behaviour.
- Login with the same account on multiple devices
- Logout on one device
- All devices will lose their account session and must log in again

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
