### PR TITLE
fix: remove command shortcut key for macos

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
@@ -26,8 +26,8 @@ export default {
 
             // The 'this' context is the component instance, bound via .call()
             const systemKey = this.$device.getSystemKey();
-            const { key, altKey, ctrlKey, metaKey } = event;
-            const systemKeyPressed = systemKey === 'CTRL' ? ctrlKey || metaKey : altKey;
+            const { key, altKey, ctrlKey } = event;
+            const systemKeyPressed = systemKey === 'CTRL' ? ctrlKey : altKey;
 
             // create combined key name and look for matching shortcut
             const combinedKey = `${systemKeyPressed ? 'SYSTEMKEY+' : ''}${key.toUpperCase()}`;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

resolves https://github.com/shopware/shopware/issues/11318

### 2. What does this change do, exactly?

disables command key from triggering admin shortcuts on MacOS

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
