### PR TITLE
feat: Add constants to global Shopware object

### DIFF
--- a/changelog/_unreleased/2025-07-23-add-constants-to-global-shopware-object.md
+++ b/changelog/_unreleased/2025-07-23-add-constants-to-global-shopware-object.md
@@ -1,0 +1,8 @@
+---
+title: Add constants to global Shopware object
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Added `Constants` object containing `CMS`, `CUSTOMER` and `FLOW` constants to the global `Shopware` object and replaced all imports by using the `Shopware.Constants` directly instead.

--- a/src/Administration/Resources/app/administration/src/core/shopware.ts
+++ b/src/Administration/Resources/app/administration/src/core/shopware.ts
@@ -47,6 +47,9 @@ import Store from 'src/app/store';
 import { createExtendableSetup, overrideComponentSetup } from 'src/app/adapter/composition-extension-system';
 import * as Vue from 'vue';
 import type { DefineComponent, Ref } from 'vue';
+import CMS from '../module/sw-cms/constant/sw-cms.constant';
+import CUSTOMER from '../module/sw-customer/constant/sw-customer.constant';
+import FLOW from '../module/sw-flow/constant/flow.constant';
 import InAppPurchase from './in-app-purchase';
 import ExtensionApi from './extension-api';
 import { LineItemType } from '../module/sw-order/order.types';
@@ -277,6 +280,12 @@ class ShopwareClass implements CustomShopwareProperties {
             FilterFactory: ModuleFilterFactory,
         },
     };
+
+    public Constants: CustomShopwareConstants = {
+        CMS: CMS,
+        CUSTOMER: CUSTOMER,
+        FLOW: FLOW,
+    } as CustomShopwareConstants;
 
     public Helper = {
         FlatTreeHelper: FlatTreeHelper,

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -138,6 +138,9 @@ import type { SwBulkStore } from './app/store/sw-bulk-edit.store';
 import type createTextEditorDataMappingButton from './app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-cms-data-mapping';
 import type SsoSettingsService from './core/service/api/sso-settings.service';
 import type SsoInvitationService from './core/service/api/sso-invitation.service';
+import type CMSConstant from './module/sw-cms/constant/sw-cms.constant';
+import type CUSTOMERConstant from './module/sw-customer/constant/sw-customer.constant';
+import type FLOWConstant from './module/sw-flow/constant/flow.constant';
 
 // trick to make it an "external module" to support global type extension
 
@@ -193,6 +196,12 @@ declare global {
     type Remove<T, K extends keyof T> = T & { [P in K]?: never };
 
     interface CustomShopwareProperties {}
+
+    interface CustomShopwareConstants {
+        CMS: typeof CMSConstant;
+        CUSTOMER: typeof CUSTOMERConstant;
+        FLOW: typeof FLOWConstant;
+    }
 
     /**
      * Make the Shopware object globally available

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-bubble-row/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-bubble-row/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -38,7 +36,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -53,7 +51,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },
@@ -68,7 +66,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-cover/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-cover/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewMountain,
+                        value: Shopware.Constants.CMS.MEDIA.previewMountain,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-four-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-four-column/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -51,7 +49,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },
@@ -65,7 +63,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },
@@ -79,7 +77,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewMountain,
+                        value: Shopware.Constants.CMS.MEDIA.previewMountain,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-gallery/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-gallery/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -41,21 +39,21 @@ Shopware.Service('cmsService').registerCmsBlock({
                                 url: null,
                                 newTab: false,
                                 mediaId: null,
-                                fileName: CMS.MEDIA.previewMountain,
+                                fileName: Shopware.Constants.CMS.MEDIA.previewMountain,
                                 mediaUrl: null,
                             },
                             {
                                 url: null,
                                 newTab: false,
                                 mediaId: null,
-                                fileName: CMS.MEDIA.previewGlasses,
+                                fileName: Shopware.Constants.CMS.MEDIA.previewGlasses,
                                 mediaUrl: null,
                             },
                             {
                                 url: null,
                                 newTab: false,
                                 mediaId: null,
-                                fileName: CMS.MEDIA.previewPlant,
+                                fileName: Shopware.Constants.CMS.MEDIA.previewPlant,
                                 mediaUrl: null,
                             },
                         ],

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-highlight-row/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-highlight-row/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -38,7 +36,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -52,7 +50,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },
@@ -66,7 +64,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-simple-grid/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-simple-grid/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -51,7 +49,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },
@@ -65,7 +63,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-slider/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-slider/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -41,7 +39,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                                 url: null,
                                 newTab: false,
                                 mediaId: null,
-                                fileName: CMS.MEDIA.previewMountain,
+                                fileName: Shopware.Constants.CMS.MEDIA.previewMountain,
                                 mediaUrl: null,
                             },
                         ],

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-three-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-three-column/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -51,7 +49,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },
@@ -65,7 +63,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-three-cover/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-three-cover/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -51,7 +49,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },
@@ -65,7 +63,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-two-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-two-column/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -51,7 +49,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewMountain,
+                        value: Shopware.Constants.CMS.MEDIA.previewMountain,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/sidebar-filter/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/sidebar-filter/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -20,7 +18,7 @@ Shopware.Service('cmsService').registerCmsBlock({
     category: 'sidebar',
     component: 'sw-cms-block-sidebar-filter',
     previewComponent: 'sw-cms-preview-sidebar-filter',
-    allowedPageTypes: [CMS.PAGE_TYPES.LISTING],
+    allowedPageTypes: [Shopware.Constants.CMS.PAGE_TYPES.LISTING],
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/center-text/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/center-text/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -68,7 +66,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-bubble/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-bubble/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -38,7 +36,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -69,7 +67,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },
@@ -100,7 +98,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-cover/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-cover/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewMountain,
+                        value: Shopware.Constants.CMS.MEDIA.previewMountain,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-gallery/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-gallery/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -67,7 +65,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },
@@ -97,7 +95,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-row/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-row/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewCamera,
+                        value: Shopware.Constants.CMS.MEDIA.previewCamera,
                         source: 'default',
                     },
                 },
@@ -67,7 +65,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewPlant,
+                        value: Shopware.Constants.CMS.MEDIA.previewPlant,
                         source: 'default',
                     },
                 },
@@ -97,7 +95,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewGlasses,
+                        value: Shopware.Constants.CMS.MEDIA.previewGlasses,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -37,7 +35,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewMountain,
+                        value: Shopware.Constants.CMS.MEDIA.previewMountain,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/text-on-image/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/text-on-image/index.ts
@@ -2,12 +2,6 @@
  * @private
  * @sw-package discovery
  */
-import CMS from '../../../constant/sw-cms.constant';
-
-/**
- * @private
- * @sw-package discovery
- */
 Shopware.Component.register('sw-cms-preview-text-on-image', () => import('./preview'));
 
 /**
@@ -53,7 +47,7 @@ Shopware.Service('cmsService').registerCmsBlock({
                 },
                 data: {
                     media: {
-                        value: CMS.MEDIA.previewMountain,
+                        value: Shopware.Constants.CMS.MEDIA.previewMountain,
                         source: 'default',
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
@@ -1,6 +1,5 @@
 import template from './sw-cms-page-form.html.twig';
 import './sw-cms-page-form.scss';
-import CMS from '../../constant/sw-cms.constant';
 
 /**
  * @private
@@ -33,7 +32,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         slotPositions() {
-            return CMS.SLOT_POSITIONS as { [key: string]: number };
+            return Shopware.Constants.CMS.SLOT_POSITIONS as { [key: string]: number };
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
@@ -1,5 +1,4 @@
 import template from './sw-cms-sidebar.html.twig';
-import CMS from '../../constant/sw-cms.constant';
 import './sw-cms-sidebar.scss';
 import { type PageType } from '../../service/cms-page-type.service';
 import type MediaUploadResult from '../../shared/MediaUploadResult';
@@ -9,6 +8,7 @@ const { mapPropertyErrors } = Component.getComponentHelper();
 const { Criteria } = Shopware.Data;
 const { cloneDeep } = Shopware.Utils.object;
 const types = Shopware.Utils.types;
+const { CMS } = Shopware.Constants;
 
 type DraggableBlock = Entity<'cms_block'> & {
     isDragging?: boolean;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/component/index.js
@@ -1,8 +1,8 @@
-import CMS from '../../../constant/sw-cms.constant';
 import template from './sw-cms-el-image-gallery.html.twig';
 import './sw-cms-el-image-gallery.scss';
 
 const { Mixin, Filter } = Shopware;
+const { CMS } = Shopware.Constants;
 
 /**
  * @private

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/index.js
@@ -1,8 +1,8 @@
-import CMS from '../../../constant/sw-cms.constant';
 import template from './sw-cms-el-image.html.twig';
 import './sw-cms-el-image.scss';
 
 const { Mixin, Filter } = Shopware;
+const { CMS } = Shopware.Constants;
 
 /**
  * @private

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-filter/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-filter/index.ts
@@ -1,5 +1,3 @@
-import CMS from '../../constant/sw-cms.constant';
-
 /**
  * @private
  * @sw-package discovery
@@ -26,6 +24,6 @@ Shopware.Service('cmsService').registerCmsElement({
     component: 'sw-cms-el-sidebar-filter',
     configComponent: 'sw-cms-el-config-sidebar-filter',
     previewComponent: 'sw-cms-el-preview-sidebar-filter',
-    allowedPageTypes: [CMS.PAGE_TYPES.LISTING],
+    allowedPageTypes: [Shopware.Constants.CMS.PAGE_TYPES.LISTING],
     disabledConfigInfoTextKey: 'sw-cms.elements.sidebarFilter.infoText.filterElement',
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -1,5 +1,4 @@
 import template from './sw-cms-detail.html.twig';
-import CMS from '../../constant/sw-cms.constant';
 import './sw-cms-detail.scss';
 
 const { Component, Mixin, Utils } = Shopware;
@@ -10,6 +9,7 @@ const { cloneDeep, getObjectDiff } = Shopware.Utils.object;
 const { isEmpty } = Shopware.Utils.types;
 const { warn } = Shopware.Utils.debug;
 const { Criteria } = Shopware.Data;
+const { CMS } = Shopware.Constants;
 const debounceTimeout = 800;
 
 /**

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -3,11 +3,12 @@
  */
 import { mount } from '@vue/test-utils';
 
-import CMS from 'src/module/sw-cms/constant/sw-cms.constant';
 import EntityCollection from 'src/core/data/entity-collection.data';
 import Criteria from 'src/core/data/criteria.data';
 import 'src/module/sw-cms/mixin/sw-cms-state.mixin';
 import CmsPageTypeService from '../../../sw-cms/service/cms-page-type.service';
+
+const { CMS } = Shopware.Constants;
 
 const categoryID = 'TEST-CATEGORY-ID';
 const productID = 'TEST-PRODUCT-ID';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.spec.js
@@ -4,7 +4,8 @@
 import 'src/module/sw-cms/service/cms.service';
 import 'src/module/sw-cms/mixin/sw-cms-element.mixin';
 import Entity from 'src/core/data/entity.data';
-import CMS from 'src/module/sw-cms/constant/sw-cms.constant';
+
+const { CMS } = Shopware.Constants;
 
 describe('module/sw-cms/service/cms.service.spec.js', () => {
     const cmsService = Shopware.Service('cmsService');

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form/index.js
@@ -1,6 +1,5 @@
 import template from './sw-customer-address-form.html.twig';
 import './sw-customer-address-form.scss';
-import CUSTOMER from '../../constant/sw-customer.constant';
 
 /**
  * @sw-package checkout
@@ -127,7 +126,7 @@ export default {
         },
 
         isBusinessAccountType() {
-            return this.customer?.accountType === CUSTOMER.ACCOUNT_TYPE_BUSINESS;
+            return this.customer?.accountType === Shopware.Constants.CUSTOMER.ACCOUNT_TYPE_BUSINESS;
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form/sw-customer-address-form.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form/sw-customer-address-form.spec.js
@@ -1,12 +1,12 @@
 import { mount } from '@vue/test-utils';
 import ShopwareError from 'src/core/data/ShopwareError';
 import Entity from 'src/core/data/entity.data';
-// eslint-disable-next-line import/named
-import CUSTOMER from '../../constant/sw-customer.constant';
 
 /**
  * @sw-package checkout
  */
+
+const { CUSTOMER } = Shopware.Constants;
 
 async function createWrapper() {
     const responses = global.repositoryFactoryMock.responses;

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/index.js
@@ -2,8 +2,6 @@ import template from './sw-customer-base-form.html.twig';
 import './sw-customer-base-form.scss';
 import errorConfig from '../../error-config.json';
 
-import CUSTOMER from '../../constant/sw-customer.constant';
-
 /**
  * @sw-package checkout
  */
@@ -11,6 +9,7 @@ import CUSTOMER from '../../constant/sw-customer.constant';
 const { Defaults } = Shopware;
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 const { Criteria } = Shopware.Data;
+const { CUSTOMER } = Shopware.Constants;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/index.js
@@ -2,8 +2,6 @@ import template from './sw-customer-base-info.html.twig';
 import './sw-customer-base-info.scss';
 import errorConfig from '../../error-config.json';
 
-import CUSTOMER from '../../constant/sw-customer.constant';
-
 /**
  * @sw-package checkout
  */
@@ -83,7 +81,7 @@ export default {
         ]),
 
         isBusinessAccountType() {
-            return this.customer?.accountType === CUSTOMER.ACCOUNT_TYPE_BUSINESS;
+            return this.customer?.accountType === Shopware.Constants.CUSTOMER.ACCOUNT_TYPE_BUSINESS;
         },
 
         dateFilter() {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/index.js
@@ -1,7 +1,6 @@
 import template from './sw-customer-card.html.twig';
 import './sw-customer-card.scss';
 import errorConfig from '../../error-config.json';
-import CUSTOMER from '../../constant/sw-customer.constant';
 import ApiService from '../../../../core/service/api.service';
 
 /**
@@ -11,6 +10,7 @@ import ApiService from '../../../../core/service/api.service';
 const { Mixin, Defaults } = Shopware;
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 const { Criteria } = Shopware.Data;
+const { CUSTOMER } = Shopware.Constants;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
@@ -1,5 +1,4 @@
 import template from './sw-customer-create.html.twig';
-import CUSTOMER from '../../constant/sw-customer.constant';
 
 /**
  * @sw-package checkout
@@ -9,6 +8,7 @@ const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 const { ShopwareError } = Shopware.Classes;
 const { Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
+const { CUSTOMER } = Shopware.Constants;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/index.js
@@ -1,7 +1,6 @@
 import './sw-customer-detail.scss';
 import template from './sw-customer-detail.html.twig';
 import errorConfig from '../../error-config.json';
-import CUSTOMER from '../../constant/sw-customer.constant';
 
 /**
  * @sw-package checkout
@@ -11,6 +10,7 @@ const { Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
 const { ShopwareError } = Shopware.Classes;
 const { mapPageErrors } = Shopware.Component.getComponentHelper();
+const { CUSTOMER } = Shopware.Constants;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.spec.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 
-import { ACTION } from 'src/module/sw-flow/constant/flow.constant';
 import FlowBuilderService from 'src/module/sw-flow/service/flow-builder.service';
 
 import EntityCollection from 'src/core/data/entity-collection.data';
@@ -9,6 +8,8 @@ import { createPinia, setActivePinia } from 'pinia';
 /**
  * @sw-package after-sales
  */
+
+const { ACTION } = Shopware.Constants.FLOW;
 
 Shopware.Service().register('shopwareDiscountCampaignService', () => {
     return { isDiscountCampaignActive: jest.fn(() => true) };

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-trigger/sw-flow-trigger.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-trigger/sw-flow-trigger.spec.js
@@ -1,11 +1,12 @@
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
-import { ACTION } from 'src/module/sw-flow/constant/flow.constant';
 import { createPinia, setActivePinia } from 'pinia';
 
 /**
  * @sw-package after-sales
  */
+
+const { ACTION } = Shopware.Constants.FLOW;
 
 function getSequencesCollection(collection = []) {
     return new EntityCollection(

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/constant/flow.constant.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/constant/flow.constant.js
@@ -83,10 +83,10 @@ export const ACTION_GROUP = Object.freeze({
  * @sw-package after-sales
  */
 export const GROUPS = [
+    GENERAL_GROUP,
     TAG_GROUP,
     CUSTOMER_GROUP,
     ORDER_GROUP,
-    GENERAL_GROUP,
 ];
 
 /**
@@ -96,7 +96,10 @@ export const GROUPS = [
 export default {
     ACTION,
     ACTION_TYPE,
+    GENERAL_GROUP,
+    TAG_GROUP,
+    CUSTOMER_GROUP,
+    ORDER_GROUP,
     ACTION_GROUP,
     GROUPS,
-    GENERAL_GROUP,
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/service/flow-builder.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/service/flow-builder.service.spec.js
@@ -3,7 +3,8 @@
  */
 
 import FlowBuilderService from 'src/module/sw-flow/service/flow-builder.service';
-import { ACTION } from 'src/module/sw-flow/constant/flow.constant';
+
+const { ACTION } = Shopware.Constants.FLOW;
 
 describe('module/sw-flow/service/flow-builder.service.js', () => {
     const service = new FlowBuilderService();

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/service/flow-builder.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/service/flow-builder.service.ts
@@ -1,16 +1,8 @@
 import type { I18n } from 'vue-i18n';
-import {
-    ACTION,
-    ACTION_GROUP,
-    ACTION_TYPE,
-    CUSTOMER_GROUP,
-    GENERAL_GROUP,
-    ORDER_GROUP,
-    TAG_GROUP,
-} from '../constant/flow.constant';
 
 const { Utils, EntityDefinition } = Shopware;
 const { capitalizeString, camelCase, snakeCase } = Shopware.Utils.string;
+const { ACTION, ACTION_GROUP, ACTION_TYPE, CUSTOMER_GROUP, GENERAL_GROUP, ORDER_GROUP, TAG_GROUP } = Shopware.Constants.FLOW;
 
 type Node = {
     id: string;

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/store/flow.store.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/store/flow.store.ts
@@ -1,5 +1,3 @@
-import type { ACTION } from '../constant/flow.constant';
-
 /**
  * @sw-package after-sales
  */
@@ -25,7 +23,7 @@ type EntityActions =
     | 'SET_CUSTOMER_GROUP_CUSTOM_FIELD'
     | 'ADD_CUSTOMER_AFFILIATE_AND_CAMPAIGN_CODE';
 
-type EntityActionName = (typeof ACTION)[EntityActions];
+type EntityActionName = (typeof Shopware.Constants.FLOW.ACTION)[EntityActions];
 
 const swFlowStore = Shopware.Store.register('swFlow', {
     state: () => ({

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-new-customer-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-new-customer-modal/index.js
@@ -1,6 +1,5 @@
 import template from './sw-order-new-customer-modal.html.twig';
 import './sw-order-new-customer-modal.scss';
-import CUSTOMER from '../../../sw-customer/constant/sw-customer.constant';
 
 /**
  * @sw-package checkout
@@ -9,6 +8,7 @@ import CUSTOMER from '../../../sw-customer/constant/sw-customer.constant';
 const { Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
 const { mapPageErrors } = Shopware.Component.getComponentHelper();
+const { CUSTOMER } = Shopware.Constants;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Sometimes plugin developers may want to use Administration constants like `CMS.MEDIA.previewMountain` for example. Since Shopware 6.7 and the migration to vite there is no easy way to import these constants in plugins anymore. Before that, one could use the `@administration` alias to import things like that but this alias was removed. Since you might not want direct imports of Administration files in plugins, I think there should be another way to access those constants. That's why I've added a `Constants` property to the global Shopware object.

### 2. What does this change do, exactly?
* Added `Constants` object containing `CMS`, `CUSTOMER` and `FLOW` constants to the global `Shopware` object and replaced all imports by using the `Shopware.Constants` directly instead.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
