### PR TITLE
fix: 10788-11318 admin shortcut and command key (backport 6.7.1.0)

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
@@ -26,8 +26,8 @@ export default {
 
             // The 'this' context is the component instance, bound via .call()
             const systemKey = this.$device.getSystemKey();
-            const { key, altKey, ctrlKey, metaKey } = event;
-            const systemKeyPressed = systemKey === 'CTRL' ? ctrlKey || metaKey : altKey;
+            const { key, altKey, ctrlKey } = event;
+            const systemKeyPressed = systemKey === 'CTRL' ? ctrlKey : altKey;
 
             // create combined key name and look for matching shortcut
             const combinedKey = `${systemKeyPressed ? 'SYSTEMKEY+' : ''}${key.toUpperCase()}`;


### PR DESCRIPTION
### 1. Why is this change necessary?
The fix for shorcut bug in Admin has not been backported for 6.7
Later on a backport was generated by label/github action on one of the files that does not exist yet before this backport

The backport needs to be done manually combining the 2 commits

TLDR, we need 1152 to be able to apply 11457


### 2. What does this change do, exactly?
Backport of
https://github.com/shopware/shopware/pull/11457
https://github.com/shopware/shopware/pull/11152


### 3. Describe each step to reproduce the issue or behaviour.
- Log in to the Administration.
- Press ALT+C (or Control+C on macOS). The "Clear Cache" modal should appear. Close it.
- Navigate to any other module, for example, Settings -> Shop -> Number Ranges.
- Try to use the ALT+C shortcut again.
- Press CMD + C on macOS. The "Clear Cache" modal should NOT appear. 


### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/10788
- relates https://github.com/shopware/shopware/issues/11318


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
