### PR TITLE
ci: dont run changed ats tests in nightly

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,6 +60,7 @@ jobs:
 
   acceptance-tests-changed:
     runs-on: ubuntu-24.04
+    if: ${{ github.event_name != 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
The job should not run in the nightly