### PR TITLE
fix: sorting order when search property values

### DIFF
--- a/changelog/_unreleased/2025-07-24-fix-sorting-order-when-search-property-values.md
+++ b/changelog/_unreleased/2025-07-24-fix-sorting-order-when-search-property-values.md
@@ -1,0 +1,8 @@
+---
+title: fix sorting order when search property values
+issue: #11371
+---
+# Administration
+* Changed the following computed properties in the `sw-property-search` component to update the sorting algorithm:
+    * `propertyGroupCriteria`
+    * `propertyGroupOptionCriteria`

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js
@@ -73,7 +73,7 @@ export default {
 
         propertyGroupCriteria() {
             const criteria = new Criteria(this.groupPage, 10);
-            criteria.addSorting(Criteria.sort('name', 'ASC', false));
+            criteria.addSorting(Criteria.sort('name', 'ASC', true));
             criteria.setTotalCountMode(1);
 
             return criteria;
@@ -85,7 +85,7 @@ export default {
 
         propertyGroupOptionCriteria() {
             const criteria = new Criteria(this.optionPage, 10);
-            criteria.addSorting(Criteria.sort('name', 'ASC'));
+            criteria.addSorting(Criteria.sort('name', 'ASC', true));
 
             if (this.currentGroup) {
                 criteria.addFilter(Criteria.equals('groupId', this.currentGroup.id));


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/11371

### 2. What does this change do, exactly?

Update the sorting algorithm in `sw-property-search` component

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/shopware/shopware/issues/11371

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

_

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
