### PR TITLE
fix: Do not write composer.json of bundle, if there is no change

### DIFF
--- a/src/Core/DevOps/System/Command/SyncComposerVersionCommand.php
+++ b/src/Core/DevOps/System/Command/SyncComposerVersionCommand.php
@@ -51,7 +51,7 @@ class SyncComposerVersionCommand extends Command
             $io->warning('Running in dry-run mode: no files will be changed.');
         }
 
-        $changed = false;
+        $changed = [];
         $isInRootButNotInBundle = [];
         $isInBundleButNotInRoot = [];
 
@@ -65,7 +65,7 @@ class SyncComposerVersionCommand extends Command
                     if (isset($bundleJson[$field][$package])) {
                         if ($bundleJson[$field][$package] !== $version) {
                             $bundleJson[$field][$package] = $version;
-                            $changed = true;
+                            $changed[$bundleName] = true;
                         }
                     } elseif ($field === 'require') {
                         // Dev dependencies should not be synced from root to bundles
@@ -84,7 +84,7 @@ class SyncComposerVersionCommand extends Command
                 }
             }
 
-            if (!$changed) {
+            if (!($changed[$bundleName] ?? false)) {
                 continue;
             }
 
@@ -125,7 +125,7 @@ class SyncComposerVersionCommand extends Command
             }
         }
 
-        if ($changed) {
+        if ($changed !== []) {
             if ($isDryMode) {
                 $io->error("Composer dependencies of bundles are not in sync with the root composer.json file.\nPlease run the `sync:composer:version` command without the --dry-run option to sync them.");
 

--- a/tests/unit/Core/DevOps/System/Command/SyncComposerVersionCommandTest.php
+++ b/tests/unit/Core/DevOps/System/Command/SyncComposerVersionCommandTest.php
@@ -41,6 +41,12 @@ class SyncComposerVersionCommandTest extends TestCase
 
     public function testSync(): void
     {
+        $this->fs->dumpFile($this->projectDir . '/src/Bundle2/composer.json', json_encode([
+            'require' => [
+                'foo/bar' => '1.0.0',
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
         $this->fs->dumpFile($this->projectDir . '/src/Bundle1/composer.json', json_encode([
             'require' => [
                 'symfony/symfony' => '5.2.0',
@@ -58,6 +64,7 @@ class SyncComposerVersionCommandTest extends TestCase
         static::assertSame(Command::SUCCESS, $tester->getStatusCode());
         $output = $this->getOutput($tester);
         static::assertStringContainsString('Updating composer.json of "Bundle1" bundle', $output);
+        static::assertStringNotContainsString('Updating composer.json of "Bundle2" bundle', $output);
         static::assertStringContainsString('Composer dependencies of bundles synced with the root composer.json file', $output);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

If a bundle has a change, every following bundle composer.json file will also be written, even if it has no actual change. This reduces unnecessary write operation.

### 2. What does this change do, exactly?

Improve the check, if a change is needed for a bundle.

### 3. Describe each step to reproduce the issue or behaviour.

- Change a version of a package that is also in the core composer.json
- execute command
- see that the command outputs, that it also updated Storefront and ES bundle

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
