### PR TITLE
fix(app-system): skip snippet persisting for non-existing locales

### DIFF
--- a/changelog/_unreleased/2025-07-24-skip-persisting-admin-snippets-for-non-existing-locales.md
+++ b/changelog/_unreleased/2025-07-24-skip-persisting-admin-snippets-for-non-existing-locales.md
@@ -1,0 +1,9 @@
+---
+title: Skip persisting admin snippets for non-existing locales
+author: Frederik Schmitt
+author_email: f.schmitt@shopware.com
+author_github: @fschmtt
+---
+# Core
+# Administration
+* Changed `Shopware\Administration\Snippet\AppAdministrationSnippetPersister::updateSnippets()` to skip persisting snippets for locales that do not exist in the system instead of throwing an exception.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When installing an app that provides Administration snippets for a locale which is not existing in the database, the app installation will fail because the `AppAdministrationSnippetPersister` throws an error.

A shop owner has no control about which locales an app manufacturer provides snippets for and is not able to install apps if they do not have all 

### 2. What does this change do, exactly?
Skip provided snippets for non-existing locales from being persisted instead of throwing an exception and erroring during the app installation process.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a fresh Shopware setup with a clean database (`composer init:db`)
2. Create an app that provides Administration snippets for `en-GB`, `de-DE` and `cs-CZ`
3. Try to install this app by running `php bin/console app:install -f --activate <APP_NAME>` and see the error:
  ```
  The locale cs-CZ does not exist.
  ```
