### PR TITLE
fix: ThemeLifecycleService refreshThemes being executed without plugin configurations

### DIFF
--- a/changelog/_unreleased/2025-07-24-fix-theme-lifecycle-service-refresh-themes-without-plugins.md
+++ b/changelog/_unreleased/2025-07-24-fix-theme-lifecycle-service-refresh-themes-without-plugins.md
@@ -1,0 +1,8 @@
+---
+title: Fix ThemeLifecycleService refreshThemes being executed without plugin configurations
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Storefront
+* Changed `Shopware\Storefront\Theme\ThemeLifecycleService` to correctly use the complete plugin configuration for the configurationCollection of `refreshTheme`

--- a/src/Storefront/Theme/ThemeLifecycleService.php
+++ b/src/Storefront/Theme/ThemeLifecycleService.php
@@ -63,13 +63,15 @@ class ThemeLifecycleService
         Context $context,
         ?StorefrontPluginConfigurationCollection $configurationCollection = null
     ): void {
+        $pluginConfigurationCollection = $this->pluginRegistry->getConfigurations();
+
         if ($configurationCollection === null) {
-            $configurationCollection = $this->pluginRegistry->getConfigurations()->getThemes();
+            $configurationCollection = $pluginConfigurationCollection->getThemes();
         }
 
         // iterate over all theme configs in the filesystem (plugins/bundles)
         foreach ($configurationCollection as $config) {
-            $this->refreshTheme($config, $context, $configurationCollection);
+            $this->refreshTheme($config, $context, $pluginConfigurationCollection);
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
- Using the ThemeLifecycleService `refreshThemes` function produces a invalid & broken theme runtime config in the database
- See #11492

### 2. What does this change do, exactly?
* Changed `Shopware\Storefront\Theme\ThemeLifecycleService` to correctly use the complete plugin configuration for the configurationCollection of `refreshTheme`

### 3. Describe each step to reproduce the issue or behaviour.
- Install plugins
- Run the `theme:refresh` command
- Theme runtime config is completely broken, because it is missing all plugin data

### 4. Please link to the relevant issues (if any).
- #11492

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
