### PR TITLE
fix: ThemeCompiler side effects

### DIFF
--- a/changelog/_unreleased/2025-07-24-fix-theme-compiler-side-effects.md
+++ b/changelog/_unreleased/2025-07-24-fix-theme-compiler-side-effects.md
@@ -1,0 +1,11 @@
+---
+title: Fix ThemeCompiler side effects
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Storefront
+* Changed `Shopware\Storefront\Theme\ThemeCompiler` to copy `configurationCollection` before modify actions to prevent unwanted side effects
+* Changed `Shopware\Storefront\Theme\ThemeCompiler` to use `ThemeFileResolver->resolveStyleFiles` to only calculate required files
+* Changed `Shopware\Storefront\Theme\ThemeRuntimeConfigService` to use `ThemeFileResolver->resolveScriptFiles` to only calculate required files
+* Changed `Shopware\Storefront\Theme\ThemeFileResolver` to public provide `resolveScriptFiles` & `resolveStyleFiles` functions

--- a/changelog/_unreleased/2025-07-24-fix-theme-compiler-side-effects.md
+++ b/changelog/_unreleased/2025-07-24-fix-theme-compiler-side-effects.md
@@ -5,7 +5,6 @@ author_email: Discord.Benjamin@web.de
 author_github: gecolay
 ---
 # Storefront
-* Changed `Shopware\Storefront\Theme\ThemeCompiler` to copy `configurationCollection` before modify actions to prevent unwanted side effects
 * Changed `Shopware\Storefront\Theme\ThemeCompiler` to use `ThemeFileResolver->resolveStyleFiles` to only calculate required files
 * Changed `Shopware\Storefront\Theme\ThemeRuntimeConfigService` to use `ThemeFileResolver->resolveScriptFiles` to only calculate required files
 * Changed `Shopware\Storefront\Theme\ThemeFileResolver` to public provide `resolveScriptFiles` & `resolveStyleFiles` functions

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -66,9 +66,7 @@ class ThemeCompiler implements ThemeCompilerInterface
         Context $context
     ): void {
         try {
-            $resolvedFiles = $this->themeFileResolver->resolveFiles($themeConfig, $configurationCollection, false);
-
-            $styleFiles = $resolvedFiles[ThemeFileResolver::STYLE_FILES];
+            $styleFiles = $this->themeFileResolver->resolveStyleFiles($themeConfig, $configurationCollection, false);
         } catch (\Throwable $e) {
             throw ThemeException::themeCompileException(
                 $themeConfig->getName() ?? '',
@@ -165,8 +163,8 @@ class ThemeCompiler implements ThemeCompilerInterface
         StorefrontPluginConfigurationCollection $configurationCollection,
         string $themePrefix
     ): array {
-        // The "getScriptDistFolders" method removes script files from the file collections in the configurations.
-        // This can cause missing plugin script files in the theme configurations.
+        // The "getScriptDistFolders" method can remove script files from the scriptFiles property in the configurationCollection.
+        // This can result in plugin script files being missing from later methods. Cloning the collection prevents this.
         // As structs are overriding the object cloning with the "CloneTrait" and implement a deep copy mechanism,
         // cloning the collection will prevent the mutation of the configurations and file collections inside as well.
         $scriptsDist = $this->getScriptDistFolders(clone $configurationCollection);

--- a/src/Storefront/Theme/ThemeFileResolver.php
+++ b/src/Storefront/Theme/ThemeFileResolver.php
@@ -32,22 +32,46 @@ class ThemeFileResolver
         bool $onlySourceFiles
     ): array {
         return [
-            self::SCRIPT_FILES => $this->resolve(
+            self::SCRIPT_FILES => $this->resolveScriptFiles(
                 $themeConfig,
                 $configurationCollection,
-                $onlySourceFiles,
-                $this->resolveScriptFiles(...)
+                $onlySourceFiles
             ),
-            self::STYLE_FILES => $this->resolve(
+            self::STYLE_FILES => $this->resolveStyleFiles(
                 $themeConfig,
                 $configurationCollection,
-                $onlySourceFiles,
-                fn (StorefrontPluginConfiguration $configuration) => $configuration->getStyleFiles()
+                $onlySourceFiles
             ),
         ];
     }
 
-    private function resolveScriptFiles(StorefrontPluginConfiguration $configuration, bool $onlySourceFiles): FileCollection
+    public function resolveScriptFiles(
+        StorefrontPluginConfiguration $themeConfig,
+        StorefrontPluginConfigurationCollection $configurationCollection,
+        bool $onlySourceFiles
+    ): FileCollection {
+        return $this->resolve(
+            $themeConfig,
+            $configurationCollection,
+            $onlySourceFiles,
+            $this->collectConfigurationScriptFiles(...)
+        );
+    }
+
+    public function resolveStyleFiles(
+        StorefrontPluginConfiguration $themeConfig,
+        StorefrontPluginConfigurationCollection $configurationCollection,
+        bool $onlySourceFiles
+    ): FileCollection {
+        return $this->resolve(
+            $themeConfig,
+            $configurationCollection,
+            $onlySourceFiles,
+            fn (StorefrontPluginConfiguration $configuration) => $configuration->getStyleFiles()
+        );
+    }
+
+    private function collectConfigurationScriptFiles(StorefrontPluginConfiguration $configuration, bool $onlySourceFiles): FileCollection
     {
         $fileCollection = new FileCollection();
         $scriptFiles = $configuration->getScriptFiles();

--- a/src/Storefront/Theme/ThemeRuntimeConfigService.php
+++ b/src/Storefront/Theme/ThemeRuntimeConfigService.php
@@ -110,7 +110,7 @@ class ThemeRuntimeConfigService
         $scriptFiles = null;
         try {
             // will throw an exception if theme was not built yet
-            $scriptFiles = $this->resolveJs($themeConfig, $configCollection);
+            $scriptFiles = $this->themeFileResolver->resolveScriptFiles($themeConfig, $configCollection, false)->getPublicPaths('js');
         } catch (ThemeCompileException|AppException $e) {
             $failOnFileResolveError && throw $e;
         }
@@ -217,16 +217,6 @@ class ThemeRuntimeConfigService
         }
 
         return $iconConfig;
-    }
-
-    /**
-     * @return array<string>
-     */
-    private function resolveJs(StorefrontPluginConfiguration $themeConfig, StorefrontPluginConfigurationCollection $configCollection): array
-    {
-        $resolvedFiles = $this->themeFileResolver->resolveFiles($themeConfig, $configCollection, false);
-
-        return $resolvedFiles[ThemeFileResolver::SCRIPT_FILES]->getPublicPaths('js');
     }
 
     private function generateRuntimeConfigById(string $themeId, bool $failOnFileResolve = false): ?ThemeRuntimeConfig

--- a/tests/integration/Storefront/Theme/ThemeTest.php
+++ b/tests/integration/Storefront/Theme/ThemeTest.php
@@ -516,7 +516,7 @@ class ThemeTest extends TestCase
             static::assertTrue($themeCompiled);
         } catch (ThemeCompileException $e) {
             // ignore files not found exception
-            if ($e->getMessage() !== 'Unable to compile the theme "Shopware default theme". Files could not be resolved with error: Unable to compile the theme "Storefront". Unable to load file "Resources/app/storefront/dist/storefront/storefront.js". Did you forget to build the theme? Try running ./bin/build-storefront.sh') {
+            if (!str_starts_with($e->getMessage(), 'Unable to compile the theme "Storefront - Theme-ID: ' . $childTheme->getId() . '". `~vendor/bootstrap/scss/functions` file not found for @import: src/Storefront/Resources/app/storefront/src/scss/variables.scss')) {
                 throw $e;
             }
         }
@@ -788,7 +788,7 @@ class ThemeTest extends TestCase
             );
         } catch (ThemeCompileException $e) {
             // ignore files not found exception
-            if ($e->getMessage() !== 'Unable to compile the theme "Shopware default theme". Files could not be resolved with error: Unable to compile the theme "Storefront". Unable to load file "Resources/app/storefront/dist/storefront/storefront.js". Did you forget to build the theme? Try running ./bin/build-storefront.sh') {
+            if (!str_starts_with($e->getMessage(), 'Unable to compile the theme "Storefront - Theme-ID: ' . $childTheme->getId() . '". `~vendor/bootstrap/scss/functions` file not found for @import: src/Storefront/Resources/app/storefront/src/scss/variables.scss')) {
                 throw $e;
             }
         }

--- a/tests/unit/Storefront/Theme/ThemeRuntimeConfigServiceTest.php
+++ b/tests/unit/Storefront/Theme/ThemeRuntimeConfigServiceTest.php
@@ -176,10 +176,8 @@ class ThemeRuntimeConfigServiceTest extends TestCase
 
         $this->themeFileResolver
             ->expects($this->once())
-            ->method('resolveFiles')
-            ->willReturn([
-                ThemeFileResolver::SCRIPT_FILES => $scriptFilesCollection,
-            ]);
+            ->method('resolveScriptFiles')
+            ->willReturn($scriptFilesCollection);
 
         // check that we save new config with resolved js files
         $this->storage
@@ -225,11 +223,9 @@ class ThemeRuntimeConfigServiceTest extends TestCase
 
         $this->themeFileResolver
             ->expects($this->once())
-            ->method('resolveFiles')
+            ->method('resolveScriptFiles')
             ->with($themeConfig, $configCollection, false)
-            ->willReturn([
-                ThemeFileResolver::SCRIPT_FILES => $scriptFilesCollection,
-            ]);
+            ->willReturn($scriptFilesCollection);
 
         $this->storage
             ->expects($this->once())
@@ -274,7 +270,7 @@ class ThemeRuntimeConfigServiceTest extends TestCase
         // Make resolveJs throw an exception
         $this->themeFileResolver
             ->expects($this->once())
-            ->method('resolveFiles')
+            ->method('resolveScriptFiles')
             ->willThrowException(ThemeException::themeCompileException($technicalName, 'Failed to resolve js files'));
 
         $this->storage
@@ -309,7 +305,7 @@ class ThemeRuntimeConfigServiceTest extends TestCase
         // Make resolveJs throw an exception
         $exception = ThemeException::themeCompileException($technicalName, 'Failed to resolve js files');
         $this->themeFileResolver
-            ->method('resolveFiles')
+            ->method('resolveScriptFiles')
             ->willThrowException($exception);
 
         $this->expectExceptionObject($exception);


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently there is a unwanted side effect in the ThemeCompiler, which modifies a `configurationCollection` which is later used to generate the theme runtime config
- See `3. Describe each step to reproduce the issue or behaviour.`
- See #11488
- With this PR we can also reduce the calculation time for the theme files, as we only need to calculate styles or scripts, not both in one place so we can public the direct methods in the `ThemeFileResolver` and use them in the other services

### 2. What does this change do, exactly?
* Changed `Shopware\Storefront\Theme\ThemeCompiler` to copy `configurationCollection` before modify actions to prevent unwanted side effects
* Changed `Shopware\Storefront\Theme\ThemeCompiler` to use `ThemeFileResolver->resolveStyleFiles` to only calculate required files
* Changed `Shopware\Storefront\Theme\ThemeRuntimeConfigService` to use `ThemeFileResolver->resolveScriptFiles` to only calculate required files
* Changed `Shopware\Storefront\Theme\ThemeFileResolver` to public provide `resolveScriptFiles` & `resolveStyleFiles` functions

### 3. Describe each step to reproduce the issue or behaviour.
- Create a theme which inherits the Storefront theme & plugins
- Run theme:compile
- All the javascript file from the plugins are missing in the final runtime config, as the @`Storefront` script part, which itself holds the ref to the @`Plugins` is excluded as a side effect in `getScriptDistFolders` from `ThemeCompiler`

### 4. Please link to the relevant issues (if any).
- #11488
- Fixes #11529 

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
