### PR TITLE
feat: Add optional callback parameter to `addAssociation` method in Criteira

### DIFF
--- a/changelog/_unreleased/2025-07-24-callback-on-association-add.md
+++ b/changelog/_unreleased/2025-07-24-callback-on-association-add.md
@@ -1,0 +1,16 @@
+---
+title: Add optional callback parameter to `addAssociation` method in Criteria
+author: Mirzorasul Danierov
+author_email: dmirzorasul@gmail.com
+author_github: @mdanierov
+---
+
+The `addAssociation` method in the `Criteria` class now supports an optional callback parameter.  
+This allows developers to immediately modify the final nested `Criteria` object during association chaining.
+
+Example usage:
+
+```php
+$criteria->addAssociation('products.media', function (Criteria $mediaCriteria) {
+    $mediaCriteria->addFilter(...);
+});

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -292,15 +292,20 @@ class Criteria extends Struct implements \Stringable
     }
 
     /**
-     * Add for each part of the provided path an association
+     * Add for each part of the provided path an association. If a callback is provided, it will be executed
+     * with the final association.
      *
-     * e.g
+     * Example:
+     * $criteria->addAssociation('categories.media.thumbnails');
      *
-     * $criteria->addAssociation('categories.media.thumbnails')
+     * Or with callback:
+     * $criteria->addAssociation('categories.media.thumbnails', function (Criteria $thumbnailCriteria) {
+     *     $thumbnailCriteria->addFilter(...);
+     * });
      *
      * @throws InconsistentCriteriaIdsException
      */
-    public function addAssociation(string $path): self
+    public function addAssociation(string $path, callable $callback = null): self
     {
         $parts = explode('.', $path);
 
@@ -311,6 +316,10 @@ class Criteria extends Struct implements \Stringable
             }
 
             $criteria = $criteria->getAssociation($part);
+        }
+
+        if ($callback !== null) {
+            $callback($this->getAssociation($path));
         }
 
         return $this;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfill our contribution guidelines:  
https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution

If your change needs documentation, please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The current `Criteria::addAssociation()` method only allows adding nested associations using a dot-separated path like `products.media.thumbnails`. However, when working with deeply nested data, developers often need to customize those associations — for example by adding filters or sorting criteria — immediately during creation.

Right now, the only way to do this is by manually calling `getAssociation()` after creating the association, which leads to repetitive and less readable code.

---

### 2. What does this change do, exactly?

This change extends the `addAssociation()` method to optionally accept a `callable` parameter. This callback will be executed on the final `Criteria` object created by the dot-separated association path.

By allowing this callback, developers can immediately modify the associated criteria with additional filters, sorts, or pagination directly where the association is defined.

This leads to cleaner, more maintainable code and simplifies the process of working with complex data structures in Shopware.

---

### 3. Describe each step to reproduce the issue or behaviour.

#### Current behaviour:
```php
$criteria->addAssociation('products.media');
$criteria->getAssociation('products')->getAssociation('media')->addFilter(...);
```

#### New behaviour with this change:
```php
$criteria->addAssociation('products.media', function (Criteria $mediaCriteria) {
    $mediaCriteria->addFilter(...);
});
```

This enables a more intuitive and cleaner approach for setting up nested associations.

---

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

 --- 
 
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them 