### PR TITLE
fix: creating product with duplicate product number leads to endless loading

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -1018,13 +1018,41 @@ export default {
         },
 
         onSaveFinished(response) {
+            if (response !== 'success' && response !== 'empty') {
+                const errorCode = response?.response?.data?.errors?.[0]?.code;
+
+                if (errorCode === 'CONTENT__DUPLICATE_PRODUCT_NUMBER') {
+                    const titleSaveError = this.$tc('global.default.error');
+                    const messageSaveError = this.$t('sw-product.notification.notificationSaveErrorProductNoAlreadyExists', {
+                        productNo: response.response.data.errors[0].meta.parameters.number,
+                    });
+
+                    this.createNotificationError({
+                        title: titleSaveError,
+                        message: messageSaveError,
+                    });
+                    return;
+                }
+
+                const errorDetail = response?.response?.data?.errors?.[0]?.detail;
+                const titleSaveError = this.$tc('global.default.error');
+                const messageSaveError =
+                    errorDetail ?? this.$tc('global.notification.notificationSaveErrorMessageRequiredFieldsInvalid');
+
+                this.createNotificationError({
+                    title: titleSaveError,
+                    message: messageSaveError,
+                });
+                return;
+            }
+
             if (this.updateSeoPromises.length === 0) {
                 this.isSaveSuccessful = true;
 
                 return;
             }
 
-            if (response === 'empty' && this.updateSeoPromises.length > 0) {
+            if (response === 'empty') {
                 response = 'success';
             }
 
@@ -1052,34 +1080,6 @@ export default {
                         }
 
                         default: {
-                            const errorCode = response?.response?.data?.errors?.[0]?.code;
-
-                            if (errorCode === 'CONTENT__DUPLICATE_PRODUCT_NUMBER') {
-                                const titleSaveError = this.$tc('global.default.error');
-                                const messageSaveError = this.$t(
-                                    'sw-product.notification.notificationSaveErrorProductNoAlreadyExists',
-                                    {
-                                        productNo: response.response.data.errors[0].meta.parameters.number,
-                                    },
-                                );
-
-                                this.createNotificationError({
-                                    title: titleSaveError,
-                                    message: messageSaveError,
-                                });
-                                break;
-                            }
-
-                            const errorDetail = response?.response?.data?.errors?.[0]?.detail;
-                            const titleSaveError = this.$tc('global.default.error');
-                            const messageSaveError =
-                                errorDetail ??
-                                this.$tc('global.notification.notificationSaveErrorMessageRequiredFieldsInvalid');
-
-                            this.createNotificationError({
-                                title: titleSaveError,
-                                message: messageSaveError,
-                            });
                             break;
                         }
                     }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
@@ -595,7 +595,42 @@ describe('module/sw-product/page/sw-product-detail', () => {
             message: 'sw-product.notification.notificationSaveErrorProductNoAlreadyExists',
         });
         expect(wrapper.vm.isSaveSuccessful).toBe(false);
-        expect(wrapper.vm.loadProduct).toHaveBeenCalled();
+        expect(wrapper.vm.loadProduct).not.toHaveBeenCalled();
+    });
+
+    it('should handle duplicate product number error when seo promises are empty', async () => {
+        wrapper.vm.updateSeoPromises = [];
+        wrapper.vm.isSaveSuccessful = false;
+        wrapper.vm.loadProduct = jest.fn();
+        wrapper.vm.createNotificationError = jest.fn();
+
+        const duplicateErrorResponse = {
+            response: {
+                data: {
+                    errors: [
+                        {
+                            code: 'CONTENT__DUPLICATE_PRODUCT_NUMBER',
+                            meta: {
+                                parameters: {
+                                    number: 'SW-123',
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        };
+
+        wrapper.vm.onSaveFinished(duplicateErrorResponse);
+
+        await flushPromises();
+
+        expect(wrapper.vm.createNotificationError).toHaveBeenCalledWith({
+            title: 'global.default.error',
+            message: 'sw-product.notification.notificationSaveErrorProductNoAlreadyExists',
+        });
+        expect(wrapper.vm.isSaveSuccessful).toBe(false);
+        expect(wrapper.vm.loadProduct).not.toHaveBeenCalled();
     });
 
     it('should handle generic error with detail correctly', async () => {
@@ -623,7 +658,7 @@ describe('module/sw-product/page/sw-product-detail', () => {
             message: 'Custom error message',
         });
         expect(wrapper.vm.isSaveSuccessful).toBe(false);
-        expect(wrapper.vm.loadProduct).toHaveBeenCalled();
+        expect(wrapper.vm.loadProduct).not.toHaveBeenCalled();
     });
 
     it('should handle SEO promise rejection correctly', async () => {


### PR DESCRIPTION
### Description 
 ```
if (this.updateSeoPromises.length === 0) {
   this.isSaveSuccessful = true;
   return; // <-- This is the problem
}
```
When creating a product with a duplicate number, the saveProduct method would fail, but because updateSeoPromises was empty, this if block would execute. It would incorrectly set isSaveSuccessful to true and then exit the function immediately with return.

### Solution

https://github.com/user-attachments/assets/370c253b-3c18-4052-96ff-80a6c1eda343


