### PR TITLE
fix: restore Symfony's Kernel::handle behavior to support ResetInterf (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2025-07-14-restore-kernel-handle-resetinterface.md
+++ b/changelog/_unreleased/2025-07-14-restore-kernel-handle-resetinterface.md
@@ -1,0 +1,19 @@
+---
+title:              Restore ResetInterface support in long-running runtimes
+issue:              #11215
+author:             Mateusz Flasiński
+author_email:       mateuszflasinski@gmail.com
+author_github:      @mateuszfl
+---
+
+# Core
+
+* Changed `Shopware\Core\Kernel` to restore support for Symfony's `ResetInterface` by adjusting the `boot()` method and preserving a minimal `handle()` override.
+* Changed behavior in long-running runtimes (e.g., FrankenPHP, RoadRunner) to ensure that `services_resetter` is called between requests.
+* Removed redundant logic in `Kernel::boot()` that prevented Symfony's reset lifecycle from executing correctly.
+
+___
+
+# Upgrade Information
+
+If you are running Shopware in a long-running environment (e.g., FrankenPHP or RoadRunner), this change enables Symfony to properly reset services implementing `ResetInterface` between requests. No configuration changes are required.

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -148,46 +148,35 @@ class Kernel extends HttpKernel
 
     public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
-        if (!$this->booted) {
-            $this->boot();
-        }
+        $this->boot();
 
         return $this->getHttpKernel()->handle($request, $type, $catch);
     }
 
     public function boot(): void
     {
-        if ($this->booted) {
-            if ($this->debug) {
-                $this->startTime = microtime(true);
+        if (!$this->booted) {
+            if ($this->debug && !EnvironmentHelper::hasVariable('SHELL_VERBOSITY')) {
+                putenv('SHELL_VERBOSITY=1');
+                $_ENV['SHELL_VERBOSITY'] = 1;
+                $_SERVER['SHELL_VERBOSITY'] = 1;
             }
 
-            return;
-        }
-
-        if ($this->debug) {
-            $this->startTime = microtime(true);
-        }
-
-        if ($this->debug && !EnvironmentHelper::hasVariable('SHELL_VERBOSITY')) {
-            putenv('SHELL_VERBOSITY=1');
-            $_ENV['SHELL_VERBOSITY'] = 1;
-            $_SERVER['SHELL_VERBOSITY'] = 1;
-        }
-
-        try {
-            // initialize plugins before booting
-            $this->pluginLoader->initializePlugins($this->getProjectDir());
-        } catch (DBALException $e) {
-            if (\defined('\STDERR')) {
-                fwrite(\STDERR, 'Warning: Failed to load plugins. Message: ' . $e->getMessage() . \PHP_EOL);
+            try {
+                // initialize plugins before booting
+                $this->pluginLoader->initializePlugins($this->getProjectDir());
+            } catch (DBALException $e) {
+                if (\defined('\STDERR')) {
+                    fwrite(\STDERR, 'Warning: Failed to load plugins. Message: ' . $e->getMessage() . \PHP_EOL);
+                }
             }
-        }
 
-        $this->initializeDatabaseConnectionVariables();
+            $this->initializeDatabaseConnectionVariables();
+        }
 
         parent::boot();
     }
+
 
     public static function getConnection(): Connection
     {


### PR DESCRIPTION
Backport: [#11217](https://github.com/shopware/shopware/pull/11217)

---

### 1. Why is this change necessary?

Shopware overrides `Kernel::handle()` and bypasses Symfony’s built-in reset mechanism for services implementing `Symfony\Contracts\Service\ResetInterface`.

This causes unexpected behavior in long-running runtimes (e.g. FrankenPHP, RoadRunner), where the same kernel instance handles multiple requests without resetting internal state.

### 2. What does this change do, exactly?

Instead of removing Kernel::handle(), we now keep a custom implementation that directly calls $this->boot() (instead of Symfony’s internal handle() logic that checks for http_cache). This ensures that Symfony’s boot() lifecycle (including services_resetter) is invoked, while avoiding any side effects caused by Symfony’s internal HTTP cache handler.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a service that implements `ResetInterface`.
2. Boot Shopware inside a long-lived runtime (e.g. FrankenPHP).
3. Send two HTTP requests in a row — observe that `reset()` is **not called** between requests.
4. Apply this patch.
5. Observe that `reset()` is now properly called before each new request.

### 4. Please link to the relevant issues (if any).

- closes [#11215](https://github.com/shopware/shopware/issues/11215)
- Related Slack thread: https://shopwarecommunity.slack.com/archives/C011VFQT7GB/p1752490431943509

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them