### PR TITLE
fix: phpunit reference warning for AdminProductStreamControllerTest

### DIFF
--- a/tests/unit/Administration/Controller/AdminProductStreamControllerTest.php
+++ b/tests/unit/Administration/Controller/AdminProductStreamControllerTest.php
@@ -58,7 +58,7 @@ class AdminProductStreamControllerTest extends TestCase
         $this->requestCriteriaBuilder->expects($this->once())->method('handleRequest')->willReturn(new Criteria());
 
         $this->salesChannelRepository->expects($this->once())->method('search')
-            ->willReturnCallback(function (Criteria &$criteria, SalesChannelContext $context) use ($collection) {
+            ->willReturnCallback(function (Criteria $criteria, SalesChannelContext $context) use ($collection) {
                 static::assertSame(Criteria::TOTAL_COUNT_MODE_EXACT, $criteria->getTotalCountMode());
                 static::assertTrue($criteria->hasAssociation('manufacturer'));
                 static::assertTrue($criteria->hasAssociation('options'));


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the phpunit test suite will return a phpunit warning for the AdminProductStreamControllerTest:
<img width="1418" height="199" alt="image" src="https://github.com/user-attachments/assets/07407a50-3eb9-45dc-9a3f-9946708a82c2" />

### 2. What does this change do, exactly?
- Adjusted test to use value instead of reference for criteria in `AdminProductStreamControllerTest`

### 3. Describe each step to reproduce the issue or behaviour.
- Run the phpunit tests for AdminProductStreamControllerTest

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
