### PR TITLE
feat: Add missing changelogs for Symfony update and MySQL min version increase

### DIFF
--- a/changelog/_unreleased/2025-07-28-increased-minimum-required-version-of-mysql-database.md
+++ b/changelog/_unreleased/2025-07-28-increased-minimum-required-version-of-mysql-database.md
@@ -1,0 +1,9 @@
+---
+title: Increased minimum required version of MySQL database
+author: Michael Telgmann
+author_github: @mitelg
+---
+
+# Core
+
+* Changed the minimum required MySQL version from `8.0.17` to `8.0.22` to be aligned with the minimum version stated in the [documentation](https://developer.shopware.com/docs/guides/installation/requirements.html#sql).

--- a/changelog/_unreleased/2025-07-28-symfony-components-updated.md
+++ b/changelog/_unreleased/2025-07-28-symfony-components-updated.md
@@ -1,0 +1,18 @@
+---
+title: Symfony components updated
+author: Michael Telgmann
+author_github: @mitelg
+---
+
+# Core
+
+* Changed all Symfony components to version 7.3
+
+___
+
+# Upgrade Information
+
+## Symfony components update
+All Symfony components have been updated to version 7.3.
+This might lead to deprecation warnings in your extensions or customizations.
+Please check the [Symfony 7.3 upgrade guide](https://github.com/symfony/symfony/blob/v7.3.1/UPGRADE-7.3.md) for more information.


### PR DESCRIPTION
### 1. Why is this change necessary?

changelogs are missing for important changes from https://github.com/shopware/shopware/pull/11024

Issue: https://github.com/shopware/shopware/issues/10995

### 2. What does this change do, exactly?

Add the changelogs

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
