### PR TITLE
fix: error handling on cart deserialization

### DIFF
--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -49,7 +49,7 @@ class CartPersister extends AbstractCartPersister
 
         try {
             $cart = $this->compressor->unserialize($content['payload'], (int) $content['compressed']);
-        } catch (\Exception) {
+        } catch (\Throwable) {
             // When we can't decode it, we have to delete it
             throw CartException::tokenNotFound($token);
         }

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -43,16 +43,15 @@ class RedisCartPersister extends AbstractCartPersister
 
     public function load(string $token, SalesChannelContext $context): Cart
     {
-        /** @var string|bool|array<mixed> $value */
         $value = $this->redis->get(self::PREFIX . $token);
 
-        if ($value === false || !\is_string($value)) {
+        if (!\is_string($value)) {
             throw CartException::tokenNotFound($token);
         }
 
         try {
-            $value = @\unserialize($value);
-        } catch (\Exception) {
+            $value = \unserialize($value);
+        } catch (\Throwable) {
             throw CartException::tokenNotFound($token);
         }
 
@@ -62,7 +61,7 @@ class RedisCartPersister extends AbstractCartPersister
 
         try {
             $content = $this->compressor->unserialize($value['content'], (int) $value['compressed']);
-        } catch (\Exception) {
+        } catch (\Throwable) {
             // When we can't decode it, we have to delete it
             throw CartException::tokenNotFound($token);
         }

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -50,7 +50,7 @@ class RedisCartPersister extends AbstractCartPersister
         }
 
         try {
-            $value = \unserialize($value);
+            $value = @\unserialize($value);
         } catch (\Throwable) {
             throw CartException::tokenNotFound($token);
         }

--- a/tests/unit/Core/Checkout/Cart/Order/CartPersisterTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/CartPersisterTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Order;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\CartCompressor;
+use Shopware\Core\Checkout\Cart\CartPersister;
+use Shopware\Core\Checkout\Cart\CartSerializationCleaner;
+use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
+
+/**
+ * @internal
+ */
+#[CoversClass(CartPersister::class)]
+#[Package('checkout')]
+class CartPersisterTest extends TestCase
+{
+    public function testDecorated(): void
+    {
+        $cartSerializationCleaner = $this->createMock(CartSerializationCleaner::class);
+        $connection = $this->createMock(Connection::class);
+        $persister = new CartPersister($connection, new CollectingEventDispatcher(), $cartSerializationCleaner, new CartCompressor(false, 'gzip'));
+        $this->expectException(DecorationPatternException::class);
+        $persister->getDecorated();
+    }
+
+    public function testLoadWithUnserializationTypeError(): void
+    {
+        $cartSerializationCleaner = $this->createMock(CartSerializationCleaner::class);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn(['payload' => 'invalid serialized data', 'rule_ids' => null, 'compressed' => 0]);
+
+        $cartCompressor = $this->createMock(CartCompressor::class);
+        $cartCompressor->expects($this->once())
+            ->method('unserialize')
+            ->with('invalid serialized data', 0)
+            ->willThrowException(new \TypeError('Unserialization failed'));
+
+        $persister = new CartPersister($connection, new CollectingEventDispatcher(), $cartSerializationCleaner, $cartCompressor);
+
+        $this->expectException(CartTokenNotFoundException::class);
+        $persister->load('token', Generator::generateSalesChannelContext());
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Order/RedisCartPersisterTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/RedisCartPersisterTest.php
@@ -126,7 +126,7 @@ class RedisCartPersisterTest extends TestCase
     public static function dataProviderInvalidData(): iterable
     {
         yield 'not existing' => [null, CartTokenNotFoundException::class];
-        yield 'invalid serialize' => ['abc', CartTokenNotFoundException::class];
+        yield 'invalid serialize' => ['O:32:"Shopware\Core\Checkout\Cart\Cart":1:{s:5:"price";N;}', CartTokenNotFoundException::class];
         yield 'not cart serialize' => [\serialize(new \ArrayObject()), CartTokenNotFoundException::class];
         yield 'valid outer object, but invalid content' => [\serialize(['compressed' => false, 'content' => \serialize(new \ArrayObject())]), CartTokenNotFoundException::class];
         yield 'valid outer object, but content with type error' => [\serialize(['compressed' => false, 'content' => []]), CartTokenNotFoundException::class];

--- a/tests/unit/Core/Checkout/Cart/Order/RedisCartPersisterTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/RedisCartPersisterTest.php
@@ -129,6 +129,7 @@ class RedisCartPersisterTest extends TestCase
         yield 'invalid serialize' => ['abc', CartTokenNotFoundException::class];
         yield 'not cart serialize' => [\serialize(new \ArrayObject()), CartTokenNotFoundException::class];
         yield 'valid outer object, but invalid content' => [\serialize(['compressed' => false, 'content' => \serialize(new \ArrayObject())]), CartTokenNotFoundException::class];
+        yield 'valid outer object, but content with type error' => [\serialize(['compressed' => false, 'content' => []]), CartTokenNotFoundException::class];
         yield 'valid outer object, but not cart' => [serialize(['compressed' => false, 'content' => serialize(['cart' => ''])]), CartException::class];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Carts serialized in 6.6 may have attributes, that now have stricter typing (or, in our case, a null value that has become unnullable.

### 2. What does this change do, exactly?
While it is not the most elegant solution, it throws the cart away instead of producing an error. This is already expected behavior, but we didn't catch Errors (in this case a TypeError), just Exceptions.

### 3. Describe each step to reproduce the issue or behaviour.
Phew. Hard to do.
- Start with 6.6
- Have a shipping method without a technical name (empty it via DB)
- Create a customer with cart content and select that shipping method
- Upgrade to 6.7
- Login again as the customer

### 4. Please link to the relevant issues (if any).
fixes #11155


### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
