### PR TITLE
fix: vue warning with invalid table markup

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/sw-license-violation.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/sw-license-violation.html.twig
@@ -13,67 +13,68 @@
     </span>
 
     <table class="sw-license-violation__table">
-        <tr>
-            <th width="200px">
-                {{ $tc('sw-license-violation.table.plugin') }}
-            </th>
-            <th>{{ $tc('sw-license-violation.table.warning') }}</th>
-            <th width="350px"></th>
-        </tr>
+        <thead>
+            <tr>
+                <th width="200px">
+                    {{ $tc('sw-license-violation.table.plugin') }}
+                </th>
+                <th>{{ $tc('sw-license-violation.table.warning') }}</th>
+                <th width="350px"></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr
+                v-for="violation in violations"
+                :key="violation.name"
+            >
+                <td class="sw-license-violation__table-name">
+                    <template v-if="getPluginForViolation(violation)">
+                        <img
+                            v-if="getPluginForViolation(violation).icon || getPluginForViolation(violation).iconRaw"
+                            :src="'data:image/png;base64, ' + (getPluginForViolation(violation).iconRaw || getPluginForViolation(violation).icon)"
+                            alt=""
+                        >
+                        <strong>
+                            {{ (getPluginForViolation(violation).translated && getPluginForViolation(violation).translated.label) || getPluginForViolation(violation).label}}
+                        </strong>
+                    </template>
 
-        <tr
-            v-for="violation in violations"
-            :key="violation.name"
-        >
+                    <template v-else>
+                        <p>
+                            <strong>{{ violation.name }}</strong>
+                        </p>
+                    </template>
+                </td>
 
-            <td class="sw-license-violation__table-name">
-                <template v-if="getPluginForViolation(violation)">
-                    <img
-                        v-if="getPluginForViolation(violation).icon || getPluginForViolation(violation).iconRaw"
-                        :src="'data:image/png;base64, ' + (getPluginForViolation(violation).iconRaw || getPluginForViolation(violation).icon)"
-                        alt=""
+                <td>{{ violation.extensions.licenseViolation.text }}</td>
+
+                <td class="sw-license-violation__table-actions">
+                    <div
+                        v-for="action in violation.extensions.licenseViolation.actions"
+                        :key="action.externalLink"
+                        class="sw-license-violation__table-actions-wrap"
                     >
-                    <strong>
-                        {{ (getPluginForViolation(violation).translated && getPluginForViolation(violation).translated.label) || getPluginForViolation(violation).label}}
-                    </strong>
-                </template>
+                        <mt-button
+                            class="sw-license-violation__table-action-remove"
+                            variant="critical"
+                            ghost
+                            size="small"
+                            @click.prevent="deletePlugin(violation)"
+                        >
+                            {{ $tc('sw-license-violation.deletePlugin') }}
+                        </mt-button>
 
-                <template v-else>
-                    <p>
-                        <strong>{{ violation.name }}</strong>
-                    </p>
-                </template>
-            </td>
-
-            <td>{{ violation.extensions.licenseViolation.text }}</td>
-
-            <td class="sw-license-violation__table-actions">
-                <div
-                    v-for="action in violation.extensions.licenseViolation.actions"
-                    :key="action.externalLink"
-                    class="sw-license-violation__table-actions-wrap"
-                >
-                    <mt-button
-                        class="sw-license-violation__table-action-remove"
-                        variant="critical"
-                        ghost
-                        size="small"
-                        @click.prevent="deletePlugin(violation)"
-                    >
-                        {{ $tc('sw-license-violation.deletePlugin') }}
-                    </mt-button>
-
-                    <mt-button
-                        :link="action.externalLink"
-                        ghost
-                        size="small"
-                        variant="secondary"
-                    >{{ action.label }}
-                    </mt-button>
-                </div>
-            </td>
-
-        </tr>
+                        <mt-button
+                            :link="action.externalLink"
+                            ghost
+                            size="small"
+                            variant="secondary"
+                        >{{ action.label }}
+                        </mt-button>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
     </table>
 
     <template #modal-footer>


### PR DESCRIPTION
### 1. Why is this change necessary?

```
 <tr> cannot be child of <table>, according to HTML specifications. This can cause hydration errors or potentially disrupt future 
  functionality
```


### 2. What does this change do, exactly?

add thead, tbody

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
