### PR TITLE
fix: backwards compatibility to Shopware 6.6 class

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -58,6 +58,7 @@ return [
         // Widening the property type with null is necessary and not a BC break
         preg_quote('CHANGED: Type of property Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity#$type changed from Shopware\Core\System\Tax\Aggregate\TaxRuleType\TaxRuleTypeEntity to Shopware\Core\System\Tax\Aggregate\TaxRuleType\TaxRuleTypeEntity|null', '/'),
         preg_quote('CHANGED: Type of property Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#$url changed from string to string|null', '/'),
+        preg_quote('CHANGED: Type of property Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#$mediaId changed from string to string|null', '/'),
 
         // The class has not been released
         'REMOVED: Class Shopware\\\\Elasticsearch\\\\Product\\\\CachedSearchConfigLoader has been deleted',

--- a/changelog/_unreleased/2025-07-29-fix-backward-compatibility-of-mediathumbnailentity.md
+++ b/changelog/_unreleased/2025-07-29-fix-backward-compatibility-of-mediathumbnailentity.md
@@ -1,0 +1,8 @@
+---
+title: Fix backward compatibility of MediaThumbnailEntity
+issue: 10040
+author: Dominik Grothaus
+author_email: d.grothaus@shopware.com
+---
+# Core
+* Changed `$mediaId` of `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity` from `string` to `?string` to have the same behaviour like in Shopware 6.6 so that objects serialized in Shopware 6.6 can be unserialized in 6.7 and don't throw an exception.

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -88,8 +88,14 @@ class MediaThumbnailEntity extends Entity
 
             if (!isset($this->mediaId)) {
                 return '';
-            };
+            }
+
+            return $this->mediaId;
         }
+
+        /** @deprecated tag:v6.8.0 - Will be non-nullable */
+        \assert(\is_string($this->mediaId));
+
         return $this->mediaId;
     }
 

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -30,13 +30,15 @@ class MediaThumbnailEntity extends Entity
 
     protected ?MediaEntity $media = null;
 
-    public function assign(array $options): void
+    public function assign(array $options)
     {
         parent::assign($options);
 
         if (!isset($this->mediaId) && Feature::isActive('v6.8.0.0')) {
             Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaId must not be null');
         }
+
+        return $this;
     }
 
     public function getWidth(): int

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -34,7 +34,7 @@ class MediaThumbnailEntity extends Entity
     {
         parent::assign($options);
 
-        if (!isset($this->mediaId) && Feature::isActive('v6.8.0.0')) {
+        if (!isset($this->mediaId)) {
             Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaId must not be null');
         }
 

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -83,6 +83,13 @@ class MediaThumbnailEntity extends Entity
 
     public function getMediaId(): string
     {
+        if (!Feature::isActive('v6.8.0.0')) {
+            Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaId must not be null');
+
+            if (!isset($this->mediaId)) {
+                return '';
+            };
+        }
         return $this->mediaId;
     }
 

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -83,18 +83,11 @@ class MediaThumbnailEntity extends Entity
 
     public function getMediaId(): string
     {
-        if (!Feature::isActive('v6.8.0.0')) {
+        if (!isset($this->mediaId)) {
             Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaId must not be null');
 
-            if (!isset($this->mediaId)) {
-                return '';
-            }
-
-            return $this->mediaId;
+            return '';
         }
-
-        /** @deprecated tag:v6.8.0 - Will be non-nullable */
-        \assert(\is_string($this->mediaId));
 
         return $this->mediaId;
     }

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -34,7 +34,7 @@ class MediaThumbnailEntity extends Entity
     {
         parent::assign($options);
 
-        if ($this->mediaId === null && Feature::isActive('v6.8.0.0')) {
+        if (!isset($this->mediaId) && Feature::isActive('v6.8.0.0')) {
             Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaId must not be null');
         }
     }

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -6,6 +6,7 @@ use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('discovery')]
@@ -22,9 +23,21 @@ class MediaThumbnailEntity extends Entity
 
     protected ?string $url = '';
 
-    protected string $mediaId;
+    /**
+     * @deprecated tag:v6.8.0 - Will be non-nullable
+     */
+    protected ?string $mediaId;
 
     protected ?MediaEntity $media = null;
+
+    public function assign(array $options): void
+    {
+        parent::assign($options);
+
+        if ($this->mediaId === null && Feature::isActive('v6.8.0.0')) {
+            Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaId must not be null');
+        }
+    }
 
     public function getWidth(): int
     {

--- a/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
+++ b/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
@@ -90,6 +90,7 @@ class RemoteThumbnailLoader implements ResetInterface
                 $thumbnail = new MediaThumbnailEntity();
                 $thumbnail->assign([
                     'id' => Uuid::randomHex(),
+                    'mediaId' => $mediaEntity->getUniqueIdentifier(),
                     'width' => (int) $size['width'],
                     'height' => (int) $size['height'],
                     'url' => $url,

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -2006,6 +2006,7 @@ class EntityReaderTest extends TestCase
 
     public function testReadRelationWithNestedToManyRelations(): void
     {
+        $ids = new IdsCollection();
         $context = Context::createDefaultContext();
 
         $data = [
@@ -2020,11 +2021,12 @@ class EntityReaderTest extends TestCase
             'cover' => [
                 'position' => 1,
                 'media' => [
+                    'id' => $ids->get('media'),
                     'name' => 'test-image',
                     'thumbnails' => [
-                        ['id' => Uuid::randomHex(), 'width' => 10, 'height' => 10, 'highDpi' => true],
-                        ['id' => Uuid::randomHex(), 'width' => 20, 'height' => 20, 'highDpi' => true],
-                        ['id' => Uuid::randomHex(), 'width' => 30, 'height' => 30, 'highDpi' => true],
+                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 10, 'height' => 10, 'highDpi' => true],
+                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 20, 'height' => 20, 'highDpi' => true],
+                        ['id' => Uuid::randomHex(), 'mediaId' => $ids->get('media'), 'width' => 30, 'height' => 30, 'highDpi' => true],
                     ],
                 ],
             ],

--- a/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
@@ -63,6 +63,7 @@ class RemoteThumbnailLoaderTest extends TestCase
             foreach ($entity->get('thumbnails') as $thumbnail) {
                 static::assertInstanceOf(MediaThumbnailEntity::class, $thumbnail);
                 static::assertTrue(\in_array($thumbnail->get('url'), $expected['thumbnails'], true));
+                static::assertSame($ids->get('media'), $thumbnail->getMediaId());
             }
         }
     }


### PR DESCRIPTION
In Shopware 6.6 `MediaThumbnailEntity` objects were allowed to have null for members that were not strictly typed but the getters/setters implicated that null would not be allowed.

As these objects are stored serialized in the database, when cart compression is enabled, it's impossible to `unserialize()` an object again, as the strict type now restricts `null` as a value.

With this change `$mediaId` will behave the same as in 6.6 by allowing null, but implicitly requiring a string.

Fixes #10040