### PR TITLE
fix: dont try to open browser in docker

### DIFF
--- a/src/Administration/Resources/app/administration/vite.config.mts
+++ b/src/Administration/Resources/app/administration/vite.config.mts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import symfonyPlugin from 'vite-plugin-symfony';
 import colors from 'picocolors';
-import { loadExtensions } from './build/vite-plugins/utils';
+import { isInsideDockerContainer, loadExtensions } from './build/vite-plugins/utils';
 import TwigPlugin from './build/vite-plugins/twigjs-plugin';
 import AssetPlugin from './build/vite-plugins/asset-plugin';
 import AssetPathPlugin from './build/vite-plugins/asset-path-plugin';
@@ -39,7 +39,7 @@ export default defineConfig(({ command }) => {
     const isDev = !isProd;
     const base = isProd ? '/bundles/administration/administration' : undefined;
     const useSourceMap = isDev && process.env.SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION !== '1';
-    const openBrowserForWatch = process.env.DISABLE_DEVSERVER_OPEN !== '1';
+    const openBrowserForWatch = process.env.DISABLE_DEVSERVER_OPEN !== '1' && !isInsideDockerContainer();
 
     if (isProd) {
         console.log(colors.yellow('# Production mode activated 🚀'));


### PR DESCRIPTION
### 1. Why is this change necessary?

On every vite start there is a error that it could not open the browser


### 2. What does this change do, exactly?

Dont try to open browser when we're running inside a docker container


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
