### PR TITLE
fix: add dark mode support to select components

### DIFF
--- a/changelog/_unreleased/2025-07-29-added-dark-mode-support-to-select-components.md
+++ b/changelog/_unreleased/2025-07-29-added-dark-mode-support-to-select-components.md
@@ -1,0 +1,8 @@
+---
+title: Added dark mode support to select components
+author: Nils Haberkamp
+author_email: n.haberkamp@shopware.com
+author_github: @Haberkamp
+---
+# Administration
+* Added Meteor Color Tokens to the select component

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-label/sw-label.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-label/sw-label.scss
@@ -3,23 +3,23 @@
 @import "~scss/mixins";
 @import "sw-label-variant";
 
-$sw-label-border-radius: math.div($border-radius-default, 2);
+$sw-label-border-radius: var(--border-radius-xs);
 $sw-label-pill-border-radius: 50px;
 
 .sw-label {
     display: inline-block;
     position: relative;
     max-width: 100%;
-    min-width: 56px;
-    margin: 0 6px 6px 0;
-    padding: 8px 12px;
+    min-width: var(--scale-size-56);
+    margin: 0 var(--scale-size-6) var(--scale-size-6) 0;
+    padding: var(--scale-size-8) var(--scale-size-12);
     line-height: 14px;
-    font-size: $font-size-xxs;
-    height: 32px;
-    border: 1px solid $color-gray-300;
-    background: $color-gray-50;
+    font-size: var(--font-size-2xs);
+    height: var(--scale-size-32);
+    border: 1px solid var(--color-border-primary-default);
+    background: var(--color-background-secondary-default);
     border-radius: $sw-label-border-radius;
-    color: $color-darkgray-200;
+    color: var(--color-text-primary-default);
     cursor: default;
 
     .sw-label__caption {
@@ -30,7 +30,8 @@ $sw-label-pill-border-radius: 50px;
     }
 
     &.sw-label--dismissable:hover {
-        border-color: $color-shopware-brand-500;
+        border-color: var(--color-border-brand-selected);
+        background: var(--color-background-brand-default);
 
         .sw-label__caption {
             width: calc(100% - 15px);
@@ -38,19 +39,19 @@ $sw-label-pill-border-radius: 50px;
 
         .sw-label__dismiss {
             display: inline-block;
-            color: $color-shopware-brand-500;
+            color: var(--color-icon-brand-default);
             background: transparent;
         }
     }
 
     &.sw-label--size-medium {
-        height: 24px;
-        padding: 4px 12px;
+        height: var(--scale-size-24);
+        padding: var(--scale-size-4) var(--scale-size-12);
     }
 
     &.sw-label--size-small {
-        height: 16px;
-        padding: 0 8px;
+        height: var(--scale-size-16);
+        padding: 0 var(--scale-size-8);
     }
 
     .sw-label__dismiss {

--- a/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-base-field/sw-base-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-base-field/sw-base-field.scss
@@ -2,17 +2,17 @@
 
 .sw-field {
     width: 100%;
-    margin-bottom: 32px;
+    margin-bottom: var(--scale-size-32);
 
     .sw-ai-copilot-badge {
-        height: 18px;
+        height: var(--scale-size-18);
     }
 
     .sw-field__label {
         display: flex;
-        line-height: 16px;
-        font-size: $font-size-xs;
-        margin-bottom: 8px;
+        line-height: var(--font-line-height-xs);
+        font-size: var(--font-size-xs);
+        margin-bottom: var(--scale-size-8);
         color: var(--color-text-primary-default);
 
         label {
@@ -22,16 +22,16 @@
 
     .sw-field__label .is--required::after {
         content: "*";
-        color: $color-shopware-brand-500;
+        color: var(--color-text-brand-default);
     }
 
     .sw-field__inheritance-icon {
-        margin-right: 8px;
+        margin-right: var(--scale-size-8);
     }
 
     .sw-field__button-restore {
-        color: $color-darkgray-200;
-        padding: 0 8px;
+        color: var(--color-text-primary-default);
+        padding: 0 var(--scale-size-8);
         border: none;
         background: none;
         outline: none;
@@ -46,23 +46,23 @@
 
     &.is--inherited {
         .sw-field__label {
-            color: $color-module-purple-900;
+            color: var(--color-text-accent-default);
         }
     }
 
     &.has--error {
-        margin-bottom: 12px;
+        margin-bottom: var(--scale-size-12);
 
         .sw-field__label {
-            color: $color-crimson-500;
+            color: var(--color-text-critical-default);
         }
     }
 
     &__hint {
-        margin-top: 4px;
-        font-size: $font-size-xxs;
+        margin-top: var(--scale-size-4);
+        font-size: var(--font-size-2xs);
         display: flex;
         align-items: center;
-        gap: 8px;
+        gap: var(--scale-size-8);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-block-field/sw-block-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-block-field/sw-block-field.scss
@@ -4,7 +4,7 @@ $sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
 
 .sw-block-field {
     .sw-block-field__block {
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-primary-default);
         border-radius: $border-radius-default;
         overflow: hidden;
         height: 48px;
@@ -22,11 +22,11 @@ $sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
         min-width: 0;
         padding: 12px 16px;
         border: none;
-        background: $color-white;
-        font-size: $font-size-xs;
-        line-height: 22px;
+        background: var(--color-elevation-surface-raised);
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
         transition: $sw-field-transition;
-        color: $color-darkgray-200;
+        color: var(--color-text-primary-default);
         outline: none;
         -webkit-appearance: none;
         -moz-appearance: none;
@@ -50,8 +50,8 @@ $sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
 
     &.has--focus {
         .sw-block-field__block {
-            border-color: $color-shopware-brand-500;
-            box-shadow: 0 0 4px lighten($color-shopware-brand-500, 30%);
+            outline-offset: var(--scale-size-2);
+            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
@@ -41,7 +41,8 @@
                 <mt-icon
                     class="sw-select__select-indicator sw-select__select-indicator-clear"
                     name="regular-times-s"
-                    size="16px"
+                    size="var(--scale-size-16)"
+                    color="var(--color-icon-primary-default)"
                 />
             </button>
 
@@ -49,7 +50,8 @@
                 class="sw-select__select-indicator sw-select__select-indicator-expand"
                 :class="{ 'sw-select__select-indicator-expand--rotated': !expanded }"
                 name="regular-chevron-up-xs"
-                size="10px"
+                color="var(--color-icon-primary-default)"
+                size="var(--scale-size-10)"
                 @click="toggleExpand"
             />
         </div>

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
@@ -1,13 +1,10 @@
 @import "~scss/variables";
 
-$sw-select-focus-transition: all ease-in-out 0.2s;
-
 .sw-select {
     position: relative;
 
     .sw-block-field__block {
-        transition: $sw-select-focus-transition;
-        background-color: $color-white;
+        background-color: var(--color-elevation-surface-raised);
         position: relative;
         overflow: visible;
     }
@@ -15,11 +12,11 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
     .sw-select__selection {
         position: relative;
         height: 100%;
-        padding: 0 8px;
+        padding: 0 var(--scale-size-8);
         border: none;
-        font-size: $font-size-xs;
-        line-height: 22px;
-        color: $color-darkgray-200;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
+        color: var(--color-text-primary-default);
         outline: none;
         -webkit-appearance: none;
         -moz-appearance: none;
@@ -29,17 +26,17 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
         position: absolute;
         display: flex;
         align-items: center;
-        gap: 8px;
+        gap: var(--scale-size-8);
         top: 50%;
-        right: 16px;
+        right: var(--scale-size-16);
         transform: translate(0, -50%);
         z-index: 1;
     }
 
     .sw-select__selection-indicators .sw-loader {
         position: static;
-        width: 16px;
-        height: 16px;
+        width: var(--scale-size-16);
+        height: var(--scale-size-16);
         margin: 0;
 
         .sw-loader__container {
@@ -52,9 +49,14 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
     .sw-select__select-indicator-hitbox {
         background-color: transparent;
         border: 0 solid transparent;
-        color: $color-darkgray-200;
-        padding: 0 4px;
+        padding: 0 var(--scale-size-4);
         cursor: pointer;
+        border-radius: var(--border-radius-xs);
+
+        &:focus-visible {
+            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline-offset: var(--scale-size-2);
+        }
 
         .sw-select__select-indicator {
             display: block;
@@ -84,8 +86,8 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
     }
 
     .sw-select__select-indicator-clear {
-        width: 16px;
-        height: 16px;
+        width: var(--scale-size-16);
+        height: var(--scale-size-16);
         padding: 3px;
         transition: 0.1s opacity ease;
         opacity: 0;
@@ -100,7 +102,7 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
     }
 
     &.sw-field--medium .sw-select__selection {
-        padding: 4px 6px 0;
+        padding: 4px var(--scale-size-16) 0;
     }
 
     &.sw-field--small .sw-block-field__block {
@@ -109,15 +111,22 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
 
     &.is--disabled {
         .sw-block-field__block {
-            background-color: $color-gray-100;
+            background-color: var(--color-background-primary-disabled);
         }
 
-        .sw-label {
-            background-color: $color-gray-100;
+        .sw-label,
+        .sw-label--dismissable:hover {
+            background-color: var(--color-interaction-secondary-disabled);
+            color: var(--color-text-primary-disabled);
+            border-color: var(--color-border-primary-default);
+
+            .sw-label__dismiss {
+                color: var(--color-icon-primary-disabled);
+            }
         }
 
         input {
-            background-color: $color-gray-100;
+            background-color: var(--color-background-primary-disabled);
         }
     }
 }
@@ -125,7 +134,6 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
 // Vue.js transitions
 .sw-select-result-list-fade-down-enter-active,
 .sw-select-result-list-fade-down-leave-active {
-    transition: $sw-select-focus-transition;
     transform: translateY(0);
 }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result-list/sw-select-result-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result-list/sw-select-result-list.html.twig
@@ -32,7 +32,8 @@
                 {% block sw_select_result_list_empty_icon %}
                 <mt-icon
                     name="regular-search"
-                    size="20px"
+                    size="var(--scale-size-16)"
+                    color="var(--color-icon-primary-default)"
                 />
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result-list/sw-select-result-list.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result-list/sw-select-result-list.scss
@@ -38,12 +38,12 @@ $sw-select-result-list-transition: all ease-in-out 0.2s;
     max-height: 250px;
     overflow-x: hidden;
     overflow-y: auto;
-    border: 1px solid $color-gray-100;
-    box-shadow: 0 3px 6px 0 $color-gray-300;
-    background-color: $color-white;
-    font-size: $font-size-xs;
-    padding: 8px;
-    border-radius: 4px;
+    border: 1px solid var(--color-border-primary-default);
+    box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
+    background-color: var(--color-elevation-surface-overlay);
+    font-size: var(--font-size-xs);
+    padding: var(--scale-size-8);
+    border-radius: var(--border-radius-overlay);
 
     .sw-select-result-list__item-list {
         list-style: none;
@@ -51,6 +51,10 @@ $sw-select-result-list-transition: all ease-in-out 0.2s;
 
     .sw-select-result-list__empty {
         padding: 10px 16px;
+        color: var(--color-text-primary-default);
+        display: flex;
+        align-items: center;
+        gap: var(--scale-size-12);
     }
 }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.scss
@@ -1,15 +1,15 @@
 @import "~scss/variables";
 
-$sw-select-result-active-color-background: lighten($color-shopware-brand-500, 40%);
-$sw-select-result-active-color-text: $color-shopware-brand-500;
-$sw-select-result-color-border: $color-gray-300;
-$sw-select-result-color-icon: darken($color-gray-100, 20%);
+$sw-select-result-active-color-background: var(--color-background-brand-default);
+$sw-select-result-active-color-text: var(--color-text-primary-default);
+$sw-select-result-color-border: var(--color-border-primary-default);
+$sw-select-result-color-icon: var(--color-text-primary-default);
 $sw-select-result-transition-item-icon: all ease-in-out 0.15s;
-$sw-select-result-disabled-color-background: $color-gray-100;
-$sw-select-result-disabled-color-text: darken($color-gray-300, 15%);
+$sw-select-result-disabled-color-background: var(--color-background-primary-disabled);
+$sw-select-result-disabled-color-text: var(--color-text-primary-disabled);
 
 .sw-select-result {
-    padding: 12px 15px;
+    padding: var(--scale-size-12) 15px;
     cursor: pointer;
     display: grid;
     grid-template-columns: auto 1fr auto auto;
@@ -19,7 +19,7 @@ $sw-select-result-disabled-color-text: darken($color-gray-300, 15%);
 
     .sw-select-result__result-item-preview {
         order: 1;
-        margin-right: 10px;
+        margin-right: var(--scale-size-10);
         display: block;
         grid-area: a;
 
@@ -33,19 +33,19 @@ $sw-select-result-disabled-color-text: darken($color-gray-300, 15%);
         word-break: break-word;
         display: flex;
         flex-direction: column;
-        color: $color-darkgray-200;
+        color: var(--color-text-primary-default);
         order: 2;
         overflow: hidden;
         grid-area: b;
     }
 
     .sw-select-result__result-item-checkmark {
-        width: 16px;
-        height: 16px;
-        padding-top: 4px;
-        padding-right: 2px;
+        width: var(--scale-size-16);
+        height: var(--scale-size-16);
+        padding-top: var(--scale-size-4);
+        padding-right: var(--scale-size-2);
         padding-bottom: 3px;
-        padding-left: 2px;
+        padding-left: var(--scale-size-2);
     }
 
     &.is--active {
@@ -59,10 +59,10 @@ $sw-select-result-disabled-color-text: darken($color-gray-300, 15%);
 
     .sw-select-result__result-item-description {
         width: 100%;
-        color: $color-gray-600;
+        color: var(--color-text-secondary-default);
         order: 3;
         line-height: 14px;
-        padding: 0 0 0 8px;
+        padding: 0 0 0 var(--scale-size-8);
         grid-area: c;
     }
 
@@ -82,7 +82,7 @@ $sw-select-result-disabled-color-text: darken($color-gray-300, 15%);
 
         .sw-select-result__result-item-description {
             grid-column-start: 1;
-            padding: 8px 0 0;
+            padding: var(--scale-size-8) 0 0;
             order: 3;
 
             &:empty {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-selection-list/sw-select-selection-list.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-selection-list/sw-select-selection-list.scss
@@ -18,14 +18,14 @@
     }
 
     button.sw-select-selection-list__load-more-button {
-        padding: 8px 12px;
-        margin: 0 6px 0 0;
-        color: $color-shopware-brand-500;
+        padding: var(--scale-size-8) var(--scale-size-12);
+        margin: 0 var(--scale-size-6) 0 0;
+        color: var(--color-text-brand-default);
         font-size: $font-size-xxs;
         line-height: 14px;
-        border-radius: 2px;
+        border-radius: var(--border-radius-xs);
         height: unset;
-        border-color: $color-gray-300;
+        border-color: var(--color-border-primary-default);
     }
 
     .sw-select-selection-list__input-wrapper {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-field-deprecated/sw-select-field-deprecated.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-field-deprecated/sw-select-field-deprecated.html.twig
@@ -54,6 +54,7 @@
             <mt-icon
                 name="regular-chevron-down-xs"
                 size="16px"
+                color="var(--color-icon-primary-default)"
                 decorative
             />
         </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

To add Dark Mode support for select components.


### 2. What does this change do, exactly?

I replaced the SCSS variables with the Meteor Design Tokens.


### 3. Describe each step to reproduce the issue or behaviour.

1. Checkout the branch
2. Add a `data-theme="dark"` to the `body` element
3. Go to any page with a select component (there's one on the product detail page)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
