### PR TITLE
fix: promotion discount advanced prices responsitivity

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -449,17 +449,17 @@ export default {
             this.discount.value = discountHandler.getFixedValue(this.discount.value, this.discount.type);
         },
 
-        onDiscountValueChanged: Utils.debounce(function debounceUpdateValue(value) {
+        onDiscountValueChanged(value) {
             this.discount.value = discountHandler.getFixedValue(value, this.discount.type);
 
             this.recalculatePrices();
-        }, 500),
+        },
 
         // The number field does not allow a NULL input
         // so the value cannot be cleared anymore.
         // If the user removes the value, it will be 0 and converted
         // into NULL, which means no max value applies anymore.
-        onMaxValueChanged: Utils.debounce(function debounceUpdateMaxValue(value) {
+        onMaxValueChanged(value) {
             if (value === 0) {
                 // clear max value
                 this.discount.maxValue = null;
@@ -468,7 +468,7 @@ export default {
             } else {
                 this.recalculatePrices();
             }
-        }, 500),
+        },
 
         onClickAdvancedPrices() {
             this.currencies.forEach((currency) => {
@@ -476,55 +476,40 @@ export default {
                     // if we have a max-value setting active
                     // then our advanced prices is for this
                     // otherwise its for the promotion value itself
-                    if (this.showMaxValueAdvancedPrices) {
-                        this.prepareAdvancedPrices(currency, this.discount.maxValue);
-                    } else {
-                        this.prepareAdvancedPrices(currency, this.discount.value);
-                    }
+                    // now create the value with the calculated and translated value
+                    const newAdvancedCurrencyPrices = this.advancedPricesRepo.create(Shopware.Context.api);
+                    newAdvancedCurrencyPrices.discountId = this.discount.id;
+                    newAdvancedCurrencyPrices.price = this.calculatePrice(currency);
+                    newAdvancedCurrencyPrices.currencyId = currency.id;
+                    newAdvancedCurrencyPrices.currency = currency;
+
+                    this.discount.promotionDiscountPrices.add(newAdvancedCurrencyPrices);
                 }
             });
             this.displayAdvancedPrices = true;
         },
 
         recalculatePrices() {
-            const basePrice = this.showMaxValueAdvancedPrices ? this.discount.maxValue : this.discount.value;
+            this.discount.promotionDiscountPrices.forEach((price) => {
+                const currency = this.currencies.get(price.currencyId);
+                if (!currency) {
+                    return;
+                }
 
-            const currencyMapping = {};
-            this.currencies.forEach((currency) => {
-                currencyMapping[currency.id] = currency.factor;
+                price.price = this.calculatePrice(currency);
             });
-
-            this.discount.promotionDiscountPrices = this.discount.promotionDiscountPrices
-                .filter((price) => currencyMapping[price.currencyId] !== undefined)
-                .map((price) => {
-                    const setPrice = (basePrice ?? discountHandler.getMinValue()) * currencyMapping[price.currencyId];
-                    price.price = Math.min(setPrice, discountHandler.getMinValue());
-
-                    return price;
-                });
         },
 
-        prepareAdvancedPrices(currency, basePrice) {
-            // first get the minimum value that is allowed
-            let setPrice = discountHandler.getMinValue();
-            // if basePrice is undefined take the minimum price
-            if (basePrice !== undefined) {
-                setPrice = basePrice;
-            }
-            // foreign currencies are translated at the exchange rate of the default currency
-            setPrice *= currency.factor;
-            // even if translated correctly the value may not be less than the allowed minimum value
-            if (setPrice < discountHandler.getMinValue()) {
-                setPrice = discountHandler.getMinValue();
-            }
-            // now create the value with the calculated and translated value
-            const newAdvancedCurrencyPrices = this.advancedPricesRepo.create(Shopware.Context.api);
-            newAdvancedCurrencyPrices.discountId = this.discount.id;
-            newAdvancedCurrencyPrices.price = setPrice;
-            newAdvancedCurrencyPrices.currencyId = currency.id;
-            newAdvancedCurrencyPrices.currency = currency;
+        calculatePrice(currency) {
+            const price = this.showMaxValueAdvancedPrices ? this.discount.maxValue : this.discount.value;
 
-            this.discount.promotionDiscountPrices.add(newAdvancedCurrencyPrices);
+            // if basePrice is undefined or lower than minimum, take the minimum price
+            if (!price || price < discountHandler.getMinValue()) {
+                return discountHandler.getMinValue();
+            }
+
+            // foreign currencies are translated at the exchange rate of the default currency
+            return price * currency.factor;
         },
 
         clearAdvancedPrices() {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -3,7 +3,7 @@ import template from './sw-promotion-discount-component.html.twig';
 import './sw-promotion-discount-component.scss';
 import DiscountHandler from './handler';
 
-const { Mixin, Utils } = Shopware;
+const { Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
 const discountHandler = new DiscountHandler();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.spec.js
@@ -53,13 +53,15 @@ async function createWrapper() {
                             if (entity === 'currency') {
                                 return {
                                     search: () =>
-                                        Promise.resolve(new EntityCollection('', 'currency', Shopware.Context.api, new Criteria(1, 25), [
-                                            {
-                                                id: 'currencyId',
-                                                isSystemDefault: true,
-                                                factor: 3,
-                                            },
-                                        ])),
+                                        Promise.resolve(
+                                            new EntityCollection('', 'currency', Shopware.Context.api, new Criteria(1, 25), [
+                                                {
+                                                    id: 'currencyId',
+                                                    isSystemDefault: true,
+                                                    factor: 3,
+                                                },
+                                            ]),
+                                        ),
                                 };
                             }
 
@@ -134,7 +136,12 @@ async function createWrapper() {
                     apiAlias: null,
                     id: 'discountId',
                     discountRules: new EntityCollection('', 'rule', Shopware.Context.api, new Criteria(1, 25)),
-                    promotionDiscountPrices: new EntityCollection('', 'promotion_discount_prices', Shopware.Context.api, new Criteria(1, 25)),
+                    promotionDiscountPrices: new EntityCollection(
+                        '',
+                        'promotion_discount_prices',
+                        Shopware.Context.api,
+                        new Criteria(1, 25),
+                    ),
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.spec.js
@@ -53,16 +53,19 @@ async function createWrapper() {
                             if (entity === 'currency') {
                                 return {
                                     search: () =>
-                                        Promise.resolve([
+                                        Promise.resolve(new EntityCollection('', 'currency', Shopware.Context.api, new Criteria(1, 25), [
                                             {
-                                                id: 'promotionId1',
+                                                id: 'currencyId',
                                                 isSystemDefault: true,
+                                                factor: 3,
                                             },
-                                        ]),
+                                        ])),
                                 };
                             }
+
                             return {
                                 search: () => Promise.resolve([{ id: 'promotionId1' }]),
+                                create: () => ({}),
                             };
                         },
                     },
@@ -131,7 +134,7 @@ async function createWrapper() {
                     apiAlias: null,
                     id: 'discountId',
                     discountRules: new EntityCollection('', 'rule', Shopware.Context.api, new Criteria(1, 25)),
-                    promotionDiscountPrices: [],
+                    promotionDiscountPrices: new EntityCollection('', 'promotion_discount_prices', Shopware.Context.api, new Criteria(1, 25)),
                 },
             },
         },
@@ -199,5 +202,23 @@ describe('src/module/sw-promotion-v2/component/sw-promotion-discount-component',
         await wrapper.vm.$nextTick();
 
         expect(wrapper.find('.sw-promotion-discount-component__select-discount-rules').exists()).toBeTruthy();
+    });
+
+    it('should create advanced prices and recalculate advanced prices when value changes', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.discount.value = 2;
+        wrapper.vm.onClickAdvancedPrices();
+
+        expect(wrapper.vm.discount.promotionDiscountPrices).toHaveLength(1);
+        expect(wrapper.vm.discount.promotionDiscountPrices[0].currencyId).toBe('currencyId');
+        expect(wrapper.vm.discount.promotionDiscountPrices[0].price).toBe(6);
+
+        wrapper.vm.discount.value = 3;
+        wrapper.vm.recalculatePrices();
+
+        expect(wrapper.vm.discount.promotionDiscountPrices).toHaveLength(1);
+        expect(wrapper.vm.discount.promotionDiscountPrices[0].currencyId).toBe('currencyId');
+        expect(wrapper.vm.discount.promotionDiscountPrices[0].price).toBe(9);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
The recent introduction of a debounce function made saving values impossible, when the field was still in focus when hitting save.

### 2. What does this change do, exactly?
Remove debounce function (not important, as there are no big calculations or irritating behavior).
Also cleaned up the duplicate calculation code.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a promotion with a discount and a value.
- Save it.
- Edit the value and then hit save without previously defocusing the value field.

### 4. Please link to the relevant issues (if any).
closes #10987 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
