### PR TITLE
fix: Set state machine history FK constraint to integration to SET NULL

### DIFF
--- a/changelog/_unreleased/2025-07-29-fix-state-machine-history-fk-constraint.md
+++ b/changelog/_unreleased/2025-07-29-fix-state-machine-history-fk-constraint.md
@@ -1,0 +1,6 @@
+---
+title: Fix state machine history FK constraint to integration
+issue: #11583
+---
+# Core
+* Changed `ON DELETE` action for foreign key `fk.state_machine_history.integration_id` on `state_machine_history`table to `SET NULL` to prevent constraint violation when deleting an integration that has added state machine history entities.

--- a/src/Core/Migration/V6_7/Migration1753799632FixStateMachineHistoryIntegrationConstraint.php
+++ b/src/Core/Migration/V6_7/Migration1753799632FixStateMachineHistoryIntegrationConstraint.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore
+ */
+#[Package('checkout')]
+class Migration1753799632FixStateMachineHistoryIntegrationConstraint extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1753799632;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->dropForeignKeyIfExists($connection, 'state_machine_history', 'fk.state_machine_history.integration_id');
+
+        $connection->executeStatement('
+            ALTER TABLE `state_machine_history`
+            ADD CONSTRAINT `fk.state_machine_history.integration_id` FOREIGN KEY (`integration_id`)
+                REFERENCES `integration` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1753799632FixStateMachineHistoryIntegrationConstraint.php
+++ b/src/Core/Migration/V6_7/Migration1753799632FixStateMachineHistoryIntegrationConstraint.php
@@ -21,6 +21,7 @@ class Migration1753799632FixStateMachineHistoryIntegrationConstraint extends Mig
 
     public function update(Connection $connection): void
     {
+        /** @phpstan-ignore shopware.dropStatement (FK is directly added again so dropping the FK is no issue for blue green) */
         $this->dropForeignKeyIfExists($connection, 'state_machine_history', 'fk.state_machine_history.integration_id');
 
         $connection->executeStatement('
@@ -28,10 +29,5 @@ class Migration1753799632FixStateMachineHistoryIntegrationConstraint extends Mig
             ADD CONSTRAINT `fk.state_machine_history.integration_id` FOREIGN KEY (`integration_id`)
                 REFERENCES `integration` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
         ');
-    }
-
-    public function updateDestructive(Connection $connection): void
-    {
-        // implement update destructive
     }
 }

--- a/tests/migration/Core/V6_7/Migration1753799632FixStateMachineHistoryIntegrationConstraintTest.php
+++ b/tests/migration/Core/V6_7/Migration1753799632FixStateMachineHistoryIntegrationConstraintTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppDefinition;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\ColumnExistsTrait;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1752499887UpdateAppRequestedPrivileges;
+use Shopware\Core\Migration\V6_7\Migration1753799632FixStateMachineHistoryIntegrationConstraint;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryDefinition;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Migration1753799632FixStateMachineHistoryIntegrationConstraint::class)]
+class Migration1753799632FixStateMachineHistoryIntegrationConstraintTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+
+        try {
+            $this->connection->executeStatement('
+                ALTER TABLE `state_machine_history` DROP FOREIGN KEY `fk.state_machine_history.integration_id`;
+            ');
+
+        } catch (\Throwable) {
+        }
+    }
+
+    public function testMigration(): void
+    {
+        $migration = new Migration1753799632FixStateMachineHistoryIntegrationConstraint();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $fks = $this->connection->createSchemaManager()->listTableForeignKeys(StateMachineHistoryDefinition::ENTITY_NAME);;
+        $fk = current(array_filter($fks, fn(ForeignKeyConstraint $fk) => $fk->getName() === 'fk.state_machine_history.integration_id'));
+
+        static::assertInstanceOf(ForeignKeyConstraint::class, $fk);
+        static::assertSame(ReferentialAction::SET_NULL, $fk->getOnDeleteAction());
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1753799632FixStateMachineHistoryIntegrationConstraintTest.php
+++ b/tests/migration/Core/V6_7/Migration1753799632FixStateMachineHistoryIntegrationConstraintTest.php
@@ -7,11 +7,8 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\App\AppDefinition;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Migration\ColumnExistsTrait;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
-use Shopware\Core\Migration\V6_7\Migration1752499887UpdateAppRequestedPrivileges;
 use Shopware\Core\Migration\V6_7\Migration1753799632FixStateMachineHistoryIntegrationConstraint;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryDefinition;
 
@@ -32,7 +29,6 @@ class Migration1753799632FixStateMachineHistoryIntegrationConstraintTest extends
             $this->connection->executeStatement('
                 ALTER TABLE `state_machine_history` DROP FOREIGN KEY `fk.state_machine_history.integration_id`;
             ');
-
         } catch (\Throwable) {
         }
     }
@@ -43,8 +39,8 @@ class Migration1753799632FixStateMachineHistoryIntegrationConstraintTest extends
         $migration->update($this->connection);
         $migration->update($this->connection);
 
-        $fks = $this->connection->createSchemaManager()->listTableForeignKeys(StateMachineHistoryDefinition::ENTITY_NAME);;
-        $fk = current(array_filter($fks, fn(ForeignKeyConstraint $fk) => $fk->getName() === 'fk.state_machine_history.integration_id'));
+        $fks = $this->connection->createSchemaManager()->listTableForeignKeys(StateMachineHistoryDefinition::ENTITY_NAME);
+        $fk = current(array_filter($fks, fn (ForeignKeyConstraint $fk) => $fk->getName() === 'fk.state_machine_history.integration_id'));
 
         static::assertInstanceOf(ForeignKeyConstraint::class, $fk);
         static::assertSame(ReferentialAction::SET_NULL, $fk->getOnDeleteAction());


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/11583

### 1. Why is this change necessary?
The FK was added here: https://github.com/shopware/shopware/pull/8989/files#diff-7e93e76d1e17baa1da96b2b99becf9bcbf0d03c7c740c0a85bcf381ca898c918R26
With on delete action `NO ACTION` which equals `RESTRICT` for InnoDB: https://dev.mysql.com/doc/refman/8.4/en/create-table-foreign-keys.html#foreign-key-referential-actions

Thus integrations that added state machine state changes could not be uninstalled anymore.

### 2. What does this change do, exactly?
Set the on delete action for the FK to `SET NULL`, to allow integrations to be uninstalled again. 
This is similar to the behaviour for the `user_id` column for that table. 

And funny enough we had the same issue with that column as well, see: https://github.com/shopware/shopware/blob/trunk/src/Core/Migration/V6_3/Migration1609857999FixStateMachineHistoryUserConstraint.php#L15


### 3. Describe each step to reproduce the issue or behaviour.
Install a integration that mutates order states and try to delete it again after it changed the state of an order.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/11583
