### PR TITLE
fix: MySQL primary connection is not working when replica configured

### DIFF
--- a/changelog/_unreleased/2025-07-29-fix-primary-connection-is-not-working-when-replica-configured.md
+++ b/changelog/_unreleased/2025-07-29-fix-primary-connection-is-not-working-when-replica-configured.md
@@ -3,4 +3,4 @@ title: Fix primary connection is not working when replica configured
 issue: https://github.com/shopware/shopware/issues/11085
 ---
 # Core
-* Changed `Shopware\Core\Framework\Adapter\Database\MySQLFactory` to parse the primary connection dsn similarly to the replica dsn.
+* Changed `Shopware\Core\Framework\Adapter\Database\MySQLFactory` to parse the primary connection DSN similarly to the replica DSN.

--- a/changelog/_unreleased/2025-07-29-fix-primary-connection-is-not-working-when-replica-configured.md
+++ b/changelog/_unreleased/2025-07-29-fix-primary-connection-is-not-working-when-replica-configured.md
@@ -1,0 +1,6 @@
+---
+title: Fix primary connection is not working when replica configured
+issue: https://github.com/shopware/shopware/issues/11085
+---
+# Core
+* Changed `Shopware\Core\Framework\Adapter\Database\MySQLFactory` to parse the primary connection dsn similarly to the replica dsn.

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\Adapter\Database;
 
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
@@ -41,9 +42,25 @@ class MySQLFactoryTest extends TestCase
 
         // If we get here, the connection was successful and we can test the parameters
         static::assertArrayHasKey('wrapperClass', $params);
+        static::assertSame(PrimaryReadReplicaConnection::class, $params['wrapperClass']);
         static::assertArrayHasKey('primary', $params);
         static::assertArrayHasKey('replica', $params);
         static::assertCount(2, $params['replica']);
+
+        // Check primary parameters
+        $primary = $params['primary'];
+        static::assertArrayHasKey('host', $primary);
+        static::assertSame('localhost', $primary['host']);
+        static::assertArrayHasKey('port', $primary);
+        static::assertSame(3306, $primary['port']);
+        static::assertArrayHasKey('user', $primary);
+        static::assertSame('user', $primary['user']);
+        static::assertArrayHasKey('password', $primary);
+        static::assertSame('pass', $primary['password']);
+        static::assertArrayHasKey('dbname', $primary);
+        static::assertSame('shopware', $primary['dbname']);
+        static::assertArrayHasKey('charset', $primary);
+        static::assertSame('utf8mb4', $primary['charset']);
 
         // Check first replica parameters
         $replica0 = $params['replica'][0];

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -46,63 +46,69 @@ class MySQLFactoryTest extends TestCase
         static::assertArrayHasKey('primary', $params);
         static::assertArrayHasKey('replica', $params);
         static::assertCount(2, $params['replica']);
+        static::assertArrayHasKey('driverOptions', $params);
 
         // Check primary parameters
-        $primary = $params['primary'];
-        static::assertArrayHasKey('host', $primary);
-        static::assertSame('localhost', $primary['host']);
-        static::assertArrayHasKey('port', $primary);
-        static::assertSame(3306, $primary['port']);
-        static::assertArrayHasKey('user', $primary);
-        static::assertSame('user', $primary['user']);
-        static::assertArrayHasKey('password', $primary);
-        static::assertSame('pass', $primary['password']);
-        static::assertArrayHasKey('dbname', $primary);
-        static::assertSame('shopware', $primary['dbname']);
-        static::assertArrayHasKey('charset', $primary);
-        static::assertSame('utf8mb4', $primary['charset']);
+        $this->assertConnectionParameters($params['primary'], [
+            'host' => 'localhost',
+            'port' => 3306,
+            'user' => 'user',
+            'password' => 'pass',
+            'dbname' => 'shopware',
+            'driver' => 'pdo_mysql',
+            'charset' => 'utf8mb4',
+            'driverOptions' => $params['driverOptions'],
+        ]);
 
         // Check first replica parameters
         $replica0 = $params['replica'][0];
-        static::assertArrayHasKey('host', $replica0);
-        static::assertSame('replica_host', $replica0['host']);
-        static::assertArrayHasKey('port', $replica0);
-        static::assertSame(3307, $replica0['port']);
-        static::assertArrayHasKey('user', $replica0);
-        static::assertSame('replica_user', $replica0['user']);
-        static::assertArrayHasKey('password', $replica0);
-        static::assertSame('replica_pass', $replica0['password']);
-        static::assertArrayHasKey('dbname', $replica0);
-        static::assertSame('replica_db', $replica0['dbname']);
-        static::assertArrayHasKey('charset', $replica0);
-        static::assertSame('utf8mb4', $replica0['charset']);
+        $this->assertConnectionParameters($replica0, [
+            'host' => 'replica_host',
+            'port' => 3307,
+            'user' => 'replica_user',
+            'password' => 'replica_pass',
+            'dbname' => 'replica_db',
+            'driver' => 'pdo_mysql',
+            'charset' => 'utf8mb4',
+            'driverOptions' => $params['driverOptions'],
+        ]);
 
         // Check second replica parameters
         $replica1 = $params['replica'][1];
-        static::assertArrayHasKey('host', $replica1);
-        static::assertSame('replica_host2', $replica1['host']);
-        static::assertArrayHasKey('port', $replica1);
-        static::assertSame(3308, $replica1['port']);
-        static::assertArrayHasKey('user', $replica1);
-        static::assertSame('replica_user2', $replica1['user']);
-        static::assertArrayHasKey('password', $replica1);
-        static::assertSame('replica_pass2', $replica1['password']);
-        static::assertArrayHasKey('dbname', $replica1);
-        static::assertSame('replica_db2', $replica1['dbname']);
-        static::assertArrayHasKey('charset', $replica1);
-        static::assertSame('utf8mb4', $replica1['charset']);
+        $this->assertConnectionParameters($replica1, [
+            'host' => 'replica_host2',
+            'port' => 3308,
+            'user' => 'replica_user2',
+            'password' => 'replica_pass2',
+            'dbname' => 'replica_db2',
+            'driver' => 'pdo_mysql',
+            'charset' => 'utf8mb4',
+            'driverOptions' => $params['driverOptions'],
+        ]);
+    }
 
-        // Verify that parameters are merged correctly
-        static::assertArrayHasKey('driver', $replica0);
-        static::assertSame('pdo_mysql', $replica0['driver']);
-        static::assertArrayHasKey('driverOptions', $params);
-        static::assertArrayHasKey('driverOptions', $replica0);
-        static::assertSame($replica0['driverOptions'], $params['driverOptions']);
-
-        static::assertArrayHasKey('driver', $replica1);
-        static::assertSame('pdo_mysql', $replica1['driver']);
-        static::assertArrayHasKey('driverOptions', $replica1);
-        static::assertSame($replica1['driverOptions'], $params['driverOptions']);
+    /**
+     * @param array<string, mixed> $actualParams
+     * @param array<string, mixed> $expectedParams
+     */
+    private function assertConnectionParameters(array $actualParams, array $expectedParams): void
+    {
+        static::assertArrayHasKey('host', $actualParams);
+        static::assertSame($expectedParams['host'], $actualParams['host']);
+        static::assertArrayHasKey('port', $actualParams);
+        static::assertSame($expectedParams['port'], $actualParams['port']);
+        static::assertArrayHasKey('user', $actualParams);
+        static::assertSame($expectedParams['user'], $actualParams['user']);
+        static::assertArrayHasKey('password', $actualParams);
+        static::assertSame($expectedParams['password'], $actualParams['password']);
+        static::assertArrayHasKey('dbname', $actualParams);
+        static::assertSame($expectedParams['dbname'], $actualParams['dbname']);
+        static::assertArrayHasKey('charset', $actualParams);
+        static::assertSame($expectedParams['charset'], $actualParams['charset']);
+        static::assertArrayHasKey('driverOptions', $actualParams);
+        static::assertSame($expectedParams['driverOptions'], $actualParams['driverOptions']);
+        static::assertArrayHasKey('driver', $actualParams);
+        static::assertSame($expectedParams['driver'], $actualParams['driver']);
     }
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

MySQL primary connection is not initialized properly when replica configured.

### 2. What does this change do, exactly?

Initializes primary connection similarly to replica connection (using DsnParser).

### 3. Describe each step to reproduce the issue or behaviour.

Configure main and replica connections like:
```
DATABASE_URL="mysql://user:password@127.0.0.1:3306/dbname"
DATABASE_REPLICA_0_URL="mysql://user:password@127.0.0.1:3306/dbname"
```
and run some operation that writes to the database, like
```
./bin/console plugin:refresh
```

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/11085

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
