### PR TITLE
ci: fix external-contribution label on backports

### DIFF
--- a/.github/workflows/external-contributor-label.yml
+++ b/.github/workflows/external-contributor-label.yml
@@ -2,7 +2,7 @@ name: Add the "external-contribution" label to PRs created by community members
 
 on:
   pull_request_target:
-    types: [ opened, reopened ]
+    types: [opened, reopened]
 
 jobs:
   add-label:
@@ -18,20 +18,20 @@ jobs:
           script: |
             const pullRequestNumber = context.payload.pull_request.number;
             const contribLabel = process.env.CONTRIBUTOR_LABEL;
-            
+
             let hasWriteAccess = false;
-            
+
             const permissionLevel = await github.rest.repos.getCollaboratorPermissionLevel({
               ...context.repo,
               username: context.actor,
             });
-            
+
             if (permissionLevel.status !== 200) {
               core.info(`Failed to get permission level for "${context.actor}", assuming no write access.`);
             } else {
-              hasWriteAccess = ['admin', 'write'].includes(permissionLevel?.data?.permission);
+              hasWriteAccess = ['admin', 'write'].includes(permissionLevel?.data?.permission) || permissionLevel?.data?.user.node_id == "BOT_kgDOCV3tAw";
             }
-            
+
             if (hasWriteAccess) {
               core.info(`User "${context.actor}" has write access, skipping label addition.`);
             } else {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when we create a backport, the backport gets the `external-contribution` label as `octo-sts` doesn't have direct write permission on this repo.

### 2. What does this change do, exactly?
I've added a check to check if the user is the `octo-sts` user. (Node ID: `BOT_kgDOCV3tAw`)

### 3. Describe each step to reproduce the issue or behaviour.
Backport a PR

### 4. Please link to the relevant issues (if any).
- closes #11589
