### PR TITLE
fix: update flow sequence before action execution

### DIFF
--- a/src/Core/Content/Flow/Dispatching/FlowExecutor.php
+++ b/src/Core/Content/Flow/Dispatching/FlowExecutor.php
@@ -133,6 +133,7 @@ class FlowExecutor
         }
 
         $event->setConfig($sequence->config);
+        $event->getFlowState()->currentSequence = $sequence;
 
         $this->callHandle($sequence, $event);
 
@@ -144,7 +145,6 @@ class FlowExecutor
             return;
         }
 
-        $event->getFlowState()->currentSequence = $sequence->nextAction;
         $this->executeAction($sequence->nextAction, $event);
     }
 

--- a/src/Core/Content/Flow/Dispatching/FlowExecutor.php
+++ b/src/Core/Content/Flow/Dispatching/FlowExecutor.php
@@ -124,8 +124,7 @@ class FlowExecutor
 
     public function executeAction(ActionSequence $sequence, StorableFlow $event): void
     {
-        $actionName = $sequence->action;
-        if (!$actionName) {
+        if (!$sequence->action) {
             return;
         }
 
@@ -141,13 +140,12 @@ class FlowExecutor
             return;
         }
 
-        $event->getFlowState()->currentSequence = $sequence;
-
-        /** @var ActionSequence $nextAction */
-        $nextAction = $sequence->nextAction;
-        if ($nextAction !== null) {
-            $this->executeAction($nextAction, $event);
+        if (!$sequence->nextAction instanceof ActionSequence) {
+            return;
         }
+
+        $event->getFlowState()->currentSequence = $sequence->nextAction;
+        $this->executeAction($sequence->nextAction, $event);
     }
 
     public function executeIf(IfSequence $sequence, StorableFlow $event): void

--- a/tests/integration/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessActionTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessActionTest.php
@@ -192,7 +192,7 @@ class GrantDownloadAccessActionTest extends TestCase
     {
         $sequence = $event->getStorableFlow()->getFlowState()->currentSequence;
 
-        if ($sequence instanceof ActionSequence && $sequence->action !== 'action.grant.download.access') {
+        if ($sequence instanceof ActionSequence && $sequence->action !== 'action.mail.send') {
             return null;
         }
 


### PR DESCRIPTION
### Why is this change necessary?
When you put multiple actions behind a rule in the Flow Builder (i.e. `EVENT → Rule → (TRUE) → Action A → Action B`), both child actions were receiving the same `sequenceId`  at runtime. This made it impossible to distinguish Action A from Action B inside of these Actions. Setting the `currentSequence` ensures each action sees its own, correct `sequenceId`.

### What does this change do, exactly?
In the `FlowExecutor` we now update the sequence before calling the action, setting the correct flow state before, instead of afterward.

### Please link to the relevant issues (if any).
closes #9976