### PR TITLE
fix: mediaThumbnailSizeId not null in MediaThumbnailEntity

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -60,6 +60,11 @@ return [
         preg_quote('CHANGED: Type of property Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#$url changed from string to string|null', '/'),
         preg_quote('CHANGED: Type of property Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#$mediaId changed from string to string|null', '/'),
 
+        // The media thumbnail size id changes have not been released
+        preg_quote('CHANGED: Type of property Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#$mediaThumbnailSizeId changed from string to string|null', '/'),
+        preg_quote('CHANGED: The return type of Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#getMediaThumbnailSizeId() changed from string to the non-covariant string|null', '/'),
+        preg_quote('CHANGED: The return type of Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#getMediaThumbnailSizeId() changed from string to string|null', '/'),
+
         // The class has not been released
         'REMOVED: Class Shopware\\\\Elasticsearch\\\\Product\\\\CachedSearchConfigLoader has been deleted',
     ],

--- a/changelog/_unreleased/2025-07-31-fix-media-thumbnail-size-id-not-null.md
+++ b/changelog/_unreleased/2025-07-31-fix-media-thumbnail-size-id-not-null.md
@@ -1,0 +1,9 @@
+---
+title: Fix mediaThumbnailSizeId not null in MediaThumbnailEntity
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailDefinition` to allow a null value for `mediaThumbnailSizeId`
+* Changed `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity` to allow a null value for `mediaThumbnailSizeId`

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
@@ -55,8 +55,7 @@ class MediaThumbnailDefinition extends EntityDefinition
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
 
-            /** @deprecated tag:v6.8.0 - Will be required */
-            (new FkField('media_id', 'mediaId', MediaDefinition::class))->addFlags(new ApiAware()),
+            (new FkField('media_id', 'mediaId', MediaDefinition::class))->addFlags(new ApiAware(), new Required()),
             /** @deprecated tag:v6.8.0 - Will be required */
             (new FkField('media_thumbnail_size_id', 'mediaThumbnailSizeId', MediaThumbnailSizeDefinition::class))->addFlags(new ApiAware()),
 

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
@@ -55,8 +55,10 @@ class MediaThumbnailDefinition extends EntityDefinition
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
 
-            (new FkField('media_id', 'mediaId', MediaDefinition::class))->addFlags(new ApiAware(), new Required()),
-            (new FkField('media_thumbnail_size_id', 'mediaThumbnailSizeId', MediaThumbnailSizeDefinition::class))->addFlags(new Required()),
+            /** @deprecated tag:v6.8.0 - Will be required */
+            (new FkField('media_id', 'mediaId', MediaDefinition::class))->addFlags(new ApiAware()),
+            /** @deprecated tag:v6.8.0 - Will be required */
+            (new FkField('media_thumbnail_size_id', 'mediaThumbnailSizeId', MediaThumbnailSizeDefinition::class))->addFlags(new ApiAware()),
 
             (new IntField('width', 'width'))->addFlags(new ApiAware(), new Required(), new WriteProtected(Context::SYSTEM_SCOPE)),
             (new IntField('height', 'height'))->addFlags(new ApiAware(), new Required(), new WriteProtected(Context::SYSTEM_SCOPE)),

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -27,11 +27,14 @@ class MediaThumbnailEntity extends Entity
     /**
      * @deprecated tag:v6.8.0 - Will be non-nullable
      */
-    protected ?string $mediaId;
+    protected ?string $mediaId = null;
 
     protected ?MediaEntity $media = null;
 
-    protected string $mediaThumbnailSizeId;
+    /**
+     * @deprecated tag:v6.8.0 - Will be non-nullable
+     */
+    protected ?string $mediaThumbnailSizeId = null;
 
     protected ?MediaThumbnailSizeEntity $mediaThumbnailSize = null;
 
@@ -41,6 +44,10 @@ class MediaThumbnailEntity extends Entity
 
         if (!isset($this->mediaId)) {
             Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaId must not be null');
+        }
+
+        if (!isset($this->mediaThumbnailSizeId)) {
+            Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaThumbnailSizeId must not be null');
         }
 
         return $this;
@@ -112,8 +119,17 @@ class MediaThumbnailEntity extends Entity
         $this->media = $media;
     }
 
-    public function getMediaThumbnailSizeId(): string
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - return type will be only string and condition will be removed
+     */
+    public function getMediaThumbnailSizeId(): ?string
     {
+        if (!isset($this->mediaThumbnailSizeId)) {
+            Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaThumbnailSizeId must not be null');
+
+            return null;
+        }
+
         return $this->mediaThumbnailSizeId;
     }
 

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -27,7 +27,7 @@ class MediaThumbnailEntity extends Entity
     /**
      * @deprecated tag:v6.8.0 - Will be non-nullable
      */
-    protected ?string $mediaId = null;
+    protected ?string $mediaId;
 
     protected ?MediaEntity $media = null;
 

--- a/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
+++ b/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\Service\ResetInterface;
 class RemoteThumbnailLoader implements ResetInterface
 {
     /**
-     * @var ?array<string, array<array{width: string, height: string}>>
+     * @var ?array<string, array<array{media_thumbnail_size_id: string, width: string, height: string}>>
      */
     private ?array $mediaFolderThumbnailSizes = null;
 
@@ -144,7 +144,11 @@ class RemoteThumbnailLoader implements ResetInterface
 
         $entities = $this->connection->fetchAllAssociative(
             '
-            SELECT LOWER(HEX(mf.id)) as media_folder_id, LOWER(HEX(mts.id)) as media_thumbnail_size_id, mts.width, mts.height
+            SELECT
+                LOWER(HEX(mf.id)) as media_folder_id,
+                LOWER(HEX(mts.id)) as media_thumbnail_size_id,
+                mts.width,
+                mts.height
             FROM media_folder mf
             INNER JOIN media_folder_configuration mfc ON mf.media_folder_configuration_id = mfc.id
             INNER JOIN media_folder_configuration_media_thumbnail_size mfcmts ON mfcmts.media_folder_configuration_id = mfc.id

--- a/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
+++ b/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
@@ -91,6 +91,7 @@ class RemoteThumbnailLoader implements ResetInterface
                 $thumbnail->assign([
                     'id' => Uuid::randomHex(),
                     'mediaId' => $mediaEntity->getUniqueIdentifier(),
+                    'mediaThumbnailSizeId' => $size['media_thumbnail_size_id'],
                     'width' => (int) $size['width'],
                     'height' => (int) $size['height'],
                     'url' => $url,
@@ -133,7 +134,7 @@ class RemoteThumbnailLoader implements ResetInterface
     }
 
     /**
-     * @return array<string, array<array{width: string, height: string}>>
+     * @return array<string, array<array{media_thumbnail_size_id: string, width: string, height: string}>>
      */
     private function getMediaThumbnailSizes(): array
     {
@@ -143,7 +144,7 @@ class RemoteThumbnailLoader implements ResetInterface
 
         $entities = $this->connection->fetchAllAssociative(
             '
-            SELECT LOWER(HEX(mf.id)) as media_folder_id, mts.width, mts.height
+            SELECT LOWER(HEX(mf.id)) as media_folder_id, LOWER(HEX(mts.id)) as media_thumbnail_size_id, mts.width, mts.height
             FROM media_folder mf
             INNER JOIN media_folder_configuration mfc ON mf.media_folder_configuration_id = mfc.id
             INNER JOIN media_folder_configuration_media_thumbnail_size mfcmts ON mfcmts.media_folder_configuration_id = mfc.id
@@ -156,9 +157,13 @@ class RemoteThumbnailLoader implements ResetInterface
 
         $grouped = [];
 
-        /** @var array{media_folder_id: string, width: string, height: string} $entity */
+        /** @var array{media_folder_id: string, media_thumbnail_size_id: string, width: string, height: string} $entity */
         foreach ($entities as $entity) {
-            $grouped[$entity['media_folder_id']][] = ['width' => $entity['width'], 'height' => $entity['height']];
+            $grouped[$entity['media_folder_id']][] = [
+                'media_thumbnail_size_id' => $entity['media_thumbnail_size_id'],
+                'width' => $entity['width'],
+                'height' => $entity['height'],
+            ];
         }
 
         return $this->mediaFolderThumbnailSizes = $grouped;

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -157,8 +158,14 @@ class ThumbnailService
 
         foreach ($toBeCreatedSizes as $thumbnailSize) {
             foreach ($toBeDeletedThumbnails as $thumbnail) {
-                if ($thumbnailSize->getId() !== $thumbnail->getMediaThumbnailSizeId()) {
-                    continue;
+                if (Feature::isActive('v6.8.0.0')) {
+                    if ($thumbnailSize->getId() !== $thumbnail->getMediaThumbnailSizeId()) {
+                        continue;
+                    }
+                } else {
+                    if ($thumbnail->getMediaThumbnailSizeId() && $thumbnailSize->getId() !== $thumbnail->getMediaThumbnailSizeId()) {
+                        continue;
+                    }
                 }
 
                 if ($strict === true && !$this->getFileSystem($media)->fileExists($thumbnail->getPath())) {

--- a/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
+++ b/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
@@ -564,6 +564,7 @@
     "media_default_folder.updatedAt",
     "media_thumbnail.id",
     "media_thumbnail.mediaId",
+    "media_thumbnail.mediaThumbnailSizeId",
     "media_thumbnail.width",
     "media_thumbnail.height",
     "media_thumbnail.url",

--- a/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
@@ -80,9 +80,9 @@ class RemoteThumbnailLoaderTest extends TestCase
                 'private' => false,
             ]),
             [
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '200', 'height' => '200'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '400', 'height' => '400'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '600', 'height' => '600'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
             ],
             [
                 'media' => 'http://localhost:8000/foo/bar.png',
@@ -104,9 +104,9 @@ class RemoteThumbnailLoaderTest extends TestCase
                 'private' => false,
             ]),
             [
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '200', 'height' => '200'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '400', 'height' => '400'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '600', 'height' => '600'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
             ],
             [
                 'media' => 'http://localhost:8000/foo/bar.png?ts=946684800',
@@ -143,9 +143,9 @@ class RemoteThumbnailLoaderTest extends TestCase
                 'private' => false,
             ]),
             [
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '200', 'height' => '200'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '400', 'height' => '400'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '600', 'height' => '600'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
+                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
             ],
             [
                 'media' => 'https://test.com/photo/flower.jpg?ts=946684800',
@@ -164,8 +164,8 @@ class RemoteThumbnailLoaderTest extends TestCase
         $filesystem = new Filesystem(new InMemoryFilesystemAdapter(), ['public_url' => 'http://localhost:8000']);
 
         $thumbnailSizes = [
-            ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '200', 'height' => '200'],
-            ['media_folder_id' => $ids->get('mediaFolderId'), 'width' => '400', 'height' => '400'],
+            ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
+            ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
         ];
 
         $connection = $this->createMock(Connection::class);


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/commit/de8605468da3edb574d9b2e2129ae2920865f79b#r163148399
- See https://github.com/shopware/shopware/pull/11417
- https://github.com/shopware/shopware/issues/11632

### 2. What does this change do, exactly?
* Changed `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailDefinition` to allow a null value for `mediaThumbnailSizeId`
* Changed `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity` to allow a null value for `mediaThumbnailSizeId`

### 3. Describe each step to reproduce the issue or behaviour.
- https://github.com/shopware/shopware/commit/de8605468da3edb574d9b2e2129ae2920865f79b#r163148399

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/commit/de8605468da3edb574d9b2e2129ae2920865f79b#r163148399
- https://github.com/shopware/shopware/pull/11417
- Fixes #11632

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
