### PR TITLE
feat: config endpoints cached indefinitely

### DIFF
--- a/changelog/_unreleased/2025-07-31-config-endpoints-cached-indefinitely.md
+++ b/changelog/_unreleased/2025-07-31-config-endpoints-cached-indefinitely.md
@@ -1,0 +1,10 @@
+---
+title: config endpoints cached indefinitely
+issue: #11314
+---
+# Core
+* Changed `src/Administration/Controller/UserConfigController.php` to allow updating user config with a PATCH request method
+___
+# Administration
+* Changed `src/core/factory/cache-adapter.factory.js` to cache the config endpoints indefinitely
+* Changed `src/core/service/api/user-config.api.service.ts` to use a PATCH instead of a POST method

--- a/src/Administration/Controller/UserConfigController.php
+++ b/src/Administration/Controller/UserConfigController.php
@@ -53,7 +53,7 @@ class UserConfigController extends AbstractController
         return new JsonResponse(['data' => $data]);
     }
 
-    #[Route(path: '/api/_info/config-me', name: 'api.config_me.update', defaults: ['auth_required' => true], methods: ['POST'])]
+    #[Route(path: '/api/_info/config-me', name: 'api.config_me.update', defaults: ['auth_required' => true], methods: ['POST', 'PATCH'])]
     public function updateConfigMe(Context $context, Request $request): Response
     {
         $postUpdateConfigs = $request->request->all();

--- a/src/Administration/Resources/app/administration/src/core/service/api/user-config.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/user-config.api.service.spec.js
@@ -54,13 +54,13 @@ describe('userConfigService', () => {
         const mockAdapter = new MockAdapter(client);
         const userConfigService = newUserConfigService(client);
 
-        mockAdapter.onPost('/api/_info/config-me').replyOnce(204);
+        mockAdapter.onPatch('/api/_info/config-me').replyOnce(204);
 
         await userConfigService.upsert({
             'core.userConfig': ['new-value'],
         });
 
-        expect(mockAdapter.history.post).toHaveLength(1);
-        expect(mockAdapter.history.post[0].data).toEqual(JSON.stringify({ 'core.userConfig': ['new-value'] }));
+        expect(mockAdapter.history.patch).toHaveLength(1);
+        expect(mockAdapter.history.patch[0].data).toEqual(JSON.stringify({ 'core.userConfig': ['new-value'] }));
     });
 });

--- a/src/Administration/Resources/app/administration/src/core/service/api/user-config.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/user-config.api.service.ts
@@ -40,7 +40,7 @@ export default class UserConfigService extends ApiService {
     upsert(upsertData: Record<string, unknown[]>): Promise<void> {
         const headers = this.getBasicHeaders();
 
-        return this.httpClient.post<void>(this.getApiBasePath(), upsertData, { headers }).then((response) => {
+        return this.httpClient.patch<void>(this.getApiBasePath(), upsertData, { headers }).then((response) => {
             return ApiService.handleResponse(response);
         });
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-dashboard-banner/sw-settings-services-dashboard-banner.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-dashboard-banner/sw-settings-services-dashboard-banner.spec.js
@@ -54,7 +54,7 @@ describe('src/module/sw-settings-services/component/sw-settings-services-dashboa
         });
 
         axiosMock
-            .onPost('_info/config-me', {
+            .onPatch('_info/config-me', {
                 'core.hide-services-dashboard-banner': [true],
             })
             .replyOnce(204);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

see https://github.com/shopware/shopware/issues/11314

### 2. What does this change do, exactly?

to cache the config endpoints indefinitely

### 3. Describe each step to reproduce the issue or behaviour.

try with the global search and the search on every listing page

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

_

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them