### PR TITLE
feat: Add unit and newsletter_recipient to apps custom field entities

### DIFF
--- a/changelog/_unreleased/2025-07-30-add-custom-field-entities-to-apps.md
+++ b/changelog/_unreleased/2025-07-30-add-custom-field-entities-to-apps.md
@@ -1,0 +1,11 @@
+---
+title: Add custom field entities (unit and newsletter_recipient) to apps
+issue: #9635
+---
+# Core
+* Changed `manifest.xsd` to allow defining custom field sets for all entities that support to show custom fields in the admin, specifically the `unit` and `newsletter_recipient` entities were added.
+___ 
+# Upgrade Information
+## App System: Unit and NewsletterRecipient support for custom field sets
+
+It is now possible to define custom field sets in your app's `manifest.xml` file for the `unit` and `newsletter_recipient` entities.

--- a/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
+++ b/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
@@ -446,6 +446,8 @@
             <xs:element name="salutation" type="empty" minOccurs="0"/>
             <xs:element name="shipping_method" type="empty" minOccurs="0"/>
             <xs:element name="tax" type="empty" minOccurs="0"/>
+            <xs:element name="unit" type="empty" minOccurs="0"/>
+            <xs:element name="newsletter_recipient" type="empty" minOccurs="0"/>
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="empty">


### PR DESCRIPTION
Fixes: https://github.com/shopware/shopware/issues/9635

### 1. Why is this change necessary?
Not all entities that support custom field sets in the admin UI are available over the app system

### 2. What does this change do, exactly?
Add the missing `unit` and `newsletter_recipient` entities.

### 3. Describe each step to reproduce the issue or behaviour.
Adding custom field sets was not possible for those entities befire

### 4. Please link to the relevant issues (if any).
Fixes: https://github.com/shopware/shopware/issues/9635
