### PR TITLE
fix: ScriptLoader loading invalid cache paths

### DIFF
--- a/changelog/_unreleased/2025-07-31-fix-script-loader-loading-invalid-cache-paths.md
+++ b/changelog/_unreleased/2025-07-31-fix-script-loader-loading-invalid-cache-paths.md
@@ -1,0 +1,8 @@
+---
+title: Fix ScriptLoader loading invalid cache paths
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `Shopware\Core\Framework\Script\Execution\ScriptLoader` to no longer load a invalid app twig scripts cache path from the cached app-scripts state, if the cache path for the app twig scripts has been changes in the meantime

--- a/src/Core/Framework/App/Source/Local.php
+++ b/src/Core/Framework/App/Source/Local.php
@@ -39,7 +39,9 @@ readonly class Local implements Source
     {
         return new Filesystem(
             match (true) {
-                $app instanceof AppEntity => Path::join($this->projectRoot, $app->getPath()),
+                $app instanceof AppEntity => str_starts_with($app->getPath(), $this->projectRoot)
+                        ? $app->getPath()
+                        : Path::join($this->projectRoot, $app->getPath()),
                 $app instanceof Manifest => $app->getPath(),
             }
         );

--- a/src/Core/Framework/Rule/ScriptRule.php
+++ b/src/Core/Framework/Rule/ScriptRule.php
@@ -54,16 +54,9 @@ class ScriptRule extends Rule
 
     public function match(RuleScope $scope): bool
     {
+        $name = $this->identifier ?? $this->getName();
         $context = [...['scope' => $scope], ...$this->values];
         $lastModified = $this->lastModified ?? $scope->getCurrentTime();
-        $name = $this->identifier ?? $this->getName();
-
-        $twigOptions = ['auto_reload' => true];
-        if (!$this->debug) {
-            $twigOptions['cache'] = new FilesystemCache($this->cacheDir . '/' . $name);
-        } else {
-            $twigOptions['debug'] = true;
-        }
 
         $script = new Script(
             $name,
@@ -76,9 +69,15 @@ class ScriptRule extends Rule
                 {{- var -}}
             ', implode(', ', array_keys($context)), $this->script),
             $lastModified,
-            null,
-            $twigOptions,
         );
+
+        $twigOptions = ['auto_reload' => true];
+        if (!$this->debug) {
+            $twigOptions['cache'] = new FilesystemCache($this->cacheDir . '/' . $name);
+        } else {
+            $twigOptions['debug'] = true;
+        }
+        $script->setTwigOptions($twigOptions);
 
         $twig = new TwigEnvironment(
             new ScriptTwigLoader($script),

--- a/src/Core/Framework/Rule/ScriptRule.php
+++ b/src/Core/Framework/Rule/ScriptRule.php
@@ -58,11 +58,11 @@ class ScriptRule extends Rule
         $lastModified = $this->lastModified ?? $scope->getCurrentTime();
         $name = $this->identifier ?? $this->getName();
 
-        $options = ['auto_reload' => true];
+        $twigOptions = ['auto_reload' => true];
         if (!$this->debug) {
-            $options['cache'] = new FilesystemCache($this->cacheDir . '/' . $name);
+            $twigOptions['cache'] = new FilesystemCache($this->cacheDir . '/' . $name);
         } else {
-            $options['debug'] = true;
+            $twigOptions['debug'] = true;
         }
 
         $script = new Script(
@@ -77,7 +77,7 @@ class ScriptRule extends Rule
             ', implode(', ', array_keys($context)), $this->script),
             $lastModified,
             null,
-            $options
+            $twigOptions,
         );
 
         $twig = new TwigEnvironment(

--- a/src/Core/Framework/Script/Execution/Script.php
+++ b/src/Core/Framework/Script/Execution/Script.php
@@ -4,15 +4,18 @@ namespace Shopware\Core\Framework\Script\Execution;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
+use Twig\Cache\FilesystemCache;
 
 /**
  * @internal only for use by the app-system
+ *
+ * @phpstan-type TwigOptions array{cache?: FilesystemCache, debug?: bool, auto_reload?: bool}
  */
 #[Package('framework')]
 class Script extends Struct
 {
     /**
-     * @param array<string, mixed> $twigOptions
+     * @param TwigOptions $twigOptions
      * @param array<Script> $includes
      */
     public function __construct(
@@ -22,7 +25,7 @@ class Script extends Struct
         private readonly ?ScriptAppInformation $scriptAppInformation = null,
         protected array $twigOptions = [],
         protected array $includes = [],
-        private readonly bool $active = true
+        private readonly bool $active = true,
     ) {
     }
 
@@ -37,11 +40,19 @@ class Script extends Struct
     }
 
     /**
-     * @return array<string, mixed>
+     * @return TwigOptions
      */
     public function getTwigOptions(): array
     {
         return $this->twigOptions;
+    }
+
+    /**
+     * @param TwigOptions $twigOptions
+     */
+    public function setTwigOptions(array $twigOptions): void
+    {
+        $this->twigOptions = $twigOptions;
     }
 
     public function getLastModified(): \DateTimeInterface

--- a/src/Core/Framework/Script/Execution/Script.php
+++ b/src/Core/Framework/Script/Execution/Script.php
@@ -15,7 +15,11 @@ use Twig\Cache\FilesystemCache;
 class Script extends Struct
 {
     /**
-     * @param TwigOptions $twigOptions
+     * @var TwigOptions
+     */
+    private array $twigOptions = [];
+
+    /**
      * @param array<Script> $includes
      */
     public function __construct(
@@ -23,7 +27,6 @@ class Script extends Struct
         protected string $script,
         protected \DateTimeInterface $lastModified,
         private readonly ?ScriptAppInformation $scriptAppInformation = null,
-        protected array $twigOptions = [],
         protected array $includes = [],
         private readonly bool $active = true,
     ) {

--- a/src/Core/Framework/Script/Execution/ScriptAppInformation.php
+++ b/src/Core/Framework/Script/Execution/ScriptAppInformation.php
@@ -13,7 +13,8 @@ class ScriptAppInformation
     public function __construct(
         private readonly string $id,
         private readonly string $name,
-        private readonly string $integrationId
+        private readonly string $version,
+        private readonly string $integrationId,
     ) {
     }
 
@@ -25,6 +26,11 @@ class ScriptAppInformation
     public function getAppName(): string
     {
         return $this->name;
+    }
+
+    public function getAppVersion(): string
+    {
+        return $this->version;
     }
 
     public function getIntegrationId(): string

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -110,28 +110,33 @@ class ScriptLoader implements EventSubscriberInterface
         ');
 
         $executableScripts = [];
+        $appIncludes = [];
 
         foreach ($scripts as $script) {
             if ($script['hook'] === 'include') {
                 continue;
             }
 
-            $includes = array_filter($scripts, fn (array $include) => $include['hook'] === 'include' && $include['app_id'] === $script['app_id']);
+            if (!isset($appIncludes[$script['app_id']])) {
+                $includes = array_filter($scripts, fn (array $include) => $include['hook'] === 'include' && $include['app_id'] === $script['app_id']);
+
+                $appIncludes[$script['app_id']] = array_map(function (array $include): Script {
+                    return new Script(
+                        $include['scriptName'],
+                        $include['script'],
+                        new \DateTimeImmutable($include['lastModified']),
+                        $this->getAppInfo($include),
+                        [],
+                        (bool) $include['active'],
+                    );
+                }, $includes);
+            }
+
+            $includes = $appIncludes[$script['app_id']];
 
             $dates = [...[$script['lastModified']], ...array_column($includes, 'lastModified')];
 
             $lastModified = new \DateTimeImmutable(max($dates));
-
-            $includes = array_map(function (array $include): Script {
-                return new Script(
-                    $include['scriptName'],
-                    $include['script'],
-                    new \DateTimeImmutable($include['lastModified']),
-                    $this->getAppInfo($include),
-                    [],
-                    (bool) $include['active'],
-                );
-            }, $includes);
 
             $executableScripts[$script['hook']][] = new Script(
                 $script['scriptName'],

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -134,14 +134,12 @@ class ScriptLoader implements EventSubscriberInterface
 
             $includes = $appIncludes[$script['app_id']];
 
-            $dates = [...[$script['lastModified']], ...array_column($includes, 'lastModified')];
-
-            $lastModified = new \DateTimeImmutable(max($dates));
+            $dates = [...[new \DateTimeImmutable($script['lastModified'])], ...array_column($includes, 'lastModified')];
 
             $executableScripts[$script['hook']][] = new Script(
                 $script['scriptName'],
                 $script['script'],
-                $lastModified,
+                max($dates),
                 $this->getAppInfo($script),
                 $includes,
                 (bool) $script['active'],

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -124,21 +124,22 @@ class ScriptLoader implements EventSubscriberInterface
 
             $includes = array_map(function (array $include): Script {
                 return new Script(
-                    name: $include['scriptName'],
-                    script: $include['script'],
-                    lastModified: new \DateTimeImmutable($include['lastModified']),
-                    scriptAppInformation: $this->getAppInfo($include),
-                    active: (bool) $include['active'],
+                    $include['scriptName'],
+                    $include['script'],
+                    new \DateTimeImmutable($include['lastModified']),
+                    $this->getAppInfo($include),
+                    [],
+                    (bool) $include['active'],
                 );
             }, $includes);
 
             $executableScripts[$script['hook']][] = new Script(
-                name: $script['scriptName'],
-                script: $script['script'],
-                lastModified: $lastModified,
-                scriptAppInformation: $this->getAppInfo($script),
-                twigOptions: $includes,
-                active: (bool) $script['active'],
+                $script['scriptName'],
+                $script['script'],
+                $lastModified,
+                $this->getAppInfo($script),
+                $includes,
+                (bool) $script['active'],
             );
         }
 

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -103,7 +103,7 @@ class ScriptLoader implements EventSubscriberInterface
                    `app`.`version` AS appVersion,
                    LOWER(HEX(`app`.`integration_id`)) AS integrationId,
                    IFNULL(`script`.`updated_at`, `script`.`created_at`) AS lastModified,
-                   IF(`script`.`active` AND `app`.`active`, 1, 0) AS active
+                   IF(`script`.`active` = 1 AND (`app`.id IS NULL OR `app`.`active` = 1), 1, 0) AS active
             FROM `script`
             LEFT JOIN `app` ON `script`.`app_id` = `app`.`id`
             ORDER BY `app`.`created_at`, `app`.`id`, `script`.`name`

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -133,13 +133,12 @@ class ScriptLoader implements EventSubscriberInterface
             }, $includes);
 
             $executableScripts[$script['hook']][] = new Script(
-                $script['scriptName'],
-                $script['script'],
-                $lastModified,
-                $this->getAppInfo($script),
-                $includes,
-                [], // Twig options will be set outside of the cached scripts
-                (bool) $script['active'],
+                name: $script['scriptName'],
+                script: $script['script'],
+                lastModified: $lastModified,
+                scriptAppInformation: $this->getAppInfo($script),
+                twigOptions: $includes,
+                active: (bool) $script['active'],
             );
         }
 

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Cache\CacheCompressor;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ScriptPersister;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
@@ -16,13 +15,12 @@ use Twig\Cache\FilesystemCache;
 /**
  * @internal only for use by the app-system
  *
- * @phpstan-type ScriptInfo = array{app_id: ?string, scriptName: string, script: string, hook: string, appName: ?string, integrationId: ?string, lastModified: string, appVersion: string, active: bool}
- * @phpstan-type IncludesInfo = array{app_id: ?string, name: string, script: string, appName: ?string, integrationId: ?string, lastModified: string}
+ * @phpstan-type ScriptInfo = array{app_id: ?string, scriptName: string, script: string, hook: string, appName: ?string, appVersion: ?string, integrationId: ?string, lastModified: string, active: bool}
  */
 #[Package('framework')]
 class ScriptLoader implements EventSubscriberInterface
 {
-    final public const CACHE_KEY = 'shopware-app-scripts';
+    final public const CACHE_KEY = 'shopware-executable-app-scripts';
 
     private readonly string $cacheDir;
 
@@ -38,25 +36,47 @@ class ScriptLoader implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        return ['script.written' => 'invalidateCache'];
+        return [
+            'script.written' => 'invalidateCache',
+            'app.written' => 'invalidateCache',
+        ];
     }
 
     /**
-     * @return Script[]
+     * @return list<Script>
      */
     public function get(string $hook): array
     {
+        $hookScripts = [];
+
         $cacheItem = $this->cache->getItem(self::CACHE_KEY);
         if ($cacheItem->isHit() && $cacheItem->get()) {
-            return CacheCompressor::uncompress($cacheItem)[$hook] ?? [];
+            /** @var list<Script> */
+            $hookScripts = CacheCompressor::uncompress($cacheItem)[$hook] ?? [];
+        } else {
+            $scripts = $this->load();
+
+            $cacheItem = CacheCompressor::compress($cacheItem, $scripts);
+            $this->cache->save($cacheItem);
+
+            $hookScripts = $scripts[$hook] ?? [];
         }
 
-        $scripts = $this->load();
+        foreach ($hookScripts as $script) {
+            $info = $script->getScriptAppInformation();
+            $cachePrefix = $info ? Hasher::hash($info->getAppName() . $info->getAppVersion()) : EnvironmentHelper::getVariable('INSTANCE_ID', '');
 
-        $cacheItem = CacheCompressor::compress($cacheItem, $scripts);
-        $this->cache->save($cacheItem);
+            $twigOptions = [];
+            if (!$this->debug) {
+                $twigOptions['cache'] = new FilesystemCache($this->cacheDir . '/' . $cachePrefix);
+            } else {
+                $twigOptions['debug'] = true;
+            }
 
-        return $scripts[$hook] ?? [];
+            $script->setTwigOptions($twigOptions);
+        }
+
+        return $hookScripts;
     }
 
     public function invalidateCache(): void
@@ -79,71 +99,47 @@ class ScriptLoader implements EventSubscriberInterface
                    `script`.`name` AS scriptName,
                    `script`.`script` AS script,
                    `script`.`hook` AS hook,
-                   IFNULL(`script`.`updated_at`, `script`.`created_at`) AS lastModified,
                    `app`.`name` AS appName,
-                   LOWER(HEX(`app`.`integration_id`)) AS integrationId,
                    `app`.`version` AS appVersion,
-                   `script`.`active` AS active
-            FROM `script`
-            LEFT JOIN `app` ON `script`.`app_id` = `app`.`id`
-            WHERE `script`.`hook` != \'include\'
-            ORDER BY `app`.`created_at`, `app`.`id`, `script`.`name`
-        ');
-
-        $includes = $this->connection->fetchAllAssociative('
-            SELECT LOWER(HEX(`script`.`app_id`)) as `app_id`,
-                   `script`.`name` AS name,
-                   `script`.`script` AS script,
-                   `app`.`name` AS appName,
                    LOWER(HEX(`app`.`integration_id`)) AS integrationId,
-                   IFNULL(`script`.`updated_at`, `script`.`created_at`) AS lastModified
+                   IFNULL(`script`.`updated_at`, `script`.`created_at`) AS lastModified,
+                   IF(`script`.`active` AND `app`.`active`, 1, 0) AS active
             FROM `script`
             LEFT JOIN `app` ON `script`.`app_id` = `app`.`id`
-            WHERE `script`.`hook` = \'include\'
             ORDER BY `app`.`created_at`, `app`.`id`, `script`.`name`
         ');
-
-        /** @var array<string, list<IncludesInfo>> $allIncludes */
-        $allIncludes = FetchModeHelper::group($includes);
 
         $executableScripts = [];
-        foreach ($scripts as $script) {
-            $appId = $script['app_id'];
 
-            $includes = $allIncludes[$appId] ?? [];
+        foreach ($scripts as $script) {
+            if ($script['hook'] === 'include') {
+                continue;
+            }
+
+            $includes = array_filter($scripts, fn (array $include) => $include['hook'] === 'include' && $include['app_id'] === $script['app_id']);
 
             $dates = [...[$script['lastModified']], ...array_column($includes, 'lastModified')];
 
             $lastModified = new \DateTimeImmutable(max($dates));
 
-            $cachePrefix = $script['appName'] ? Hasher::hash($script['appName'] . $script['appVersion']) : EnvironmentHelper::getVariable('INSTANCE_ID', '');
-
-            $includes = array_map(function (array $script) use ($appId) {
-                $script['app_id'] = $appId;
-
+            $includes = array_map(function (array $include): Script {
                 return new Script(
-                    $script['name'],
-                    $script['script'],
-                    new \DateTimeImmutable($script['lastModified']),
-                    $this->getAppInfo($script)
+                    name: $include['scriptName'],
+                    script: $include['script'],
+                    lastModified: new \DateTimeImmutable($include['lastModified']),
+                    scriptAppInformation: $this->getAppInfo($include),
+                    active: (bool) $include['active'],
                 );
             }, $includes);
-
-            $options = [];
-            if (!$this->debug) {
-                $options['cache'] = new FilesystemCache($this->cacheDir . '/' . $cachePrefix);
-            } else {
-                $options['debug'] = true;
-            }
 
             $executableScripts[$script['hook']][] = new Script(
                 $script['scriptName'],
                 $script['script'],
                 $lastModified,
                 $this->getAppInfo($script),
-                $options,
                 $includes,
-                (bool) $script['active']
+                [], // Twig options will be set outside of the cached scripts
+                (bool) $script['active'],
             );
         }
 
@@ -151,18 +147,19 @@ class ScriptLoader implements EventSubscriberInterface
     }
 
     /**
-     * @param ScriptInfo|IncludesInfo $script
+     * @param ScriptInfo $script
      */
     private function getAppInfo(array $script): ?ScriptAppInformation
     {
-        if (!$script['app_id'] || !$script['appName'] || !$script['integrationId']) {
+        if (!$script['app_id'] || !$script['appName'] || !$script['appVersion'] || !$script['integrationId']) {
             return null;
         }
 
         return new ScriptAppInformation(
             $script['app_id'],
             $script['appName'],
-            $script['integrationId']
+            $script['appVersion'],
+            $script['integrationId'],
         );
     }
 }

--- a/src/Core/Framework/Script/Execution/ScriptTwigLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptTwigLoader.php
@@ -67,7 +67,7 @@ class ScriptTwigLoader implements LoaderInterface
         }
 
         foreach ($this->script->getIncludes() as $include) {
-            if ($include->getName() === $name) {
+            if ($include->getName() === $name && $include->isActive()) {
                 return $include;
             }
         }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacadeTest.php
@@ -391,6 +391,7 @@ class RepositoryFacadeTest extends TestCase
         return new ScriptAppInformation(
             $app->getId(),
             $app->getName(),
+            $app->getVersion(),
             $app->getIntegrationId()
         );
     }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryWriterFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryWriterFacadeTest.php
@@ -364,6 +364,7 @@ class RepositoryWriterFacadeTest extends TestCase
         return new ScriptAppInformation(
             $app->getId(),
             $app->getName(),
+            $app->getVersion(),
             $app->getIntegrationId()
         );
     }

--- a/tests/integration/Core/System/SystemConfig/Facade/SystemConfigFacadeTest.php
+++ b/tests/integration/Core/System/SystemConfig/Facade/SystemConfigFacadeTest.php
@@ -198,6 +198,7 @@ class SystemConfigFacadeTest extends TestCase
         return new ScriptAppInformation(
             $app->getId(),
             $app->getName(),
+            $app->getVersion(),
             $app->getIntegrationId()
         );
     }

--- a/tests/integration/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/integration/Storefront/Controller/CountryStateControllerTest.php
@@ -91,7 +91,7 @@ class CountryStateControllerTest extends TestCase
         static::getContainer()->get('app.repository')->create([[
             'id' => $appId,
             'name' => 'Test',
-            'path' => __DIR__ . '/../Manifest/_fixtures/test',
+            'path' => __DIR__ . '/fixtures/Apps/storefront-endpoint-cases',
             'active' => true,
             'version' => '0.0.1',
             'label' => 'test',

--- a/tests/integration/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/integration/Storefront/Controller/CountryStateControllerTest.php
@@ -92,6 +92,7 @@ class CountryStateControllerTest extends TestCase
             'id' => $appId,
             'name' => 'Test',
             'path' => __DIR__ . '/../Manifest/_fixtures/test',
+            'active' => true,
             'version' => '0.0.1',
             'label' => 'test',
             'accessToken' => 'test',

--- a/tests/integration/Storefront/Controller/fixtures/Apps/storefront-endpoint-cases/Resources/scripts/country-loaded/loaded.script.twig
+++ b/tests/integration/Storefront/Controller/fixtures/Apps/storefront-endpoint-cases/Resources/scripts/country-loaded/loaded.script.twig
@@ -1,0 +1,1 @@
+{% do debug.dump(hook.getPage.getStates.count) %}

--- a/tests/unit/Core/Framework/Script/AppContextCreatorTest.php
+++ b/tests/unit/Core/Framework/Script/AppContextCreatorTest.php
@@ -110,7 +110,7 @@ class DummyScript extends Script
         string $name,
         ?string $appId,
     ) {
-        $app = $appId ? new ScriptAppInformation($appId, '', '') : null;
+        $app = $appId ? new ScriptAppInformation($appId, '', '', '') : null;
 
         parent::__construct($name, 'foo', new \DateTimeImmutable(), $app);
     }

--- a/tests/unit/Core/Framework/Test/Script/Execution/ScriptTwigLoaderTest.php
+++ b/tests/unit/Core/Framework/Test/Script/Execution/ScriptTwigLoaderTest.php
@@ -120,7 +120,7 @@ class DummyScript extends Script
         string $name,
         ?string $appId,
     ) {
-        $app = $appId ? new ScriptAppInformation($appId, '', '') : null;
+        $app = $appId ? new ScriptAppInformation($appId, '', '', '') : null;
 
         parent::__construct($name, 'foo', new \DateTimeImmutable(), $app);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
- See `3. Describe each step to reproduce the issue or behaviour.`
- See https://github.com/shopware/shopware/issues/11585

### 2. What does this change do, exactly?
* Changed `Shopware\Core\Framework\Script\Execution\ScriptLoader` to no longer load a invalid app twig scripts cache path from the cached app-scripts state, if the cache path for the app twig scripts has been changes in the meantime

### 3. Describe each step to reproduce the issue or behaviour.
- Load the app scripts via e.g. page load with a active cache so they get cached
- Change the cache directory
- Access the page again
- Old invalid cached cache path can't access new cache path -> exception page can't load

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/shopware/issues/11585

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
