### PR TITLE
fix: document squished line item listing

### DIFF
--- a/changelog/_unreleased/2025-08-01-document-styling.md
+++ b/changelog/_unreleased/2025-08-01-document-styling.md
@@ -1,5 +1,5 @@
 ---
-title: Document styling
+title: Fixing document squished line item listing
 issue: 11654
 author: Simon Fiebranz
 author_email: s.fiebranz@shopware.com

--- a/changelog/_unreleased/2025-08-01-document-styling.md
+++ b/changelog/_unreleased/2025-08-01-document-styling.md
@@ -1,0 +1,10 @@
+---
+title: Document styling
+issue: 11654
+author: Simon Fiebranz
+author_email: s.fiebranz@shopware.com
+author_github: @CR0YD
+---
+# Core
+* Changed document styling to fix render issue with text blocks over multiple page breaks.
+* Changed document styling to fix squished text blocks.

--- a/src/Core/Framework/Resources/views/documents/style_base_landscape.css.twig
+++ b/src/Core/Framework/Resources/views/documents/style_base_landscape.css.twig
@@ -8,7 +8,8 @@
         }
 
         main {
-            float: left;
+            width: 100%;
+            float: right;
         }
 
         .letter-header {

--- a/src/Core/Framework/Resources/views/documents/style_base_portrait.css.twig
+++ b/src/Core/Framework/Resources/views/documents/style_base_portrait.css.twig
@@ -8,7 +8,8 @@
         }
 
         main {
-            float: left;
+            width: 100%;
+            float: right;
         }
 
         .letter-header {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

As described in the ticket, the line item listing in the documents was weirdly oriented to the left and did not use the full page width.

### 2. What does this change do, exactly?

This change reorientates the page content and ensures that is does use the full width.
As a small success, it also removes the issue with snippets over multiple pages.

[document_basic.pdf](https://github.com/user-attachments/files/21531512/document_basic.pdf)
[document_multiple_page_breaks.pdf](https://github.com/user-attachments/files/21531513/Document_multiple_page_breaks.pdf)
[document_single_page.pdf](https://github.com/user-attachments/files/21531514/document_single_page.pdf)


### 3. Describe each step to reproduce the issue or behaviour.

Install the Paypal plugin and create an order with payment on invoice (PUI).
Then create a delivery notice (`document_basic`) and invoice (`document_single_page`).
After that, change the snippet `paypal.payUponInvoice.document.paymentNoteRatepay` to multiple lines of Lorem ipsum (I used for `document_multiple_page_breaks` 500 sentences).

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #11600
- closes #11438 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
