### PR TITLE
fix: media file preview text not centered

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
@@ -172,10 +172,6 @@ $sw-media-base-item-preview-background: $color-white;
         border: 1px solid $sw-media-base-item-color-border;
         border-radius: $sw-media-base-item-border-radius;
 
-        &:not(.sw-media-library__parent-folder) .sw-media-base-item__preview-container {
-            grid-row: 1 / span 2;
-        }
-
         .sw-media-base-item__preview-container {
             width: 40px;
             height: 40px;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

We have the visual bug that the file name next to a media preview field isn't centered.
<img width="291" height="93" alt="media_preview_not_centered" src="https://github.com/user-attachments/assets/cddc91d8-8ab0-4613-bb6e-63f18e5be91d" />

### 2. What does this change do, exactly?

This change centers the file name next to a media select preview field.

<img width="304" height="90" alt="media_preview_centered" src="https://github.com/user-attachments/assets/32886d57-5f6e-4313-a077-eba1e7c47359" />


### 3. Describe each step to reproduce the issue or behaviour.

Go to Settings > Documents > invoice and select a file as comany logo. 

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #11664 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
