### PR TITLE
feat: Add commands to schedule and deactivate scheduled tasks

### DIFF
--- a/changelog/_unreleased/2025-07-31-add-commands-to-schedule-and-disable-scheduled-tasks.md
+++ b/changelog/_unreleased/2025-07-31-add-commands-to-schedule-and-disable-scheduled-tasks.md
@@ -1,0 +1,8 @@
+---
+title: Add commands to schedule and disable scheduled tasks
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Added commands to schedule and disable scheduled tasks, `scheduled-task:schedule` and `scheduled-task:deactivate`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1882,12 +1882,6 @@ parameters:
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
 			count: 1
-			path: src/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistry.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
 			path: src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
 
 		-

--- a/src/Core/Framework/DependencyInjection/scheduled-task.xml
+++ b/src/Core/Framework/DependencyInjection/scheduled-task.xml
@@ -75,6 +75,18 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="Shopware\Core\Framework\MessageQueue\Command\DeactivateScheduledTaskCommand">
+            <argument type="service" id="Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry"/>
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\MessageQueue\Command\ScheduleScheduledTaskCommand">
+            <argument type="service" id="Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry"/>
+
+            <tag name="console.command"/>
+        </service>
+
         <service id="Shopware\Core\Framework\MessageQueue\Api\ScheduledTaskController" public="true">
             <argument type="service" id="Shopware\Core\Framework\MessageQueue\ScheduledTask\Scheduler\TaskScheduler"/>
             <call method="setContainer">

--- a/src/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommand.php
+++ b/src/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommand.php
@@ -50,7 +50,7 @@ class DeactivateScheduledTaskCommand extends Command
         $io->warning('Be aware that this command will not cancel a running task execution (e.g. via the queue worker), only disable its scheduling.');
 
         $taskName = $input->getArgument('taskName');
-        $force = $input->getOption('force');
+        $force = (bool) $input->getOption('force');
 
         $status = $this->taskRegistry->deactivateTask($taskName, $force, Context::createCLIContext());
 

--- a/src/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommand.php
+++ b/src/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommand.php
@@ -20,6 +20,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[Package('framework')]
 class DeactivateScheduledTaskCommand extends Command
 {
+    private const STATUSES_SUCCESS = [
+        ScheduledTaskDefinition::STATUS_INACTIVE,
+    ];
+
+    private const STATUSES_FORCE_NEEDED = [
+        ScheduledTaskDefinition::STATUS_QUEUED,
+        ScheduledTaskDefinition::STATUS_RUNNING,
+    ];
+
     /**
      * @internal
      */
@@ -31,7 +40,7 @@ class DeactivateScheduledTaskCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('taskName', InputArgument::REQUIRED, 'Scheduled task name like log_entry.cleanup');
-        $this->addOption('force', 'f', null, 'Force deactivation of schedule task');
+        $this->addOption('force', 'f', null, 'Force the deactivation of the scheduled task');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -45,25 +54,19 @@ class DeactivateScheduledTaskCommand extends Command
 
         $status = $this->taskRegistry->deactivateTask($taskName, $force, Context::createCLIContext());
 
-        switch ($status) {
-            case ScheduledTaskDefinition::STATUS_INACTIVE:
-                $io->success('Scheduled task "' . $taskName . '" was deactivated.');
+        if (\in_array($status, self::STATUSES_SUCCESS, true)) {
+            $io->success('Scheduled task "' . $taskName . '" was deactivated.');
 
-                return self::SUCCESS;
-            case ScheduledTaskDefinition::STATUS_QUEUED:
-            case ScheduledTaskDefinition::STATUS_RUNNING:
-                $io->warning('Scheduled task "' . $taskName . '" is marked as currently running, use --force to force deactivation.');
-
-                return self::FAILURE;
-            case ScheduledTaskDefinition::STATUS_FAILED:
-            case ScheduledTaskDefinition::STATUS_SCHEDULED:
-            case ScheduledTaskDefinition::STATUS_SKIPPED:
-                $io->error('Scheduled task "' . $taskName . '" could not be deactivated.');
-
-                return self::FAILURE;
+            return self::SUCCESS;
         }
 
-        $io->error('Scheduled task "' . $taskName . '" was set to an unknown state: ' . $status);
+        if (\in_array($status, self::STATUSES_FORCE_NEEDED, true)) {
+            $io->warning('Scheduled task "' . $taskName . '" is marked as currently "' . $status . '", use --force to force deactivation.');
+
+            return self::FAILURE;
+        }
+
+        $io->error('Could not deactivate task "' . $taskName . '", task has unexpected state: ' . $status);
 
         return self::FAILURE;
     }

--- a/src/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommand.php
+++ b/src/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommand.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\MessageQueue\Command;
+
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'scheduled-task:deactivate',
+    description: 'Deactivate a scheduled task',
+)]
+#[Package('framework')]
+class DeactivateScheduledTaskCommand extends Command
+{
+    /**
+     * @internal
+     */
+    public function __construct(private readonly TaskRegistry $taskRegistry)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('taskName', InputArgument::REQUIRED, 'Scheduled task name like log_entry.cleanup');
+        $this->addOption('force', 'f', null, 'Force deactivation of schedule task');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+
+        $io->warning('Be aware that this command will not cancel a running task execution (e.g. via the queue worker), only disable its scheduling.');
+
+        $taskName = $input->getArgument('taskName');
+        $force = $input->getOption('force');
+
+        $status = $this->taskRegistry->deactivateTask($taskName, $force, Context::createCLIContext());
+
+        switch ($status) {
+            case ScheduledTaskDefinition::STATUS_INACTIVE:
+                $io->success('Scheduled task "' . $taskName . '" was deactivated.');
+
+                return self::SUCCESS;
+            case ScheduledTaskDefinition::STATUS_QUEUED:
+            case ScheduledTaskDefinition::STATUS_RUNNING:
+                $io->warning('Scheduled task "' . $taskName . '" is marked as currently running, use --force to force deactivation.');
+
+                return self::FAILURE;
+            case ScheduledTaskDefinition::STATUS_FAILED:
+            case ScheduledTaskDefinition::STATUS_SCHEDULED:
+            case ScheduledTaskDefinition::STATUS_SKIPPED:
+                $io->error('Scheduled task "' . $taskName . '" could not be deactivated.');
+
+                return self::FAILURE;
+        }
+
+        $io->error('Scheduled task "' . $taskName . '" was set to an unknown state: ' . $status);
+
+        return self::FAILURE;
+    }
+}

--- a/src/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommand.php
+++ b/src/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommand.php
@@ -51,7 +51,7 @@ class ScheduleScheduledTaskCommand extends Command
 
         $taskName = $input->getArgument('taskName');
         $immediately = (bool) $input->getOption('immediately');
-        $force = $input->getOption('force');
+        $force = (bool) $input->getOption('force');
 
         $status = $this->taskRegistry->scheduleTask($taskName, $immediately, $force, Context::createCLIContext());
 

--- a/src/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommand.php
+++ b/src/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommand.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\MessageQueue\Command;
+
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'scheduled-task:schedule',
+    description: 'Schedule a scheduled task',
+)]
+#[Package('framework')]
+class ScheduleScheduledTaskCommand extends Command
+{
+    /**
+     * @internal
+     */
+    public function __construct(private readonly TaskRegistry $taskRegistry)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('taskName', InputArgument::REQUIRED, 'Scheduled task name like log_entry.cleanup');
+        $this->addOption('force', 'f', null, 'Force scheduling of scheduled task');
+        $this->addOption('immediately', 'i', null, 'Set next execution time to now');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+
+        $taskName = $input->getArgument('taskName');
+        $immediately = $input->getOption('immediately');
+        $force = $input->getOption('force');
+
+        $status = $this->taskRegistry->scheduleTask($taskName, $immediately, $force, Context::createCLIContext());
+
+        switch ($status) {
+            case ScheduledTaskDefinition::STATUS_SCHEDULED:
+            case ScheduledTaskDefinition::STATUS_SKIPPED:
+                $io->success('Scheduled task "' . $taskName . '" was scheduled.');
+
+                return self::SUCCESS;
+            case ScheduledTaskDefinition::STATUS_QUEUED:
+            case ScheduledTaskDefinition::STATUS_RUNNING:
+                $io->warning('Scheduled task "' . $taskName . '" is marked as currently running, use --force to force scheduling.');
+
+                return self::FAILURE;
+            case ScheduledTaskDefinition::STATUS_FAILED:
+            case ScheduledTaskDefinition::STATUS_INACTIVE:
+                $io->error('Scheduled task "' . $taskName . '" could not be scheduled.');
+
+                return self::FAILURE;
+        }
+
+        $io->error('Scheduled task "' . $taskName . '" was set to an unknown state: ' . $status);
+
+        return self::FAILURE;
+    }
+}

--- a/src/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommand.php
+++ b/src/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommand.php
@@ -20,6 +20,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[Package('framework')]
 class ScheduleScheduledTaskCommand extends Command
 {
+    private const STATUSES_SUCCESS = [
+        ScheduledTaskDefinition::STATUS_SCHEDULED,
+        ScheduledTaskDefinition::STATUS_SKIPPED,
+    ];
+
+    private const STATUSES_FORCE_NEEDED = [
+        ScheduledTaskDefinition::STATUS_QUEUED,
+        ScheduledTaskDefinition::STATUS_RUNNING,
+    ];
+
     /**
      * @internal
      */
@@ -31,8 +41,8 @@ class ScheduleScheduledTaskCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('taskName', InputArgument::REQUIRED, 'Scheduled task name like log_entry.cleanup');
-        $this->addOption('force', 'f', null, 'Force scheduling of scheduled task');
-        $this->addOption('immediately', 'i', null, 'Set next execution time to now');
+        $this->addOption('force', 'f', null, 'Force the scheduling of the scheduled task');
+        $this->addOption('immediately', 'i', null, 'Set the next execution time to now');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -40,30 +50,24 @@ class ScheduleScheduledTaskCommand extends Command
         $io = new ShopwareStyle($input, $output);
 
         $taskName = $input->getArgument('taskName');
-        $immediately = $input->getOption('immediately');
+        $immediately = (bool) $input->getOption('immediately');
         $force = $input->getOption('force');
 
         $status = $this->taskRegistry->scheduleTask($taskName, $immediately, $force, Context::createCLIContext());
 
-        switch ($status) {
-            case ScheduledTaskDefinition::STATUS_SCHEDULED:
-            case ScheduledTaskDefinition::STATUS_SKIPPED:
-                $io->success('Scheduled task "' . $taskName . '" was scheduled.');
+        if (\in_array($status, self::STATUSES_SUCCESS, true)) {
+            $io->success('Scheduled task "' . $taskName . '" was scheduled' . ($immediately ? ' to now' : '') . '.');
 
-                return self::SUCCESS;
-            case ScheduledTaskDefinition::STATUS_QUEUED:
-            case ScheduledTaskDefinition::STATUS_RUNNING:
-                $io->warning('Scheduled task "' . $taskName . '" is marked as currently running, use --force to force scheduling.');
-
-                return self::FAILURE;
-            case ScheduledTaskDefinition::STATUS_FAILED:
-            case ScheduledTaskDefinition::STATUS_INACTIVE:
-                $io->error('Scheduled task "' . $taskName . '" could not be scheduled.');
-
-                return self::FAILURE;
+            return self::SUCCESS;
         }
 
-        $io->error('Scheduled task "' . $taskName . '" was set to an unknown state: ' . $status);
+        if (\in_array($status, self::STATUSES_FORCE_NEEDED, true)) {
+            $io->warning('Scheduled task "' . $taskName . '" is marked as currently running, use --force to force scheduling.');
+
+            return self::FAILURE;
+        }
+
+        $io->error('Could not schedule task "' . $taskName . '", task has unexpected state: ' . $status);
 
         return self::FAILURE;
     }

--- a/src/Core/Framework/MessageQueue/MessageQueueException.php
+++ b/src/Core/Framework/MessageQueue/MessageQueueException.php
@@ -15,6 +15,8 @@ class MessageQueueException extends HttpException
     public const CANNOT_FIND_SCHEDULED_TASK = 'FRAMEWORK__CANNOT_FIND_SCHEDULED_TASK';
     public const QUEUE_MESSAGE_SIZE_EXCEEDS = 'FRAMEWORK__QUEUE_MESSAGE_SIZE_EXCEEDS';
     public const QUEUE_STATS_NOT_FOUND = 'FRAMEWORK__QUEUE_STATS_NOT_FOUND';
+    public const MISSING_EXTENDS_CODE = 'FRAMEWORK__SCHEDULED_TASK_MISSING_EXTENDS';
+    public const NOT_FOUND_CODE = 'FRAMEWORK__SCHEDULED_TASK_NOT_FOUND';
 
     public static function validReceiverNameNotProvided(): self
     {
@@ -67,6 +69,26 @@ class MessageQueueException extends HttpException
                 'message' => $messageName,
                 'size' => $size,
             ]
+        );
+    }
+
+    public static function missingExtends(string $class): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::MISSING_EXTENDS_CODE,
+            'Tried to register "{{ class }}" as scheduled task, but class does not extend ScheduledTask',
+            ['class' => $class]
+        );
+    }
+
+    public static function notFound(string $name): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::NOT_FOUND_CODE,
+            'Tried to fetch "{{ name }}" scheduled task, but scheduled task does not exist',
+            ['name' => $name]
         );
     }
 }

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistry.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistry.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\MessageQueueException;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
@@ -102,10 +103,7 @@ class TaskRegistry
         $updates = [];
         foreach ($this->tasks as $task) {
             if (!$task instanceof ScheduledTask) {
-                throw new \RuntimeException(\sprintf(
-                    'Tried to register "%s" as scheduled task, but class does not extend ScheduledTask',
-                    $task::class
-                ));
+                throw MessageQueueException::missingExtends($task::class);
             }
 
             $registeredTask = $this->getAlreadyRegisteredTask($alreadyRegisteredTasks, $task);
@@ -242,10 +240,7 @@ class TaskRegistry
             ->first();
 
         if (!$scheduledTask instanceof ScheduledTaskEntity) {
-            throw new \RuntimeException(\sprintf(
-                'Tried to fetch "%s" scheduled task, but scheduled task does not exist',
-                $name
-            ));
+            throw MessageQueueException::notFound($name);
         }
 
         return $scheduledTask;

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistry.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistry.php
@@ -7,6 +7,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
@@ -56,6 +57,44 @@ class TaskRegistry
         if (\count($deletionPayload) > 0) {
             $this->scheduledTaskRepository->delete($deletionPayload, $context);
         }
+    }
+
+    public function scheduleTask(string $name, bool $immediately, bool $force, Context $context): string
+    {
+        $scheduledTask = $this->fetchScheduledTask($name, $context);
+
+        if (!$force && \in_array($scheduledTask->getStatus(), [ScheduledTaskDefinition::STATUS_QUEUED, ScheduledTaskDefinition::STATUS_RUNNING], true)) {
+            return $scheduledTask->getStatus();
+        }
+
+        $data = [
+            'id' => $scheduledTask->getId(),
+            'status' => ScheduledTaskDefinition::STATUS_SCHEDULED,
+        ];
+
+        if ($immediately) {
+            $data['nextExecutionTime'] = new \DateTimeImmutable();
+        }
+
+        $this->scheduledTaskRepository->update([$data], $context);
+
+        return $this->fetchScheduledTask($name, $context)->getStatus();
+    }
+
+    public function deactivateTask(string $name, bool $force, Context $context): string
+    {
+        $scheduledTask = $this->fetchScheduledTask($name, $context);
+
+        if (!$force && \in_array($scheduledTask->getStatus(), [ScheduledTaskDefinition::STATUS_QUEUED, ScheduledTaskDefinition::STATUS_RUNNING], true)) {
+            return $scheduledTask->getStatus();
+        }
+
+        $this->scheduledTaskRepository->update([[
+            'id' => $scheduledTask->getId(),
+            'status' => ScheduledTaskDefinition::STATUS_INACTIVE,
+        ]], $context);
+
+        return $this->fetchScheduledTask($name, $context)->getStatus();
     }
 
     private function upsertTasks(ScheduledTaskCollection $alreadyRegisteredTasks, Context $context): void
@@ -190,5 +229,25 @@ class TaskRegistry
         }
 
         return $payload;
+    }
+
+    private function fetchScheduledTask(string $name, Context $context): ScheduledTaskEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $name));
+        $criteria->setLimit(1);
+
+        $scheduledTask = $this->scheduledTaskRepository
+            ->search($criteria, $context)
+            ->first();
+
+        if (!$scheduledTask instanceof ScheduledTaskEntity) {
+            throw new \RuntimeException(\sprintf(
+                'Tried to fetch "%s" scheduled task, but scheduled task does not exist',
+                $name
+            ));
+        }
+
+        return $scheduledTask;
     }
 }

--- a/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Framework\MessageQueue\Command;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -19,7 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(DeactivateScheduledTaskCommand::class)]
 class DeactivateScheduledTaskCommandTest extends TestCase
 {
-    private TaskRegistry $taskRegistry;
+    private MockObject&TaskRegistry $taskRegistry;
 
     private DeactivateScheduledTaskCommand $command;
 

--- a/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
@@ -46,7 +46,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was deactivated.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" was deactivated.', $this->getCommandDisplay());
     }
 
     public function testDeactivationWithForceOption(): void
@@ -63,7 +63,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was deactivated.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" was deactivated.', $this->getCommandDisplay());
     }
 
     public function testFailureWhenTaskIsQueued(): void
@@ -79,7 +79,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force deactivation.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" is marked as currently "queued", use --force to force deactivation.', $this->getCommandDisplay());
     }
 
     public function testFailureWhenTaskIsRunning(): void
@@ -95,7 +95,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force deactivation.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" is marked as currently "running", use --force to force deactivation.', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsFailed(): void
@@ -111,7 +111,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" could not be deactivated.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Could not deactivate task "test.task", task has unexpected state: failed', $this->getCommandDisplay());
     }
 
     public function testFailureWhenTaskIsScheduled(): void
@@ -127,7 +127,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" could not be deactivated.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Could not deactivate task "test.task", task has unexpected state: scheduled', $this->getCommandDisplay());
     }
 
     public function testFailureWhenTaskIsSkipped(): void
@@ -143,7 +143,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" could not be deactivated.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Could not deactivate task "test.task", task has unexpected state: skipped', $this->getCommandDisplay());
     }
 
     public function testFailureWithUnknownStatus(): void
@@ -159,6 +159,11 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was set to an unknown state: unknown_status', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Could not deactivate task "test.task", task has unexpected state: unknown_status', $this->getCommandDisplay());
+    }
+
+    private function getCommandDisplay(): string
+    {
+        return (string) str_replace(["\n\r", "\n", "\r"], '', $this->commandTester->getDisplay(true));
     }
 }

--- a/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
@@ -46,7 +46,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was deactivated.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was deactivated.', $this->commandTester->getDisplay());
     }
 
     public function testDeactivationWithForceOption(): void
@@ -63,7 +63,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was deactivated.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was deactivated.', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsQueued(): void
@@ -79,7 +79,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" is marked as currently "queued", use --force to force deactivation.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" is marked as currently "queued", use --force to force deactivation.', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsRunning(): void
@@ -95,7 +95,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" is marked as currently "running", use --force to force deactivation.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" is marked as currently "running", use --force to force deactivation.', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsFailed(): void
@@ -111,7 +111,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Could not deactivate task "test.task", task has unexpected state: failed', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Could not deactivate task "test.task", task has unexpected state: failed', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsScheduled(): void
@@ -127,7 +127,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Could not deactivate task "test.task", task has unexpected state: scheduled', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Could not deactivate task "test.task", task has unexpected state: scheduled', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsSkipped(): void
@@ -143,7 +143,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Could not deactivate task "test.task", task has unexpected state: skipped', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Could not deactivate task "test.task", task has unexpected state: skipped', $this->commandTester->getDisplay());
     }
 
     public function testFailureWithUnknownStatus(): void
@@ -159,11 +159,6 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Could not deactivate task "test.task", task has unexpected state: unknown_status', $this->getCommandDisplay());
-    }
-
-    private function getCommandDisplay(): string
-    {
-        return (string) str_replace(["\n\r", "\n", "\r"], '', $this->commandTester->getDisplay(true));
+        static::assertStringContainsStringIgnoringLineEndings('Could not deactivate task "test.task", task has unexpected state: unknown_status', $this->commandTester->getDisplay());
     }
 }

--- a/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
@@ -46,7 +46,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was deactivated.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" was deactivated.'), $this->getCompressedCommandDisplay());
     }
 
     public function testDeactivationWithForceOption(): void
@@ -63,7 +63,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was deactivated.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" was deactivated.'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsQueued(): void
@@ -79,7 +79,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" is marked as currently "queued", use --force to force deactivation.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" is marked as currently "queued", use --force to force deactivation.'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsRunning(): void
@@ -95,7 +95,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" is marked as currently "running", use --force to force deactivation.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" is marked as currently "running", use --force to force deactivation.'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsFailed(): void
@@ -111,7 +111,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Could not deactivate task "test.task", task has unexpected state: failed', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Could not deactivate task "test.task", task has unexpected state: failed'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsScheduled(): void
@@ -127,7 +127,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Could not deactivate task "test.task", task has unexpected state: scheduled', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Could not deactivate task "test.task", task has unexpected state: scheduled'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsSkipped(): void
@@ -143,7 +143,7 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Could not deactivate task "test.task", task has unexpected state: skipped', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Could not deactivate task "test.task", task has unexpected state: skipped'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWithUnknownStatus(): void
@@ -159,6 +159,16 @@ class DeactivateScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Could not deactivate task "test.task", task has unexpected state: unknown_status', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Could not deactivate task "test.task", task has unexpected state: unknown_status'), $this->getCompressedCommandDisplay());
+    }
+
+    private function compressString(string $string): string
+    {
+        return (string) str_replace(' ', '', $string);
+    }
+
+    private function getCompressedCommandDisplay(): string
+    {
+        return (string) str_replace(["\n\r", "\n", "\r", ' '], '', $this->commandTester->getDisplay(true));
     }
 }

--- a/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/DeactivateScheduledTaskCommandTest.php
@@ -1,0 +1,163 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\MessageQueue\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\Command\DeactivateScheduledTaskCommand;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DeactivateScheduledTaskCommand::class)]
+class DeactivateScheduledTaskCommandTest extends TestCase
+{
+    private TaskRegistry $taskRegistry;
+
+    private DeactivateScheduledTaskCommand $command;
+
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->taskRegistry = $this->createMock(TaskRegistry::class);
+        $this->command = new DeactivateScheduledTaskCommand($this->taskRegistry);
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    public function testSuccessfulDeactivation(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('deactivateTask')
+            ->with('test.task', false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_INACTIVE);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::SUCCESS, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was deactivated.', $this->commandTester->getDisplay());
+    }
+
+    public function testDeactivationWithForceOption(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('deactivateTask')
+            ->with('test.task', true, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_INACTIVE);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+            '--force' => true,
+        ]);
+
+        static::assertSame(Command::SUCCESS, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was deactivated.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsQueued(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('deactivateTask')
+            ->with('test.task', false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_QUEUED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force deactivation.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsRunning(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('deactivateTask')
+            ->with('test.task', false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_RUNNING);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force deactivation.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsFailed(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('deactivateTask')
+            ->with('test.task', false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_FAILED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" could not be deactivated.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsScheduled(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('deactivateTask')
+            ->with('test.task', false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_SCHEDULED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" could not be deactivated.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsSkipped(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('deactivateTask')
+            ->with('test.task', false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_SKIPPED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" could not be deactivated.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWithUnknownStatus(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('deactivateTask')
+            ->with('test.task', false, static::isInstanceOf(Context::class))
+            ->willReturn('unknown_status');
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was set to an unknown state: unknown_status', $this->commandTester->getDisplay());
+    }
+}

--- a/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
@@ -46,7 +46,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->getCommandDisplay());
     }
 
     public function testSuccessfulSchedulingWithSkippedStatus(): void
@@ -62,7 +62,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->getCommandDisplay());
     }
 
     public function testSchedulingWithImmediatelyOption(): void
@@ -79,7 +79,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled to now.', $this->getCommandDisplay());
     }
 
     public function testSchedulingWithForceOption(): void
@@ -96,7 +96,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->getCommandDisplay());
     }
 
     public function testSchedulingWithBothOptions(): void
@@ -114,7 +114,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled to now.', $this->getCommandDisplay());
     }
 
     public function testFailureWhenTaskIsQueued(): void
@@ -130,7 +130,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->getCommandDisplay());
     }
 
     public function testFailureWhenTaskIsRunning(): void
@@ -146,7 +146,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->getCommandDisplay());
     }
 
     public function testFailureWhenTaskIsFailed(): void
@@ -162,7 +162,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" could not be scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Could not schedule task "test.task", task has unexpected state: failed', $this->getCommandDisplay());
     }
 
     public function testFailureWhenTaskIsInactive(): void
@@ -178,7 +178,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" could not be scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Could not schedule task "test.task", task has unexpected state: inactive', $this->getCommandDisplay());
     }
 
     public function testFailureWithUnknownStatus(): void
@@ -194,6 +194,11 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was set to an unknown state: unknown_status', $this->commandTester->getDisplay());
+        static::assertStringContainsString('Could not schedule task "test.task", task has unexpected state: unknown_status', $this->getCommandDisplay());
+    }
+
+    private function getCommandDisplay(): string
+    {
+        return (string) str_replace(["\n\r", "\n", "\r"], '', $this->commandTester->getDisplay(true));
     }
 }

--- a/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Framework\MessageQueue\Command;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -19,7 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(ScheduleScheduledTaskCommand::class)]
 class ScheduleScheduledTaskCommandTest extends TestCase
 {
-    private TaskRegistry $taskRegistry;
+    private MockObject&TaskRegistry $taskRegistry;
 
     private ScheduleScheduledTaskCommand $command;
 

--- a/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
@@ -1,0 +1,198 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\MessageQueue\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\Command\ScheduleScheduledTaskCommand;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ScheduleScheduledTaskCommand::class)]
+class ScheduleScheduledTaskCommandTest extends TestCase
+{
+    private TaskRegistry $taskRegistry;
+
+    private ScheduleScheduledTaskCommand $command;
+
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->taskRegistry = $this->createMock(TaskRegistry::class);
+        $this->command = new ScheduleScheduledTaskCommand($this->taskRegistry);
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    public function testSuccessfulScheduling(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', false, false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_SCHEDULED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::SUCCESS, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+    }
+
+    public function testSuccessfulSchedulingWithSkippedStatus(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', false, false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_SKIPPED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::SUCCESS, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+    }
+
+    public function testSchedulingWithImmediatelyOption(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', true, false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_SCHEDULED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+            '--immediately' => true,
+        ]);
+
+        static::assertSame(Command::SUCCESS, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+    }
+
+    public function testSchedulingWithForceOption(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', false, true, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_SCHEDULED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+            '--force' => true,
+        ]);
+
+        static::assertSame(Command::SUCCESS, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+    }
+
+    public function testSchedulingWithBothOptions(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', true, true, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_SCHEDULED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+            '--immediately' => true,
+            '--force' => true,
+        ]);
+
+        static::assertSame(Command::SUCCESS, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsQueued(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', false, false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_QUEUED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsRunning(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', false, false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_RUNNING);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsFailed(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', false, false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_FAILED);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" could not be scheduled.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWhenTaskIsInactive(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', false, false, static::isInstanceOf(Context::class))
+            ->willReturn(ScheduledTaskDefinition::STATUS_INACTIVE);
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" could not be scheduled.', $this->commandTester->getDisplay());
+    }
+
+    public function testFailureWithUnknownStatus(): void
+    {
+        $this->taskRegistry
+            ->expects($this->once())
+            ->method('scheduleTask')
+            ->with('test.task', false, false, static::isInstanceOf(Context::class))
+            ->willReturn('unknown_status');
+
+        $exitCode = $this->commandTester->execute([
+            'taskName' => 'test.task',
+        ]);
+
+        static::assertSame(Command::FAILURE, $exitCode);
+        static::assertStringContainsString('Scheduled task "test.task" was set to an unknown state: unknown_status', $this->commandTester->getDisplay());
+    }
+}

--- a/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
@@ -46,7 +46,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" was scheduled.'), $this->getCompressedCommandDisplay());
     }
 
     public function testSuccessfulSchedulingWithSkippedStatus(): void
@@ -62,7 +62,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" was scheduled.'), $this->getCompressedCommandDisplay());
     }
 
     public function testSchedulingWithImmediatelyOption(): void
@@ -79,7 +79,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled to now.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" was scheduled to now.'), $this->getCompressedCommandDisplay());
     }
 
     public function testSchedulingWithForceOption(): void
@@ -96,7 +96,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" was scheduled.'), $this->getCompressedCommandDisplay());
     }
 
     public function testSchedulingWithBothOptions(): void
@@ -114,7 +114,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled to now.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" was scheduled to now.'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsQueued(): void
@@ -130,7 +130,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsRunning(): void
@@ -146,7 +146,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsFailed(): void
@@ -162,7 +162,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Could not schedule task "test.task", task has unexpected state: failed', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Could not schedule task "test.task", task has unexpected state: failed'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWhenTaskIsInactive(): void
@@ -178,7 +178,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Could not schedule task "test.task", task has unexpected state: inactive', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Could not schedule task "test.task", task has unexpected state: inactive'), $this->getCompressedCommandDisplay());
     }
 
     public function testFailureWithUnknownStatus(): void
@@ -194,6 +194,16 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsStringIgnoringLineEndings('Could not schedule task "test.task", task has unexpected state: unknown_status', $this->commandTester->getDisplay());
+        static::assertStringContainsStringIgnoringLineEndings($this->compressString('Could not schedule task "test.task", task has unexpected state: unknown_status'), $this->getCompressedCommandDisplay());
+    }
+
+    private function compressString(string $string): string
+    {
+        return (string) str_replace(' ', '', $string);
+    }
+
+    private function getCompressedCommandDisplay(): string
+    {
+        return (string) str_replace(["\n\r", "\n", "\r", ' '], '', $this->commandTester->getDisplay(true));
     }
 }

--- a/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Command/ScheduleScheduledTaskCommandTest.php
@@ -46,7 +46,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
     }
 
     public function testSuccessfulSchedulingWithSkippedStatus(): void
@@ -62,7 +62,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
     }
 
     public function testSchedulingWithImmediatelyOption(): void
@@ -79,7 +79,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled to now.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled to now.', $this->commandTester->getDisplay());
     }
 
     public function testSchedulingWithForceOption(): void
@@ -96,7 +96,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled.', $this->commandTester->getDisplay());
     }
 
     public function testSchedulingWithBothOptions(): void
@@ -114,7 +114,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::SUCCESS, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" was scheduled to now.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" was scheduled to now.', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsQueued(): void
@@ -130,7 +130,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsRunning(): void
@@ -146,7 +146,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Scheduled task "test.task" is marked as currently running, use --force to force scheduling.', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsFailed(): void
@@ -162,7 +162,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Could not schedule task "test.task", task has unexpected state: failed', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Could not schedule task "test.task", task has unexpected state: failed', $this->commandTester->getDisplay());
     }
 
     public function testFailureWhenTaskIsInactive(): void
@@ -178,7 +178,7 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Could not schedule task "test.task", task has unexpected state: inactive', $this->getCommandDisplay());
+        static::assertStringContainsStringIgnoringLineEndings('Could not schedule task "test.task", task has unexpected state: inactive', $this->commandTester->getDisplay());
     }
 
     public function testFailureWithUnknownStatus(): void
@@ -194,11 +194,6 @@ class ScheduleScheduledTaskCommandTest extends TestCase
         ]);
 
         static::assertSame(Command::FAILURE, $exitCode);
-        static::assertStringContainsString('Could not schedule task "test.task", task has unexpected state: unknown_status', $this->getCommandDisplay());
-    }
-
-    private function getCommandDisplay(): string
-    {
-        return (string) str_replace(["\n\r", "\n", "\r"], '', $this->commandTester->getDisplay(true));
+        static::assertStringContainsStringIgnoringLineEndings('Could not schedule task "test.task", task has unexpected state: unknown_status', $this->commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently, there is no way to change the status of a scheduled task without directly editing the database.

### 2. What does this change do, exactly?

It adds 2 commands to schedule and disable scheduled tasks.

 - `scheduled-task:schedule`
 - `scheduled-task:deactivate`

### 3. Describe each step to reproduce the issue or behavior.

Let a scheduled task fail, and now there is no way to re-enable it without editing the database correctly.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
