### PR TITLE
feat(app-system): put fingerprints on shop id

### DIFF
--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -378,7 +378,7 @@ WHERE app.active = 1 AND app.base_app_url is not null');
         try {
             return $this->shopIdProvider->getShopId();
         } catch (AppUrlChangeDetectedException $e) {
-            return $e->getShopId();
+            return $e->getShopId()->id;
         }
     }
 }

--- a/src/Core/Framework/App/AppException.php
+++ b/src/Core/Framework/App/AppException.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\App\Exception\AppNotFoundException;
 use Shopware\Core\Framework\App\Exception\AppRegistrationException;
 use Shopware\Core\Framework\App\Exception\AppXmlParsingException;
 use Shopware\Core\Framework\App\Exception\InvalidAppFlowActionVariableException;
+use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\Exception\UserAbortedCommandException;
 use Shopware\Core\Framework\App\Validation\Error\Error;
 use Shopware\Core\Framework\Feature;
@@ -55,6 +56,9 @@ class AppException extends HttpException
     final public const REQUIRES_ADMIN_API_SOURCE = 'FRAMEWORK__APP_ACTION_REQUIRES_ADMIN_API_SOURCE';
     final public const MISSING_USER_IN_CONTEXT_SOURCE = 'FRAMEWORK__APP_MISSING_USER_IN_CONTEXT_SOURCE';
     final public const INTEGRATION_MISSING = 'FRAMEWORK__APP_MISSING_INTEGRATION';
+    final public const SHOP_ID_CHANGE_SUGGESTED = 'FRAMEWORK__APP_SHOP_ID_CHANGE_SUGGESTED';
+    final public const APP_URL_NOT_CONFIGURED = 'FRAMEWORK__APP_URL_NOT_CONFIGURED';
+    final public const INVALID_SHOP_ID_CONFIGURATION = 'FRAMEWORK__APP_INVALID_SHOP_ID_CONFIGURATION';
 
     /**
      * @internal will be removed once store extensions are installed over composer
@@ -505,6 +509,32 @@ class AppException extends HttpException
             Response::HTTP_FORBIDDEN,
             self::INTEGRATION_MISSING,
             'Forbidden. Not a valid integration source.',
+        );
+    }
+
+    /**
+     * @param list<string> $mismatchingFingerprints
+     */
+    public static function shopIdChangeSuggested(array $mismatchingFingerprints): self
+    {
+        return new ShopIdChangeSuggestedException($mismatchingFingerprints);
+    }
+
+    public static function appUrlNotConfigured(): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::APP_URL_NOT_CONFIGURED,
+            'The environment variable "APP_URL" is not set. Please set it to point the URL to your Admin API.'
+        );
+    }
+
+    public static function invalidShopIdConfiguration(): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::INVALID_SHOP_ID_CONFIGURATION,
+            'The configuration value for "core.app.shopId" in the system config is invalid.'
         );
     }
 }

--- a/src/Core/Framework/App/AppException.php
+++ b/src/Core/Framework/App/AppException.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\App\Exception\AppXmlParsingException;
 use Shopware\Core\Framework\App\Exception\InvalidAppFlowActionVariableException;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\Exception\UserAbortedCommandException;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
 use Shopware\Core\Framework\App\Validation\Error\Error;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
@@ -512,12 +513,9 @@ class AppException extends HttpException
         );
     }
 
-    /**
-     * @param list<string> $mismatchingFingerprints
-     */
-    public static function shopIdChangeSuggested(array $mismatchingFingerprints): self
+    public static function shopIdChangeSuggested(FingerprintComparisonResult $comparisonResult): self
     {
-        return new ShopIdChangeSuggestedException($mismatchingFingerprints);
+        return new ShopIdChangeSuggestedException($comparisonResult);
     }
 
     public static function appUrlNotConfigured(): self
@@ -525,7 +523,7 @@ class AppException extends HttpException
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::APP_URL_NOT_CONFIGURED,
-            'The environment variable "APP_URL" is not set. Please set it to point the URL to your Admin API.'
+            'The environment variable "APP_URL" is not set. Please set it to the URL to your Admin API.'
         );
     }
 
@@ -534,7 +532,7 @@ class AppException extends HttpException
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::INVALID_SHOP_ID_CONFIGURATION,
-            'The configuration value for "core.app.shopId" in the system config is invalid.'
+            'The configuration values for "core.app.shopIdV2" and "core.app.shopId" in the system config are invalid.'
         );
     }
 }

--- a/src/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategy.php
+++ b/src/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategy.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Framework\App\AppUrlChangeResolver;
 
-use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
@@ -62,7 +61,7 @@ class MoveShopPermanentlyStrategy extends AbstractAppUrlChangeStrategy
             // no resolution needed
             return;
         } catch (AppUrlChangeDetectedException $e) {
-            $this->shopIdProvider->setShopId($e->getShopId(), (string) EnvironmentHelper::getVariable('APP_URL'));
+            $this->shopIdProvider->regenerateAndSetShopId($e->getShopId()->id);
         }
 
         $this->forEachInstalledApp($context, function (Manifest $manifest, AppEntity $app, Context $context): void {

--- a/src/Core/Framework/App/Exception/AppUrlChangeDetectedException.php
+++ b/src/Core/Framework/App/Exception/AppUrlChangeDetectedException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\Exception;
 
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -13,7 +14,7 @@ class AppUrlChangeDetectedException extends \Exception
     public function __construct(
         private readonly string $previousUrl,
         private readonly string $currentUrl,
-        private readonly string $shopId,
+        private readonly ShopId $shopId,
     ) {
         parent::__construct(\sprintf('Detected APP_URL change, was "%s" and is now "%s".', $previousUrl, $currentUrl));
     }
@@ -28,7 +29,7 @@ class AppUrlChangeDetectedException extends \Exception
         return $this->currentUrl;
     }
 
-    public function getShopId(): string
+    public function getShopId(): ShopId
     {
         return $this->shopId;
     }

--- a/src/Core/Framework/App/Exception/ShopIdChangeSuggestedException.php
+++ b/src/Core/Framework/App/Exception/ShopIdChangeSuggestedException.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\App\Exception;
 
 use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -12,11 +13,8 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('framework')]
 class ShopIdChangeSuggestedException extends AppException
 {
-    /**
-     * @param list<string> $mismatchingFingerprints
-     */
     public function __construct(
-        public readonly array $mismatchingFingerprints,
+        public readonly FingerprintComparisonResult $comparisonResult,
     ) {
         parent::__construct(
             Response::HTTP_INTERNAL_SERVER_ERROR,

--- a/src/Core/Framework/App/Exception/ShopIdChangeSuggestedException.php
+++ b/src/Core/Framework/App/Exception/ShopIdChangeSuggestedException.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Exception;
+
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class ShopIdChangeSuggestedException extends AppException
+{
+    /**
+     * @param list<string> $mismatchingFingerprints
+     */
+    public function __construct(
+        public readonly array $mismatchingFingerprints,
+    ) {
+        parent::__construct(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            AppException::SHOP_ID_CHANGE_SUGGESTED,
+            'Changes in your system were detected that suggest a change of the shop ID.'
+        );
+    }
+}

--- a/src/Core/Framework/App/ShopId/Fingerprint.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+interface Fingerprint
+{
+    public function getIdentifier(): string;
+
+    public function getScore(): int;
+
+    public function getStamp(): string;
+}

--- a/src/Core/Framework/App/ShopId/Fingerprint.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint.php
@@ -6,13 +6,32 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * Fingerprints are put on the shop ID to detect changes in the environment that might suggest a change in the shop ID.
+ * They are stored as part of the system configuration and are matched against the runtime stamps any time the shop ID is requested.
+ *
+ * @see \Shopware\Core\Framework\App\ShopId\ShopIdProvider::getShopId()
  */
 #[Package('framework')]
 interface Fingerprint
 {
+    /**
+     * A unique identifier for the fingerprint.
+     */
     public function getIdentifier(): string;
 
+    /**
+     * The score of every mismatching fingerprint is summed up and leads to a suggestion to change the shop ID if it exceeds a certain threshold.
+     *
+     * A score of 100 indicates a very high certainty that the shop has been permanently moved or cloned to a new environment.
+     *
+     * @see FingerprintGenerator::STATE_CHANGE_THRESHOLD
+     * @see \Shopware\Core\Framework\App\ShopId\FingerprintGenerator::compare()
+     */
     public function getScore(): int;
 
+    /**
+     * The runtime stamp of the fingerprint, which is used to compare against the stored stamp.
+     */
     public function getStamp(): string;
 }

--- a/src/Core/Framework/App/ShopId/Fingerprint/AppUrl.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint/AppUrl.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId\Fingerprint;
+
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\ShopId\Fingerprint;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+readonly class AppUrl implements Fingerprint
+{
+    final public const IDENTIFIER = 'app_url';
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function getScore(): int
+    {
+        return 100;
+    }
+
+    public function getStamp(): string
+    {
+        return (string) EnvironmentHelper::getVariable('APP_URL') ?: throw AppException::appUrlNotConfigured();
+    }
+}

--- a/src/Core/Framework/App/ShopId/Fingerprint/AppUrl.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint/AppUrl.php
@@ -20,6 +20,9 @@ readonly class AppUrl implements Fingerprint
         return self::IDENTIFIER;
     }
 
+    /**
+     * Changing the APP_URL usually indicates with near certainty that the shop has been permanently moved or has been cloned to a new environment.
+     */
     public function getScore(): int
     {
         return 100;

--- a/src/Core/Framework/App/ShopId/Fingerprint/InstallationPath.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint/InstallationPath.php
@@ -23,6 +23,9 @@ readonly class InstallationPath implements Fingerprint
         return self::IDENTIFIER;
     }
 
+    /**
+     * A change in the installation path usually indicates with near certainty that the shop has been permanently moved or has been cloned to a new environment.
+     */
     public function getScore(): int
     {
         return 100;

--- a/src/Core/Framework/App/ShopId/Fingerprint/InstallationPath.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint/InstallationPath.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId\Fingerprint;
+
+use Shopware\Core\Framework\App\ShopId\Fingerprint;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+readonly class InstallationPath implements Fingerprint
+{
+    final public const IDENTIFIER = 'installation_path';
+
+    public function __construct(
+        private string $projectDir,
+    ) {
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function getScore(): int
+    {
+        return 100;
+    }
+
+    public function getStamp(): string
+    {
+        return $this->projectDir;
+    }
+}

--- a/src/Core/Framework/App/ShopId/Fingerprint/SalesChannelDomainUrls.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint/SalesChannelDomainUrls.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId\Fingerprint;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\App\ShopId\Fingerprint;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+readonly class SalesChannelDomainUrls implements Fingerprint
+{
+    final public const IDENTIFIER = 'sales_channel_domain_urls';
+
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function getScore(): int
+    {
+        return 25;
+    }
+
+    public function getStamp(): string
+    {
+        return $this->generateHash($this->fetchSalesChannelDomainUrls());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fetchSalesChannelDomainUrls(): array
+    {
+        return $this->connection
+            ->fetchFirstColumn('SELECT url FROM sales_channel_domain');
+    }
+
+    /**
+     * @param list<string> $urls
+     */
+    private function generateHash(array $urls): string
+    {
+        // @phpstan-ignore-next-line shopware.hasher
+        return \hash('md5', implode('', $urls));
+    }
+}

--- a/src/Core/Framework/App/ShopId/Fingerprint/SalesChannelDomainUrls.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint/SalesChannelDomainUrls.php
@@ -24,6 +24,9 @@ readonly class SalesChannelDomainUrls implements Fingerprint
         return self::IDENTIFIER;
     }
 
+    /**
+     * Newly added, removed or changed sales channel domains are an early indication that the shop ID should be changed.
+     */
     public function getScore(): int
     {
         return 25;

--- a/src/Core/Framework/App/ShopId/FingerprintComparisonResult.php
+++ b/src/Core/Framework/App/ShopId/FingerprintComparisonResult.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+readonly class FingerprintComparisonResult
+{
+    public int $score;
+
+    /**
+     * @param array<string, FingerprintMatch> $matchingFingerprints
+     * @param array<string, FingerprintMismatch> $mismatchingFingerprints
+     */
+    public function __construct(
+        public array $matchingFingerprints,
+        public array $mismatchingFingerprints,
+        public int $threshold,
+    ) {
+        $this->score = array_sum(array_map(fn (FingerprintMismatch $mismatch) => $mismatch->score, $mismatchingFingerprints));
+    }
+
+    public function getMismatchingFingerprint(string $identifier): ?FingerprintMismatch
+    {
+        return $this->mismatchingFingerprints[$identifier] ?? null;
+    }
+}

--- a/src/Core/Framework/App/ShopId/FingerprintGenerator.php
+++ b/src/Core/Framework/App/ShopId/FingerprintGenerator.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId;
+
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class FingerprintGenerator
+{
+    private const STATE_CHANGE_THRESHOLD = 75;
+
+    /**
+     * @var array<string, Fingerprint>
+     */
+    private array $fingerprints;
+
+    /**
+     * @param iterable<Fingerprint> $fingerprints
+     */
+    public function __construct(
+        iterable $fingerprints,
+    ) {
+        foreach ($fingerprints as $fingerprint) {
+            $this->fingerprints[$fingerprint->getIdentifier()] = $fingerprint;
+        }
+    }
+
+    /**
+     * @param array<string, string> $fingerprints
+     */
+    public function compare(array $fingerprints): void
+    {
+        $score = 0;
+        $mismatchingFingerprints = [];
+
+        foreach ($this->fingerprints as $fingerprint) {
+            $stamp = $fingerprints[$fingerprint->getIdentifier()] ?? null;
+            if ($stamp === $fingerprint->getStamp()) {
+                continue;
+            }
+
+            $mismatchingFingerprints[] = $fingerprint->getIdentifier();
+            $score += $fingerprint->getScore();
+        }
+
+        if ($score >= self::STATE_CHANGE_THRESHOLD) {
+            throw AppException::shopIdChangeSuggested($mismatchingFingerprints);
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function takeFingerprints(): array
+    {
+        $fingerprints = [];
+
+        foreach ($this->fingerprints as $fingerprint) {
+            $fingerprints[$fingerprint->getIdentifier()] = $fingerprint->getStamp();
+        }
+
+        return $fingerprints;
+    }
+}

--- a/src/Core/Framework/App/ShopId/FingerprintGenerator.php
+++ b/src/Core/Framework/App/ShopId/FingerprintGenerator.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Framework\App\ShopId;
 
-use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -32,24 +31,37 @@ class FingerprintGenerator
     /**
      * @param array<string, string> $fingerprints
      */
-    public function compare(array $fingerprints): void
+    public function compare(array $fingerprints): FingerprintComparisonResult
     {
-        $score = 0;
+        $matchingFingerprints = [];
         $mismatchingFingerprints = [];
 
         foreach ($this->fingerprints as $fingerprint) {
-            $stamp = $fingerprints[$fingerprint->getIdentifier()] ?? null;
-            if ($stamp === $fingerprint->getStamp()) {
+            $storedStamp = $fingerprints[$fingerprint->getIdentifier()] ?? null;
+            $expectedStamp = $fingerprint->getStamp();
+
+            if ($storedStamp === $expectedStamp) {
+                $matchingFingerprints[$fingerprint->getIdentifier()] = new FingerprintMatch(
+                    $fingerprint->getIdentifier(),
+                    $fingerprint->getStamp(),
+                );
+
                 continue;
             }
 
-            $mismatchingFingerprints[] = $fingerprint->getIdentifier();
-            $score += $fingerprint->getScore();
+            $mismatchingFingerprints[$fingerprint->getIdentifier()] = new FingerprintMismatch(
+                $fingerprint->getIdentifier(),
+                $storedStamp,
+                $expectedStamp,
+                $fingerprint->getScore(),
+            );
         }
 
-        if ($score >= self::STATE_CHANGE_THRESHOLD) {
-            throw AppException::shopIdChangeSuggested($mismatchingFingerprints);
-        }
+        return new FingerprintComparisonResult(
+            $matchingFingerprints,
+            $mismatchingFingerprints,
+            self::STATE_CHANGE_THRESHOLD,
+        );
     }
 
     /**

--- a/src/Core/Framework/App/ShopId/FingerprintMatch.php
+++ b/src/Core/Framework/App/ShopId/FingerprintMatch.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId;
+
+use PHPUnit\Framework\Attributes\CodeCoverageIgnore;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore
+ */
+#[Package('framework')]
+readonly class FingerprintMatch
+{
+    public function __construct(
+        public string $identifier,
+        public string $stamp,
+    ) {
+    }
+}

--- a/src/Core/Framework/App/ShopId/FingerprintMismatch.php
+++ b/src/Core/Framework/App/ShopId/FingerprintMismatch.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore
+ */
+#[Package('framework')]
+readonly class FingerprintMismatch
+{
+    public function __construct(
+        public string $identifier,
+        public ?string $storedStamp,
+        public string $expectedStamp,
+        public int $score,
+    ) {
+    }
+}

--- a/src/Core/Framework/App/ShopId/ShopId.php
+++ b/src/Core/Framework/App/ShopId/ShopId.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\App\ShopId;
 
 use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -29,9 +30,9 @@ readonly class ShopId
         return $this->fingerprints[$identifier] ?? null;
     }
 
-    public static function v1(string $id): self
+    public static function v1(string $id, string $appUrl): self
     {
-        return new self($id, [], 1);
+        return new self($id, [AppUrl::IDENTIFIER => $appUrl], 1);
     }
 
     /**
@@ -48,7 +49,7 @@ readonly class ShopId
     public static function fromSystemConfig(array $config): self
     {
         if (self::isV1($config)) {
-            return self::v1($config['value']);
+            return self::v1($config['value'], $config['app_url']);
         }
 
         if (self::isV2($config)) {

--- a/src/Core/Framework/App/ShopId/ShopId.php
+++ b/src/Core/Framework/App/ShopId/ShopId.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId;
+
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @phpstan-type ShopIdV1Config array{value: string, app_url: string}
+ * @phpstan-type ShopIdV2Config array{id: string, version: 2, fingerprints: array<string, string>}
+ */
+#[Package('framework')]
+readonly class ShopId
+{
+    /**
+     * @param array<string, string> $fingerprints
+     */
+    private function __construct(
+        public string $id,
+        public array $fingerprints = [],
+        public int $version = 2,
+    ) {
+    }
+
+    public function getFingerprint(string $identifier): ?string
+    {
+        return $this->fingerprints[$identifier] ?? null;
+    }
+
+    public static function v1(string $id): self
+    {
+        return new self($id, [], 1);
+    }
+
+    /**
+     * @param array<string, string> $fingerprints
+     */
+    public static function v2(string $id, array $fingerprints = []): self
+    {
+        return new self($id, $fingerprints, 2);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public static function fromSystemConfig(array $config): self
+    {
+        if (self::isV1($config)) {
+            return self::v1($config['value']);
+        }
+
+        if (self::isV2($config)) {
+            return self::v2($config['id'], $config['fingerprints']);
+        }
+
+        throw AppException::invalidShopIdConfiguration();
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private static function isV1(array $config): bool
+    {
+        return isset($config['value'])
+            && isset($config['app_url']);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private static function isV2(array $config): bool
+    {
+        return isset($config['id'])
+            && isset($config['version'])
+            && isset($config['fingerprints']);
+    }
+}

--- a/src/Core/Framework/App/ShopId/ShopIdChangedEvent.php
+++ b/src/Core/Framework/App/ShopId/ShopIdChangedEvent.php
@@ -7,19 +7,13 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @internal
- *
- * @phpstan-import-type ShopId from ShopIdProvider
  */
 #[Package('framework')]
 class ShopIdChangedEvent extends Event
 {
-    /**
-     * @param ShopId $newShopId
-     * @param ShopId|null $oldShopId
-     */
     public function __construct(
-        public readonly array $newShopId,
-        public readonly ?array $oldShopId
+        public readonly ShopId $newShopId,
+        public readonly ?ShopId $oldShopId
     ) {
     }
 }

--- a/src/Core/Framework/App/ShopId/ShopIdProvider.php
+++ b/src/Core/Framework/App/ShopId/ShopIdProvider.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
-use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
@@ -92,15 +91,9 @@ class ShopIdProvider
 
     private function hasAppUrlChanged(ShopId $shopId): bool
     {
-        $hasAppUrlChanged = false;
-
-        try {
-            $this->fingerprintGenerator->compare($shopId->fingerprints);
-        } catch (ShopIdChangeSuggestedException $e) {
-            $hasAppUrlChanged = \in_array(AppUrl::IDENTIFIER, $e->mismatchingFingerprints, true);
-        }
-
-        return $hasAppUrlChanged;
+        return $this->fingerprintGenerator
+                ->compare($shopId->fingerprints)
+                ->getMismatchingFingerprint(AppUrl::IDENTIFIER) instanceof FingerprintMismatch;
     }
 
     private function fetchShopIdFromSystemConfig(): ?ShopId

--- a/src/Core/Framework/App/ShopId/ShopIdProvider.php
+++ b/src/Core/Framework/App/ShopId/ShopIdProvider.php
@@ -14,11 +14,15 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type ShopIdV1Config from ShopId
+ * @phpstan-import-type ShopIdV2Config from ShopId
  */
 #[Package('framework')]
 class ShopIdProvider
 {
     final public const SHOP_ID_SYSTEM_CONFIG_KEY = 'core.app.shopId';
+    final public const SHOP_ID_SYSTEM_CONFIG_KEY_V2 = 'core.app.shopIdV2';
 
     public function __construct(
         private readonly SystemConfigService $systemConfigService,
@@ -73,14 +77,16 @@ class ShopIdProvider
 
     private function setShopId(ShopId $shopId): void
     {
-        $oldShopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $oldShopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY_V2)
+            ?? $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY)
+            ?? null;
         if (\is_array($oldShopId)) {
             $oldShopId = ShopId::fromSystemConfig($oldShopId);
         } else {
             $oldShopId = null;
         }
 
-        $this->systemConfigService->set(self::SHOP_ID_SYSTEM_CONFIG_KEY, (array) $shopId);
+        $this->systemConfigService->set(self::SHOP_ID_SYSTEM_CONFIG_KEY_V2, (array) $shopId);
         $this->eventDispatcher->dispatch(new ShopIdChangedEvent($shopId, $oldShopId));
     }
 
@@ -98,19 +104,21 @@ class ShopIdProvider
 
     private function fetchShopIdFromSystemConfig(): ?ShopId
     {
-        /** @var array<string, mixed>|null $shopId */
-        $shopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
-        if (!\is_array($shopId)) {
-            return null;
+        /** @var ShopIdV2Config|null $shopIdV2 */
+        $shopIdV2 = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
+        if (\is_array($shopIdV2)) {
+            return ShopId::fromSystemConfig($shopIdV2);
         }
 
-        $shopId = ShopId::fromSystemConfig($shopId);
+        /** @var ShopIdV1Config|null $shopIdV1 */
+        $shopIdV1 = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
+        if (\is_array($shopIdV1)) {
+            $shopIdV1 = ShopId::fromSystemConfig($shopIdV1);
 
-        if ($shopId->version === 1) {
-            return $this->regenerateAndSetShopId($shopId->id);
+            return $this->regenerateAndSetShopId($shopIdV1->id);
         }
 
-        return $shopId;
+        return null;
     }
 
     private function loadAppUrlFromEnvironment(): string

--- a/src/Core/Framework/App/ShopId/ShopIdProvider.php
+++ b/src/Core/Framework/App/ShopId/ShopIdProvider.php
@@ -71,6 +71,7 @@ class ShopIdProvider
     public function deleteShopId(): void
     {
         $this->systemConfigService->delete(self::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $this->systemConfigService->delete(self::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
 
         $this->eventDispatcher->dispatch(new ShopIdDeletedEvent());
     }
@@ -78,8 +79,7 @@ class ShopIdProvider
     private function setShopId(ShopId $shopId): void
     {
         $oldShopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY_V2)
-            ?? $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY)
-            ?? null;
+            ?? $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
         if (\is_array($oldShopId)) {
             $oldShopId = ShopId::fromSystemConfig($oldShopId);
         } else {

--- a/src/Core/Framework/App/ShopId/ShopIdProvider.php
+++ b/src/Core/Framework/App/ShopId/ShopIdProvider.php
@@ -4,16 +4,17 @@ namespace Shopware\Core\Framework\App\ShopId;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
+use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @internal only for use by the app-system
- *
- * @phpstan-type ShopId array{value: string, app_url: ?string}
+ * @internal
  */
 #[Package('framework')]
 class ShopIdProvider
@@ -24,6 +25,7 @@ class ShopIdProvider
         private readonly SystemConfigService $systemConfigService,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly Connection $connection,
+        private readonly FingerprintGenerator $fingerprintGenerator
     ) {
     }
 
@@ -32,41 +34,35 @@ class ShopIdProvider
      */
     public function getShopId(): string
     {
-        $shopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $shopId = $this->fetchShopIdFromSystemConfig() ?? $this->regenerateAndSetShopId();
 
-        if (!\is_array($shopId)) {
-            $newShopId = $this->generateShopId();
-            $this->setShopId($newShopId, (string) EnvironmentHelper::getVariable('APP_URL'));
-
-            return $newShopId;
-        }
-
-        $appUrl = EnvironmentHelper::getVariable('APP_URL');
-        if (\is_string($appUrl) && $appUrl !== ($shopId['app_url'] ?? '')) {
+        if ($this->hasAppUrlChanged($shopId)) {
             if ($this->hasAppsRegisteredAtAppServers()) {
-                throw new AppUrlChangeDetectedException($shopId['app_url'], $appUrl, $shopId['value']);
+                throw new AppUrlChangeDetectedException(
+                    $shopId->getFingerprint(AppUrl::IDENTIFIER) ?? '',
+                    $this->loadAppUrlFromEnvironment(),
+                    $shopId
+                );
             }
 
             // if the shop does not have any apps we can update the existing shop id value
             // with the new APP_URL as no app knows the shop id
-            $this->setShopId($shopId['value'], $appUrl);
+            $this->regenerateAndSetShopId($shopId->id);
         }
 
-        return $shopId['value'];
+        return $shopId->id;
     }
 
-    public function setShopId(string $shopId, string $appUrl): void
+    public function regenerateAndSetShopId(?string $existingShopId = null): ShopId
     {
-        /** @var ShopId|null $oldShopId */
-        $oldShopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
-        $newShopId = [
-            'app_url' => $appUrl,
-            'value' => $shopId,
-        ];
+        $shopId = ShopId::v2(
+            $existingShopId ?? Random::getAlphanumericString(16),
+            $this->fingerprintGenerator->takeFingerprints(),
+        );
 
-        $this->systemConfigService->set(self::SHOP_ID_SYSTEM_CONFIG_KEY, $newShopId);
+        $this->setShopId($shopId);
 
-        $this->eventDispatcher->dispatch(new ShopIdChangedEvent($newShopId, $oldShopId));
+        return $shopId;
     }
 
     public function deleteShopId(): void
@@ -76,13 +72,62 @@ class ShopIdProvider
         $this->eventDispatcher->dispatch(new ShopIdDeletedEvent());
     }
 
-    private function generateShopId(): string
+    private function setShopId(ShopId $shopId): void
     {
-        return Random::getAlphanumericString(16);
+        $oldShopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
+        if (\is_array($oldShopId)) {
+            $oldShopId = ShopId::fromSystemConfig($oldShopId);
+        } else {
+            $oldShopId = null;
+        }
+
+        $this->systemConfigService->set(self::SHOP_ID_SYSTEM_CONFIG_KEY, (array) $shopId);
+        $this->eventDispatcher->dispatch(new ShopIdChangedEvent($shopId, $oldShopId));
     }
 
     private function hasAppsRegisteredAtAppServers(): bool
     {
         return (int) $this->connection->fetchOne('SELECT COUNT(id) FROM app WHERE app_secret IS NOT NULL') > 0;
+    }
+
+    private function hasAppUrlChanged(ShopId $shopId): bool
+    {
+        $hasAppUrlChanged = false;
+
+        try {
+            $this->fingerprintGenerator->compare($shopId->fingerprints);
+        } catch (ShopIdChangeSuggestedException $e) {
+            $hasAppUrlChanged = \in_array(AppUrl::IDENTIFIER, $e->mismatchingFingerprints, true);
+        }
+
+        return $hasAppUrlChanged;
+    }
+
+    private function fetchShopIdFromSystemConfig(): ?ShopId
+    {
+        /** @var array<string, mixed>|null $shopId */
+        $shopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
+        if (!\is_array($shopId)) {
+            return null;
+        }
+
+        $shopId = ShopId::fromSystemConfig($shopId);
+
+        if ($shopId->version === 1) {
+            return $this->regenerateAndSetShopId($shopId->id);
+        }
+
+        return $shopId;
+    }
+
+    private function loadAppUrlFromEnvironment(): string
+    {
+        $appUrl = EnvironmentHelper::getVariable('APP_URL');
+
+        if (!\is_string($appUrl)) {
+            throw AppException::appUrlNotConfigured();
+        }
+
+        return $appUrl;
     }
 }

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -680,21 +680,21 @@
         <service id="Shopware\Core\Framework\App\ShopId\Fingerprint\SalesChannelDomainUrls">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
 
-            <tag name="shopware.app_system.shop_id_change_detector"/>
+            <tag name="shopware.app_system.shop_id_fingerprint"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\ShopId\Fingerprint\InstallationPath">
             <argument>%kernel.project_dir%</argument>
 
-            <tag name="shopware.app_system.shop_id_change_detector"/>
+            <tag name="shopware.app_system.shop_id_fingerprint"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl">
-            <tag name="shopware.app_system.shop_id_change_detector"/>
+            <tag name="shopware.app_system.shop_id_fingerprint"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\ShopId\FingerprintGenerator">
-            <argument type="tagged_iterator" tag="shopware.app_system.shop_id_change_detector"/>
+            <argument type="tagged_iterator" tag="shopware.app_system.shop_id_fingerprint"/>
         </service>
     </services>
 </container>

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -30,6 +30,7 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Framework\App\ShopId\FingerprintGenerator"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\Manifest\ModuleLoader">
@@ -674,6 +675,26 @@
         <service id="Shopware\Core\Framework\App\Api\AppPrivilegeController" public="true">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\App\Privileges\Privileges"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\App\ShopId\Fingerprint\SalesChannelDomainUrls">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+
+            <tag name="shopware.app_system.shop_id_change_detector"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\App\ShopId\Fingerprint\InstallationPath">
+            <argument>%kernel.project_dir%</argument>
+
+            <tag name="shopware.app_system.shop_id_change_detector"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl">
+            <tag name="shopware.app_system.shop_id_change_detector"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\App\ShopId\FingerprintGenerator">
+            <argument type="tagged_iterator" tag="shopware.app_system.shop_id_change_detector"/>
         </service>
     </services>
 </container>

--- a/src/Core/Maintenance/DependencyInjection/services.xml
+++ b/src/Core/Maintenance/DependencyInjection/services.xml
@@ -141,7 +141,7 @@
 
         <service id="Shopware\Core\Maintenance\Staging\Handler\StagingAppHandler">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
-            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
 
             <tag name="kernel.event_listener"/>
         </service>

--- a/src/Core/Maintenance/Staging/Handler/StagingAppHandler.php
+++ b/src/Core/Maintenance/Staging/Handler/StagingAppHandler.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Maintenance\Staging\Event\SetupStagingEvent;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
  * @internal
@@ -16,7 +15,7 @@ readonly class StagingAppHandler
 {
     public function __construct(
         private Connection $connection,
-        private SystemConfigService $systemConfigService
+        private ShopIdProvider $shopIdProvider
     ) {
     }
 
@@ -24,7 +23,7 @@ readonly class StagingAppHandler
     {
         $this->deleteAppsWithAppServer($event);
 
-        $this->systemConfigService->delete(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $this->shopIdProvider->deleteShopId();
     }
 
     private function deleteAppsWithAppServer(SetupStagingEvent $event): void

--- a/src/Core/System/UsageData/Services/ShopIdProvider.php
+++ b/src/Core/System/UsageData/Services/ShopIdProvider.php
@@ -11,22 +11,23 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
  * @internal
  */
 #[Package('data-services')]
-class ShopIdProvider
+readonly class ShopIdProvider
 {
     public function __construct(
-        private readonly AppSystemShopIdProvider $shopIdProvider,
-        private readonly SystemConfigService $systemConfigService
+        private AppSystemShopIdProvider $shopIdProvider,
+        private SystemConfigService $systemConfigService,
     ) {
     }
 
     public function getShopId(): string
     {
-        $shopId = $this->systemConfigService->get(AppSystemShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $shopId = $this->systemConfigService->get(AppSystemShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2)
+            ?? $this->systemConfigService->get(AppSystemShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
 
-        if (!\is_array($shopId)) {
-            return $this->shopIdProvider->getShopId();
+        if (\is_array($shopId)) {
+            return ShopId::fromSystemConfig($shopId)->id;
         }
 
-        return ShopId::fromSystemConfig($shopId)->id;
+        return $this->shopIdProvider->getShopId();
     }
 }

--- a/src/Core/System/UsageData/Services/ShopIdProvider.php
+++ b/src/Core/System/UsageData/Services/ShopIdProvider.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\UsageData\Services;
 
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider as AppSystemShopIdProvider;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -26,6 +27,6 @@ class ShopIdProvider
             return $this->shopIdProvider->getShopId();
         }
 
-        return $shopId['value'];
+        return ShopId::fromSystemConfig($shopId)->id;
     }
 }

--- a/src/Core/System/UsageData/Subscriber/ShopIdChangedSubscriber.php
+++ b/src/Core/System/UsageData/Subscriber/ShopIdChangedSubscriber.php
@@ -51,10 +51,7 @@ class ShopIdChangedSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (
-            $event->newShopId['value'] === $event->oldShopId['value']
-            && $event->newShopId['app_url'] === $event->oldShopId['app_url']
-        ) {
+        if ($event->newShopId->id === $event->oldShopId->id) {
             return;
         }
 

--- a/tests/integration/Core/Framework/App/ActionButton/ExecutorTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/ExecutorTest.php
@@ -16,6 +16,8 @@ use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\App\Payload\Source;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -312,13 +314,9 @@ class ExecutorTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/../Manifest/_fixtures/test');
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
-        $systemConfigService->set(
-            ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY,
-            [
-                'app_url' => 'http://random-shop.url',
-                'value' => 'shopId',
-            ]
-        );
+        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, (array) ShopId::v2('shopId', [
+            AppUrl::IDENTIFIER => 'http://random-shop.url',
+        ]));
 
         $appUrl = EnvironmentHelper::getVariable('APP_URL');
         static::assertIsString($appUrl);

--- a/tests/integration/Core/Framework/App/ActionButton/ExecutorTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/ExecutorTest.php
@@ -314,7 +314,7 @@ class ExecutorTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/../Manifest/_fixtures/test');
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
-        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, (array) ShopId::v2('shopId', [
+        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, (array) ShopId::v2('shopId', [
             AppUrl::IDENTIFIER => 'http://random-shop.url',
         ]));
 

--- a/tests/integration/Core/Framework/App/Api/AppUrlChangeControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppUrlChangeControllerTest.php
@@ -109,7 +109,7 @@ class AppUrlChangeControllerTest extends TestCase
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
 
         $oldUrl = 'http://old.com';
-        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, (array) ShopId::v2('1234567890', [
+        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, (array) ShopId::v2('1234567890', [
             AppUrl::IDENTIFIER => $oldUrl,
         ]));
 
@@ -118,7 +118,7 @@ class AppUrlChangeControllerTest extends TestCase
 
         static::assertNotFalse($this->getBrowser()->getResponse()->getContent());
 
-        $response = \json_decode($this->getBrowser()->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $response = \json_decode($this->getBrowser()->getResponse()->getContent(), true, flags: \JSON_THROW_ON_ERROR);
 
         static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
         static::assertSame(['oldUrl' => $oldUrl, 'newUrl' => $_SERVER['APP_URL']], $response);

--- a/tests/integration/Core/Framework/App/Api/AppUrlChangeControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppUrlChangeControllerTest.php
@@ -5,6 +5,8 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Api;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppUrlChangeResolver\Resolver;
 use Shopware\Core\Framework\App\AppUrlChangeResolver\UninstallAppsStrategy;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -107,10 +109,9 @@ class AppUrlChangeControllerTest extends TestCase
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
 
         $oldUrl = 'http://old.com';
-        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, [
-            'app_url' => $oldUrl,
-            'value' => Uuid::randomHex(),
-        ]);
+        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, (array) ShopId::v2('1234567890', [
+            AppUrl::IDENTIFIER => $oldUrl,
+        ]));
 
         $url = '/api/app-system/app-url-change/url-difference';
         $this->getBrowser()->request('GET', $url);

--- a/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Hmac\QuerySigner;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -45,19 +47,16 @@ class QuerySignerTest extends TestCase
         $signedUri = $this->querySigner->signUri('http://app.url/?foo=bar', $this->app, Context::createDefaultContext());
         parse_str($signedUri->getQuery(), $signedQuery);
 
+        $shopIdConfig = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        static::assertIsArray($shopIdConfig);
+
+        $shopId = ShopId::fromSystemConfig($shopIdConfig);
+
         static::assertArrayHasKey('shop-id', $signedQuery);
-        $shopConfig = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
-        static::assertIsArray($shopConfig);
-        static::assertArrayHasKey('value', $shopConfig);
-        $shopId = $shopConfig['value'];
-        static::assertIsString($shopId);
-        static::assertSame($shopId, $signedQuery['shop-id']);
+        static::assertSame($shopId->id, $signedQuery['shop-id']);
 
         static::assertArrayHasKey('shop-url', $signedQuery);
-        static::assertArrayHasKey('app_url', $shopConfig);
-        $shopUrl = $shopConfig['app_url'];
-        static::assertIsString($shopUrl);
-        static::assertSame($shopUrl, $signedQuery['shop-url']);
+        static::assertSame($shopId->getFingerprint(AppUrl::IDENTIFIER), $signedQuery['shop-url']);
 
         static::assertArrayHasKey('timestamp', $signedQuery);
 

--- a/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -47,7 +47,7 @@ class QuerySignerTest extends TestCase
         $signedUri = $this->querySigner->signUri('http://app.url/?foo=bar', $this->app, Context::createDefaultContext());
         parse_str($signedUri->getQuery(), $signedQuery);
 
-        $shopIdConfig = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $shopIdConfig = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
         static::assertIsArray($shopIdConfig);
 
         $shopId = ShopId::fromSystemConfig($shopIdConfig);

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/AppRegistrationServiceTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/AppRegistrationServiceTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Lifecycle\Registration\HandshakeFactory;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Manifest\Xml\Permission\Permissions;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -213,7 +214,7 @@ class AppRegistrationServiceTest extends TestCase
         $shopIdMock = $this->createMock(ShopIdProvider::class);
         $shopIdMock->expects($this->once())
             ->method('getShopId')
-            ->willThrowException(new AppUrlChangeDetectedException('https://test.com', 'https://new.com', $shopId));
+            ->willThrowException(new AppUrlChangeDetectedException('https://test.com', 'https://new.com', ShopId::v2($shopId)));
 
         $registrator = new AppRegistrationService(
             $handshakeFactory,

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/HandshakeFactoryTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/HandshakeFactoryTest.php
@@ -52,7 +52,7 @@ class HandshakeFactoryTest extends TestCase
         $shopUrl = 'test.shop.com';
 
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
-        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, (array) ShopId::v2(Uuid::randomHex(), [
+        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, (array) ShopId::v2(Uuid::randomHex(), [
             AppUrl::IDENTIFIER => 'https://test.com',
         ]));
 

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/HandshakeFactoryTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/HandshakeFactoryTest.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\App\Lifecycle\Registration\HandshakeFactory;
 use Shopware\Core\Framework\App\Lifecycle\Registration\PrivateHandshake;
 use Shopware\Core\Framework\App\Lifecycle\Registration\StoreHandshake;
 use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -50,10 +52,9 @@ class HandshakeFactoryTest extends TestCase
         $shopUrl = 'test.shop.com';
 
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
-        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, [
-            'app_url' => 'https://test.com',
-            'value' => Uuid::randomHex(),
-        ]);
+        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, (array) ShopId::v2(Uuid::randomHex(), [
+            AppUrl::IDENTIFIER => 'https://test.com',
+        ]));
 
         $factory = new HandshakeFactory(
             $shopUrl,

--- a/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
@@ -102,7 +102,7 @@ class ModuleLoaderTest extends TestCase
         $this->registerAppsWithModules();
 
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
-        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, (array) ShopId::v2(Uuid::randomHex(), [
+        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, (array) ShopId::v2(Uuid::randomHex(), [
             AppUrl::IDENTIFIER => 'https://test.com',
         ]));
 
@@ -270,7 +270,7 @@ class ModuleLoaderTest extends TestCase
         $expectedUrl = parse_url($urlPath);
         static::assertSame($expectedUrl, $url);
 
-        $shopIdConfig = static::getContainer()->get(SystemConfigService::class)->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $shopIdConfig = static::getContainer()->get(SystemConfigService::class)->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
         static::assertIsArray($shopIdConfig);
         $shopId = ShopId::fromSystemConfig($shopIdConfig);
 

--- a/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
@@ -4,6 +4,8 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Manifest;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Manifest\ModuleLoader;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -100,10 +102,9 @@ class ModuleLoaderTest extends TestCase
         $this->registerAppsWithModules();
 
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
-        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, [
-            'app_url' => 'https://test.com',
-            'value' => Uuid::randomHex(),
-        ]);
+        $systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, (array) ShopId::v2(Uuid::randomHex(), [
+            AppUrl::IDENTIFIER => 'https://test.com',
+        ]));
 
         $loadedModules = $this->getSortedModules();
 
@@ -269,13 +270,14 @@ class ModuleLoaderTest extends TestCase
         $expectedUrl = parse_url($urlPath);
         static::assertSame($expectedUrl, $url);
 
-        $shopId = static::getContainer()->get(SystemConfigService::class)->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
-        static::assertIsArray($shopId);
+        $shopIdConfig = static::getContainer()->get(SystemConfigService::class)->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        static::assertIsArray($shopIdConfig);
+        $shopId = ShopId::fromSystemConfig($shopIdConfig);
 
         parse_str($queryString, $query);
         static::assertSame($_SERVER['APP_URL'], $query['shop-url']);
         static::assertArrayHasKey('shop-id', $query);
-        static::assertSame($shopId['value'], $query['shop-id']);
+        static::assertSame($shopId->id, $query['shop-id']);
         static::assertArrayHasKey('sw-version', $query);
         static::assertSame(static::getContainer()->getParameter('kernel.shopware_version'), $query['sw-version']);
         static::assertArrayHasKey('sw-context-language', $query);

--- a/tests/integration/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/integration/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -3,8 +3,12 @@
 namespace Shopware\Tests\Integration\Core\Framework\App\ShopId;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -12,7 +16,11 @@ use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type ShopIdV1Config from ShopId
+ * @phpstan-import-type ShopIdV2Config from ShopId
  */
+#[Package('framework')]
 class ShopIdProviderTest extends TestCase
 {
     use AppSystemTestBehaviour;
@@ -29,84 +37,94 @@ class ShopIdProviderTest extends TestCase
         $this->systemConfigService = static::getContainer()->get(SystemConfigService::class);
     }
 
-    public function testGetShopIdWithoutStoredShopId(): void
+    public function testGeneratesNewShopIdV2IfNoShopIdPresentInSystemConfig(): void
     {
+        static::assertNull($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
+
         $shopId = $this->shopIdProvider->getShopId();
+        $shopIdConfig = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
 
-        static::assertEquals([
-            'app_url' => $_SERVER['APP_URL'],
+        static::assertIsArray($shopIdConfig);
+
+        static::assertArrayHasKey('id', $shopIdConfig);
+        static::assertSame($shopId, $shopIdConfig['id']);
+
+        static::assertArrayHasKey('version', $shopIdConfig);
+        static::assertSame(2, $shopIdConfig['version']);
+
+        static::assertArrayHasKey('fingerprints', $shopIdConfig);
+        static::assertArrayHasKey(AppUrl::IDENTIFIER, $shopIdConfig['fingerprints']);
+        static::assertSame($_SERVER['APP_URL'], $shopIdConfig['fingerprints'][AppUrl::IDENTIFIER]);
+    }
+
+    public function testUpgradesShopIdToV2IfShopIdV1PresentInSystemConfig(): void
+    {
+        static::assertNull($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
+
+        $this->systemConfigService->set(
+            ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY,
+            $this->createShopIdV1Config('1234567890', $_SERVER['APP_URL'])
+        );
+
+        $this->setEnvVars(['APP_URL' => $newAppUrl = 'https://new.url']);
+
+        $shopId = $this->shopIdProvider->getShopId();
+        $shopIdV2Config = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+
+        static::assertIsArray($shopIdV2Config);
+
+        static::assertArrayHasKey('id', $shopIdV2Config);
+        static::assertSame($shopId, $shopIdV2Config['id']);
+
+        static::assertArrayHasKey('version', $shopIdV2Config);
+        static::assertSame(2, $shopIdV2Config['version']);
+
+        static::assertArrayHasKey('fingerprints', $shopIdV2Config);
+        static::assertArrayHasKey(AppUrl::IDENTIFIER, $shopIdV2Config['fingerprints']);
+        static::assertSame($newAppUrl, $shopIdV2Config['fingerprints'][AppUrl::IDENTIFIER]);
+    }
+
+    public function testThrowsIfAppUrlHasChangedAndHasAppsRegisteredAtAppServers(): void
+    {
+        $oldAppUrl = EnvironmentHelper::getVariable('APP_URL');
+
+        $this->loadAppsFromDir(__DIR__ . '/../Manifest/_fixtures/test');
+
+        $this->setEnvVars(['APP_URL' => $newAppUrl = 'https://new.url']);
+
+        try {
+            $this->shopIdProvider->getShopId();
+
+            static::fail(\sprintf('Expected %s to be thrown', AppUrlChangeDetectedException::class));
+        } catch (AppUrlChangeDetectedException $e) {
+            static::assertSame($oldAppUrl, $e->getPreviousUrl());
+            static::assertSame($newAppUrl, $e->getCurrentUrl());
+        }
+    }
+
+    public function testUpdatesShopIdIfAppUrlHasChangedButHasNoAppsRegisteredAtAppServers(): void
+    {
+        /** @var string $appUrlBeforeUpdate */
+        $appUrlBeforeUpdate = EnvironmentHelper::getVariable('APP_URL');
+        $shopIdBeforeUpdate = $this->shopIdProvider->getShopId();
+        $shopIdConfigBeforeUpdate = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        static::assertSame($appUrlBeforeUpdate, $shopIdConfigBeforeUpdate['fingerprints'][AppUrl::IDENTIFIER] ?? null);
+
+        $this->setEnvVars(['APP_URL' => $newAppUrl = 'https://new.url']);
+        $shopIdAfterUpdate = $this->shopIdProvider->getShopId();
+        static::assertSame($shopIdBeforeUpdate, $shopIdAfterUpdate);
+        $shopIdConfigAfterUpdate = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        static::assertSame($newAppUrl, $shopIdConfigAfterUpdate['fingerprints'][AppUrl::IDENTIFIER] ?? null);
+    }
+
+    /**
+     * @return ShopIdV1Config
+     */
+    private function createShopIdV1Config(string $shopId, string $appUrl): array
+    {
+        return [
             'value' => $shopId,
-        ], $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
-    }
-
-    public function testGetShopIdReturnsSameIdOnMultipleCalls(): void
-    {
-        $firstShopId = $this->shopIdProvider->getShopId();
-        $secondShopId = $this->shopIdProvider->getShopId();
-
-        static::assertSame($firstShopId, $secondShopId);
-
-        static::assertEquals([
-            'app_url' => $_SERVER['APP_URL'],
-            'value' => $firstShopId,
-        ], $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
-    }
-
-    public function testGetShopIdThrowsIfAppUrlIsChangedAndAppsArePresent(): void
-    {
-        $this->loadAppsFromDir(__DIR__ . '/../Manifest/_fixtures/test');
-
-        $this->shopIdProvider->getShopId();
-
-        $this->setEnvVars([
-            'APP_URL' => 'http://test.com',
-        ]);
-
-        try {
-            $this->shopIdProvider->getShopId();
-            static::fail('expected AppUrlChangeDetectedException was not thrown.');
-        } catch (AppUrlChangeDetectedException) {
-            // exception is expected
-        }
-    }
-
-    public function testGetShopIdUpdatesItselfIfAppUrlIsChangedAndNoAppsArePresent(): void
-    {
-        $firstShopId = $this->shopIdProvider->getShopId();
-
-        $this->setEnvVars([
-            'APP_URL' => 'http://test.com',
-        ]);
-
-        $secondShopId = $this->shopIdProvider->getShopId();
-
-        static::assertEquals([
-            'app_url' => 'http://test.com',
-            'value' => $firstShopId,
-        ], $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
-
-        static::assertSame($firstShopId, $secondShopId);
-    }
-
-    public function testItRemovesTheAppUrlChangedMarkerIfOutdated(): void
-    {
-        $this->loadAppsFromDir(__DIR__ . '/../Manifest/_fixtures/test');
-
-        $this->shopIdProvider->getShopId();
-
-        $this->setEnvVars([
-            'APP_URL' => 'http://test.com',
-        ]);
-
-        try {
-            $this->shopIdProvider->getShopId();
-            static::fail('expected AppUrlChangeDetectedException was not thrown.');
-        } catch (AppUrlChangeDetectedException) {
-            // exception is expected
-        }
-
-        $this->resetEnvVars();
-
-        $this->shopIdProvider->getShopId();
+            'app_url' => $appUrl,
+        ];
     }
 }

--- a/tests/integration/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/integration/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -40,9 +40,10 @@ class ShopIdProviderTest extends TestCase
     public function testGeneratesNewShopIdV2IfNoShopIdPresentInSystemConfig(): void
     {
         static::assertNull($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
+        static::assertNull($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2));
 
         $shopId = $this->shopIdProvider->getShopId();
-        $shopIdConfig = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $shopIdConfig = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
 
         static::assertIsArray($shopIdConfig);
 
@@ -60,6 +61,7 @@ class ShopIdProviderTest extends TestCase
     public function testUpgradesShopIdToV2IfShopIdV1PresentInSystemConfig(): void
     {
         static::assertNull($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
+        static::assertNull($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2));
 
         $this->systemConfigService->set(
             ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY,
@@ -69,7 +71,7 @@ class ShopIdProviderTest extends TestCase
         $this->setEnvVars(['APP_URL' => $newAppUrl = 'https://new.url']);
 
         $shopId = $this->shopIdProvider->getShopId();
-        $shopIdV2Config = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $shopIdV2Config = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
 
         static::assertIsArray($shopIdV2Config);
 
@@ -107,14 +109,28 @@ class ShopIdProviderTest extends TestCase
         /** @var string $appUrlBeforeUpdate */
         $appUrlBeforeUpdate = EnvironmentHelper::getVariable('APP_URL');
         $shopIdBeforeUpdate = $this->shopIdProvider->getShopId();
-        $shopIdConfigBeforeUpdate = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $shopIdConfigBeforeUpdate = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
         static::assertSame($appUrlBeforeUpdate, $shopIdConfigBeforeUpdate['fingerprints'][AppUrl::IDENTIFIER] ?? null);
 
         $this->setEnvVars(['APP_URL' => $newAppUrl = 'https://new.url']);
         $shopIdAfterUpdate = $this->shopIdProvider->getShopId();
         static::assertSame($shopIdBeforeUpdate, $shopIdAfterUpdate);
-        $shopIdConfigAfterUpdate = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+        $shopIdConfigAfterUpdate = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
         static::assertSame($newAppUrl, $shopIdConfigAfterUpdate['fingerprints'][AppUrl::IDENTIFIER] ?? null);
+    }
+
+    public function testDeletesShopIdConfigV1AndShopIdConfigV2(): void
+    {
+        $this->systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, ['value' => '1234567890', 'app_url' => 'https://foo.bar']);
+        $this->systemConfigService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, ['value' => '1234567890', 'version' => 2, 'fingerprints' => ['app_url' => 'https://foo.bar']]);
+
+        static::assertIsArray($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
+        static::assertIsArray($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2));
+
+        $this->shopIdProvider->deleteShopId();
+
+        static::assertNull($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
+        static::assertNull($this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2));
     }
 
     /**

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\Controller\InfoController;
 use Shopware\Core\Framework\Api\Route\ApiRouteInfoResolver;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\BusinessEventCollector;
@@ -137,7 +138,7 @@ class InfoControllerTest extends TestCase
         $this->shopIdProvider
             ->expects($this->once())
             ->method('getShopId')
-            ->willThrowException(new AppUrlChangeDetectedException('http://localhost', 'http://globalhost', 'current-shop-id'));
+            ->willThrowException(new AppUrlChangeDetectedException('http://localhost', 'http://globalhost', ShopId::v2('current-shop-id')));
 
         $response = $this->infoController->config(Context::createDefaultContext(), Request::create('http://localhost'));
 

--- a/tests/unit/Core/Framework/App/AppExceptionTest.php
+++ b/tests/unit/Core/Framework/App/AppExceptionTest.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Exception\AppAlreadyInstalledException;
 use Shopware\Core\Framework\App\Exception\AppDownloadException;
 use Shopware\Core\Framework\App\Exception\AppNotFoundException;
+use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
 use Shopware\Core\Framework\App\Validation\Error\AppNameError;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
@@ -179,11 +181,13 @@ class AppExceptionTest extends TestCase
 
     public function testShopIdChangeSuggested(): void
     {
-        $e = AppException::shopIdChangeSuggested(['foo', 'bar']);
+        $e = AppException::shopIdChangeSuggested($comparisonResult = new FingerprintComparisonResult([], [], 75));
 
+        static::assertInstanceOf(ShopIdChangeSuggestedException::class, $e);
         static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
         static::assertSame('FRAMEWORK__APP_SHOP_ID_CHANGE_SUGGESTED', $e->getErrorCode());
         static::assertSame('Changes in your system were detected that suggest a change of the shop ID.', $e->getMessage());
+        static::assertSame($comparisonResult, $e->comparisonResult);
     }
 
     public function testAppUrlNotConfigured(): void

--- a/tests/unit/Core/Framework/App/AppExceptionTest.php
+++ b/tests/unit/Core/Framework/App/AppExceptionTest.php
@@ -196,7 +196,7 @@ class AppExceptionTest extends TestCase
 
         static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
         static::assertSame('FRAMEWORK__APP_URL_NOT_CONFIGURED', $e->getErrorCode());
-        static::assertSame('The environment variable "APP_URL" is not set. Please set it to point the URL to your Admin API.', $e->getMessage());
+        static::assertSame('The environment variable "APP_URL" is not set. Please set it to the URL to your Admin API.', $e->getMessage());
     }
 
     public function testInvalidShopIdConfiguration(): void
@@ -205,6 +205,6 @@ class AppExceptionTest extends TestCase
 
         static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
         static::assertSame('FRAMEWORK__APP_INVALID_SHOP_ID_CONFIGURATION', $e->getErrorCode());
-        static::assertSame('The configuration value for "core.app.shopId" in the system config is invalid.', $e->getMessage());
+        static::assertSame('The configuration values for "core.app.shopIdV2" and "core.app.shopId" in the system config are invalid.', $e->getMessage());
     }
 }

--- a/tests/unit/Core/Framework/App/AppExceptionTest.php
+++ b/tests/unit/Core/Framework/App/AppExceptionTest.php
@@ -176,4 +176,31 @@ class AppExceptionTest extends TestCase
         static::assertSame('FRAMEWORK__APP_MISSING_INTEGRATION', $e->getErrorCode());
         static::assertSame('Forbidden. Not a valid integration source.', $e->getMessage());
     }
+
+    public function testShopIdChangeSuggested(): void
+    {
+        $e = AppException::shopIdChangeSuggested(['foo', 'bar']);
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame('FRAMEWORK__APP_SHOP_ID_CHANGE_SUGGESTED', $e->getErrorCode());
+        static::assertSame('Changes in your system were detected that suggest a change of the shop ID.', $e->getMessage());
+    }
+
+    public function testAppUrlNotConfigured(): void
+    {
+        $e = AppException::appUrlNotConfigured();
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame('FRAMEWORK__APP_URL_NOT_CONFIGURED', $e->getErrorCode());
+        static::assertSame('The environment variable "APP_URL" is not set. Please set it to point the URL to your Admin API.', $e->getMessage());
+    }
+
+    public function testInvalidShopIdConfiguration(): void
+    {
+        $e = AppException::invalidShopIdConfiguration();
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame('FRAMEWORK__APP_INVALID_SHOP_ID_CONFIGURATION', $e->getErrorCode());
+        static::assertSame('The configuration value for "core.app.shopId" in the system config is invalid.', $e->getMessage());
+    }
 }

--- a/tests/unit/Core/Framework/App/Exception/AppUrlChangeDetectedExceptionTest.php
+++ b/tests/unit/Core/Framework/App/Exception/AppUrlChangeDetectedExceptionTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 
 /**
  * @internal
@@ -14,7 +15,7 @@ class AppUrlChangeDetectedExceptionTest extends TestCase
 {
     public function testException(): void
     {
-        $exception = new AppUrlChangeDetectedException('oldUrl', 'currentUrl', 'shopId');
+        $exception = new AppUrlChangeDetectedException('oldUrl', 'currentUrl', ShopId::v2('shopId'));
 
         static::assertSame(
             'Detected APP_URL change, was "oldUrl" and is now "currentUrl".',
@@ -33,7 +34,7 @@ class AppUrlChangeDetectedExceptionTest extends TestCase
 
         static::assertSame(
             'shopId',
-            $exception->getShopId()
+            $exception->getShopId()->id
         );
     }
 }

--- a/tests/unit/Core/Framework/App/Exception/ShopIdChangeSuggestedExceptionTest.php
+++ b/tests/unit/Core/Framework/App/Exception/ShopIdChangeSuggestedExceptionTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\InstallationPath;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\SalesChannelDomainUrls;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[CoversClass(ShopIdChangeSuggestedException::class)]
+#[Package('framework')]
+class ShopIdChangeSuggestedExceptionTest extends TestCase
+{
+    public function testException(): void
+    {
+        $mismatchingFingerprints = [
+            AppUrl::IDENTIFIER,
+            InstallationPath::IDENTIFIER,
+            SalesChannelDomainUrls::IDENTIFIER,
+        ];
+
+        $e = new ShopIdChangeSuggestedException($mismatchingFingerprints);
+
+        static::assertSame(500, $e->getStatusCode());
+        static::assertSame('FRAMEWORK__APP_SHOP_ID_CHANGE_SUGGESTED', $e->getErrorCode());
+        static::assertSame('Changes in your system were detected that suggest a change of the shop ID.', $e->getMessage());
+        static::assertSame($mismatchingFingerprints, $e->mismatchingFingerprints);
+    }
+}

--- a/tests/unit/Core/Framework/App/Exception/ShopIdChangeSuggestedExceptionTest.php
+++ b/tests/unit/Core/Framework/App/Exception/ShopIdChangeSuggestedExceptionTest.php
@@ -7,7 +7,9 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\InstallationPath;
-use Shopware\Core\Framework\App\ShopId\Fingerprint\SalesChannelDomainUrls;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
+use Shopware\Core\Framework\App\ShopId\FingerprintMatch;
+use Shopware\Core\Framework\App\ShopId\FingerprintMismatch;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -19,17 +21,29 @@ class ShopIdChangeSuggestedExceptionTest extends TestCase
 {
     public function testException(): void
     {
-        $mismatchingFingerprints = [
-            AppUrl::IDENTIFIER,
-            InstallationPath::IDENTIFIER,
-            SalesChannelDomainUrls::IDENTIFIER,
-        ];
+        $result = new FingerprintComparisonResult(
+            [
+                InstallationPath::IDENTIFIER => new FingerprintMatch(
+                    InstallationPath::IDENTIFIER,
+                    '/old/path'
+                ),
+            ],
+            [
+                AppUrl::IDENTIFIER => new FingerprintMismatch(
+                    AppUrl::IDENTIFIER,
+                    'https://old.url',
+                    'https://new.url',
+                    100
+                ),
+            ],
+            75,
+        );
 
-        $e = new ShopIdChangeSuggestedException($mismatchingFingerprints);
+        $e = new ShopIdChangeSuggestedException($result);
 
         static::assertSame(500, $e->getStatusCode());
         static::assertSame('FRAMEWORK__APP_SHOP_ID_CHANGE_SUGGESTED', $e->getErrorCode());
         static::assertSame('Changes in your system were detected that suggest a change of the shop ID.', $e->getMessage());
-        static::assertSame($mismatchingFingerprints, $e->mismatchingFingerprints);
+        static::assertSame($result, $e->comparisonResult);
     }
 }

--- a/tests/unit/Core/Framework/App/ShopId/Fingerprint/AppUrlTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/Fingerprint/AppUrlTest.php
@@ -50,7 +50,7 @@ class AppUrlTest extends TestCase
         $this->setEnvVars(['APP_URL' => null]);
 
         static::expectException(AppException::class);
-        static::expectExceptionMessage('The environment variable "APP_URL" is not set. Please set it to point the URL to your Admin API.');
+        static::expectExceptionMessage('The environment variable "APP_URL" is not set. Please set it to the URL to your Admin API.');
 
         $fingerprint->getStamp();
     }

--- a/tests/unit/Core/Framework/App/ShopId/Fingerprint/AppUrlTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/Fingerprint/AppUrlTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopId\Fingerprint;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+
+/**
+ * @internal
+ */
+#[CoversClass(AppUrl::class)]
+#[Package('framework')]
+class AppUrlTest extends TestCase
+{
+    use EnvTestBehaviour;
+
+    public function testIdentifier(): void
+    {
+        $fingerprint = new AppUrl();
+
+        static::assertSame('app_url', $fingerprint->getIdentifier());
+    }
+
+    public function testScore(): void
+    {
+        $fingerprint = new AppUrl();
+
+        static::assertSame(100, $fingerprint->getScore());
+    }
+
+    public function testTakesAppUrlFromEnv(): void
+    {
+        $fingerprint = new AppUrl();
+
+        $this->setEnvVars(['APP_URL' => 'https://example.com']);
+        static::assertSame('https://example.com', $fingerprint->getStamp());
+
+        $this->setEnvVars(['APP_URL' => 'https://foo.bar.com']);
+        static::assertSame('https://foo.bar.com', $fingerprint->getStamp());
+    }
+
+    public function testThrowsIfAppUrlEnvVarIsNotSet(): void
+    {
+        $fingerprint = new AppUrl();
+
+        $this->setEnvVars(['APP_URL' => null]);
+
+        static::expectException(AppException::class);
+        static::expectExceptionMessage('The environment variable "APP_URL" is not set. Please set it to point the URL to your Admin API.');
+
+        $fingerprint->getStamp();
+    }
+}

--- a/tests/unit/Core/Framework/App/ShopId/Fingerprint/InstallationPathTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/Fingerprint/InstallationPathTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopId\Fingerprint;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\InstallationPath;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[CoversClass(InstallationPath::class)]
+#[Package('framework')]
+class InstallationPathTest extends TestCase
+{
+    public function testIdentifier(): void
+    {
+        $fingerprint = new InstallationPath('/var/www/html');
+
+        static::assertSame('installation_path', $fingerprint->getIdentifier());
+    }
+
+    public function testScore(): void
+    {
+        $fingerprint = new InstallationPath('/var/www/html');
+
+        static::assertSame(100, $fingerprint->getScore());
+    }
+
+    public function testTakesInstallationPath(): void
+    {
+        $fingerprint = new InstallationPath('/var/www/html');
+
+        static::assertSame('/var/www/html', $fingerprint->getStamp());
+    }
+}

--- a/tests/unit/Core/Framework/App/ShopId/Fingerprint/SalesChannelDomainUrlsTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/Fingerprint/SalesChannelDomainUrlsTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopId\Fingerprint;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\SalesChannelDomainUrls;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[CoversClass(SalesChannelDomainUrls::class)]
+#[Package('framework')]
+class SalesChannelDomainUrlsTest extends TestCase
+{
+    public function testIdentifier(): void
+    {
+        $fingerprint = new SalesChannelDomainUrls($this->createMock(Connection::class));
+
+        static::assertSame('sales_channel_domain_urls', $fingerprint->getIdentifier());
+    }
+
+    public function testScore(): void
+    {
+        $fingerprint = new SalesChannelDomainUrls($this->createMock(Connection::class));
+
+        static::assertSame(25, $fingerprint->getScore());
+    }
+
+    public function testTakesSalesChannelDomainUrlsHash(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchFirstColumn')
+            ->willReturn($urls = ['foo', 'bar', 'baz']);
+
+        $fingerprint = new SalesChannelDomainUrls($connection);
+
+        static::assertSame(\hash('md5', implode('', $urls)), $fingerprint->getStamp());
+    }
+}

--- a/tests/unit/Core/Framework/App/ShopId/FingerprintComparisonResultTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/FingerprintComparisonResultTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopId;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
+use Shopware\Core\Framework\App\ShopId\FingerprintMismatch;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(FingerprintComparisonResult::class)]
+class FingerprintComparisonResultTest extends TestCase
+{
+    public function testSumsUpScoreOfMisMatchingFingerprints(): void
+    {
+        $result = new FingerprintComparisonResult(
+            [],
+            [
+                'foo' => new FingerprintMismatch('foo', null, 'FOO', 10),
+                'bar' => new FingerprintMismatch('bar', null, 'BAR', 25),
+                'baz' => new FingerprintMismatch('baz', null, 'BAZ', 50),
+            ],
+            75,
+        );
+
+        static::assertSame(85, $result->score);
+    }
+
+    public function testProvidesFingerprintMismatchForGivenIdentifier(): void
+    {
+        $result = new FingerprintComparisonResult(
+            [],
+            [
+                'foo' => $mismatchingFingerprint = new FingerprintMismatch('foo', null, 'FOO', 10),
+            ],
+            75,
+        );
+
+        static::assertSame($mismatchingFingerprint, $result->getMismatchingFingerprint('foo'));
+        static::assertNull($result->getMismatchingFingerprint('bar'));
+        static::assertNull($result->getMismatchingFingerprint('baz'));
+    }
+}

--- a/tests/unit/Core/Framework/App/ShopId/FingerprintGeneratorTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/FingerprintGeneratorTest.php
@@ -3,10 +3,13 @@
 namespace Shopware\Tests\Unit\Core\Framework\App\ShopId;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\ShopId\Fingerprint;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
 use Shopware\Core\Framework\App\ShopId\FingerprintGenerator;
+use Shopware\Core\Framework\App\ShopId\FingerprintMatch;
+use Shopware\Core\Framework\App\ShopId\FingerprintMismatch;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -41,71 +44,74 @@ class FingerprintGeneratorTest extends TestCase
         static::assertSame('baz', $fingerprints['baz']);
     }
 
-    public function testDoesNotSuggestShopIdChangeIfAllFingerprintsMatch(): void
+    /**
+     * @param array<string, string> $fingerprints
+     */
+    #[DataProvider('fingerprintsForComparison')]
+    public function testComparesFingerPrintAndReturnsResult(array $fingerprints, FingerprintComparisonResult $result): void
     {
-        $fingerprints = [
-            'foo' => 'foo',
-            'bar' => 'bar',
-            'baz' => 'baz',
-        ];
+        $fingerprintGenerator = new FingerprintGenerator([
+            new FooFingerprint(),
+            new BarFingerprint(),
+            new BazFingerprint(),
+        ]);
 
-        $this->fingerprintGenerator->compare($fingerprints);
-
-        static::expectNotToPerformAssertions();
+        static::assertEquals($result, $fingerprintGenerator->compare($fingerprints));
     }
 
-    public function testDoesNotSuggestShopIdChangeIfScoreIsBelowThreshold(): void
+    public static function fingerprintsForComparison(): \Generator
     {
-        $fingerprints = [
-            'foo' => 'foo',
-            'bar' => 'rab',
-            'baz' => 'baz',
+        yield 'all match' => [
+            [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ],
+            new FingerprintComparisonResult(
+                [
+                    'foo' => new FingerprintMatch('foo', 'foo'),
+                    'bar' => new FingerprintMatch('bar', 'bar'),
+                    'baz' => new FingerprintMatch('baz', 'baz'),
+                ],
+                [],
+                75,
+            ),
         ];
 
-        $this->fingerprintGenerator->compare($fingerprints);
-
-        static::expectNotToPerformAssertions();
-    }
-
-    public function testSuggestsShopIdChangeIfScoreIsEqualToThreshold(): void
-    {
-        $fingerprints = [
-            'foo' => 'foo',
-            'bar' => 'rab',
-            'baz' => 'zab',
+        yield 'one mismatch' => [
+            [
+                'foo' => 'foo',
+                'bar' => 'wrong',
+                'baz' => 'baz',
+            ],
+            new FingerprintComparisonResult(
+                [
+                    'foo' => new FingerprintMatch('foo', 'foo'),
+                    'baz' => new FingerprintMatch('baz', 'baz'),
+                ],
+                [
+                    'bar' => new FingerprintMismatch('bar', 'wrong', 'bar', 50),
+                ],
+                75,
+            ),
         ];
 
-        try {
-            $this->fingerprintGenerator->compare($fingerprints);
-
-            static::fail(\sprintf('Expected "%s" to be thrown.', ShopIdChangeSuggestedException::class));
-        } catch (ShopIdChangeSuggestedException $e) {
-            static::assertSame([
-                'bar',
-                'baz',
-            ], $e->mismatchingFingerprints);
-        }
-    }
-
-    public function testSuggestsShopIdChangeIfScoreIsAboveThreshold(): void
-    {
-        $fingerprints = [
-            'foo' => 'oof',
-            'bar' => 'rab',
-            'baz' => 'zab',
+        yield 'all mismatch' => [
+            [
+                'foo' => 'wrong',
+                'bar' => 'wrong',
+                'baz' => 'wrong',
+            ],
+            new FingerprintComparisonResult(
+                [],
+                [
+                    'foo' => new FingerprintMismatch('foo', 'wrong', 'foo', 100),
+                    'bar' => new FingerprintMismatch('bar', 'wrong', 'bar', 50),
+                    'baz' => new FingerprintMismatch('baz', 'wrong', 'baz', 25),
+                ],
+                75,
+            ),
         ];
-
-        try {
-            $this->fingerprintGenerator->compare($fingerprints);
-
-            static::fail(\sprintf('Expected "%s" to be thrown.', ShopIdChangeSuggestedException::class));
-        } catch (ShopIdChangeSuggestedException $e) {
-            static::assertSame([
-                'foo',
-                'bar',
-                'baz',
-            ], $e->mismatchingFingerprints);
-        }
     }
 }
 

--- a/tests/unit/Core/Framework/App/ShopId/FingerprintGeneratorTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/FingerprintGeneratorTest.php
@@ -1,0 +1,173 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopId;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
+use Shopware\Core\Framework\App\ShopId\Fingerprint;
+use Shopware\Core\Framework\App\ShopId\FingerprintGenerator;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[CoversClass(FingerprintGenerator::class)]
+#[Package('framework')]
+class FingerprintGeneratorTest extends TestCase
+{
+    private FingerprintGenerator $fingerprintGenerator;
+
+    protected function setUp(): void
+    {
+        $this->fingerprintGenerator = new FingerprintGenerator([
+            new FooFingerprint(),
+            new BarFingerprint(),
+            new BazFingerprint(),
+        ]);
+    }
+
+    public function testTakesFingerprints(): void
+    {
+        $fingerprints = $this->fingerprintGenerator->takeFingerprints();
+
+        static::assertArrayHasKey('foo', $fingerprints);
+        static::assertSame('foo', $fingerprints['foo']);
+
+        static::assertArrayHasKey('bar', $fingerprints);
+        static::assertSame('bar', $fingerprints['bar']);
+
+        static::assertArrayHasKey('baz', $fingerprints);
+        static::assertSame('baz', $fingerprints['baz']);
+    }
+
+    public function testDoesNotSuggestShopIdChangeIfAllFingerprintsMatch(): void
+    {
+        $fingerprints = [
+            'foo' => 'foo',
+            'bar' => 'bar',
+            'baz' => 'baz',
+        ];
+
+        $this->fingerprintGenerator->compare($fingerprints);
+
+        static::expectNotToPerformAssertions();
+    }
+
+    public function testDoesNotSuggestShopIdChangeIfScoreIsBelowThreshold(): void
+    {
+        $fingerprints = [
+            'foo' => 'foo',
+            'bar' => 'rab',
+            'baz' => 'baz',
+        ];
+
+        $this->fingerprintGenerator->compare($fingerprints);
+
+        static::expectNotToPerformAssertions();
+    }
+
+    public function testSuggestsShopIdChangeIfScoreIsEqualToThreshold(): void
+    {
+        $fingerprints = [
+            'foo' => 'foo',
+            'bar' => 'rab',
+            'baz' => 'zab',
+        ];
+
+        try {
+            $this->fingerprintGenerator->compare($fingerprints);
+
+            static::fail(\sprintf('Expected "%s" to be thrown.', ShopIdChangeSuggestedException::class));
+        } catch (ShopIdChangeSuggestedException $e) {
+            static::assertSame([
+                'bar',
+                'baz',
+            ], $e->mismatchingFingerprints);
+        }
+    }
+
+    public function testSuggestsShopIdChangeIfScoreIsAboveThreshold(): void
+    {
+        $fingerprints = [
+            'foo' => 'oof',
+            'bar' => 'rab',
+            'baz' => 'zab',
+        ];
+
+        try {
+            $this->fingerprintGenerator->compare($fingerprints);
+
+            static::fail(\sprintf('Expected "%s" to be thrown.', ShopIdChangeSuggestedException::class));
+        } catch (ShopIdChangeSuggestedException $e) {
+            static::assertSame([
+                'foo',
+                'bar',
+                'baz',
+            ], $e->mismatchingFingerprints);
+        }
+    }
+}
+
+/**
+ * @internal
+ */
+class FooFingerprint implements Fingerprint
+{
+    public function getIdentifier(): string
+    {
+        return 'foo';
+    }
+
+    public function getScore(): int
+    {
+        return 100;
+    }
+
+    public function getStamp(): string
+    {
+        return 'foo';
+    }
+}
+
+/**
+ * @internal
+ */
+class BarFingerprint implements Fingerprint
+{
+    public function getIdentifier(): string
+    {
+        return 'bar';
+    }
+
+    public function getScore(): int
+    {
+        return 50;
+    }
+
+    public function getStamp(): string
+    {
+        return 'bar';
+    }
+}
+
+/**
+ * @internal
+ */
+class BazFingerprint implements Fingerprint
+{
+    public function getIdentifier(): string
+    {
+        return 'baz';
+    }
+
+    public function getScore(): int
+    {
+        return 25;
+    }
+
+    public function getStamp(): string
+    {
+        return 'baz';
+    }
+}

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -20,21 +20,39 @@ use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type ShopIdV1Config from ShopId
  */
 #[CoversClass(ShopIdProvider::class)]
 class ShopIdProviderTest extends TestCase
 {
+    /**
+     * @param ShopIdV1Config|null $shopIdV1Config
+     */
     #[DataProvider('oldShopIdsProvider')]
-    public function testGeneratesNewShopIdV2(?string $oldShopId): void
+    public function testGeneratesNewShopIdV2(?array $shopIdV1Config): void
     {
         $systemConfigService = $this->createMock(SystemConfigService::class);
-        $systemConfigService->expects($this->exactly(2))
+        $systemConfigService->expects($matcher = $this->exactly(4))
             ->method('get')
-            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY)
-            ->willReturnOnConsecutiveCalls(null, $oldShopId ? (array) ShopId::v1($oldShopId) : null);
+            ->willReturnCallback(function (...$parameters) use ($matcher, $shopIdV1Config) {
+                if ($matcher->numberOfInvocations() === 1 || $matcher->numberOfInvocations() === 3) {
+                    static::assertSame(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, $parameters[0]);
+
+                    return null;
+                }
+
+                if ($matcher->numberOfInvocations() === 2 || $matcher->numberOfInvocations() === 4) {
+                    static::assertSame(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, $parameters[0]);
+
+                    return \is_array($shopIdV1Config) ? (array) ShopId::v1($shopIdV1Config['value'], $shopIdV1Config['app_url']) : null;
+                }
+
+                static::fail(\sprintf('SystemConfigService was not expected to be called more than %s times', $matcher->numberOfInvocations()));
+            });
         $systemConfigService->expects($this->once())
             ->method('set')
-            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, static::callback(function (array $config): bool {
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, static::callback(function (array $config): bool {
                 static::assertSame(2, $config['version'] ?? null);
                 static::assertSame([], $config['fingerprints'] ?? null);
 
@@ -54,7 +72,8 @@ class ShopIdProviderTest extends TestCase
 
         $shopIdChangedEvent = $eventDispatcher->getEvents()[0] ?? null;
         static::assertInstanceOf(ShopIdChangedEvent::class, $shopIdChangedEvent);
-        static::assertSame($oldShopId, $shopIdChangedEvent->oldShopId?->id);
+        static::assertSame($shopIdV1Config['value'] ?? null, $shopIdChangedEvent->oldShopId?->id);
+        static::assertSame($shopIdV1Config['app_url'] ?? null, $shopIdChangedEvent->oldShopId?->getFingerprint(AppUrl::IDENTIFIER) ?? null);
         static::assertSame($shopId, $shopIdChangedEvent->newShopId->id);
     }
 
@@ -72,13 +91,26 @@ class ShopIdProviderTest extends TestCase
         ];
 
         $systemConfigService = $this->createMock(SystemConfigService::class);
-        $systemConfigService->expects($this->exactly(2))
+        $systemConfigService->expects($matcher = $this->exactly(4))
             ->method('get')
-            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY)
-            ->willReturn($shopIdV1Config, $shopIdV2Config);
+            ->willReturnCallback(function (...$parameters) use ($matcher, $shopIdV1Config) {
+                if ($matcher->numberOfInvocations() === 1 || $matcher->numberOfInvocations() === 3) {
+                    static::assertSame(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, $parameters[0]);
+
+                    return null;
+                }
+
+                if ($matcher->numberOfInvocations() === 2 || $matcher->numberOfInvocations() === 4) {
+                    static::assertSame(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, $parameters[0]);
+
+                    return $shopIdV1Config;
+                }
+
+                static::fail(\sprintf('SystemConfigService was not expected to be called more than %s times', $matcher->numberOfInvocations()));
+            });
         $systemConfigService->expects($this->once())
             ->method('set')
-            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, static::callback(function (array $config) use ($shopIdV2Config): bool {
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, static::callback(function (array $config) use ($shopIdV2Config): bool {
                 static::assertSame($shopIdV2Config, $config);
 
                 return true;
@@ -109,7 +141,7 @@ class ShopIdProviderTest extends TestCase
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $systemConfigService->expects($this->once())
             ->method('get')
-            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY)
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2)
             ->willReturn((array) $shopId);
 
         $connection = $this->createMock(Connection::class);
@@ -152,7 +184,7 @@ class ShopIdProviderTest extends TestCase
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $systemConfigService->expects($this->exactly(2))
             ->method('get')
-            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY)
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2)
             ->willReturnOnConsecutiveCalls((array) $shopId, (array) $shopId);
 
         $connection = $this->createMock(Connection::class);
@@ -214,6 +246,6 @@ class ShopIdProviderTest extends TestCase
     public static function oldShopIdsProvider(): \Generator
     {
         yield 'old shop id NOT present' => [null];
-        yield 'old shop id IS present' => ['0987654321'];
+        yield 'old shop id IS present' => [['value' => '1234567890', 'app_url' => 'https://foo.bar']];
     }
 }

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -226,9 +226,17 @@ class ShopIdProviderTest extends TestCase
     public function testDeletesShopId(): void
     {
         $systemConfigService = $this->createMock(SystemConfigService::class);
-        $systemConfigService->expects($this->once())
+        $systemConfigService->expects($matcher = $this->exactly(2))
             ->method('delete')
-            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
+            ->willReturnCallback(function (...$parameters) use ($matcher): void {
+                if ($matcher->numberOfInvocations() === 1) {
+                    static::assertSame(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, $parameters[0]);
+                }
+
+                if ($matcher->numberOfInvocations() === 2) {
+                    static::assertSame(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, $parameters[0]);
+                }
+            });
 
         $provider = new ShopIdProvider(
             $systemConfigService,

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -4,14 +4,18 @@ namespace Shopware\Tests\Unit\Core\Framework\App\ShopId;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\FingerprintGenerator;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdChangedEvent;
 use Shopware\Core\Framework\App\ShopId\ShopIdDeletedEvent;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
-use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 
 /**
  * @internal
@@ -19,160 +23,174 @@ use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 #[CoversClass(ShopIdProvider::class)]
 class ShopIdProviderTest extends TestCase
 {
-    public function testGetShopIdWillCreateOneIfNoneIsGiven(): void
+    #[DataProvider('oldShopIdsProvider')]
+    public function testGeneratesNewShopIdV2(?string $oldShopId): void
     {
-        $systemConfigService = new StaticSystemConfigService();
-        $eventDispatcher = new CollectingEventDispatcher();
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->expects($this->exactly(2))
+            ->method('get')
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY)
+            ->willReturnOnConsecutiveCalls(null, $oldShopId ? (array) ShopId::v1($oldShopId) : null);
+        $systemConfigService->expects($this->once())
+            ->method('set')
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, static::callback(function (array $config): bool {
+                static::assertSame(2, $config['version'] ?? null);
+                static::assertSame([], $config['fingerprints'] ?? null);
 
-        $shopIdProvider = new ShopIdProvider(
+                return true;
+            }));
+
+        $provider = new ShopIdProvider(
             $systemConfigService,
-            $eventDispatcher,
-            $this->createMock(Connection::class)
+            $eventDispatcher = new CollectingEventDispatcher(),
+            $this->createMock(Connection::class),
+            $this->createMock(FingerprintGenerator::class),
         );
 
-        $shopId = $shopIdProvider->getShopId();
+        $shopId = $provider->getShopId();
 
-        static::assertSame(16, \strlen($shopId));
+        static::assertCount(1, $eventDispatcher->getEvents());
 
-        $systemConfigValue = $systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
-
-        static::assertIsArray($systemConfigValue);
-        static::assertEquals([
-            'value' => $shopId,
-            'app_url' => EnvironmentHelper::getVariable('APP_URL'),
-        ], $systemConfigValue);
-
-        $events = $eventDispatcher->getEvents();
-
-        static::assertCount(1, $events);
-
-        $shopIdChangedEvent = $events[0];
+        $shopIdChangedEvent = $eventDispatcher->getEvents()[0] ?? null;
         static::assertInstanceOf(ShopIdChangedEvent::class, $shopIdChangedEvent);
-
-        static::assertSame($shopId, $shopIdChangedEvent->newShopId['value']);
-        static::assertSame(EnvironmentHelper::getVariable('APP_URL'), $shopIdChangedEvent->newShopId['app_url']);
-        static::assertNull($shopIdChangedEvent->oldShopId);
+        static::assertSame($oldShopId, $shopIdChangedEvent->oldShopId?->id);
+        static::assertSame($shopId, $shopIdChangedEvent->newShopId->id);
     }
 
-    public function testGetShopIdWillNotCreateNewIfAlreadyGiven(): void
+    public function testUpgradesShopIdToV2IfShopIdInSystemConfigIsV1(): void
     {
-        $systemConfigService = new StaticSystemConfigService([
-            ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY => [
-                'app_url' => EnvironmentHelper::getVariable('APP_URL'),
-                'value' => '1234567890',
-            ],
-        ]);
+        $shopIdV1Config = [
+            'value' => '1234567890',
+            'app_url' => 'https://foo.bar',
+        ];
 
-        $eventDispatcher = new CollectingEventDispatcher();
+        $shopIdV2Config = [
+            'id' => $shopIdV1Config['value'],
+            'fingerprints' => [],
+            'version' => 2,
+        ];
 
-        $shopIdProvider = new ShopIdProvider(
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->expects($this->exactly(2))
+            ->method('get')
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY)
+            ->willReturn($shopIdV1Config, $shopIdV2Config);
+        $systemConfigService->expects($this->once())
+            ->method('set')
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, static::callback(function (array $config) use ($shopIdV2Config): bool {
+                static::assertSame($shopIdV2Config, $config);
+
+                return true;
+            }));
+
+        $provider = new ShopIdProvider(
             $systemConfigService,
-            $eventDispatcher,
-            $this->createMock(Connection::class)
+            $eventDispatcher = new CollectingEventDispatcher(),
+            $this->createMock(Connection::class),
+            $this->createMock(FingerprintGenerator::class),
         );
 
-        $shopId = $shopIdProvider->getShopId();
+        $upgradedShopId = $provider->getShopId();
 
-        static::assertSame('1234567890', $shopId);
-        static::assertCount(0, $eventDispatcher->getEvents());
+        static::assertCount(1, $eventDispatcher->getEvents());
+
+        $shopIdChangedEvent = $eventDispatcher->getEvents()[0] ?? null;
+        static::assertInstanceOf(ShopIdChangedEvent::class, $shopIdChangedEvent);
+        static::assertSame($shopIdV1Config['value'], $shopIdChangedEvent->oldShopId?->id);
+        static::assertSame($shopIdV1Config['value'], $shopIdChangedEvent->newShopId->id);
+        static::assertSame($shopIdV1Config['value'], $upgradedShopId);
     }
 
-    public function testItThrowsAppUrlChangedExceptionIfAppsAreInstalled(): void
+    public function testThrowsIfAppUrlHasChangedAndHasAppsRegisteredAtAppServers(): void
     {
-        $newAppUrl = EnvironmentHelper::getVariable('APP_URL');
-        $oldAppUrl = $newAppUrl . 'foo';
+        $shopId = ShopId::v2('1234567890');
 
-        $systemConfigService = new StaticSystemConfigService([
-            ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY => [
-                'value' => '1234567890',
-                'app_url' => $oldAppUrl,
-            ],
-        ]);
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->expects($this->once())
+            ->method('get')
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY)
+            ->willReturn((array) $shopId);
 
         $connection = $this->createMock(Connection::class);
-        $connection->method('fetchOne')->willReturn(1);
+        $connection->expects($this->once())
+            ->method('fetchOne')
+            ->willReturn(1);
 
-        $shopIdProvider = new ShopIdProvider(
+        $fingerprintGenerator = $this->createMock(FingerprintGenerator::class);
+        $fingerprintGenerator->method('compare')
+            ->willThrowException(AppException::shopIdChangeSuggested([AppUrl::IDENTIFIER]));
+
+        $provider = new ShopIdProvider(
             $systemConfigService,
             new CollectingEventDispatcher(),
-            $connection
+            $connection,
+            $fingerprintGenerator,
         );
 
         static::expectException(AppUrlChangeDetectedException::class);
-        $shopIdProvider->getShopId();
+        $provider->getShopId();
     }
 
-    public function testItWillUpdateTheAppUrlIfNoAppsAreInstalledAndTheUrlChanged(): void
+    public function testUpdatesShopIdIfAppUrlHasChangedButHasNoAppsRegisteredAtAppServers(): void
     {
-        $newAppUrl = EnvironmentHelper::getVariable('APP_URL');
-        $oldAppUrl = $newAppUrl . 'foo';
-        $shopId = '1234567890';
-
-        $systemConfigService = new StaticSystemConfigService([
-            ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY => [
-                'app_url' => $oldAppUrl,
-                'value' => $shopId,
-            ],
+        $shopId = ShopId::v2('1234567890', [
+            AppUrl::IDENTIFIER => 'https://old.url',
         ]);
+
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->expects($this->exactly(2))
+            ->method('get')
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY)
+            ->willReturnOnConsecutiveCalls((array) $shopId, (array) $shopId);
 
         $connection = $this->createMock(Connection::class);
-        $connection->method('fetchOne')->willReturn(0);
+        $connection->expects($this->once())
+            ->method('fetchOne')
+            ->willReturn(0);
 
-        $eventDispatcher = new CollectingEventDispatcher();
+        $fingerprintGenerator = $this->createMock(FingerprintGenerator::class);
+        $fingerprintGenerator->expects($this->once())
+            ->method('compare')
+            ->willThrowException(AppException::shopIdChangeSuggested([AppUrl::IDENTIFIER]));
+        $fingerprintGenerator->expects($this->once())
+            ->method('takeFingerprints')
+            ->willReturn([
+                AppUrl::IDENTIFIER => 'https://new.url',
+            ]);
 
-        $shopIdProvider = new ShopIdProvider(
+        $provider = new ShopIdProvider(
             $systemConfigService,
-            $eventDispatcher,
+            new CollectingEventDispatcher(),
             $connection,
+            $fingerprintGenerator,
         );
 
-        $result = $shopIdProvider->getShopId();
-        static::assertSame($shopId, $result);
-        static::assertEquals([
-            'value' => $result,
-            'app_url' => $newAppUrl,
-        ], $systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
-
-        $events = $eventDispatcher->getEvents();
-        static::assertCount(1, $events);
-
-        $shopIdChangedEvent = $events[0];
-        static::assertInstanceOf(ShopIdChangedEvent::class, $shopIdChangedEvent);
-
-        static::assertSame($shopId, $shopIdChangedEvent->newShopId['value']);
-        static::assertSame($newAppUrl, $shopIdChangedEvent->newShopId['app_url']);
-
-        $oldConfigValue = $shopIdChangedEvent->oldShopId;
-        static::assertNotNull($oldConfigValue);
-        static::assertSame($shopId, $oldConfigValue['value']);
-        static::assertSame($oldAppUrl, $oldConfigValue['app_url']);
+        static::assertSame($shopId->id, $provider->getShopId());
     }
 
-    public function testDeleteShopId(): void
+    public function testDeletesShopId(): void
     {
-        $systemConfigService = new StaticSystemConfigService([
-            ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY => [
-                'value' => '123456789',
-                'app_url' => 'http://someShop',
-            ],
-        ]);
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->expects($this->once())
+            ->method('delete')
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY);
 
-        $eventDispatcher = new CollectingEventDispatcher();
-
-        $shopIdProvider = new ShopIdProvider(
+        $provider = new ShopIdProvider(
             $systemConfigService,
-            $eventDispatcher,
-            $this->createMock(Connection::class)
+            $eventDispatcher = new CollectingEventDispatcher(),
+            $this->createMock(Connection::class),
+            $this->createMock(FingerprintGenerator::class),
         );
 
-        static::assertNotNull($systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
+        $provider->deleteShopId();
 
-        $shopIdProvider->deleteShopId();
+        static::assertCount(1, $eventDispatcher->getEvents());
+        static::assertInstanceOf(ShopIdDeletedEvent::class, $eventDispatcher->getEvents()[0]);
+    }
 
-        static::assertNull($systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
-
-        $events = $eventDispatcher->getEvents();
-        static::assertCount(1, $events);
-        static::assertInstanceOf(ShopIdDeletedEvent::class, $events[0]);
+    public static function oldShopIdsProvider(): \Generator
+    {
+        yield 'old shop id NOT present' => [null];
+        yield 'old shop id IS present' => ['0987654321'];
     }
 }

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -6,10 +6,11 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
 use Shopware\Core\Framework\App\ShopId\FingerprintGenerator;
+use Shopware\Core\Framework\App\ShopId\FingerprintMismatch;
 use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdChangedEvent;
 use Shopware\Core\Framework\App\ShopId\ShopIdDeletedEvent;
@@ -118,7 +119,18 @@ class ShopIdProviderTest extends TestCase
 
         $fingerprintGenerator = $this->createMock(FingerprintGenerator::class);
         $fingerprintGenerator->method('compare')
-            ->willThrowException(AppException::shopIdChangeSuggested([AppUrl::IDENTIFIER]));
+            ->willReturn(new FingerprintComparisonResult(
+                [],
+                [
+                    AppUrl::IDENTIFIER => new FingerprintMismatch(
+                        AppUrl::IDENTIFIER,
+                        'https://old.url',
+                        'https://new.url',
+                        100,
+                    ),
+                ],
+                75,
+            ));
 
         $provider = new ShopIdProvider(
             $systemConfigService,
@@ -151,7 +163,18 @@ class ShopIdProviderTest extends TestCase
         $fingerprintGenerator = $this->createMock(FingerprintGenerator::class);
         $fingerprintGenerator->expects($this->once())
             ->method('compare')
-            ->willThrowException(AppException::shopIdChangeSuggested([AppUrl::IDENTIFIER]));
+            ->willReturn(new FingerprintComparisonResult(
+                [],
+                [
+                    AppUrl::IDENTIFIER => new FingerprintMismatch(
+                        AppUrl::IDENTIFIER,
+                        'https://old.url',
+                        'https://new.url',
+                        100,
+                    ),
+                ],
+                75,
+            ));
         $fingerprintGenerator->expects($this->once())
             ->method('takeFingerprints')
             ->willReturn([

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdTest.php
@@ -25,7 +25,7 @@ class ShopIdTest extends TestCase
 
         static::assertSame($shopId->id, $config['value']);
         static::assertSame(1, $shopId->version);
-        static::assertSame([], $shopId->fingerprints);
+        static::assertSame(['app_url' => $config['app_url']], $shopId->fingerprints);
     }
 
     public function testCreatesShopIdFromValidV2Config(): void

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdTest.php
@@ -44,7 +44,7 @@ class ShopIdTest extends TestCase
     public function testThrowsIfSystemConfigIsInvalid(): void
     {
         static::expectException(AppException::class);
-        static::expectExceptionMessage('The configuration value for "core.app.shopId" in the system config is invalid.');
+        static::expectExceptionMessage('The configuration values for "core.app.shopIdV2" and "core.app.shopId" in the system config are invalid.');
 
         ShopId::fromSystemConfig(['foo' => 'bar']);
     }

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopId;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\ShopId\ShopId;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @phpstan-import-type ShopIdV1Config from ShopId
+ * @phpstan-import-type ShopIdV2Config from ShopId
+ */
+#[CoversClass(ShopId::class)]
+#[Package('framework')]
+class ShopIdTest extends TestCase
+{
+    public function testCreatesShopIdFromValidV1Config(): void
+    {
+        $config = ['value' => '123456789', 'app_url' => 'https://foo.bar'];
+        $shopId = ShopId::fromSystemConfig($config);
+
+        static::assertSame($shopId->id, $config['value']);
+        static::assertSame(1, $shopId->version);
+        static::assertSame([], $shopId->fingerprints);
+    }
+
+    public function testCreatesShopIdFromValidV2Config(): void
+    {
+        $config = ['id' => '123456789', 'version' => 2, 'fingerprints' => [
+            'sales_channel_domain_urls' => 'SALES_CHANNEL_DOMAIN_URLS',
+            'app_url' => 'APP_URL',
+        ]];
+        $shopId = ShopId::fromSystemConfig($config);
+
+        static::assertSame($shopId->id, $config['id']);
+        static::assertSame(2, $shopId->version);
+        static::assertSame($config['fingerprints'], $shopId->fingerprints);
+    }
+
+    public function testThrowsIfSystemConfigIsInvalid(): void
+    {
+        static::expectException(AppException::class);
+        static::expectExceptionMessage('The configuration value for "core.app.shopId" in the system config is invalid.');
+
+        ShopId::fromSystemConfig(['foo' => 'bar']);
+    }
+
+    public function testPutsFingerprintsOn(): void
+    {
+        $fingerprints = [
+            'sales_channel_domain_urls' => 'SALES_CHANNEL_DOMAIN_URLS',
+            'app_url' => 'APP_URL',
+        ];
+
+        $shopId = ShopId::v2('123456789', $fingerprints);
+
+        static::assertSame($fingerprints['sales_channel_domain_urls'], $shopId->getFingerprint('sales_channel_domain_urls'));
+        static::assertSame($fingerprints['app_url'], $shopId->getFingerprint('app_url'));
+        static::assertNull($shopId->getFingerprint('installation_path'));
+    }
+}

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingAppHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingAppHandlerTest.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Maintenance\Staging\Event\SetupStagingEvent;
 use Shopware\Core\Maintenance\Staging\Handler\StagingAppHandler;
-use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -39,18 +38,17 @@ class StagingAppHandlerTest extends TestCase
                 return 1;
             });
 
-        $configService = new StaticSystemConfigService();
-        $configService->set(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, 'test');
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())
+            ->method('deleteShopId');
 
-        $handler = new StagingAppHandler($connection, $configService);
+        $handler = new StagingAppHandler($connection, $shopIdProvider);
         $handler->__invoke(new SetupStagingEvent(
             Context::createDefaultContext(),
             $this->createMock(SymfonyStyle::class),
             false,
             []
         ));
-
-        static::assertNull($configService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY));
 
         static::assertSame(['app', 'integration'], $tables);
         static::assertSame(['app_id', 'integration_id'], $ids);

--- a/tests/unit/Core/Service/ServiceClientFactoryTest.php
+++ b/tests/unit/Core/Service/ServiceClientFactoryTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Service\ServiceClientFactory;
@@ -139,7 +140,7 @@ class ServiceClientFactoryTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $this->appPayloadServiceHelper->method('buildSource')->willThrowException(new AppUrlChangeDetectedException('App URL changed', 'foo', 'shopid'));
+        $this->appPayloadServiceHelper->method('buildSource')->willThrowException(new AppUrlChangeDetectedException('App URL changed', 'foo', ShopId::v2('shopid')));
 
         $this->expectException(AppUrlChangeDetectedException::class);
         $serviceClientRegistry = static::createMock(ServiceRegistryClient::class);

--- a/tests/unit/Core/System/UsageData/Subscriber/ShopIdChangedSubscriberTest.php
+++ b/tests/unit/Core/System/UsageData/Subscriber/ShopIdChangedSubscriberTest.php
@@ -99,7 +99,7 @@ class ShopIdChangedSubscriberTest extends TestCase
         );
 
         $shopIdChangedSubscriber->handleShopIdChanged(
-            new ShopIdChangedEvent(ShopId::v1('newShopId'), null),
+            new ShopIdChangedEvent(ShopId::v1('newShopId', 'https://foo.bar'), null),
         );
     }
 

--- a/tests/unit/Core/System/UsageData/Subscriber/ShopIdChangedSubscriberTest.php
+++ b/tests/unit/Core/System/UsageData/Subscriber/ShopIdChangedSubscriberTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\System\UsageData\Subscriber;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdChangedEvent;
 use Shopware\Core\Framework\App\ShopId\ShopIdDeletedEvent;
 use Shopware\Core\Framework\Log\Package;
@@ -76,16 +77,9 @@ class ShopIdChangedSubscriberTest extends TestCase
             $entityDispatchService
         );
 
-        $shopIdChangedSubscriber->handleShopIdChanged(new ShopIdChangedEvent(
-            [
-                'value' => 'newShopId',
-                'app_url' => 'newAppUrl',
-            ],
-            [
-                'value' => 'oldShopId',
-                'app_url' => 'oldAppUrl',
-            ],
-        ));
+        $shopIdChangedSubscriber->handleShopIdChanged(
+            new ShopIdChangedEvent(ShopId::v2('newShopId'), ShopId::v2('oldShopId')),
+        );
     }
 
     public function testHandleShopIdChangedDoesNothingIfOldShopIdIsNull(): void
@@ -104,13 +98,9 @@ class ShopIdChangedSubscriberTest extends TestCase
             $entityDispatchService
         );
 
-        $shopIdChangedSubscriber->handleShopIdChanged(new ShopIdChangedEvent(
-            [
-                'value' => 'newShopId',
-                'app_url' => 'newAppUrl',
-            ],
-            null
-        ));
+        $shopIdChangedSubscriber->handleShopIdChanged(
+            new ShopIdChangedEvent(ShopId::v1('newShopId'), null),
+        );
     }
 
     public function testHandleShopIdDoesNothingIfOldShopIdWasSet(): void
@@ -129,15 +119,8 @@ class ShopIdChangedSubscriberTest extends TestCase
             $entityDispatchService
         );
 
-        $shopIdChangedSubscriber->handleShopIdChanged(new ShopIdChangedEvent(
-            [
-                'value' => 'newShopId',
-                'app_url' => 'newAppUrl',
-            ],
-            [
-                'value' => 'newShopId',
-                'app_url' => 'newAppUrl',
-            ],
-        ));
+        $shopIdChangedSubscriber->handleShopIdChanged(
+            new ShopIdChangedEvent(ShopId::v2('newShopId'), ShopId::v2('newShopId')),
+        );
     }
 }

--- a/tests/unit/Storefront/Framework/Routing/TemplateDataSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/TemplateDataSubscriberTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Seo\Hreflang\HreflangCollection;
 use Shopware\Core\Content\Seo\HreflangLoaderInterface;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\Exception\AppUrlChangeDetectedException;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
@@ -148,7 +149,7 @@ class TemplateDataSubscriberTest extends TestCase
         $this->shopIdProvider
             ->expects($this->once())
             ->method('getShopId')
-            ->willThrowException(new AppUrlChangeDetectedException('before', 'new', '123'));
+            ->willThrowException(new AppUrlChangeDetectedException('before', 'new', ShopId::v2('123')));
 
         $this->subscriber->addShopIdParameter($event);
     }


### PR DESCRIPTION
This is the first step of resolving #6749.

It changes the way a state change in the system is detected, but keeps the current logic of throwing the `AppUrlChangeDetectedException`.

In the next step, the specific `AppUrlChangeDetectedException` will be replaced with the more generic `ShopIdChangeSuggestedException` which provides a list of matching and mismatching fingerprints.

The Administration needs to be able to handle this new exception.