### PR TITLE
refactor: Use static methods for EntityCacheKeyGenerator

### DIFF
--- a/changelog/_unreleased/2025-08-01-use-static-functions-for-entity-cache-key-generator.md
+++ b/changelog/_unreleased/2025-08-01-use-static-functions-for-entity-cache-key-generator.md
@@ -1,0 +1,9 @@
+---
+title: Use static methods for EntityCacheKeyGenerator
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Added new static methods `buildSalesChannelContextHash` and `buildCriteriaHash` in `Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator`
+* Deprecated methods `getSalesChannelContextHash` and `getCriteriaHash` in `Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator`

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -334,7 +334,6 @@
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator"/>
             <argument type="service" id="Shopware\Core\Content\Product\Cart\ProductFeatureBuilder"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Price\ProductPriceCalculator"/>
-            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
 
             <tag name="shopware.cart.processor" priority="5000"/>

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -56,7 +56,6 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
         private readonly QuantityPriceCalculator $calculator,
         private readonly ProductFeatureBuilder $featureBuilder,
         private readonly AbstractProductPriceCalculator $priceCalculator,
-        private readonly EntityCacheKeyGenerator $generator,
         private readonly Connection $connection
     ) {
     }
@@ -573,7 +572,7 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
 
     private function getDataContextHash(SalesChannelContext $context): string
     {
-        $contextHash = $this->generator->getSalesChannelContextHash($context, [RuleAreas::PRODUCT_AREA]);
+        $contextHash = EntityCacheKeyGenerator::buildSalesChannelContextHash($context, [RuleAreas::PRODUCT_AREA]);
 
         $activeTaxRules = array_map(static function (TaxEntity $taxRule) {
             return $taxRule->getRules()?->getIds() ?: $taxRule->getId();

--- a/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Shopware\Core\Framework\DataAbstractionLayer\Cache;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -29,7 +30,7 @@ class EntityCacheKeyGenerator
     /**
      * @param string[] $areas
      */
-    public function getSalesChannelContextHash(SalesChannelContext $context, array $areas = []): string
+    public static function buildSalesChannelContextHash(SalesChannelContext $context, array $areas = []): string
     {
         $ruleIds = $context->getRuleIdsByAreas($areas);
 
@@ -45,7 +46,7 @@ class EntityCacheKeyGenerator
         ]);
     }
 
-    public function getCriteriaHash(Criteria $criteria): string
+    public static function buildCriteriaHash(Criteria $criteria): string
     {
         return Hasher::hash([
             $criteria->getIds(),
@@ -61,5 +62,27 @@ class EntityCacheKeyGenerator
             $criteria->getAggregations(),
             $criteria->getAssociations(),
         ]);
+    }
+
+    /**
+     * @param string[] $areas
+     *
+     * @deprecated tag:v6.8.0 - Will be removed, use `buildSalesChannelContextHash` instead
+     */
+    public function getSalesChannelContextHash(SalesChannelContext $context, array $areas = []): string
+    {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0', self::class . '::buildSalesChannelContextHash'));
+
+        return self::buildSalesChannelContextHash($context, $areas);
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed, use `buildCriteriaHash` instead
+     */
+    public function getCriteriaHash(Criteria $criteria): string
+    {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0', self::class . '::buildCriteriaHash'));
+
+        return self::buildCriteriaHash($criteria);
     }
 }

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -727,9 +727,7 @@ frame-ancestors 'none';
             <argument>%shopware.cache.invalidation.http_cache%</argument>
         </service>
 
-        <service id="Shopware\Core\Framework\Routing\ContextAwareCacheHeadersService">
-            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator"/>
-        </service>
+        <service id="Shopware\Core\Framework\Routing\ContextAwareCacheHeadersService"/>
 
         <service id="Shopware\Core\Framework\Routing\ContextAwareCacheHeadersSubscriber">
             <argument type="service" id="Shopware\Core\Framework\Routing\ContextAwareCacheHeadersService"/>

--- a/src/Core/Framework/Routing/ContextAwareCacheHeadersService.php
+++ b/src/Core/Framework/Routing/ContextAwareCacheHeadersService.php
@@ -15,11 +15,6 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('framework')]
 readonly class ContextAwareCacheHeadersService
 {
-    public function __construct(
-        private EntityCacheKeyGenerator $cacheKeyGenerator
-    ) {
-    }
-
     public function addContextHeaders(Request $request, Response $response, SalesChannelContext $context): void
     {
         // Add context headers to response
@@ -36,7 +31,7 @@ readonly class ContextAwareCacheHeadersService
         $areaRuleIds = $context->getAreaRuleIds();
         $ruleAreas = array_keys($areaRuleIds);
 
-        return $this->cacheKeyGenerator->getSalesChannelContextHash($context, $ruleAreas);
+        return EntityCacheKeyGenerator::buildSalesChannelContextHash($context, $ruleAreas);
     }
 
     private function addVaryHeaders(Response $response): void

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -182,7 +182,6 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
             <argument>%kernel.debug%</argument>
             <argument type="service" id="cache.object"/>
-            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheInvalidator"/>
             <argument type="service" id="event_dispatcher"/>
             <argument>%session.storage.options%</argument>

--- a/src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php
+++ b/src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php
@@ -53,7 +53,6 @@ class NotFoundSubscriber implements EventSubscriberInterface, ResetInterface
         private readonly SalesChannelContextServiceInterface $contextService,
         private bool $kernelDebug, // Do not change to readonly, as it is used in tests
         private readonly CacheInterface $cache,
-        private readonly EntityCacheKeyGenerator $generator,
         private readonly CacheInvalidator $cacheInvalidator,
         private readonly EventDispatcherInterface $eventDispatcher,
         array $sessionOptions = []
@@ -153,7 +152,7 @@ class NotFoundSubscriber implements EventSubscriberInterface, ResetInterface
 
     private function generateKey(string $salesChannelId, string $domainId, string $languageId, Request $request, SalesChannelContext $context): string
     {
-        $key = self::buildName($salesChannelId, $domainId, $languageId) . $this->generator->getSalesChannelContextHash($context);
+        $key = self::buildName($salesChannelId, $domainId, $languageId) . EntityCacheKeyGenerator::buildSalesChannelContextHash($context);
 
         $event = new NotFoundPageCacheKeyEvent($key, $request, $context);
 

--- a/tests/unit/Core/Checkout/Cart/ProductCartProcessorTest.php
+++ b/tests/unit/Core/Checkout/Cart/ProductCartProcessorTest.php
@@ -26,7 +26,6 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\Price\ProductPriceCalculator;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Product\State;
-use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\Checkout\EmptyPrice;
@@ -131,7 +130,6 @@ class ProductCartProcessorTest extends TestCase
             $this->createMock(QuantityPriceCalculator::class),
             $this->createMock(ProductFeatureBuilder::class),
             $calculator,
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(Connection::class)
         );
 
@@ -199,7 +197,6 @@ class ProductCartProcessorTest extends TestCase
             $this->createMock(QuantityPriceCalculator::class),
             $this->createMock(ProductFeatureBuilder::class),
             $calculator,
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(Connection::class)
         );
 
@@ -246,7 +243,6 @@ class ProductCartProcessorTest extends TestCase
             $this->createMock(QuantityPriceCalculator::class),
             $this->createMock(ProductFeatureBuilder::class),
             $this->createMock(ProductPriceCalculator::class),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(Connection::class)
         );
 
@@ -287,7 +283,6 @@ class ProductCartProcessorTest extends TestCase
             $calculator,
             $this->createMock(ProductFeatureBuilder::class),
             $this->createMock(ProductPriceCalculator::class),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(Connection::class)
         );
 
@@ -337,7 +332,6 @@ class ProductCartProcessorTest extends TestCase
             $this->createMock(QuantityPriceCalculator::class),
             $this->createMock(ProductFeatureBuilder::class),
             $this->createMock(ProductPriceCalculator::class),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(Connection::class)
         );
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
@@ -53,9 +53,7 @@ class EntityCacheKeyGeneratorTest extends TestCase
     #[DataProvider('criteriaHashProvider')]
     public function testCriteriaHash(Criteria $criteria, string $hash): void
     {
-        $generator = new EntityCacheKeyGenerator();
-
-        static::assertSame($hash, $generator->getCriteriaHash($criteria));
+        static::assertSame($hash, EntityCacheKeyGenerator::buildCriteriaHash($criteria));
     }
 
     public static function criteriaHashProvider(): \Generator
@@ -95,11 +93,9 @@ class EntityCacheKeyGeneratorTest extends TestCase
     #[DataProvider('contextHashProvider')]
     public function testContextHash(SalesChannelContext $compared): void
     {
-        $generator = new EntityCacheKeyGenerator();
-
         static::assertNotSame(
-            $generator->getSalesChannelContextHash(new DummyContext(), ['test']),
-            $generator->getSalesChannelContextHash($compared, ['test'])
+            EntityCacheKeyGenerator::buildSalesChannelContextHash(new DummyContext(), ['test']),
+            EntityCacheKeyGenerator::buildSalesChannelContextHash($compared, ['test'])
         );
     }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Query/ScoreQueryTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Query/ScoreQueryTest.php
@@ -18,7 +18,7 @@ class ScoreQueryTest extends TestCase
         $scoreQuery = new ScoreQuery(new ContainsFilter('productNumber', '123456'), 100);
 
         /**
-         * @see \Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator::getCriteriaHash
+         * @see \Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator::buildCriteriaHash
          */
         $json = json_encode($scoreQuery, \JSON_THROW_ON_ERROR);
 

--- a/tests/unit/Core/Framework/Routing/ContextAwareCacheHeadersServiceTest.php
+++ b/tests/unit/Core/Framework/Routing/ContextAwareCacheHeadersServiceTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\Routing\ContextAwareCacheHeadersService;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\Currency\CurrencyEntity;
@@ -27,8 +26,7 @@ class ContextAwareCacheHeadersServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $entityCacheKeyGenerator = new EntityCacheKeyGenerator();
-        $this->contextAwareCacheService = new ContextAwareCacheHeadersService($entityCacheKeyGenerator);
+        $this->contextAwareCacheService = new ContextAwareCacheHeadersService();
     }
 
     /**

--- a/tests/unit/Storefront/Framework/Routing/NotFound/NotFoundSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/NotFound/NotFoundSubscriberTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
-use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Kernel;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
@@ -39,7 +38,6 @@ class NotFoundSubscriberTest extends TestCase
             $this->createMock(SalesChannelContextServiceInterface::class),
             true,
             $this->createMock(CacheInterface::class),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(CacheInvalidator::class),
             new EventDispatcher()
         );
@@ -71,7 +69,6 @@ class NotFoundSubscriberTest extends TestCase
             $this->createMock(SalesChannelContextServiceInterface::class),
             false,
             new TagAwareAdapter(new ArrayAdapter(), new ArrayAdapter()),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(CacheInvalidator::class),
             new EventDispatcher()
         );
@@ -111,7 +108,6 @@ class NotFoundSubscriberTest extends TestCase
             $this->createMock(SalesChannelContextServiceInterface::class),
             false,
             new TagAwareAdapter($arrayAdapter, $arrayAdapter),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(CacheInvalidator::class),
             new EventDispatcher(),
             []
@@ -157,7 +153,6 @@ class NotFoundSubscriberTest extends TestCase
             $this->createMock(SalesChannelContextServiceInterface::class),
             false,
             new TagAwareAdapter(new ArrayAdapter(), new ArrayAdapter()),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(CacheInvalidator::class),
             new EventDispatcher()
         );
@@ -202,7 +197,6 @@ class NotFoundSubscriberTest extends TestCase
             $this->createMock(SalesChannelContextServiceInterface::class),
             false,
             new TagAwareAdapter(new ArrayAdapter(), new ArrayAdapter()),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $this->createMock(CacheInvalidator::class),
             $eventDispatcher,
         );
@@ -233,7 +227,6 @@ class NotFoundSubscriberTest extends TestCase
             $this->createMock(SalesChannelContextServiceInterface::class),
             true,
             $this->createMock(CacheInterface::class),
-            $this->createMock(EntityCacheKeyGenerator::class),
             $cacheInvalidator,
             new EventDispatcher()
         );


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently you always have to import the `EntityCacheKeyGenerator` service to use the `getSalesChannelContextHash` & `getCriteriaHash` functions, even though they don't need any class services themself and so they can be static
- This reduces the need to import the `EntityCacheKeyGenerator` as a service class

### 2. What does this change do, exactly?
* Changed `getSalesChannelContextHash` & `getCriteriaHash` in `Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator` to `static` functions

### 3. Describe each step to reproduce the issue or behaviour.
- Try to use the `getSalesChannelContextHash` & `getCriteriaHash` functions from `EntityCacheKeyGenerator` without importing the service

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
