### PR TITLE
fix: Do not deprecate usage of ProductNotFoundException

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -27,6 +27,7 @@ return [
 
         // Incorrectly deprecated
         'The return type of Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentException.* changed from self',
+        preg_quote('The return type of Shopware\Core\Content\Product\ProductException::productNotFound() changed from self|Shopware\Core\Content\Product\Exception\ProductNotFoundException to Shopware\Core\Content\Product\Exception\ProductNotFoundException', '/'),
 
         // Expected to be appended when new event is added
         preg_quote('Value of constant Shopware\Core\Framework\Webhook\Hookable', '/'),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -733,12 +733,6 @@ parameters:
 			path: src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
 
 		-
-			message: '#^Method Shopware\\Core\\Content\\Product\\Exception\\VariantNotFoundException\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Content/Product/Exception/VariantNotFoundException.php
-
-		-
 			message: '#^Mixed variable in a `\$a\-\>get\(''group''\)\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
 			identifier: typePerfect.noMixedMethodCaller
 			count: 3
@@ -787,28 +781,10 @@ parameters:
 			path: src/Core/Content/Product/PropertyGroupSorter.php
 
 		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRoute.php
-
-		-
 			message: '#^Method Shopware\\Core\\Content\\Product\\SalesChannel\\FindVariant\\FoundCombination\:\:getOptions\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/SalesChannel/FindVariant/FoundCombination.php
-
-		-
-			message: '#^Expected domain exception class Shopware\\Core\\Content\\Product\\ProductException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
-
-		-
-			message: '#^Expected domain exception class Shopware\\Core\\Content\\Product\\ProductException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Content/Product/SearchKeyword/ProductSearchBuilder.php
 
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'

--- a/src/Core/Content/Product/Exception/ProductNotFoundException.php
+++ b/src/Core/Content/Product/Exception/ProductNotFoundException.php
@@ -2,28 +2,21 @@
 
 namespace Shopware\Core\Content\Product\Exception;
 
+use Shopware\Core\Content\Product\ProductException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('inventory')]
-class ProductNotFoundException extends ShopwareHttpException
+class ProductNotFoundException extends ProductException
 {
     public function __construct(string $productId)
     {
         parent::__construct(
-            'Product for id {{ productId }} not found.',
-            ['productId' => $productId]
+            Response::HTTP_NOT_FOUND,
+            Feature::isActive('v6.8.0.0') ? self::PRODUCT_NOT_FOUND : 'CONTENT__PRODUCT_NOT_FOUND',
+            self::$couldNotFindMessage,
+            ['entity' => 'product', 'field' => 'id', 'value' => $productId]
         );
-    }
-
-    public function getErrorCode(): string
-    {
-        return 'CONTENT__PRODUCT_NOT_FOUND';
-    }
-
-    public function getStatusCode(): int
-    {
-        return Response::HTTP_NOT_FOUND;
     }
 }

--- a/src/Core/Content/Product/Exception/VariantNotFoundException.php
+++ b/src/Core/Content/Product/Exception/VariantNotFoundException.php
@@ -2,33 +2,28 @@
 
 namespace Shopware\Core\Content\Product\Exception;
 
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('inventory')]
-class VariantNotFoundException extends ShopwareHttpException
+class VariantNotFoundException extends ProductException
 {
+    /**
+     * @param array<string> $options
+     */
     public function __construct(
         string $productId,
         array $options
     ) {
         parent::__construct(
+            Response::HTTP_NOT_FOUND,
+            self::PRODUCT_VARIANT_NOT_FOUND,
             'Variant for productId {{ productId }} with options {{ options }} not found.',
             [
                 'productId' => $productId,
                 'options' => json_encode($options, \JSON_THROW_ON_ERROR),
             ]
         );
-    }
-
-    public function getErrorCode(): string
-    {
-        return 'CONTENT__PRODUCT_VARIANT_NOT_FOUND';
-    }
-
-    public function getStatusCode(): int
-    {
-        return Response::HTTP_NOT_FOUND;
     }
 }

--- a/src/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRoute.php
+++ b/src/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRoute.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Content\Product\SalesChannel\FindVariant;
 
-use Shopware\Core\Content\Product\Exception\VariantNotFoundException;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -19,9 +19,12 @@ class FindProductVariantRoute extends AbstractFindProductVariantRoute
 {
     /**
      * @internal
+     *
+     * @param SalesChannelRepository<ProductCollection> $productRepository
      */
-    public function __construct(private readonly SalesChannelRepository $productRepository)
-    {
+    public function __construct(
+        private readonly SalesChannelRepository $productRepository
+    ) {
     }
 
     public function getDecorated(): AbstractFindProductVariantRoute
@@ -29,10 +32,14 @@ class FindProductVariantRoute extends AbstractFindProductVariantRoute
         throw new DecorationPatternException(self::class);
     }
 
-    #[Route(path: '/store-api/product/{productId}/find-variant', name: 'store-api.product.find-variant', methods: ['POST'], defaults: ['_entity' => 'product'])]
+    #[Route(
+        path: '/store-api/product/{productId}/find-variant',
+        name: 'store-api.product.find-variant',
+        defaults: ['_entity' => 'product'],
+        methods: ['POST']
+    )]
     public function load(string $productId, Request $request, SalesChannelContext $context): FindProductVariantRouteResponse
     {
-        /** @var string|null $switchedGroup */
         $switchedGroup = $request->get('switchedGroup');
 
         $options = $request->get('options') ? $request->get('options', []) : [];
@@ -65,7 +72,7 @@ class FindProductVariantRoute extends AbstractFindProductVariantRoute
             }
         }
 
-        throw new VariantNotFoundException($productId, $options);
+        throw ProductException::variantNotFound($productId, $options);
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
@@ -6,12 +6,12 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\Events\ProductSuggestCriteriaEvent;
 use Shopware\Core\Content\Product\Events\ProductSuggestResultEvent;
 use Shopware\Core\Content\Product\ProductEvents;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Processor\CompositeListingProcessor;
 use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -37,11 +37,16 @@ class ResolvedCriteriaProductSuggestRoute extends AbstractProductSuggestRoute
         return $this->decorated;
     }
 
-    #[Route(path: '/store-api/search-suggest', name: 'store-api.search.suggest', methods: ['POST'], defaults: ['_entity' => 'product'])]
+    #[Route(
+        path: '/store-api/search-suggest',
+        name: 'store-api.search.suggest',
+        defaults: ['_entity' => 'product'],
+        methods: ['POST']
+    )]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): ProductSuggestRouteResponse
     {
         if (!$request->get('search')) {
-            throw RoutingException::missingRequestParameter('search');
+            throw ProductException::missingRequestParameter('search');
         }
 
         $criteria->addState(ProductSuggestRoute::STATE);

--- a/src/Core/Content/Product/SearchKeyword/ProductSearchBuilder.php
+++ b/src/Core/Content/Product/SearchKeyword/ProductSearchBuilder.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Product\SearchKeyword;
 
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
@@ -11,7 +12,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchPattern;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -49,7 +49,7 @@ class ProductSearchBuilder implements ProductSearchBuilderInterface
         }
 
         if (empty($term)) {
-            throw RoutingException::missingRequestParameter('search');
+            throw ProductException::missingRequestParameter('search');
         }
 
         $pattern = $this->interpreter->interpret($term, $context->getContext());

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/AddWishlistProductRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/AddWishlistProductRouteTest.php
@@ -10,7 +10,6 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
-use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
@@ -27,11 +26,8 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 class AddWishlistProductRouteTest extends TestCase
 {
     use CustomerTestTrait;
-    use IntegrationTestBehaviour;
 
     private KernelBrowser $browser;
-
-    private IdsCollection $ids;
 
     private Context $context;
 
@@ -42,10 +38,10 @@ class AddWishlistProductRouteTest extends TestCase
     protected function setUp(): void
     {
         $this->context = Context::createDefaultContext();
-        $this->ids = new IdsCollection();
+        $ids = new IdsCollection();
 
         $this->browser = $this->createCustomSalesChannelBrowser([
-            'id' => $this->ids->create('sales-channel'),
+            'id' => $ids->create('sales-channel'),
         ]);
         $this->assignSalesChannelContext($this->browser);
 
@@ -166,7 +162,7 @@ class AddWishlistProductRouteTest extends TestCase
         static::assertSame(404, $this->browser->getResponse()->getStatusCode());
         static::assertSame('CONTENT__PRODUCT_NOT_FOUND', $errors['code']);
         static::assertSame('Not Found', $errors['title']);
-        static::assertSame('Product for id ' . $productId . ' not found.', $errors['detail']);
+        static::assertSame(\sprintf('Could not find product with id "%s"', $productId), $errors['detail']);
     }
 
     /**

--- a/tests/unit/Core/Content/Breadcrumb/BreadcrumbExceptionTest.php
+++ b/tests/unit/Core/Content/Breadcrumb/BreadcrumbExceptionTest.php
@@ -37,6 +37,6 @@ class BreadcrumbExceptionTest extends TestCase
         $exception = BreadcrumbException::productNotFound('invalidId');
 
         static::assertInstanceOf(ProductNotFoundException::class, $exception);
-        static::assertSame('CONTENT__PRODUCT_NOT_FOUND', $exception->getErrorCode());
+        static::assertSame('PRODUCT_PRODUCT_NOT_FOUND', $exception->getErrorCode());
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Suggest/ProductSuggestRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Suggest/ProductSuggestRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Processor\CompositeListingProcessor;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
@@ -17,7 +18,6 @@ use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,14 +40,14 @@ class ProductSuggestRouteTest extends TestCase
 
     public function testGetDecoratedShouldThrowException(): void
     {
-        static::expectException(DecorationPatternException::class);
+        $this->expectExceptionObject(new DecorationPatternException(ProductSuggestRoute::class));
 
         $this->getProductSuggestRoute()->getDecorated();
     }
 
     public function testLoadThrowsExceptionForMissingSearchParameter(): void
     {
-        static::expectException(RoutingException::class);
+        $this->expectExceptionObject(ProductException::missingRequestParameter('search'));
 
         $route = new ResolvedCriteriaProductSuggestRoute(
             $this->createMock(ProductSearchBuilderInterface::class),


### PR DESCRIPTION
### 1. Why is this change necessary?

the specific ProductNotFoundException should not be removed, as it is still caught in several places

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
