### PR TITLE
Use chunking for media upload in administration

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/api/media.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/media.api.service.js
@@ -132,7 +132,7 @@ class MediaApiService extends ApiService {
         });
     }
 
-    runUploads(tag) {
+    async runUploads(tag) {
         const affectedUploads = array.remove(this.uploads, (upload) => {
             return upload.uploadTag === tag;
         });
@@ -145,8 +145,13 @@ class MediaApiService extends ApiService {
         const totalUploads = affectedUploads.length;
         let successUploads = 0;
         let failureUploads = 0;
-        return Promise.all(
-            affectedUploads.map((task) => {
+        
+        const concurrentLimit = 5;
+        const results = [];
+        
+        for (let i = 0; i < affectedUploads.length; i += concurrentLimit) {
+            const chunk = affectedUploads.slice(i, i + concurrentLimit);
+            const chunkPromises = chunk.map((task) => {
                 if (task.running) {
                     return Promise.resolve();
                 }
@@ -178,8 +183,13 @@ class MediaApiService extends ApiService {
                             listener(this._createUploadEvent(UploadEvents.UPLOAD_FAILED, tag, task));
                         });
                     });
-            }),
-        );
+            });
+            
+            const chunkResults = await Promise.all(chunkPromises);
+            results.push(...chunkResults);
+        }
+        
+        return results;
     }
 
     _startUpload(task) {


### PR DESCRIPTION
1. Why is this change necessary?

  When users select a large number of files (e.g., 1000 files) for upload in the administration media manager, all
   files are uploaded concurrently. This causes performance issues, memory exhaustion, and can overwhelm the
  server with too many simultaneous connections, leading to failed uploads and poor user experience.

  2. What does this change do, exactly?

  This change implements chunked uploading with a concurrency limit of 5 files. Instead of uploading all selected
  files at once using Promise.all(), the implementation now:
  - Processes uploads in sequential chunks of 5 files maximum
  - Each chunk runs concurrently, but only after the previous chunk completes
  - Maintains all existing event listeners and progress tracking functionality

  3. Describe each step to reproduce the issue or behaviour.

  1. Navigate to the Shopware Administration panel
  2. Go to Content > Media
  3. Click on "Upload files"
  4. Select a large number of files (100+ files, ideally 1000+)
  5. Without this fix: All files attempt to upload simultaneously, causing browser/server issues
  6. With this fix: Files upload in controlled batches of 5 at a time

  4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/11571

  5. Checklist

  - [ ] I have written tests and verified that they fail without my change
  - [ ] I have created a [changelog
  file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all
  necessary information about my changes
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them
