### PR TITLE
feat: add cart rule loader extension event

### DIFF
--- a/changelog/_unreleased/2025-08-04-add-cart-rule-loader-extension-event.md
+++ b/changelog/_unreleased/2025-08-04-add-cart-rule-loader-extension-event.md
@@ -1,0 +1,10 @@
+---
+title: add cart rule loader extension event
+issue: #11282
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Added `Shopware\Core\Checkout\Cart\Extension\CheckoutCartRuleLoaderExtension` to be dispatched in the `CartRuleLoader`.
+* Changed `Shopware\Core\Checkout\Cart\CartRuleLoader` to dispatch `CheckoutCartRuleLoaderExtension`.

--- a/src/Core/Checkout/Cart/CartRuleLoader.php
+++ b/src/Core/Checkout/Cart/CartRuleLoader.php
@@ -98,7 +98,7 @@ class CartRuleLoader implements ResetInterface
 
             $result = $this->extensions->publish(
                 name: CheckoutCartRuleLoaderExtension::NAME,
-                extension: new CheckoutCartRuleLoaderExtension($cart, $context, $behaviorContext, $new),
+                extension: new CheckoutCartRuleLoaderExtension($context, $cart, $behaviorContext, $new),
                 function: $this->_load(...),
             );
 
@@ -115,9 +115,9 @@ class CartRuleLoader implements ResetInterface
         });
     }
 
-    private function _load(SalesChannelContext $context, Cart $cart, CartBehavior $behaviorContext, bool $new): RuleLoaderResult
+    private function _load(SalesChannelContext $salesChannelContext, Cart $originalCart, CartBehavior $cartBehavior, bool $new): RuleLoaderResult
     {
-        $rules = $this->loadRules($context->getContext());
+        $rules = $this->loadRules($salesChannelContext->getContext());
 
         // save all rules for later usage
         $all = $rules;
@@ -125,16 +125,16 @@ class CartRuleLoader implements ResetInterface
         // For existing carts filter rules to only contain the rules from the current cart
         if ($new === false) {
             $rules = $rules->filter(
-                fn (RuleEntity $rule) => \in_array($rule->getId(), $cart->getRuleIds(), true)
+                fn (RuleEntity $rule) => \in_array($rule->getId(), $originalCart->getRuleIds(), true)
             );
         }
 
         // update rules in current context
-        $context->setRuleIds($rules->getIds());
-        $context->setAreaRuleIds($rules->getIdsByArea());
+        $salesChannelContext->setRuleIds($rules->getIds());
+        $salesChannelContext->setAreaRuleIds($rules->getIdsByArea());
 
         // start first cart calculation to have all objects enriched
-        $cart = $this->processor->process($cart, $context, $behaviorContext);
+        $cart = $this->processor->process($originalCart, $salesChannelContext, $cartBehavior);
 
         $iteration = 1;
         do {
@@ -145,20 +145,20 @@ class CartRuleLoader implements ResetInterface
             }
 
             // filter rules which matches to current scope
-            $rules = $rules->filterMatchingRules($cart, $context);
+            $rules = $rules->filterMatchingRules($cart, $salesChannelContext);
 
             // update matching rules in context
-            $context->setRuleIds($rules->getIds());
-            $context->setAreaRuleIds($rules->getIdsByArea());
+            $salesChannelContext->setRuleIds($rules->getIds());
+            $salesChannelContext->setAreaRuleIds($rules->getIdsByArea());
 
             // calculate cart again
-            $cart = $this->processor->process($cart, $context, $behaviorContext);
+            $cart = $this->processor->process($cart, $salesChannelContext, $cartBehavior);
 
             // check if the cart changed, in this case we have to recalculate the cart again
             $recalculate = $this->cartChanged($cart, $compare);
 
             // check if rules changed for the last calculated cart, in this case we have to recalculate
-            $ruleCompare = $all->filterMatchingRules($cart, $context);
+            $ruleCompare = $all->filterMatchingRules($cart, $salesChannelContext);
 
             if (!$rules->equals($ruleCompare)) {
                 $recalculate = true;
@@ -168,7 +168,7 @@ class CartRuleLoader implements ResetInterface
             ++$iteration;
         } while ($recalculate);
 
-        $cart = $this->validateTaxFree($context, $cart, $behaviorContext);
+        $cart = $this->validateTaxFree($salesChannelContext, $cart, $cartBehavior);
 
         $index = 0;
         foreach ($rules as $rule) {
@@ -178,8 +178,8 @@ class CartRuleLoader implements ResetInterface
             );
         }
 
-        $context->setRuleIds($rules->getIds());
-        $context->setAreaRuleIds($rules->getIdsByArea());
+        $salesChannelContext->setRuleIds($rules->getIds());
+        $salesChannelContext->setAreaRuleIds($rules->getIdsByArea());
 
         return new RuleLoaderResult($cart, $rules);
     }

--- a/src/Core/Checkout/Cart/CartRuleLoader.php
+++ b/src/Core/Checkout/Cart/CartRuleLoader.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Checkout\Cart;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
+use Shopware\Core\Checkout\Cart\Extension\CheckoutCartRuleLoaderExtension;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\AbstractTaxDetector;
@@ -12,6 +13,7 @@ use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\FloatComparator;
@@ -47,6 +49,7 @@ class CartRuleLoader implements ResetInterface
         private readonly AbstractTaxDetector $taxDetector,
         private readonly Connection $connection,
         private readonly CartFactory $cartFactory,
+        private readonly ExtensionDispatcher $extensions,
     ) {
     }
 
@@ -90,89 +93,95 @@ class CartRuleLoader implements ResetInterface
                 $hasDeferredErrors = false;
             }
 
-            $rules = $this->loadRules($context->getContext());
+            $timestamps = $cart->getLineItems()->fmap(static fn (LineItem $lineItem) => $lineItem->getDataTimestamp()?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+            $dataHashes = $cart->getLineItems()->fmap(static fn (LineItem $lineItem) => $lineItem->getDataContextHash());
 
-            // save all rules for later usage
-            $all = $rules;
-
-            // For existing carts filter rules to only contain the rules from the current cart
-            if ($new === false) {
-                $rules = $rules->filter(
-                    fn (RuleEntity $rule) => \in_array($rule->getId(), $cart->getRuleIds(), true)
-                );
-            }
-
-            // update rules in current context
-            $context->setRuleIds($rules->getIds());
-            $context->setAreaRuleIds($rules->getIdsByArea());
-
-            $timestamps = $cart->getLineItems()->fmap(function (LineItem $lineItem) {
-                return $lineItem->getDataTimestamp()?->format(Defaults::STORAGE_DATE_TIME_FORMAT);
-            });
-
-            $dataHashes = $cart->getLineItems()->fmap(function (LineItem $lineItem) {
-                return $lineItem->getDataContextHash();
-            });
-
-            // start first cart calculation to have all objects enriched
-            $cart = $this->processor->process($cart, $context, $behaviorContext);
-
-            $iteration = 1;
-            do {
-                $compare = $cart;
-
-                if ($iteration > self::MAX_ITERATION) {
-                    break;
-                }
-
-                // filter rules which matches to current scope
-                $rules = $rules->filterMatchingRules($cart, $context);
-
-                // update matching rules in context
-                $context->setRuleIds($rules->getIds());
-                $context->setAreaRuleIds($rules->getIdsByArea());
-
-                // calculate cart again
-                $cart = $this->processor->process($cart, $context, $behaviorContext);
-
-                // check if the cart changed, in this case we have to recalculate the cart again
-                $recalculate = $this->cartChanged($cart, $compare);
-
-                // check if rules changed for the last calculated cart, in this case we have to recalculate
-                $ruleCompare = $all->filterMatchingRules($cart, $context);
-
-                if (!$rules->equals($ruleCompare)) {
-                    $recalculate = true;
-                    $rules = $ruleCompare;
-                }
-
-                ++$iteration;
-            } while ($recalculate);
-
-            $cart = $this->validateTaxFree($context, $cart, $behaviorContext);
-
-            $index = 0;
-            foreach ($rules as $rule) {
-                ++$index;
-                $this->logger->info(
-                    \sprintf('#%d Rule detection: %s with priority %d (id: %s)', $index, $rule->getName(), $rule->getPriority(), $rule->getId())
-                );
-            }
-
-            $context->setRuleIds($rules->getIds());
-            $context->setAreaRuleIds($rules->getIdsByArea());
+            $result = $this->extensions->publish(
+                name: CheckoutCartRuleLoaderExtension::NAME,
+                extension: new CheckoutCartRuleLoaderExtension($cart, $context, $behaviorContext, $new),
+                function: $this->_load(...),
+            );
 
             // save the cart if errors exist, so the errors get persisted
-            if ($this->updated($cart, $timestamps, $dataHashes)
-                || $cart->getErrorHash() !== $cart->getErrors()->getUniqueHash()
+            if ($this->updated($result->getCart(), $timestamps, $dataHashes)
+                || $result->getCart()->getErrorHash() !== $result->getCart()->getErrors()->getUniqueHash()
                 || $hasDeferredErrors
             ) {
-                $cart->setErrorHash($cart->getErrors()->getUniqueHash());
-                $this->cartPersister->save($cart, $context);
+                $result->getCart()->setErrorHash($result->getCart()->getErrors()->getUniqueHash());
+                $this->cartPersister->save($result->getCart(), $context);
             }
 
-            return new RuleLoaderResult($cart, $rules);
+            return $result;
         });
+    }
+
+    private function _load(SalesChannelContext $context, Cart $cart, CartBehavior $behaviorContext, bool $new): RuleLoaderResult
+    {
+        $rules = $this->loadRules($context->getContext());
+
+        // save all rules for later usage
+        $all = $rules;
+
+        // For existing carts filter rules to only contain the rules from the current cart
+        if ($new === false) {
+            $rules = $rules->filter(
+                fn (RuleEntity $rule) => \in_array($rule->getId(), $cart->getRuleIds(), true)
+            );
+        }
+
+        // update rules in current context
+        $context->setRuleIds($rules->getIds());
+        $context->setAreaRuleIds($rules->getIdsByArea());
+
+        // start first cart calculation to have all objects enriched
+        $cart = $this->processor->process($cart, $context, $behaviorContext);
+
+        $iteration = 1;
+        do {
+            $compare = $cart;
+
+            if ($iteration > self::MAX_ITERATION) {
+                break;
+            }
+
+            // filter rules which matches to current scope
+            $rules = $rules->filterMatchingRules($cart, $context);
+
+            // update matching rules in context
+            $context->setRuleIds($rules->getIds());
+            $context->setAreaRuleIds($rules->getIdsByArea());
+
+            // calculate cart again
+            $cart = $this->processor->process($cart, $context, $behaviorContext);
+
+            // check if the cart changed, in this case we have to recalculate the cart again
+            $recalculate = $this->cartChanged($cart, $compare);
+
+            // check if rules changed for the last calculated cart, in this case we have to recalculate
+            $ruleCompare = $all->filterMatchingRules($cart, $context);
+
+            if (!$rules->equals($ruleCompare)) {
+                $recalculate = true;
+                $rules = $ruleCompare;
+            }
+
+            ++$iteration;
+        } while ($recalculate);
+
+        $cart = $this->validateTaxFree($context, $cart, $behaviorContext);
+
+        $index = 0;
+        foreach ($rules as $rule) {
+            ++$index;
+            $this->logger->info(
+                \sprintf('#%d Rule detection: %s with priority %d (id: %s)', $index, $rule->getName(), $rule->getPriority(), $rule->getId())
+            );
+        }
+
+        $context->setRuleIds($rules->getIds());
+        $context->setAreaRuleIds($rules->getIdsByArea());
+
+        return new RuleLoaderResult($cart, $rules);
     }
 
     private function loadRules(Context $context): RuleCollection

--- a/src/Core/Checkout/Cart/Extension/CheckoutCartRuleLoaderExtension.php
+++ b/src/Core/Checkout/Cart/Extension/CheckoutCartRuleLoaderExtension.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Extension;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartBehavior;
+use Shopware\Core\Checkout\Cart\RuleLoaderResult;
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * @extends Extension<RuleLoaderResult>
+ */
+#[Package('checkout')]
+final class CheckoutCartRuleLoaderExtension extends Extension
+{
+    public const NAME = 'checkout.cart.rule-load';
+
+    /**
+     * @internal shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(
+        public readonly Cart $cart,
+        public readonly SalesChannelContext $context,
+        public readonly CartBehavior $behaviorContext,
+        protected readonly bool $new,
+    ) {
+    }
+}

--- a/src/Core/Checkout/Cart/Extension/CheckoutCartRuleLoaderExtension.php
+++ b/src/Core/Checkout/Cart/Extension/CheckoutCartRuleLoaderExtension.php
@@ -23,9 +23,9 @@ final class CheckoutCartRuleLoaderExtension extends Extension
      * @internal shopware owns the __constructor, but the properties are public API
      */
     public function __construct(
-        public readonly Cart $cart,
-        public readonly SalesChannelContext $context,
-        public readonly CartBehavior $behaviorContext,
+        public readonly SalesChannelContext $salesChannelContext,
+        public readonly Cart $originalCart,
+        public readonly CartBehavior $cartBehavior,
         protected readonly bool $new,
     ) {
     }

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -388,6 +388,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Cart\Tax\TaxDetector"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartFactory"/>
+            <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
 
             <tag name="kernel.reset" method="reset"/>
         </service>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It's not possible to hook before or after the cart rule loading, but still before the cart persist event.
In the past, we may used the `CartVerifyPersistEvent`, which is not really appropriate.

### 2. What does this change do, exactly?
Adds a extension event `CheckoutCartRuleLoaderExtension`, which is dispatched before and after the rule loading, but still before the cart persist call.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- relates to #11282

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
