### PR TITLE
feat: add guest logout manipulation

### DIFF
--- a/changelog/_unreleased/2025-08-04-add-guest-logout-manipulation-possibility.md
+++ b/changelog/_unreleased/2025-08-04-add-guest-logout-manipulation-possibility.md
@@ -1,0 +1,7 @@
+---
+title: Fix guest logout manipulation possibility
+author: Max Stegmeyer
+author_email: m.stegmeyer@shopware.com
+---
+# Storefront
+* Added property `logoutCustomer` to `CheckoutFinishPage` to allow manipulation of the guest logout after ordering

--- a/src/Core/Test/Generator.php
+++ b/src/Core/Test/Generator.php
@@ -173,6 +173,7 @@ class Generator extends TestCase
             $customer->setGroup($currentCustomerGroup);
             $customer->setSalesChannelId($salesChannel->getId());
             $customer->setSalesChannel($salesChannel);
+            $customer->setGuest(false);
         }
 
         $itemRounding ??= clone $baseContext->getRounding();

--- a/src/Storefront/Controller/CheckoutController.php
+++ b/src/Storefront/Controller/CheckoutController.php
@@ -22,7 +22,6 @@ use Shopware\Core\PlatformRequest;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\StateMachine\Exception\IllegalTransitionException;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Checkout\Cart\Error\PaymentMethodChangedError;
 use Shopware\Storefront\Checkout\Cart\Error\ShippingMethodChangedError;
 use Shopware\Storefront\Framework\AffiliateTracking\AffiliateTrackingListener;
@@ -65,7 +64,6 @@ class CheckoutController extends StorefrontController
         private readonly OrderService $orderService,
         private readonly PaymentProcessor $paymentProcessor,
         private readonly OffcanvasCartPageLoader $offcanvasCartPageLoader,
-        private readonly SystemConfigService $config,
         private readonly AbstractLogoutRoute $logoutRoute,
         private readonly AbstractCartLoadRoute $cartLoadRoute,
         private readonly HeaderPageletLoaderInterface $headerPageletLoader,
@@ -194,7 +192,7 @@ class CheckoutController extends StorefrontController
             );
         }
 
-        if ($context->getCustomer()->getGuest() && $this->config->get('core.cart.logoutGuestAfterCheckout', $context->getSalesChannelId())) {
+        if ($page->isLogoutCustomer()) {
             $this->logoutRoute->logout($context, $dataBag);
         }
 

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -100,7 +100,6 @@
             <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderService"/>
             <argument type="service" id="Shopware\Core\Checkout\Payment\PaymentProcessor"/>
             <argument type="service" id="Shopware\Storefront\Page\Checkout\Offcanvas\OffcanvasCartPageLoader"/>
-            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute"/>
             <argument type="service" id="Shopware\Storefront\Pagelet\Header\HeaderPageletLoader"/>

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -290,6 +290,7 @@
             <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderRoute"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
         </service>
 
         <service id="Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoader">

--- a/src/Storefront/Page/Checkout/Finish/CheckoutFinishPage.php
+++ b/src/Storefront/Page/Checkout/Finish/CheckoutFinishPage.php
@@ -15,6 +15,8 @@ class CheckoutFinishPage extends Page
 
     protected bool $paymentFailed = false;
 
+    protected bool $logoutCustomer = false;
+
     public function getOrder(): OrderEntity
     {
         return $this->order;
@@ -43,5 +45,15 @@ class CheckoutFinishPage extends Page
     public function setPaymentFailed(bool $paymentFailed): void
     {
         $this->paymentFailed = $paymentFailed;
+    }
+
+    public function isLogoutCustomer(): bool
+    {
+        return $this->logoutCustomer;
+    }
+
+    public function setLogoutCustomer(bool $logoutCustomer): void
+    {
+        $this->logoutCustomer = $logoutCustomer;
     }
 }

--- a/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoader.php
+++ b/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoader.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Page\GenericPageLoaderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,7 +37,8 @@ class CheckoutFinishPageLoader
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly GenericPageLoaderInterface $genericLoader,
         private readonly AbstractOrderRoute $orderRoute,
-        private readonly AbstractTranslator $translator
+        private readonly AbstractTranslator $translator,
+        private readonly SystemConfigService $systemConfigService,
     ) {
     }
 
@@ -61,6 +63,8 @@ class CheckoutFinishPageLoader
         $page->setChangedPayment((bool) $request->get('changedPayment', false));
 
         $page->setPaymentFailed((bool) $request->get('paymentFailed', false));
+
+        $page->setLogoutCustomer($salesChannelContext->getCustomer()?->getGuest() && $this->systemConfigService->get('core.cart.logoutGuestAfterCheckout', $salesChannelContext->getSalesChannelId()));
 
         $this->eventDispatcher->dispatch(
             new CheckoutFinishPageLoadedEvent($page, $salesChannelContext, $request)

--- a/tests/unit/Storefront/Controller/CheckoutControllerTest.php
+++ b/tests/unit/Storefront/Controller/CheckoutControllerTest.php
@@ -25,7 +25,7 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\StateMachine\Exception\IllegalTransitionException;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Checkout\Cart\Error\ShippingMethodChangedError;
 use Shopware\Storefront\Controller\CheckoutController;
 use Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPage;
@@ -66,8 +66,6 @@ class CheckoutControllerTest extends TestCase
 
     private OffcanvasCartPageLoader&MockObject $offcanvasCartPageLoaderMock;
 
-    private SystemConfigService&MockObject $configMock;
-
     private AbstractLogoutRoute&MockObject $logoutRouteMock;
 
     private AbstractCartLoadRoute&MockObject $cartLoadRouteMock;
@@ -81,7 +79,6 @@ class CheckoutControllerTest extends TestCase
         $this->orderServiceMock = $this->createMock(OrderService::class);
         $this->paymentProcessorMock = $this->createMock(PaymentProcessor::class);
         $this->offcanvasCartPageLoaderMock = $this->createMock(OffcanvasCartPageLoader::class);
-        $this->configMock = $this->createMock(SystemConfigService::class);
         $this->logoutRouteMock = $this->createMock(AbstractLogoutRoute::class);
         $this->cartLoadRouteMock = $this->createMock(AbstractCartLoadRoute::class);
 
@@ -93,7 +90,6 @@ class CheckoutControllerTest extends TestCase
             $this->orderServiceMock,
             $this->paymentProcessorMock,
             $this->offcanvasCartPageLoaderMock,
-            $this->configMock,
             $this->logoutRouteMock,
             $this->cartLoadRouteMock,
             $this->createMock(HeaderPageletLoaderInterface::class),
@@ -342,18 +338,13 @@ class CheckoutControllerTest extends TestCase
 
     public function testFinishPageGuestLogout(): void
     {
-        $customer = new CustomerEntity();
-        $customer->setGuest(true);
-
-        $context = $this->createMock(SalesChannelContext::class);
-        $context->method('getCustomer')->willReturn($customer);
+        $context = Generator::generateSalesChannelContext();
 
         $page = new CheckoutFinishPage();
         $page->setPaymentFailed(false);
+        $page->setLogoutCustomer(true);
 
         $this->finishPageLoaderMock->method('load')->willReturn($page);
-
-        $this->configMock->method('get')->willReturn(true);
 
         $this->logoutRouteMock->expects($this->once())->method('logout');
 
@@ -365,18 +356,13 @@ class CheckoutControllerTest extends TestCase
 
     public function testFinishPageNoGuestLogout(): void
     {
-        $customer = new CustomerEntity();
-        $customer->setGuest(false);
-
-        $context = $this->createMock(SalesChannelContext::class);
-        $context->method('getCustomer')->willReturn($customer);
+        $context = Generator::generateSalesChannelContext();
 
         $page = new CheckoutFinishPage();
         $page->setPaymentFailed(false);
+        $page->setLogoutCustomer(false);
 
         $this->finishPageLoaderMock->method('load')->willReturn($page);
-
-        $this->configMock->method('get')->willReturn(true);
 
         $this->logoutRouteMock->expects($this->never())->method('logout');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If the setting "guest logout after order" is enabled, there is no way for extensions to reverse that setting, in case some special use case needs this to be the case. E.g. shopware/SwagPayPal#315

### 2. What does this change do, exactly?
Moves the setting for this behavior to the `CheckoutFinishPageLoader` so it is manipulatable via event.

### 3. Describe each step to reproduce the issue or behaviour.
---

### 4. Please link to the relevant issues (if any).
- relates to shopware/SwagPayPal#315

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
