### PR TITLE
feat: Add cart data to the symfony profiler

### DIFF
--- a/changelog/_unreleased/2025-08-04-add-cart-data-to-the-symfony-profiler.md
+++ b/changelog/_unreleased/2025-08-04-add-cart-data-to-the-symfony-profiler.md
@@ -1,0 +1,8 @@
+---
+title: Add cart data to the symfony profiler
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added cart data to the symfony profiler, in the toolbar and the full-screen profiler

--- a/src/Core/Profiling/DependencyInjection/services_dev.xml
+++ b/src/Core/Profiling/DependencyInjection/services_dev.xml
@@ -47,5 +47,12 @@
             <tag name="data_collector"/>
             <argument type="service" id="request_stack"/>
         </service>
+
+        <service id="Shopware\Core\Profiling\Subscriber\CartDataCollectorSubscriber">
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
+
+            <tag name="kernel.event_subscriber"/>
+            <tag name="data_collector"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Profiling/Resources/views/Collector/cart.html.twig
+++ b/src/Core/Profiling/Resources/views/Collector/cart.html.twig
@@ -1,0 +1,198 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block toolbar %}
+    {% set icon %}
+        {{ include('@Profiling/Collector/cart.svg', {height: 24}) }}
+        <span class="sf-toolbar-value">{{ collector.itemCount }} items</span>
+    {% endset %}
+
+    {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <b>Total Items</b>
+            <span>{{ collector.itemCount }}</span>
+        </div>
+
+        <div class="sf-toolbar-info-piece">
+            <b>Cart Total</b>
+            <span>{{ collector.cartTotal|format_currency(collector.currency) }}</span>
+        </div>
+
+        {% if collector.cart is not null and collector.cart.lineItems is defined %}
+            {% for lineItem in collector.cart.lineItems %}
+                {% if loop.index <= 3 %}
+                    <div class="sf-toolbar-info-piece">
+                        <b>{{ lineItem.label }}</b>
+                        <span>{{ lineItem.quantity }} × {{ lineItem.price.unitPrice|format_currency(collector.currency) }}</span>
+                    </div>
+                {% endif %}
+            {% endfor %}
+
+            {% if collector.itemCount > 3 %}
+                <div class="sf-toolbar-info-piece">
+                    <span class="sf-toolbar-status">+{{ collector.itemCount - 3 }} more</span>
+                </div>
+            {% endif %}
+        {% endif %}
+    {% endset %}
+
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: true }) }}
+{% endblock %}
+
+{% block menu %}
+    {# This left-hand menu appears when using the full-screen profiler. #}
+    <span class="label {{ collector.itemCount == 0 ? 'disabled' }}">
+        <span class="icon">{{ include('@Profiling/Collector/cart.svg') }}</span>
+        <strong>Cart</strong>
+        <span class="count">
+            <span>{{ collector.itemCount }}</span>
+        </span>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Cart Information</h2>
+
+    {% if collector.cart is null %}
+        <div class="empty">
+            <p>No cart available.</p>
+        </div>
+    {% else %}
+        <div class="metrics">
+            <div class="metric">
+                <span class="value">{{ collector.itemCount }}</span>
+                <span class="label">Items in Cart</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.cartTotal|format_currency(collector.currency) }}</span>
+                <span class="label">Cart Total</span>
+            </div>
+        </div>
+
+        {% if collector.cart.lineItems is defined and collector.cart.lineItems|length > 0 %}
+            <h3>Line Items</h3>
+            <table class="cart-line-item-table">
+                <thead>
+                    <tr>
+                        <th class="text-right">Quantity</th>
+                        <th>Item</th>
+                        <th>Type</th>
+                        <th class="text-right">Unit Price</th>
+                        <th class="text-right">Total Price</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for lineItem in collector.cart.lineItems %}
+                        <tr>
+                            <td class="font-normal text-right nowrap">{{ lineItem.quantity }}</td>
+                            <td class="font-normal">
+                                <span class="expandable-block-title" data-toggle="code-{{ loop.index }}">
+                                    {{ lineItem.label }}
+                                    <span class="sf-toggle-icon">
+                                        <svg class="icon icon-expand" width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+                                            <path fill="#AAA" d="M10.28 6.28L3.989 11.5 2.979 10.28l4.251-3.99-4.414-4.014 1.022-1.202 6.388 5.157.054.066z"/>
+                                        </svg>
+                                    </span>
+                                </span>
+                            </td>
+                            <td class="font-normal">{{ lineItem.type }}</td>
+                            <td class="font-normal text-right nowrap">{{ lineItem.price.unitPrice|format_currency(collector.currency) }}</td>
+                            <td class="font-normal text-right nowrap">{{ lineItem.price.totalPrice|format_currency(collector.currency) }}</td>
+                        </tr>
+                        <tr class="code-block-row hidden" id="code-{{ loop.index }}">
+                            <td colspan="5">
+                                {{ dump(lineItem) }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th class="font-normal" colspan="4">Subtotal</th>
+                        <th class="font-normal text-right nowrap">{{ collector.cart.price.positionPrice|format_currency(collector.currency) }}</th>
+                    </tr>
+
+                    {% if collector.cart.deliveries is defined and collector.cart.deliveries|length > 0 %}
+                        <tr>
+                            <th class="font-normal" colspan="4">Shipping</th>
+                            <th class="font-normal text-right nowrap">{{ collector.cart.deliveries|first.shippingCosts.totalPrice|format_currency(collector.currency) }}</th>
+                        </tr>
+                    {% endif %}
+
+                    {% if collector.cart.price.calculatedTaxes is defined %}
+                        {% for tax in collector.cart.price.calculatedTaxes %}
+                            <tr>
+                                <td class="font-normal" colspan="4">{{ tax.taxRate }}% VAT</td>
+                                <td class="font-normal text-right nowrap">{{ tax.tax|format_currency(collector.currency) }}</td>
+                            </tr>
+                        {% endfor %}
+                    {% endif %}
+
+                    <tr class="status-success">
+                        <th class="font-normal" colspan="4">Total</th>
+                        <th class="font-normal text-right nowrap">{{ collector.cartTotal|format_currency(collector.currency) }}</th>
+                    </tr>
+                </tfoot>
+            </table>
+        {% else %}
+            <div class="empty">
+                <p>Cart contains no items.</p>
+            </div>
+        {% endif %}
+    {% endif %}
+
+    {% if collector.cart is not null and collector.cart.lineItems is defined and collector.cart.lineItems|length > 0 %}
+        <script type="text/javascript">
+            document.addEventListener('DOMContentLoaded', function() {
+                const toggleElements = document.querySelectorAll('.expandable-block-title');
+                toggleElements.forEach(function(element) {
+                    element.addEventListener('click', function() {
+                        const targetId = this.getAttribute('data-toggle');
+                        const targetElement = document.getElementById(targetId);
+
+                        if (targetElement.classList.contains('hidden')) {
+                            targetElement.classList.remove('hidden');
+                            this.classList.add('expanded');
+                        } else {
+                            targetElement.classList.add('hidden');
+                            this.classList.remove('expanded');
+                        }
+                    });
+                });
+            });
+        </script>
+
+        <style>
+            .cart-line-item-table tfoot {
+                border-top: 1px solid var(--table-border-color);
+            }
+
+            .expandable-block-title {
+                cursor: pointer;
+                display: flex;
+                align-items: center;
+            }
+
+            .expandable-block-title .sf-toggle-icon {
+                margin-left: 5px;
+                transition: transform 0.2s;
+            }
+
+            tr:has(.expandable-block-title.expanded) td {
+                border-bottom: none;
+            }
+
+            .expandable-block-title.expanded .sf-toggle-icon {
+                transform: rotate(90deg);
+            }
+
+            .code-block-row td {
+                border-top: none;
+                padding-top: 0;
+            }
+
+            .code-block-row.hidden {
+                display: none;
+            }
+        </style>
+    {% endif %}
+{% endblock %}

--- a/src/Core/Profiling/Resources/views/Collector/cart.svg
+++ b/src/Core/Profiling/Resources/views/Collector/cart.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="9" cy="21" r="1"></circle>
+    <circle cx="20" cy="21" r="1"></circle>
+    <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"></path>
+</svg>

--- a/src/Core/Profiling/Subscriber/CartDataCollectorSubscriber.php
+++ b/src/Core/Profiling/Subscriber/CartDataCollectorSubscriber.php
@@ -89,6 +89,10 @@ class CartDataCollectorSubscriber extends AbstractDataCollector implements Event
             return null;
         }
 
-        return $this->cartPersister->load($this->cartToken, $this->salesChannelContext);
+        try {
+            return $this->cartPersister->load($this->cartToken, $this->salesChannelContext);
+        } catch (\Exception) {
+            return null;
+        }
     }
 }

--- a/src/Core/Profiling/Subscriber/CartDataCollectorSubscriber.php
+++ b/src/Core/Profiling/Subscriber/CartDataCollectorSubscriber.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Profiling\Subscriber;
+
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\Event\SalesChannelContextResolvedEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class CartDataCollectorSubscriber extends AbstractDataCollector implements EventSubscriberInterface, ResetInterface
+{
+    private ?string $cartToken = null;
+
+    private ?SalesChannelContext $salesChannelContext = null;
+
+    public function __construct(private readonly AbstractCartPersister $cartPersister)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SalesChannelContextResolvedEvent::class => 'onContextResolved',
+        ];
+    }
+
+    public function reset(): void
+    {
+        parent::reset();
+        $this->cartToken = null;
+        $this->salesChannelContext = null;
+    }
+
+    public function getCart(): ?Cart
+    {
+        $cart = $this->data['cart'] ?? null;
+        if (!$cart instanceof Cart) {
+            return null;
+        }
+
+        return $cart;
+    }
+
+    public function getCurrency(): string
+    {
+        // Should never be null if there is a cart, however if it would be the case, the symfony toolbar yields an error, which should be prevented
+        return $this->data['currency'] ?? 'EUR';
+    }
+
+    public function getItemCount(): int
+    {
+        return $this->getCart()?->getLineItems()->count() ?? 0;
+    }
+
+    public function getCartTotal(): float
+    {
+        return $this->getCart()?->getPrice()?->getTotalPrice() ?? 0.0;
+    }
+
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+        $this->data = ['cart' => $this->getCartData(), 'currency' => $this->salesChannelContext?->getCurrency()->getIsoCode()];
+    }
+
+    public static function getTemplate(): string
+    {
+        return '@Profiling/Collector/cart.html.twig';
+    }
+
+    public function onContextResolved(SalesChannelContextResolvedEvent $event): void
+    {
+        $this->cartToken = $event->getUsedToken();
+        $this->salesChannelContext = $event->getSalesChannelContext();
+    }
+
+    private function getCartData(): ?Cart
+    {
+        if (empty($this->cartToken)) {
+            return null;
+        }
+
+        return $this->cartPersister->load($this->cartToken, $this->salesChannelContext);
+    }
+}

--- a/src/Core/Profiling/Subscriber/CartDataCollectorSubscriber.php
+++ b/src/Core/Profiling/Subscriber/CartDataCollectorSubscriber.php
@@ -85,7 +85,7 @@ class CartDataCollectorSubscriber extends AbstractDataCollector implements Event
 
     private function getCartData(): ?Cart
     {
-        if (empty($this->cartToken)) {
+        if ($this->cartToken === null || $this->salesChannelContext === null) {
             return null;
         }
 

--- a/tests/unit/Core/Profiling/Subscriber/CartDataCollectorSubscriberTest.php
+++ b/tests/unit/Core/Profiling/Subscriber/CartDataCollectorSubscriberTest.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Profiling\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Routing\Event\SalesChannelContextResolvedEvent;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Profiling\Subscriber\CartDataCollectorSubscriber;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[CoversClass(CartDataCollectorSubscriber::class)]
+class CartDataCollectorSubscriberTest extends TestCase
+{
+    public function testEvents(): void
+    {
+        static::assertSame(
+            [
+                SalesChannelContextResolvedEvent::class => 'onContextResolved',
+            ],
+            CartDataCollectorSubscriber::getSubscribedEvents()
+        );
+    }
+
+    public function testDataCollection(): void
+    {
+        $cartToken = Uuid::randomHex();
+
+        $cart = new Cart('test-cart');
+        $lineItem = new LineItem('line-item-id', 'product', 'product-id', 2);
+        $lineItem->setLabel('Test Product');
+        $lineItem->setPrice(new CalculatedPrice(
+            100.00,
+            200.00,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection()
+        ));
+
+        $cart->addLineItems(new LineItemCollection([$lineItem]));
+        $cart->setPrice(new CartPrice(
+            200.00,
+            200.00,
+            200.00,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection(),
+            CartPrice::TAX_STATE_GROSS
+        ));
+
+        $currency = new CurrencyEntity();
+        $currency->setId(Uuid::randomHex());
+        $currency->setIsoCode('EUR');
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $context = new Context(new SystemSource());
+        $salesChannelContext->method('getContext')->willReturn($context);
+        $salesChannelContext->method('getCurrency')->willReturn($currency);
+
+        $event = new SalesChannelContextResolvedEvent($salesChannelContext, $cartToken);
+
+        $cartPersister = $this->createMock(AbstractCartPersister::class);
+        $cartPersister->method('load')->willReturn($cart);
+
+        $subscriber = new CartDataCollectorSubscriber($cartPersister);
+        $subscriber->onContextResolved($event);
+        $subscriber->collect(new Request(), new Response());
+
+        static::assertEquals($cart, $subscriber->getCart());
+        static::assertEquals(1, $subscriber->getItemCount());
+        static::assertEquals(200.00, $subscriber->getCartTotal());
+        static::assertEquals('EUR', $subscriber->getCurrency());
+    }
+
+    public function testEmptyCart(): void
+    {
+        $cartToken = Uuid::randomHex();
+
+        $cart = new Cart('empty-cart');
+
+        $currency = new CurrencyEntity();
+        $currency->setId(Uuid::randomHex());
+        $currency->setIsoCode('EUR');
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getCurrency')->willReturn($currency);
+
+        $event = new SalesChannelContextResolvedEvent($salesChannelContext, $cartToken);
+        $cartPersister = $this->createMock(AbstractCartPersister::class);
+        $cartPersister->method('load')->willReturn($cart);
+
+        $subscriber = new CartDataCollectorSubscriber($cartPersister);
+        $subscriber->onContextResolved($event);
+        $subscriber->collect(new Request(), new Response());
+        static::assertEquals($cart, $subscriber->getCart());
+        static::assertEquals(0, $subscriber->getItemCount());
+        static::assertEquals(0, $subscriber->getCartTotal());
+        static::assertEquals('EUR', $subscriber->getCurrency());
+    }
+
+    public function testReset(): void
+    {
+        $cartToken = Uuid::randomHex();
+
+        $cart = new Cart('test-cart');
+
+        $currency = new CurrencyEntity();
+        $currency->setId(Uuid::randomHex());
+        $currency->setIsoCode('EUR');
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getCurrency')->willReturn($currency);
+
+        $event = new SalesChannelContextResolvedEvent($salesChannelContext, $cartToken);
+
+        $cartPersister = $this->createMock(AbstractCartPersister::class);
+        $cartPersister->method('load')->willReturn($cart);
+
+        $subscriber = new CartDataCollectorSubscriber($cartPersister);
+        $subscriber->onContextResolved($event);
+        $subscriber->collect(new Request(), new Response());
+
+        static::assertEquals($cart, $subscriber->getCart());
+
+        $subscriber->reset();
+
+        $subscriber->collect(new Request(), new Response());
+
+        static::assertNull($subscriber->getCart());
+    }
+}

--- a/tests/unit/Core/Profiling/Subscriber/CartDataCollectorSubscriberTest.php
+++ b/tests/unit/Core/Profiling/Subscriber/CartDataCollectorSubscriberTest.php
@@ -81,9 +81,9 @@ class CartDataCollectorSubscriberTest extends TestCase
         $subscriber->collect(new Request(), new Response());
 
         static::assertEquals($cart, $subscriber->getCart());
-        static::assertEquals(1, $subscriber->getItemCount());
-        static::assertEquals(200.00, $subscriber->getCartTotal());
-        static::assertEquals('EUR', $subscriber->getCurrency());
+        static::assertSame(1, $subscriber->getItemCount());
+        static::assertSame(200.00, $subscriber->getCartTotal());
+        static::assertSame('EUR', $subscriber->getCurrency());
     }
 
     public function testEmptyCart(): void
@@ -107,9 +107,9 @@ class CartDataCollectorSubscriberTest extends TestCase
         $subscriber->onContextResolved($event);
         $subscriber->collect(new Request(), new Response());
         static::assertEquals($cart, $subscriber->getCart());
-        static::assertEquals(0, $subscriber->getItemCount());
-        static::assertEquals(0, $subscriber->getCartTotal());
-        static::assertEquals('EUR', $subscriber->getCurrency());
+        static::assertSame(0, $subscriber->getItemCount());
+        static::assertSame(0.0, $subscriber->getCartTotal());
+        static::assertSame('EUR', $subscriber->getCurrency());
     }
 
     public function testReset(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
When working with the cart, I usually dump the cart somewhere on the page, this should help, as it displays the cart in the Symfony profiler.

### 2. What does this change do, exactly?
Show the cart in the Symfony profiler:
<img width="681" height="274" alt="image" src="https://github.com/user-attachments/assets/5d370757-44ca-4c81-98f0-7452abb0ca41" />
<img width="1848" height="1803" alt="image" src="https://github.com/user-attachments/assets/9865934a-1072-408d-9e95-e6aabd94eae0" />

### 3. Describe each step to reproduce the issue or behaviour.
Debug something in the cart.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
