### PR TITLE
fix: Fix CMS block slot config error highlighting

### DIFF
--- a/changelog/_unreleased/2025-08-04-fix-cms-block-slot-config-error-highlighting.md
+++ b/changelog/_unreleased/2025-08-04-fix-cms-block-slot-config-error-highlighting.md
@@ -1,0 +1,10 @@
+---
+title: Fix CMS block slot config error highlighting
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Deprecated `pageSlotconfigError` data property of `sw-cms-section` component.
+* Changed `hasSlotConfigErrors` method of `sw-cms-section` component to use mapped `pageSlotConfigError` again.
+* Changed return types of error mappers in `src/app/service/map-errors.service.ts`.

--- a/src/Administration/Resources/app/administration/src/app/service/map-errors.service.ts
+++ b/src/Administration/Resources/app/administration/src/app/service/map-errors.service.ts
@@ -3,15 +3,15 @@
  */
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
-export type CamelCasePath<T extends string> = T extends `${infer A}.${infer B}${infer C}`
-    ? `${Lowercase<A>}${Capitalize<B>}${CamelCasePath<C>}`
-    : Lowercase<T>;
+export type CamelCasePath<T extends string> = T extends `${infer A}.${infer B}`
+    ? `${Capitalize<Lowercase<A>>}${CamelCasePath<Capitalize<B>>}`
+    : Capitalize<T>;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations, max-len
 export function mapPropertyErrors<T extends string, K extends string>(
     entityName: T,
     properties: K[] = [],
-): Record<`${Lowercase<T>}${Capitalize<CamelCasePath<K>>}Error`, () => unknown> {
+): Record<`${T}${CamelCasePath<K>}Error`, () => unknown> {
     const computedValues: Record<string, () => unknown> = {};
 
     properties.forEach((property) => {
@@ -43,7 +43,7 @@ export function mapSystemConfigErrors(entityName: string, saleChannelId: string 
 export function mapCollectionPropertyErrors<T extends string, K extends string>(
     entityCollectionName: T,
     properties: K[] = [],
-): Record<`${Lowercase<T>}${Capitalize<CamelCasePath<K>>}Error`, () => unknown> {
+): Record<`${T}${CamelCasePath<K>}Error`, () => unknown> {
     const computedValues: Record<string, () => unknown> = {};
 
     properties.forEach((property) => {
@@ -68,7 +68,7 @@ export function mapCollectionPropertyErrors<T extends string, K extends string>(
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations, max-len
 export function mapPageErrors<T extends string>(
     errorConfig: Record<T, Record<string, string[]>>,
-): Record<`${CamelCasePath<T>}Error`, () => boolean> {
+): Record<`${Uncapitalize<CamelCasePath<T>>}Error`, () => boolean> {
     const map: Record<string, () => boolean> = {};
     Object.keys(errorConfig).forEach((routeName) => {
         const subjects = errorConfig[routeName as T];

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
@@ -75,6 +75,9 @@ export default Shopware.Component.wrapComponentConfig({
     data() {
         return {
             isCollapsed: true,
+            /**
+             * @deprecated tag:v6.8.0 - will be removed, is not used anymore
+             */
             pageSlotconfigError: null as SlotConfigErrorObject | null,
         };
     },
@@ -286,7 +289,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         hasSlotConfigErrors(block: Entity<'cms_block'>) {
-            const errorElements = (this.pageSlotconfigError as SlotConfigErrorObject)?.parameters?.elements;
+            const errorElements = (this.pageSlotConfigError as SlotConfigErrorObject)?.parameters?.elements;
 
             if (!errorElements) {
                 return false;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.spec.js
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
+import ShopwareError from 'src/core/data/ShopwareError';
 import 'src/module/sw-cms/mixin/sw-cms-state.mixin';
 
 async function createWrapper() {
@@ -11,7 +12,12 @@ async function createWrapper() {
         }),
         {
             props: {
-                page: {},
+                page: {
+                    id: '1',
+                    getEntityName: () => {
+                        return 'cms_page';
+                    },
+                },
                 section: {
                     visibility: {
                         mobile: true,
@@ -197,5 +203,29 @@ describe('module/sw-cms/component/sw-cms-section', () => {
                 type: 'foo-bar',
             },
         });
+    });
+
+    it('should highlight blocks with slot config errors', async () => {
+        Shopware.Store.get('error').addApiError({
+            expression: `cms_page.1.slotConfig`,
+            error: new ShopwareError({
+                code: 'requiredConfigMissing',
+                meta: {
+                    parameters: {
+                        elements: [
+                            {
+                                name: 'foo-bar-slot.missing',
+                                blockId: '1a2b',
+                            },
+                        ],
+                    },
+                },
+            }),
+        });
+
+        const wrapper = await createWrapper();
+
+        const fooBarBlock = wrapper.findComponent('.sw-cms-section__content .sw-cms-block-foo-bar');
+        expect(wrapper.vm.hasSlotConfigErrors(fooBarBlock.props('block'))).toBeTruthy();
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Since 118b543 blocks with missing required slot configs are not highlighted anymore when saving a cms page.

### 2. What does this change do, exactly?
* Deprecated `pageSlotconfigError` data property of `sw-cms-section` component.
* Changed `hasSlotConfigErrors` method of `sw-cms-section` component to use mapped `pageSlotConfigError` again.
* Changed return types of error mappers in `src/app/service/map-errors.service.ts`.

### 3. Describe each step to reproduce the issue or behaviour.
In the Administration, create a new cms page > add the "Three columns, product boxes" block > save the page without configuring the product boxes.

The general error message pops up but the block with missing slot configurations is not highlighted.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
