### PR TITLE
fix: use mysql 8.4 in devenv

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1747717470,
+        "lastModified": 1754344171,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c7f2256ee4a4a4ee9cbf1e82a6e49b253c374995",
+        "rev": "03e3a284d2e16e5aaced317cf84dfb392470ca6e",
         "type": "github"
       },
       "original": {
@@ -40,10 +40,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1747372754,
+        "lastModified": 1750779888,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -74,10 +74,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747885982,
+        "lastModified": 1754278406,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a16efe5d2fc7455d7328a01f4692bfec152965b3",
+        "rev": "6a489c9482ca676ce23c0bcd7f2e1795383325fa",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,19 +6,6 @@ let
     extraConfig = config.languages.php.ini;
   };
 in {
-  overlays = [
-    # Each overlay is a function that takes two arguments: final and prev
-    (final: prev: {
-      # Override an existing package
-      boost177 = prev.boost177.overrideAttrs (oldAttrs: {
-        # The postFixup hook is where the signing check runs.
-        # By setting it to an empty string, we tell Nix to skip it.
-        # This is generally safe for development shells.
-        postFixup = "";
-      });
-    })
-  ];
-
   packages = [
     pkgs.gnupatch
     pkgs.nodePackages_latest.yalc
@@ -37,6 +24,8 @@ in {
   process.manager.implementation = lib.mkDefault "honcho";
 
   dotenv.disableHint = true;
+  cachix.enable = false;
+  devenv.warnOnNewVersion = false;
 
   languages.javascript = {
     enable = lib.mkDefault true;
@@ -105,7 +94,7 @@ in {
 
   services.mysql = {
     enable = true;
-    package = pkgs.mysql80;
+    package = pkgs.mysql84;
     initialDatabases = lib.mkDefault [{ name = "shopware"; }];
     ensureUsers = lib.mkDefault [
       {


### PR DESCRIPTION

### 1. Why is this change necessary?

mysql 8.0 is broken in nix right now, switch to 8.4

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
