### PR TITLE
fix: cms toolbar language switch grid cell sizing

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-toolbar/sw-cms-toolbar.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-toolbar/sw-cms-toolbar.scss
@@ -5,7 +5,7 @@
     min-height: 70px;
     border-bottom: 2px solid $color-gray-300;
     display: grid;
-    grid-template-columns: 1fr 1fr 158px auto;
+    grid-template-columns: 1fr 1fr auto auto;
     align-items: center;
     align-content: center;
     z-index: 251;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The language switch and save button are overlapping on the CMS detail page due to wrong siziing of the toolbar CSS grid cells.

<img width="1233" height="548" alt="Screenshot 2025-08-05 at 13 43 28" src="https://github.com/user-attachments/assets/514eeb01-d51e-43a6-95f1-3c982cdcc25e" />


### 2. What does this change do, exactly?

<img width="1237" height="495" alt="Screenshot 2025-08-05 at 13 43 04" src="https://github.com/user-attachments/assets/0ebfcb79-74c2-40b1-bbd9-25816ac0c980" />

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
