### PR TITLE
chore: Use correct SalesChannelRepository types for phpstan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -184,14 +184,6 @@ parameters:
                 - tests/integration/Core/Framework/**
                 - tests/unit/Core/**
 
-        - # WIP implementation (See NEXT-29041 - https://github.com/shopware/shopware/issues/6175)
-            message: '#.* generic class Shopware\\Core\\System\\SalesChannel\\Entity\\SalesChannelRepository.*not specify its types: TEntityCollection#'
-            paths:
-                - src/Core/Content/**
-                - src/Core/System/**
-                - tests/integration/Core/**
-                - tests/unit/Core/Content/**
-
         - # No need to fix for now, as the facades are only used in twig context
             message: '#.* generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult.*does not specify its types: TEntityCollection#'
             paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -197,12 +197,6 @@ parameters:
                 - src/Core/Framework/DataAbstractionLayer/EntityRepository.php
                 - src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
 
-        - # It is not possible to specify the type of the EntitySearchResult, as the CmsSlotDataResolver and the ElementDataCollection are used for multiple entities at the same time
-            message: '#.* with generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityCollection.*not specify its types: TElement#'
-            paths:
-                - src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
-                - src/Core/Content/Cms/DataResolver/Element/ElementDataCollection.php
-        - '#Parameter \#2 \$entitySearchResult of method Shopware\\Core\\Content\\Cms\\DataResolver\\Element\\ElementDataCollection::add\(\) expects Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult<Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityCollection>, Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult<Shopware\\.*Collection> given#'
         - # It is not possible to specify the type of the EntityResult, as the Aggregators are used for multiple entities at the same time
             message: '#Method Shopware\\.*::hydrateEntityAggregation\(\) return type with generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\AggregationResult\\Metric\\EntityResult does not specify its types: TEntityCollection#'
             paths:

--- a/src/Core/Content/Category/SalesChannel/CategoryRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CategoryRoute.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Category\SalesChannel;
 
 use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationEntity;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\CategoryException;
@@ -28,6 +29,8 @@ class CategoryRoute extends AbstractCategoryRoute
 
     /**
      * @internal
+     *
+     * @param SalesChannelRepository<CategoryCollection> $categoryRepository
      */
     public function __construct(
         private readonly SalesChannelRepository $categoryRepository,
@@ -115,10 +118,7 @@ class CategoryRoute extends AbstractCategoryRoute
         $criteria->addAssociation('media');
         $criteria->addAssociation('translations');
 
-        $category = $this->categoryRepository
-            ->search($criteria, $context)
-            ->get($categoryId);
-
+        $category = $this->categoryRepository->search($criteria, $context)->getEntities()->get($categoryId);
         if (!$category instanceof CategoryEntity) {
             throw CategoryException::categoryNotFound($categoryId);
         }

--- a/src/Core/Content/Category/SalesChannel/NavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/NavigationRoute.php
@@ -36,6 +36,8 @@ class NavigationRoute extends AbstractNavigationRoute
 
     /**
      * @internal
+     *
+     * @param SalesChannelRepository<CategoryCollection> $categoryRepository
      */
     public function __construct(
         private readonly Connection $connection,
@@ -110,10 +112,7 @@ class NavigationRoute extends AbstractNavigationRoute
         $criteria->addAssociation('media');
         $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_NONE);
 
-        /** @var CategoryCollection $missing */
-        $missing = $this->categoryRepository->search($criteria, $context)->getEntities();
-
-        return $missing;
+        return $this->categoryRepository->search($criteria, $context)->getEntities();
     }
 
     private function loadLevels(string $rootId, int $rootLevel, SalesChannelContext $context, Criteria $criteria, int $depth = 2): CategoryCollection
@@ -131,7 +130,6 @@ class NavigationRoute extends AbstractNavigationRoute
         $criteria->setLimit(null);
         $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_NONE);
 
-        /** @var CategoryCollection $levels */
         $levels = $this->categoryRepository->search($criteria, $context)->getEntities();
 
         $this->addVisibilityCounts($rootId, $rootLevel, $depth, $levels, $context);

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -34,9 +34,9 @@ class CmsSlotsDataResolver
 
     /**
      * @internal
-     *
+     * 
      * @param iterable<CmsElementResolverInterface> $resolvers
-     * @param array<string, SalesChannelRepository> $repositories
+     * @param array<string, SalesChannelRepository<covariant EntityCollection<covariant Entity>>> $repositories
      */
     public function __construct(
         iterable $resolvers,
@@ -277,11 +277,17 @@ class CmsSlotsDataResolver
         return true;
     }
 
+    /**
+     * @return EntityRepository<covariant EntityCollection<covariant Entity>>
+     */
     private function getApiRepository(EntityDefinition $definition): EntityRepository
     {
         return $this->definitionRegistry->getRepository($definition->getEntityName());
     }
 
+    /**
+     * @return ?SalesChannelRepository<covariant EntityCollection<covariant Entity>>
+     */
     private function getSalesChannelApiRepository(EntityDefinition $definition): ?SalesChannelRepository
     {
         return $this->repositories[$definition->getEntityName()] ?? null;

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -110,11 +110,9 @@ class CmsSlotsDataResolver
     }
 
     /**
-     * @template TEntityCollection of EntityCollection
-     *
      * @param array<CriteriaCollection> $criteriaList
-     * @param array<EntitySearchResult<TEntityCollection>> $identifierResult
-     * @param array<array<EntitySearchResult<TEntityCollection>>> $criteriaResult
+     * @param array<EntitySearchResult<covariant EntityCollection<covariant Entity>>> $identifierResult
+     * @param array<array<EntitySearchResult<covariant EntityCollection<covariant Entity>>>> $criteriaResult
      */
     private function enrichCmsSlots(
         CmsSlotCollection $slots,
@@ -147,7 +145,7 @@ class CmsSlotsDataResolver
     /**
      * @param string[][] $directReads
      *
-     * @return array<string, EntitySearchResult<EntityCollection>>
+     * @return array<string, EntitySearchResult<covariant EntityCollection<covariant Entity>>>
      */
     private function fetchByIdentifier(array $directReads, SalesChannelContext $context): array
     {
@@ -172,7 +170,7 @@ class CmsSlotsDataResolver
     /**
      * @param array<string, array<string, Criteria>> $searches
      *
-     * @return array<string, array<string, EntitySearchResult<EntityCollection>>>
+     * @return array<string, array<string, EntitySearchResult<covariant EntityCollection<covariant Entity>>>>
      */
     private function fetchByCriteria(array $searches, SalesChannelContext $context): array
     {
@@ -313,10 +311,8 @@ class CmsSlotsDataResolver
     }
 
     /**
-     * @template TEntityCollection of EntityCollection
-     *
      * @param array<string, CriteriaCollection> $criteriaObjects
-     * @param array<string, array<EntitySearchResult<TEntityCollection>>> $searchResults
+     * @param array<string, array<EntitySearchResult<covariant EntityCollection<covariant Entity>>>> $searchResults
      */
     private function mapSearchResults(ElementDataCollection $result, CmsSlotEntity $slot, array $criteriaObjects, array $searchResults): void
     {
@@ -343,10 +339,8 @@ class CmsSlotsDataResolver
     }
 
     /**
-     * @template TEntityCollection of EntityCollection
-     *
      * @param array<string, CriteriaCollection> $criteriaObjects
-     * @param array<string, EntitySearchResult<TEntityCollection>> $entities
+     * @param array<string, EntitySearchResult<covariant EntityCollection<covariant Entity>>> $entities
      */
     private function mapEntities(ElementDataCollection $result, CmsSlotEntity $slot, array $criteriaObjects, array $entities): void
     {

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -34,7 +34,7 @@ class CmsSlotsDataResolver
 
     /**
      * @internal
-     * 
+     *
      * @param iterable<CmsElementResolverInterface> $resolvers
      * @param array<string, SalesChannelRepository<covariant EntityCollection<covariant Entity>>> $repositories
      */

--- a/src/Core/Content/Cms/DataResolver/Element/ElementDataCollection.php
+++ b/src/Core/Content/Cms/DataResolver/Element/ElementDataCollection.php
@@ -2,23 +2,24 @@
 
 namespace Shopware\Core\Content\Cms\DataResolver\Element;
 
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @implements \IteratorAggregate<array-key, EntitySearchResult<EntityCollection>>
+ * @implements \IteratorAggregate<array-key, EntitySearchResult<covariant EntityCollection<covariant Entity>>>
  */
 #[Package('discovery')]
 class ElementDataCollection implements \IteratorAggregate, \Countable
 {
     /**
-     * @var array<string, EntitySearchResult<EntityCollection>>
+     * @var array<string, EntitySearchResult<covariant EntityCollection<covariant Entity>>>
      */
     protected array $searchResults = [];
 
     /**
-     * @param EntitySearchResult<EntityCollection> $entitySearchResult
+     * @param EntitySearchResult<covariant EntityCollection<covariant Entity>> $entitySearchResult
      */
     public function add(string $key, EntitySearchResult $entitySearchResult): void
     {
@@ -26,7 +27,7 @@ class ElementDataCollection implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @return EntitySearchResult<EntityCollection>|null
+     * @return EntitySearchResult<covariant EntityCollection<covariant Entity>>|null
      */
     public function get(string $key): ?EntitySearchResult
     {
@@ -34,7 +35,7 @@ class ElementDataCollection implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @return \Traversable<string, EntitySearchResult<EntityCollection>>
+     * @return \Traversable<string, EntitySearchResult<covariant EntityCollection<covariant Entity>>>
      */
     public function getIterator(): \Traversable
     {

--- a/src/Core/Content/Cms/Extension/CmsSlotsDataEnrichExtension.php
+++ b/src/Core/Content/Cms/Extension/CmsSlotsDataEnrichExtension.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Cms\Extension;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Extensions\Extension;
@@ -17,8 +18,6 @@ use Shopware\Core\Framework\Log\Package;
  *
  * @description This event allows interception of the enrichment process,
  * during which CMS slots used in a rendered CMS page are populated with data loaded by the respective CMS resolver from the search results.
- *
- * @template TEntityCollection of EntityCollection
  *
  * @codeCoverageIgnore
  *
@@ -52,7 +51,7 @@ final class CmsSlotsDataEnrichExtension extends Extension
          *
          * @description The fetched slot data which was searched by the identifiers
          *
-         * @var array<EntitySearchResult<TEntityCollection>>
+         * @var array<EntitySearchResult<covariant EntityCollection<covariant Entity>>>
          */
         public readonly array $identifierResult,
         /**
@@ -60,7 +59,7 @@ final class CmsSlotsDataEnrichExtension extends Extension
          *
          * @description The fetched slot data which was searched by the criteria list
          *
-         * @var array<array<string, EntitySearchResult<TEntityCollection>>>
+         * @var array<array<string, EntitySearchResult<covariant EntityCollection<covariant Entity>>>>
          */
         public readonly array $criteriaResult,
         /**

--- a/src/Core/Content/LandingPage/SalesChannel/LandingPageRoute.php
+++ b/src/Core/Content/LandingPage/SalesChannel/LandingPageRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\LandingPage\SalesChannel;
 
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
 use Shopware\Core\Content\LandingPage\LandingPageException;
@@ -26,6 +27,8 @@ class LandingPageRoute extends AbstractLandingPageRoute
 {
     /**
      * @internal
+     *
+     * @param SalesChannelRepository<LandingPageCollection> $landingPageRepository
      */
     public function __construct(
         private readonly SalesChannelRepository $landingPageRepository,
@@ -86,10 +89,7 @@ class LandingPageRoute extends AbstractLandingPageRoute
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addFilter(new EqualsFilter('salesChannels.id', $context->getSalesChannelId()));
 
-        $landingPage = $this->landingPageRepository
-            ->search($criteria, $context)
-            ->get($landingPageId);
-
+        $landingPage = $this->landingPageRepository->search($criteria, $context)->getEntities()->get($landingPageId);
         if (!$landingPage instanceof LandingPageEntity) {
             throw LandingPageException::notFound($landingPageId);
         }

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\Detail\Event\ResolveVariantIdEvent;
 use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
@@ -39,6 +40,8 @@ class ProductDetailRoute extends AbstractProductDetailRoute
 {
     /**
      * @internal
+     *
+     * @param SalesChannelRepository<SalesChannelProductCollection> $productRepository
      */
     public function __construct(
         private readonly SalesChannelRepository $productRepository,
@@ -91,10 +94,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             $criteria->setIds([$productId]);
             $criteria->setTitle('product-detail-route');
 
-            $product = $this->productRepository
-                ->search($criteria, $context)
-                ->first();
-
+            $product = $this->productRepository->search($criteria, $context)->getEntities()->first();
             if (!($product instanceof SalesChannelProductEntity)) {
                 throw ProductException::productNotFound($productId);
             }

--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -4,8 +4,8 @@ namespace Shopware\Core\Content\ProductExport\Service;
 
 use Doctrine\DBAL\Connection;
 use Monolog\Level;
-use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\ProductExport\Event\ProductExportChangeEncodingEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportProductCriteriaEvent;
@@ -42,7 +42,7 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
     /**
      * @internal
      *
-     * @param SalesChannelRepository<ProductCollection> $productRepository
+     * @param SalesChannelRepository<SalesChannelProductCollection> $productRepository
      */
     public function __construct(
         private readonly ProductStreamBuilderInterface $productStreamBuilder,

--- a/src/Core/Framework/Api/Controller/ApiController.php
+++ b/src/Core/Framework/Api/Controller/ApiController.php
@@ -274,6 +274,7 @@ class ApiController extends AbstractController
 
         $aggregations = $context->scope(Context::CRUD_API_SCOPE, fn (Context $context): AggregationResultCollection => $repository->aggregate($criteria, $context));
 
+        /** @var EntitySearchResult<covariant EntityCollection<covariant Entity>> */
         $result = new EntitySearchResult($entityName, 0, new EntityCollection(), $aggregations, $criteria, $context);
 
         $definition = $this->getDefinitionOfPath($entityName, $path, $context);
@@ -424,7 +425,7 @@ class ApiController extends AbstractController
     }
 
     /**
-     * @return array{0: Criteria, 1: EntityRepository}
+     * @return array{0: Criteria, 1: EntityRepository<covariant EntityCollection<covariant Entity>>}
      */
     private function resolveSearch(Request $request, Context $context, string $entityName, string $path): array
     {

--- a/src/Core/Framework/Api/Response/ResponseFactoryInterface.php
+++ b/src/Core/Framework/Api/Response/ResponseFactoryInterface.php
@@ -28,9 +28,7 @@ interface ResponseFactoryInterface
     ): Response;
 
     /**
-     * @template TEntityCollection of EntityCollection
-     *
-     * @param EntitySearchResult<covariant TEntityCollection> $searchResult
+     * @param EntitySearchResult<covariant EntityCollection<covariant Entity>> $searchResult
      */
     public function createListingResponse(
         Criteria $criteria,

--- a/src/Core/Framework/Api/Response/Type/JsonFactoryBase.php
+++ b/src/Core/Framework/Api/Response/Type/JsonFactoryBase.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Api\Response\Type;
 
 use Shopware\Core\Framework\Api\Response\ResponseFactoryInterface;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -34,9 +35,7 @@ abstract class JsonFactoryBase implements ResponseFactoryInterface
     }
 
     /**
-     * @template TEntityCollection of EntityCollection
-     *
-     * @param EntitySearchResult<covariant TEntityCollection> $searchResult
+     * @param EntitySearchResult<covariant EntityCollection<covariant Entity>> $searchResult
      * @param array<string, mixed> $parameters
      *
      * @return array{first?: string, prev?: string, next?: string, last?: string}

--- a/src/Core/Framework/Api/Serializer/JsonApiEncoder.php
+++ b/src/Core/Framework/Api/Serializer/JsonApiEncoder.php
@@ -31,7 +31,9 @@ class JsonApiEncoder
     private array $serializeCache = [];
 
     /**
-     * @param EntityCollection<covariant Entity>|Entity|null $data
+     * @template TEntityCollection of EntityCollection
+     *
+     * @param TEntityCollection|Entity|null $data
      * @param array<string, mixed> $metaData
      *
      * @throws ApiException
@@ -125,7 +127,9 @@ class JsonApiEncoder
     }
 
     /**
-     * @param Entity|EntityCollection<covariant Entity> $data
+     * @template TEntityCollection of EntityCollection
+     *
+     * @param Entity|TEntityCollection $data
      */
     private function encodeData(ResponseFields $fields, EntityDefinition $definition, Entity|EntityCollection $data, JsonApiEncodingResult $result): void
     {

--- a/src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
+++ b/src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
@@ -28,7 +28,9 @@ class JsonEntityEncoder
     }
 
     /**
-     * @param EntityCollection<Entity>|Entity|null $data
+     * @template TEntityCollection of EntityCollection
+     *
+     * @param TEntityCollection|Entity|null $data
      *
      * @return ($data is Entity ? array<string, mixed> : list<array<string, mixed>>)
      */
@@ -46,7 +48,9 @@ class JsonEntityEncoder
     }
 
     /**
-     * @param EntityCollection<Entity> $collection
+     * @template TEntityCollection of EntityCollection
+     *
+     * @param TEntityCollection $collection
      *
      * @return list<array<string, mixed>>
      */

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -68,7 +68,7 @@ class EntityHydrator
     }
 
     /**
-     * @template TEntityCollection of EntityCollection<Entity>
+     * @template TEntityCollection of EntityCollection
      *
      * @param TEntityCollection $collection
      * @param array<mixed> $rows

--- a/src/Core/System/Currency/SalesChannel/CurrencyRoute.php
+++ b/src/Core/System/Currency/SalesChannel/CurrencyRoute.php
@@ -22,6 +22,8 @@ class CurrencyRoute extends AbstractCurrencyRoute
 
     /**
      * @internal
+     *
+     * @param SalesChannelRepository<CurrencyCollection> $currencyRepository
      */
     public function __construct(
         private readonly SalesChannelRepository $currencyRepository,
@@ -44,9 +46,6 @@ class CurrencyRoute extends AbstractCurrencyRoute
     {
         $this->cacheTagCollector->addTag(self::buildName($context->getSalesChannelId()), self::ALL_TAG);
 
-        /** @var CurrencyCollection $currencyCollection */
-        $currencyCollection = $this->currencyRepository->search($criteria, $context)->getEntities();
-
-        return new CurrencyRouteResponse($currencyCollection);
+        return new CurrencyRouteResponse($this->currencyRepository->search($criteria, $context)->getEntities());
     }
 }

--- a/src/Core/System/SalesChannel/Entity/DefinitionRegistryChain.php
+++ b/src/Core/System/SalesChannel/Entity/DefinitionRegistryChain.php
@@ -33,7 +33,7 @@ class DefinitionRegistryChain
     }
 
     /**
-     * @return EntityRepository<EntityCollection<Entity>>|SalesChannelRepository<EntityCollection<Entity>>
+     * @return EntityRepository<covariant EntityCollection<covariant Entity>>|SalesChannelRepository<covariant EntityCollection<covariant Entity>>
      */
     public function getRepository(string $entity): EntityRepository|SalesChannelRepository
     {

--- a/src/Core/System/SalesChannel/Entity/SalesChannelDefinitionInstanceRegistry.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelDefinitionInstanceRegistry.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\System\SalesChannel\Entity;
 
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Exception\SalesChannelRepositoryNotFoundException;
@@ -28,6 +30,8 @@ class SalesChannelDefinitionInstanceRegistry extends DefinitionInstanceRegistry
 
     /**
      * @throws SalesChannelRepositoryNotFoundException
+     *
+     * @return SalesChannelRepository<covariant EntityCollection<covariant Entity>>
      */
     public function getSalesChannelRepository(string $entityName): SalesChannelRepository
     {

--- a/tests/integration/Core/Framework/Api/ResponseTypeRegistryTest.php
+++ b/tests/integration/Core/Framework/Api/ResponseTypeRegistryTest.php
@@ -150,7 +150,8 @@ class ResponseTypeRegistryTest extends TestCase
 
         $col = new CategoryCollection([$category]);
         $criteria = new Criteria();
-        $searchResult = new EntitySearchResult('product', 1, $col, null, $criteria, $context);
+        /** @var EntitySearchResult<CategoryCollection> */
+        $searchResult = new EntitySearchResult('category', 1, $col, null, $criteria, $context);
 
         $definition = static::getContainer()->get(CategoryDefinition::class);
         $request = Request::create($path, 'GET', [], [], [], ['HTTP_ACCEPT' => $accept]);

--- a/tests/integration/Core/Framework/Seo/SeoUrl/StorefrontSeoUrlRepositoryTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrl/StorefrontSeoUrlRepositoryTest.php
@@ -27,6 +27,9 @@ class StorefrontSeoUrlRepositoryTest extends TestCase
      */
     private EntityRepository $seoUrlRepository;
 
+    /**
+     * @var SalesChannelRepository<SeoUrlCollection>
+     */
     private SalesChannelRepository $salesChannelSeoUrlRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/System/SalesChannel/Entity/SalesChannelDefinitionTest.php
+++ b/tests/integration/Core/System/SalesChannel/Entity/SalesChannelDefinitionTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Category\SalesChannel\SalesChannelCategoryDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Defaults;
@@ -40,6 +41,9 @@ class SalesChannelDefinitionTest extends TestCase
      */
     private EntityRepository $apiRepository;
 
+    /**
+     * @var SalesChannelRepository<SalesChannelProductCollection>
+     */
     private SalesChannelRepository $salesChannelProductRepository;
 
     private AbstractSalesChannelContextFactory $factory;

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Seo\MainCategory\MainCategoryCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -354,6 +355,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
     /**
      * @param array<ProductEntity> $productEntityCollection1
      * @param array<ProductEntity> $productEntityCollection2
+     *
+     * @return SalesChannelRepository<SalesChannelProductCollection>
      */
     private function getProductRepositoryMock(array $productEntityCollection1, array $productEntityCollection2): SalesChannelRepository
     {

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
@@ -105,7 +105,7 @@ class CmsSlotsMultiDataResolverTest extends TestCase
     }
 
     /**
-     * @return SalesChannelRepository<covariant EntityCollection<covariant Entity>>|Stub
+     * @return SalesChannelRepository<covariant EntityCollection<covariant Entity>>&Stub
      */
     private function createRepositoryMock(EntityDefinition $definition): SalesChannelRepository
     {

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Shopware\Tests\Unit\Core\Content\Cms\DataResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
@@ -14,6 +15,8 @@ use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
@@ -101,6 +104,9 @@ class CmsSlotsMultiDataResolverTest extends TestCase
         return new MultiCmsElementResolver($type, $definition);
     }
 
+    /**
+     * @return SalesChannelRepository<covariant EntityCollection<covariant Entity>>|Stub
+     */
     private function createRepositoryMock(EntityDefinition $definition): SalesChannelRepository
     {
         $repository = static::createStub(SalesChannelRepository::class);

--- a/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
@@ -40,6 +40,9 @@ class ProductStreamProcessorTest extends TestCase
 
     private ProductStreamBuilderInterface&MockObject $productStreamBuilder;
 
+    /**
+     * @var SalesChannelRepository<ProductCollection>&MockObject
+     */
     private SalesChannelRepository&MockObject $productRepository;
 
     protected function setUp(): void

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -44,7 +44,7 @@ use Symfony\Component\HttpFoundation\Request;
 class ProductDetailRouteTest extends TestCase
 {
     /**
-     * @var MockObject&SalesChannelRepository
+     * @var MockObject&SalesChannelRepository<ProductCollection>
      */
     private SalesChannelRepository $productRepository;
 

--- a/tests/unit/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Exception\VariantNotFoundException;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\FindVariant\FindProductVariantRoute;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -24,6 +25,9 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(FindProductVariantRoute::class)]
 class FindProductVariantRouteTest extends TestCase
 {
+    /**
+     * @var MockObject&SalesChannelRepository<SalesChannelProductCollection>
+     */
     private MockObject&SalesChannelRepository $productRepositoryMock;
 
     private FindProductVariantRoute $route;

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Content\ProductExport\Service\ProductExportGenerator;
@@ -36,6 +37,9 @@ class ProductExportGeneratorTest extends TestCase
 {
     private MockObject&ProductStreamBuilderInterface $productStreamBuilder;
 
+    /**
+     * @var MockObject&SalesChannelRepository<SalesChannelProductCollection>
+     */
     private MockObject&SalesChannelRepository $productRepository;
 
     private MockObject&ProductExportRendererInterface $productExportRender;


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently a few SalesChannelRepository types are missing their phpstan type

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the SalesChannelRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
