### PR TITLE
chore: Use correct EntityRepository types for phpstan in core (Maintenance, Profiling, Service)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -176,9 +176,6 @@ parameters:
             paths:
                 - src/Core/Content/**
                 - src/Core/Framework/**
-                - src/Core/Maintenance/**
-                - src/Core/Profiling/**
-                - src/Core/Service/**
                 - src/Core/Test/**
                 - tests/integration/Core/Content/**
                 - tests/integration/Core/Framework/**

--- a/src/Core/Maintenance/SalesChannel/Command/SalesChannelMaintenanceEnableCommand.php
+++ b/src/Core/Maintenance/SalesChannel/Command/SalesChannelMaintenanceEnableCommand.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -25,6 +26,9 @@ class SalesChannelMaintenanceEnableCommand extends Command
 {
     protected bool $setMaintenanceMode = true;
 
+    /**
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     */
     public function __construct(
         private readonly EntityRepository $salesChannelRepository
     ) {

--- a/src/Core/Maintenance/SalesChannel/Service/SalesChannelCreator.php
+++ b/src/Core/Maintenance/SalesChannel/Service/SalesChannelCreator.php
@@ -3,6 +3,9 @@
 namespace Shopware\Core\Maintenance\SalesChannel\Service;
 
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupDefinition;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
@@ -13,6 +16,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Maintenance\MaintenanceException;
+use Shopware\Core\System\Country\CountryCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
 /**
  * @internal
@@ -22,6 +27,12 @@ class SalesChannelCreator
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     * @param EntityRepository<PaymentMethodCollection> $paymentMethodRepository
+     * @param EntityRepository<ShippingMethodCollection> $shippingMethodRepository
+     * @param EntityRepository<CountryCollection> $countryRepository
+     * @param EntityRepository<CategoryCollection> $categoryRepository
      */
     public function __construct(
         private readonly DefinitionInstanceRegistry $definitionRegistry,

--- a/src/Core/Profiling/Subscriber/ActiveRulesDataCollectorSubscriber.php
+++ b/src/Core/Profiling/Subscriber/ActiveRulesDataCollectorSubscriber.php
@@ -2,9 +2,9 @@
 
 namespace Shopware\Core\Profiling\Subscriber;
 
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -27,6 +27,9 @@ class ActiveRulesDataCollectorSubscriber extends AbstractDataCollector implement
      */
     private array $ruleIds = [];
 
+    /**
+     * @param EntityRepository<RuleCollection> $ruleRepository
+     */
     public function __construct(private readonly EntityRepository $ruleRepository)
     {
     }
@@ -63,7 +66,7 @@ class ActiveRulesDataCollectorSubscriber extends AbstractDataCollector implement
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
-        $this->data = $this->getMatchingRules();
+        $this->data = $this->getMatchingRules()->getElements();
     }
 
     public static function getTemplate(): string
@@ -76,17 +79,14 @@ class ActiveRulesDataCollectorSubscriber extends AbstractDataCollector implement
         $this->ruleIds = $event->getContext()->getRuleIds();
     }
 
-    /**
-     * @return array<string, Entity>
-     */
-    private function getMatchingRules(): array
+    private function getMatchingRules(): RuleCollection
     {
         if (empty($this->ruleIds)) {
-            return [];
+            return new RuleCollection();
         }
 
         $criteria = new Criteria($this->ruleIds);
 
-        return $this->ruleRepository->search($criteria, Context::createDefaultContext())->getElements();
+        return $this->ruleRepository->search($criteria, Context::createDefaultContext())->getEntities();
     }
 }

--- a/src/Core/Service/ScheduledTask/InstallServicesTaskHandler.php
+++ b/src/Core/Service/ScheduledTask/InstallServicesTaskHandler.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Shopware\Core\Service\LifecycleManager;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -17,6 +18,9 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler(handles: InstallServicesTask::class)]
 final class InstallServicesTaskHandler extends ScheduledTaskHandler
 {
+    /**
+     * @param EntityRepository<ScheduledTaskCollection> $repository
+     */
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,

--- a/src/Core/Service/Subscriber/LicenseSyncSubscriber.php
+++ b/src/Core/Service/Subscriber/LicenseSyncSubscriber.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Service\Subscriber;
 
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Event\AppInstalledEvent;
 use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
@@ -28,6 +29,9 @@ class LicenseSyncSubscriber implements EventSubscriberInterface
 
     public const CONFIG_STORE_LICENSE_HOST = 'core.store.licenseHost';
 
+    /**
+     * @param EntityRepository<AppCollection> $appRepository
+     */
     public function __construct(
         private readonly SystemConfigService $config,
         private readonly Client $serviceRegistryClient,
@@ -73,7 +77,6 @@ class LicenseSyncSubscriber implements EventSubscriberInterface
         $licenseKey = $key === self::CONFIG_STORE_LICENSE_KEY ? $value : $this->config->getString(self::CONFIG_STORE_LICENSE_KEY);
         $licenseHost = $key === self::CONFIG_STORE_LICENSE_HOST ? $value : $this->config->getString(self::CONFIG_STORE_LICENSE_HOST);
 
-        /** @var AppEntity $app */
         foreach ($apps as $app) {
             if (!$app->getAppSecret() || !$app->isSelfManaged()) {
                 continue;


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently a few EntityRepository types are missing their phpstan type
- As in the past we group this updates to the EntityRepository types by areas to keep the PR size reasonable
- This PR includes core `Maintenance, Profiling, Service` areas

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the EntityRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
