### PR TITLE
fix: Use mariaDb as Shopware isn't MySQL 8.4 compatible

### DIFF
--- a/changelog/_unreleased/2025-08-05-use-mariadb.md
+++ b/changelog/_unreleased/2025-08-05-use-mariadb.md
@@ -1,0 +1,8 @@
+---
+title: Use mariaDb as Shopware isn't MySQL 8.4 compatible
+author: Tommy Quissens
+author_github: @quisse
+---
+# devenv
+
+* use mariadb instead of MySQL 8.4 to prevent compatibility issues

--- a/devenv.nix
+++ b/devenv.nix
@@ -94,7 +94,7 @@ in {
 
   services.mysql = {
     enable = true;
-    package = pkgs.mysql84;
+    package = pkgs.mariaDb;
     initialDatabases = lib.mkDefault [{ name = "shopware"; }];
     ensureUsers = lib.mkDefault [
       {

--- a/devenv.nix
+++ b/devenv.nix
@@ -94,7 +94,7 @@ in {
 
   services.mysql = {
     enable = true;
-    package = pkgs.mariaDb;
+    package = pkgs.mariadb;
     initialDatabases = lib.mkDefault [{ name = "shopware"; }];
     ensureUsers = lib.mkDefault [
       {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Importing an existing Shopware 6.5 database doesn't work as the schema isn't MySQL 8.4 compatible


### 2. What does this change do, exactly?
Use mariadb, as this has no issues with [boost177](https://github.com/shopware/shopware/pull/11452)

### 3. Describe each step to reproduce the issue or behaviour.
Import a database from shopware 6.5, it will return `ERROR 6125 (HY000) at line 1441: Failed to add the foreign key constraint. Missing unique key for constraint 'fk.category_sales_channel.category_id' in the referenced table 'category'`

Info about the error;

> The error ERROR 6125 (HY000): Failed to add the foreign key constraint. Missing unique key for constraint 'fk.category_sales_channel.category_id' in the referenced table 'category' occurs because the foreign key constraint fk.category_sales_channel.category_id in the category_sales_channel table references the id column in the category table, but the referenced column (id) is not defined as a unique key or primary key on its own in the category table.
> Root Cause
> In the category table, the primary key is a composite key consisting of both id and version_id:
> sqlPRIMARY KEY (`id`, `version_id`)
> The foreign key constraint in the category_sales_channel table, however, only references the category_id column:
> sqlCONSTRAINT `fk.category_sales_channel.category_id` FOREIGN KEY (`category_id`) REFERENCES `category` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
> MySQL requires that the referenced column(s) in a foreign key constraint must be either a primary key or have a unique constraint in the referenced table. Since id alone in the category table is not uniquely constrained (only the combination of id and version_id is), MySQL rejects the foreign key creation.
> This issue may arise due to differences in MySQL versions (dump from 8.0, target 8.4). MySQL 8.4 might enforce stricter checks on foreign key constraints, or the database dump might not fully capture the necessary constraints due to differences in schema generation or export settings.
> Solution
> To resolve this, you need to ensure that the foreign key in category_sales_channel references the full composite primary key (id, version_id) of the category table, as this is the unique constraint in the referenced table. 

### 4. Please link to the relevant issues (if any).
fixes https://github.com/shopware/shopware/pull/11736 

<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
