### PR TITLE
fix: Profiler icon of cache tags

### DIFF
--- a/src/Core/Profiling/Resources/views/Collector/http_cache_tags.html.twig
+++ b/src/Core/Profiling/Resources/views/Collector/http_cache_tags.html.twig
@@ -23,7 +23,7 @@
 {% block menu %}
     {# This left-hand menu appears when using the full-screen profiler. #}
     <span class="label">
-        <span class="icon">{{ include('@WebProfiler/Icon/form.svg') }}</span>
+        <span class="icon">{{ include('@WebProfiler/Icon/cache.svg') }}</span>
         <strong>Cache tags</strong>
     </span>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The cache tags in the profiler currently have the icon of the "Active Rules".

### 2. What does this change do, exactly?
Show the icon in the profiler for the cache tags, which is also shown in the toolbar:
<img width="328" height="114" alt="image" src="https://github.com/user-attachments/assets/fe7e2b01-0d36-47fb-89c1-3059eddde6c8" />

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
