### PR TITLE
fix: Do not read manifest.json twice from file system

### DIFF
--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Plugin\Util;
 
+use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Visibility;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
@@ -275,12 +276,9 @@ class AssetService
         }
 
         $hashes = [];
-        if ($this->privateFilesystem->fileExists('asset-manifest.json')) {
-            $hashes = json_decode(
-                $this->privateFilesystem->read('asset-manifest.json'),
-                true,
-                \JSON_THROW_ON_ERROR
-            );
+        try {
+            $hashes = json_decode($this->privateFilesystem->read('asset-manifest.json'), true, flags: \JSON_THROW_ON_ERROR);
+        } catch (FilesystemException $e) {
         }
 
         return $hashes;

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -2,8 +2,8 @@
 
 namespace Shopware\Core\Framework\Plugin\Util;
 
-use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToReadFile;
 use League\Flysystem\Visibility;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
@@ -278,7 +278,7 @@ class AssetService
         $hashes = [];
         try {
             $hashes = json_decode($this->privateFilesystem->read('asset-manifest.json'), true, flags: \JSON_THROW_ON_ERROR);
-        } catch (FilesystemException $e) {
+        } catch (UnableToReadFile) {
         }
 
         return $hashes;

--- a/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
@@ -215,6 +215,7 @@ class AssetServiceTest extends TestCase
 
                 return true;
             });
+        $adapter->method('read')->willReturn(json_encode([], \JSON_THROW_ON_ERROR));
 
         $filesystem = new Filesystem($adapter);
         $assetService = new AssetService(


### PR DESCRIPTION
### 1. Why is this change necessary?

Checking with `fileExists` means another read of the external file system. Better for performance, is to try to read the file and catch the exception.

### 2. What does this change do, exactly?

Exchange the existence check with a try/catch

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
