### PR TITLE
chore: Use correct EntityRepository types for phpstan in core (System)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -179,11 +179,9 @@ parameters:
                 - src/Core/Maintenance/**
                 - src/Core/Profiling/**
                 - src/Core/Service/**
-                - src/Core/System/**
                 - src/Core/Test/**
                 - tests/integration/Core/Content/**
                 - tests/integration/Core/Framework/**
-                - tests/integration/Core/System/**
                 - tests/unit/Core/**
 
         - # WIP implementation (See NEXT-29041 - https://github.com/shopware/shopware/issues/6175)

--- a/src/Core/System/CustomEntity/CustomEntityRegistrar.php
+++ b/src/Core/System/CustomEntity/CustomEntityRegistrar.php
@@ -5,6 +5,8 @@ namespace Shopware\Core\System\CustomEntity;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
@@ -67,6 +69,9 @@ class CustomEntityRegistrar
         }
     }
 
+    /**
+     * @return EntityRepository<EntityCollection<Entity>>
+     */
     public static function createRepository(ContainerInterface $container, EntityDefinition $definition): EntityRepository
     {
         return EntityRepository::createLazyGhost(function (EntityRepository $instance) use ($definition, $container): void {

--- a/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementRedisStorage.php
+++ b/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementRedisStorage.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\System\NumberRange\NumberRangeCollection;
 use Symfony\Component\Lock\LockFactory;
 
 /**
@@ -18,6 +19,7 @@ class IncrementRedisStorage extends AbstractIncrementStorage
 {
     /**
      * @param RedisTypeHint $redis
+     * @param EntityRepository<NumberRangeCollection> $numberRangeRepository
      */
     public function __construct(
         /** @phpstan-ignore shopware.propertyNativeType (Cannot type natively, as Symfony might change the implementation in the future) */

--- a/src/Core/System/SalesChannel/Context/Cleanup/CleanupSalesChannelContextTaskHandler.php
+++ b/src/Core/System/SalesChannel/Context/Cleanup/CleanupSalesChannelContextTaskHandler.php
@@ -7,6 +7,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -19,6 +20,8 @@ final class CleanupSalesChannelContextTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ScheduledTaskCollection> $repository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextRestorer.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextRestorer.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Cart\CartBehavior;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Checkout\Cart\Order\OrderConverter;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -26,6 +27,8 @@ class SalesChannelContextRestorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<OrderCollection> $orderRepository
      */
     public function __construct(
         private readonly AbstractSalesChannelContextFactory $factory,
@@ -187,11 +190,7 @@ class SalesChannelContextRestorer
 
         $this->eventDispatcher->dispatch(new SalesChannelContextRestorerOrderCriteriaEvent($criteria, $context));
 
-        /** @var OrderEntity|null $orderEntity */
-        $orderEntity = $this->orderRepository->search($criteria, $context)
-            ->get($orderId);
-
-        return $orderEntity;
+        return $this->orderRepository->search($criteria, $context)->getEntities()->get($orderId);
     }
 
     /**

--- a/src/Core/System/SalesChannel/DataAbstractionLayer/SalesChannelIndexer.php
+++ b/src/Core/System/SalesChannel/DataAbstractionLayer/SalesChannelIndexer.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ManyToManyIdFieldUpdat
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\Event\SalesChannelIndexerEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -21,6 +22,8 @@ class SalesChannelIndexer extends EntityIndexer
 
     /**
      * @internal
+     *
+     * @param EntityRepository<SalesChannelCollection> $repository
      */
     public function __construct(
         private readonly IteratorFactory $iteratorFactory,

--- a/src/Core/System/SalesChannel/Entity/DefinitionRegistryChain.php
+++ b/src/Core/System/SalesChannel/Entity/DefinitionRegistryChain.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\System\SalesChannel\Entity;
 
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\DefinitionNotFoundException;
@@ -30,6 +32,9 @@ class DefinitionRegistryChain
         return $this->core->get($class);
     }
 
+    /**
+     * @return EntityRepository<EntityCollection<Entity>>|SalesChannelRepository<EntityCollection<Entity>>
+     */
     public function getRepository(string $entity): EntityRepository|SalesChannelRepository
     {
         try {

--- a/src/Core/System/SalesChannel/Subscriber/SalesChannelAnalyticsLoader.php
+++ b/src/Core/System/SalesChannel/Subscriber/SalesChannelAnalyticsLoader.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\System\SalesChannel\Subscriber;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics\SalesChannelAnalyticsEntity;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics\SalesChannelAnalyticsCollection;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
 
 /**
@@ -14,6 +14,9 @@ use Shopware\Storefront\Event\StorefrontRenderEvent;
 #[Package('discovery')]
 class SalesChannelAnalyticsLoader
 {
+    /**
+     * @param EntityRepository<SalesChannelAnalyticsCollection> $salesChannelAnalyticsRepository
+     */
     public function __construct(
         private readonly EntityRepository $salesChannelAnalyticsRepository,
     ) {
@@ -32,8 +35,7 @@ class SalesChannelAnalyticsLoader
         $criteria = new Criteria([$analyticsId]);
         $criteria->setTitle('sales-channel::load-analytics');
 
-        /** @var SalesChannelAnalyticsEntity|null $analytics */
-        $analytics = $this->salesChannelAnalyticsRepository->search($criteria, $salesChannelContext->getContext())->first();
+        $analytics = $this->salesChannelAnalyticsRepository->search($criteria, $salesChannelContext->getContext())->getEntities()->first();
 
         $event->setParameter('storefrontAnalytics', $analytics);
     }

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -6,6 +6,8 @@ use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderStateAction;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\DefinitionNotFoundException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
@@ -15,9 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryCollection;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateCollection;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
-use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionCollection;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionEntity;
 use Shopware\Core\System\StateMachine\Event\StateMachineStateChangeEvent;
 use Shopware\Core\System\StateMachine\Event\StateMachineTransitionEvent;
@@ -36,6 +38,10 @@ class StateMachineRegistry implements ResetInterface
 
     /**
      * @internal
+     *
+     * @param EntityRepository<StateMachineCollection> $stateMachineRepository
+     * @param EntityRepository<StateMachineStateCollection> $stateMachineStateRepository
+     * @param EntityRepository<StateMachineHistoryCollection> $stateMachineHistoryRepository
      */
     public function __construct(
         private readonly EntityRepository $stateMachineRepository,
@@ -69,10 +75,9 @@ class StateMachineRegistry implements ResetInterface
         $criteria->getAssociation('states')
             ->addSorting(new FieldSorting('state_machine_state.technicalName'));
 
-        $results = $this->stateMachineRepository->search($criteria, $context);
+        $results = $this->stateMachineRepository->search($criteria, $context)->getEntities();
 
         if ($stateMachine = $results->first()) {
-            /** @var StateMachineEntity $stateMachine */
             return $this->stateMachines[$name] = $stateMachine;
         }
 
@@ -232,8 +237,8 @@ class StateMachineRegistry implements ResetInterface
 
         $transitions = [];
         foreach ($stateMachineTransitions as $transition) {
-            /** @var StateMachineStateEntity $fromState */
             $fromState = $transition->getFromStateMachineState();
+            \assert($fromState !== null);
             if ($fromState->getId() === $fromStateId) {
                 $transitions[] = $transition;
             }
@@ -252,12 +257,12 @@ class StateMachineRegistry implements ResetInterface
     {
         $stateMachine = $this->getStateMachine($stateMachineName, $context);
 
-        /** @var StateMachineTransitionCollection $stateMachineTransitions */
         $stateMachineTransitions = $stateMachine->getTransitions();
+        \assert($stateMachineTransitions !== null);
 
         foreach ($stateMachineTransitions as $transition) {
-            /** @var StateMachineStateEntity $toState */
             $toState = $transition->getToStateMachineState();
+            \assert($toState !== null);
 
             // Not the transition that was requested step over
             if ($transition->getActionName() !== $transitionName) {
@@ -269,8 +274,9 @@ class StateMachineRegistry implements ResetInterface
                 throw StateMachineException::unnecessaryTransition($transitionName);
             }
 
-            /** @var StateMachineStateEntity $fromState */
             $fromState = $transition->getFromStateMachineState();
+            \assert($fromState !== null);
+
             // Desired transition found
             if ($fromState->getId() === $fromStateId) {
                 return $toState;
@@ -281,8 +287,7 @@ class StateMachineRegistry implements ResetInterface
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('technicalName', $transitionName));
             $criteria->addFilter(new EqualsFilter('stateMachineId', $stateMachine->getId()));
-            /** @var StateMachineStateEntity|null $toPlace */
-            $toPlace = $this->stateMachineStateRepository->search($criteria, $context)->first();
+            $toPlace = $this->stateMachineStateRepository->search($criteria, $context)->getEntities()->first();
             if ($toPlace?->getId() === $fromStateId) {
                 throw StateMachineException::unnecessaryTransition($transitionName);
             }
@@ -319,6 +324,8 @@ class StateMachineRegistry implements ResetInterface
     }
 
     /**
+     * @param EntityRepository<EntityCollection<Entity>> $repository
+     *
      * @throws InconsistentCriteriaIdsException
      * @throws StateMachineException
      */
@@ -341,8 +348,7 @@ class StateMachineRegistry implements ResetInterface
             throw StateMachineException::stateMachineInvalidStateField($stateFieldName);
         }
 
-        /** @var StateMachineStateEntity|null $fromPlace */
-        $fromPlace = $this->stateMachineStateRepository->search(new Criteria([$fromPlaceId]), $context)->get($fromPlaceId);
+        $fromPlace = $this->stateMachineStateRepository->search(new Criteria([$fromPlaceId]), $context)->getEntities()->get($fromPlaceId);
 
         if (!$fromPlace) {
             throw StateMachineException::stateMachineInvalidStateField($stateFieldName);

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -238,7 +238,10 @@ class StateMachineRegistry implements ResetInterface
         $transitions = [];
         foreach ($stateMachineTransitions as $transition) {
             $fromState = $transition->getFromStateMachineState();
-            \assert($fromState !== null);
+            if (!$fromState) {
+                continue;
+            }
+
             if ($fromState->getId() === $fromStateId) {
                 $transitions[] = $transition;
             }
@@ -261,11 +264,13 @@ class StateMachineRegistry implements ResetInterface
         \assert($stateMachineTransitions !== null);
 
         foreach ($stateMachineTransitions as $transition) {
-            $toState = $transition->getToStateMachineState();
-            \assert($toState !== null);
-
             // Not the transition that was requested step over
             if ($transition->getActionName() !== $transitionName) {
+                continue;
+            }
+
+            $toState = $transition->getToStateMachineState();
+            if (!$toState) {
                 continue;
             }
 
@@ -275,7 +280,9 @@ class StateMachineRegistry implements ResetInterface
             }
 
             $fromState = $transition->getFromStateMachineState();
-            \assert($fromState !== null);
+            if (!$fromState) {
+                continue;
+            }
 
             // Desired transition found
             if ($fromState->getId() === $fromStateId) {

--- a/src/Core/System/SystemConfig/Service/ConfigurationService.php
+++ b/src/Core/System/SystemConfig/Service/ConfigurationService.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\SystemConfig\Service;
 
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\Bundle;
 use Shopware\Core\Framework\Context;
@@ -23,6 +24,7 @@ class ConfigurationService
      * @internal
      *
      * @param BundleInterface[] $bundles
+     * @param EntityRepository<AppCollection> $appRepository
      */
     public function __construct(
         private readonly iterable $bundles,

--- a/src/Core/System/UsageData/Consent/BannerService.php
+++ b/src/Core/System/UsageData/Consent/BannerService.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity;
+use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
 
 /**
  * @internal
@@ -18,6 +18,9 @@ class BannerService
 {
     public const USER_CONFIG_KEY_HIDE_CONSENT_BANNER = 'core.usageData.hideConsentBanner';
 
+    /**
+     * @param EntityRepository<UserConfigCollection> $userConfigRepository
+     */
     public function __construct(private readonly EntityRepository $userConfigRepository)
     {
     }
@@ -46,8 +49,7 @@ class BannerService
         $criteria->addFilter(new EqualsFilter('key', self::USER_CONFIG_KEY_HIDE_CONSENT_BANNER));
         $criteria->addFilter(new EqualsFilter('userId', $userId));
 
-        /** @var UserConfigEntity|null $userConfig */
-        $userConfig = $this->userConfigRepository->search($criteria, $context)->first();
+        $userConfig = $this->userConfigRepository->search($criteria, $context)->getEntities()->first();
         if ($userConfig === null) {
             return false;
         }
@@ -69,8 +71,7 @@ class BannerService
 
         $updates = [];
 
-        /** @var UserConfigEntity $userConfig */
-        foreach ($userConfigs->getElements() as $userConfig) {
+        foreach ($userConfigs->getEntities() as $userConfig) {
             $updates[] = [
                 'id' => $userConfig->getId(),
                 'userId' => $userConfig->getUserId(),

--- a/src/Core/System/UsageData/Consent/ConsentService.php
+++ b/src/Core/System/UsageData/Consent/ConsentService.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SystemConfig\SystemConfigCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\UsageData\UsageDataException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -20,6 +21,9 @@ class ConsentService
 {
     public const SYSTEM_CONFIG_KEY_CONSENT_STATE = 'core.usageData.consentState';
 
+    /**
+     * @param EntityRepository<SystemConfigCollection> $systemConfigRepository
+     */
     public function __construct(
         private readonly SystemConfigService $systemConfigService,
         private readonly EntityRepository $systemConfigRepository,
@@ -83,7 +87,7 @@ class ConsentService
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('configurationKey', self::SYSTEM_CONFIG_KEY_CONSENT_STATE));
         $criteria->setLimit(1);
-        $entitySearchResult = $this->systemConfigRepository->search($criteria, Context::createDefaultContext());
+        $entitySearchResult = $this->systemConfigRepository->search($criteria, Context::createDefaultContext())->getEntities();
         $config = $entitySearchResult->first();
 
         $updatedAt = $config?->getUpdatedAt();

--- a/src/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskHandler.php
+++ b/src/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskHandler.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\System\UsageData\ScheduledTask;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Shopware\Core\System\UsageData\Services\EntityDispatchService;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -16,6 +17,9 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler(handles: CollectEntityDataTask::class)]
 final class CollectEntityDataTaskHandler extends ScheduledTaskHandler
 {
+    /**
+     * @param EntityRepository<ScheduledTaskCollection> $repository
+     */
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,

--- a/src/Core/System/User/Service/UserValidationService.php
+++ b/src/Core/System/User/Service/UserValidationService.php
@@ -10,12 +10,15 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\User\UserCollection;
 
 #[Package('fundamentals@framework')]
 class UserValidationService
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<UserCollection> $userRepo
      */
     public function __construct(private readonly EntityRepository $userRepo)
     {

--- a/tests/integration/Core/System/SalesChannel/SalesChannel/ContextSwitchRouteTest.php
+++ b/tests/integration/Core/System/SalesChannel/SalesChannel/ContextSwitchRouteTest.php
@@ -5,6 +5,8 @@ namespace Shopware\Tests\Integration\Core\System\SalesChannel\SalesChannel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -29,8 +31,14 @@ class ContextSwitchRouteTest extends TestCase
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
+    /**
+     * @var EntityRepository<CustomerAddressCollection>
+     */
     private EntityRepository $customerAddressRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -8,12 +8,15 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -376,11 +379,17 @@ class SalesChannelValidatorTest extends TestCase
         return $default;
     }
 
+    /**
+     * @return EntityRepository<SalesChannelCollection>
+     */
     private function getSalesChannelRepository(): EntityRepository
     {
         return static::getContainer()->get('sales_channel.repository');
     }
 
+    /**
+     * @return EntityRepository<EntityCollection<Entity>>
+     */
     private function getSalesChannelLanguageRepository(): EntityRepository
     {
         return static::getContainer()->get('sales_channel_language.repository');

--- a/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
+++ b/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
@@ -12,6 +12,8 @@ use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderStates;
@@ -29,6 +31,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryCollection;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryEntity;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
@@ -45,10 +48,19 @@ class StateMachineActionControllerTest extends TestCase
     use IntegrationTestBehaviour;
     use TaxAddToSalesChannelTestBehaviour;
 
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
+    /**
+     * @var EntityRepository<StateMachineHistoryCollection>
+     */
     private EntityRepository $stateMachineHistoryRepository;
 
     protected function setUp(): void
@@ -215,7 +227,7 @@ class StateMachineActionControllerTest extends TestCase
 
         $orderId = $cartService->order($cart, $salesChannelContext, new RequestDataBag());
 
-        /** @var EntityRepository $orderRepository */
+        /** @var EntityRepository<OrderCollection> $orderRepository */
         $orderRepository = static::getContainer()->get('order.repository');
 
         /** @var OrderEntity $order */
@@ -279,7 +291,7 @@ class StateMachineActionControllerTest extends TestCase
 
         $orderId = $cartService->order($cart, $salesChannelContext, new RequestDataBag());
 
-        /** @var EntityRepository $orderRepository */
+        /** @var EntityRepository<OrderCollection> $orderRepository */
         $orderRepository = static::getContainer()->get('order.repository');
 
         /** @var OrderEntity $order */

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionEntity;
+use Shopware\Core\System\StateMachine\StateMachineCollection;
 use Shopware\Core\System\StateMachine\StateMachineException;
 use Shopware\Core\System\StateMachine\StateMachineRegistry;
 use Shopware\Core\System\StateMachine\Transition;
@@ -50,6 +51,9 @@ class StateMachineRegistryTest extends TestCase
 
     private StateMachineRegistry $stateMachineRegistry;
 
+    /**
+     * @var EntityRepository<StateMachineCollection>
+     */
     private EntityRepository $stateMachineRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/System/UsageData/Subscriber/EntityDeleteSubscriberTest.php
+++ b/tests/integration/Core/System/UsageData/Subscriber/EntityDeleteSubscriberTest.php
@@ -4,9 +4,12 @@ namespace Shopware\Tests\Integration\Core\System\UsageData\Subscriber;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -14,6 +17,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\UsageData\Consent\ConsentService;
 use Shopware\Core\System\UsageData\Consent\ConsentState;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\Clock\Test\ClockSensitiveTrait;
@@ -65,7 +69,7 @@ class EntityDeleteSubscriberTest extends TestCase
         $productBuilder = new ProductBuilder($productIds, 'product-to-delete', 1);
         $productBuilder->price(3.14);
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
 
         $productRepository->create([$productBuilder->build()], Context::createDefaultContext());
@@ -101,7 +105,7 @@ class EntityDeleteSubscriberTest extends TestCase
         // non live version should not trigger the subscriber
         $product['versionId'] = Uuid::randomHex();
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
 
         $productRepository->create([$product], Context::createDefaultContext());
@@ -126,7 +130,7 @@ class EntityDeleteSubscriberTest extends TestCase
         $product = $this->insertTestProduct($idsCollection, Uuid::randomHex());
         $category = $this->insertTestCategory($idsCollection, Defaults::LIVE_VERSION);
 
-        /** @var EntityRepository $productCategoryRepository */
+        /** @var EntityRepository<EntityCollection<Entity>> $productCategoryRepository */
         $productCategoryRepository = static::getContainer()->get('product_category.repository');
         $productCategoryRepository->create([
             [
@@ -165,7 +169,7 @@ class EntityDeleteSubscriberTest extends TestCase
             'localeId' => static::getContainer()->get(Connection::class)->fetchOne('SELECT LOWER(HEX(id)) FROM locale LIMIT 1'),
         ];
 
-        /** @var EntityRepository $userRepository */
+        /** @var EntityRepository<UserCollection> $userRepository */
         $userRepository = static::getContainer()->get('user.repository');
         $userRepository->create([$userData], Context::createDefaultContext());
 
@@ -184,7 +188,7 @@ class EntityDeleteSubscriberTest extends TestCase
         $aclRoleRepository = static::getContainer()->get('acl_role.repository');
         $aclRoleRepository->create([$aclRoleData], Context::createDefaultContext());
 
-        /** @var EntityRepository $aclUserRoleRepository */
+        /** @var EntityRepository<EntityCollection<Entity>> $aclUserRoleRepository */
         $aclUserRoleRepository = static::getContainer()->get('acl_user_role.repository');
         $aclUserRoleRepository->create([
             [
@@ -225,7 +229,7 @@ class EntityDeleteSubscriberTest extends TestCase
         $productBuilder = new ProductBuilder($idsCollection, 'product-1', 1);
         $productBuilder->price(3.14);
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
 
         $product = $productBuilder->build();

--- a/tests/integration/Core/System/User/Service/UserValidationServiceTest.php
+++ b/tests/integration/Core/System/User/Service/UserValidationServiceTest.php
@@ -9,7 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Locale\LocaleCollection;
 use Shopware\Core\System\User\Service\UserValidationService;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -20,8 +22,14 @@ class UserValidationServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<UserCollection>
+     */
     private EntityRepository $userRepository;
 
+    /**
+     * @var EntityRepository<LocaleCollection>
+     */
     private EntityRepository $localeRepository;
 
     private UserValidationService $userValidationService;

--- a/tests/unit/Core/System/NumberRange/ValueGenerator/IncrementRedisStorageTest.php
+++ b/tests/unit/Core/System/NumberRange/ValueGenerator/IncrementRedisStorageTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\NumberRange\NumberRangeCollection;
 use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\IncrementStorage\IncrementRedisStorage;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Symfony\Component\Lock\LockFactory;
@@ -31,10 +32,13 @@ class IncrementRedisStorageTest extends TestCase
         $this->lockFactoryMock = $this->createMock(LockFactory::class);
         $this->redisMock = $this->createMock('Redis');
 
+        /** @var StaticEntityRepository<NumberRangeCollection> */
+        $repository = new StaticEntityRepository([]);
+
         $this->storage = new IncrementRedisStorage(
             $this->redisMock,
             $this->lockFactoryMock,
-            new StaticEntityRepository([])
+            $repository,
         );
     }
 
@@ -223,10 +227,13 @@ class IncrementRedisStorageTest extends TestCase
             ->method('get')
             ->willReturnOnConsecutiveCalls('10', '5', false);
 
+        /** @var StaticEntityRepository<NumberRangeCollection> */
+        $repository = new StaticEntityRepository([$idSearchResult]);
+
         $this->storage = new IncrementRedisStorage(
             $this->redisMock,
             $this->lockFactoryMock,
-            new StaticEntityRepository([$idSearchResult])
+            $repository,
         );
 
         static::assertSame(['abc' => 10, 'def' => 5], $this->storage->list());

--- a/tests/unit/Core/System/SalesChannel/Subscriber/SalesChannelAnalyticsLoaderTest.php
+++ b/tests/unit/Core/System/SalesChannel/Subscriber/SalesChannelAnalyticsLoaderTest.php
@@ -23,6 +23,7 @@ class SalesChannelAnalyticsLoaderTest extends TestCase
     public function testSalesChannelDoesNotHaveAnalytics(): void
     {
         $event = $this->getEvent(Generator::generateSalesChannelContext());
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> */
         $repository = new StaticEntityRepository([]);
 
         $loader = new SalesChannelAnalyticsLoader($repository);
@@ -39,6 +40,7 @@ class SalesChannelAnalyticsLoaderTest extends TestCase
         $event = $this->getEvent($salesChannelContext);
         $analytics = new SalesChannelAnalyticsEntity();
         $analytics->setId($analyticsId);
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([$analytics])]);
 
         $loader = new SalesChannelAnalyticsLoader($repository);
@@ -54,6 +56,7 @@ class SalesChannelAnalyticsLoaderTest extends TestCase
         $salesChannelContext = Generator::generateSalesChannelContext();
         $salesChannelContext->getSalesChannel()->setAnalyticsId($analyticsId);
         $event = $this->getEvent($salesChannelContext);
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
 
         $loader = new SalesChannelAnalyticsLoader($repository);

--- a/tests/unit/Core/System/SystemConfig/Service/ConfigurationServiceTest.php
+++ b/tests/unit/Core/System/SystemConfig/Service/ConfigurationServiceTest.php
@@ -280,13 +280,16 @@ class ConfigurationServiceTest extends TestCase
         $configReader = $this->createMock(ConfigReader::class);
         $configReader->method('getConfigFromBundle')->willReturn($config);
 
+        /** @var StaticEntityRepository<AppCollection> */
+        $repository = new StaticEntityRepository([new AppCollection()]);
+
         $service = new ConfigurationService(
             [
                 new SwagExampleTest(true, ''),
             ],
             $configReader,
             $this->createMock(AppConfigReader::class),
-            new StaticEntityRepository([new AppCollection()]),
+            $repository,
             new StaticSystemConfigService(['SwagExampleTest.email' => 'foo'])
         );
 

--- a/tests/unit/Core/System/UsageData/Consent/BannerServiceTest.php
+++ b/tests/unit/Core/System/UsageData/Consent/BannerServiceTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\System\UsageData\Consent;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
@@ -31,6 +32,7 @@ class BannerServiceTest extends TestCase
         $userId = '018a93bbe90570eda0d89c600de7dd19';
         $context = Context::createDefaultContext(new AdminApiSource($userId));
 
+        /** @var StaticEntityRepository<UserConfigCollection> */
         $userConfigRepository = new StaticEntityRepository([
             new UserConfigCollection([]),
         ]);
@@ -55,6 +57,7 @@ class BannerServiceTest extends TestCase
             '_value' => true,
         ]);
 
+        /** @var StaticEntityRepository<UserConfigCollection> */
         $userConfigRepository = new StaticEntityRepository([
             new UserConfigCollection([$userConfig]),
         ]);
@@ -75,6 +78,7 @@ class BannerServiceTest extends TestCase
         $criteria->addFilter(new EqualsFilter('userId', $userId));
         $criteria->addFilter(new EqualsFilter('key', BannerService::USER_CONFIG_KEY_HIDE_CONSENT_BANNER));
 
+        /** @var StaticEntityRepository<UserConfigCollection> */
         $userConfigRepository = new StaticEntityRepository([
             new IdSearchResult(
                 0,
@@ -112,6 +116,7 @@ class BannerServiceTest extends TestCase
         $criteria->addFilter(new EqualsFilter('userId', $userId));
         $criteria->addFilter(new EqualsFilter('key', BannerService::USER_CONFIG_KEY_HIDE_CONSENT_BANNER));
 
+        /** @var StaticEntityRepository<UserConfigCollection> */
         $userConfigRepository = new StaticEntityRepository([
             new IdSearchResult(
                 1,
@@ -147,6 +152,7 @@ class BannerServiceTest extends TestCase
 
         $userConfigCollection = $this->createUserConfigEntities($idsCollection, 10);
 
+        /** @var EntityRepository<UserConfigCollection>&MockObject */
         $userConfigRepository = $this->createMock(EntityRepository::class);
         $userConfigRepository->method('search')
             ->with($criteria, $context)

--- a/tests/unit/Core/System/UsageData/Consent/ConsentServiceTest.php
+++ b/tests/unit/Core/System/UsageData/Consent/ConsentServiceTest.php
@@ -271,11 +271,12 @@ class ConsentServiceTest extends TestCase
 
         $updatedAt = new \DateTimeImmutable('2021-01-01 00:00:00');
         $systemConfigEntity = new SystemConfigEntity();
+        $systemConfigEntity->setId('test-id');
         $systemConfigEntity->setUpdatedAt($updatedAt);
 
         $entitySearchResult = $this->createMock(EntitySearchResult::class);
-        $entitySearchResult->method('first')
-            ->willReturn($systemConfigEntity);
+        $entitySearchResult->method('getEntities')
+            ->willReturn(new SystemConfigCollection([$systemConfigEntity]));
 
         $systemConfigRepository = $this->createMock(EntityRepository::class);
         $systemConfigRepository->method('search')

--- a/tests/unit/Core/System/UsageData/Consent/ConsentServiceTest.php
+++ b/tests/unit/Core/System/UsageData/Consent/ConsentServiceTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SystemConfig\SystemConfigCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigEntity;
 use Shopware\Core\System\UsageData\Consent\ConsentService;
 use Shopware\Core\System\UsageData\Consent\ConsentState;
@@ -33,9 +34,12 @@ class ConsentServiceTest extends TestCase
             ConsentService::SYSTEM_CONFIG_KEY_CONSENT_STATE => ConsentState::ACCEPTED->value,
         ]);
 
+        /** @var StaticEntityRepository<SystemConfigCollection> */
+        $repository = new StaticEntityRepository([]);
+
         $consentService = new ConsentService(
             $systemConfig,
-            new StaticEntityRepository([]),
+            $repository,
             new CollectingEventDispatcher(),
             new MockClock(),
         );
@@ -49,9 +53,12 @@ class ConsentServiceTest extends TestCase
 
     public function testIsApprovalGivenIsFalseIfConfigValueIsNotSet(): void
     {
+        /** @var StaticEntityRepository<SystemConfigCollection> */
+        $repository = new StaticEntityRepository([]);
+
         $consentService = new ConsentService(
             new StaticSystemConfigService(),
-            new StaticEntityRepository([]),
+            $repository,
             new CollectingEventDispatcher(),
             new MockClock(),
         );

--- a/tests/unit/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskHandlerTest.php
+++ b/tests/unit/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskHandlerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\System\UsageData\ScheduledTask\CollectEntityDataTaskHandler;
 use Shopware\Core\System\UsageData\Services\EntityDispatchService;
@@ -24,8 +25,11 @@ class CollectEntityDataTaskHandlerTest extends TestCase
         $entityDispatchService->expects($this->once())
             ->method('dispatchCollectEntityDataMessage');
 
+        /** @var StaticEntityRepository<ScheduledTaskCollection> */
+        $repository = new StaticEntityRepository([], new ScheduledTaskDefinition());
+
         $taskHandler = new CollectEntityDataTaskHandler(
-            new StaticEntityRepository([], new ScheduledTaskDefinition()),
+            $repository,
             $this->createMock(LoggerInterface::class),
             $entityDispatchService
         );

--- a/tests/unit/Core/System/UsageData/Services/EntityDispatchServiceTest.php
+++ b/tests/unit/Core/System/UsageData/Services/EntityDispatchServiceTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
+use Shopware\Core\System\SystemConfig\SystemConfigCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigEntity;
 use Shopware\Core\System\UsageData\Consent\ConsentService;
 use Shopware\Core\System\UsageData\Consent\ConsentState;
@@ -697,13 +698,14 @@ class EntityDispatchServiceTest extends TestCase
     private function createConsentService(bool $isApprovalGiven, ?\DateTimeImmutable $lastConsentDate, \DateTimeImmutable $now = new \DateTimeImmutable()): ConsentService
     {
         $systemConfigEntity = new SystemConfigEntity();
+        $systemConfigEntity->setId('test-id');
         if ($lastConsentDate) {
             $systemConfigEntity->setUpdatedAt($lastConsentDate);
         }
 
         $entitySearchResult = $this->createMock(EntitySearchResult::class);
-        $entitySearchResult->method('first')
-            ->willReturn($systemConfigEntity);
+        $entitySearchResult->method('getEntities')
+            ->willReturn(new SystemConfigCollection([$systemConfigEntity]));
 
         $systemConfigRepository = $this->createMock(EntityRepository::class);
         $systemConfigRepository->method('search')


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently a few EntityRepository types are missing their phpstan type
- As in the past we group this updates to the EntityRepository types by areas to keep the PR size reasonable
- This PR includes core System area

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the EntityRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/11754

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
