### PR TITLE
fix: properly restore content slot overrides and clear module states

### DIFF
--- a/changelog/_unreleased/2025-08-06-fix-cms-content-slot-overrides-for-modules-and-languages.md
+++ b/changelog/_unreleased/2025-08-06-fix-cms-content-slot-overrides-for-modules-and-languages.md
@@ -5,5 +5,5 @@ author_email: b.schulze-baek@shopware.com
 author_github: @bschulzebaek
 ---
 # Administration
-* CMS slot config overrides are now correctly applied on individual pages (Category layout, Product layout) and for non-default language configurations.
+* Changed CMS slot config to now correctly apply config overrides on individual pages (Category, Landing, Product) and languages.
 * Deprecated method `resetCmsPageState` in `module/sw-cms/page/sw-cms-detail/index.js`. Use `resetRelatedStores` instead.

--- a/changelog/_unreleased/2025-08-06-fix-cms-content-slot-overrides-for-modules-and-languages.md
+++ b/changelog/_unreleased/2025-08-06-fix-cms-content-slot-overrides-for-modules-and-languages.md
@@ -1,0 +1,9 @@
+---
+title: Fix CMS content slot overrides for modules and languages
+author: Benedikt Schulze Baek
+author_email: b.schulze-baek@shopware.com
+author_github: @bschulzebaek
+---
+# Administration
+* CMS slot config overrides are now correctly applied on individual pages (Category layout, Product layout) and for non-default language configurations.
+* Deprecated method `resetCmsPageState` in `module/sw-cms/page/sw-cms-detail/index.js`. Use `resetRelatedStores` instead.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/component/index.js
@@ -143,13 +143,13 @@ export default {
 
                 return [
                     {
-                        url: this.assetFilter(`administration/static/img/cms/${previewMountain}`),
+                        url: this.assetFilter(`administration/administration/static/img/cms/${previewMountain}`),
                     },
                     {
-                        url: this.assetFilter(`administration/static/img/cms/${previewGlasses}`),
+                        url: this.assetFilter(`administration/administration/static/img/cms/${previewGlasses}`),
                     },
                     {
-                        url: this.assetFilter(`administration/static/img/cms/${previewPlant}`),
+                        url: this.assetFilter(`administration/administration/static/img/cms/${previewPlant}`),
                     },
                 ];
             }
@@ -158,7 +158,7 @@ export default {
                 const fileName = media.fileName.slice(media.fileName.lastIndexOf('/') + 1);
 
                 return {
-                    url: this.assetFilter(`/administration/static/img/cms/${fileName}`),
+                    url: this.assetFilter(`/administration/administration/static/img/cms/${fileName}`),
                 };
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-name/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-name/component/component.spec.js
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
+import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
 
 async function createWrapper(propsOverride) {
     return mount(
@@ -14,7 +15,7 @@ async function createWrapper(propsOverride) {
                     config: {
                         content: {
                             source: 'static',
-                            value: null,
+                            value: '',
                         },
                         verticalAlign: {
                             source: 'static',
@@ -42,9 +43,7 @@ async function createWrapper(propsOverride) {
 
 describe('module/sw-cms/elements/product-name/component', () => {
     beforeAll(async () => {
-        await import('src/module/sw-cms/store/cms-page.store');
-        await import('src/module/sw-cms/service/cms.service');
-        await import('src/module/sw-cms/mixin/sw-cms-element.mixin');
+        await setupCmsEnvironment();
     });
 
     afterEach(() => {
@@ -62,6 +61,9 @@ describe('module/sw-cms/elements/product-name/component', () => {
     });
 
     it('should not initially map to a product name if element translated config exists', async () => {
+        Shopware.Store.get('cmsPage').setCurrentPage({
+            type: 'product_detail',
+        });
         const wrapper = await createWrapper({
             element: {
                 config: {
@@ -69,16 +71,16 @@ describe('module/sw-cms/elements/product-name/component', () => {
                         source: 'static',
                         value: 'Sample Product',
                     },
-                    verticalAlign: {
-                        source: 'static',
-                        value: null,
-                    },
                 },
                 translated: {
                     config: {
                         content: {
                             source: 'static',
                             value: 'Sample Product',
+                        },
+                        verticalAlign: {
+                            source: 'static',
+                            value: null,
                         },
                     },
                 },
@@ -121,6 +123,7 @@ describe('module/sw-cms/elements/product-name/component', () => {
                 },
             },
         });
+
 
         await wrapper.setData({
             cmsPageState: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-name/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-name/component/component.spec.js
@@ -124,7 +124,6 @@ describe('module/sw-cms/elements/product-name/component', () => {
             },
         });
 
-
         await wrapper.setData({
             cmsPageState: {
                 currentDemoEntity: null,

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
@@ -15,7 +15,7 @@ const defaultElement = {
 /**
  * Using a real component for testing
  */
-async function createWrapper(element = defaultElement, routeMeta = {}) {
+async function createWrapper(element = defaultElement, routeName = '') {
     return mount(await wrapTestComponent('sw-cms-el-text', { sync: true }), {
         props: {
             element,
@@ -29,7 +29,7 @@ async function createWrapper(element = defaultElement, routeMeta = {}) {
             },
             mocks: {
                 $route: {
-                    meta: routeMeta,
+                    name: routeName,
                 },
             },
         },
@@ -87,11 +87,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
             overrideFromCategory: 'bar',
         };
 
-        const wrapper = await createWrapper(defaultElement, {
-            $module: {
-                entity: 'category',
-            },
-        });
+        const wrapper = await createWrapper(defaultElement, 'sw.category.detail');
         wrapper.vm.initElementConfig('text');
 
         expect(wrapper.vm.element.config).toEqual(expectedElementConfig);
@@ -178,11 +174,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
     });
 
     it('should return correct moduleEntity based on route meta', async () => {
-        const wrapper = await createWrapper(defaultElement, {
-            $module: {
-                entity: 'category',
-            },
-        });
+        const wrapper = await createWrapper(defaultElement, 'sw.category.detail');
         const mockCategory = {
             id: 'category-1',
             name: 'Test Category',
@@ -218,7 +210,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
     });
 
     it('should return configOverride from entity slot config', async () => {
-        const wrapper = await createWrapper();
+        const wrapper = await createWrapper(defaultElement, 'sw.category.detail');
         Shopware.Store.get('swCategoryDetail').category = {
             id: 'category-1',
             translated: {
@@ -226,14 +218,6 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
                     [defaultElement.id]: {
                         content: 'override content',
                     },
-                },
-            },
-        };
-
-        wrapper.vm.$route = {
-            meta: {
-                $module: {
-                    entity: 'category',
                 },
             },
         };
@@ -255,7 +239,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
     });
 
     it('should return slot config from entity translated data', async () => {
-        const wrapper = await createWrapper();
+        const wrapper = await createWrapper(defaultElement, 'sw.category.detail');
         Shopware.Store.get('swCategoryDetail').category = {
             id: 'category-1',
             translated: {
@@ -267,21 +251,13 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
             },
         };
 
-        wrapper.vm.$route = {
-            meta: {
-                $module: {
-                    entity: 'category',
-                },
-            },
-        };
-
         const slotConfig = wrapper.vm.getEntitySlotConfig();
 
         expect(slotConfig.content).toBe('entity content');
     });
 
     it('should fall back to default translations when no translated config found', async () => {
-        const wrapper = await createWrapper();
+        const wrapper = await createWrapper(defaultElement, 'sw.category.detail');
 
         Shopware.Store.get('swCategoryDetail').category = {
             id: 'category-1',
@@ -295,14 +271,6 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
                     },
                 },
             ],
-        };
-
-        wrapper.vm.$route = {
-            meta: {
-                $module: {
-                    entity: 'category',
-                },
-            },
         };
 
         const slotConfig = wrapper.vm.getEntitySlotConfig();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
@@ -15,7 +15,7 @@ const defaultElement = {
 /**
  * Using a real component for testing
  */
-async function createWrapper(element = defaultElement) {
+async function createWrapper(element = defaultElement, routeMeta = {}) {
     return mount(await wrapTestComponent('sw-cms-el-text', { sync: true }), {
         props: {
             element,
@@ -27,6 +27,11 @@ async function createWrapper(element = defaultElement) {
             stubs: {
                 'sw-text-editor': true,
             },
+            mocks: {
+                $route: {
+                    meta: routeMeta,
+                },
+            },
         },
     });
 }
@@ -35,10 +40,18 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
     beforeAll(async () => {
         await setupCmsEnvironment();
         await import('src/module/sw-cms/elements/text');
+
+        Shopware.Store.register({
+            id: 'swProductDetail',
+            state: () => ({
+                product: null,
+            }),
+        });
     });
 
     beforeEach(() => {
         Shopware.Store.get('swCategoryDetail').$reset();
+        Shopware.Store.get('swProductDetail').$reset();
     });
 
     afterEach(() => {
@@ -53,7 +66,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
                     languageId: Shopware.Context.api.systemLanguageId,
                     name: 'Category name B',
                     slotConfig: {
-                        'sw-cms-el-text-1234': {
+                        [defaultElement.id]: {
                             overrideFromCategory: 'bar',
                         },
                     },
@@ -71,11 +84,14 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
                 source: 'static',
                 value: null,
             },
-            overrideFromProp: 'foo',
             overrideFromCategory: 'bar',
         };
 
-        const wrapper = await createWrapper();
+        const wrapper = await createWrapper(defaultElement, {
+            $module: {
+                entity: 'category',
+            },
+        });
         wrapper.vm.initElementConfig('text');
 
         expect(wrapper.vm.element.config).toEqual(expectedElementConfig);
@@ -129,5 +145,168 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
         };
 
         expect(wrapper.vm.getDemoValue('category.translations')).toMatchObject(store.currentDemoEntity.translations);
+    });
+
+    it('should return category from store when available', async () => {
+        const wrapper = await createWrapper();
+        const mockCategory = {
+            id: 'category-1',
+            name: 'Test Category',
+            translations: [],
+        };
+
+        expect(wrapper.vm.category).toBeNull();
+
+        Shopware.Store.get('swCategoryDetail').category = mockCategory;
+
+        expect(wrapper.vm.category).toMatchObject(mockCategory);
+    });
+
+    it('should return product from store when available', async () => {
+        const wrapper = await createWrapper();
+        const mockProduct = {
+            id: 'product-1',
+            name: 'Test Product',
+            translations: [],
+        };
+
+        expect(wrapper.vm.product).toBeNull();
+
+        Shopware.Store.get('swProductDetail').product = mockProduct;
+
+        expect(wrapper.vm.product).toMatchObject(mockProduct);
+    });
+
+    it('should return correct moduleEntity based on route meta', async () => {
+        const wrapper = await createWrapper(defaultElement, {
+            $module: {
+                entity: 'category',
+            },
+        });
+        const mockCategory = {
+            id: 'category-1',
+            name: 'Test Category',
+            translations: [],
+        };
+
+        Shopware.Store.get('swCategoryDetail').category = mockCategory;
+        expect(wrapper.vm.moduleEntity).toMatchObject(mockCategory);
+    });
+
+    it('should return null when no module entity is defined', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.$route = {
+            meta: {},
+        };
+
+        expect(wrapper.vm.moduleEntity).toBeNull();
+    });
+
+    it('should return null for unknown module entity', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.$route = {
+            meta: {
+                $module: {
+                    entity: 'foo-bar',
+                },
+            },
+        };
+
+        expect(wrapper.vm.moduleEntity).toBeNull();
+    });
+
+    it('should return configOverride from entity slot config', async () => {
+        const wrapper = await createWrapper();
+        Shopware.Store.get('swCategoryDetail').category = {
+            id: 'category-1',
+            translated: {
+                slotConfig: {
+                    [defaultElement.id]: {
+                        content: 'override content',
+                    },
+                },
+            },
+        };
+
+        wrapper.vm.$route = {
+            meta: {
+                $module: {
+                    entity: 'category',
+                },
+            },
+        };
+
+        expect(wrapper.vm.configOverride.content).toBe('override content');
+    });
+
+    it('should fall back to element translated config when no entity config found', async () => {
+        const wrapper = await createWrapper({
+            ...defaultElement,
+            translated: {
+                config: {
+                    content: 'translated content',
+                },
+            },
+        });
+
+        expect(wrapper.vm.configOverride.content).toBe('translated content');
+    });
+
+    it('should return slot config from entity translated data', async () => {
+        const wrapper = await createWrapper();
+        Shopware.Store.get('swCategoryDetail').category = {
+            id: 'category-1',
+            translated: {
+                slotConfig: {
+                    [defaultElement.id]: {
+                        content: 'entity content',
+                    },
+                },
+            },
+        };
+
+        wrapper.vm.$route = {
+            meta: {
+                $module: {
+                    entity: 'category',
+                },
+            },
+        };
+
+        const slotConfig = wrapper.vm.getEntitySlotConfig();
+
+        expect(slotConfig.content).toBe('entity content');
+    });
+
+    it('should fall back to default translations when no translated config found', async () => {
+        const wrapper = await createWrapper();
+
+        Shopware.Store.get('swCategoryDetail').category = {
+            id: 'category-1',
+            translations: [
+                {
+                    languageId: Shopware.Context.api.systemLanguageId,
+                    slotConfig: {
+                        [defaultElement.id]: {
+                            content: 'default content',
+                        },
+                    },
+                },
+            ],
+        };
+
+        wrapper.vm.$route = {
+            meta: {
+                $module: {
+                    entity: 'category',
+                },
+            },
+        };
+
+        const slotConfig = wrapper.vm.getEntitySlotConfig();
+
+        expect(slotConfig.content).toBe('default content');
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -3,6 +3,7 @@ import { type EnrichedSlotData, type RuntimeSlot, type CmsSlotConfig } from '../
 
 const { Mixin } = Shopware;
 const { types } = Shopware.Utils;
+const { isEmpty } = types;
 const { cloneDeep, merge } = Shopware.Utils.object;
 
 interface Translation {
@@ -108,7 +109,7 @@ export default Mixin.register(
 
                 const translatedConfig = this.element?.translated?.config;
 
-                if (translatedConfig && !Array.isArray(translatedConfig)) {
+                if (translatedConfig && !isEmpty(translatedConfig)) {
                     return translatedConfig as EnrichedSlotData;
                 }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -1,6 +1,5 @@
 import { defineComponent } from 'vue';
-import { type RuntimeSlot } from '../service/cms.service';
-import '../../sw-category/page/sw-category-detail/store';
+import { type EnrichedSlotData, type RuntimeSlot, type CmsSlotConfig } from '../service/cms.service';
 
 const { Mixin } = Shopware;
 const { types } = Shopware.Utils;
@@ -9,8 +8,16 @@ const { cloneDeep, merge } = Shopware.Utils.object;
 interface Translation {
     languageId: string;
 }
+
+interface TranslationWithSlotConfig extends Translation {
+    slotConfig?: {
+        [slotId: string]: CmsSlotConfig;
+    };
+}
+
 interface Entity {
     translations: Translation[];
+    translated?: TranslationWithSlotConfig;
 }
 
 /**
@@ -50,33 +57,44 @@ export default Mixin.register(
                 return this.cmsService.getCmsElementRegistry();
             },
 
-            category(): EntitySchema.Entities['category'] {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                return Shopware.Store.get('swCategoryDetail')?.category as EntitySchema.Entities['category'];
+            category(): Entity | null {
+                try {
+                    return Shopware.Store.get('swCategoryDetail')?.category as Entity;
+                } catch {
+                    return null;
+                }
+            },
+
+            product(): Entity | null {
+                try {
+                    return Shopware.Store.get('swProductDetail')?.product as Entity;
+                } catch {
+                    return null;
+                }
+            },
+
+            configOverride(): EnrichedSlotData {
+                return (
+                    this.getEntitySlotConfig() ??
+                    this.element?.translated?.config ??
+                    this.element?.config ??
+                    {}
+                ) as EnrichedSlotData;
             },
         },
 
         methods: {
             initElementConfig(elementName: string) {
                 let defaultConfig = this.defaultConfig;
+
                 if (!defaultConfig) {
                     const elementConfig = this.cmsElements[elementName];
                     defaultConfig = elementConfig?.defaultConfig || {};
                 }
 
-                let fallbackCategoryConfig = {};
-                if (this.category?.translations) {
-                    // @ts-expect-error
-                    // eslint-disable-next-line max-len
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-                    fallbackCategoryConfig = this.getDefaultTranslations(this.category)?.slotConfig?.[this.element.id];
-                }
-
                 this.element.config = merge(
                     cloneDeep(defaultConfig),
-                    this.element?.translated?.config || {},
-                    fallbackCategoryConfig || {},
-                    this.element?.config || {},
+                    this.configOverride,
                 );
             },
 
@@ -94,8 +112,23 @@ export default Mixin.register(
                 return this.cmsService.getPropertyByMappingPath(this.cmsPageState.currentDemoEntity, mappingPath);
             },
 
+            getEntitySlotConfig() {
+                const entity = this.category ?? this.product;
+
+                if (!entity) {
+                    return null;
+                }
+
+                const translation = (
+                    entity.translated ??
+                    this.getDefaultTranslations(entity)
+                ) as TranslationWithSlotConfig;
+
+                return translation?.slotConfig?.[this.element.id] ?? null;
+            },
+
             getDefaultTranslations(entity: Entity) {
-                return entity.translations.find((translation) => {
+                return entity.translations?.find((translation) => {
                     return translation.languageId === Shopware.Context.api.systemLanguageId;
                 });
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -20,10 +20,6 @@ interface Entity {
     translated?: TranslationWithSlotConfig;
 }
 
-interface ModuleDefinition {
-    entity?: string;
-}
-
 /**
  * @private
  * @sw-package discovery
@@ -116,7 +112,7 @@ export default Mixin.register(
                     return translatedConfig as EnrichedSlotData;
                 }
 
-                return this.element?.config ?? {} as EnrichedSlotData;
+                return (this.element?.config ?? {}) as unknown as EnrichedSlotData;
             },
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -77,30 +77,46 @@ export default Mixin.register(
                 }
             },
 
-            moduleEntity() {
-                const moduleEntity = (this.$route.meta?.$module as ModuleDefinition)?.entity;
-
-                if (!moduleEntity) {
+            landingPage() {
+                try {
+                    return Shopware.Store.get('swCategoryDetail')?.landingPage as Entity;
+                } catch {
                     return null;
-                }
-
-                switch (moduleEntity) {
-                    case 'category':
-                        return this.category;
-                    case 'product':
-                        return this.product;
-                    default:
-                        return null;
                 }
             },
 
+            moduleEntity() {
+                const name = this.$route.name?.toString() || '';
+
+                if (name.startsWith('sw.category.landingPageDetail')) {
+                    return this.landingPage;
+                }
+
+                if (name.startsWith('sw.category.')) {
+                    return this.category;
+                }
+
+                if (name.startsWith('sw.product.')) {
+                    return this.product;
+                }
+
+                return null;
+            },
+
             configOverride(): EnrichedSlotData {
-                return (
-                    this.getEntitySlotConfig() ??
-                    this.element?.translated?.config ??
-                    this.element?.config ??
-                    {}
-                ) as EnrichedSlotData;
+                const entitySlotConfig = this.getEntitySlotConfig();
+
+                if (entitySlotConfig) {
+                    return entitySlotConfig as unknown as EnrichedSlotData;
+                }
+
+                const translatedConfig = this.element?.translated?.config;
+
+                if (translatedConfig && !Array.isArray(translatedConfig)) {
+                    return translatedConfig as EnrichedSlotData;
+                }
+
+                return this.element?.config ?? {} as EnrichedSlotData;
             },
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -20,6 +20,10 @@ interface Entity {
     translated?: TranslationWithSlotConfig;
 }
 
+interface ModuleDefinition {
+    entity?: string;
+}
+
 /**
  * @private
  * @sw-package discovery
@@ -73,6 +77,23 @@ export default Mixin.register(
                 }
             },
 
+            moduleEntity() {
+                const moduleEntity = (this.$route.meta?.$module as ModuleDefinition)?.entity;
+
+                if (!moduleEntity) {
+                    return null;
+                }
+
+                switch (moduleEntity) {
+                    case 'category':
+                        return this.category;
+                    case 'product':
+                        return this.product;
+                    default:
+                        return null;
+                }
+            },
+
             configOverride(): EnrichedSlotData {
                 return (
                     this.getEntitySlotConfig() ??
@@ -85,16 +106,11 @@ export default Mixin.register(
 
         methods: {
             initElementConfig(elementName: string) {
-                let defaultConfig = this.defaultConfig;
-
-                if (!defaultConfig) {
-                    const elementConfig = this.cmsElements[elementName];
-                    defaultConfig = elementConfig?.defaultConfig || {};
-                }
+                const defaultConfig = this.defaultConfig || this.cmsElements[elementName]?.defaultConfig || {};
 
                 this.element.config = merge(
                     cloneDeep(defaultConfig),
-                    this.configOverride,
+                    cloneDeep(this.configOverride),
                 );
             },
 
@@ -113,7 +129,7 @@ export default Mixin.register(
             },
 
             getEntitySlotConfig() {
-                const entity = this.category ?? this.product;
+                const entity = this.moduleEntity;
 
                 if (!entity) {
                     return null;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -121,10 +121,7 @@ export default Mixin.register(
             initElementConfig(elementName: string) {
                 const defaultConfig = this.defaultConfig || this.cmsElements[elementName]?.defaultConfig || {};
 
-                this.element.config = merge(
-                    cloneDeep(defaultConfig),
-                    cloneDeep(this.configOverride),
-                );
+                this.element.config = merge(cloneDeep(defaultConfig), cloneDeep(this.configOverride));
             },
 
             initElementData(elementName: string) {
@@ -148,10 +145,7 @@ export default Mixin.register(
                     return null;
                 }
 
-                const translation = (
-                    entity.translated ??
-                    this.getDefaultTranslations(entity)
-                ) as TranslationWithSlotConfig;
+                const translation = (entity.translated ?? this.getDefaultTranslations(entity)) as TranslationWithSlotConfig;
 
                 return translation?.slotConfig?.[this.element.id] ?? null;
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/index.js
@@ -46,7 +46,7 @@ export default {
             const isSystemDefaultLanguage = Shopware.Store.get('context').isSystemDefaultLanguage;
             if (!isSystemDefaultLanguage) {
                 Shopware.Store.get('context').resetLanguageToDefault();
-                this.$store.commit('cmsPageState/setIsSystemDefaultLanguage', isSystemDefaultLanguage);
+                Shopware.Store.get('cmsPage').setIsSystemDefaultLanguage(isSystemDefaultLanguage);
             }
 
             this.page = this.pageRepository.create();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/index.js
@@ -41,6 +41,7 @@ export default {
     methods: {
         createdComponent() {
             Shopware.Store.get('adminMenu').collapseSidebar();
+            this.resetRelatedStores();
 
             const isSystemDefaultLanguage = Shopware.Store.get('context').isSystemDefaultLanguage;
             if (!isSystemDefaultLanguage) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/sw-cms-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/sw-cms-create.spec.js
@@ -217,4 +217,13 @@ describe('module/sw-cms/page/sw-cms-create', () => {
             message: 'sw-cms.create.notification.assignToEntityError',
         });
     });
+
+    it('should call resetRelatedStores in createdComponent', async () => {
+        const wrapper = await createWrapper();
+        const resetSpy = jest.spyOn(wrapper.vm, 'resetRelatedStores');
+
+        await wrapper.vm.createdComponent();
+
+        expect(resetSpy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -320,11 +320,10 @@ export default {
                 scope: this,
             });
             Shopware.Store.get('adminMenu').collapseSidebar();
+            this.resetRelatedStores();
 
             const isSystemDefaultLanguage = Shopware.Store.get('context').isSystemDefaultLanguage;
             this.cmsPageState.setIsSystemDefaultLanguage(isSystemDefaultLanguage);
-
-            this.resetCmsPageState();
 
             if (this.$route.params.id) {
                 this.pageId = this.$route.params.id.toLowerCase();
@@ -351,12 +350,19 @@ export default {
             this.setPageContext();
         },
 
+        beforeDestroyedComponent() {
+            this.resetRelatedStores();
+        },
+
         setPageContext() {
             this.getDefaultFolderId().then((folderId) => {
                 this.cmsPageState.setDefaultMediaFolderId(folderId);
             });
         },
 
+        /**
+         * @deprecated: v6.8.0 - Replaced by "resetRelatedStores" method
+         */
         resetCmsPageState() {
             this.cmsPageState.resetCmsPageState();
         },
@@ -376,12 +382,6 @@ export default {
             });
         },
 
-        beforeDestroyedComponent() {
-            const store = this.cmsPageState;
-            store.removeCurrentPage();
-            store.removeSelectedBlock();
-            store.removeSelectedSection();
-        },
 
         loadPage(pageId) {
             this.isLoading = true;
@@ -1163,6 +1163,18 @@ export default {
             } else {
                 await this.$router.push({ name: 'sw.cms.index' });
             }
+        },
+
+        resetRelatedStores() {
+            const stores = ['cmsPage', 'swCategoryDetail', 'swProductDetail'];
+
+            stores.forEach((name) => {
+                try {
+                    Shopware.Store.get(name).$reset();
+                } catch {
+                    // Not all stores are always registered. We can safely ignore errors here.
+                }
+            });
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -395,7 +395,7 @@ export default {
                 }
 
                 await this.hydratePage();
-            } catch(exception) {
+            } catch (exception) {
                 this.createNotificationError({
                     title: exception.message,
                     message: exception.response.statusText,
@@ -422,7 +422,7 @@ export default {
                     path: 'page',
                     scope: this,
                 });
-            } catch(exception) {
+            } catch (exception) {
                 this.createNotificationError({
                     title: exception.message,
                     message: exception.response,
@@ -1209,7 +1209,11 @@ export default {
         },
 
         resetRelatedStores() {
-            const stores = ['cmsPage', 'swCategoryDetail', 'swProductDetail'];
+            const stores = [
+                'cmsPage',
+                'swCategoryDetail',
+                'swProductDetail',
+            ];
 
             stores.forEach((name) => {
                 try {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -362,7 +362,7 @@ export default {
         },
 
         /**
-         * @deprecated: v6.8.0 - Replaced by "resetRelatedStores" method
+         * @deprecated: tag:v6.8.0 - Replaced by "resetRelatedStores" method
          */
         resetCmsPageState() {
             this.cmsPageState.resetCmsPageState();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -7,6 +7,7 @@ const { mapPropertyErrors } = Component.getComponentHelper();
 const { ShopwareError } = Shopware.Classes;
 const { debounce } = Shopware.Utils;
 const { cloneDeep, getObjectDiff } = Shopware.Utils.object;
+const { isEmpty } = Shopware.Utils.types;
 const { warn } = Shopware.Utils.debug;
 const { Criteria } = Shopware.Data;
 const debounceTimeout = 800;
@@ -382,7 +383,6 @@ export default {
             });
         },
 
-
         loadPage(pageId) {
             this.isLoading = true;
 
@@ -505,7 +505,40 @@ export default {
         },
 
         abortOnLanguageChange() {
-            return Object.keys(getObjectDiff(this.page, this.pageOrigin)).length > 0;
+            return this.hasUnsavedChanges();
+        },
+
+        hasUnsavedChanges() {
+            if (this.page._isDirty) {
+                return true;
+            }
+
+            for (let i = 0; i < this.page.sections.length; i += 1) {
+                const section = this.page.sections[i];
+
+                if (section._isDirty) {
+                    return true;
+                }
+
+                for (let j = 0; j < section.blocks.length; j += 1) {
+                    const block = section.blocks[j];
+
+                    if (block._isDirty) {
+                        return true;
+                    }
+
+                    for (let k = 0; k < block.slots.length; k += 1) {
+                        const slot = block.slots[k];
+                        const originSlot = this.pageOrigin.sections.get(section.id).blocks.get(block.id).slots.get(slot.id);
+
+                        if (slot._isDirty || !isEmpty(getObjectDiff(originSlot, slot))) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         },
 
         saveOnLanguageChange() {
@@ -904,6 +937,7 @@ export default {
         updateSectionAndBlockPositions() {
             this.page.sections.forEach((section, index) => {
                 section.position = index;
+
                 this.updateBlockPositions(section);
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -383,71 +383,72 @@ export default {
             });
         },
 
-        loadPage(pageId) {
+        async loadPage(pageId) {
             this.isLoading = true;
 
-            return this.pageRepository
-                .get(pageId, Shopware.Context.api, this.loadPageCriteria)
-                .then((page) => {
-                    this.page = { sections: [] };
-                    this.page = page;
+            try {
+                this.page = await this.pageRepository.get(pageId, Shopware.Context.api, this.loadPageCriteria);
+                this.cmsPageState.setCurrentPageType(this.page.type);
 
-                    this.cmsPageState.setCurrentPageType(page.type);
+                if (this.acl.can('system_config:read')) {
+                    await this.setDefaultLayout();
+                }
 
-                    if (this.acl.can('system_config:read')) {
-                        this.setDefaultLayout();
-                    }
-
-                    this.cmsDataResolverService
-                        .resolve(this.page)
-                        .then(() => {
-                            this.updateSectionAndBlockPositions();
-                            this.cmsPageState.setCurrentPage(this.page);
-
-                            this.updateDataMapping();
-                            this.pageOrigin = cloneDeep(this.page);
-
-                            if (this.selectedBlock) {
-                                const blockId = this.selectedBlock.id;
-                                const blockSectionId = this.selectedBlock.sectionId;
-                                this.page.sections.forEach((section) => {
-                                    if (section.id === blockSectionId) {
-                                        section.blocks.forEach((block) => {
-                                            if (block.id === blockId) {
-                                                this.setSelectedBlock(blockSectionId, block);
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-
-                            Shopware.ExtensionAPI.publishData({
-                                id: 'sw-cms-detail__page',
-                                path: 'page',
-                                scope: this,
-                            });
-
-                            this.isLoading = false;
-                        })
-                        .catch((exception) => {
-                            this.isLoading = false;
-                            this.createNotificationError({
-                                title: exception.message,
-                                message: exception.response,
-                            });
-
-                            warn(this._name, exception.message, exception.response);
-                        });
-                })
-                .catch((exception) => {
-                    this.isLoading = false;
-                    this.createNotificationError({
-                        title: exception.message,
-                        message: exception.response.statusText,
-                    });
-
-                    warn(this._name, exception.message, exception.response);
+                await this.hydratePage();
+            } catch(exception) {
+                this.createNotificationError({
+                    title: exception.message,
+                    message: exception.response.statusText,
                 });
+
+                warn(this._name, exception.message, exception.response);
+            } finally {
+                this.cmsPageState.setCurrentPage(this.page);
+                this.pageOrigin = cloneDeep(this.page);
+                this.restoreActiveBlock();
+                this.isLoading = false;
+            }
+        },
+
+        async hydratePage() {
+            try {
+                await this.cmsDataResolverService.resolve(this.page);
+
+                this.updateSectionAndBlockPositions();
+                this.updateDataMapping();
+
+                Shopware.ExtensionAPI.publishData({
+                    id: 'sw-cms-detail__page',
+                    path: 'page',
+                    scope: this,
+                });
+            } catch(exception) {
+                this.createNotificationError({
+                    title: exception.message,
+                    message: exception.response,
+                });
+
+                warn(this._name, exception.message, exception.response);
+            }
+        },
+
+        restoreActiveBlock() {
+            if (!this.selectedBlock) {
+                return;
+            }
+
+            const blockId = this.selectedBlock.id;
+            const blockSectionId = this.selectedBlock.sectionId;
+
+            this.page.sections.forEach((section) => {
+                if (section.id === blockSectionId) {
+                    section.blocks.forEach((block) => {
+                        if (block.id === blockId) {
+                            this.setSelectedBlock(blockSectionId, block);
+                        }
+                    });
+                }
+            });
         },
 
         updateDataMapping() {
@@ -508,6 +509,13 @@ export default {
             return this.hasUnsavedChanges();
         },
 
+        /**
+         * This check is not perfect, since some components (like sw-cms-section) change values at runtime,
+         * which should not be considered as unsaved changes.
+         *
+         * Further improvement should focus on removing these runtime changes,
+         * so a single "getObjectDiff" on the page is sufficient.
+         */
         hasUnsavedChanges() {
             if (this.page._isDirty) {
                 return true;
@@ -530,8 +538,9 @@ export default {
                     for (let k = 0; k < block.slots.length; k += 1) {
                         const slot = block.slots[k];
                         const originSlot = this.pageOrigin.sections.get(section.id).blocks.get(block.id).slots.get(slot.id);
+                        const slotDiff = getObjectDiff(originSlot, slot);
 
-                        if (slot._isDirty || !isEmpty(getObjectDiff(originSlot, slot))) {
+                        if (slot._isDirty || !isEmpty(slotDiff)) {
                             return true;
                         }
                     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
@@ -563,4 +563,11 @@ Application.addServiceProvider('cmsService', () => new CmsService());
  * @private
  * @sw-package discovery
  */
-export { CmsService, type CmsElementConfig, type CmsBlockConfig, type CmsSlotConfig, type RuntimeSlot };
+export {
+    CmsService,
+    type CmsElementConfig,
+    type CmsBlockConfig,
+    type CmsSlotConfig,
+    type RuntimeSlot,
+    type EnrichedSlotData
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
@@ -569,5 +569,5 @@ export {
     type CmsBlockConfig,
     type CmsSlotConfig,
     type RuntimeSlot,
-    type EnrichedSlotData
+    type EnrichedSlotData,
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
@@ -52,8 +52,14 @@ async function resolve(page) {
                 if (Object.keys(slotData).length > 0) {
                     slotEntityList[slot.id] = slotData;
                 }
+
+                slot._isDirty = false;
             });
+
+            block._isDirty = false;
         });
+
+        section._isDirty = false;
     });
 
     const { directReads, searches } = optimizeCriteriaObjects(slotEntityList);
@@ -120,6 +126,8 @@ function initVisibility(element) {
 
         element.visibility[key] = true;
     });
+
+
 }
 
 /**

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
@@ -126,8 +126,6 @@ function initVisibility(element) {
 
         element.visibility[key] = true;
     });
-
-
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
CMS slot configs are not initialized properly in the admin, meaning that in many cases a "config override" on product or category default pages would be overriden by the config created in the default language, or by the shared config created in the cms module. 

### 2. What does this change do, exactly?
Properly merge CMS slot configs from different sources, correctly load configs from translations.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- #6948 
- #10898 
- #10537 
- #8696
- #7826
- #7023
- #6948
- #6248

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
