### PR TITLE
feat: Implement app user change

### DIFF
--- a/changelog/_unreleased/2025-08-06-add-app-user-id-header.md
+++ b/changelog/_unreleased/2025-08-06-add-app-user-id-header.md
@@ -1,0 +1,10 @@
+---
+title: Add app user ID header and fix domain exception patterns
+issue: #11608
+
+author_email: s.vorgers@shopware.com
+author_github: SimonVorgers
+---
+# API
+* Added `\Shopware\Core\PlatformRequest::HEADER_APP_USER_ID`
+* Added new app user ID header support in `\Shopware\Core\Framework\Routing\ApiRequestContextResolver` for API requests from apps to run in the context of the app user

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1941,12 +1941,6 @@ parameters:
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
-			count: 2
-			path: src/Core/Framework/Routing/ApiRequestContextResolver.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Routing/RouteScopeListener.php
 

--- a/src/Core/Framework/Routing/RoutingException.php
+++ b/src/Core/Framework/Routing/RoutingException.php
@@ -18,6 +18,8 @@ class RoutingException extends HttpException
 
     public const CUSTOMER_NOT_LOGGED_IN_CODE = 'FRAMEWORK__ROUTING_CUSTOMER_NOT_LOGGED_IN';
     public const ACCESS_DENIED_FOR_XML_HTTP_REQUEST = 'FRAMEWORK__ACCESS_DENIED_FOR_XML_HTTP_REQUEST';
+    public const CURRENCY_NOT_FOUND = 'FRAMEWORK__ROUTING_CURRENCY_NOT_FOUND';
+    public const MISSING_PRIVILEGE = 'FRAMEWORK__ROUTING_MISSING_PRIVILEGE';
 
     public static function invalidRequestParameter(string $name): self
     {
@@ -80,6 +82,33 @@ class RoutingException extends HttpException
             self::ACCESS_DENIED_FOR_XML_HTTP_REQUEST,
             $message,
             ['route' => $route, 'url' => $url, 'referer' => $referer]
+        );
+    }
+
+    public static function currencyNotFound(string $currencyId): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::CURRENCY_NOT_FOUND,
+            'Currency with id "{{ currencyId }}" not found.',
+            ['currencyId' => $currencyId]
+        );
+    }
+
+    /**
+     * @param string[] $privileges
+     */
+    public static function missingPrivileges(array $privileges): self
+    {
+        $errorMessage = json_encode([
+            'message' => 'Missing privilege',
+            'missingPrivileges' => $privileges,
+        ], \JSON_THROW_ON_ERROR);
+
+        return new self(
+            Response::HTTP_FORBIDDEN,
+            self::MISSING_PRIVILEGE,
+            $errorMessage ?: ''
         );
     }
 }

--- a/src/Core/PlatformRequest.php
+++ b/src/Core/PlatformRequest.php
@@ -25,7 +25,7 @@ final class PlatformRequest
     public const HEADER_INCLUDE_SEO_URLS = 'sw-include-seo-urls';
     public const HEADER_SKIP_TRIGGER_FLOW = 'sw-skip-trigger-flow';
     public const HEADER_APP_INTEGRATION_ID = 'sw-app-integration-id';
-
+    public const HEADER_APP_USER_ID = 'sw-app-user-id';
     public const HEADER_INDEXING_BEHAVIOR = 'indexing-behavior';
     public const HEADER_INDEXING_SKIP = 'indexing-skip';
     public const HEADER_FORCE_CACHE_INVALIDATE = 'sw-force-cache-invalidate';

--- a/tests/unit/Core/Framework/Routing/RoutingExceptionTest.php
+++ b/tests/unit/Core/Framework/Routing/RoutingExceptionTest.php
@@ -73,4 +73,33 @@ class RoutingExceptionTest extends TestCase
         static::assertSame(Response::HTTP_FORBIDDEN, $e->getStatusCode());
         static::assertSame(RoutingException::ACCESS_DENIED_FOR_XML_HTTP_REQUEST, $e->getErrorCode());
     }
+
+    public function testCurrencyNotFound(): void
+    {
+        $currencyId = 'test-currency-id';
+        $e = RoutingException::currencyNotFound($currencyId);
+
+        static::assertSame(RoutingException::class, $e::class);
+        static::assertSame(Response::HTTP_NOT_FOUND, $e->getStatusCode());
+        static::assertSame(RoutingException::CURRENCY_NOT_FOUND, $e->getErrorCode());
+        static::assertStringContainsString($currencyId, $e->getMessage());
+    }
+
+    public function testMissingPrivileges(): void
+    {
+        $privileges = ['product:read', 'category:write'];
+        $e = RoutingException::missingPrivileges($privileges);
+
+        static::assertSame(RoutingException::class, $e::class);
+        static::assertSame(Response::HTTP_FORBIDDEN, $e->getStatusCode());
+        static::assertSame(RoutingException::MISSING_PRIVILEGE, $e->getErrorCode());
+
+        // The message should be a JSON string containing the privileges
+        $decodedMessage = json_decode($e->getMessage(), true);
+        static::assertIsArray($decodedMessage);
+        static::assertArrayHasKey('message', $decodedMessage);
+        static::assertArrayHasKey('missingPrivileges', $decodedMessage);
+        static::assertSame('Missing privilege', $decodedMessage['message']);
+        static::assertSame($privileges, $decodedMessage['missingPrivileges']);
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

As an app developer integrating the Admin API, I would like to optionally execute API requests within the context and permissions of the currently authenticated user, so that I can ensure that the request respects user-level access control and avoid exposing sensitive data to unauthorized users.

### 2. What does this change do, exactly?
Adds an optional http Header. If the header is present and the integration-id is assigned to an app, the permission of the context will be an intersection from the app and the user.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
closes: https://github.com/shopware/shopware/issues/11608

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them


Documentation PR: https://github.com/shopware/docs/pull/1893

