### PR TITLE
fix: Opimize CMS create wizard page type selection spacing

### DIFF
--- a/changelog/_unreleased/2025-08-06-optimize-cms-create-wizard-page-type-selection-spacing.md
+++ b/changelog/_unreleased/2025-08-06-optimize-cms-create-wizard-page-type-selection-spacing.md
@@ -1,0 +1,8 @@
+---
+title: Opimize CMS create wizard page type selection spacing
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed styles of `sw-cms-create-wizard` component to optimize spacing of page types in page type selection.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/sw-cms-create-wizard.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/sw-cms-create-wizard.scss
@@ -42,6 +42,7 @@
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
+        gap: 20px;
         margin: 40px 200px 20px;
     }
 
@@ -50,7 +51,6 @@
         color: $color-darkgray-200;
         background: #fff;
         padding: 28px 20px;
-        margin-right: 20px;
         text-align: center;
         cursor: pointer;
         border-radius: $border-radius-default;
@@ -67,10 +67,6 @@
 
         .mt-icon {
             margin-bottom: 8px;
-        }
-
-        &:last-child {
-            margin-right: 0;
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If an additional page type is added, the page type selection of the cms create wizard component breaks into a new line. There is no horizontal spacing between the two lines.

<img width="710" height="398" alt="page-type-selection" src="https://github.com/user-attachments/assets/7a31c385-5f81-48d4-b525-6942d70419df" />

### 2. What does this change do, exactly?
* Changed styles of `sw-cms-create-wizard` component to optimize spacing of page types in page type selection.

### 3. Describe each step to reproduce the issue or behaviour.
Add a new page type and create a new cms page.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
