### PR TITLE
chore: Use correct EntityRepository types for phpstan in core (Framework)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -412,7 +412,7 @@
         "phpstan": [
             "Composer\\Config::disableProcessTimeout",
             "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
-            "phpstan analyze --memory-limit=2G -v"
+            "phpstan analyze -v"
         ],
         "phpstan-errors-by-area": [
             "php src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php phpstan-baseline.neon"

--- a/composer.json
+++ b/composer.json
@@ -412,7 +412,7 @@
         "phpstan": [
             "Composer\\Config::disableProcessTimeout",
             "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
-            "phpstan analyze -v"
+            "phpstan analyze --memory-limit=2G -v"
         ],
         "phpstan-errors-by-area": [
             "php src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php phpstan-baseline.neon"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1999,12 +1999,6 @@ parameters:
 			path: src/Core/Framework/Store/Authentication/FrwRequestOptionsProvider.php
 
 		-
-			message: '#^Call to an undefined method Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\:\:getLocale\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Core/Framework/Store/Authentication/LocaleProvider.php
-
-		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
 			count: 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -175,7 +175,6 @@ parameters:
             message: '#.* generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityRepository.*not specify its types: TEntityCollection#'
             paths:
                 - src/Core/Content/**
-                - src/Core/Framework/**
                 - src/Core/Maintenance/**
                 - src/Core/Profiling/**
                 - src/Core/Service/**
@@ -183,12 +182,6 @@ parameters:
                 - tests/integration/Core/Content/**
                 - tests/integration/Core/Framework/**
                 - tests/unit/Core/**
-
-        - # No need to fix for now, as the facades are only used in twig context
-            message: '#.* generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult.*does not specify its types: TEntityCollection#'
-            paths:
-                - src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
-                - src/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacade.php
 
         - # Needs a proper class-string annotation in `\Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition::getCollectionClass` and all child classes
             message: '#PHPDoc tag @var with type .*Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityCollection.* is not subtype of native type string#'

--- a/src/Core/Framework/Adapter/Twig/AppTemplateIterator.php
+++ b/src/Core/Framework/Adapter/Twig/AppTemplateIterator.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Adapter\Twig;
 
+use Shopware\Core\Framework\App\Template\TemplateCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\TermsAggregation;
@@ -18,6 +19,8 @@ class AppTemplateIterator implements \IteratorAggregate
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<TemplateCollection> $templateRepository
      */
     public function __construct(
         private readonly \IteratorAggregate $templateIterator,

--- a/src/Core/Framework/Adapter/Twig/AppTemplateIterator.php
+++ b/src/Core/Framework/Adapter/Twig/AppTemplateIterator.php
@@ -19,7 +19,7 @@ class AppTemplateIterator implements \IteratorAggregate
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<TemplateCollection> $templateRepository
      */
     public function __construct(

--- a/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php
@@ -15,6 +15,8 @@ class MediaExtension extends AbstractExtension
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<MediaCollection> $mediaRepository
      */
     public function __construct(private readonly EntityRepository $mediaRepository)
     {
@@ -38,11 +40,6 @@ class MediaExtension extends AbstractExtension
 
         $criteria = new Criteria($ids);
 
-        /** @var MediaCollection $media */
-        $media = $this->mediaRepository
-            ->search($criteria, $context)
-            ->getEntities();
-
-        return $media;
+        return $this->mediaRepository->search($criteria, $context)->getEntities();
     }
 }

--- a/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php
@@ -15,7 +15,7 @@ class MediaExtension extends AbstractExtension
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<MediaCollection> $mediaRepository
      */
     public function __construct(private readonly EntityRepository $mediaRepository)

--- a/src/Core/Framework/Api/Command/CreateIntegrationCommand.php
+++ b/src/Core/Framework/Api/Command/CreateIntegrationCommand.php
@@ -23,7 +23,7 @@ class CreateIntegrationCommand extends Command
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<IntegrationCollection> $integrationRepository
      */
     public function __construct(private readonly EntityRepository $integrationRepository)

--- a/src/Core/Framework/Api/Command/CreateIntegrationCommand.php
+++ b/src/Core/Framework/Api/Command/CreateIntegrationCommand.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Integration\IntegrationCollection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,6 +23,8 @@ class CreateIntegrationCommand extends Command
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<IntegrationCollection> $integrationRepository
      */
     public function __construct(private readonly EntityRepository $integrationRepository)
     {

--- a/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
+++ b/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
@@ -38,6 +38,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SalesChannel\Event\SalesChannelContextSwitchEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
@@ -72,6 +73,8 @@ class SalesChannelProxyController extends AbstractController
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(
         private readonly KernelInterface $kernel,
@@ -274,8 +277,7 @@ class SalesChannelProxyController extends AbstractController
      */
     private function fetchSalesChannel(string $salesChannelId, Context $context): SalesChannelEntity
     {
-        /** @var SalesChannelEntity|null $salesChannel */
-        $salesChannel = $this->salesChannelRepository->search(new Criteria([$salesChannelId]), $context)->get($salesChannelId);
+        $salesChannel = $this->salesChannelRepository->search(new Criteria([$salesChannelId]), $context)->getEntities()->get($salesChannelId);
 
         if ($salesChannel === null) {
             throw ApiException::invalidSalesChannelId($salesChannelId);

--- a/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
+++ b/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
@@ -73,7 +73,7 @@ class SalesChannelProxyController extends AbstractController
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(

--- a/src/Core/Framework/Api/Controller/UserController.php
+++ b/src/Core/Framework/Api/Controller/UserController.php
@@ -34,7 +34,7 @@ class UserController extends AbstractController
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<UserCollection> $userRepository
      * @param EntityRepository<EntityCollection<Entity>> $userRoleRepository
      * @param EntityRepository<AclRoleCollection> $roleRepository

--- a/src/Core/Framework/Api/Controller/UserController.php
+++ b/src/Core/Framework/Api/Controller/UserController.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Api\Controller;
 
 use League\OAuth2\Server\Exception\OAuthServerException;
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
 use Shopware\Core\Framework\Api\ApiException;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
@@ -10,6 +11,8 @@ use Shopware\Core\Framework\Api\Controller\Exception\PermissionDeniedException;
 use Shopware\Core\Framework\Api\OAuth\Scope\UserVerifiedScope;
 use Shopware\Core\Framework\Api\Response\ResponseFactoryInterface;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
@@ -17,6 +20,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\User\Aggregate\UserAccessKey\UserAccessKeyCollection;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserDefinition;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,6 +34,11 @@ class UserController extends AbstractController
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<UserCollection> $userRepository
+     * @param EntityRepository<EntityCollection<Entity>> $userRoleRepository
+     * @param EntityRepository<AclRoleCollection> $roleRepository
+     * @param EntityRepository<UserAccessKeyCollection> $keyRepository
      */
     public function __construct(
         private readonly EntityRepository $userRepository,
@@ -53,7 +63,7 @@ class UserController extends AbstractController
         $criteria = new Criteria([$userId]);
         $criteria->addAssociations(['aclRoles', 'avatarMedia']);
 
-        $user = $this->userRepository->search($criteria, $context)->first();
+        $user = $this->userRepository->search($criteria, $context)->getEntities()->first();
         if (!$user) {
             throw OAuthServerException::invalidCredentials();
         }

--- a/src/Core/Framework/App/Command/AbstractAppActivationCommand.php
+++ b/src/Core/Framework/App/Command/AbstractAppActivationCommand.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\App\Command;
 
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -19,6 +20,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[Package('framework')]
 abstract class AbstractAppActivationCommand extends Command
 {
+    /**
+     * @param EntityRepository<AppCollection> $appRepo
+     */
     public function __construct(
         protected EntityRepository $appRepo,
         private readonly string $action,

--- a/src/Core/Framework/App/Command/ActivateAppCommand.php
+++ b/src/Core/Framework/App/Command/ActivateAppCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\Command;
 
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppStateService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -20,6 +21,9 @@ class ActivateAppCommand extends AbstractAppActivationCommand
 {
     private const ACTION = 'activate';
 
+    /**
+     * @param EntityRepository<AppCollection> $appRepo
+     */
     public function __construct(
         EntityRepository $appRepo,
         private readonly AppStateService $appStateService

--- a/src/Core/Framework/App/Command/DeactivateAppCommand.php
+++ b/src/Core/Framework/App/Command/DeactivateAppCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\Command;
 
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppStateService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -20,6 +21,9 @@ class DeactivateAppCommand extends AbstractAppActivationCommand
 {
     private const ACTION = 'deactivate';
 
+    /**
+     * @param EntityRepository<AppCollection> $appRepo
+     */
     public function __construct(
         EntityRepository $appRepo,
         private readonly AppStateService $appStateService

--- a/src/Core/Framework/App/Lifecycle/AppLifecycleIterator.php
+++ b/src/Core/Framework/App/Lifecycle/AppLifecycleIterator.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\Lifecycle;
 
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
 use Shopware\Core\Framework\App\Manifest\Manifest;
@@ -19,6 +20,9 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 class AppLifecycleIterator
 {
+    /**
+     * @param EntityRepository<AppCollection> $appRepository
+     */
     public function __construct(
         private readonly EntityRepository $appRepository,
         private readonly AppLoader $appLoader

--- a/src/Core/Framework/App/Lifecycle/Persister/FlowActionPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/FlowActionPersister.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\App\Lifecycle\Persister;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Flow\Action\Action;
 use Shopware\Core\Framework\App\Source\SourceResolver;
@@ -17,6 +18,9 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('framework')]
 class FlowActionPersister
 {
+    /**
+     * @param EntityRepository<AppFlowActionCollection> $flowActionsRepository
+     */
     public function __construct(
         private readonly EntityRepository $flowActionsRepository,
         private readonly SourceResolver $sourceResolver,

--- a/src/Core/Framework/App/Lifecycle/Persister/FlowEventPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/FlowEventPersister.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\App\Lifecycle\Persister;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventCollection;
 use Shopware\Core\Framework\App\Flow\Event\Event;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -15,6 +16,9 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('framework')]
 class FlowEventPersister
 {
+    /**
+     * @param EntityRepository<AppFlowEventCollection> $flowEventsRepository
+     */
     public function __construct(
         private readonly EntityRepository $flowEventsRepository,
         private readonly Connection $connection

--- a/src/Core/Framework/App/Payment/PaymentMethodStateService.php
+++ b/src/Core/Framework/App/Payment/PaymentMethodStateService.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\Payment;
 
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -14,6 +15,9 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('checkout')]
 class PaymentMethodStateService
 {
+    /**
+     * @param EntityRepository<PaymentMethodCollection> $paymentMethodRepository
+     */
     public function __construct(private readonly EntityRepository $paymentMethodRepository)
     {
     }

--- a/src/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandler.php
+++ b/src/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandler.php
@@ -28,7 +28,7 @@ final class DeleteCascadeAppsHandler extends ScheduledTaskHandler
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
      * @param EntityRepository<AclRoleCollection> $aclRoleRepository
      * @param EntityRepository<IntegrationCollection> $integrationRepository

--- a/src/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandler.php
+++ b/src/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandler.php
@@ -4,12 +4,17 @@ namespace Shopware\Core\Framework\App\ScheduledTask;
 
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Shopware\Core\System\Integration\IntegrationCollection;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
@@ -23,6 +28,10 @@ final class DeleteCascadeAppsHandler extends ScheduledTaskHandler
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
+     * @param EntityRepository<AclRoleCollection> $aclRoleRepository
+     * @param EntityRepository<IntegrationCollection> $integrationRepository
      */
     public function __construct(
         EntityRepository $scheduledTaskRepository,
@@ -47,6 +56,9 @@ final class DeleteCascadeAppsHandler extends ScheduledTaskHandler
         $this->deleteIds($this->integrationRepository, $criteria, $context);
     }
 
+    /**
+     * @param EntityRepository<covariant EntityCollection<covariant Entity>> $repository
+     */
     private function deleteIds(EntityRepository $repository, Criteria $criteria, Context $context): void
     {
         $data = $repository->searchIds($criteria, $context)->getData();

--- a/src/Core/Framework/App/Template/TemplateStateService.php
+++ b/src/Core/Framework/App/Template/TemplateStateService.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 class TemplateStateService
 {
+    /**
+     * @param EntityRepository<TemplateCollection> $templateRepo
+     */
     public function __construct(
         private readonly EntityRepository $templateRepo,
         private readonly CacheClearer $cacheClearer,

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -20,7 +20,7 @@ class RepositoryIterator
     private readonly Criteria $criteria;
 
     /**
-     * @var EntityRepository<TEntityCollection>
+     * @var EntityRepository<covariant TEntityCollection>
      */
     private readonly EntityRepository $repository;
 
@@ -29,7 +29,7 @@ class RepositoryIterator
     private bool $autoIncrement = false;
 
     /**
-     * @param EntityRepository<TEntityCollection> $repository
+     * @param EntityRepository<covariant TEntityCollection> $repository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -29,7 +29,7 @@ class RepositoryIterator
     private bool $autoIncrement = false;
 
     /**
-     * @param EntityRepository<covariant TEntityCollection> $repository
+     * @param EntityRepository<TEntityCollection> $repository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -29,7 +29,7 @@ class RepositoryIterator
     private bool $autoIncrement = false;
 
     /**
-     * @param EntityRepository<TEntityCollection> $repository
+     * @param EntityRepository<covariant TEntityCollection> $repository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/Framework/DataAbstractionLayer/DefinitionInstanceRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionInstanceRegistry.php
@@ -33,7 +33,7 @@ class DefinitionInstanceRegistry
 
     /**
      * @throws EntityRepositoryNotFoundException
-     * 
+     *
      * @return EntityRepository<covariant EntityCollection<covariant Entity>>
      */
     public function getRepository(string $entityName): EntityRepository

--- a/src/Core/Framework/DataAbstractionLayer/DefinitionInstanceRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionInstanceRegistry.php
@@ -33,6 +33,8 @@ class DefinitionInstanceRegistry
 
     /**
      * @throws EntityRepositoryNotFoundException
+     * 
+     * @return EntityRepository<covariant EntityCollection<covariant Entity>>
      */
     public function getRepository(string $entityName): EntityRepository
     {

--- a/src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
+++ b/src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Api\Acl\AclCriteriaValidator;
 use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -39,7 +41,7 @@ class RepositoryFacade
      * @param string $entityName The name of the Entity you want to search for, e.g. `product` or `media`.
      * @param array<string, mixed> $criteria The criteria used for your search.
      *
-     * @return EntitySearchResult A `EntitySearchResult` including all entities that matched your criteria.
+     * @return EntitySearchResult<covariant EntityCollection<covariant Entity>> A `EntitySearchResult` including all entities that matched your criteria.
      *
      * @example repository-search-by-id/script.twig Load a single product.
      * @example repository-filter/script.twig Filter the search result.

--- a/src/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacade.php
+++ b/src/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacade.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Facade;
 
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -40,7 +42,7 @@ class SalesChannelRepositoryFacade
      * @param string $entityName The name of the Entity you want to search for, e.g. `product` or `media`.
      * @param array<string, mixed> $criteria The criteria used for your search.
      *
-     * @return EntitySearchResult A `EntitySearchResult` including all entities that matched your criteria.
+     * @return EntitySearchResult<covariant EntityCollection> A `EntitySearchResult` including all entities that matched your criteria.
      *
      * @example store-search-by-id/script.twig Load a single storefront product.
      * @example store-filter/script.twig Filter the search result.

--- a/src/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacade.php
+++ b/src/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacade.php
@@ -42,7 +42,7 @@ class SalesChannelRepositoryFacade
      * @param string $entityName The name of the Entity you want to search for, e.g. `product` or `media`.
      * @param array<string, mixed> $criteria The criteria used for your search.
      *
-     * @return EntitySearchResult<covariant EntityCollection> A `EntitySearchResult` including all entities that matched your criteria.
+     * @return EntitySearchResult<covariant EntityCollection<covariant Entity>> A `EntitySearchResult` including all entities that matched your criteria.
      *
      * @example store-search-by-id/script.twig Load a single storefront product.
      * @example store-filter/script.twig Filter the search result.

--- a/src/Core/Framework/DataAbstractionLayer/Version/Cleanup/CleanupVersionTaskHandler.php
+++ b/src/Core/Framework/DataAbstractionLayer/Version/Cleanup/CleanupVersionTaskHandler.php
@@ -7,6 +7,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -19,6 +20,8 @@ final class CleanupVersionTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<ScheduledTaskCollection> $repository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/Framework/DataAbstractionLayer/Version/Cleanup/CleanupVersionTaskHandler.php
+++ b/src/Core/Framework/DataAbstractionLayer/Version/Cleanup/CleanupVersionTaskHandler.php
@@ -20,7 +20,7 @@ final class CleanupVersionTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<ScheduledTaskCollection> $repository
      */
     public function __construct(

--- a/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
@@ -4,7 +4,9 @@ namespace Shopware\Core\Framework\Demodata\Generator;
 
 use Doctrine\DBAL\Connection;
 use Faker\Generator;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
@@ -32,6 +34,9 @@ class CategoryGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<CategoryCollection> $categoryRepository
+     * @param EntityRepository<CmsPageCollection> $cmsPageRepository
      */
     public function __construct(
         private readonly EntityRepository $categoryRepository,

--- a/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
@@ -34,7 +34,7 @@ class CategoryGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<CategoryCollection> $categoryRepository
      * @param EntityRepository<CmsPageCollection> $cmsPageRepository
      */

--- a/src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
@@ -27,7 +27,7 @@ class CustomFieldGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<CustomFieldSetCollection> $attributeSetRepository
      */
     public function __construct(

--- a/src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetCollection;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetDefinition;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
 
@@ -26,6 +27,8 @@ class CustomFieldGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<CustomFieldSetCollection> $attributeSetRepository
      */
     public function __construct(
         private readonly EntityRepository $attributeSetRepository,

--- a/src/Core/Framework/Demodata/Generator/CustomerGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CustomerGenerator.php
@@ -34,7 +34,7 @@ class CustomerGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<CustomerGroupCollection> $customerGroupRepository
      */
     public function __construct(

--- a/src/Core/Framework/Demodata/Generator/CustomerGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CustomerGenerator.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Demodata\Generator;
 
 use Doctrine\DBAL\Connection;
 use Faker\Generator;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -33,6 +34,8 @@ class CustomerGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<CustomerGroupCollection> $customerGroupRepository
      */
     public function __construct(
         private readonly EntityWriterInterface $writer,

--- a/src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Demodata\Generator;
 
 use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeCollection;
-use Shopware\Core\Content\MailTemplate\MailTemplateCollection;
 use Shopware\Core\Content\MailTemplate\MailTemplateDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -25,7 +24,7 @@ class MailTemplateGenerator implements DemodataGeneratorInterface
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository
      */
     public function __construct(

--- a/src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Framework\Demodata\Generator;
 
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeCollection;
+use Shopware\Core\Content\MailTemplate\MailTemplateCollection;
 use Shopware\Core\Content\MailTemplate\MailTemplateDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -23,6 +25,8 @@ class MailTemplateGenerator implements DemodataGeneratorInterface
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository
      */
     public function __construct(
         private readonly EntityWriterInterface $writer,

--- a/src/Core/Framework/Demodata/Generator/MediaGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MediaGenerator.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use Faker\Generator;
 use Maltyxx\ImagesGenerator\ImagesGeneratorProvider;
 use Shopware\Core\Content\Media\Aggregate\MediaDefaultFolder\MediaDefaultFolderCollection;
-use Shopware\Core\Content\Media\Aggregate\MediaDefaultFolder\MediaDefaultFolderEntity;
 use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderCollection;
 use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Media\File\FileSaver;
@@ -35,7 +34,7 @@ class MediaGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<MediaDefaultFolderCollection> $defaultFolderRepository
      * @param EntityRepository<MediaFolderCollection> $folderRepository
      */

--- a/src/Core/Framework/Demodata/Generator/MediaGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MediaGenerator.php
@@ -5,7 +5,9 @@ namespace Shopware\Core\Framework\Demodata\Generator;
 use Doctrine\DBAL\Connection;
 use Faker\Generator;
 use Maltyxx\ImagesGenerator\ImagesGeneratorProvider;
+use Shopware\Core\Content\Media\Aggregate\MediaDefaultFolder\MediaDefaultFolderCollection;
 use Shopware\Core\Content\Media\Aggregate\MediaDefaultFolder\MediaDefaultFolderEntity;
+use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderCollection;
 use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Media\File\FileSaver;
 use Shopware\Core\Content\Media\File\MediaFile;
@@ -33,6 +35,9 @@ class MediaGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<MediaDefaultFolderCollection> $defaultFolderRepository
+     * @param EntityRepository<MediaFolderCollection> $folderRepository
      */
     public function __construct(
         private readonly EntityWriterInterface $writer,
@@ -196,8 +201,10 @@ class MediaGenerator implements DemodataGeneratorInterface
             return $mediaFolderId;
         }
 
-        /** @var MediaDefaultFolderEntity $defaultFolder */
-        $defaultFolder = $defaultFolders->first();
+        $defaultFolder = $defaultFolders->getEntities()->first();
+        if (!$defaultFolder) {
+            return $mediaFolderId;
+        }
 
         if ($defaultFolder->getFolder()) {
             return $defaultFolder->getFolder()->getId();

--- a/src/Core/Framework/Demodata/Generator/PropertyGroupGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/PropertyGroupGenerator.php
@@ -21,7 +21,7 @@ class PropertyGroupGenerator implements DemodataGeneratorInterface
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<PropertyGroupCollection> $propertyGroupRepository
      */
     public function __construct(private readonly EntityRepository $propertyGroupRepository)

--- a/src/Core/Framework/Demodata/Generator/PropertyGroupGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/PropertyGroupGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Demodata\Generator;
 
+use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Content\Property\PropertyGroupDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -20,6 +21,8 @@ class PropertyGroupGenerator implements DemodataGeneratorInterface
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<PropertyGroupCollection> $propertyGroupRepository
      */
     public function __construct(private readonly EntityRepository $propertyGroupRepository)
     {

--- a/src/Core/Framework/Demodata/Generator/RuleGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/RuleGenerator.php
@@ -41,7 +41,7 @@ class RuleGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<RuleCollection> $ruleRepository
      * @param EntityRepository<PaymentMethodCollection> $paymentMethodRepository
      * @param EntityRepository<ShippingMethodCollection> $shippingMethodRepository

--- a/src/Core/Framework/Demodata/Generator/RuleGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/RuleGenerator.php
@@ -6,6 +6,9 @@ use Faker\Generator;
 use Shopware\Core\Checkout\Cart\Rule\GoodsPriceRule;
 use Shopware\Core\Checkout\Customer\Rule\CustomerGroupRule;
 use Shopware\Core\Checkout\Customer\Rule\DaysSinceFirstLoginRule;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -38,6 +41,10 @@ class RuleGenerator implements DemodataGeneratorInterface
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<RuleCollection> $ruleRepository
+     * @param EntityRepository<PaymentMethodCollection> $paymentMethodRepository
+     * @param EntityRepository<ShippingMethodCollection> $shippingMethodRepository
      */
     public function __construct(
         private readonly EntityRepository $ruleRepository,

--- a/src/Core/Framework/Demodata/Generator/UserGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/UserGenerator.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
-use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\User\UserDefinition;
 
 /**
@@ -25,7 +24,7 @@ class UserGenerator implements DemodataGeneratorInterface
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<LanguageCollection> $languageRepository
      */
     public function __construct(

--- a/src/Core/Framework/Demodata/Generator/UserGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/UserGenerator.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
 use Shopware\Core\Framework\Demodata\DemodataService;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\User\UserDefinition;
 
@@ -24,6 +25,8 @@ class UserGenerator implements DemodataGeneratorInterface
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<LanguageCollection> $languageRepository
      */
     public function __construct(
         private readonly EntityWriterInterface $writer,
@@ -91,8 +94,8 @@ class UserGenerator implements DemodataGeneratorInterface
 
     private function getLocaleId(Context $context): string
     {
-        /** @var LanguageEntity $first */
-        $first = $this->languageRepository->search(new Criteria([Defaults::LANGUAGE_SYSTEM]), $context)->first();
+        $first = $this->languageRepository->search(new Criteria([Defaults::LANGUAGE_SYSTEM]), $context)->getEntities()->first();
+        \assert($first !== null);
 
         return $first->getLocaleId();
     }

--- a/src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
+++ b/src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
@@ -38,7 +38,7 @@ class CleanPersonalDataCommand extends Command
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<CustomerCollection> $customerRepository
      */
     public function __construct(

--- a/src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
+++ b/src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Demodata\PersonalData;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -37,6 +38,8 @@ class CleanPersonalDataCommand extends Command
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<CustomerCollection> $customerRepository
      */
     public function __construct(
         private readonly Connection $connection,

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
@@ -29,7 +29,7 @@ class TaskScheduler
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
      */
     public function __construct(

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -28,6 +29,8 @@ class TaskScheduler
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
      */
     public function __construct(
         private readonly EntityRepository $scheduledTaskRepository,
@@ -49,7 +52,6 @@ class TaskScheduler
         // Tasks **must not** be queued before their state in the database has been updated. Otherwise,
         // a worker could have already fetched the task and set its state to running before it gets set to
         // queued, thus breaking the task.
-        /** @var ScheduledTaskEntity $task */
         foreach ($tasks as $task) {
             $this->queueTask($task, $context);
         }

--- a/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
@@ -28,6 +28,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[Package('framework')]
 abstract class AbstractPluginLifecycleCommand extends Command
 {
+    /**
+     * @param EntityRepository<PluginCollection> $pluginRepo
+     */
     public function __construct(
         protected PluginLifecycleService $pluginLifecycleService,
         private readonly EntityRepository $pluginRepo,
@@ -148,7 +151,6 @@ abstract class AbstractPluginLifecycleCommand extends Command
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('name', $plugins[0]));
 
-            /** @var PluginCollection $matches */
             $matches = $this->pluginRepo->search($criteria, $context)->getEntities();
             if ($matches->count() === 1) {
                 return $matches;
@@ -163,7 +165,6 @@ abstract class AbstractPluginLifecycleCommand extends Command
         $criteria->addSorting(new FieldSorting('name'));
         $criteria->addFilter(new MultiFilter(MultiFilter::CONNECTION_OR, $filter));
 
-        /** @var PluginCollection $pluginCollection */
         $pluginCollection = $this->pluginRepo->search($criteria, $context)->getEntities();
 
         if ($pluginCollection->count() <= 1) {

--- a/src/Core/Framework/Plugin/Command/Lifecycle/PluginUpdateAllCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/PluginUpdateAllCommand.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Plugin\PluginService;
@@ -24,6 +25,8 @@ class PluginUpdateAllCommand extends Command
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<PluginCollection> $pluginRepository
      */
     public function __construct(
         private readonly PluginService $pluginService,
@@ -58,7 +61,6 @@ class PluginUpdateAllCommand extends Command
 
         $this->pluginService->refreshPlugins($context, new ConsoleIO($composerInput, $output, $helperSet));
 
-        /** @var EntityCollection<PluginEntity> $plugins */
         $plugins = $this->pluginRepository->search(new Criteria(), $context)->getEntities();
 
         foreach ($plugins as $plugin) {

--- a/src/Core/Framework/Plugin/Command/Lifecycle/PluginUpdateAllCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/PluginUpdateAllCommand.php
@@ -4,12 +4,10 @@ namespace Shopware\Core\Framework\Plugin\Command\Lifecycle;
 
 use Composer\IO\ConsoleIO;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginCollection;
-use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Plugin\PluginService;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -25,7 +23,7 @@ class PluginUpdateAllCommand extends Command
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<PluginCollection> $pluginRepository
      */
     public function __construct(

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -28,6 +28,8 @@ class PluginListCommand extends Command
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<PluginCollection> $pluginRepo
      */
     public function __construct(private readonly EntityRepository $pluginRepo, private readonly ComposerPluginLoader $composerPluginLoader)
     {
@@ -63,7 +65,7 @@ class PluginListCommand extends Command
                 ]
             ));
         }
-        /** @var PluginCollection $plugins */
+
         $plugins = $this->pluginRepo->search($criteria, $context)->getEntities();
 
         if ($input->getOption('json')) {
@@ -83,7 +85,6 @@ class PluginListCommand extends Command
             $io->comment(\sprintf('Filtering for: %s', $filter));
         }
 
-        /** @var PluginEntity $plugin */
         foreach ($plugins as $plugin) {
             $pluginActive = $plugin->getActive();
             $pluginInstalled = $plugin->getInstalledAt();

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\Framework\Plugin\PluginCollection;
-use Shopware\Core\Framework\Plugin\PluginEntity;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,7 +27,7 @@ class PluginListCommand extends Command
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<PluginCollection> $pluginRepo
      */
     public function __construct(private readonly EntityRepository $pluginRepo, private readonly ComposerPluginLoader $composerPluginLoader)

--- a/src/Core/Framework/Plugin/Util/PluginIdProvider.php
+++ b/src/Core/Framework/Plugin/Util/PluginIdProvider.php
@@ -7,12 +7,15 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginCollection;
 
 #[Package('framework')]
 class PluginIdProvider
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<PluginCollection> $pluginRepo
      */
     public function __construct(private readonly EntityRepository $pluginRepo)
     {

--- a/src/Core/Framework/Plugin/Util/PluginIdProvider.php
+++ b/src/Core/Framework/Plugin/Util/PluginIdProvider.php
@@ -14,7 +14,7 @@ class PluginIdProvider
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<PluginCollection> $pluginRepo
      */
     public function __construct(private readonly EntityRepository $pluginRepo)

--- a/src/Core/Framework/Store/Api/ExtensionStoreDataController.php
+++ b/src/Core/Framework/Store/Api/ExtensionStoreDataController.php
@@ -12,6 +12,8 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,6 +27,10 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Package('checkout')]
 class ExtensionStoreDataController extends AbstractController
 {
+    /**
+     * @param EntityRepository<UserCollection> $userRepository
+     * @param EntityRepository<LanguageCollection> $languageRepository
+     */
     public function __construct(
         private readonly AbstractExtensionDataProvider $extensionDataProvider,
         private readonly EntityRepository $userRepository,
@@ -57,8 +63,7 @@ class ExtensionStoreDataController extends AbstractController
 
         $criteria = new Criteria([$source->getUserId()]);
 
-        /** @var UserEntity|null $user */
-        $user = $this->userRepository->search($criteria, $context)->first();
+        $user = $this->userRepository->search($criteria, $context)->getEntities()->first();
 
         if ($user === null) {
             return $context;

--- a/src/Core/Framework/Store/Api/ExtensionStoreDataController.php
+++ b/src/Core/Framework/Store/Api/ExtensionStoreDataController.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\User\UserCollection;
-use Shopware\Core\System\User\UserEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Core/Framework/Store/Api/FirstRunWizardController.php
+++ b/src/Core/Framework/Store/Api/FirstRunWizardController.php
@@ -28,6 +28,10 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Package('fundamentals@after-sales')]
 class FirstRunWizardController extends AbstractController
 {
+    /**
+     * @param EntityRepository<PluginCollection> $pluginRepo
+     * @param EntityRepository<AppCollection> $appRepo
+     */
     public function __construct(
         private readonly FirstRunWizardService $frwService,
         private readonly EntityRepository $pluginRepo,
@@ -50,9 +54,7 @@ class FirstRunWizardController extends AbstractController
     #[Route(path: '/api/_action/store/language-plugins', name: 'api.custom.store.language-plugins', methods: ['GET'])]
     public function getLanguagePluginList(Context $context): JsonResponse
     {
-        /** @var PluginCollection $plugins */
         $plugins = $this->pluginRepo->search(new Criteria(), $context)->getEntities();
-        /** @var AppCollection $apps */
         $apps = $this->appRepo->search(new Criteria(), $context)->getEntities();
 
         try {
@@ -70,9 +72,7 @@ class FirstRunWizardController extends AbstractController
     #[Route(path: '/api/_action/store/demo-data-plugins', name: 'api.custom.store.demo-data-plugins', methods: ['GET'])]
     public function getDemoDataPluginList(Context $context): JsonResponse
     {
-        /** @var PluginCollection $plugins */
         $plugins = $this->pluginRepo->search(new Criteria(), $context)->getEntities();
-        /** @var AppCollection $apps */
         $apps = $this->appRepo->search(new Criteria(), $context)->getEntities();
 
         try {
@@ -108,9 +108,7 @@ class FirstRunWizardController extends AbstractController
         $region = $request->query->has('region') ? (string) $request->query->get('region') : null;
         $category = $request->query->has('category') ? (string) $request->query->get('category') : null;
 
-        /** @var PluginCollection $plugins */
         $plugins = $this->pluginRepo->search(new Criteria(), $context)->getEntities();
-        /** @var AppCollection $apps */
         $apps = $this->appRepo->search(new Criteria(), $context)->getEntities();
 
         try {

--- a/src/Core/Framework/Store/Api/StoreController.php
+++ b/src/Core/Framework/Store/Api/StoreController.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Store\Exception\StoreTokenMissingException;
 use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -31,6 +32,9 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Package('checkout')]
 class StoreController extends AbstractController
 {
+    /**
+     * @param EntityRepository<UserCollection> $userRepository
+     */
     public function __construct(
         private readonly StoreClient $storeClient,
         private readonly EntityRepository $userRepository,

--- a/src/Core/Framework/Store/Authentication/FrwRequestOptionsProvider.php
+++ b/src/Core/Framework/Store/Authentication/FrwRequestOptionsProvider.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardService;
 use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
-use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity;
 
 /**
  * @internal

--- a/src/Core/Framework/Store/Authentication/FrwRequestOptionsProvider.php
+++ b/src/Core/Framework/Store/Authentication/FrwRequestOptionsProvider.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardService;
+use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
 use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity;
 
 /**
@@ -20,6 +21,9 @@ class FrwRequestOptionsProvider extends AbstractStoreRequestOptionsProvider
 {
     private const SHOPWARE_TOKEN_HEADER = 'X-Shopware-Token';
 
+    /**
+     * @param EntityRepository<UserConfigCollection> $userConfigRepository
+     */
     public function __construct(
         private readonly AbstractStoreRequestOptionsProvider $optionsProvider,
         private readonly EntityRepository $userConfigRepository,
@@ -50,8 +54,7 @@ class FrwRequestOptionsProvider extends AbstractStoreRequestOptionsProvider
             new EqualsFilter('key', FirstRunWizardService::USER_CONFIG_KEY_FRW_USER_TOKEN),
         );
 
-        /** @var UserConfigEntity|null $userConfig */
-        $userConfig = $this->userConfigRepository->search($criteria, $context)->first();
+        $userConfig = $this->userConfigRepository->search($criteria, $context)->getEntities()->first();
 
         return $userConfig === null ? null : $userConfig->getValue()[FirstRunWizardService::USER_CONFIG_VALUE_FRW_USER_TOKEN] ?? null;
     }

--- a/src/Core/Framework/Store/Authentication/LocaleProvider.php
+++ b/src/Core/Framework/Store/Authentication/LocaleProvider.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\EntityNotFoundException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\Locale\LocaleEntity;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserDefinition;
 
 /**
@@ -17,6 +17,9 @@ use Shopware\Core\System\User\UserDefinition;
 #[Package('checkout')]
 class LocaleProvider
 {
+    /**
+     * @param EntityRepository<UserCollection> $userRepository
+     */
     public function __construct(private readonly EntityRepository $userRepository)
     {
     }
@@ -37,14 +40,14 @@ class LocaleProvider
         $criteria = new Criteria([$source->getUserId()]);
         $criteria->addAssociation('locale');
 
-        $user = $this->userRepository->search($criteria, $context)->first();
+        $user = $this->userRepository->search($criteria, $context)->getEntities()->first();
 
         if ($user === null) {
             throw new EntityNotFoundException(UserDefinition::ENTITY_NAME, $source->getUserId());
         }
 
-        /** @var LocaleEntity $locale */
         $locale = $user->getLocale();
+        \assert($locale !== null);
 
         return $locale->getCode();
     }

--- a/src/Core/Framework/Store/Command/StoreLoginCommand.php
+++ b/src/Core/Framework/Store/Command/StoreLoginCommand.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Store\Exception\StoreApiException;
 use Shopware\Core\Framework\Store\Exception\StoreInvalidCredentialsException;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\System\User\UserCollection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,6 +32,9 @@ use Symfony\Component\Console\Question\Question;
 #[Package('checkout')]
 class StoreLoginCommand extends Command
 {
+    /**
+     * @param EntityRepository<UserCollection> $userRepository
+     */
     public function __construct(
         private readonly StoreClient $storeClient,
         private readonly EntityRepository $userRepository,

--- a/src/Core/Framework/Store/Services/ExtensionDataProvider.php
+++ b/src/Core/Framework/Store/Services/ExtensionDataProvider.php
@@ -24,6 +24,10 @@ class ExtensionDataProvider extends AbstractExtensionDataProvider
 {
     final public const HEADER_NAME_TOTAL_COUNT = 'SW-Meta-Total';
 
+    /**
+     * @param EntityRepository<AppCollection> $appRepository
+     * @param EntityRepository<PluginCollection> $pluginRepository
+     */
     public function __construct(
         private readonly ExtensionLoader $extensionLoader,
         private readonly EntityRepository $appRepository,
@@ -39,13 +43,11 @@ class ExtensionDataProvider extends AbstractExtensionDataProvider
         $appCriteria->addAssociation('translations');
         $appCriteria->addFilter(new EqualsFilter('selfManaged', false));
 
-        /** @var AppCollection $installedApps */
         $installedApps = $this->appRepository->search($appCriteria, $context)->getEntities();
 
         $pluginCriteria = $searchCriteria ? clone $searchCriteria : new Criteria();
         $pluginCriteria->addAssociation('translations');
 
-        /** @var PluginCollection $installedPlugins */
         $installedPlugins = $this->pluginRepository->search($pluginCriteria, $context)->getEntities();
         $pluginCollection = $this->extensionLoader->loadFromPluginCollection($context, $installedPlugins);
 
@@ -65,7 +67,7 @@ class ExtensionDataProvider extends AbstractExtensionDataProvider
         $criteria = (new Criteria())->addFilter(new EqualsFilter('name', $technicalName));
         $app = $this->appRepository->search($criteria, $context)->getEntities()->first();
 
-        if (!$app instanceof AppEntity) {
+        if (!$app) {
             throw StoreException::extensionNotFoundFromTechnicalName($technicalName);
         }
 
@@ -77,7 +79,7 @@ class ExtensionDataProvider extends AbstractExtensionDataProvider
         $criteria = new Criteria([$id]);
         $app = $this->appRepository->search($criteria, $context)->getEntities()->first();
 
-        if (!$app instanceof AppEntity) {
+        if (!$app) {
             throw StoreException::extensionNotFoundFromId($id);
         }
 

--- a/src/Core/Framework/Store/Services/ExtensionDownloader.php
+++ b/src/Core/Framework/Store/Services/ExtensionDownloader.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginManagementService;
 use Shopware\Core\Framework\Store\Exception\StoreApiException;
@@ -23,6 +24,9 @@ class ExtensionDownloader
 {
     private readonly string $relativePluginDir;
 
+    /**
+     * @param EntityRepository<PluginCollection> $pluginRepository
+     */
     public function __construct(
         private readonly EntityRepository $pluginRepository,
         private readonly StoreClient $storeClient,
@@ -38,8 +42,7 @@ class ExtensionDownloader
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('plugin.name', $technicalName));
 
-        /** @var PluginEntity|null $plugin */
-        $plugin = $this->pluginRepository->search($criteria, $context)->first();
+        $plugin = $this->pluginRepository->search($criteria, $context)->getEntities()->first();
 
         if ($plugin !== null && $plugin->getManagedByComposer() && !str_starts_with($plugin->getPath() ?? '', $this->relativePluginDir)) {
             throw StoreException::cannotDeleteManaged($plugin->getName());

--- a/src/Core/Framework/Store/Services/ExtensionDownloader.php
+++ b/src/Core/Framework/Store/Services/ExtensionDownloader.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginCollection;
-use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginManagementService;
 use Shopware\Core\Framework\Store\Exception\StoreApiException;
 use Shopware\Core\Framework\Store\StoreException;

--- a/src/Core/Framework/Store/Services/ExtensionLoader.php
+++ b/src/Core/Framework/Store/Services/ExtensionLoader.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\Store\Struct\VariantCollection;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\SystemConfig\Service\ConfigurationService;
 use Shopware\Storefront\Framework\ThemeInterface;
+use Shopware\Storefront\Theme\ThemeCollection;
 use Symfony\Component\Intl\Languages;
 use Symfony\Component\Intl\Locales;
 
@@ -46,6 +47,9 @@ class ExtensionLoader
      */
     private ?array $installedThemeNames = null;
 
+    /**
+     * @param ?EntityRepository<ThemeCollection> $themeRepository
+     */
     public function __construct(
         private readonly ?EntityRepository $themeRepository,
         private readonly AppLoader $appLoader,

--- a/src/Core/Framework/Store/Services/FirstRunWizardService.php
+++ b/src/Core/Framework/Store/Services/FirstRunWizardService.php
@@ -33,6 +33,7 @@ use Shopware\Core\Framework\Store\Struct\PluginRegionStruct;
 use Shopware\Core\Framework\Store\Struct\ShopUserTokenStruct;
 use Shopware\Core\Framework\Store\Struct\StorePluginStruct;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -51,6 +52,9 @@ class FirstRunWizardService
 
     private const FRW_MAX_FAILURES = 3;
 
+    /**
+     * @param EntityRepository<UserConfigCollection> $userConfigRepository
+     */
     public function __construct(
         private readonly StoreService $storeService,
         private readonly SystemConfigService $configService,

--- a/src/Core/Framework/Store/Services/StoreService.php
+++ b/src/Core/Framework/Store/Services/StoreService.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Struct\AccessTokenStruct;
+use Shopware\Core\System\User\UserCollection;
 
 /**
  * @internal
@@ -17,6 +18,9 @@ class StoreService
     final public const CONFIG_KEY_STORE_LICENSE_DOMAIN = 'core.store.licenseHost';
     final public const CONFIG_KEY_STORE_LICENSE_EDITION = 'core.store.licenseEdition';
 
+    /**
+     * @param EntityRepository<UserCollection> $userRepository
+     */
     final public function __construct(private readonly EntityRepository $userRepository)
     {
     }

--- a/src/Core/Framework/Test/Plugin/PluginTestsHelper.php
+++ b/src/Core/Framework/Test/Plugin/PluginTestsHelper.php
@@ -7,14 +7,20 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
+use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginService;
 use Shopware\Core\Framework\Plugin\Util\PluginFinder;
 use Shopware\Core\Framework\Plugin\Util\VersionSanitizer;
+use Shopware\Core\System\Language\LanguageCollection;
 use SwagTestPlugin\SwagTestPlugin;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait PluginTestsHelper
 {
+    /**
+     * @param EntityRepository<PluginCollection> $pluginRepo
+     * @param EntityRepository<LanguageCollection> $languageRepo
+     */
     protected function createPluginService(
         string $pluginDir,
         string $projectDir,
@@ -32,6 +38,9 @@ trait PluginTestsHelper
         );
     }
 
+    /**
+     * @param EntityRepository<PluginCollection> $pluginRepo
+     */
     protected function createPlugin(
         EntityRepository $pluginRepo,
         Context $context,

--- a/src/Core/Framework/Test/Seo/StorefrontSalesChannelTestHelper.php
+++ b/src/Core/Framework/Test/Seo/StorefrontSalesChannelTestHelper.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Test\Seo;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -71,7 +72,7 @@ trait StorefrontSalesChannelTestHelper
         array $languageIds = [],
         ?string $categoryEntrypoint = null
     ): SalesChannelContext {
-        /** @var EntityRepository $repo */
+        /** @var EntityRepository<SalesChannelCollection> $repo */
         $repo = static::getContainer()->get('sales_channel.repository');
         $languageIds[] = $defaultLanguageId;
         $languageIds = array_unique($languageIds);
@@ -123,7 +124,7 @@ trait StorefrontSalesChannelTestHelper
 
     public function updateSalesChannelNavigationEntryPoint(string $id, string $categoryId): void
     {
-        /** @var EntityRepository $repo */
+        /** @var EntityRepository<SalesChannelCollection> $repo */
         $repo = static::getContainer()->get('sales_channel.repository');
 
         $repo->update([['id' => $id, 'navigationCategoryId' => $categoryId]], Context::createDefaultContext());
@@ -160,6 +161,7 @@ trait StorefrontSalesChannelTestHelper
             'customerNumber' => 'asdf',
         ];
 
+        /** @var EntityRepository<CustomerCollection> */
         $customerRepository = $container->get('customer.repository');
         $customerRepository->upsert([$customer], Context::createDefaultContext());
 

--- a/src/Core/Framework/Test/TestCaseBase/CountryAddToSalesChannelTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/CountryAddToSalesChannelTestBehaviour.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Test\TestCaseBase;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -18,7 +19,7 @@ trait CountryAddToSalesChannelTestBehaviour
      */
     protected function addCountriesToSalesChannel(array $additionalCountryIds = [], string $salesChannelId = TestDefaults::SALES_CHANNEL): void
     {
-        /** @var EntityRepository $salesChannelRepository */
+        /** @var EntityRepository<SalesChannelCollection> $salesChannelRepository */
         $salesChannelRepository = static::getContainer()->get('sales_channel.repository');
 
         $countryIds = array_merge([

--- a/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
+++ b/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
@@ -30,7 +30,7 @@ final readonly class WebhookEventMessageHandler
 
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<ScheduledTaskCollection> $webhookEventLogRepository
      */
     public function __construct(

--- a/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
+++ b/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteTypeIntendException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Service\RelatedWebhooks;
@@ -29,6 +30,8 @@ final readonly class WebhookEventMessageHandler
 
     /**
      * @internal
+     * 
+     * @param EntityRepository<ScheduledTaskCollection> $webhookEventLogRepository
      */
     public function __construct(
         private Client $client,

--- a/src/Core/Framework/Webhook/ScheduledTask/CleanupWebhookEventLogTaskHandler.php
+++ b/src/Core/Framework/Webhook/ScheduledTask/CleanupWebhookEventLogTaskHandler.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Webhook\ScheduledTask;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Shopware\Core\Framework\Webhook\Service\WebhookCleanup;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -18,6 +19,8 @@ final class CleanupWebhookEventLogTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
+     * 
+     * @param EntityRepository<ScheduledTaskCollection> $repository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/Framework/Webhook/ScheduledTask/CleanupWebhookEventLogTaskHandler.php
+++ b/src/Core/Framework/Webhook/ScheduledTask/CleanupWebhookEventLogTaskHandler.php
@@ -19,7 +19,7 @@ final class CleanupWebhookEventLogTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
-     * 
+     *
      * @param EntityRepository<ScheduledTaskCollection> $repository
      */
     public function __construct(

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -331,7 +331,7 @@ class StateMachineRegistry implements ResetInterface
     }
 
     /**
-     * @param EntityRepository<EntityCollection<Entity>> $repository
+     * @param EntityRepository<covariant EntityCollection<covariant Entity>> $repository
      *
      * @throws InconsistentCriteriaIdsException
      * @throws StateMachineException

--- a/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleIteratorTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleIteratorTest.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 

--- a/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleIteratorTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleIteratorTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycleIterator;
 use Shopware\Core\Framework\App\Lifecycle\AppLoader;
@@ -11,6 +12,7 @@ use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 
@@ -27,8 +29,11 @@ class AppLifecycleIteratorTest extends TestCase
             'ValidManifestApp' => Manifest::createFromXmlFile(__DIR__ . '/_fixtures/appDirValidationTest/ValidManifestApp/manifest.xml'),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
+        $repository = new StaticEntityRepository([new EntityCollection(), new EntityCollection()]);
+
         $lifecycle = new AppLifecycleIterator(
-            new StaticEntityRepository([new EntityCollection(), new EntityCollection()]),
+            $repository,
             $appLoader
         );
 
@@ -56,8 +61,11 @@ class AppLifecycleIteratorTest extends TestCase
             'ValidManifestApp' => Manifest::createFromXmlFile(__DIR__ . '/_fixtures/appDirValidationTest/ValidManifestApp/manifest.xml'),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
+        $repository = new StaticEntityRepository([new EntityCollection([$existingApp]), new EntityCollection([$existingApp])]);
+
         $lifecycle = new AppLifecycleIterator(
-            new StaticEntityRepository([new EntityCollection([$existingApp]), new EntityCollection([$existingApp])]),
+            $repository,
             $appLoader
         );
 
@@ -86,8 +94,11 @@ class AppLifecycleIteratorTest extends TestCase
             'ValidManifestApp' => Manifest::createFromXmlFile(__DIR__ . '/_fixtures/appDirValidationTest/ValidManifestApp/manifest.xml'),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
+        $repository = new StaticEntityRepository([new EntityCollection([$existingApp]), new EntityCollection([$existingApp])]);
+
         $lifecycle = new AppLifecycleIterator(
-            new StaticEntityRepository([new EntityCollection([$existingApp]), new EntityCollection([$existingApp])]),
+            $repository,
             $appLoader
         );
 
@@ -113,8 +124,11 @@ class AppLifecycleIteratorTest extends TestCase
 
         $appLoader = $this->createMock(AppLoader::class);
 
+        /** @var StaticEntityRepository<AppCollection> */
+        $repository = new StaticEntityRepository([new EntityCollection([$existingApp]), new EntityCollection([$existingApp])]);
+
         $lifecycle = new AppLifecycleIterator(
-            new StaticEntityRepository([new EntityCollection([$existingApp]), new EntityCollection([$existingApp])]),
+            $repository,
             $appLoader
         );
 
@@ -141,8 +155,11 @@ class AppLifecycleIteratorTest extends TestCase
 
         $appLoader = $this->createMock(AppLoader::class);
 
+        /** @var StaticEntityRepository<AppCollection> */
+        $repository = new StaticEntityRepository([new EntityCollection([$existingApp]), new EntityCollection([$existingApp])]);
+
         $lifecycle = new AppLifecycleIterator(
-            new StaticEntityRepository([new EntityCollection([$existingApp]), new EntityCollection([$existingApp])]),
+            $repository,
             $appLoader
         );
 
@@ -166,8 +183,11 @@ class AppLifecycleIteratorTest extends TestCase
             'ValidManifestApp' => Manifest::createFromXmlFile(__DIR__ . '/_fixtures/appDirValidationTest/ValidManifestApp/manifest.xml'),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
+        $repository = new StaticEntityRepository([new EntityCollection(), new EntityCollection()]);
+
         $lifecycle = new AppLifecycleIterator(
-            new StaticEntityRepository([new EntityCollection(), new EntityCollection()]),
+            $repository,
             $appLoader
         );
 

--- a/tests/unit/Core/Framework/Plugin/Command/Lifecycle/PluginUpdateAllCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Lifecycle/PluginUpdateAllCommandTest.php
@@ -28,6 +28,7 @@ class PluginUpdateAllCommandTest extends TestCase
         $pluginService = $this->createMock(PluginService::class);
         $pluginService->expects($this->once())->method('refreshPlugins');
 
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([new PluginCollection([
             $this->createPlugin('Test'),
             $this->createPlugin('Test2'),
@@ -48,6 +49,7 @@ class PluginUpdateAllCommandTest extends TestCase
         $pluginService = $this->createMock(PluginService::class);
         $pluginService->expects($this->once())->method('refreshPlugins');
 
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([new PluginCollection([
             $this->createPlugin('Test'),
             $this->createPlugin('Test2', false, '2.0.0'),
@@ -69,6 +71,7 @@ class PluginUpdateAllCommandTest extends TestCase
         $pluginService->expects($this->once())->method('refreshPlugins');
 
         $updateAblePlugin = $this->createPlugin('Test2', upgradeVersion: '1.0.1');
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([new PluginCollection([
             $this->createPlugin('Test'),
             $updateAblePlugin,
@@ -104,6 +107,7 @@ class PluginUpdateAllCommandTest extends TestCase
         $pluginService->expects($this->once())->method('refreshPlugins');
 
         $updateAblePlugin = $this->createPlugin('Test2', upgradeVersion: '1.0.1');
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([new PluginCollection([
             $this->createPlugin('Test'),
             $updateAblePlugin,

--- a/tests/unit/Core/Framework/Store/Api/FirstRunWizardControllerTest.php
+++ b/tests/unit/Core/Framework/Store/Api/FirstRunWizardControllerTest.php
@@ -50,11 +50,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('startFrw');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->frwStart($this->createContext());
 
@@ -68,11 +64,7 @@ class FirstRunWizardControllerTest extends TestCase
             ->method('startFrw')
             ->willThrowException($this->createClientException($exceptionMessage));
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         static::expectException(StoreApiException::class);
         static::expectExceptionMessage($exceptionMessage);
@@ -84,12 +76,14 @@ class FirstRunWizardControllerTest extends TestCase
         $context = $this->createContext();
         $plugin1Name = 'SwagTest1';
 
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([
             $this->createPluginSearchResult($context, [
                 ['name' => $plugin1Name],
             ]),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
         $appRepository = new StaticEntityRepository([
             new EntitySearchResult(
                 AppEntity::class,
@@ -124,12 +118,14 @@ class FirstRunWizardControllerTest extends TestCase
     {
         $context = $this->createContext();
 
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([
             $this->createPluginSearchResult($context, [
                 ['name' => 'SwagTest1'],
             ]),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
         $appRepository = new StaticEntityRepository([
             new EntitySearchResult(
                 AppEntity::class,
@@ -162,12 +158,14 @@ class FirstRunWizardControllerTest extends TestCase
         $context = $this->createContext();
         $plugin1Name = 'SwagTest1';
 
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([
             $this->createPluginSearchResult($context, [
                 ['name' => $plugin1Name],
             ]),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
         $appRepository = new StaticEntityRepository([
             new EntitySearchResult(
                 AppEntity::class,
@@ -202,12 +200,14 @@ class FirstRunWizardControllerTest extends TestCase
     {
         $context = $this->createContext();
 
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([
             $this->createPluginSearchResult($context, [
                 ['name' => 'SwagTest1'],
             ]),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
         $appRepository = new StaticEntityRepository([
             new EntitySearchResult(
                 AppEntity::class,
@@ -241,11 +241,7 @@ class FirstRunWizardControllerTest extends TestCase
             ->method('getRecommendationRegions')
             ->willReturn(new PluginRegionCollection([]));
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->getRecommendationRegions($this->createContext());
         $responseData = $this->decodeJsonResponse($response);
@@ -261,11 +257,7 @@ class FirstRunWizardControllerTest extends TestCase
             ->method('getRecommendationRegions')
             ->willThrowException($this->createClientException($exceptionMessage));
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         static::expectException(StoreApiException::class);
         static::expectExceptionMessage($exceptionMessage);
@@ -277,12 +269,14 @@ class FirstRunWizardControllerTest extends TestCase
         $context = $this->createContext();
         $plugin1Name = 'SwagTest1';
 
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([
             $this->createPluginSearchResult($context, [
                 ['name' => $plugin1Name],
             ]),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
         $appRepository = new StaticEntityRepository([
             new EntitySearchResult(
                 AppEntity::class,
@@ -317,12 +311,14 @@ class FirstRunWizardControllerTest extends TestCase
     {
         $context = $this->createContext();
 
+        /** @var StaticEntityRepository<PluginCollection> */
         $pluginRepository = new StaticEntityRepository([
             $this->createPluginSearchResult($context, [
                 ['name' => 'SwagTest1'],
             ]),
         ]);
 
+        /** @var StaticEntityRepository<AppCollection> */
         $appRepository = new StaticEntityRepository([
             new EntitySearchResult(
                 AppEntity::class,
@@ -360,11 +356,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('frwLogin');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->frwLogin($requestDataBag, $this->createContext());
 
@@ -380,11 +372,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->never())
             ->method('frwLogin');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         static::expectException(StoreInvalidCredentialsException::class);
         $frwController->frwLogin($requestDataBag, $this->createContext());
@@ -399,11 +387,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->never())
             ->method('frwLogin');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         static::expectException(StoreInvalidCredentialsException::class);
         $frwController->frwLogin($requestDataBag, $this->createContext());
@@ -421,11 +405,7 @@ class FirstRunWizardControllerTest extends TestCase
             ->method('frwLogin')
             ->willThrowException($this->createClientException($exceptionMessage));
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         static::expectException(StoreApiException::class);
         static::expectExceptionMessage($exceptionMessage);
@@ -437,11 +417,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('getLicenseDomains');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->getDomainList($this->createContext());
         $responseData = $this->decodeJsonResponse($response);
@@ -457,11 +433,7 @@ class FirstRunWizardControllerTest extends TestCase
             ->method('getLicenseDomains')
             ->willThrowException($this->createClientException($exceptionMessage));
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         static::expectException(StoreApiException::class);
         static::expectExceptionMessage($exceptionMessage);
@@ -473,11 +445,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('verifyLicenseDomain');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->verifyDomain(new QueryDataBag([
             'domain' => 'test-domain.com',
@@ -493,11 +461,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('verifyLicenseDomain');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->verifyDomain(
             new QueryDataBag(['testEnvironment' => 'false']),
@@ -513,11 +477,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('verifyLicenseDomain');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->verifyDomain(
             new QueryDataBag(['domain' => 'test-domain.com']),
@@ -533,11 +493,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('verifyLicenseDomain');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->verifyDomain(new QueryDataBag([
             'domain' => 'test-domain.com',
@@ -555,11 +511,7 @@ class FirstRunWizardControllerTest extends TestCase
             ->method('verifyLicenseDomain')
             ->willThrowException($this->createClientException($exceptionMessage));
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         static::expectException(StoreApiException::class);
         static::expectExceptionMessage($exceptionMessage);
@@ -576,11 +528,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('upgradeAccessToken');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->frwFinish(new QueryDataBag(['failed' => 'true']), $this->createContext());
 
@@ -594,11 +542,7 @@ class FirstRunWizardControllerTest extends TestCase
         $this->firstRunWizardService->expects($this->once())
             ->method('upgradeAccessToken');
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->frwFinish(new QueryDataBag([]), $this->createContext());
 
@@ -614,11 +558,7 @@ class FirstRunWizardControllerTest extends TestCase
             ->method('upgradeAccessToken')
             ->willThrowException(new \Exception($exceptionMessage));
 
-        $frwController = new FirstRunWizardController(
-            $this->firstRunWizardService,
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-        );
+        $frwController = $this->createFirstRunWizardController();
 
         $response = $frwController->frwFinish(new QueryDataBag(['failed' => 'false']), $this->createContext());
 
@@ -674,6 +614,21 @@ class FirstRunWizardControllerTest extends TestCase
             null,
             new Criteria(),
             $context
+        );
+    }
+
+    private function createFirstRunWizardController(): FirstRunWizardController
+    {
+        /** @var StaticEntityRepository<PluginCollection> */
+        $pluginRepository = new StaticEntityRepository([]);
+
+        /** @var StaticEntityRepository<AppCollection> */
+        $appRepository = new StaticEntityRepository([]);
+
+        return new FirstRunWizardController(
+            $this->firstRunWizardService,
+            $pluginRepository,
+            $appRepository,
         );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently a few EntityRepository types are missing their phpstan type
- As in the past we group this updates to the EntityRepository types by areas to keep the PR size reasonable
- This PR includes core Framework area

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the EntityRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/11765

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
