### PR TITLE
feat: Load all category levels of currently active path

### DIFF
--- a/changelog/_unreleased/2025-08-06-load-all-category-levels-for-current-path.md
+++ b/changelog/_unreleased/2025-08-06-load-all-category-levels-for-current-path.md
@@ -1,0 +1,19 @@
+---
+title: Load all category levels for current path
+---
+# Core
+* Changed `\Shopware\Core\Content\Category\SalesChannel\NavigationRoute` to load all category levels in the path to the currently active category.
+___
+# Storefront
+* Changed `storefront/layout/sidebar/category-navigation.html.twig` template to show all loaded category levels and don't stop on the configured level
+
+___
+
+# Upgrade Information
+
+## Load all category levels for current path in NavigationRoute
+
+The navigation route now loads all category levels in the path to the currently active category.
+Before it only loaded the configured levels as well as parents and children of the currently active category.
+However the "siblings" of all the parents were missing, which caused the navigation to be incomplete when you wanted to render the tree to the active path.
+As a result now the sidebar navigation in the CMS element now expands to the full path to the currently active category.

--- a/src/Core/Content/Category/SalesChannel/NavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/NavigationRoute.php
@@ -6,14 +6,18 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\CategoryException;
+use Shopware\Core\Content\Category\Tree\CategoryTreePathResolver;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\TermsAggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\CountAggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Bucket\TermsResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -41,6 +45,7 @@ class NavigationRoute extends AbstractNavigationRoute
         private readonly Connection $connection,
         private readonly SalesChannelRepository $categoryRepository,
         private readonly CacheTagCollector $cacheTagCollector,
+        private readonly CategoryTreePathResolver $categoryTreePathResolver,
     ) {
     }
 
@@ -82,49 +87,62 @@ class NavigationRoute extends AbstractNavigationRoute
 
         $isChild = $this->isChildCategory($activeId, $active['path'], $rootId);
 
+        $activePath = $active['path'];
         // If the provided activeId is not part of the rootId, a fallback to the rootId must be made here.
         // The passed activeId is therefore part of another navigation and must therefore not be loaded.
         // The availability validation has already been done in the `validate` function.
         if (!$isChild) {
             $activeId = $rootId;
+            $activePath = $root['path'];
         }
+
+        $additionalPathToLoad = $this->categoryTreePathResolver->getAdditionalPathsToLoad($activeId, $activePath, $rootId, $root['path'], $depth);
 
         $categories = new CategoryCollection();
-        if ($depth > 0) {
+        if ($depth > 0 || $additionalPathToLoad !== []) {
             // Load the first two levels without using the activeId in the query
-            $categories = $this->loadLevels($rootId, (int) $root['level'], $context, clone $criteria, $depth);
+            $categories = $this->loadLevels($rootId, (int) $root['level'], $context, clone $criteria, $depth, $additionalPathToLoad);
         }
-
-        // If the active category is part of the provided root id, we have to load the children and the parents of the active id
-        $categories = $this->loadChildren($activeId, $context, $rootId, $metaInfo, $categories, clone $criteria);
 
         return new NavigationRouteResponse($categories);
     }
 
     /**
-     * @param string[] $ids
+     * @param list<string> $additionalPaths
      */
-    private function loadCategories(array $ids, SalesChannelContext $context, Criteria $criteria): CategoryCollection
-    {
-        $criteria->setIds($ids);
-        $criteria->addAssociation('media');
-        $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_NONE);
+    private function loadLevels(
+        string $rootId,
+        int $rootLevel,
+        SalesChannelContext $context,
+        Criteria $criteria,
+        int $depth,
+        array $additionalPaths
+    ): CategoryCollection {
+        $filters = [
+            new EqualsFilter('id', $rootId),
+        ];
 
-        /** @var CategoryCollection $missing */
-        $missing = $this->categoryRepository->search($criteria, $context)->getEntities();
+        if ($depth > 0) {
+            $filters[] = new AndFilter([
+                new ContainsFilter('path', '|' . $rootId . '|'),
+                new RangeFilter('level', [
+                    RangeFilter::GT => $rootLevel,
+                    RangeFilter::LTE => $rootLevel + $depth + 1,
+                ]),
+            ]);
+        }
 
-        return $missing;
-    }
+        if ($additionalPaths !== []) {
+            $filters[] = new EqualsAnyFilter('path', $additionalPaths);
+        }
 
-    private function loadLevels(string $rootId, int $rootLevel, SalesChannelContext $context, Criteria $criteria, int $depth = 2): CategoryCollection
-    {
-        $criteria->addFilter(
-            new ContainsFilter('path', '|' . $rootId . '|'),
-            new RangeFilter('level', [
-                RangeFilter::GT => $rootLevel,
-                RangeFilter::LTE => $rootLevel + $depth + 1,
-            ])
-        );
+        switch (\count($filters)) {
+            case 1:
+                $criteria->addFilter($filters[0]);
+                break;
+            default:
+                $criteria->addFilter(new OrFilter($filters));
+        }
 
         $criteria->addAssociation('media');
 
@@ -148,7 +166,7 @@ class NavigationRoute extends AbstractNavigationRoute
             # navigation-route::meta-information
             SELECT LOWER(HEX(`id`)), `path`, `level`
             FROM `category`
-            WHERE `id` = :activeId OR `parent_id` = :activeId OR `id` = :rootId
+            WHERE `id` = :activeId OR `id` = :rootId
         ', ['activeId' => Uuid::fromHexToBytes($activeId), 'rootId' => Uuid::fromHexToBytes($rootId)]);
 
         if (!$result) {
@@ -173,46 +191,6 @@ class NavigationRoute extends AbstractNavigationRoute
         }
 
         return $metaInfo[$id];
-    }
-
-    /**
-     * @param array<string, CategoryMetaInformation> $metaInfo
-     */
-    private function loadChildren(string $activeId, SalesChannelContext $context, string $rootId, array $metaInfo, CategoryCollection $categories, Criteria $criteria): CategoryCollection
-    {
-        $active = $this->getMetaInfoById($activeId, $metaInfo);
-
-        unset($metaInfo[$rootId], $metaInfo[$activeId]);
-
-        $childIds = array_keys($metaInfo);
-
-        // Fetch all parents and first-level children of the active category, if they're not already fetched
-        $missing = $this->getMissingIds($activeId, $active['path'], $childIds, $categories);
-        if (empty($missing)) {
-            return $categories;
-        }
-
-        $categories->merge(
-            $this->loadCategories($missing, $context, $criteria)
-        );
-
-        return $categories;
-    }
-
-    /**
-     * @param array<string> $childIds
-     *
-     * @return list<string>
-     */
-    private function getMissingIds(string $activeId, ?string $path, array $childIds, CategoryCollection $alreadyLoaded): array
-    {
-        $parentIds = array_filter(explode('|', $path ?? ''));
-
-        $haveToBeIncluded = array_merge($childIds, $parentIds, [$activeId]);
-        $included = $alreadyLoaded->getIds();
-        $included = array_flip($included);
-
-        return array_values(array_diff($haveToBeIncluded, $included));
     }
 
     private function validate(string $activeId, ?string $path, SalesChannelContext $context): void

--- a/src/Core/Content/Category/Tree/CategoryTreePathResolver.php
+++ b/src/Core/Content/Category/Tree/CategoryTreePathResolver.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\Tree;
+
+/**
+ * @internal
+ */
+class CategoryTreePathResolver
+{
+    /**
+     * Returns a list of paths to load so the whole tree branch for the active category is loaded
+     * It skips the paths that will be automatically loaded because they are in the defined depths of the root category
+     *
+     * @return list<string>
+     */
+    public function getAdditionalPathsToLoad(string $activeId, ?string $activePath, string $rootId, ?string $rootPath, int $depth): array
+    {
+        $pathToLoad = !empty($activePath) ? $activePath . $activeId . '|' : '|' . $activeId . '|';
+        $rootPath = !empty($rootPath) ? $rootPath . $rootId . '|' : '|' . $rootId . '|';
+        $ids = array_filter(explode('|', $pathToLoad));
+
+        $currentPath = '|';
+        $pathsToLoad = [];
+
+        foreach ($ids as $id) {
+            $currentPath .= $id . '|';
+
+            if (str_contains($rootPath, $currentPath)) {
+                // we don't need to fetch the category level above the root
+                continue;
+            }
+
+            // when the current path starts with the root path,
+            // we need to figure out how many levels below the root we are
+            // if we are below the depth, we can skip this path
+            if (\strlen($rootPath) > 1 && str_starts_with($currentPath, $rootPath)) {
+                $subPath = substr($currentPath, \strlen($rootPath));
+                $levelsBelow = substr_count($subPath, '|');
+
+                if ($levelsBelow <= $depth) {
+                    continue;
+                }
+            }
+
+            $pathsToLoad[] = $currentPath;
+        }
+
+        return $pathsToLoad;
+    }
+}

--- a/src/Core/Content/Category/Tree/CategoryTreePathResolver.php
+++ b/src/Core/Content/Category/Tree/CategoryTreePathResolver.php
@@ -2,9 +2,12 @@
 
 namespace Shopware\Core\Content\Category\Tree;
 
+use Shopware\Core\Framework\Log\Package;
+
 /**
  * @internal
  */
+#[Package('framework')]
 class CategoryTreePathResolver
 {
     /**

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -30,7 +30,10 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="sales_channel.category.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollector"/>
+            <argument type="service" id="Shopware\Core\Content\Category\Tree\CategoryTreePathResolver"/>
         </service>
+
+        <service id="Shopware\Core\Content\Category\Tree\CategoryTreePathResolver"/>
 
         <service id="Shopware\Core\Content\Category\SalesChannel\TreeBuildingNavigationRoute" decorates="Shopware\Core\Content\Category\SalesChannel\NavigationRoute" decoration-priority="-2000" public="true">
             <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\TreeBuildingNavigationRoute.inner"/>

--- a/src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig
@@ -37,7 +37,7 @@
                             {% endif %}
 
                             {% block layout_navigation_categories_recoursion %}
-                                {% if level < navigationMaxDepth and item.children %}
+                                {% if item.children %}
                                     {% sw_include '@Storefront/storefront/layout/sidebar/category-navigation.html.twig' with {
                                         navigationTree: item.children,
                                         level: level + 1

--- a/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
+++ b/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
@@ -6,13 +6,18 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Tree\CategoryTreePathResolver;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
 #[CoversClass(CategoryTreePathResolver::class)]
+#[Package('framework')]
 class CategoryTreePathResolverTest extends TestCase
 {
+    /**
+     * @param list<string> $expected
+     */
     #[DataProvider('pathTestCases')]
     public function testPathResolution(
         string $activeId,
@@ -27,7 +32,7 @@ class CategoryTreePathResolverTest extends TestCase
     }
 
     /**
-     * @return array<string, array{string, ?string, string, ?string, int, array<string>, string}>
+     * @return array<string, array{string, ?string, string, ?string, int, list<string>}>
      */
     public static function pathTestCases(): array
     {

--- a/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
+++ b/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Category\Tree;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Tree\CategoryTreePathResolver;
+
+/**
+ * @internal
+ */
+#[CoversClass(CategoryTreePathResolver::class)]
+class CategoryTreePathResolverTest extends TestCase
+{
+    #[DataProvider('pathTestCases')]
+    public function testPathResolution(
+        string $activeId,
+        ?string $activePath,
+        string $rootId,
+        ?string $rootPath,
+        int $depth,
+        array $expected,
+    ): void {
+        $result = (new CategoryTreePathResolver())->getAdditionalPathsToLoad($activeId, $activePath, $rootId, $rootPath, $depth);
+        static::assertSame($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{string, ?string, string, ?string, int, array<string>, string}>
+     */
+    public static function pathTestCases(): array
+    {
+        return [
+            'Should return paths not loaded by depth of root' => [
+                '3',
+                '|1|2|',
+                '1',
+                '',
+                1,
+                ['|1|2|3|'],
+            ],
+            'Should skip paths within depth below root' => [
+                '4',
+                '|1|2|3|',
+                '2',
+                '|1|',
+                1,
+                ['|1|2|3|4|'],
+            ],
+            'Should handle null active path' => [
+                '2',
+                null,
+                '1',
+                '|',
+                0,
+                ['|2|'],
+            ],
+            'Should handle null root path' => [
+                '3',
+                '|1|2|',
+                '1',
+                null,
+                1,
+                ['|1|2|3|'],
+            ],
+            'Should handle empty active and root paths' => [
+                '5',
+                null,
+                '',
+                null,
+                1,
+                ['|5|'],
+            ],
+            'Should skip paths if active equals root' => [
+                '2',
+                '|1|',
+                '2',
+                '|1|',
+                1,
+                [],
+            ],
+            'Should skip paths if active and children are in depths' => [
+                '2',
+                '|1|',
+                '1',
+                '',
+                2,
+                [],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Navigation Loader only loaded direct parents & children of active category if it was below the general depth. However the siblings of the parents where missing, that lead to the sidebar navigation not being complete.

### 2. What does this change do, exactly?
Load all the levels in the category tree for the currently active path and let the sidebar navigation expand automatically to the level that is loaded on backend side

### 3. Describe each step to reproduce the issue or behaviour.
Use category layout with sidebar navigation and have a category structure that is 6 or more levels deep (keep the main navigation depths settings in the sales channel config to 3)

-> before you could only navigate to level 3 in the sidebar nav, with the change you can navigate all levels

### 5. Checklist

Did a performance trace: https://blackfire.io/profiles/compare/6a865446-6b42-4a6f-8a83-403c59a6db65/graph
Yes it get's slower, but keep in mind that it is for a request on the 6 level, so the added time is mainly for hydrating and rendering the additional categories that are now displayed, that were completely ignored before -> for that the performance impact is what you would impact from a feature like that 