### PR TITLE
fix: advanced prices for fixed item price discount

### DIFF
--- a/changelog/_unreleased/2025-08-06-fix-advanced-prices-for-fixed-item-price-discount.md
+++ b/changelog/_unreleased/2025-08-06-fix-advanced-prices-for-fixed-item-price-discount.md
@@ -1,0 +1,7 @@
+---
+title: Fix advanced prices for fixed item price discount
+author: Max Stegmeyer
+author_github: @mstegmeyer
+---
+# Administration
+* Changed `sw-promotion-discount-component` to correctly show the link to advanced prices when a fixed item price discount is used in a promotion.

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -173,9 +173,11 @@ export default {
         },
 
         showAbsoluteAdvancedPricesSettings() {
-            return this.discount.type === DiscountTypes.ABSOLUTE
-                || this.discount.type === DiscountTypes.FIXED
-                || this.discount.type === DiscountTypes.FIXED_UNIT;
+            return (
+                this.discount.type === DiscountTypes.ABSOLUTE ||
+                this.discount.type === DiscountTypes.FIXED ||
+                this.discount.type === DiscountTypes.FIXED_UNIT
+            );
         },
 
         // only show advanced max value settings if

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -173,7 +173,9 @@ export default {
         },
 
         showAbsoluteAdvancedPricesSettings() {
-            return this.discount.type === DiscountTypes.ABSOLUTE || this.discount.type === DiscountTypes.FIXED;
+            return this.discount.type === DiscountTypes.ABSOLUTE
+                || this.discount.type === DiscountTypes.FIXED
+                || this.discount.type === DiscountTypes.FIXED_UNIT;
         },
 
         // only show advanced max value settings if


### PR DESCRIPTION
### 1. Why is this change necessary?
Advanced prices are valid for more kinds of discounts (and can also be used in the Cart this way)

### 2. What does this change do, exactly?
Show the link to advanced prices also for fixed item discounts

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #11638

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
