### PR TITLE
fix: Adjust MatrixElement extends Struct for StoreApi

### DIFF
--- a/changelog/_unreleased/2025-08-06-adjust-matrix-element-extends-struct-for-store-api.md
+++ b/changelog/_unreleased/2025-08-06-adjust-matrix-element-extends-struct-for-store-api.md
@@ -1,0 +1,8 @@
+---
+title: Adjust MatrixElement extends Struct for StoreApi
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `Shopware\Core\Content\Product\SalesChannel\Review\MatrixElement` to extend `Shopware\Core\Framework\Struct\Struct` so it can be serialized for the StoreApi

--- a/src/Core/Content/Product/SalesChannel/Review/MatrixElement.php
+++ b/src/Core/Content/Product/SalesChannel/Review/MatrixElement.php
@@ -3,9 +3,10 @@
 namespace Shopware\Core\Content\Product\SalesChannel\Review;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
 
 #[Package('after-sales')]
-class MatrixElement
+class MatrixElement extends Struct
 {
     public function __construct(
         protected int $points,


### PR DESCRIPTION
### 1. Why is this change necessary?
- If you return the `RatingMatrix` object via the StoreApi the actual `matrix` is a array with empty array values, because the `MatrixElement` class is missing the `extends Struct` part

### 2. What does this change do, exactly?
* Changed `Shopware\Core\Content\Product\SalesChannel\Review\MatrixElement` to extend `Shopware\Core\Framework\Struct\Struct` so it can be serialized for the StoreApi

### 3. Describe each step to reproduce the issue or behaviour.
- Create a route endpoint to fetch the `RatingMatrix`
- The `matrix` is a array with empty array values

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
