### PR TITLE
fix: Remove assign override of MediaThumbnailEntity

### DIFF
--- a/changelog/_unreleased/2025-08-06-remove-assign-override-of-media-thumbnail-entity.md
+++ b/changelog/_unreleased/2025-08-06-remove-assign-override-of-media-thumbnail-entity.md
@@ -1,0 +1,8 @@
+---
+title: Remove assign override of MediaThumbnailEntity
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Removed `assign` method override in `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity` to prevent extensive deprecated message logging

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -38,21 +38,6 @@ class MediaThumbnailEntity extends Entity
 
     protected ?MediaThumbnailSizeEntity $mediaThumbnailSize = null;
 
-    public function assign(array $options)
-    {
-        parent::assign($options);
-
-        if (!isset($this->mediaId)) {
-            Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaId must not be null');
-        }
-
-        if (!isset($this->mediaThumbnailSizeId)) {
-            Feature::triggerDeprecationOrThrow('v6.8.0.0', '$mediaThumbnailSizeId must not be null');
-        }
-
-        return $this;
-    }
-
     public function getWidth(): int
     {
         return $this->width;


### PR DESCRIPTION
### 1. Why is this change necessary?
- https://github.com/shopware/shopware/pull/11633#issuecomment-3154798743
- https://github.com/shopware/shopware/pull/11633#issuecomment-3155307166
- The EntityHydrator assigns each property individually, so the method only ever checks a single property if used by the EntityHydrator, which always triggers the deprecated message
- We will still throw a error, if the user tries to access a null mediaId in the `getMediaId` method

### 2. What does this change do, exactly?
* Removed `assign` method override in `Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity` to prevent extensive deprecated message logging

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/11633#issuecomment-3154798743
- https://github.com/shopware/shopware/pull/11633#issuecomment-3155307166

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
