### PR TITLE
fix: recursive usage of CartItemRemoveRoute

### DIFF
--- a/changelog/_unreleased/2025-08-06-fix-recursive-usage-of-cartitemremoveroute.md
+++ b/changelog/_unreleased/2025-08-06-fix-recursive-usage-of-cartitemremoveroute.md
@@ -1,0 +1,7 @@
+---
+title: Fix advanced prices for fixed item price discount
+author: Max Stegmeyer
+author_github: @mstegmeyer
+---
+# Core
+* Changed `Shopware\Core\Checkout\Promotion\Subscriber\Storefront\StorefrontCartSubscriber` not use the CartItemRemoveRoute as this creates recursion but to just remove from the LineItemCollection.

--- a/src/Core/Checkout/DependencyInjection/promotion.xml
+++ b/src/Core/Checkout/DependencyInjection/promotion.xml
@@ -113,7 +113,7 @@
 
         <!-- SUBSCRIBERS -->
         <service id="Shopware\Core\Checkout\Promotion\Subscriber\Storefront\StorefrontCartSubscriber">
-            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="request_stack"/>
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
+++ b/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
@@ -144,9 +144,9 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
             ->filter(fn (LineItem $lineItem) => $lineItem->getType() === PromotionProcessor::LINE_ITEM_TYPE && $lineItem->getPayloadValue('promotionId') === $removedLineItem->getPayloadValue('promotionId'));
 
         foreach ($lineItemsOfSamePromotion as $lineItemOfSamePromotion) {
-            $this->eventDispatcher->dispatch(new BeforeLineItemRemovedEvent($lineItemOfSamePromotion, $cart, $context));
-
             $cart->remove($lineItemOfSamePromotion->getId());
+
+            $this->eventDispatcher->dispatch(new BeforeLineItemRemovedEvent($lineItemOfSamePromotion, $cart, $context));
         }
     }
 

--- a/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
+++ b/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
@@ -2,13 +2,13 @@
 
 namespace Shopware\Core\Checkout\Promotion\Subscriber\Storefront;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Event\BeforeLineItemAddedEvent;
 use Shopware\Core\Checkout\Cart\Event\BeforeLineItemRemovedEvent;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
-use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
@@ -29,7 +29,7 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
      * @internal
      */
     public function __construct(
-        private readonly CartService $cartService,
+        private readonly EventDispatcherInterface $eventDispatcher,
         private readonly RequestStack $requestStack
     ) {
     }
@@ -121,10 +121,6 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!$lineItem->hasPayloadValue('discountType')) {
-            return;
-        }
-
         if ($lineItem->getPayloadValue('discountType') !== PromotionDiscountEntity::TYPE_FIXED_UNIT) {
             return;
         }
@@ -135,34 +131,22 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
 
         $discountId = $lineItem->getPayloadValue('discountId');
 
-        $removeThisDiscounts = $lineItems->filter(static fn (LineItem $lineItem) => $lineItem->hasPayloadValue('discountId') && $lineItem->getPayloadValue('discountId') === $discountId);
+        $removeThisDiscounts = $lineItems->filter(static fn (LineItem $lineItem) => $lineItem->getPayloadValue('discountId') === $discountId);
 
         foreach ($removeThisDiscounts as $discountItem) {
             $cart->remove($discountItem->getId());
         }
     }
 
-    private function removeOtherDiscountsOfPromotion(Cart $cart, LineItem $lineItem, SalesChannelContext $context): void
+    private function removeOtherDiscountsOfPromotion(Cart $cart, LineItem $removedLineItem, SalesChannelContext $context): void
     {
-        // ge all promotions from cart
-        $lineItems = $cart->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE);
-        if ($lineItems->count() < 1) {
-            return;
-        }
+        $lineItemsOfSamePromotion = $cart->getLineItems()
+            ->filter(fn (LineItem $lineItem) => $lineItem->getType() === PromotionProcessor::LINE_ITEM_TYPE && $lineItem->getPayloadValue('promotionId') === $removedLineItem->getPayloadValue('promotionId'));
 
-        // filter them by the promotion which discounts should be deleted
-        $lineItems = $lineItems->filter(fn (LineItem $promotionLineItem) => $promotionLineItem->getPayloadValue('promotionId') === $lineItem->getPayloadValue('promotionId'));
+        foreach ($lineItemsOfSamePromotion as $lineItemOfSamePromotion) {
+            $this->eventDispatcher->dispatch(new BeforeLineItemRemovedEvent($lineItemOfSamePromotion, $cart, $context));
 
-        if ($lineItems->count() < 1) {
-            return;
-        }
-
-        $promotionLineItem = $lineItems->first();
-
-        if ($promotionLineItem instanceof LineItem) {
-            // this is recursive because we are listening on LineItemRemovedEvent, it will stop if there
-            // are no discounts in the cart, that belong to the promotion that should be deleted
-            $this->cartService->remove($cart, $promotionLineItem->getId(), $context);
+            $cart->remove($lineItemOfSamePromotion->getId());
         }
     }
 
@@ -170,34 +154,29 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
     {
         $extension = $this->getExtension($cart);
         $extension->addCode($code);
-
-        $cart->addExtension(CartExtension::KEY, $extension);
     }
 
     private function removeCode(string $code, Cart $cart): void
     {
         $extension = $this->getExtension($cart);
         $extension->removeCode($code);
-
-        $cart->addExtension(CartExtension::KEY, $extension);
     }
 
     private function blockPromotion(string $id, Cart $cart): void
     {
         $extension = $this->getExtension($cart);
         $extension->blockPromotion($id);
-
-        $cart->addExtension(CartExtension::KEY, $extension);
     }
 
     private function getExtension(Cart $cart): CartExtension
     {
-        if (!$cart->hasExtension(CartExtension::KEY)) {
-            $cart->addExtension(CartExtension::KEY, new CartExtension());
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+        if ($extension === null) {
+            // If the extension is not present, we create a new one
+            // to ensure that we can add codes and promotions to it.
+            $extension = new CartExtension();
+            $cart->addExtension(CartExtension::KEY, $extension);
         }
-
-        /** @var CartExtension $extension */
-        $extension = $cart->getExtension(CartExtension::KEY);
 
         return $extension;
     }

--- a/tests/unit/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriberTest.php
@@ -1,0 +1,235 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Promotion\Subscriber\Storefront;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Event\BeforeLineItemAddedEvent;
+use Shopware\Core\Checkout\Cart\Event\BeforeLineItemRemovedEvent;
+use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Checkout\Promotion\Subscriber\Storefront\StorefrontCartSubscriber;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(StorefrontCartSubscriber::class)]
+class StorefrontCartSubscriberTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = StorefrontCartSubscriber::getSubscribedEvents();
+        static::assertArrayHasKey(BeforeLineItemAddedEvent::class, $events);
+        static::assertArrayHasKey(BeforeLineItemRemovedEvent::class, $events);
+        static::assertArrayHasKey(CheckoutOrderPlacedEvent::class, $events);
+    }
+
+    public function testResetCodesNoMainRequest(): void
+    {
+        $requestStack = new RequestStack();
+        $subscriber = $this->createSubscriber(null, $requestStack);
+        $subscriber->resetCodes();
+
+        static::expectNotToPerformAssertions();
+    }
+
+    public function testResetCodesNoSession(): void
+    {
+        $mainRequest = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push($mainRequest);
+        $subscriber = $this->createSubscriber(null, $requestStack);
+        $subscriber->resetCodes();
+
+        static::expectNotToPerformAssertions();
+    }
+
+    public function testResetCodesWithSession(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->expects($this->once())
+            ->method('set')
+            ->with(StorefrontCartSubscriber::SESSION_KEY_PROMOTION_CODES, []);
+
+        $mainRequest = new Request();
+        $mainRequest->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($mainRequest);
+
+        $subscriber = $this->createSubscriber(null, $requestStack);
+        $subscriber->resetCodes();
+    }
+
+    public function testOnLineItemAddedNotPromotion(): void
+    {
+        $cart = Generator::createCart();
+        $lineItem = new LineItem('id', 'not-promotion');
+        $event = new BeforeLineItemAddedEvent($lineItem, $cart, Generator::generateSalesChannelContext());
+        $subscriber = $this->createSubscriber();
+        $subscriber->onLineItemAdded($event);
+
+        static::assertEmpty($cart->getExtensions());
+    }
+
+    public function testOnLineItemAddedPromotionNoCode(): void
+    {
+        $cart = Generator::createCart();
+        $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
+        $lineItem->setReferencedId('');
+        $event = new BeforeLineItemAddedEvent($lineItem, $cart, Generator::generateSalesChannelContext());
+        $subscriber = $this->createSubscriber();
+        $subscriber->onLineItemAdded($event);
+
+        static::assertEmpty($cart->getExtensions());
+    }
+
+    public function testOnLineItemAddedPromotionWithCode(): void
+    {
+        $cart = Generator::createCart();
+        $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
+        $lineItem->setReferencedId('CODE123');
+        $event = new BeforeLineItemAddedEvent($lineItem, $cart, Generator::generateSalesChannelContext());
+
+        $subscriber = $this->createSubscriber();
+        $subscriber->onLineItemAdded($event);
+
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+
+        static::assertInstanceOf(CartExtension::class, $extension);
+        static::assertTrue($extension->hasCode('CODE123'));
+    }
+
+    public function testOnLineItemRemovedNotPromotion(): void
+    {
+        $cart = new Cart('token');
+        $lineItem = new LineItem('id', 'not-promotion');
+        $cart->add($lineItem);
+
+        $event = new BeforeLineItemRemovedEvent($lineItem, $cart, Generator::generateSalesChannelContext());
+        $subscriber = $this->createSubscriber();
+        $subscriber->onLineItemRemoved($event);
+
+        static::assertTrue($cart->has($lineItem->getId()));
+    }
+
+    public function testOnLineItemRemovedPromotionWithCode(): void
+    {
+        $cart = Generator::createCart();
+
+        $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
+        $lineItem->setReferencedId('CODE123');
+        $lineItem->setRemovable(true);
+
+        $otherLineItem = new LineItem('otherid', PromotionProcessor::LINE_ITEM_TYPE);
+        $otherLineItem->setReferencedId('CODE123');
+        $otherLineItem->setRemovable(true);
+
+        $cart->add($otherLineItem);
+
+        $cart->addExtension(CartExtension::KEY, new CartExtension());
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+        static::assertInstanceOf(CartExtension::class, $extension);
+        $extension->addCode('CODE123');
+        $context = Generator::generateSalesChannelContext();
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(BeforeLineItemRemovedEvent::class));
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+
+        $event = new BeforeLineItemRemovedEvent($lineItem, $cart, $context);
+        $subscriber->onLineItemRemoved($event);
+
+        static::assertFalse($cart->has($otherLineItem->getId()));
+        static::assertFalse($extension->hasCode('CODE123'));
+    }
+
+    public function testOnLineItemRemovedPromotionWithCodeNoDiscountType(): void
+    {
+        $cart = Generator::createCart();
+        $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
+        $lineItem->setReferencedId('CODE123');
+        $lineItem->setRemovable(true);
+        $cart->add($lineItem);
+        $cart->addExtension(CartExtension::KEY, new CartExtension());
+        $context = Generator::generateSalesChannelContext();
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())->method('dispatch');
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+        $event = new BeforeLineItemRemovedEvent($lineItem, $cart, $context);
+        $subscriber->onLineItemRemoved($event);
+
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+        static::assertInstanceOf(CartExtension::class, $extension);
+        static::assertFalse($extension->hasCode('CODE123'));
+    }
+
+    public function testOnLineItemRemovedPromotionWithCodeNoDiscountId(): void
+    {
+        $cart = Generator::createCart();
+        $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
+        $lineItem->setReferencedId('CODE123');
+        $lineItem->setPayloadValue('discountType', PromotionDiscountEntity::TYPE_FIXED_UNIT);
+        $lineItem->setRemovable(true);
+        $cart->add($lineItem);
+        $cart->addExtension(CartExtension::KEY, new CartExtension());
+
+        $context = Generator::generateSalesChannelContext();
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())->method('dispatch');
+
+        $subscriber = $this->createSubscriber($eventDispatcher);
+        $event = new BeforeLineItemRemovedEvent($lineItem, $cart, $context);
+        $subscriber->onLineItemRemoved($event);
+
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+        static::assertInstanceOf(CartExtension::class, $extension);
+        static::assertFalse($extension->hasCode('CODE123'));
+    }
+
+    public function testOnLineItemRemovedPromotionNoCodeButPromotionId(): void
+    {
+        $cart = Generator::createCart();
+        $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
+        $lineItem->setPayloadValue('promotionId', 'PROMOID');
+        $lineItem->setRemovable(true);
+        $cart->add($lineItem);
+        $cart->addExtension(CartExtension::KEY, new CartExtension());
+
+        $subscriber = $this->createSubscriber();
+        $event = new BeforeLineItemRemovedEvent($lineItem, $cart, Generator::generateSalesChannelContext());
+
+        $subscriber->onLineItemRemoved($event);
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+        static::assertInstanceOf(CartExtension::class, $extension);
+        static::assertTrue($extension->isPromotionBlocked('PROMOID'));
+    }
+
+    private function createSubscriber(
+        ?EventDispatcherInterface $eventDispatcher = null,
+        ?RequestStack $requestStack = null
+    ): StorefrontCartSubscriber {
+        $eventDispatcher = $eventDispatcher ?? new CollectingEventDispatcher();
+        $requestStack = $requestStack ?? new RequestStack();
+
+        return new StorefrontCartSubscriber($eventDispatcher, $requestStack);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, the StorefrontCartSubscriber of promotions may call the CartItemRemoveRoute to remove more discounts, if one of a promotion is removed. This creates recursive calling and with the new cart locking mechanism, a deadlock.

### 2. What does this change do, exactly?
Just removes them from the line item collection, but continues to dispatch events.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a promotion with 2 discounts and a code (!).
- try to remove one of the discounts (expected behavior is for the other one to be removed as well)

### 4. Please link to the relevant issues (if any).
fixes #11716 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
