### PR TITLE
chore: enable deprecation details for phpunit suites

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,12 +2,12 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          bootstrap="src/Core/TestBootstrap.php"
+         cacheDirectory=".phpunit.cache"
          cacheResult="false"
          executionOrder="random"
          displayDetailsOnPhpunitDeprecations="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
-         displayDetailsOnTestsThatTriggerDeprecations="true"
-         cacheDirectory=".phpunit.cache">
+         displayDetailsOnTestsThatTriggerDeprecations="true">
     <coverage includeUncoveredFiles="true"/>
     <source ignoreSuppressionOfDeprecations="true"
             ignoreIndirectDeprecations="true"
@@ -15,6 +15,8 @@
             restrictWarnings="true">
         <deprecationTrigger>
             <function>trigger_deprecation</function>
+            <method>Doctrine\Deprecations\Deprecation::trigger</method>
+            <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>
         </deprecationTrigger>
         <include>
             <directory suffix=".php">src</directory>
@@ -169,6 +171,6 @@
         <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\FeatureFlag\FeatureFlagExtension"/>
         <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\Datadog\DatadogExtension"/>
         <!-- Enable to see the db side effects of the tests. -->
-        <!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>-->
+<!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>&ndash;&gt;-->
     </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,9 +6,16 @@
          executionOrder="random"
          displayDetailsOnPhpunitDeprecations="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          cacheDirectory=".phpunit.cache">
     <coverage includeUncoveredFiles="true"/>
-    <source>
+    <source ignoreSuppressionOfDeprecations="true"
+            ignoreIndirectDeprecations="true"
+            restrictNotices="true"
+            restrictWarnings="true">
+        <deprecationTrigger>
+            <function>trigger_deprecation</function>
+        </deprecationTrigger>
         <include>
             <directory suffix=".php">src</directory>
         </include>
@@ -27,7 +34,6 @@
             <directory suffix="Field.php">src/Administration/Snippet/</directory>
             <directory suffix="Struct.php">src/Administration/Snippet/</directory>
             <directory suffix="Collection.php">src/Administration/Snippet/</directory>
-
 
             <file>src/Core/Framework/Adapter/Twig/functions.php</file>
             <directory suffix=".php">src/Core/Test/Integration/Builder</directory>
@@ -101,9 +107,6 @@
         <server name="TESTS_RUNNING" value="1"/>
         <server name="MAILER_URL" value="null://localhost"/>
         <server name="HTTPS" value="off"/>
-        <!--To see the full stackTrace of a Deprecation set the value to a regex matching the deprecation warning-->
-        <!--https://symfony.com/doc/current/components/phpunit_bridge.html#display-the-full-stack-trace-->
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;ignoreFile=./deprecation.ignore" />
     </php>
     <testsuites>
         <testsuite name="unit">
@@ -166,6 +169,6 @@
         <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\FeatureFlag\FeatureFlagExtension"/>
         <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\Datadog\DatadogExtension"/>
         <!-- Enable to see the db side effects of the tests. -->
-<!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>-->
+        <!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>-->
     </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -171,6 +171,6 @@
         <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\FeatureFlag\FeatureFlagExtension"/>
         <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\Datadog\DatadogExtension"/>
         <!-- Enable to see the db side effects of the tests. -->
-<!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>&ndash;&gt;-->
+<!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>-->
     </extensions>
 </phpunit>


### PR DESCRIPTION
### 1. Why is this change necessary?
We need to see the details of the deprecations from the tests
(Symfony DeprecationErrorHandler got muted after upgrade to 7.3 + phpunit 11+)

### 2. What does this change do, exactly?
- It enables deprecation details for phpunit suites
- It discards the former handler of symfony, who has been disabled anyway for phpunit 10+ (see https://github.com/shopware/shopware/issues/11789)
- It does NOT fail the suites

### 3. Describe each step to reproduce the issue or behaviour.
- Run the tests (unit will be enough)
- Or, observe the tests reports for phpunit (multiple `D` instead of `.` and descriptions will appear in the report)
https://github.com/shopware/shopware/actions/runs/16781451588/job/47520927734?pr=11790
<img width="1056" height="832" alt="Screenshot 2025-08-06 at 17 38 33" src="https://github.com/user-attachments/assets/06b41349-ada0-4af1-bdb3-02524001822f" />


### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/11789


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
