### PR TITLE
fix: event interfaces for extension events

### DIFF
--- a/changelog/_unreleased/2025-08-06-event-interfaces-for-extension-events.md
+++ b/changelog/_unreleased/2025-08-06-event-interfaces-for-extension-events.md
@@ -1,0 +1,9 @@
+---
+title: Event interfaces for extension events
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `Shopware\Core\Checkout\Cart\Extension\CheckoutCartRuleLoaderExtension` to implement `Shopware\Core\Framework\Event\ShopwareSalesChannelEvent` and `Shopware\Core\Checkout\Cart\Event\CartEvent`
+* Changed `Shopware\Core\Checkout\Cart\Extension\CheckoutPlaceOrderExtension` to implement `Shopware\Core\Framework\Event\ShopwareSalesChannelEvent` and `Shopware\Core\Checkout\Cart\Event\CartEvent`

--- a/src/Core/Checkout/Cart/Extension/CheckoutCartRuleLoaderExtension.php
+++ b/src/Core/Checkout/Cart/Extension/CheckoutCartRuleLoaderExtension.php
@@ -4,7 +4,10 @@ namespace Shopware\Core\Checkout\Cart\Extension;
 
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartBehavior;
+use Shopware\Core\Checkout\Cart\Event\CartEvent;
 use Shopware\Core\Checkout\Cart\RuleLoaderResult;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Extensions\Extension;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -15,7 +18,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  * @extends Extension<RuleLoaderResult>
  */
 #[Package('checkout')]
-final class CheckoutCartRuleLoaderExtension extends Extension
+final class CheckoutCartRuleLoaderExtension extends Extension implements ShopwareSalesChannelEvent, CartEvent
 {
     public const NAME = 'checkout.cart.rule-load';
 
@@ -28,5 +31,20 @@ final class CheckoutCartRuleLoaderExtension extends Extension
         public readonly CartBehavior $cartBehavior,
         protected readonly bool $new,
     ) {
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getCart(): Cart
+    {
+        return $this->originalCart;
     }
 }

--- a/src/Core/Checkout/Cart/Extension/CheckoutPlaceOrderExtension.php
+++ b/src/Core/Checkout/Cart/Extension/CheckoutPlaceOrderExtension.php
@@ -3,7 +3,10 @@
 namespace Shopware\Core\Checkout\Cart\Extension;
 
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Event\CartEvent;
 use Shopware\Core\Checkout\Cart\Order\OrderPlaceResult;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Extensions\Extension;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -15,7 +18,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  * @extends Extension<OrderPlaceResult>
  */
 #[Package('checkout')]
-final class CheckoutPlaceOrderExtension extends Extension
+final class CheckoutPlaceOrderExtension extends Extension implements ShopwareSalesChannelEvent, CartEvent
 {
     public const NAME = 'checkout.place-order';
 
@@ -42,5 +45,17 @@ final class CheckoutPlaceOrderExtension extends Extension
          */
         public readonly RequestDataBag $data
     ) {
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext {
+        return $this->context;
+    }
+
+    public function getContext(): Context {
+        return $this->context->getContext();
+    }
+
+    public function getCart(): Cart {
+        return $this->cart;
     }
 }

--- a/src/Core/Checkout/Cart/Extension/CheckoutPlaceOrderExtension.php
+++ b/src/Core/Checkout/Cart/Extension/CheckoutPlaceOrderExtension.php
@@ -47,15 +47,18 @@ final class CheckoutPlaceOrderExtension extends Extension implements ShopwareSal
     ) {
     }
 
-    public function getSalesChannelContext(): SalesChannelContext {
+    public function getSalesChannelContext(): SalesChannelContext
+    {
         return $this->context;
     }
 
-    public function getContext(): Context {
+    public function getContext(): Context
+    {
         return $this->context->getContext();
     }
 
-    public function getCart(): Cart {
+    public function getCart(): Cart
+    {
         return $this->cart;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`Extension` events should implement event interfaces like any other.
Needed e.g. to correctly identify and prefix events in our subscription bubble ([Ref](https://github.com/shopware/SwagCommercial/blob/dbe5c8e93c1753aa74cae5e264151825fa8be303/src/Subscription/Framework/Event/SubscriptionEventRegistry.php)).

### 2. What does this change do, exactly?
Implement `ShopwareSalesChannelEvent` and `CartEvent` for `CheckoutPlaceOrderExtension` and `CheckoutCartRuleLoaderExtension`


### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
