### PR TITLE
fix: line item tax display with tax providers

### DIFF
--- a/changelog/_unreleased/2025-08-07-fix-display-of-line-item-taxes-with-tax-provider.md
+++ b/changelog/_unreleased/2025-08-07-fix-display-of-line-item-taxes-with-tax-provider.md
@@ -1,0 +1,7 @@
+---
+title: Fix display of line item taxes with tax provider
+author: Max Stegmeyer
+author_github: @mstegmeyer
+---
+# Administration
+* Changed `sw-order-line-item-grid` to correctly show calculated taxes for line items with tax provider.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
@@ -237,6 +237,7 @@ export default {
             };
             item.price = {
                 taxRules: [{ taxRate: 0 }],
+                calculatedTaxes: [{ taxRate: 0, tax: 0 }],
                 unitPrice: 0,
                 quantity: 1,
                 totalPrice: 0,
@@ -366,7 +367,7 @@ export default {
         showTaxValue(item) {
             return (this.isCreditItem(item.id) || this.isPromotionItem(item)) && item.price.taxRules.length > 1
                 ? this.$tc('sw-order.detailBase.textCreditTax')
-                : `${item.price.taxRules[0].taxRate} %`;
+                : `${item.price.calculatedTaxes[0].taxRate} %`;
         },
 
         checkItemPrice(price, item) {
@@ -449,6 +450,7 @@ export default {
                 !this.itemCreatedFromProduct(item.id) &&
                 item.priceDefinition &&
                 item.priceDefinition.taxRules &&
+                item.price?.taxRules[0].taxRate === item.price.calculatedTaxes[0].taxRate &&
                 !this.isCreditItem(item.id)
             );
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
The administration displays taxes based on taxRules, but with the TaxProvider, these are set just as CalculatedTaxes.

### 2. What does this change do, exactly?
Display calculated taxes and remove the inline edit if a TaxProvider is at play.

### 3. Describe each step to reproduce the issue or behaviour.
- use a tax provider to calculate a different tax than Shopware Tax Calculation
- display the order in the administration

### 4. Please link to the relevant issues (if any).
- fixes #11486

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
