### PR TITLE
fix: Fix CMS block component rendering

### DIFF
--- a/changelog/_unreleased/2025-08-07-fix-cms-block-component-rendering.md
+++ b/changelog/_unreleased/2025-08-07-fix-cms-block-component-rendering.md
@@ -1,0 +1,12 @@
+---
+title: Fix CMS block component rendering
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `sw-cms-section` component to render CMS block components by using their component name from block config. `sw-cms-block-${block.type}` is used as a fallback if no component name is defined.
+___
+# Upgrade Information
+## CMS block component name will be used
+When rendering CMS block components in the Administration, the `component` property of the block config will be used instead of `sw-cms-block-${block.type}`. If there is no component name defined, `sw-cms-block-${block.type}` will be used as a fallback. Make sure you have set the correct component name in your CMS block configs.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
@@ -301,5 +301,9 @@ export default Shopware.Component.wrapComponentConfig({
         toggleVisibility() {
             this.isCollapsed = !this.isCollapsed;
         },
+
+        getBlockComponent(type: string) {
+            return this.cmsService.getCmsBlockConfigByName(type)?.component ?? `sw-cms-block-${type}`;
+        },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.html.twig
@@ -75,7 +75,10 @@
                     >
 
                         {% block sw_cms_section_sidebar_block_component %}
-                        <component :is="`sw-cms-block-${block.type}`">
+                        <component
+                            :is="getBlockComponent(block.type)"
+                            :block="block"
+                        >
                             {% block sw_cms_section_content_block_slot %}
                             <template
                                 v-for="el in block.slots"
@@ -160,7 +163,7 @@
 
                         {% block sw_cms_section_content_block_component %}
                         <component
-                            :is="`sw-cms-block-${block.type}`"
+                            :is="getBlockComponent(block.type)"
                             :block="block"
                         >
                             {% block sw_cms_section_content_block_component_slot %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.spec.js
@@ -46,6 +46,16 @@ async function createWrapper() {
                             sectionPosition: 'main',
                             type: 'foo-bar-removed',
                         },
+                        {
+                            id: '9ij0',
+                            sectionPosition: 'sidebar',
+                            type: 'custom-foo-bar',
+                        },
+                        {
+                            id: '1kl2',
+                            sectionPosition: 'main',
+                            type: 'custom-foo-bar',
+                        },
                     ],
                 },
             },
@@ -63,6 +73,10 @@ async function createWrapper() {
                         props: ['block'],
                         template: '<div class="sw-cms-block-foo-bar"></div>',
                     },
+                    'custom-cms-block-foo-bar': {
+                        props: ['block'],
+                        template: '<div class="custom-cms-block-foo-bar"></div>',
+                    },
                     'sw-cms-slot': true,
                 },
                 provide: {
@@ -71,7 +85,13 @@ async function createWrapper() {
                         getCmsBlockRegistry: () => {
                             return {
                                 'foo-bar': {},
+                                'custom-foo-bar': {
+                                    component: 'custom-cms-block-foo-bar',
+                                },
                             };
+                        },
+                        getCmsBlockConfigByName(name) {
+                            return this.getCmsBlockRegistry()[name] ?? null;
                         },
                     },
                 },
@@ -108,7 +128,7 @@ describe('module/sw-cms/component/sw-cms-section', () => {
         expect(cmsBlock.attributes().disabled).toBeFalsy();
 
         const cmsStageAddBlocks = wrapper.findAll('.sw-cms-stage-add-block');
-        expect(cmsStageAddBlocks).toHaveLength(4);
+        expect(cmsStageAddBlocks).toHaveLength(6);
 
         cmsStageAddBlocks.forEach((cmsStageAddBlock) => {
             expect(cmsStageAddBlock.exists()).toBeTruthy();
@@ -227,5 +247,17 @@ describe('module/sw-cms/component/sw-cms-section', () => {
 
         const fooBarBlock = wrapper.findComponent('.sw-cms-section__content .sw-cms-block-foo-bar');
         expect(wrapper.vm.hasSlotConfigErrors(fooBarBlock.props('block'))).toBeTruthy();
+    });
+
+    it('should use block component name to render the block', async () => {
+        const wrapper = await createWrapper();
+
+        // custom block component name custom-foo-bar
+        const customFooBarBlock = wrapper.findComponent('.sw-cms-section__content .custom-cms-block-foo-bar');
+        expect(customFooBarBlock.exists()).toBeTruthy();
+
+        // default block component name foo-bar
+        const fooBarBlock = wrapper.findComponent('.sw-cms-section__content .sw-cms-block-foo-bar');
+        expect(fooBarBlock.exists()).toBeTruthy();
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -206,6 +206,9 @@ async function createWrapper(versionId = '0fa91ce3e96a4bc2be4bd9ce752c3425') {
                         isBlockAllowedInPageType: () => {
                             return true;
                         },
+                        getCmsBlockConfigByName(name) {
+                            return this.getCmsBlockRegistry()[name] ?? null;
+                        },
                     },
                     appCmsService: {},
                     cmsDataResolverService: {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The `component` property of a cms block is not used to render the block component in `sw-cms-section`. Instead, `sw-cms-block-${block.type}` is used for that.

### 2. What does this change do, exactly?
* Changed `sw-cms-section` component to render CMS block components by using their component name from block config. `sw-cms-block-${block.type}` is used as a fallback if no component name is defined.

### 3. Describe each step to reproduce the issue or behaviour.
Try to register a CMS block with a custom component name - not being `sw-cms-block-${block.type}`.

```js
Shopware.Service('cmsService').registerCmsBlock({
    name: 'custom-text',
    label: 'sw-cms.blocks.text.text.label',
    category: 'text',
    component: 'custom-cms-block-text',
    previewComponent: 'custom-cms-preview-text',
    defaultConfig: {
        marginBottom: '20px',
        marginTop: '20px',
        marginLeft: null,
        marginRight: null,
        sizingMode: 'boxed',
    },
    slots: {
        content: 'text',
    },
});
```

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
