### PR TITLE
docs: Exchange link to Slack with link to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Crowdin](https://badges.crowdin.net/shopware6/localized.svg)](https://translate.shopware.com/project/shopware6)
 [![License](https://img.shields.io/github/license/shopware/shopware.svg)](https://github.com/shopware/shopware/blob/trunk/LICENSE)
 [![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/shopware/shopware.svg)](https://github.com/shopware/shopware/pulls)
-[![Slack](https://img.shields.io/badge/chat-on%20slack-%23ECB22E)](https://slack.shopware.com?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Discord](https://img.shields.io/badge/chat-on%20discord-%23ECB22E)](https://chat.shopware.com/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 </div>
 
@@ -22,7 +22,7 @@
 
 <p align="center"><strong>Modern open source e-Commerce</strong>
 
-Shopware 6 is an open headless commerce platform powered by [Symfony 7](https://symfony.com) and [Vue.js 3](https://vuejs.org) that is used by thousands of shops and supported by a huge, [worldwide community](https://slack.shopware.com) of developers, agencies and merchants.
+Shopware 6 is an open headless commerce platform powered by [Symfony 7](https://symfony.com) and [Vue.js 3](https://vuejs.org) that is used by thousands of shops and supported by a huge, [worldwide community](https://chat.shopware.com/) of developers, agencies and merchants.
 
 If you like Shopware 6, give us a&nbsp;⭐️ &nbsp;on GitHub!
 
@@ -33,7 +33,7 @@ If you like Shopware 6, give us a&nbsp;⭐️ &nbsp;on GitHub!
 * 🉐 &nbsp;[Translate](https://translate.shopware.com) Shopware or help by contributing to existing languages
 * 🛠 &nbsp;[Report bugs](https://github.com/shopware/shopware/issues) in our issue tracker
 * 💡 &nbsp;Give us [feedback](https://feedback.shopware.com/) or vote existing ideas
-* 👪 &nbsp;Exchange with more than 9.000 Shopware developers in our [Slack community workspace](https://slack.shopware.com)
+* 👪 &nbsp;Exchange with other Shopware developers in our own [Community Hub](https://hub.shopware.com/) or the [Discord community](https://chat.shopware.com/)
 * 🗨 &nbsp;Help and get helped on [Stack Overflow](https://stackoverflow.com/questions/tagged/shopware6?tab=Newest) or in our [Community forum](https://forum.shopware.com/)
 
 ## Table of contents

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "forum": "https://forum.shopware.com",
         "wiki": "https://developer.shopware.com",
         "docs": "https://developer.shopware.com",
-        "chat": "https://slack.shopware.com"
+        "chat": "https://chat.shopware.com/"
     },
     "extra": {
         "bamarni-bin": {

--- a/src/Administration/composer.json
+++ b/src/Administration/composer.json
@@ -19,7 +19,7 @@
         "forum": "https://forum.shopware.com",
         "wiki": "https://developer.shopware.com",
         "docs": "https://developer.shopware.com",
-        "chat": "https://slack.shopware.com"
+        "chat": "https://chat.shopware.com/"
     },
     "extra": {
         "branch-alias": {

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -24,7 +24,7 @@
         "forum": "https://forum.shopware.com",
         "wiki": "https://developer.shopware.com",
         "docs": "https://developer.shopware.com",
-        "chat": "https://slack.shopware.com"
+        "chat": "https://chat.shopware.com/"
     },
     "extra": {
         "branch-alias": {

--- a/src/Elasticsearch/composer.json
+++ b/src/Elasticsearch/composer.json
@@ -19,7 +19,7 @@
         "forum": "https://forum.shopware.com",
         "wiki": "https://developer.shopware.com",
         "docs": "https://developer.shopware.com",
-        "chat": "https://slack.shopware.com"
+        "chat": "https://chat.shopware.com/"
     },
     "extra": {
         "branch-alias": {

--- a/src/Storefront/composer.json
+++ b/src/Storefront/composer.json
@@ -19,7 +19,7 @@
         "forum": "https://forum.shopware.com",
         "wiki": "https://developer.shopware.com",
         "docs": "https://developer.shopware.com",
-        "chat": "https://slack.shopware.com"
+        "chat": "https://chat.shopware.com/"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
### 1. Why is this change necessary?

Slack will be discontinued

### 2. What does this change do, exactly?

Use links to discord
