### PR TITLE
feat: Improve property group loading performance

### DIFF
--- a/changelog/_unreleased/2025-08-08-improve-property-group-loading-performance.md
+++ b/changelog/_unreleased/2025-08-08-improve-property-group-loading-performance.md
@@ -1,0 +1,7 @@
+---
+title: Improve property group loading performance
+issue: #11748
+---
+# Core
+* Changed `\Shopware\Core\Content\Product\SalesChannel\Listing\Filter\PropertyListingFilterHandler::process` to fetch groups and options separately instead of joining the group for every option, and to chunk the fetched ids instead of using pagination to improve performance.
+* Changed `\Shopware\Core\Content\Property\PropertyGroupCollection::sortByConfig` to use multisort to improve performance.

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -288,6 +288,7 @@
         <service id="Shopware\Core\Content\Product\SalesChannel\Listing\Filter\ShippingFreeListingFilterHandler"/>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Listing\Filter\PropertyListingFilterHandler">
+            <argument type="service" id="property_group.repository"/>
             <argument type="service" id="property_group_option.repository"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
-use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
+use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation;
@@ -18,8 +18,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -37,7 +37,8 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
      * @internal
      */
     public function __construct(
-        private readonly EntityRepository $repository,
+        private readonly EntityRepository $groupRepository,
+        private readonly EntityRepository $optionRepository,
         private readonly Connection $connection
     ) {
     }
@@ -66,27 +67,59 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
             return;
         }
 
-        $criteria = new Criteria($ids);
-        $criteria->setLimit(500);
-        $criteria->addAssociation('group');
-        $criteria->addAssociation('media');
-        $criteria->addFilter(new EqualsFilter('group.filterable', true));
-        $criteria->setTitle('product-listing::property-filter');
-        $criteria->addSorting(new FieldSorting('id', FieldSorting::ASCENDING));
+        $groupCriteria = new Criteria();
+        $groupCriteria->addFilter(new EqualsFilter('filterable', true));
 
-        $mergedOptions = new PropertyGroupOptionCollection();
+        $chunkIds = array_chunk($ids, 500);
+        $groups = new PropertyGroupCollection();
+        $previousIds = [];
 
-        $repositoryIterator = new RepositoryIterator($this->repository, $context->getContext(), $criteria);
-        while (($loop = $repositoryIterator->fetch()) !== null) {
-            $entities = $loop->getEntities();
+        foreach ($chunkIds as $chunk) {
+            $cloned = clone $groupCriteria;
 
-            $mergedOptions->merge($entities);
+            $cloned->setLimit(\count($chunk));
+            $cloned->addFilter(new EqualsAnyFilter('options.id', $chunk));
+
+            if (!empty($previousIds)) {
+                $cloned->addFilter(new NotEqualsAnyFilter(
+                    'id',
+                    $previousIds
+                ));
+            }
+
+            $groupResult = $this->groupRepository->search($cloned, $context->getContext());
+
+            $entities = $groupResult->getElements();
+            $previousIds = $groupResult->getIds();
+            $groups->fill($entities);
         }
 
-        // group options by their property-group
-        $grouped = $mergedOptions->groupByPropertyGroups();
-        $grouped->sortByPositions();
-        $grouped->sortByConfig();
+        foreach ($groups as $group) {
+            $group->setOptions(new PropertyGroupOptionCollection());
+        }
+
+        $optionCriteria = new Criteria();
+        $optionCriteria->addAssociation('media');
+        $optionCriteria->setTitle('product-listing::property-filter');
+
+        $options = new PropertyGroupOptionCollection();
+
+        foreach ($chunkIds as $chunk) {
+            $cloned = clone $optionCriteria;
+            $cloned->setLimit(\count($chunk));
+            $cloned->setIds($chunk);
+
+            $entities = $this->optionRepository->search($cloned, $context->getContext());
+
+            $options->fill($entities->getElements());
+        }
+
+        foreach ($options->getIterator() as $option) {
+            $groups->get($option->getGroupId())->getOptions()?->add($option);
+        }
+
+        $groups->sortByPositions();
+        $groups->sortByConfig();
 
         $aggregations = $result->getAggregations();
 
@@ -95,7 +128,7 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
         $aggregations->remove('configurators');
         $aggregations->remove('options');
 
-        $aggregations->add(new EntityResult('properties', $grouped));
+        $aggregations->add(new EntityResult('properties', $groups));
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
@@ -70,7 +70,7 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
         $groupCriteria = new Criteria();
         $groupCriteria->addFilter(new EqualsFilter('filterable', true));
 
-        $chunkIds = array_chunk($ids, 500);
+        $chunkIds = array_chunk($ids, 1000);
         $groups = new PropertyGroupCollection();
         $previousIds = [];
 
@@ -94,15 +94,11 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
             $groups->fill($entities);
         }
 
-        foreach ($groups as $group) {
-            $group->setOptions(new PropertyGroupOptionCollection());
-        }
-
         $optionCriteria = new Criteria();
         $optionCriteria->addAssociation('media');
         $optionCriteria->setTitle('product-listing::property-filter');
 
-        $options = new PropertyGroupOptionCollection();
+        $options = [];
 
         foreach ($chunkIds as $chunk) {
             $cloned = clone $optionCriteria;
@@ -111,10 +107,14 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
 
             $entities = $this->optionRepository->search($cloned, $context->getContext());
 
-            $options->fill($entities->getElements());
+            $options = array_merge($options, $entities->getElements());
         }
 
-        foreach ($options->getIterator() as $option) {
+        foreach ($groups as $group) {
+            $group->setOptions(new PropertyGroupOptionCollection());
+        }
+
+        foreach ($options as $option) {
             $groups->get($option->getGroupId())->getOptions()?->add($option);
         }
 

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -18,7 +19,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -34,6 +34,9 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
     final public const PROPERTY_GROUP_IDS_REQUEST_PARAM = 'property-whitelist';
 
     /**
+     * @param EntityRepository<PropertyGroupCollection> $groupRepository
+     * @param EntityRepository<PropertyGroupOptionCollection> $optionRepository
+     *
      * @internal
      */
     public function __construct(
@@ -67,47 +70,47 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
             return;
         }
 
-        $groupCriteria = new Criteria();
-        $groupCriteria->addFilter(new EqualsFilter('filterable', true));
-
         $chunkIds = array_chunk($ids, 1000);
-        $groups = new PropertyGroupCollection();
-        $previousIds = [];
-
-        foreach ($chunkIds as $chunk) {
-            $cloned = clone $groupCriteria;
-
-            $cloned->setLimit(\count($chunk));
-            $cloned->addFilter(new EqualsAnyFilter('options.id', $chunk));
-
-            if (!empty($previousIds)) {
-                $cloned->addFilter(new NotEqualsAnyFilter(
-                    'id',
-                    $previousIds
-                ));
-            }
-
-            $groupResult = $this->groupRepository->search($cloned, $context->getContext());
-
-            $entities = $groupResult->getElements();
-            $previousIds = $groupResult->getIds();
-            $groups->fill($entities);
-        }
 
         $optionCriteria = new Criteria();
         $optionCriteria->addAssociation('media');
         $optionCriteria->setTitle('product-listing::property-filter');
 
         $options = [];
+        $groupIds = [];
 
         foreach ($chunkIds as $chunk) {
             $cloned = clone $optionCriteria;
-            $cloned->setLimit(\count($chunk));
             $cloned->setIds($chunk);
 
             $entities = $this->optionRepository->search($cloned, $context->getContext());
 
             $options = array_merge($options, $entities->getElements());
+
+            /** @var PropertyGroupOptionEntity $option */
+            foreach ($entities as $option) {
+                if (!isset($groupIds[$option->getGroupId()])) {
+                    $groupIds[$option->getGroupId()] = true;
+                }
+            }
+        }
+
+        $groupCriteria = new Criteria();
+        $groupCriteria->setTitle('product-listing::property-group-filter');
+        $groupCriteria->addFilter(new EqualsFilter('filterable', true));
+
+        $groups = new PropertyGroupCollection();
+
+        $chunkIds = array_chunk(array_keys($groupIds), 1000);
+
+        foreach ($chunkIds as $chunk) {
+            $cloned = clone $groupCriteria;
+
+            $cloned->setIds($chunk);
+
+            $groupResult = $this->groupRepository->search($cloned, $context->getContext());
+
+            $groups->fill($groupResult->getElements());
         }
 
         foreach ($groups as $group) {
@@ -115,7 +118,7 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
         }
 
         foreach ($options as $option) {
-            $groups->get($option->getGroupId())->getOptions()?->add($option);
+            $groups->get($option->getGroupId())?->getOptions()?->add($option);
         }
 
         $groups->sortByPositions();

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionCollection.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionCollection.php
@@ -72,6 +72,22 @@ class PropertyGroupOptionCollection extends EntityCollection
         return $groups;
     }
 
+    /**
+     * @internal
+     * Performance optimization: By design this skips the expected class validation,
+     * should only be used internally, when we need to add a lot of entities, that are already validated.
+     *
+     * @param array<PropertyGroupOptionEntity> $options
+     *
+     */
+    public function fillOptions(array $options): void
+    {
+        foreach ($options as $option) {
+            $this->elements[$option->getUniqueIdentifier()] = $option;
+        }
+    }
+
+
     public function getApiAlias(): string
     {
         return 'product_group_option_collection';

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionCollection.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionCollection.php
@@ -78,7 +78,6 @@ class PropertyGroupOptionCollection extends EntityCollection
      * should only be used internally, when we need to add a lot of entities, that are already validated.
      *
      * @param array<PropertyGroupOptionEntity> $options
-     *
      */
     public function fillOptions(array $options): void
     {
@@ -86,7 +85,6 @@ class PropertyGroupOptionCollection extends EntityCollection
             $this->elements[$option->getUniqueIdentifier()] = $option;
         }
     }
-
 
     public function getApiAlias(): string
     {

--- a/src/Core/Content/Property/PropertyGroupCollection.php
+++ b/src/Core/Content/Property/PropertyGroupCollection.php
@@ -70,7 +70,11 @@ class PropertyGroupCollection extends EntityCollection
 
             array_multisort($columns, \SORT_ASC, \SORT_NATURAL, $entities);
 
-            $group->setOptions(new PropertyGroupOptionCollection($entities));
+            $sortedOptions = new PropertyGroupOptionCollection();
+            // Bypass expected class validation for performance optimization
+            $sortedOptions->fillOptions($entities);
+
+            $group->setOptions($sortedOptions);
         }
     }
 

--- a/src/Core/Content/Property/PropertyGroupCollection.php
+++ b/src/Core/Content/Property/PropertyGroupCollection.php
@@ -2,7 +2,8 @@
 
 namespace Shopware\Core\Content\Property;
 
-use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Log\Package;
 
@@ -18,7 +19,7 @@ class PropertyGroupCollection extends EntityCollection
     public function getOptionIdMap(): array
     {
         $map = [];
-        /** @var PropertyGroupEntity $group */
+
         foreach ($this->elements as $group) {
             if ($group->getOptions() === null) {
                 continue;
@@ -34,7 +35,7 @@ class PropertyGroupCollection extends EntityCollection
 
     public function sortByPositions(): void
     {
-        uasort($this->elements, function (Entity $a, Entity $b) {
+        uasort($this->elements, function (PropertyGroupEntity $a, PropertyGroupEntity $b) {
             $posA = $a->getTranslation('position') ?? $a->getPosition() ?? 0;
             $posB = $b->getTranslation('position') ?? $b->getPosition() ?? 0;
             if ($posA === $posB) {
@@ -47,20 +48,30 @@ class PropertyGroupCollection extends EntityCollection
 
     public function sortByConfig(): void
     {
-        /** @var Entity $group */
         foreach ($this->elements as $group) {
-            $options = $group->get('options');
-            if (!$options instanceof EntityCollection) {
+            $options = $group->getOptions();
+            if (!$options instanceof PropertyGroupOptionCollection) {
                 continue;
             }
 
-            $options->sort(static function (Entity $a, Entity $b) use ($group) {
-                if ($group->get('sortingType') === PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC) {
-                    return strnatcmp((string) $a->getTranslation('name'), (string) $b->getTranslation('name'));
+            $columns = [];
+            $entities = [];
+
+            $sortingType = PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC;
+
+            foreach ($options->getIterator() as $option) {
+                if ($sortingType) {
+                    $columns[] = (string) ($option->getTranslation('name') ?? '');
+                } else {
+                    $columns[] = (int) ($option->getTranslation('position') ?? $option->getPosition() ?? 0);
                 }
 
-                return ($a->getTranslation('position') ?? $a->get('position') ?? 0) <=> ($b->getTranslation('position') ?? $b->get('position') ?? 0);
-            });
+                $entities[] = $option;
+            }
+
+            array_multisort($columns, SORT_ASC, $entities);
+
+            $group->setOptions(new PropertyGroupOptionCollection($entities));
         }
     }
 

--- a/src/Core/Content/Property/PropertyGroupCollection.php
+++ b/src/Core/Content/Property/PropertyGroupCollection.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Content\Property;
 
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
-use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Log\Package;
 
@@ -69,7 +68,7 @@ class PropertyGroupCollection extends EntityCollection
                 $entities[] = $option;
             }
 
-            array_multisort($columns, SORT_ASC, $entities);
+            array_multisort($columns, \SORT_ASC, $entities);
 
             $group->setOptions(new PropertyGroupOptionCollection($entities));
         }

--- a/src/Core/Content/Property/PropertyGroupCollection.php
+++ b/src/Core/Content/Property/PropertyGroupCollection.php
@@ -56,10 +56,10 @@ class PropertyGroupCollection extends EntityCollection
             $columns = [];
             $entities = [];
 
-            $sortingType = PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC;
+            $sortingType = $group->getSortingType();
 
             foreach ($options->getIterator() as $option) {
-                if ($sortingType) {
+                if ($sortingType === PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC) {
                     $columns[] = (string) ($option->getTranslation('name') ?? '');
                 } else {
                     $columns[] = (int) ($option->getTranslation('position') ?? $option->getPosition() ?? 0);
@@ -68,7 +68,7 @@ class PropertyGroupCollection extends EntityCollection
                 $entities[] = $option;
             }
 
-            array_multisort($columns, \SORT_ASC, $entities);
+            array_multisort($columns, \SORT_ASC, \SORT_NATURAL, $entities);
 
             $group->setOptions(new PropertyGroupOptionCollection($entities));
         }

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/Filter/PropertyFilterHandlerTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/Filter/PropertyFilterHandlerTest.php
@@ -54,6 +54,7 @@ class PropertyFilterHandlerTest extends TestCase
 
         $handler = new PropertyListingFilterHandler(
             new StaticEntityRepository([]),
+            new StaticEntityRepository([]),
             $connection
         );
 
@@ -73,6 +74,7 @@ class PropertyFilterHandlerTest extends TestCase
             ->method('fetchAllAssociative');
 
         $handler = new PropertyListingFilterHandler(
+            new StaticEntityRepository([]),
             new StaticEntityRepository([]),
             $connection
         );
@@ -116,6 +118,7 @@ class PropertyFilterHandlerTest extends TestCase
 
         $handler = new PropertyListingFilterHandler(
             new StaticEntityRepository([]),
+            new StaticEntityRepository([]),
             $connection
         );
 
@@ -147,6 +150,7 @@ class PropertyFilterHandlerTest extends TestCase
         $connection = $this->createMock(Connection::class);
 
         $handler = new PropertyListingFilterHandler(
+            new StaticEntityRepository([]),
             new StaticEntityRepository([]),
             $connection
         );
@@ -180,6 +184,7 @@ class PropertyFilterHandlerTest extends TestCase
             ->method('fetchAllAssociative');
 
         $handler = new PropertyListingFilterHandler(
+            new StaticEntityRepository([]),
             new StaticEntityRepository([]),
             $connection
         );
@@ -276,7 +281,11 @@ class PropertyFilterHandlerTest extends TestCase
             new PropertyGroupOptionCollection(),
         ], $definition);
 
-        $handler = new PropertyListingFilterHandler($repository, $this->createMock(Connection::class));
+        $handler = new PropertyListingFilterHandler(
+            $repository,
+            new StaticEntityRepository([]),
+            $this->createMock(Connection::class)
+        );
 
         $result = new ProductListingResult(
             'test',

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/Filter/PropertyFilterHandlerTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/Filter/PropertyFilterHandlerTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionDefinition;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
+use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Content\Property\PropertyGroupDefinition;
 use Shopware\Core\Content\Property\PropertyGroupEntity;
 use Shopware\Core\Framework\Context;
@@ -28,13 +29,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @internal
@@ -52,11 +50,7 @@ class PropertyFilterHandlerTest extends TestCase
         $connection->expects($this->never())
             ->method('fetchAllAssociative');
 
-        $handler = new PropertyListingFilterHandler(
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-            $connection
-        );
+        $handler = $this->getHandlerWithConnection($connection);
 
         $result = $handler->create($request, $context);
 
@@ -73,11 +67,7 @@ class PropertyFilterHandlerTest extends TestCase
         $connection->expects($this->never())
             ->method('fetchAllAssociative');
 
-        $handler = new PropertyListingFilterHandler(
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-            $connection
-        );
+        $handler = $this->getHandlerWithConnection($connection);
 
         $result = $handler->create($request, $context);
 
@@ -116,11 +106,7 @@ class PropertyFilterHandlerTest extends TestCase
             ->method('fetchAllAssociative')
             ->willReturn($mapping);
 
-        $handler = new PropertyListingFilterHandler(
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-            $connection
-        );
+        $handler = $this->getHandlerWithConnection($connection);
 
         $result = $handler->create($request, $context);
 
@@ -149,11 +135,7 @@ class PropertyFilterHandlerTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
 
-        $handler = new PropertyListingFilterHandler(
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-            $connection
-        );
+        $handler = $this->getHandlerWithConnection($connection);
 
         $result = $handler->create($request, $context);
 
@@ -183,11 +165,7 @@ class PropertyFilterHandlerTest extends TestCase
         $connection->expects($this->never())
             ->method('fetchAllAssociative');
 
-        $handler = new PropertyListingFilterHandler(
-            new StaticEntityRepository([]),
-            new StaticEntityRepository([]),
-            $connection
-        );
+        $handler = $this->getHandlerWithConnection($connection);
 
         $result = $handler->create($request, $context);
 
@@ -222,12 +200,29 @@ class PropertyFilterHandlerTest extends TestCase
         $context = $this->createMock(SalesChannelContext::class);
         $context->method('getContext')->willReturn(Context::createDefaultContext());
 
-        new StaticDefinitionInstanceRegistry(
-            [$definition = new PropertyGroupOptionDefinition()],
-            $this->createMock(ValidatorInterface::class),
-            $this->createMock(EntityWriteGatewayInterface::class)
-        );
+        /** @var StaticEntityRepository<PropertyGroupCollection> $groupRepository */
+        $groupRepository = new StaticEntityRepository([
+            function (Criteria $criteria) {
+                static::assertContains('color', $criteria->getIds());
+                static::assertContains('size', $criteria->getIds());
 
+                return new PropertyGroupCollection([
+                    (new PropertyGroupEntity())->assign([
+                        'id' => 'color',
+                        'sortingType' => PropertyGroupDefinition::SORTING_TYPE_POSITION,
+                        'position' => 1,
+                    ]),
+                    (new PropertyGroupEntity())->assign([
+                        'id' => 'size',
+                        'sortingType' => PropertyGroupDefinition::SORTING_TYPE_POSITION,
+                        'position' => 2,
+                    ]),
+                ]);
+            },
+            new PropertyGroupCollection(),
+        ], new PropertyGroupDefinition());
+
+        /** @var StaticEntityRepository<PropertyGroupOptionCollection> $repository */
         $repository = new StaticEntityRepository([
             function (Criteria $criteria) {
                 static::assertContains('red', $criteria->getIds());
@@ -240,50 +235,30 @@ class PropertyFilterHandlerTest extends TestCase
                         'id' => 'red',
                         'groupId' => 'color',
                         'position' => 1,
-                        'group' => (new PropertyGroupEntity())->assign([
-                            'id' => 'color',
-                            'sortingType' => PropertyGroupDefinition::SORTING_TYPE_POSITION,
-                            'position' => 1,
-                        ]),
                     ]),
                     (new PropertyGroupOptionEntity())->assign([
                         'id' => 'green',
                         'groupId' => 'color',
                         'position' => 2,
-                        'group' => (new PropertyGroupEntity())->assign([
-                            'id' => 'color',
-                            'sortingType' => PropertyGroupDefinition::SORTING_TYPE_POSITION,
-                            'position' => 2,
-                        ]),
                     ]),
                     (new PropertyGroupOptionEntity())->assign([
                         'id' => 'xl',
                         'groupId' => 'size',
                         'position' => 2,
-                        'group' => (new PropertyGroupEntity())->assign([
-                            'id' => 'size',
-                            'sortingType' => PropertyGroupDefinition::SORTING_TYPE_POSITION,
-                            'position' => 1,
-                        ]),
                     ]),
                     (new PropertyGroupOptionEntity())->assign([
                         'id' => 'l',
                         'groupId' => 'size',
                         'position' => 1,
-                        'group' => (new PropertyGroupEntity())->assign([
-                            'id' => 'size',
-                            'sortingType' => PropertyGroupDefinition::SORTING_TYPE_POSITION,
-                            'position' => 1,
-                        ]),
                     ]),
                 ]);
             },
             new PropertyGroupOptionCollection(),
-        ], $definition);
+        ], new PropertyGroupOptionDefinition());
 
         $handler = new PropertyListingFilterHandler(
+            $groupRepository,
             $repository,
-            new StaticEntityRepository([]),
             $this->createMock(Connection::class)
         );
 
@@ -456,5 +431,19 @@ class PropertyFilterHandlerTest extends TestCase
                 ['property_group_id' => $ids->get('color'), 'id' => $ids->get('green')],
             ],
         ];
+    }
+
+    private function getHandlerWithConnection(Connection $connection): PropertyListingFilterHandler
+    {
+        /** @var StaticEntityRepository<PropertyGroupCollection> $groupRepository */
+        $groupRepository = new StaticEntityRepository([], new PropertyGroupDefinition());
+        /** @var StaticEntityRepository<PropertyGroupOptionCollection> $optionRepository */
+        $optionRepository = new StaticEntityRepository([], new PropertyGroupOptionDefinition());
+
+        return new PropertyListingFilterHandler(
+            $groupRepository,
+            $optionRepository,
+            $connection
+        );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Loading property group options is a known performance bottleneck

### 2. What does this change do, exactly?
Improve the performance by:
Reading property groups separately instead of joining them for every option
Chunking the ids for read, instead of pagination
use multisport to sort property groups

### 3. Describe each step to reproduce the issue or behaviour.
have a category with products that have 100s of property groups

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/11748
