### PR TITLE
fix: unit test SystemLanguageChangedSubscriberTest triggers PHP deprecation

### DIFF
--- a/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
+++ b/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
@@ -169,7 +169,6 @@ class SystemLanguageChangedSubscriberTest extends TestCase
             'id' => Uuid::randomHex(),
             'appId' => $appId,
             'localeId' => $localeId,
-            'name' => 'snippet-name',
             'value' => 'snippet-value',
         ]);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
After https://github.com/shopware/shopware/pull/11288 the phpunit suite for unit is triggering PHP deprecations

```
(devenv) SW-N91LJFG2YQ:platform nfortier$ composer run phpunit -- --testsuite unit --filter SystemLanguageChangedSubscriberTest
> phpunit '--testsuite' 'unit' '--filter' 'SystemLanguageChangedSubscriberTest'
PHPUnit 11.5.28 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.29
Configuration: /Users/nfortier/Dev/platform/phpunit.xml.dist
Random Seed:   1754656148

DDDD..DDDDD                                                       11 / 11 (100%)

Detected 1 test where the duration exceeded the maximum duration.

1. 00:08.658 (00:00.500) Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForPreviousLocaleWithPreviousLocaleId with data set #2 ('es-ES')

Time: 00:10.180, Memory: 173.00 MB

9 tests triggered 1 PHP deprecation:

1) /Users/nfortier/Dev/platform/src/Core/Framework/DataAbstractionLayer/Entity.php:53
Creation of dynamic property Shopware\Administration\Snippet\AppAdministrationSnippetEntity::$name is deprecated

Triggered by:

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testDoesNotUpdateSnippetsIfSystemLanguageIsChangedFromEnGbToDeDe (4 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:52

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForNewLocaleWithNewLocaleId#0 (2 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:122

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForNewLocaleWithNewLocaleId#1 (2 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:122

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForNewLocaleWithNewLocaleId#2 (2 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:122

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForNewLocaleWithNewLocaleId#3 (2 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:122

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForPreviousLocaleWithPreviousLocaleId#0 (4 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:83

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForPreviousLocaleWithPreviousLocaleId#1 (4 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:83

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForPreviousLocaleWithPreviousLocaleId#2 (4 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:83

* Shopware\Tests\Unit\Administration\Framework\App\Subscriber\SystemLanguageChangedSubscriberTest::testUpdatesSnippetsForPreviousLocaleWithPreviousLocaleId#3 (4 times)
  /Users/nfortier/Dev/platform/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php:83

OK, but there were issues!
Tests: 11, Assertions: 15, Deprecations: 1.
```


### 2. What does this change do, exactly?
Removes the unknown and unused property `name` from the entities consumed

We are allowing this to happen in the main class entity https://github.com/shopware/shopware/blob/8c48b2f39bf5b63e9ea87ff70a55e7d16191674f/src/Core/Framework/DataAbstractionLayer/Entity.php#L53 when a property does not exist and assign() is used, then we are dynamically creating it, which triggers that PHP warning.

In general within test files realm, it's better to verify those properties have accessors, unless it is really the intent to do a check on those abused properties.

### 3. Describe each step to reproduce the issue or behaviour.
- Run in local env `composer run phpunit -- --testsuite unit --filter SystemLanguageChangedSubscriberTest`
- In pipeline, check this deprecation is gone within phpunit check step


### 4. Please link to the relevant issues (if any).
- relates to https://github.com/shopware/shopware/issues/11789

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
