### PR TITLE
fix: phpunit deprecation in runner fails

### DIFF
--- a/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextPersisterTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextPersisterTest.php
@@ -344,7 +344,7 @@ class SalesChannelContextPersisterTest extends TestCase
         static::assertArrayNotHasKey(SalesChannelContextService::CUSTOMER_ID, $result);
     }
 
-    #[DataProvider('testRevokeTokensDataProvider')]
+    #[DataProvider('revokeTokensDataProvider')]
     public function testRevokeTokens(string $token, ?string $preserveToken): void
     {
         $customerId = $this->createCustomer();
@@ -367,7 +367,7 @@ class SalesChannelContextPersisterTest extends TestCase
         }
     }
 
-    public static function testRevokeTokensDataProvider(): \Generator
+    public static function revokeTokensDataProvider(): \Generator
     {
         yield [Uuid::randomHex(), ''];
         yield [$token = Uuid::randomHex(), $token];


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit fails silently on deprecation thrown in runner
Though this was tackled with https://github.com/sebastianbergmann/phpunit/issues/6304, we need to clean our own deprecations anyway.

This means removing any remaining dataprovider which name is starting with `test`

### 2. What does this change do, exactly?

Removes `test` from dataprovider name 

### 3. Describe each step to reproduce the issue or behaviour.
- Run these tests locally
- Run the pipeline

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
