### PR TITLE
chore: Use correct EntityRepository types for phpstan in core (Content)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -174,7 +174,6 @@ parameters:
         - # WIP implementation (See NEXT-29041 - https://github.com/shopware/shopware/issues/6175)
             message: '#.* generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityRepository.*not specify its types: TEntityCollection#'
             paths:
-                - src/Core/Content/**
                 - src/Core/Test/**
                 - tests/integration/Core/Content/**
                 - tests/integration/Core/Framework/**

--- a/src/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdater.php
+++ b/src/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdater.php
@@ -16,13 +16,16 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\Language\LanguageCollection;
 
 #[Package('discovery')]
 class CategoryBreadcrumbUpdater
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CategoryCollection> $categoryRepository
+     * @param EntityRepository<LanguageCollection> $languageRepository
      */
     public function __construct(
         private readonly Connection $connection,
@@ -64,9 +67,8 @@ class CategoryBreadcrumbUpdater
         $languageCriteria = new Criteria();
         $languageCriteria->addFilter(new EqualsFilter('active', true));
 
-        $languages = $this->languageRepository->search($languageCriteria, $context);
+        $languages = $this->languageRepository->search($languageCriteria, $context)->getEntities();
 
-        /** @var LanguageEntity $language */
         foreach ($languages as $language) {
             $context = new Context(
                 new SystemSource(),
@@ -89,7 +91,6 @@ class CategoryBreadcrumbUpdater
         $versionId = Uuid::fromHexToBytes($context->getVersionId());
         $languageId = Uuid::fromHexToBytes($context->getLanguageId());
 
-        /** @var CategoryCollection $categories */
         $categories = $this->categoryRepository
             ->search(new Criteria($all), $context)
             ->getEntities();

--- a/src/Core/Content/Cms/Command/CreatePageCommand.php
+++ b/src/Core/Content/Cms/Command/CreatePageCommand.php
@@ -3,6 +3,10 @@
 namespace Shopware\Core\Content\Cms\Command;
 
 use Faker\Factory;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Cms\CmsPageCollection;
+use Shopware\Core\Content\Media\MediaCollection;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -33,6 +37,12 @@ class CreatePageCommand extends Command
      */
     private array $media;
 
+    /**
+     * @param EntityRepository<CmsPageCollection> $cmsPageRepository
+     * @param EntityRepository<ProductCollection> $productRepository
+     * @param EntityRepository<CategoryCollection> $categoryRepository
+     * @param EntityRepository<MediaCollection> $mediaRepository
+     */
     public function __construct(
         private readonly EntityRepository $cmsPageRepository,
         private readonly EntityRepository $productRepository,

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
@@ -3,13 +3,13 @@
 namespace Shopware\Core\Content\ContactForm\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\Service\EmailIdnConverter;
-use Shopware\Core\Content\Category\CategoryEntity;
-use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\ContactForm\Event\ContactFormEvent;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
-use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
-use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\Salutation\SalutationCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Attribute\Route;
@@ -35,6 +36,12 @@ class ContactFormRoute extends AbstractContactFormRoute
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CmsSlotCollection> $cmsSlotRepository
+     * @param EntityRepository<SalutationCollection> $salutationRepository
+     * @param EntityRepository<CategoryCollection> $categoryRepository
+     * @param EntityRepository<LandingPageCollection> $landingPageRepository
+     * @param EntityRepository<ProductCollection> $productRepository
      */
     public function __construct(
         private readonly DataValidationFactoryInterface $contactFormValidationFactory,
@@ -127,7 +134,6 @@ class ContactFormRoute extends AbstractContactFormRoute
 
         $criteria = new Criteria([$navigationId]);
 
-        /** @var CategoryEntity|ProductEntity|LandingPageEntity $entity */
         $entity = match ($entityName) {
             ProductDefinition::ENTITY_NAME => $this->productRepository->search($criteria, $context->getContext())->first(),
             LandingPageDefinition::ENTITY_NAME => $this->landingPageRepository->search($criteria, $context->getContext())->first(),
@@ -170,7 +176,6 @@ class ContactFormRoute extends AbstractContactFormRoute
 
         $criteria = new Criteria([$slotId]);
 
-        /** @var CmsSlotEntity|null $slot */
         $slot = $this->cmsSlotRepository->search($criteria, $context->getContext())->getEntities()->first();
 
         if (!$slot) {

--- a/src/Core/Content/Flow/Api/FlowActionCollector.php
+++ b/src/Core/Content/Flow/Api/FlowActionCollector.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Content\Flow\Api;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowAction;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Events\FlowActionCollectorEvent;
-use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionEntity;
+use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -19,6 +19,7 @@ class FlowActionCollector
      * @internal
      *
      * @param iterable<FlowAction> $actions
+     * @param EntityRepository<AppFlowActionCollection> $appFlowActionRepo
      */
     public function __construct(
         protected iterable $actions,
@@ -55,7 +56,6 @@ class FlowActionCollector
         $criteria = new Criteria();
         $appActions = $this->appFlowActionRepo->search($criteria, $context)->getEntities();
 
-        /** @var AppFlowActionEntity $action */
         foreach ($appActions as $action) {
             $definition = new FlowActionDefinition(
                 $action->getName(),

--- a/src/Core/Content/Flow/Controller/TriggerFlowController.php
+++ b/src/Core/Content/Flow/Controller/TriggerFlowController.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Flow\Controller;
 
 use Shopware\Core\Content\Flow\FlowException;
+use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventCollection;
 use Shopware\Core\Framework\App\Event\CustomAppEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -24,6 +25,8 @@ class TriggerFlowController extends AbstractController
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<AppFlowEventCollection> $appFlowEventRepository
      */
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,

--- a/src/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeAction.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Flow\Dispatching\Action;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -19,6 +20,8 @@ class AddCustomerAffiliateAndCampaignCodeAction extends FlowAction implements De
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CustomerCollection> $customerRepository
      */
     public function __construct(
         private readonly Connection $connection,

--- a/src/Core/Content/Flow/Dispatching/Action/AddCustomerTagAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/AddCustomerTagAction.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Action;
 
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -17,6 +18,8 @@ class AddCustomerTagAction extends FlowAction implements DelayableAction
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CustomerCollection> $customerRepository
      */
     public function __construct(private readonly EntityRepository $customerRepository)
     {

--- a/src/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeAction.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Flow\Dispatching\Action;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -19,6 +20,8 @@ class AddOrderAffiliateAndCampaignCodeAction extends FlowAction implements Delay
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<OrderCollection> $orderRepository
      */
     public function __construct(
         private readonly Connection $connection,

--- a/src/Core/Content/Flow/Dispatching/Action/AddOrderTagAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/AddOrderTagAction.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Action;
 
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -17,6 +18,8 @@ class AddOrderTagAction extends FlowAction implements DelayableAction
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<OrderCollection> $orderRepository
      */
     public function __construct(private readonly EntityRepository $orderRepository)
     {

--- a/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupAction.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Action;
 
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -17,6 +18,8 @@ class ChangeCustomerGroupAction extends FlowAction implements DelayableAction
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CustomerCollection> $customerRepository
      */
     public function __construct(private readonly EntityRepository $customerRepository)
     {

--- a/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusAction.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Action;
 
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -17,6 +18,8 @@ class ChangeCustomerStatusAction extends FlowAction implements DelayableAction
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CustomerCollection> $customerRepository
      */
     public function __construct(private readonly EntityRepository $customerRepository)
     {

--- a/src/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessAction.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Action;
 
-use Shopware\Core\Checkout\Order\Aggregate\OrderLineItemDownload\OrderLineItemDownloadEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderLineItemDownload\OrderLineItemDownloadCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
@@ -18,6 +18,9 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('after-sales')]
 class GrantDownloadAccessAction extends FlowAction implements DelayableAction
 {
+    /**
+     * @param EntityRepository<OrderLineItemDownloadCollection> $orderLineItemDownloadRepository
+     */
     public function __construct(private readonly EntityRepository $orderLineItemDownloadRepository)
     {
     }
@@ -71,7 +74,6 @@ class GrantDownloadAccessAction extends FlowAction implements DelayableAction
                 continue;
             }
 
-            /** @var OrderLineItemDownloadEntity $download */
             foreach ($lineItem->getDownloads() as $download) {
                 $downloadIds[] = $download->getId();
                 $download->setAccessGranted((bool) $config['value']);

--- a/src/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagAction.php
@@ -5,6 +5,8 @@ namespace Shopware\Core\Content\Flow\Dispatching\Action;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Log\Package;
@@ -17,6 +19,8 @@ class RemoveCustomerTagAction extends FlowAction implements DelayableAction
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<EntityCollection<Entity>> $customerTagRepository
      */
     public function __construct(private readonly EntityRepository $customerTagRepository)
     {

--- a/src/Core/Content/Flow/Dispatching/Action/RemoveOrderTagAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/RemoveOrderTagAction.php
@@ -5,6 +5,8 @@ namespace Shopware\Core\Content\Flow\Dispatching\Action;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Log\Package;
@@ -17,6 +19,8 @@ class RemoveOrderTagAction extends FlowAction implements DelayableAction
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<EntityCollection<Entity>> $orderTagRepository
      */
     public function __construct(private readonly EntityRepository $orderTagRepository)
     {

--- a/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
@@ -9,7 +9,9 @@ use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Events\FlowSendMailActionEvent;
 use Shopware\Core\Content\Mail\Service\AbstractMailService;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsConfig;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeCollection;
 use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
+use Shopware\Core\Content\MailTemplate\MailTemplateCollection;
 use Shopware\Core\Content\MailTemplate\MailTemplateEntity;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
@@ -45,6 +47,9 @@ class SendMailAction extends FlowAction implements DelayableAction
 
     /**
      * @internal
+     *
+     * @param EntityRepository<MailTemplateCollection> $mailTemplateRepository
+     * @param EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository
      */
     public function __construct(
         private readonly AbstractMailService $emailService,
@@ -271,12 +276,7 @@ class SendMailAction extends FlowAction implements DelayableAction
         $criteria->addAssociation('media.media');
         $criteria->setLimit(1);
 
-        /** @var ?MailTemplateEntity $mailTemplate */
-        $mailTemplate = $this->mailTemplateRepository
-            ->search($criteria, $context)
-            ->first();
-
-        return $mailTemplate;
+        return $this->mailTemplateRepository->search($criteria, $context)->getEntities()->first();
     }
 
     private function injectTranslator(Context $context, ?string $salesChannelId): bool

--- a/src/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorer.php
@@ -22,6 +22,8 @@ class A11yRenderedDocumentStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<DocumentCollection> $documentRepository
      */
     public function __construct(
         private readonly EntityRepository $documentRepository,
@@ -84,7 +86,6 @@ class A11yRenderedDocumentStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        /** @var DocumentCollection $documents */
         $documents = $this->documentRepository
             ->search($criteria, $context)
             ->getEntities();

--- a/src/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorer.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupCollection;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupDefinition;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
@@ -19,6 +20,8 @@ class CustomerGroupStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CustomerGroupCollection> $customerGroupRepository
      */
     public function __construct(
         private readonly EntityRepository $customerGroupRepository,
@@ -78,10 +81,9 @@ class CustomerGroupStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        $customerGroup = $this->customerGroupRepository->search($criteria, $context)->get($id);
+        $customerGroup = $this->customerGroupRepository->search($criteria, $context)->getEntities()->get($id);
 
         if ($customerGroup) {
-            /** @var CustomerGroupEntity $customerGroup */
             return $customerGroup;
         }
 

--- a/src/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorer.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerRecovery\CustomerRecoveryCollection;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerRecovery\CustomerRecoveryDefinition;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerRecovery\CustomerRecoveryEntity;
 use Shopware\Core\Content\Flow\Dispatching\Aware\CustomerRecoveryAware;
@@ -19,6 +20,8 @@ class CustomerRecoveryStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CustomerRecoveryCollection> $customerRecoveryRepository
      */
     public function __construct(
         private readonly EntityRepository $customerRecoveryRepository,
@@ -78,10 +81,9 @@ class CustomerRecoveryStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        $customerRecovery = $this->customerRecoveryRepository->search($criteria, $context)->get($id);
+        $customerRecovery = $this->customerRecoveryRepository->search($criteria, $context)->getEntities()->get($id);
 
         if ($customerRecovery) {
-            /** @var CustomerRecoveryEntity $customerRecovery */
             return $customerRecovery;
         }
 

--- a/src/Core/Content/Flow/Dispatching/Storer/CustomerStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/CustomerStorer.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
@@ -20,6 +21,8 @@ class CustomerStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CustomerCollection> $customerRepository
      */
     public function __construct(
         private readonly EntityRepository $customerRepository,
@@ -90,10 +93,9 @@ class CustomerStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        $customer = $this->customerRepository->search($criteria, $context)->get($id);
+        $customer = $this->customerRepository->search($criteria, $context)->getEntities()->get($id);
 
         if ($customer) {
-            /** @var CustomerEntity $customer */
             return $customer;
         }
 

--- a/src/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorer.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 use Shopware\Core\Content\Flow\Dispatching\Aware\NewsletterRecipientAware;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientCollection;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Framework\Context;
@@ -19,6 +20,8 @@ class NewsletterRecipientStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<NewsletterRecipientCollection> $newsletterRecipientRepository
      */
     public function __construct(
         private readonly EntityRepository $newsletterRecipientRepository,
@@ -76,10 +79,9 @@ class NewsletterRecipientStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        $newsletterRecipient = $this->newsletterRecipientRepository->search($criteria, $context)->get($id);
+        $newsletterRecipient = $this->newsletterRecipientRepository->search($criteria, $context)->getEntities()->get($id);
 
         if ($newsletterRecipient) {
-            /** @var NewsletterRecipientEntity $newsletterRecipient */
             return $newsletterRecipient;
         }
 

--- a/src/Core/Content/Flow/Dispatching/Storer/OrderStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/OrderStorer.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
@@ -20,6 +21,8 @@ class OrderStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<OrderCollection> $orderRepository
      */
     public function __construct(
         private readonly EntityRepository $orderRepository,
@@ -97,10 +100,9 @@ class OrderStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        $order = $this->orderRepository->search($criteria, $context)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $context)->getEntities()->get($orderId);
 
         if ($order) {
-            /** @var OrderEntity $order */
             return $order;
         }
 

--- a/src/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorer.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Content\Flow\Dispatching\Aware\OrderTransactionAware;
@@ -19,6 +20,8 @@ class OrderTransactionStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<OrderTransactionCollection> $orderTransactionRepository
      */
     public function __construct(
         private readonly EntityRepository $orderTransactionRepository,
@@ -76,10 +79,9 @@ class OrderTransactionStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        $orderTransaction = $this->orderTransactionRepository->search($criteria, $context)->get($id);
+        $orderTransaction = $this->orderTransactionRepository->search($criteria, $context)->getEntities()->get($id);
 
         if ($orderTransaction) {
-            /** @var OrderTransactionEntity $orderTransaction */
             return $orderTransaction;
         }
 

--- a/src/Core/Content/Flow/Dispatching/Storer/ProductStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/ProductStorer.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\Context;
@@ -19,6 +20,8 @@ class ProductStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductCollection> $productRepository
      */
     public function __construct(
         private readonly EntityRepository $productRepository,
@@ -73,9 +76,6 @@ class ProductStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        /** @var ProductEntity|null $product */
-        $product = $this->productRepository->search($criteria, $context)->get($id);
-
-        return $product;
+        return $this->productRepository->search($criteria, $context)->getEntities()->get($id);
     }
 }

--- a/src/Core/Content/Flow/Dispatching/Storer/UserStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/UserStorer.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\UserAware;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryCollection;
 use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryDefinition;
 use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryEntity;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -19,6 +20,8 @@ class UserStorer extends FlowStorer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<UserRecoveryCollection> $userRecoveryRepository
      */
     public function __construct(
         private readonly EntityRepository $userRecoveryRepository,
@@ -73,10 +76,9 @@ class UserStorer extends FlowStorer
 
         $this->dispatcher->dispatch($event, $event->getName());
 
-        $user = $this->userRecoveryRepository->search($criteria, $context)->get($id);
+        $user = $this->userRecoveryRepository->search($criteria, $context)->getEntities()->get($id);
 
         if ($user) {
-            /** @var UserRecoveryEntity $user */
             return $user;
         }
 

--- a/src/Core/Content/Flow/Indexing/FlowIndexer.php
+++ b/src/Core/Content/Flow/Indexing/FlowIndexer.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Flow\Indexing;
 
 use Shopware\Core\Content\Flow\Events\FlowIndexerEvent;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Flow\FlowDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -23,6 +24,8 @@ class FlowIndexer extends EntityIndexer
 
     /**
      * @internal
+     *
+     * @param EntityRepository<FlowCollection> $repository
      */
     public function __construct(
         private readonly IteratorFactory $iteratorFactory,

--- a/src/Core/Content/ImportExport/Controller/ImportExportActionController.php
+++ b/src/Core/Content/ImportExport/Controller/ImportExportActionController.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\ImportExport\Service\SupportedFeaturesService;
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
@@ -40,6 +41,8 @@ class ImportExportActionController extends AbstractController
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<EntityCollection<ImportExportProfileEntity>> $profileRepository
      */
     public function __construct(
         private readonly SupportedFeaturesService $supportedFeaturesService,
@@ -202,7 +205,7 @@ class ImportExportActionController extends AbstractController
             ->getEntities()
             ->get($profileId);
 
-        if ($profile instanceof ImportExportProfileEntity) {
+        if ($profile) {
             return $profile;
         }
 

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryDefinition;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -22,6 +23,8 @@ class CountrySerializer extends EntitySerializer implements ResetInterface
 
     /**
      * @internal
+     *
+     * @param EntityRepository<CountryCollection> $countryRepository
      */
     public function __construct(private readonly EntityRepository $countryRepository)
     {

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Entity;
 
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Framework\Context;
@@ -10,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('fundamentals@after-sales')]
@@ -18,6 +20,8 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
     /**
      * @internal
      *
+     * @param EntityRepository<CustomerGroupCollection> $customerGroupRepository
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      * @param array<string, string|null> $cacheCustomerGroups
      * @param array<string, string|null> $cacheSalesChannels
      */

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializer.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\Language\LanguageEntity;
 use Symfony\Contracts\Service\ResetInterface;
@@ -24,6 +25,8 @@ class LanguageSerializer extends EntitySerializer implements ResetInterface
 
     /**
      * @internal
+     *
+     * @param EntityRepository<LanguageCollection> $languageRepository
      */
     public function __construct(private readonly EntityRepository $languageRepository)
     {

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
@@ -4,7 +4,10 @@ namespace Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Ent
 
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityEntity;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -19,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
 #[Package('fundamentals@after-sales')]
 class ProductSerializer extends EntitySerializer
@@ -31,6 +35,11 @@ class ProductSerializer extends EntitySerializer
 
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductVisibilityCollection> $visibilityRepository
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     * @param EntityRepository<ProductMediaCollection> $productMediaRepository
+     * @param EntityRepository<ProductConfiguratorSettingCollection> $productConfiguratorSettingRepository
      */
     public function __construct(
         private readonly EntityRepository $visibilityRepository,

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/PromotionIndividualCodeSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/PromotionIndividualCodeSerializer.php
@@ -2,7 +2,9 @@
 
 namespace Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Entity;
 
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionIndividualCode\PromotionIndividualCodeCollection;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionIndividualCode\PromotionIndividualCodeDefinition;
+use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -27,6 +29,9 @@ class PromotionIndividualCodeSerializer extends EntitySerializer implements Rese
 
     /**
      * @internal
+     *
+     * @param EntityRepository<PromotionIndividualCodeCollection> $promoCodeRepository
+     * @param EntityRepository<PromotionCollection> $promoRepository
      */
     public function __construct(
         private readonly EntityRepository $promoCodeRepository,

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Salutation\SalutationCollection;
 use Shopware\Core\System\Salutation\SalutationDefinition;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -22,6 +23,8 @@ class SalutationSerializer extends EntitySerializer implements ResetInterface
 
     /**
      * @internal
+     *
+     * @param EntityRepository<SalutationCollection> $salutationRepository
      */
     public function __construct(private readonly EntityRepository $salutationRepository)
     {

--- a/src/Core/Content/ImportExport/Event/Subscriber/ProductCategoryPathsSubscriber.php
+++ b/src/Core/Content/ImportExport/Event/Subscriber/ProductCategoryPathsSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\ImportExport\Event\Subscriber;
 
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\ImportExport\Event\ImportExportBeforeImportRecordEvent;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -30,6 +31,8 @@ class ProductCategoryPathsSubscriber implements EventSubscriberInterface, ResetI
 
     /**
      * @internal
+     *
+     * @param EntityRepository<CategoryCollection> $categoryRepository
      */
     public function __construct(
         private readonly EntityRepository $categoryRepository,

--- a/src/Core/Content/ImportExport/Event/Subscriber/ProductVariantsSubscriber.php
+++ b/src/Core/Content/ImportExport/Event/Subscriber/ProductVariantsSubscriber.php
@@ -8,6 +8,8 @@ use Shopware\Core\Content\ImportExport\Event\ImportExportAfterImportRecordEvent;
 use Shopware\Core\Content\ImportExport\Exception\ProcessingException;
 use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
+use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\Api\Sync\SyncBehavior;
 use Shopware\Core\Framework\Api\Sync\SyncOperation;
 use Shopware\Core\Framework\Api\Sync\SyncServiceInterface;
@@ -41,6 +43,9 @@ class ProductVariantsSubscriber implements EventSubscriberInterface, ResetInterf
 
     /**
      * @internal
+     *
+     * @param EntityRepository<PropertyGroupCollection> $groupRepository
+     * @param EntityRepository<PropertyGroupOptionCollection> $optionRepository
      */
     public function __construct(
         private readonly SyncServiceInterface $syncService,

--- a/src/Core/Content/ImportExport/ImportExport.php
+++ b/src/Core/Content/ImportExport/ImportExport.php
@@ -23,6 +23,7 @@ use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Content\ImportExport\Struct\Progress;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
@@ -53,6 +54,9 @@ class ImportExport
      */
     private array $failedWriteCommands = [];
 
+    /**
+     * @param EntityRepository<covariant EntityCollection<covariant Entity>> $repository
+     */
     public function __construct(
         private readonly ImportExportService $importExportService,
         private ImportExportLogEntity $logEntity,

--- a/src/Core/Content/ImportExport/ImportExportFactory.php
+++ b/src/Core/Content/ImportExport/ImportExportFactory.php
@@ -17,6 +17,8 @@ use Shopware\Core\Content\ImportExport\Strategy\Import\BatchImportStrategy;
 use Shopware\Core\Content\ImportExport\Strategy\Import\OneByOneImportStrategy;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -74,6 +76,9 @@ class ImportExportFactory
         );
     }
 
+    /**
+     * @return EntityRepository<covariant EntityCollection<covariant Entity>>
+     */
     private function getRepository(ImportExportLogEntity $logEntity): EntityRepository
     {
         $profile = $logEntity->getProfile();

--- a/src/Core/Content/ImportExport/ScheduledTask/CleanupImportExportFileTaskHandler.php
+++ b/src/Core/Content/ImportExport/ScheduledTask/CleanupImportExportFileTaskHandler.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\ImportExport\Service\DeleteExpiredFilesService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -19,6 +20,8 @@ final class CleanupImportExportFileTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ScheduledTaskCollection> $repository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/Content/ImportExport/Service/DeleteExpiredFilesService.php
+++ b/src/Core/Content/ImportExport/Service/DeleteExpiredFilesService.php
@@ -2,7 +2,9 @@
 
 namespace Shopware\Core\Content\ImportExport\Service;
 
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
@@ -14,6 +16,9 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('fundamentals@after-sales')]
 class DeleteExpiredFilesService
 {
+    /**
+     * @param EntityRepository<EntityCollection<ImportExportFileEntity>> $fileRepository
+     */
     public function __construct(private readonly EntityRepository $fileRepository)
     {
     }

--- a/src/Core/Content/ImportExport/Service/FileService.php
+++ b/src/Core/Content/ImportExport/Service/FileService.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
 use Shopware\Core\Content\ImportExport\Processing\Writer\AbstractWriter;
 use Shopware\Core\Content\ImportExport\Processing\Writer\CsvFileWriter;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -22,6 +23,8 @@ class FileService extends AbstractFileService
 
     /**
      * @internal
+     *
+     * @param EntityRepository<EntityCollection<ImportExportFileEntity>> $fileRepository
      */
     public function __construct(
         private readonly FilesystemOperator $filesystem,

--- a/src/Core/Content/ImportExport/Strategy/Import/BatchImportStrategy.php
+++ b/src/Core/Content/ImportExport/Strategy/Import/BatchImportStrategy.php
@@ -8,6 +8,8 @@ use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Content\ImportExport\Struct\ImportResult;
 use Shopware\Core\Content\ImportExport\Struct\Progress;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -26,6 +28,9 @@ class BatchImportStrategy extends OneByOneImportStrategy implements ResetInterfa
      */
     protected array $toImport = [];
 
+    /**
+     * @param EntityRepository<covariant EntityCollection<covariant Entity>> $repository
+     */
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         EntityRepository $repository,

--- a/src/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategy.php
+++ b/src/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategy.php
@@ -8,6 +8,8 @@ use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Content\ImportExport\Struct\ImportResult;
 use Shopware\Core\Content\ImportExport\Struct\Progress;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -18,6 +20,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 #[Package('fundamentals@after-sales')]
 class OneByOneImportStrategy implements ImportStrategyService
 {
+    /**
+     * @param EntityRepository<covariant EntityCollection<covariant Entity>> $repository
+     */
     public function __construct(
         protected readonly EventDispatcherInterface $eventDispatcher,
         protected readonly EntityRepository $repository,

--- a/src/Core/Content/LandingPage/DataAbstractionLayer/LandingPageIndexer.php
+++ b/src/Core/Content/LandingPage/DataAbstractionLayer/LandingPageIndexer.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\LandingPage\DataAbstractionLayer;
 
 use Shopware\Core\Content\LandingPage\Event\LandingPageIndexerEvent;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -19,6 +20,8 @@ class LandingPageIndexer extends EntityIndexer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<LandingPageCollection> $repository
      */
     public function __construct(
         private readonly IteratorFactory $iteratorFactory,

--- a/src/Core/Content/Mail/Transport/MailerTransportDecorator.php
+++ b/src/Core/Content/Mail/Transport/MailerTransportDecorator.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Mail\Transport;
 
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\UnableToRetrieveMetadata;
+use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Content\Mail\Service\Mail;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsBuilder;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
@@ -21,6 +22,9 @@ use Symfony\Component\Mime\RawMessage;
 #[Package('after-sales')]
 class MailerTransportDecorator implements TransportInterface
 {
+    /**
+     * @param EntityRepository<DocumentCollection> $documentRepository
+     */
     public function __construct(
         private readonly TransportInterface $decorated,
         private readonly MailAttachmentsBuilder $attachmentsBuilder,

--- a/src/Core/Content/Mail/Transport/MailerTransportLoader.php
+++ b/src/Core/Content/Mail/Transport/MailerTransportLoader.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Mail\Transport;
 
 use Doctrine\DBAL\Exception\DriverException;
 use League\Flysystem\FilesystemOperator;
+use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Content\Mail\MailException;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -24,6 +25,8 @@ class MailerTransportLoader
 
     /**
      * @internal
+     *
+     * @param EntityRepository<DocumentCollection> $documentRepository
      */
     public function __construct(
         private readonly Transport $envBasedTransport,

--- a/src/Core/Content/Media/Commands/DeleteThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/DeleteThumbnailsCommand.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Media\Commands;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollection;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -21,6 +22,8 @@ class DeleteThumbnailsCommand extends Command
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<MediaThumbnailCollection> $thumbnailRepository
      */
     public function __construct(
         private readonly Connection $connection,

--- a/src/Core/Content/Media/Commands/GenerateMediaTypesCommand.php
+++ b/src/Core/Content/Media/Commands/GenerateMediaTypesCommand.php
@@ -31,6 +31,8 @@ class GenerateMediaTypesCommand extends Command
 
     /**
      * @internal
+     *
+     * @param EntityRepository<MediaCollection> $mediaRepository
      */
     public function __construct(
         private readonly TypeDetector $typeDetector,
@@ -99,7 +101,6 @@ class GenerateMediaTypesCommand extends Command
         do {
             $result = $this->mediaRepository->search($criteria, $context);
 
-            /** @var MediaCollection $medias */
             $medias = $result->getEntities();
             foreach ($medias as $media) {
                 $this->detectMediaType($context, $media);

--- a/src/Core/Content/Media/DataAbstractionLayer/MediaFolderIndexer.php
+++ b/src/Core/Content/Media/DataAbstractionLayer/MediaFolderIndexer.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Media\DataAbstractionLayer;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderCollection;
 use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderDefinition;
 use Shopware\Core\Content\Media\Event\MediaFolderIndexerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
@@ -27,6 +28,8 @@ class MediaFolderIndexer extends EntityIndexer
 
     /**
      * @internal
+     *
+     * @param EntityRepository<MediaFolderCollection> $folderRepository
      */
     public function __construct(
         private readonly IteratorFactory $iteratorFactory,

--- a/src/Core/Content/Media/DataAbstractionLayer/MediaIndexer.php
+++ b/src/Core/Content/Media/DataAbstractionLayer/MediaIndexer.php
@@ -3,7 +3,9 @@
 namespace Shopware\Core\Content\Media\DataAbstractionLayer;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollection;
 use Shopware\Core\Content\Media\Event\MediaIndexerEvent;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
@@ -23,6 +25,9 @@ class MediaIndexer extends EntityIndexer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<MediaCollection> $repository
+     * @param EntityRepository<MediaThumbnailCollection> $thumbnailRepository
      */
     public function __construct(
         private readonly IteratorFactory $iteratorFactory,

--- a/src/Core/Content/Media/MediaService.php
+++ b/src/Core/Content/Media/MediaService.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Media;
 
 use Psr\Http\Message\StreamInterface;
+use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderCollection;
 use Shopware\Core\Content\Media\File\FileFetcher;
 use Shopware\Core\Content\Media\File\FileLoader;
 use Shopware\Core\Content\Media\File\FileSaver;
@@ -20,6 +21,9 @@ class MediaService
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<MediaCollection> $mediaRepository
+     * @param EntityRepository<MediaFolderCollection> $mediaFolderRepository
      */
     public function __construct(
         private readonly EntityRepository $mediaRepository,

--- a/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
+++ b/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
@@ -19,6 +19,8 @@ final readonly class GenerateThumbnailsHandler
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<MediaCollection> $mediaRepository
      */
     public function __construct(
         private ThumbnailService $thumbnailService,
@@ -39,7 +41,6 @@ final readonly class GenerateThumbnailsHandler
         $criteria->addAssociation('mediaFolder.configuration.mediaThumbnailSizes');
         $criteria->addFilter(new EqualsAnyFilter('media.id', $msg->getMediaIds()));
 
-        /** @var MediaCollection $entities */
         $entities = $this->mediaRepository->search($criteria, $context)->getEntities();
 
         if ($msg instanceof UpdateThumbnailsMessage) {

--- a/src/Core/Content/Media/Upload/MediaUploadService.php
+++ b/src/Core/Content/Media/Upload/MediaUploadService.php
@@ -6,6 +6,7 @@ use Shopware\Core\Content\Media\Event\MediaUploadedEvent;
 use Shopware\Core\Content\Media\File\FileFetcher;
 use Shopware\Core\Content\Media\File\FileSaver;
 use Shopware\Core\Content\Media\File\MediaFile;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
@@ -28,6 +29,8 @@ readonly class MediaUploadService
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<MediaCollection> $mediaRepository
      */
     public function __construct(
         private EntityRepository $mediaRepository,

--- a/src/Core/Content/Newsletter/DataAbstractionLayer/NewsletterRecipientIndexer.php
+++ b/src/Core/Content/Newsletter/DataAbstractionLayer/NewsletterRecipientIndexer.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Newsletter\DataAbstractionLayer;
 
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientCollection;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
 use Shopware\Core\Content\Newsletter\DataAbstractionLayer\Indexing\CustomerNewsletterSalesChannelsUpdater;
 use Shopware\Core\Content\Newsletter\Event\NewsletterRecipientIndexerEvent;
@@ -21,6 +22,8 @@ class NewsletterRecipientIndexer extends EntityIndexer
 
     /**
      * @internal
+     *
+     * @param EntityRepository<NewsletterRecipientCollection> $repository
      */
     public function __construct(
         private readonly IteratorFactory $iteratorFactory,

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Newsletter\SalesChannel;
 
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientCollection;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Content\Newsletter\Event\NewsletterConfirmEvent;
 use Shopware\Core\Content\Newsletter\NewsletterException;
@@ -30,6 +31,8 @@ class NewsletterConfirmRoute extends AbstractNewsletterConfirmRoute
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<NewsletterRecipientCollection> $newsletterRecipientRepository
      */
     public function __construct(
         private readonly EntityRepository $newsletterRecipientRepository,
@@ -75,7 +78,6 @@ class NewsletterConfirmRoute extends AbstractNewsletterConfirmRoute
         $criteria->addAssociation('salutation');
         $criteria->setLimit(1);
 
-        /** @var NewsletterRecipientEntity|null $newsletterRecipient */
         $newsletterRecipient = $this->newsletterRecipientRepository->search($criteria, $context)->getEntities()->first();
 
         if (!$newsletterRecipient) {

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterUnsubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterUnsubscribeRoute.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Newsletter\SalesChannel;
 
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientCollection;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Content\Newsletter\Event\NewsletterUnsubscribeEvent;
 use Shopware\Core\Content\Newsletter\NewsletterException;
@@ -28,6 +29,8 @@ class NewsletterUnsubscribeRoute extends AbstractNewsletterUnsubscribeRoute
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<NewsletterRecipientCollection> $newsletterRecipientRepository
      */
     public function __construct(
         private readonly EntityRepository $newsletterRecipientRepository,
@@ -81,7 +84,7 @@ class NewsletterUnsubscribeRoute extends AbstractNewsletterUnsubscribeRoute
             $context->getContext()
         )->getEntities()->first();
 
-        if (!$newsletterRecipient instanceof NewsletterRecipientEntity) {
+        if (!$newsletterRecipient) {
             throw NewsletterException::recipientNotFound('email', $email);
         }
 

--- a/src/Core/Content/Newsletter/ScheduledTask/NewsletterRecipientTaskHandler.php
+++ b/src/Core/Content/Newsletter/ScheduledTask/NewsletterRecipientTaskHandler.php
@@ -3,12 +3,14 @@
 namespace Shopware\Core\Content\Newsletter\ScheduledTask;
 
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -21,6 +23,9 @@ final class NewsletterRecipientTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
+     * @param EntityRepository<NewsletterRecipientCollection> $newsletterRecipientRepository
      */
     public function __construct(
         EntityRepository $scheduledTaskRepository,

--- a/src/Core/Content/Product/Cleanup/CleanupProductKeywordDictionaryTaskHandler.php
+++ b/src/Core/Content/Product/Cleanup/CleanupProductKeywordDictionaryTaskHandler.php
@@ -7,6 +7,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -19,6 +20,8 @@ final class CleanupProductKeywordDictionaryTaskHandler extends ScheduledTaskHand
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ScheduledTaskCollection> $repository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/Content/Product/Cleanup/CleanupUnusedDownloadMediaTaskHandler.php
+++ b/src/Core/Content/Product/Cleanup/CleanupUnusedDownloadMediaTaskHandler.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Media\UnusedMediaPurger;
 use Shopware\Core\Content\Product\Aggregate\ProductDownload\ProductDownloadDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -17,6 +18,9 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler(handles: CleanupUnusedDownloadMediaTask::class)]
 final class CleanupUnusedDownloadMediaTaskHandler extends ScheduledTaskHandler
 {
+    /**
+     * @param EntityRepository<ScheduledTaskCollection> $repository
+     */
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,

--- a/src/Core/Content/Product/Cms/BuyBoxCmsElementResolver.php
+++ b/src/Core/Content/Product/Cms/BuyBoxCmsElementResolver.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\BuyBoxStruct;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewCollection;
 use Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -23,6 +24,8 @@ class BuyBoxCmsElementResolver extends AbstractProductDetailCmsElementResolver
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductReviewCollection> $repository
      */
     public function __construct(
         private readonly ProductConfiguratorLoader $configuratorLoader,

--- a/src/Core/Content/Product/Cms/ProductListingCmsElementResolver.php
+++ b/src/Core/Content/Product/Cms/ProductListingCmsElementResolver.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\PriceListingFilter
 use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\PropertyListingFilterHandler;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\RatingListingFilterHandler;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\ShippingFreeListingFilterHandler;
+use Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -33,6 +34,8 @@ class ProductListingCmsElementResolver extends AbstractCmsElementResolver
 
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductSortingCollection> $sortingRepository
      */
     public function __construct(
         private readonly AbstractProductListingRoute $listingRoute,

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Content\Product\SalesChannel\Detail;
 
-use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
@@ -21,6 +21,8 @@ class ProductConfiguratorLoader
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductConfiguratorSettingCollection> $configuratorRepository
      */
     public function __construct(
         private readonly EntityRepository $configuratorRepository,
@@ -97,7 +99,6 @@ class ProductConfiguratorLoader
         }
         $groups = [];
 
-        /** @var ProductConfiguratorSettingEntity $setting */
         foreach ($settings as $setting) {
             $option = $setting->getOption();
             if ($option === null) {
@@ -152,7 +153,6 @@ class ProductConfiguratorLoader
             $sorted[$group->getId()] = $group;
         }
 
-        /** @var PropertyGroupEntity $group */
         foreach ($sorted as $group) {
             $options = $group->getOptions();
             if ($options === null) {

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
-use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -83,11 +82,10 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
             $cloned = clone $optionCriteria;
             $cloned->setIds($chunk);
 
-            $entities = $this->optionRepository->search($cloned, $context->getContext());
+            $entities = $this->optionRepository->search($cloned, $context->getContext())->getEntities();
 
             $options = array_merge($options, $entities->getElements());
 
-            /** @var PropertyGroupOptionEntity $option */
             foreach ($entities as $option) {
                 if (!isset($groupIds[$option->getGroupId()])) {
                     $groupIds[$option->getGroupId()] = true;

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Product\SalesChannel\Listing;
 
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Extension\ProductListingCriteriaExtension;
@@ -28,6 +29,8 @@ class ProductListingRoute extends AbstractProductListingRoute
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CategoryCollection> $categoryRepository
      */
     public function __construct(
         private readonly ProductListingLoader $listingLoader,
@@ -63,8 +66,8 @@ class ProductListingRoute extends AbstractProductListingRoute
         $categoryCriteria->addFields(['productAssignmentType', 'productStreamId']);
         $categoryCriteria->setLimit(1);
 
-        /** @var PartialEntity|null $category */
-        $category = $this->categoryRepository->search($categoryCriteria, $context->getContext())->first();
+        /** @var ?PartialEntity */
+        $category = $this->categoryRepository->search($categoryCriteria, $context->getContext())->getEntities()->first();
         if (!$category) {
             throw ProductException::categoryNotFound($categoryId);
         }

--- a/src/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRoute.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Product\SalesChannel\Review;
 
 use Shopware\Core\Checkout\Customer\Service\EmailIdnConverter;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewCollection;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Review\Event\ReviewFormEvent;
 use Shopware\Core\Framework\Context;
@@ -37,6 +38,8 @@ class ProductReviewSaveRoute extends AbstractProductReviewSaveRoute
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductReviewCollection> $repository
      */
     public function __construct(
         private readonly EntityRepository $repository,

--- a/src/Core/Content/ProductExport/Api/ProductExportController.php
+++ b/src/Core/Content/ProductExport/Api/ProductExportController.php
@@ -18,7 +18,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -32,6 +34,9 @@ class ProductExportController extends AbstractController
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<SalesChannelDomainCollection> $salesChannelDomainRepository
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(
         private readonly EntityRepository $salesChannelDomainRepository,
@@ -138,12 +143,13 @@ class ProductExportController extends AbstractController
         $criteria = (new Criteria([$salesChannelDomainId]))
             ->addAssociation('language.locale')
             ->addAssociation('salesChannel');
+
         $salesChannelDomain = $this->salesChannelDomainRepository->search(
             $criteria,
             $context
-        )->get($salesChannelDomainId);
+        )->getEntities()->get($salesChannelDomainId);
 
-        if (!($salesChannelDomain instanceof SalesChannelDomainEntity)) {
+        if ($salesChannelDomain === null) {
             $salesChannelDomainNotFoundException = new SalesChannelDomainNotFoundException($salesChannelDomainId);
             $loggingEvent = new ProductExportLoggingEvent(
                 $context,
@@ -166,9 +172,9 @@ class ProductExportController extends AbstractController
         $salesChannel = $this->salesChannelRepository->search(
             $criteria,
             $context
-        )->get($salesChannelId);
+        )->getEntities()->get($salesChannelId);
 
-        if (!($salesChannel instanceof SalesChannelEntity)) {
+        if ($salesChannel === null) {
             $salesChannelNotFoundException = new SalesChannelNotFoundException($salesChannelId);
             $loggingEvent = new ProductExportLoggingEvent(
                 $context,

--- a/src/Core/Content/ProductExport/EventListener/ProductExportEventListener.php
+++ b/src/Core/Content/ProductExport/EventListener/ProductExportEventListener.php
@@ -56,17 +56,15 @@ class ProductExportEventListener implements EventSubscriberInterface
                 ],
                 $event->getContext()
             );
-            $productExportResult = $this->productExportRepository->search(new Criteria([$primaryKey]), $event->getContext())->getEntities();
-            if ($productExportResult->count() !== 0) {
-                $productExport = $productExportResult->first();
-                if (!$productExport) {
-                    continue;
-                }
 
-                $filePath = $this->productExportFileHandler->getFilePath($productExport);
-                if ($this->fileSystem->fileExists($filePath)) {
-                    $this->fileSystem->delete($filePath);
-                }
+            $productExport = $this->productExportRepository->search(new Criteria([$primaryKey]), $event->getContext())->getEntities()->first();
+            if (!$productExport) {
+                continue;
+            }
+
+            $filePath = $this->productExportFileHandler->getFilePath($productExport);
+            if ($this->fileSystem->fileExists($filePath)) {
+                $this->fileSystem->delete($filePath);
             }
         }
     }

--- a/src/Core/Content/ProductExport/EventListener/ProductExportEventListener.php
+++ b/src/Core/Content/ProductExport/EventListener/ProductExportEventListener.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\Content\ProductExport\EventListener;
 
 use League\Flysystem\FilesystemOperator;
-use Shopware\Core\Content\ProductExport\ProductExportEntity;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\Service\ProductExportFileHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
@@ -20,6 +20,8 @@ class ProductExportEventListener implements EventSubscriberInterface
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductExportCollection> $productExportRepository
      */
     public function __construct(
         private readonly EntityRepository $productExportRepository,
@@ -54,10 +56,12 @@ class ProductExportEventListener implements EventSubscriberInterface
                 ],
                 $event->getContext()
             );
-            $productExportResult = $this->productExportRepository->search(new Criteria([$primaryKey]), $event->getContext());
-            if ($productExportResult->getTotal() !== 0) {
-                /** @var ProductExportEntity $productExport */
+            $productExportResult = $this->productExportRepository->search(new Criteria([$primaryKey]), $event->getContext())->getEntities();
+            if ($productExportResult->count() !== 0) {
                 $productExport = $productExportResult->first();
+                if (!$productExport) {
+                    continue;
+                }
 
                 $filePath = $this->productExportFileHandler->getFilePath($productExport);
                 if ($this->fileSystem->fileExists($filePath)) {

--- a/src/Core/Content/ProductExport/SalesChannel/ExportController.php
+++ b/src/Core/Content/ProductExport/SalesChannel/ExportController.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\ProductExport\Event\ProductExportContentTypeEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Content\ProductExport\Exception\ExportNotFoundException;
 use Shopware\Core\Content\ProductExport\Exception\ExportNotGeneratedException;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Content\ProductExport\Service\ProductExporterInterface;
@@ -32,6 +33,8 @@ class ExportController
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductExportCollection> $productExportRepository
      */
     public function __construct(
         private readonly ProductExporterInterface $productExportService,
@@ -55,8 +58,7 @@ class ExportController
             ->addFilter(new EqualsFilter('salesChannel.active', true))
             ->addAssociation('salesChannelDomain');
 
-        /** @var ProductExportEntity|null $productExport */
-        $productExport = $this->productExportRepository->search($criteria, $context)->first();
+        $productExport = $this->productExportRepository->search($criteria, $context)->getEntities()->first();
 
         if ($productExport === null) {
             $exportNotFoundException = new ExportNotFoundException(null, $request->get('fileName'));

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\ProductExport\ScheduledTask;
 
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -11,9 +12,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -26,6 +29,10 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     * @param EntityRepository<ProductExportCollection> $productExportRepository
      */
     public function __construct(
         EntityRepository $scheduledTaskRepository,
@@ -45,13 +52,13 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
         foreach ($salesChannelIds as $salesChannelId) {
             $productExports = $this->fetchProductExports($salesChannelId);
 
-            if (\count($productExports) === 0) {
+            if ($productExports->count() === 0) {
                 continue;
             }
 
             $now = new \DateTimeImmutable('now');
 
-            foreach ($productExports as $productExport) {
+            foreach ($productExports->getElements() as $productExport) {
                 if (!$this->shouldBeRun($productExport, $now)) {
                     continue;
                 }
@@ -81,10 +88,7 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
             ->getIds();
     }
 
-    /**
-     * @return array<ProductExportEntity>
-     */
-    private function fetchProductExports(string $salesChannelId): array
+    private function fetchProductExports(string $salesChannelId): ProductExportCollection
     {
         $salesChannelContext = $this->salesChannelContextFactory->create(Uuid::randomHex(), $salesChannelId);
 
@@ -110,10 +114,7 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
                 )
             );
 
-        /**
-         * @var array<ProductExportEntity>
-         */
-        return $this->productExportRepository->search($criteria, $salesChannelContext->getContext())->getElements();
+        return $this->productExportRepository->search($criteria, $salesChannelContext->getContext())->getEntities();
     }
 
     private function shouldBeRun(ProductExportEntity $productExport, \DateTimeImmutable $now): bool

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -58,7 +58,7 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
 
             $now = new \DateTimeImmutable('now');
 
-            foreach ($productExports->getElements() as $productExport) {
+            foreach ($productExports as $productExport) {
                 if (!$this->shouldBeRun($productExport, $now)) {
                     continue;
                 }

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\ProductExport\ScheduledTask;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Content\ProductExport\Service\ProductExportFileHandlerInterface;
@@ -36,6 +37,8 @@ final readonly class ProductExportPartialGenerationHandler
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductExportCollection> $productExportRepository
      */
     public function __construct(
         private ProductExportGeneratorInterface $productExportGenerator,
@@ -119,12 +122,7 @@ final readonly class ProductExportPartialGenerationHandler
             ->addAssociation('productStream.filters.queries')
             ->setLimit(1);
 
-        /** @var ProductExportEntity|null $productExport */
-        $productExport = $this->productExportRepository
-            ->search($criteria, $context)
-            ->first();
-
-        return $productExport;
+        return $this->productExportRepository->search($criteria, $context)->getEntities()->first();
     }
 
     private function runExport(

--- a/src/Core/Content/ProductExport/Service/ProductExporter.php
+++ b/src/Core/Content/ProductExport/Service/ProductExporter.php
@@ -24,6 +24,8 @@ class ProductExporter implements ProductExporterInterface
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductExportCollection> $productExportRepository
      */
     public function __construct(
         private readonly EntityRepository $productExportRepository,
@@ -54,7 +56,6 @@ class ProductExporter implements ProductExporterInterface
             $criteria->addFilter(new EqualsFilter('salesChannel.active', true));
         }
 
-        /** @var ProductExportCollection $productExports */
         $productExports = $this->productExportRepository->search($criteria, $context->getContext())->getEntities();
 
         if ($productExports->count() === 0) {

--- a/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
+++ b/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\ProductStream\Event\ProductStreamIndexerEvent;
+use Shopware\Core\Content\ProductStream\ProductStreamCollection;
 use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
@@ -28,6 +29,8 @@ class ProductStreamIndexer extends EntityIndexer
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductStreamCollection> $repository
      */
     public function __construct(
         private readonly Connection $connection,

--- a/src/Core/Content/ProductStream/ScheduledTask/UpdateProductStreamMappingTaskHandler.php
+++ b/src/Core/Content/ProductStream/ScheduledTask/UpdateProductStreamMappingTaskHandler.php
@@ -3,12 +3,14 @@
 namespace Shopware\Core\Content\ProductStream\ScheduledTask;
 
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Content\ProductStream\ProductStreamCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -21,6 +23,9 @@ final class UpdateProductStreamMappingTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ScheduledTaskCollection> $repository
+     * @param EntityRepository<ProductStreamCollection> $productStreamRepository
      */
     public function __construct(
         EntityRepository $repository,

--- a/src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+++ b/src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\ProductStream\Service;
 
 use Shopware\Core\Content\ProductStream\Exception\NoFilterException;
+use Shopware\Core\Content\ProductStream\ProductStreamCollection;
 use Shopware\Core\Content\ProductStream\ProductStreamEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -18,6 +19,8 @@ class ProductStreamBuilder implements ProductStreamBuilderInterface
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ProductStreamCollection> $repository
      */
     public function __construct(
         private readonly EntityRepository $repository,

--- a/src/Core/Content/Rule/DataAbstractionLayer/RuleIndexer.php
+++ b/src/Core/Content/Rule/DataAbstractionLayer/RuleIndexer.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Rule\DataAbstractionLayer;
 
 use Shopware\Core\Content\Rule\Event\RuleIndexerEvent;
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -25,6 +26,8 @@ class RuleIndexer extends EntityIndexer
 
     /**
      * @internal
+     *
+     * @param EntityRepository<RuleCollection> $repository
      */
     public function __construct(
         private readonly IteratorFactory $iteratorFactory,

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Seo;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Seo\Event\SeoUrlUpdateEvent;
+use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -22,6 +23,8 @@ class SeoUrlPersister
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<SeoUrlCollection> $seoUrlRepository
      */
     public function __construct(
         private readonly Connection $connection,

--- a/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
+++ b/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
@@ -12,9 +12,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -29,6 +30,9 @@ final class SitemapGenerateTaskHandler extends ScheduledTaskHandler
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(
         EntityRepository $scheduledTaskRepository,
@@ -63,7 +67,6 @@ final class SitemapGenerateTaskHandler extends ScheduledTaskHandler
 
         $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
 
-        /** @var SalesChannelEntity $salesChannel */
         foreach ($salesChannels as $salesChannel) {
             if ($salesChannel->getDomains() === null) {
                 continue;

--- a/src/Core/Content/Test/Flow/OrderActionTrait.php
+++ b/src/Core/Content/Test/Flow/OrderActionTrait.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -39,6 +40,9 @@ trait OrderActionTrait
 
     private IdsCollection $ids;
 
+    /**
+     * @var ?EntityRepository<CustomerCollection>
+     */
     private ?EntityRepository $customerRepository = null;
 
     private function createCustomerAndLogin(): void

--- a/src/Core/Content/Test/ImportExport/MockRepository.php
+++ b/src/Core/Content/Test/ImportExport/MockRepository.php
@@ -18,6 +18,10 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal can only be used in test setups where bypass finals is activated
+ *
+ * @template TEntityCollection of EntityCollection
+ *
+ * @extends EntityRepository<TEntityCollection>
  */
 #[Package('fundamentals@after-sales')]
 class MockRepository extends EntityRepository

--- a/src/Core/Content/Test/Product/ProductBuilder.php
+++ b/src/Core/Content/Test/Product/ProductBuilder.php
@@ -7,6 +7,8 @@ use Shopware\Core\Content\Test\Cms\LayoutBuilder;
 use Shopware\Core\Content\Test\TestProductSeoUrlRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -681,7 +683,7 @@ class ProductBuilder
     public function writeDependencies(ContainerInterface $container): void
     {
         foreach ($this->dependencies as $entity => $records) {
-            /** @var EntityRepository $repository */
+            /** @var EntityRepository<EntityCollection<Entity>> $repository */
             $repository = $container->get($entity . '.repository');
 
             $repository->create($records, Context::createDefaultContext());

--- a/src/Core/Test/Integration/Traits/Promotion/PromotionTestFixtureBehaviour.php
+++ b/src/Core/Test/Integration/Traits/Promotion/PromotionTestFixtureBehaviour.php
@@ -2,12 +2,10 @@
 
 namespace Shopware\Core\Test\Integration\Traits\Promotion;
 
-use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountCollection;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
-use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscountPrice\PromotionDiscountPriceCollection;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionIndividualCode\PromotionIndividualCodeCollection;
 use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
-use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -58,7 +56,6 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixtureProduct(string $productId, float $grossPrice, float $taxRate, ContainerInterface $container, SalesChannelContext $context): void
     {
-        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = $container->get('product.repository');
 
         $tax = ['id' => Uuid::randomHex(), 'taxRate' => $taxRate, 'name' => 'with id'];
@@ -99,7 +96,7 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixtureAbsolutePromotion(string $promotionId, string $code, float $value, ContainerInterface $container, string $scope = PromotionDiscountEntity::SCOPE_CART): string
     {
-        /** @var EntityRepository<PromotionCollection> $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> */
         $promotionRepository = $container->get('promotion.repository');
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -119,7 +116,7 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixturePercentagePromotion(string $promotionId, ?string $code, float $percentage, ?float $maxValue, ContainerInterface $container, string $scope = PromotionDiscountEntity::SCOPE_CART): string
     {
-        /** @var EntityRepository<PromotionCollection> $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> */
         $promotionRepository = $container->get('promotion.repository');
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -139,7 +136,7 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixtureSetGroupPromotion(string $promotionId, ?string $code, ContainerInterface $container): void
     {
-        /** @var EntityRepository<PromotionCollection> $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> */
         $promotionRepository = $container->get('promotion.repository');
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -168,7 +165,6 @@ trait PromotionTestFixtureBehaviour
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
 
-        /** @var EntityRepository<PromotionDiscountCollection> $discountRepository */
         $discountRepository = $container->get('promotion_discount.repository');
 
         $discountId = Uuid::randomHex();
@@ -200,7 +196,6 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixtureAdvancedPrice(string $discountId, string $currency, float $price, ContainerInterface $container): void
     {
-        /** @var EntityRepository<PromotionDiscountPriceCollection> $pricesRepository */
         $pricesRepository = $container->get('promotion_discount_prices.repository');
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -230,7 +225,6 @@ trait PromotionTestFixtureBehaviour
         SalesChannelContext $context,
         bool $considerAdvancedRules = false
     ): string {
-        /** @var EntityRepository<PromotionDiscountCollection> $discountRepository */
         $discountRepository = $container->get('promotion_discount.repository');
 
         $discountId = Uuid::randomHex();
@@ -254,7 +248,7 @@ trait PromotionTestFixtureBehaviour
     }
 
     /**
-     * function creates a promotion
+     * @param EntityRepository<PromotionCollection> $promotionRepository
      */
     private function createPromotion(string $promotionId, ?string $code, EntityRepository $promotionRepository, SalesChannelContext $context): EntityWrittenContainerEvent
     {
@@ -272,6 +266,7 @@ trait PromotionTestFixtureBehaviour
 
     /**
      * @param array<string, mixed> $data
+     * @param EntityRepository<PromotionCollection> $promotionRepository
      */
     private function createPromotionWithCustomData(array $data, EntityRepository $promotionRepository, SalesChannelContext $context): EntityWrittenContainerEvent
     {
@@ -290,7 +285,7 @@ trait PromotionTestFixtureBehaviour
     }
 
     /**
-     * function creates an individual promotion code
+     * @param EntityRepository<PromotionIndividualCodeCollection> $promotionIndividualRepository
      */
     private function createIndividualCode(string $promotionId, ?string $code, EntityRepository $promotionIndividualRepository, Context $context): EntityWrittenContainerEvent
     {
@@ -303,6 +298,9 @@ trait PromotionTestFixtureBehaviour
         return $promotionIndividualRepository->create([$data], $context);
     }
 
+    /**
+     * @param EntityRepository<PromotionCollection> $promotionRepository
+     */
     private function createSetGroupPromotion(string $promotionId, ?string $code, EntityRepository $promotionRepository, SalesChannelContext $context): void
     {
         $data = [
@@ -335,7 +333,7 @@ trait PromotionTestFixtureBehaviour
         SalesChannelContext $context,
         ?string $code
     ): string {
-        /** @var EntityRepository<PromotionCollection> $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> */
         $promotionRepository = $container->get('promotion.repository');
 
         $this->createPromotion(
@@ -371,7 +369,7 @@ trait PromotionTestFixtureBehaviour
         SalesChannelContext $context,
         bool $considerAdvancedRules = false
     ): string {
-        /** @var EntityRepository<PromotionCollection> $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> */
         $promotionRepository = $container->get('promotion.repository');
 
         $this->createPromotion(
@@ -407,7 +405,7 @@ trait PromotionTestFixtureBehaviour
         ContainerInterface $container,
         SalesChannelContext $context
     ): string {
-        /** @var EntityRepository<PromotionCollection> $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> */
         $promotionRepository = $container->get('promotion.repository');
 
         $this->createPromotion(

--- a/src/Core/Test/Integration/Traits/Promotion/PromotionTestFixtureBehaviour.php
+++ b/src/Core/Test/Integration/Traits/Promotion/PromotionTestFixtureBehaviour.php
@@ -2,8 +2,12 @@
 
 namespace Shopware\Core\Test\Integration\Traits\Promotion;
 
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountCollection;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscountPrice\PromotionDiscountPriceCollection;
+use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -54,7 +58,7 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixtureProduct(string $productId, float $grossPrice, float $taxRate, ContainerInterface $container, SalesChannelContext $context): void
     {
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = $container->get('product.repository');
 
         $tax = ['id' => Uuid::randomHex(), 'taxRate' => $taxRate, 'name' => 'with id'];
@@ -95,7 +99,7 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixtureAbsolutePromotion(string $promotionId, string $code, float $value, ContainerInterface $container, string $scope = PromotionDiscountEntity::SCOPE_CART): string
     {
-        /** @var EntityRepository $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> $promotionRepository */
         $promotionRepository = $container->get('promotion.repository');
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -115,7 +119,7 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixturePercentagePromotion(string $promotionId, ?string $code, float $percentage, ?float $maxValue, ContainerInterface $container, string $scope = PromotionDiscountEntity::SCOPE_CART): string
     {
-        /** @var EntityRepository $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> $promotionRepository */
         $promotionRepository = $container->get('promotion.repository');
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -135,7 +139,7 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixtureSetGroupPromotion(string $promotionId, ?string $code, ContainerInterface $container): void
     {
-        /** @var EntityRepository $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> $promotionRepository */
         $promotionRepository = $container->get('promotion.repository');
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -164,7 +168,7 @@ trait PromotionTestFixtureBehaviour
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
 
-        /** @var EntityRepository $discountRepository */
+        /** @var EntityRepository<PromotionDiscountCollection> $discountRepository */
         $discountRepository = $container->get('promotion_discount.repository');
 
         $discountId = Uuid::randomHex();
@@ -196,7 +200,7 @@ trait PromotionTestFixtureBehaviour
      */
     private function createTestFixtureAdvancedPrice(string $discountId, string $currency, float $price, ContainerInterface $container): void
     {
-        /** @var EntityRepository $pricesRepository */
+        /** @var EntityRepository<PromotionDiscountPriceCollection> $pricesRepository */
         $pricesRepository = $container->get('promotion_discount_prices.repository');
 
         $context = $container->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -226,6 +230,7 @@ trait PromotionTestFixtureBehaviour
         SalesChannelContext $context,
         bool $considerAdvancedRules = false
     ): string {
+        /** @var EntityRepository<PromotionDiscountCollection> $discountRepository */
         $discountRepository = $container->get('promotion_discount.repository');
 
         $discountId = Uuid::randomHex();
@@ -330,7 +335,7 @@ trait PromotionTestFixtureBehaviour
         SalesChannelContext $context,
         ?string $code
     ): string {
-        /** @var EntityRepository $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> $promotionRepository */
         $promotionRepository = $container->get('promotion.repository');
 
         $this->createPromotion(
@@ -366,7 +371,7 @@ trait PromotionTestFixtureBehaviour
         SalesChannelContext $context,
         bool $considerAdvancedRules = false
     ): string {
-        /** @var EntityRepository $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> $promotionRepository */
         $promotionRepository = $container->get('promotion.repository');
 
         $this->createPromotion(
@@ -402,7 +407,7 @@ trait PromotionTestFixtureBehaviour
         ContainerInterface $container,
         SalesChannelContext $context
     ): string {
-        /** @var EntityRepository $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> $promotionRepository */
         $promotionRepository = $container->get('promotion.repository');
 
         $this->createPromotion(

--- a/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
+++ b/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
@@ -276,10 +276,10 @@ class PromotionRedemptionUpdaterTest extends TestCase
 
     private function createPromotionsAndOrder(): void
     {
-        /** @var EntityRepository<PromotionCollection> $promotionRepository */
+        /** @var EntityRepository<PromotionCollection> */
         $promotionRepository = static::getContainer()->get('promotion.repository');
 
-        /** @var EntityRepository<PromotionIndividualCodeCollection> $promotionRepository */
+        /** @var EntityRepository<PromotionIndividualCodeCollection> */
         $promotionIndividualCodeRepository = static::getContainer()->get('promotion_individual_code.repository');
 
         $voucherA = $this->ids->create('voucherA');

--- a/tests/integration/Core/Content/ImportExport/AbstractImportExportTestCase.php
+++ b/tests/integration/Core/Content/ImportExport/AbstractImportExportTestCase.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Content\ImportExport;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogCollection;
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogEntity;
@@ -91,6 +92,8 @@ abstract class AbstractImportExportTestCase extends TestCase
 
     /**
      * @param array<string, bool> $configOverrides
+     *
+     * @return MockRepository<CustomerCollection>
      */
     protected function runCustomerImportWithConfigAndMockedRepository(array $configOverrides): MockRepository
     {
@@ -119,6 +122,7 @@ abstract class AbstractImportExportTestCase extends TestCase
         $readerFactory = static::getContainer()->get(CsvReaderFactory::class);
         $writerFactory = static::getContainer()->get(CsvFileWriterFactory::class);
 
+        /** @var MockRepository<CustomerCollection> */
         $mockRepository = new MockRepository(static::getContainer()->get(CustomerDefinition::class));
 
         $importExport = new ImportExport(

--- a/tests/integration/Core/Content/ImportExport/ImportExportTest.php
+++ b/tests/integration/Core/Content/ImportExport/ImportExportTest.php
@@ -1752,6 +1752,7 @@ SWTEST;1;' . $productName . ';9.35;10;0c17372fe6aa46059a97fc28b40f46c4;7;7%%;%s'
         $readerFactory = static::getContainer()->get(CsvReaderFactory::class);
         $writerFactory = static::getContainer()->get(CsvFileWriterFactory::class);
 
+        /** @var MockRepository<CustomerCollection> */
         $mockRepository = new MockRepository(static::getContainer()->get(CustomerDefinition::class));
 
         $importExport = new ImportExport(

--- a/tests/unit/Core/Content/Cms/Command/CreatePageCommandTest.php
+++ b/tests/unit/Core/Content/Cms/Command/CreatePageCommandTest.php
@@ -4,11 +4,14 @@ namespace Shopware\Tests\Unit\Core\Content\Cms\Command;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\CmsPageDefinition;
 use Shopware\Core\Content\Cms\Command\CreatePageCommand;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -30,6 +33,7 @@ class CreatePageCommandTest extends TestCase
 
     protected function setUp(): void
     {
+        /** @var StaticEntityRepository<ProductCollection> */
         $productRepository = new StaticEntityRepository([
             [
                 'product-id-1',
@@ -37,12 +41,14 @@ class CreatePageCommandTest extends TestCase
             ],
         ], new ProductDefinition());
 
+        /** @var StaticEntityRepository<CategoryCollection> */
         $categoryRepository = new StaticEntityRepository([
             [
                 'category-id-1',
             ],
         ], new CategoryDefinition());
 
+        /** @var StaticEntityRepository<MediaCollection> */
         $mediaRepository = new StaticEntityRepository([
             [
                 'media-id-1',

--- a/tests/unit/Core/Content/Flow/Controller/TriggerFlowControllerTest.php
+++ b/tests/unit/Core/Content/Flow/Controller/TriggerFlowControllerTest.php
@@ -63,6 +63,7 @@ class TriggerFlowControllerTest extends TestCase
         $request = new Request();
         $request->setMethod('POST');
         $context = Context::createDefaultContext();
+        /** @var StaticEntityRepository<AppFlowEventCollection> */
         $appFlowEventRepository = new StaticEntityRepository([
             new EntitySearchResult(
                 'app_flow_event',
@@ -86,6 +87,7 @@ class TriggerFlowControllerTest extends TestCase
         $request = new Request();
         $request->setMethod('POST');
         $context = Context::createDefaultContext();
+        /** @var StaticEntityRepository<AppFlowEventCollection> */
         $appFlowEventRepository = new StaticEntityRepository([
             new EntitySearchResult(
                 'app_flow_event',

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/SendMailActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/SendMailActionTest.php
@@ -194,8 +194,8 @@ class SendMailActionTest extends TestCase
         $flow->setConfig($config);
 
         $this->entitySearchResult->expects($this->once())
-            ->method('first')
-            ->willReturn($this->mailTemplate);
+            ->method('getEntities')
+            ->willReturn(new MailTemplateCollection([$this->mailTemplate]));
 
         $this->mailTemplateRepository->expects($this->once())
             ->method('search')
@@ -325,8 +325,8 @@ class SendMailActionTest extends TestCase
         $flow->setConfig($config);
 
         $this->entitySearchResult->expects($this->once())
-            ->method('first')
-            ->willReturn($this->mailTemplate);
+            ->method('getEntities')
+            ->willReturn(new MailTemplateCollection([$this->mailTemplate]));
 
         $this->mailTemplateRepository->expects($this->once())
             ->method('search')
@@ -501,8 +501,8 @@ class SendMailActionTest extends TestCase
         $flow->setConfig($config);
 
         $this->entitySearchResult->expects($this->once())
-            ->method('first')
-            ->willReturn($this->mailTemplate);
+            ->method('getEntities')
+            ->willReturn(new MailTemplateCollection([$this->mailTemplate]));
 
         $this->mailTemplateRepository->expects($this->once())
             ->method('search')

--- a/tests/unit/Core/Content/Flow/Dispatching/FlowFactoryTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/FlowFactoryTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\FlowFactory;
 use Shopware\Core\Content\Flow\Dispatching\Storer\OrderStorer;
@@ -51,8 +52,8 @@ class FlowFactoryTest extends TestCase
 
         $entitySearchResult = $this->createMock(EntitySearchResult::class);
         $entitySearchResult->expects($this->once())
-            ->method('get')
-            ->willReturn($order);
+            ->method('getEntities')
+            ->willReturn(new OrderCollection([$order]));
 
         $orderRepo = $this->createMock(EntityRepository::class);
         $orderRepo->expects($this->once())

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupCollection;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerGroupRegistrationDeclined;
 use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
@@ -77,7 +78,7 @@ class CustomerGroupStorerTest extends TestCase
         $this->storer->restore($storable);
         $entity = new CustomerGroupEntity();
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new CustomerGroupCollection([$entity]));
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $customerGroup = $storable->getData('customerGroup');
@@ -89,14 +90,13 @@ class CustomerGroupStorerTest extends TestCase
     {
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['customerGroupId' => 'id'], []);
         $this->storer->restore($storable);
-        $entity = null;
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new CustomerGroupCollection());
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $customerGroup = $storable->getData('customerGroup');
 
-        static::assertSame($customerGroup, $entity);
+        static::assertNull($customerGroup);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorerTest.php
@@ -77,6 +77,7 @@ class CustomerGroupStorerTest extends TestCase
 
         $this->storer->restore($storable);
         $entity = new CustomerGroupEntity();
+        $entity->setId('id');
         $result = $this->createMock(EntitySearchResult::class);
         $result->expects($this->once())->method('getEntities')->willReturn(new CustomerGroupCollection([$entity]));
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerRecovery\CustomerRecoveryCollection;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerRecovery\CustomerRecoveryEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerAccountRecoverRequestEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
@@ -78,7 +79,7 @@ class CustomerRecoveryStorerTest extends TestCase
         $this->storer->restore($storable);
         $entity = new CustomerRecoveryEntity();
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new CustomerRecoveryCollection([$entity]));
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('customerRecovery');
@@ -90,14 +91,13 @@ class CustomerRecoveryStorerTest extends TestCase
     {
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['customerRecoveryId' => 'id']);
         $this->storer->restore($storable);
-        $entity = null;
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new CustomerRecoveryCollection());
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('customerRecovery');
 
-        static::assertSame($res, $entity);
+        static::assertNull($res);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorerTest.php
@@ -78,6 +78,7 @@ class CustomerRecoveryStorerTest extends TestCase
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['customerRecoveryId' => 'id']);
         $this->storer->restore($storable);
         $entity = new CustomerRecoveryEntity();
+        $entity->setId('id');
         $result = $this->createMock(EntitySearchResult::class);
         $result->expects($this->once())->method('getEntities')->willReturn(new CustomerRecoveryCollection([$entity]));
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerStorerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
 use Shopware\Core\Checkout\Order\Event\OrderStateMachineStateChangeEvent;
@@ -89,8 +90,9 @@ class CustomerStorerTest extends TestCase
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['customerId' => 'id'], []);
         $this->storer->restore($storable);
         $entity = new CustomerEntity();
+        $entity->setId('id');
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new CustomerCollection([$entity]));
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('customer');
@@ -102,14 +104,13 @@ class CustomerStorerTest extends TestCase
     {
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['customerId' => 'id'], []);
         $this->storer->restore($storable);
-        $entity = null;
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new CustomerCollection());
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('customer');
 
-        static::assertSame($res, $entity);
+        static::assertNull($res);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorerTest.php
@@ -78,6 +78,7 @@ class NewsletterRecipientStorerTest extends TestCase
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['newsletterRecipientId' => 'id'], []);
         $this->storer->restore($storable);
         $entity = new NewsletterRecipientEntity();
+        $entity->setId('id');
         $result = $this->createMock(EntitySearchResult::class);
         $result->expects($this->once())->method('getEntities')->willReturn(new NewsletterRecipientCollection([$entity]));
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Flow\Dispatching\Aware\NewsletterRecipientAware;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Dispatching\Storer\NewsletterRecipientStorer;
 use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientCollection;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Content\Newsletter\Event\NewsletterConfirmEvent;
 use Shopware\Core\Framework\Context;
@@ -78,7 +79,7 @@ class NewsletterRecipientStorerTest extends TestCase
         $this->storer->restore($storable);
         $entity = new NewsletterRecipientEntity();
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new NewsletterRecipientCollection([$entity]));
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('newsletterRecipient');
@@ -89,14 +90,13 @@ class NewsletterRecipientStorerTest extends TestCase
     {
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['newsletterRecipientId' => 'id'], []);
         $this->storer->restore($storable);
-        $entity = null;
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new NewsletterRecipientCollection());
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('newsletterRecipient');
 
-        static::assertSame($res, $entity);
+        static::assertNull($res);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderStorerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Dispatching\Storer\OrderStorer;
@@ -78,7 +79,7 @@ class OrderStorerTest extends TestCase
         $this->storer->restore($storable);
         $entity = new OrderEntity();
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new OrderCollection([$entity]));
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('order');
@@ -90,14 +91,13 @@ class OrderStorerTest extends TestCase
     {
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['orderId' => 'id'], []);
         $this->storer->restore($storable);
-        $entity = null;
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new OrderCollection());
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('order');
 
-        static::assertSame($res, $entity);
+        static::assertNull($res);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderStorerTest.php
@@ -78,6 +78,7 @@ class OrderStorerTest extends TestCase
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['orderId' => 'id'], []);
         $this->storer->restore($storable);
         $entity = new OrderEntity();
+        $entity->setId('id');
         $result = $this->createMock(EntitySearchResult::class);
         $result->expects($this->once())->method('getEntities')->willReturn(new OrderCollection([$entity]));
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\Event\OrderPaymentMethodChangedEvent;
 use Shopware\Core\Content\Flow\Dispatching\Aware\OrderTransactionAware;
@@ -78,7 +79,7 @@ class OrderTransactionStorerTest extends TestCase
         $this->storer->restore($storable);
         $entity = new OrderTransactionEntity();
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new OrderTransactionCollection([$entity]));
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('orderTransaction');
@@ -90,14 +91,13 @@ class OrderTransactionStorerTest extends TestCase
     {
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['orderTransactionId' => 'id'], []);
         $this->storer->restore($storable);
-        $entity = null;
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new OrderTransactionCollection());
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('orderTransaction');
 
-        static::assertSame($res, $entity);
+        static::assertNull($res);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorerTest.php
@@ -78,6 +78,7 @@ class OrderTransactionStorerTest extends TestCase
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['orderTransactionId' => 'id'], []);
         $this->storer->restore($storable);
         $entity = new OrderTransactionEntity();
+        $entity->setId('id');
         $result = $this->createMock(EntitySearchResult::class);
         $result->expects($this->once())->method('getEntities')->willReturn(new OrderTransactionCollection([$entity]));
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/ProductStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/ProductStorerTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Dispatching\Storer\ProductStorer;
 use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\Review\Event\ReviewFormEvent;
 use Shopware\Core\Framework\Context;
@@ -80,7 +81,7 @@ class ProductStorerTest extends TestCase
         $this->storer->restore($storable);
         $entity = new ProductEntity();
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new ProductCollection([$entity]));
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('product');
@@ -92,14 +93,13 @@ class ProductStorerTest extends TestCase
     {
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['productId' => 'id'], []);
         $this->storer->restore($storable);
-        $entity = null;
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new ProductCollection());
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('product');
 
-        static::assertSame($res, $entity);
+        static::assertNull($res);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/ProductStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/ProductStorerTest.php
@@ -80,6 +80,7 @@ class ProductStorerTest extends TestCase
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['productId' => 'id'], []);
         $this->storer->restore($storable);
         $entity = new ProductEntity();
+        $entity->setId('id');
         $result = $this->createMock(EntitySearchResult::class);
         $result->expects($this->once())->method('getEntities')->willReturn(new ProductCollection([$entity]));
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/UserStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/UserStorerTest.php
@@ -78,6 +78,7 @@ class UserStorerTest extends TestCase
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['userRecoveryId' => 'id'], []);
         $this->storer->restore($storable);
         $entity = new UserRecoveryEntity();
+        $entity->setId('id');
         $result = $this->createMock(EntitySearchResult::class);
         $result->expects($this->once())->method('getEntities')->willReturn(new UserRecoveryCollection([$entity]));
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/UserStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/UserStorerTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Event\UserAware;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryCollection;
 use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryEntity;
 use Shopware\Core\System\User\Recovery\UserRecoveryRequestEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -78,7 +79,7 @@ class UserStorerTest extends TestCase
         $this->storer->restore($storable);
         $entity = new UserRecoveryEntity();
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new UserRecoveryCollection([$entity]));
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('userRecovery');
@@ -90,14 +91,13 @@ class UserStorerTest extends TestCase
     {
         $storable = new StorableFlow('name', Context::createDefaultContext(), ['userRecoveryId' => 'id'], []);
         $this->storer->restore($storable);
-        $entity = null;
         $result = $this->createMock(EntitySearchResult::class);
-        $result->expects($this->once())->method('get')->willReturn($entity);
+        $result->expects($this->once())->method('getEntities')->willReturn(new UserRecoveryCollection());
 
         $this->repository->expects($this->once())->method('search')->willReturn($result);
         $res = $storable->getData('userRecovery');
 
-        static::assertSame($res, $entity);
+        static::assertNull($res);
     }
 
     public function testLazyLoadNullId(): void

--- a/tests/unit/Core/Content/ImportExport/ImportExportTest.php
+++ b/tests/unit/Core/Content/ImportExport/ImportExportTest.php
@@ -6,7 +6,9 @@ use Doctrine\DBAL\Connection;
 use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
@@ -67,13 +69,16 @@ class ImportExportTest extends TestCase
         $importExportService = $this->createMock(ImportExportService::class);
         $importExportService->method('findLog')->willReturn($logEntity);
 
+        /** @var StaticEntityRepository<OrderCollection> */
+        $repository = new StaticEntityRepository([], new OrderDefinition());
+
         $importExport = new ImportExport(
             $importExportService,
             $logEntity,
             $this->createMock(FilesystemOperator::class),
             new EventDispatcher(),
             $this->createMock(Connection::class),
-            new StaticEntityRepository([], new OrderDefinition()),
+            $repository,
             $pipe,
             $reader,
             $writer,
@@ -155,13 +160,16 @@ class ImportExportTest extends TestCase
         $importStrategyService->method('import')->willReturn(new ImportResult([], []));
         $importStrategyService->method('commit')->willReturn(new ImportResult([], []));
 
+        /** @var StaticEntityRepository<CustomerCollection> */
+        $repository = new StaticEntityRepository([], new CustomerDefinition());
+
         $importExport = new ImportExport(
             $importExportService,
             $logEntity,
             $this->createMock(FilesystemOperator::class),
             $eventDispatcher,
             $this->createMock(Connection::class),
-            new StaticEntityRepository([], new CustomerDefinition()),
+            $repository,
             $pipe,
             $reader,
             $writer,
@@ -210,13 +218,16 @@ class ImportExportTest extends TestCase
         $writer = $this->createMock(AbstractWriter::class);
         $writer->expects($this->never())->method('append');
 
+        /** @var StaticEntityRepository<CustomerCollection> */
+        $repository = new StaticEntityRepository([], new CustomerDefinition());
+
         $importExport = new ImportExport(
             $importExportService,
             $logEntity,
             $this->createMock(FilesystemOperator::class),
             $eventDispatcher,
             $this->createMock(Connection::class),
-            new StaticEntityRepository([], new CustomerDefinition()),
+            $repository,
             $pipe,
             $reader,
             $writer,
@@ -278,6 +289,7 @@ class ImportExportTest extends TestCase
 
         $orderId = Uuid::randomHex();
 
+        /** @var StaticEntityRepository<OrderCollection> */
         $repository = new StaticEntityRepository(
             [new EntitySearchResult(
                 OrderEntity::class,
@@ -411,6 +423,7 @@ class ImportExportTest extends TestCase
             }
         );
 
+        /** @var StaticEntityRepository<OrderCollection> */
         $repository = new StaticEntityRepository(
             [new EntitySearchResult(
                 OrderEntity::class,
@@ -563,13 +576,16 @@ class ImportExportTest extends TestCase
         $writer->expects($this->exactly(1))->method('flush');
         $writer->expects($this->exactly(1))->method('finish');
 
+        /** @var StaticEntityRepository<OrderCollection> */
+        $repository = new StaticEntityRepository([], new OrderDefinition());
+
         $importExport = new ImportExport(
             $importExportService,
             $logEntity,
             $this->createMock(FilesystemOperator::class),
             $eventDispatcher,
             $this->createMock(Connection::class),
-            new StaticEntityRepository([], new OrderDefinition()),
+            $repository,
             $pipe,
             $reader,
             $writer,

--- a/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterUnsubscribeRouteTest.php
+++ b/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterUnsubscribeRouteTest.php
@@ -47,6 +47,7 @@ class NewsletterUnsubscribeRouteTest extends TestCase
         $newsletterRecipientEntity->setSalesChannelId(TestDefaults::SALES_CHANNEL);
         $newsletterRecipientEntity->setConfirmedAt(new \DateTime());
 
+        /** @var StaticEntityRepository<NewsletterRecipientCollection> */
         $entityRepository = new StaticEntityRepository([
             new NewsletterRecipientCollection([$newsletterRecipientEntity]),
         ]);
@@ -84,6 +85,7 @@ class NewsletterUnsubscribeRouteTest extends TestCase
             'email' => null,
         ]);
 
+        /** @var StaticEntityRepository<NewsletterRecipientCollection> */
         $entityRepository = new StaticEntityRepository([]);
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
@@ -112,6 +114,7 @@ class NewsletterUnsubscribeRouteTest extends TestCase
             'email' => 'test@example.com',
         ]);
 
+        /** @var StaticEntityRepository<NewsletterRecipientCollection> */
         $entityRepository = new StaticEntityRepository([
             new NewsletterRecipientCollection([]),
         ]);

--- a/tests/unit/Core/Content/Product/Cms/BuyBoxCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/BuyBoxCmsElementResolverTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Content\Product\Cms;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
 use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
@@ -10,6 +11,7 @@ use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
 use Shopware\Core\Content\Cms\DataResolver\FieldConfigCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\BuyBoxStruct;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewCollection;
 use Shopware\Core\Content\Product\Cms\BuyBoxCmsElementResolver;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader;
@@ -31,9 +33,12 @@ class BuyBoxCmsElementResolverTest extends TestCase
 {
     public function testGetType(): void
     {
+        /** @var StaticEntityRepository<ProductReviewCollection> */
+        $repository = new StaticEntityRepository([]);
+
         $resolver = new BuyBoxCmsElementResolver(
             $this->createMock(ProductConfiguratorLoader::class),
-            new StaticEntityRepository([])
+            $repository,
         );
 
         static::assertSame('buy-box', $resolver->getType());
@@ -42,6 +47,7 @@ class BuyBoxCmsElementResolverTest extends TestCase
     public function testEnrichBuyBox(): void
     {
         $configurationLoader = $this->createMock(ProductConfiguratorLoader::class);
+        /** @var EntityRepository<ProductReviewCollection>&MockObject */
         $repository = $this->createMock(EntityRepository::class);
         $repository->method('aggregate')->willReturn(new AggregationResultCollection());
 
@@ -81,7 +87,11 @@ class BuyBoxCmsElementResolverTest extends TestCase
     public function testEnrichSetsEmptyBuyBoxWithoutConfig(): void
     {
         $configurationLoader = $this->createMock(ProductConfiguratorLoader::class);
-        $resolver = new BuyBoxCmsElementResolver($configurationLoader, new StaticEntityRepository([]));
+
+        /** @var StaticEntityRepository<ProductReviewCollection> */
+        $repository = new StaticEntityRepository([]);
+
+        $resolver = new BuyBoxCmsElementResolver($configurationLoader, $repository);
 
         $slot = new CmsSlotEntity();
         $slot->setId('slot-1');

--- a/tests/unit/Core/Content/Product/Cms/ProductListingCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductListingCmsElementResolverTest.php
@@ -31,6 +31,7 @@ class ProductListingCmsElementResolverTest extends TestCase
     public function testGetType(): void
     {
         $route = $this->createMock(AbstractProductListingRoute::class);
+        /** @var StaticEntityRepository<ProductSortingCollection> */
         $repository = new StaticEntityRepository([]);
 
         $resolver = new ProductListingCmsElementResolver($route, $repository);
@@ -40,6 +41,7 @@ class ProductListingCmsElementResolverTest extends TestCase
     public function testGetCollectReturnsNull(): void
     {
         $route = $this->createMock(AbstractProductListingRoute::class);
+        /** @var StaticEntityRepository<ProductSortingCollection> */
         $repository = new StaticEntityRepository([]);
 
         $slot = new CmsSlotEntity();
@@ -85,6 +87,7 @@ class ProductListingCmsElementResolverTest extends TestCase
             ]),
         ]);
 
+        /** @var StaticEntityRepository<ProductSortingCollection> */
         $repository = new StaticEntityRepository([$sorting]);
 
         $resolver = new ProductListingCmsElementResolver($route, $repository);
@@ -134,6 +137,7 @@ class ProductListingCmsElementResolverTest extends TestCase
             ]),
         ]);
 
+        /** @var StaticEntityRepository<ProductSortingCollection> */
         $repository = new StaticEntityRepository([$sorting]);
 
         $resolver = new ProductListingCmsElementResolver($route, $repository);

--- a/tests/unit/Core/Content/Product/Cms/Type/ProductListingTypeDataResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/Type/ProductListingTypeDataResolverTest.php
@@ -38,6 +38,7 @@ class ProductListingTypeDataResolverTest extends TestCase
             )
         );
 
+        /** @var StaticEntityRepository<ProductSortingCollection> */
         $sortingRepository = new StaticEntityRepository([new ProductSortingCollection()]);
 
         $this->listingResolver = new ProductListingCmsElementResolver($mock, $sortingRepository);

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Listing;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Product\Extension\ProductListingCriteriaExtension;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader;
@@ -32,6 +33,7 @@ class ProductListingRouteTest extends TestCase
     public function testFiltersAreSetForCategories(): void
     {
         $categoryId = 'categoryId';
+        /** @var StaticEntityRepository<CategoryCollection> */
         $categoryRepository = new StaticEntityRepository([
             new EntityCollection([
                 new PartialEntity([
@@ -65,6 +67,7 @@ class ProductListingRouteTest extends TestCase
     {
         $categoryId = 'categoryId';
         $streamId = 'streamId';
+        /** @var StaticEntityRepository<CategoryCollection> */
         $categoryRepository = new StaticEntityRepository([new EntityCollection([
             new PartialEntity(
                 [
@@ -124,6 +127,7 @@ class ProductListingRouteTest extends TestCase
     public function testExtension(): void
     {
         $categoryId = 'categoryId';
+        /** @var StaticEntityRepository<CategoryCollection> */
         $categoryRepository = new StaticEntityRepository([
             new EntityCollection([
                 new PartialEntity([

--- a/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -6,10 +6,10 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ScheduledTask\ProductExportGenerateTaskHandler;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -104,7 +104,7 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         $productEntitySearchResult = new EntitySearchResult(
             'product',
             1,
-            new EntityCollection([$productExportEntity]),
+            new ProductExportCollection([$productExportEntity]),
             null,
             new Criteria(),
             Context::createDefaultContext()

--- a/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
+++ b/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
@@ -8,10 +8,11 @@ use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamIndexer;
 use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamIndexingMessage;
+use Shopware\Core\Content\ProductStream\ProductStreamCollection;
+use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\OffsetQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
@@ -46,7 +47,7 @@ class ProductStreamIndexerTest extends TestCase
     private MockObject&EventDispatcherInterface $dispatcher;
 
     /**
-     * @var StaticEntityRepository<ProductCollection>
+     * @var StaticEntityRepository<ProductStreamCollection>
      */
     private StaticEntityRepository $repository;
 
@@ -55,7 +56,7 @@ class ProductStreamIndexerTest extends TestCase
         $this->connection = $this->createMock(Connection::class);
         $this->iteratorFactory = $this->createMock(IteratorFactory::class);
         $this->productDefinition = $this->createMock(ProductDefinition::class);
-        $this->repository = new StaticEntityRepository([], $this->productDefinition);
+        $this->repository = new StaticEntityRepository([], new ProductStreamDefinition());
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $this->indexer = new ProductStreamIndexer(

--- a/tests/unit/Core/Framework/App/Flow/Action/AppFlowActionProviderTest.php
+++ b/tests/unit/Core/Framework/App/Flow/Action/AppFlowActionProviderTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\FlowFactory;
 use Shopware\Core\Content\Flow\Dispatching\Storer\OrderStorer;
@@ -54,8 +55,8 @@ class AppFlowActionProviderTest extends TestCase
 
         $entitySearchResult = $this->createMock(EntitySearchResult::class);
         $entitySearchResult->expects($this->once())
-            ->method('get')
-            ->willReturn($order);
+            ->method('getEntities')
+            ->willReturn(new OrderCollection([$order]));
 
         $orderRepo = $this->createMock(EntityRepository::class);
         $orderRepo->expects($this->once())


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently a few EntityRepository types are missing their phpstan type
- As in the past we group this updates to the EntityRepository types by areas to keep the PR size reasonable
- This PR includes core Content area

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the EntityRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
