### PR TITLE
fix: Remove superfluous overrides of id methods in entities

### DIFF
--- a/changelog/_unreleased/2025-08-11-remove-superfluous-overrides-of-id-methods-in-entities.md
+++ b/changelog/_unreleased/2025-08-11-remove-superfluous-overrides-of-id-methods-in-entities.md
@@ -1,0 +1,10 @@
+---
+title: Remove superfluous overrides of id methods in entities
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Removed `getId` & `setId` method overrides in `Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity`
+* Removed `getId` & `setId` method overrides in `Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryEntity`
+* Removed `getId` & `setId` method overrides in `Shopware\Core\Content\Product\Aggregate\ProductKeywordDictionary\ProductKeywordDictionaryEntity`

--- a/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryEntity.php
@@ -20,16 +20,6 @@ class ProductKeywordDictionaryEntity extends Entity
 
     protected ?LanguageEntity $language = null;
 
-    public function getId(): string
-    {
-        return $this->id;
-    }
-
-    public function setId(string $id): void
-    {
-        $this->id = $id;
-    }
-
     public function getLanguageId(): string
     {
         return $this->languageId;

--- a/src/Core/System/User/Aggregate/UserConfig/UserConfigEntity.php
+++ b/src/Core/System/User/Aggregate/UserConfig/UserConfigEntity.php
@@ -23,16 +23,6 @@ class UserConfigEntity extends Entity
 
     protected ?UserEntity $user = null;
 
-    public function getId(): string
-    {
-        return $this->id;
-    }
-
-    public function setId(string $id): void
-    {
-        $this->id = $id;
-    }
-
     public function getKey(): string
     {
         return $this->key;

--- a/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryEntity.php
+++ b/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryEntity.php
@@ -18,16 +18,6 @@ class UserRecoveryEntity extends Entity
 
     protected ?UserEntity $user = null;
 
-    public function getId(): string
-    {
-        return $this->id;
-    }
-
-    public function setId(string $id): void
-    {
-        $this->id = $id;
-    }
-
     public function getUserId(): string
     {
         return $this->userId;


### PR DESCRIPTION
### 1. Why is this change necessary?
- There are a few entities which override the `getId` & `setId` methods without any reason
- This also leads to an issue where the property “_uniqueIdentifier” is not set correctly in the entity
- See `3. Describe each step to reproduce the issue or behaviour`

### 2. What does this change do, exactly?
* Removed `getId` & `setId` method overrides in `Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity`
* Removed `getId` & `setId` method overrides in `Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryEntity`
* Removed `getId` & `setId` method overrides in `Shopware\Core\Content\Product\Aggregate\ProductKeywordDictionary\ProductKeywordDictionaryEntity`

### 3. Describe each step to reproduce the issue or behaviour.
- Create a e.g. `UserRecoveryEntity`
- Set the id with `setId`
- Try to access the `_uniqueIdentifier` property via `getUniqueIdentifier` -> error because it is not initialized

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
