### PR TITLE
fix: RetryWebhookHandler correctly set error count

### DIFF
--- a/changelog/_unreleased/2025-08-12-fix-webhook-deactivation-on-failure.md
+++ b/changelog/_unreleased/2025-08-12-fix-webhook-deactivation-on-failure.md
@@ -1,0 +1,5 @@
+---
+title: Fix webhook deactivation on failure
+---
+# Core
+* Changed `\Shopware\Core\Framework\Webhook\Subscriber\RetryWebhookMessageFailedSubscriber::failed` to correctly increase the error count for the webhook and set it to inactive after the threshold is reached. 

--- a/src/Core/Framework/Webhook/Subscriber/RetryWebhookMessageFailedSubscriber.php
+++ b/src/Core/Framework/Webhook/Subscriber/RetryWebhookMessageFailedSubscriber.php
@@ -59,7 +59,7 @@ class RetryWebhookMessageFailedSubscriber implements EventSubscriberInterface
 
         $rows = $this->connection->fetchAllAssociative(
             'SELECT active, error_count FROM webhook WHERE id = :id',
-            ['id' => $webhookId]
+            ['id' => Uuid::fromHexToBytes($webhookId)]
         );
 
         /** @var array{active: int, error_count: int} $webhook */
@@ -75,7 +75,7 @@ class RetryWebhookMessageFailedSubscriber implements EventSubscriberInterface
         if ($webhookErrorCount >= self::MAX_WEBHOOK_ERROR_COUNT) {
             $params = array_merge($params, [
                 'error_count' => 0,
-                'active' => false,
+                'active' => 0,
             ]);
         }
 


### PR DESCRIPTION
It never updated the error count, that is now fixed
