### PR TITLE
fix: text-editor color and link selection

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/index.ts
@@ -49,7 +49,7 @@ export default Shopware.Component.wrapComponentConfig({
         buttonVariant: ButtonVariant;
         linkCategory: LinkCategories;
         categoryCollection?: EntityCollection<'category'>;
-        buttonVariantList: Array<{ id: number, value: ButtonVariant; label: string }>;
+        buttonVariantList: Array<{ id: number; value: ButtonVariant; label: string }>;
     } {
         return {
             linkTitle: '',

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/index.ts
@@ -49,7 +49,7 @@ export default Shopware.Component.wrapComponentConfig({
         buttonVariant: ButtonVariant;
         linkCategory: LinkCategories;
         categoryCollection?: EntityCollection<'category'>;
-        buttonVariantList: Array<{ id: ButtonVariant; name: string }>;
+        buttonVariantList: Array<{ id: number, value: ButtonVariant; label: string }>;
     } {
         return {
             linkTitle: '',
@@ -62,20 +62,24 @@ export default Shopware.Component.wrapComponentConfig({
             categoryCollection: undefined,
             buttonVariantList: [
                 {
-                    id: 'primary',
-                    name: this.$tc('sw-text-editor-toolbar.link.buttonVariantPrimary'),
+                    id: 1,
+                    value: 'primary',
+                    label: this.$tc('sw-text-editor-toolbar.link.buttonVariantPrimary'),
                 },
                 {
-                    id: 'secondary',
-                    name: this.$tc('sw-text-editor-toolbar.link.buttonVariantSecondary'),
+                    id: 2,
+                    value: 'secondary',
+                    label: this.$tc('sw-text-editor-toolbar.link.buttonVariantSecondary'),
                 },
                 {
-                    id: 'primary-sm',
-                    name: this.$tc('sw-text-editor-toolbar.link.buttonVariantPrimarySmall'),
+                    id: 3,
+                    value: 'primary-sm',
+                    label: this.$tc('sw-text-editor-toolbar.link.buttonVariantPrimarySmall'),
                 },
                 {
-                    id: 'secondary-sm',
-                    name: this.$tc('sw-text-editor-toolbar.link.buttonVariantSecondarySmall'),
+                    id: 4,
+                    value: 'secondary-sm',
+                    label: this.$tc('sw-text-editor-toolbar.link.buttonVariantSecondarySmall'),
                 },
             ],
         };

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/index.js
@@ -100,7 +100,7 @@ export default {
                 return;
             }
 
-            if (button.type === 'foreColor' && event.target.closest('.sw-colorpicker__colorpicker')) {
+            if (button.type === 'foreColor' && event.target.closest('.mt-colorpicker__colorpicker')) {
                 return;
             }
 
@@ -134,7 +134,7 @@ export default {
             }
 
             const flyoutMenuRightBound = flyoutMenu.getBoundingClientRect().right;
-            const windowRightBound = this.$root.$el.getBoundingClientRect().right;
+            const windowRightBound = this.$root.$el.parentElement.getBoundingClientRect().right;
 
             const isOutOfRightBound = flyoutMenuRightBound - windowRightBound > 0;
             this.flyoutClasses = isOutOfRightBound ? ['is--left'] : ['is--right'];

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.html.twig
@@ -57,6 +57,7 @@
             :disabled="disabled"
             compact
             :alpha="false"
+            :applyMode="true"
             @update:model-value="handleButtonClick(buttonConfig)"
         />
     </div>

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.html.twig
@@ -57,7 +57,7 @@
             :disabled="disabled"
             compact
             :alpha="false"
-            :applyMode="true"
+            :apply-mode="true"
             @update:model-value="handleButtonClick(buttonConfig)"
         />
     </div>

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/index.js
@@ -198,6 +198,10 @@ export default {
                 return;
             }
 
+            if (path.some((element) => element.classList?.contains('mt-select-result-list-popover-wrapper'))) {
+                return;
+            }
+
             if (!path.includes(this.$el)) {
                 if (!this.isInlineEdit && this.selection) {
                     this.setActiveTags();


### PR DESCRIPTION
closes: #11841
closes: #11637

### 1. Why is this change necessary?

* Text color selection is flaky and the old selection remains even when trying to select some other text.
* When selecting different link types the link overlay is closed instead of switching the link type.

### 2. What does this change do, exactly?

* Update the selectors in mouse and click events to use the new `mt-*` components. So the popover doesn't close when selecting something from the select list.
* Use the `applyMode` for the color picker like in 6.6.x because otherwise the current curser selection is never removed and causes bugs.
* Fix the `buttonVariantList` to be compatible with `mt-select`.
