### PR TITLE
fix: RedisInvalidatorStorageTest integration test failing pipeline

### DIFF
--- a/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/RedisInvalidatorStorageTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/RedisInvalidatorStorageTest.php
@@ -39,7 +39,10 @@ class RedisInvalidatorStorageTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->redis->flushAll();
+        // Clear the Redis storage only if it was set up and not skipped
+        if (isset($this->redis)) {
+            $this->redis->flushAll();
+        }
     }
 
     public function testLoadWhenEmpty(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Without Nightly fails with 
- https://github.com/shopware/shopware/actions/runs/16925131135/job/47959233062
- https://github.com/shopware/shopware/actions/runs/16925131135/job/47959232943

### 2. What does this change do, exactly?

Protects flush() invocation on property $redis, no matter it is skipped once unavailable in setup, this would be always executed in teardown leading to 
```
Shopware\Tests\Integration\Core\Framework\Adapter\Cache\InvalidatorStorage\RedisInvalidatorStorageTest::testLoadWhenEmpty
Error: Typed property Shopware\Tests\Integration\Core\Framework\Adapter\Cache\InvalidatorStorage\RedisInvalidatorStorageTest::$redis must not be accessed before initializati
```

### 3. Describe each step to reproduce the issue or behaviour.
- Run  `composer run phpunit -- --testsuite integration --filter RedisInvalidatorStorageTest` locally (without Redis instance)
- Check pipeline

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
