### PR TITLE
fix: bulk edit product active is set to null instead of false

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
@@ -1214,6 +1214,10 @@ export default {
 
                 let bulkEditValue = this.product[key];
 
+                if (key === 'active' && bulkEditValue == null) {
+                    bulkEditValue = false;
+                }
+
                 if (
                     [
                         'minPurchase',


### PR DESCRIPTION
Steps to reproduce:

* Select products for bulk editing
* Check “Change: active” but keep the “Active” toggle disabled
* Save

Expected result:

* The column ‘active’ is set to 0 in the table 'product' for the affected products
* The products appear when filtering for inactive products

Actual result:

* The column ‘active’ is set to NULL in the table 'product' for the affected products
* The products appear neither when filtering for active nor inactive

Workaround: when bulk editing, toggle the active slider at least once and then back. This will ensure that the products will correctly be set to inactive.

Version: 6.6.x

### Solution 
Set the initial value for active to false.