### PR TITLE
fix: 6.7 Migrations

### DIFF
--- a/src/Core/Migration/V6_7/Migration1720610755RemoveDefaultPaymentMethodFromCustomer.php
+++ b/src/Core/Migration/V6_7/Migration1720610755RemoveDefaultPaymentMethodFromCustomer.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Migration\V6_7;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
 
@@ -19,6 +20,10 @@ class Migration1720610755RemoveDefaultPaymentMethodFromCustomer extends Migratio
 
     public function update(Connection $connection): void
     {
+        if (!Feature::isActive('v6.7.0.0')) {
+            return;
+        }
+
         if ($this->columnExists($connection, 'customer', 'default_payment_method_id')) {
             $connection->executeStatement('ALTER TABLE `customer` MODIFY COLUMN `default_payment_method_id` BINARY(16) NULL');
         }
@@ -26,6 +31,10 @@ class Migration1720610755RemoveDefaultPaymentMethodFromCustomer extends Migratio
 
     public function updateDestructive(Connection $connection): void
     {
+        if (!Feature::isActive('v6.7.0.0')) {
+            return;
+        }
+
         if ($this->columnExists($connection, 'customer', 'default_payment_method_id')) {
             $this->dropForeignKeyIfExists($connection, 'customer', 'fk.customer.default_payment_method_id');
             $this->dropColumnIfExists($connection, 'customer', 'default_payment_method_id');

--- a/src/Core/Migration/V6_7/Migration1737430168RemoveFileTypeOfDocumentTable.php
+++ b/src/Core/Migration/V6_7/Migration1737430168RemoveFileTypeOfDocumentTable.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Migration\V6_7;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
 
@@ -23,6 +24,10 @@ class Migration1737430168RemoveFileTypeOfDocumentTable extends MigrationStep
 
     public function updateDestructive(Connection $connection): void
     {
+        if (!Feature::isActive('v6.7.0.0')) {
+            return;
+        }
+
         $this->dropColumnIfExists($connection, 'document', 'file_type');
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Some Migrations cause Issues in the 6.6.x branch without the 6.7 feature flag. Please take a look at the following Definitions and see for yourself:

- https://github.com/shopware/shopware/blob/6.6.x/src/Core/Checkout/Customer/CustomerDefinition.php#L168-L171
- https://github.com/shopware/shopware/blob/6.6.x/src/Core/Checkout/Document/DocumentDefinition.php#L80-L82

### 2. What does this change do, exactly?
It checks the 6.7 Feature flag and skips the removal of fields if the 6.7 feature flag is disabled.


### 3. Describe each step to reproduce the issue or behaviour.

1. Install Shopware in the 6.6.x branch
2. To see the customer related issue run : `APP_ENV=prod bin/console framework:demodata`
3. To see the document related issue try to order a product in the Storefront. You will get a 500 Internal Server Error on `/checkout/order`