### PR TITLE
test: protect all tests using redis instance

### DIFF
--- a/tests/integration/Core/Checkout/Cart/RedisCartPersisterTest.php
+++ b/tests/integration/Core/Checkout/Cart/RedisCartPersisterTest.php
@@ -47,7 +47,10 @@ class RedisCartPersisterTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
-        $this->redis->flushAll();
+        // Clear the Redis storage only if it was set up and not skipped
+        if (isset($this->redis)) {
+            $this->redis->flushAll();
+        }
     }
 
     public function testPersisting(): void

--- a/tests/integration/Core/Framework/Adapter/Cache/RedisConnectionFactoryTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/RedisConnectionFactoryTest.php
@@ -17,11 +17,10 @@ class RedisConnectionFactoryTest extends TestCase
     #[DataProvider('prefixProvider')]
     public function testPrefix(?string $aPrefix, ?string $bPrefix, bool $equals): void
     {
-        /** @var string $url */
-        $url = EnvironmentHelper::getVariable('REDIS_URL');
+        $url = (string) EnvironmentHelper::getVariable('REDIS_URL');
 
-        if (!$url) {
-            static::markTestSkipped('No redis server configured');
+        if ($url === '') {
+            static::markTestSkipped('Redis is not available');
         }
 
         $a = (new RedisConnectionFactory($aPrefix))->create($url);

--- a/tests/integration/Core/Framework/Adapter/Redis/RedisContainerWiringTest.php
+++ b/tests/integration/Core/Framework/Adapter/Redis/RedisContainerWiringTest.php
@@ -36,6 +36,11 @@ class RedisContainerWiringTest extends TestCase
 
     public static function tearDownAfterClass(): void
     {
+        $redisUrl = (string) EnvironmentHelper::getVariable('REDIS_URL');
+        if ($redisUrl === '') {
+            return;
+        }
+
         self::unloadKernel();
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Follow up from https://github.com/shopware/shopware/pull/11877

After it, more tests were not protected and failed the new nightly with
https://github.com/shopware/shopware/actions/runs/16953581404/job/48051145238
https://github.com/shopware/shopware/actions/runs/16953581404/job/48051145252

```
1) Shopware\Tests\Integration\Core\Checkout\Cart\RedisCartPersisterTest::testLoadZstdCompressedCart
Error: Typed property Shopware\Tests\Integration\Core\Checkout\Cart\RedisCartPersisterTest::$redis must not be accessed before initialization

/home/runner/work/shopware/shopware/tests/integration/Core/Checkout/Cart/RedisCartPersisterTest.php:50
```

```
1) Shopware\Tests\Integration\Core\Framework\Increment\RedisIncrementerTest::testDecrement with data set #1 ('test')
Symfony\Component\Cache\Exception\InvalidArgumentException: Invalid Redis DSN: it does not start with "redis[s]:" nor "valkey[s]:".

/home/runner/work/shopware/shopware/vendor/symfony/cache/Traits/RedisTrait.php:98
/home/runner/work/shopware/shopware/src/Core/Framework/Adapter/Cache/RedisConnectionFactory.php:52
/home/runner/work/shopware/shopware/tests/integration/Core/Framework/Increment/RedisIncrementerTest.php:34
```


### 2. What does this change do, exactly?
Protect teardown and any other test using Redis, relying on environment url configuration

### 3. Describe each step to reproduce the issue or behaviour.
- Run the tests locally with no Redis available
- Run a nightly

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
