### PR TITLE
fix: checkVariantListingConfig, displayParent is not always a boolean

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -176,7 +176,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
 
         $variantListingConfig = json_decode((string) $productData['variantListingConfig'], true, 512, \JSON_THROW_ON_ERROR);
 
-        if (isset($variantListingConfig['displayParent']) && $variantListingConfig['displayParent'] === true) {
+        if (isset($variantListingConfig['displayParent']) && (bool) $variantListingConfig['displayParent'] === true) {
             return null;
         }
 

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -277,6 +277,47 @@ class ProductDetailRouteTest extends TestCase
         static::assertTrue($result->getProduct()->getAvailable());
     }
 
+    public function testResolveVariantIdFromEventWithWrongTypeForDisplayParent(): void
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'variantListingConfig' => '{"displayParent": 1, "mainVariantId": "2"}', // Wrong displayParent type, should be boolean
+                'parentId' => '2',
+            ]);
+
+        $productId = Uuid::randomHex();
+        $productEntity = new SalesChannelProductEntity();
+        $productEntity->setId($productId);
+        $productEntity->setCmsPageId('4');
+        $productEntity->setUniqueIdentifier('2');
+        $productEntity->setAvailable(true);
+        $this->productRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(
+                new EntitySearchResult(
+                    'product',
+                    1,
+                    new ProductCollection([$productEntity]),
+                    null,
+                    new Criteria(),
+                    $this->context->getContext()
+                )
+            );
+
+        $this->eventDispatcher->addListener(ResolveVariantIdEvent::class, function (ResolveVariantIdEvent $event) use ($productId): void {
+            static::assertSame($productId, $event->getProductId());
+            //In checkVariantListingConfig we want to make sure that the variant ID is not returned against displayParent
+            static::assertNull($event->getResolvedVariantId(), 'Wrong variant ID resolved:' . $event->getResolvedVariantId());
+        });
+
+        $result = $this->route->load($productId, new Request(), $this->context, new Criteria());
+
+        static::assertSame('2', $result->getProduct()->getUniqueIdentifier());
+        static::assertTrue($result->getProduct()->getAvailable());
+    }
+
     public function testConfigHideCloseoutProductsWhenOutOfStockFiltersResults(): void
     {
         $productEntity = new SalesChannelProductEntity();

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -308,7 +308,7 @@ class ProductDetailRouteTest extends TestCase
 
         $this->eventDispatcher->addListener(ResolveVariantIdEvent::class, function (ResolveVariantIdEvent $event) use ($productId): void {
             static::assertSame($productId, $event->getProductId());
-            //In checkVariantListingConfig we want to make sure that the variant ID is not returned against displayParent
+            // In checkVariantListingConfig we want to make sure that the variant ID is not returned against displayParent
             static::assertNull($event->getResolvedVariantId(), 'Wrong variant ID resolved:' . $event->getResolvedVariantId());
         });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Once the retrieval of variant_listing_config was replaced from a deserialization-based approach to a direct SQL query, displayParent is not enforced to be a boolean

Then the check inside checkVariantListingConfig
```
        if (isset($variantListingConfig['displayParent']) && $variantListingConfig['displayParent'] === true) {
            return null;
        }
```
will fail, while displayParent can be 1

### 2. What does this change do, exactly?
Adds a unit test which fails without the change
```
There was 1 failure:

1) Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Detail\ProductDetailRouteTest::testResolveVariantIdFromEventWithWrongTypeForDisplayParent
Wrong variant ID resolved:2
Failed asserting that '2' is null.
```

Applies a cast to boolean for displayParent

### 3. Describe each step to reproduce the issue or behaviour.
Run the unit test 

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/11876

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
