### PR TITLE
feat: Log mail when mail sending is disabled

### DIFF
--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -56,6 +56,7 @@
             <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument>%shopware.mail.max_body_length%</argument>
+            <argument type="service" id="logger"/>
             <argument type="abstract" id="message bus"/>
         </service>
 

--- a/src/Core/Content/Mail/MailerConfigurationCompilerPass.php
+++ b/src/Core/Content/Mail/MailerConfigurationCompilerPass.php
@@ -33,6 +33,6 @@ class MailerConfigurationCompilerPass implements CompilerPassInterface
         // use the same message bus from symfony/mailer configuration.
         // matching: https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue.html#sending-mails-over-the-message-queue
         $originalMailer = $container->getDefinition('mailer.mailer');
-        $mailer->replaceArgument(4, $originalMailer->getArgument(1));
+        $mailer->replaceArgument(5, $originalMailer->getArgument(1));
     }
 }

--- a/src/Core/Content/Mail/Service/MailSender.php
+++ b/src/Core/Content/Mail/Service/MailSender.php
@@ -51,9 +51,9 @@ class MailSender extends AbstractMailSender
         $disabled = $this->configService->get(self::DISABLE_MAIL_DELIVERY);
 
         if ($disabled) {
-            $receiver = array_map(fn($address) => $address->getAddress(), $email->getTo());
+            $receiver = array_map(fn ($address) => $address->getAddress(), $email->getTo());
 
-            $this->logger->debug(
+            $this->logger->info(
                 'Tried to send mail but delivery is disabled.',
                 [
                     'subject' => $email->getSubject(),

--- a/src/Core/Content/Mail/Service/MailSender.php
+++ b/src/Core/Content/Mail/Service/MailSender.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Mail\Service;
 
 use League\Flysystem\FilesystemOperator;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Mail\MailException;
 use Shopware\Core\Content\Mail\Message\SendMailMessage;
 use Shopware\Core\Framework\Log\Package;
@@ -35,6 +36,7 @@ class MailSender extends AbstractMailSender
         private readonly FilesystemOperator $filesystem,
         private readonly SystemConfigService $configService,
         private readonly int $maxContentLength,
+        private readonly LoggerInterface $logger,
         private readonly ?MessageBusInterface $messageBus = null,
     ) {
     }
@@ -49,6 +51,17 @@ class MailSender extends AbstractMailSender
         $disabled = $this->configService->get(self::DISABLE_MAIL_DELIVERY);
 
         if ($disabled) {
+            $receiver = array_map(fn($address) => $address->getAddress(), $email->getTo());
+
+            $this->logger->debug(
+                'Tried to send mail but delivery is disabled.',
+                [
+                    'subject' => $email->getSubject(),
+                    'receiver' => implode(', ', $receiver),
+                    'content' => $email->getTextBody(),
+                ]
+            );
+
             return;
         }
 

--- a/tests/unit/Core/Content/Mail/MailerConfigurationCompilerPassTest.php
+++ b/tests/unit/Core/Content/Mail/MailerConfigurationCompilerPassTest.php
@@ -24,7 +24,7 @@ class MailerConfigurationCompilerPassTest extends TestCase
         $container->setDefinition('mailer.default_transport', new Definition(\ArrayObject::class));
         $container->setDefinition('mailer.transports', new Definition(\ArrayObject::class));
         $container->setDefinition('mailer.mailer', new Definition(\ArrayObject::class, [null, new Reference('message_bus')]));
-        $container->setDefinition(MailSender::class, new Definition(MailSender::class, [new Reference('mailer.default_transport'), new Reference('filesystem'), new Reference('config_service'), 0, new Reference('message_bus')]));
+        $container->setDefinition(MailSender::class, new Definition(MailSender::class, [new Reference('mailer.default_transport'), new Reference('filesystem'), new Reference('config_service'), 0, new Reference('logger'), new Reference('message_bus')]));
 
         $pass = new MailerConfigurationCompilerPass();
         $pass->process($container);
@@ -51,6 +51,6 @@ class MailerConfigurationCompilerPassTest extends TestCase
 
         $mailer = $container->getDefinition(MailSender::class);
         $originalMailer = $container->getDefinition('mailer.mailer');
-        static::assertSame($originalMailer->getArgument(1), $mailer->getArgument(4));
+        static::assertSame($originalMailer->getArgument(1), $mailer->getArgument(5));
     }
 }

--- a/tests/unit/Core/Content/Mail/Service/MailSenderTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailSenderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Mail\Service;
 use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Mail\MailException;
 use Shopware\Core\Content\Mail\Message\SendMailMessage;
 use Shopware\Core\Content\Mail\Service\MailSender;
@@ -29,7 +30,14 @@ class MailSenderTest extends TestCase
         $fileSystem = $this->createMock(FilesystemOperator::class);
         $configService = $this->createMock(SystemConfigService::class);
         $configService->expects($this->once())->method('get')->with(MailSender::DISABLE_MAIL_DELIVERY)->willReturn(false);
-        $mailSender = new MailSender($mailer, $fileSystem, $configService, 0, $messageBus);
+        $mailSender = new MailSender(
+            $mailer,
+            $fileSystem,
+            $configService,
+            0,
+            $this->createMock(LoggerInterface::class),
+            $messageBus
+        );
         $mail = new Email();
 
         $mailer
@@ -46,7 +54,14 @@ class MailSenderTest extends TestCase
         $fileSystem = $this->createMock(FilesystemOperator::class);
         $configService = $this->createMock(SystemConfigService::class);
         $configService->expects($this->once())->method('get')->with(MailSender::DISABLE_MAIL_DELIVERY)->willReturn(false);
-        $mailSender = new MailSender($mailer, $fileSystem, $configService, 0, null);
+        $mailSender = new MailSender(
+            $mailer,
+            $fileSystem,
+            $configService,
+            0,
+            $this->createMock(LoggerInterface::class),
+            null
+        );
         $mail = new Email();
 
         $mailer
@@ -64,7 +79,14 @@ class MailSenderTest extends TestCase
         $fileSystem = $this->createMock(FilesystemOperator::class);
         $configService = $this->createMock(SystemConfigService::class);
         $configService->expects($this->once())->method('get')->with(MailSender::DISABLE_MAIL_DELIVERY)->willReturn(false);
-        $mailSender = new MailSender($mailer, $fileSystem, $configService, 0, $messageBus);
+        $mailSender = new MailSender(
+            $mailer,
+            $fileSystem,
+            $configService,
+            0,
+            $this->createMock(LoggerInterface::class),
+            $messageBus
+        );
         $text = str_repeat('a', MailSender::MAIL_MESSAGE_SIZE_LIMIT);
         $mail = new Email(null, new TextPart($text));
 
@@ -99,8 +121,12 @@ class MailSenderTest extends TestCase
         $fileSystem = $this->createMock(FilesystemOperator::class);
         $configService = $this->createMock(SystemConfigService::class);
         $configService->expects($this->once())->method('get')->with(MailSender::DISABLE_MAIL_DELIVERY)->willReturn(true);
-        $mailSender = new MailSender($mailer, $fileSystem, $configService, 0, $messageBus);
+        $logger = $this->createMock(LoggerInterface::class);
+        $mailSender = new MailSender($mailer, $fileSystem, $configService, 0, $logger, $messageBus);
         $mail = new Email();
+
+        $logger->expects($this->once())
+            ->method('debug');
 
         $fileSystem
             ->expects($this->never())
@@ -120,7 +146,14 @@ class MailSenderTest extends TestCase
         $fileSystem = $this->createMock(FilesystemOperator::class);
         $configService = $this->createMock(SystemConfigService::class);
         $configService->expects($this->once())->method('get')->with(MailSender::DISABLE_MAIL_DELIVERY)->willReturn(false);
-        $mailSender = new MailSender($mailer, $fileSystem, $configService, 5, $messageBus);
+        $mailSender = new MailSender(
+            $mailer,
+            $fileSystem,
+            $configService,
+            5,
+            $this->createMock(LoggerInterface::class),
+            $messageBus
+        );
 
         $mail = new Email();
         $mail->text('foobar');

--- a/tests/unit/Core/Content/Mail/Service/MailSenderTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailSenderTest.php
@@ -126,7 +126,7 @@ class MailSenderTest extends TestCase
         $mail = new Email();
 
         $logger->expects($this->once())
-            ->method('debug');
+            ->method('info');
 
         $fileSystem
             ->expects($this->never())


### PR DESCRIPTION
When mail sending is disabled there is no way to tell if it would have worked, logging the mail is a good way to at least be able to debug that without sending mails