### PR TITLE
fix: Adjust product zoom window size

### DIFF
--- a/changelog/_unreleased/2025-08-15-fix-the-zoom-functionality-to-prevent-a-large-window.md
+++ b/changelog/_unreleased/2025-08-15-fix-the-zoom-functionality-to-prevent-a-large-window.md
@@ -1,0 +1,5 @@
+---
+title: Fix zoom functionality to prevent a large window
+---
+# Storefront
+* Changed `_setZoomImageSize` in `src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js` to prevent a large window when zooming in.

--- a/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
@@ -235,9 +235,10 @@ export default class MagnifierPlugin extends Plugin {
     _setZoomImageSize(imageSize) {
         const factor = imageSize.y / imageSize.x;
         const zoomImageSize = this._getZoomImageSize();
-        const height = this.options.keepAspectRatioOnZoom
-            ? this.options.scaleZoomImage ? zoomImageSize.x * factor : zoomImageSize.y
-            : zoomImageSize.x;
+        const maxHeight = window.innerHeight / 2;
+        const height = Math.min((this.options.keepAspectRatioOnZoom
+            ? (this.options.scaleZoomImage ? zoomImageSize.x * factor : zoomImageSize.y)
+            : zoomImageSize.x), maxHeight);
         this._zoomImage.style.height = `${height}px`;
         this._zoomImage.style.minHeight = `${height}px`;
     }

--- a/src/Storefront/Resources/app/storefront/test/plugin/magnifier/magnifier.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/magnifier/magnifier.plugin.test.js
@@ -1,0 +1,87 @@
+import MagnifierPlugin from 'src/plugin/magnifier/magnifier.plugin';
+
+/**
+ * @package storefront
+ */
+describe('MagnifierPlugin tests', () => {
+    let magnifierPlugin;
+    let element;
+
+    beforeEach(() => {
+        // Basic DOM setup with required containers
+        document.body.innerHTML = `
+            <div data-magnifier>
+                <div class="js-magnifier-container">
+                    <img class="js-magnifier-image" src="#" />
+                </div>
+            </div>
+            <div class="js-magnifier-zoom-image-container"></div>
+        `;
+
+        // Minimal PluginManager stub used by Plugin base class
+        window.PluginManager = {
+            getPluginInstancesFromElement: jest.fn(() => new Map()),
+            getPlugin: jest.fn(() => new Map([["instances", []]])),
+        };
+
+        // Ensure deterministic viewport height
+        Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true }); // maxHeight = 500
+
+        element = document.querySelector('[data-magnifier]');
+        magnifierPlugin = new MagnifierPlugin(element);
+
+        // Provide a _zoomImage element with controlled bounding box
+        const zoomImageEl = document.createElement('div');
+        document.querySelector('.js-magnifier-zoom-image-container').appendChild(zoomImageEl);
+        magnifierPlugin._zoomImage = zoomImageEl;
+    });
+
+    afterEach(() => {
+        magnifierPlugin = undefined;
+        element = undefined;
+        document.body.innerHTML = '';
+    });
+
+    describe('_setZoomImageSize', () => {
+        test('should clamp height to window.innerHeight / 2 when computed height exceeds maxHeight', () => {
+            // keepAspectRatioOnZoom: true (default), scaleZoomImage: false (default)
+            // zoomImageSize.y (desired) = 800 > maxHeight (500) -> expect 500
+            magnifierPlugin._zoomImage.getBoundingClientRect = () => ({ width: 400, height: 800, top: 0, left: 0, right: 0, bottom: 0 });
+
+            // imageSize doesn't affect this branch, but provide sensible values
+            const imageSize = { x: 400, y: 800 };
+
+            magnifierPlugin._setZoomImageSize(imageSize);
+
+            expect(magnifierPlugin._zoomImage.style.height).toBe('500px');
+            expect(magnifierPlugin._zoomImage.style.minHeight).toBe('500px');
+        });
+
+        test('should not clamp when computed height is smaller than maxHeight', () => {
+            // keepAspectRatioOnZoom: true (default), scaleZoomImage: false (default)
+            // zoomImageSize.y (desired) = 300 < maxHeight (500) -> expect 300
+            magnifierPlugin._zoomImage.getBoundingClientRect = () => ({ width: 400, height: 300, top: 0, left: 0, right: 0, bottom: 0 });
+
+            const imageSize = { x: 400, y: 800 };
+
+            magnifierPlugin._setZoomImageSize(imageSize);
+
+            expect(magnifierPlugin._zoomImage.style.height).toBe('300px');
+            expect(magnifierPlugin._zoomImage.style.minHeight).toBe('300px');
+        });
+
+        test('should clamp when scaleZoomImage is true and computed height exceeds maxHeight', () => {
+            // Activate scaleZoomImage path
+            magnifierPlugin.options.scaleZoomImage = true;
+
+            // zoomImageSize.x * factor -> 400 * (800/400) = 800 > 500 -> expect 500
+            magnifierPlugin._zoomImage.getBoundingClientRect = () => ({ width: 400, height: 100, top: 0, left: 0, right: 0, bottom: 0 });
+            const imageSize = { x: 400, y: 800 }; // factor = 2
+
+            magnifierPlugin._setZoomImageSize(imageSize);
+
+            expect(magnifierPlugin._zoomImage.style.height).toBe('500px');
+            expect(magnifierPlugin._zoomImage.style.minHeight).toBe('500px');
+        });
+    });
+});


### PR DESCRIPTION
### Actual behaviour

Storefront: when use the zoom-function the custom product zoom-window seems to be a bit large

<img width="1429" height="853" alt="Screenshot 2025-08-15 at 08 33 28" src="https://github.com/user-attachments/assets/d38f6472-3d81-45b9-9599-0b657198d4d2" />

### How to reproduce

create a custom product with an image
use the zoom function