### PR TITLE
fix: Cleanup invalid paths from symfony translator config

### DIFF
--- a/src/Core/Framework/Resources/config/packages/translation.yaml
+++ b/src/Core/Framework/Resources/config/packages/translation.yaml
@@ -4,7 +4,4 @@ framework:
         fallbacks:
             - 'en_GB'
             - 'en'
-        paths:
-            - "%kernel.shopware_core_dir%/System/Resources/translation"
-            - "%kernel.shopware_core_dir%/Framework/Resources/snippet"
         default_path: "%kernel.shopware_core_dir%/Framework/Resources/snippet"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We switched to the flysystem in the last language system refactoring and use new folder for the file destination.
The current used paths are invalid because the translation folder is always empty.

### 2. What does this change do, exactly?
I removed the invalid path and deleted the folder with the .gitkeep file.
Since the new translation folder exists only if the cli command has been called, it is not possible to add a static path into the translator config. We have another ticket to evaluate and fix the issue.

### 3. Describe each step to reproduce the issue or behaviour.
// not reproducible

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
