### PR TITLE
fix: endless form loading spinner

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
@@ -72,6 +72,8 @@ export default class FormCmsHandler extends Plugin {
         const response = JSON.parse(res);
         this.$emitter.publish('onFormResponse', res);
 
+        this.el.dispatchEvent(new CustomEvent('removeLoader'));
+
         if (response.length > 0) {
             let changeContent = true;
             let content = '';


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The cms newsletter form has an endless loading spinner when the ACESSIBILITY TWEAKS are active.

The fix is already in trunk. So, its only needed for 6.6.x


### 2. What does this change do, exactly?
Emit an event when the response is back to deactivate the loading spinner.

### 3. Describe each step to reproduce the issue or behaviour.
- enable accessibility tweaks
- create a cms page with newsletter form
- submit the newsletter in the storefront

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
-closes #8024 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
