### PR TITLE
feat: cookie hash store api

### DIFF
--- a/changelog/_unreleased/2025-08-15-add-cookie-hash-endpoint.md
+++ b/changelog/_unreleased/2025-08-15-add-cookie-hash-endpoint.md
@@ -1,0 +1,11 @@
+---
+title: Add cookie hash endpoint
+issue: 9451
+author: Björn Meyer
+author_email: b.meyer@shopware.com
+author_github: @BrocksiNet
+---
+# API
+* Added new Store API endpoint `/store-api/cookie-hash` to get a hash representing the current cookie configuration
+* Added `calculateCookieHash` method to `CookieService` to calculate a SHA-1 hash of all cookie groups and entries
+* Added `CookieHash` struct to represent the cookie hash in API responses

--- a/src/Core/Content/Cookie/SalesChannel/AbstractCookieHashRoute.php
+++ b/src/Core/Content/Cookie/SalesChannel/AbstractCookieHashRoute.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cookie\SalesChannel;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * This route is used to get the hash representing all cookie groups and their entries.
+ */
+#[Package('framework')]
+abstract class AbstractCookieHashRoute
+{
+    abstract public function getDecorated(): AbstractCookieHashRoute;
+
+    abstract public function getCookieHash(Request $request, SalesChannelContext $salesChannelContext): CookieHashRouteResponse;
+}

--- a/src/Core/Content/Cookie/SalesChannel/CookieHashRoute.php
+++ b/src/Core/Content/Cookie/SalesChannel/CookieHashRoute.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cookie\SalesChannel;
+
+use Shopware\Core\Content\Cookie\Service\CookieService;
+use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(defaults: ['_routeScope' => ['store-api']])]
+#[Package('framework')]
+class CookieHashRoute extends AbstractCookieHashRoute
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly CookieProviderInterface $cookieProvider,
+        private readonly CookieService $cookieService,
+    ) {
+    }
+
+    public function getDecorated(): AbstractCookieHashRoute
+    {
+        throw new DecorationPatternException(self::class);
+    }
+
+    #[Route(path: '/store-api/cookie-hash', name: 'store-api.cookie.hash', methods: ['GET'])]
+    public function getCookieHash(Request $request, SalesChannelContext $salesChannelContext): CookieHashRouteResponse
+    {
+        $translate = $request->query->getBoolean('translate', true); // Default to true for Store API consumers
+
+        $cookieGroups = $this->cookieProvider->getCookieGroups();
+        if (empty($cookieGroups)) {
+            $collection = new CookieGroupCollection();
+
+            return new CookieHashRouteResponse($this->cookieService->calculateCookieHash($collection));
+        }
+
+        $collection = $this->cookieService->getCookieGroupCollection(
+            $cookieGroups,
+            $salesChannelContext,
+            $translate
+        );
+
+        return new CookieHashRouteResponse($this->cookieService->calculateCookieHash($collection));
+    }
+}

--- a/src/Core/Content/Cookie/SalesChannel/CookieHashRouteResponse.php
+++ b/src/Core/Content/Cookie/SalesChannel/CookieHashRouteResponse.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cookie\SalesChannel;
+
+use Shopware\Core\Content\Cookie\Struct\CookieHash;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\StoreApiResponse;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * @extends StoreApiResponse<CookieHash>
+ */
+#[Package('framework')]
+class CookieHashRouteResponse extends StoreApiResponse
+{
+    public function __construct(string $cookieHash)
+    {
+        parent::__construct(new CookieHash($cookieHash));
+    }
+
+    public function getCookieHash(): string
+    {
+        return $this->object->cookieHash;
+    }
+}

--- a/src/Core/Content/Cookie/Service/CookieService.php
+++ b/src/Core/Content/Cookie/Service/CookieService.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics\SalesChannelAnalyticsCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -50,6 +51,55 @@ readonly class CookieService
         }
 
         return $this->convertToCookieGroupCollection($cookieGroups);
+    }
+
+    /**
+     * Calculate a hash representing all cookie groups and their entries
+     */
+    public function calculateCookieHash(CookieGroupCollection $collection): string
+    {
+        $hashData = [];
+
+        /** @var CookieGroup $cookieGroup */
+        foreach ($collection->getElements() as $cookieGroup) {
+            $groupData = [
+                'isRequired' => $cookieGroup->isRequired,
+                'snippetName' => $cookieGroup->snippetName ?? '',
+                'snippetDescription' => $cookieGroup->snippetDescription ?? '',
+                'cookie' => $cookieGroup->cookie ?? '',
+                'value' => $cookieGroup->value ?? '',
+                'expiration' => $cookieGroup->expiration ?? '',
+                'entries' => [],
+            ];
+
+            foreach ($cookieGroup->entries as $entry) {
+                $entryData = [
+                    'hidden' => $entry->hidden,
+                    'snippetName' => $entry->snippetName ?? '',
+                    'snippetDescription' => $entry->snippetDescription ?? '',
+                    'cookie' => $entry->cookie ?? '',
+                    'value' => $entry->value ?? '',
+                    'expiration' => $entry->expiration ?? '',
+                ];
+
+                $groupData['entries'][] = $entryData;
+            }
+
+            // Sort entries by their serialized content to ensure consistent hash
+            usort($groupData['entries'], function ($a, $b) {
+                return serialize($a) <=> serialize($b);
+            });
+
+            $hashData[] = $groupData;
+        }
+
+        // Sort groups by their serialized content to ensure consistent hash
+        usort($hashData, function ($a, $b) {
+            return serialize($a) <=> serialize($b);
+        });
+
+        // Generate SHA-1 hash of the serialized data
+        return Hasher::hash(serialize($hashData), 'sha1');
     }
 
     /**

--- a/src/Core/Content/Cookie/Struct/CookieHash.php
+++ b/src/Core/Content/Cookie/Struct/CookieHash.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cookie\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+#[Package('framework')]
+class CookieHash extends Struct
+{
+    public function __construct(
+        public readonly string $cookieHash,
+    ) {
+    }
+
+    public function getApiAlias(): string
+    {
+        return 'cookie_hash';
+    }
+}

--- a/src/Core/Content/DependencyInjection/cookie.xml
+++ b/src/Core/Content/DependencyInjection/cookie.xml
@@ -15,5 +15,10 @@
             <argument type="service" id="Shopware\Storefront\Framework\Cookie\CookieProviderInterface"/>
             <argument type="service" id="Shopware\Core\Content\Cookie\Service\CookieService"/>
         </service>
+
+        <service id="Shopware\Core\Content\Cookie\SalesChannel\CookieHashRoute" public="true">
+            <argument type="service" id="Shopware\Storefront\Framework\Cookie\CookieProviderInterface"/>
+            <argument type="service" id="Shopware\Core\Content\Cookie\Service\CookieService"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/cookie.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/cookie.json
@@ -8,6 +8,16 @@
         "items": {
           "$ref": "#/components/schemas/CookieGroup"
         }
+      },
+      "CookieHashResponse": {
+        "type": "object",
+        "properties": {
+          "cookieHash": {
+            "type": "string",
+            "description": "SHA-1 hash representing all cookie groups and their entries. Changes when any cookie configuration is modified."
+          }
+        },
+        "required": ["cookieHash"]
       }
     }
   },
@@ -27,6 +37,36 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CookieGroupCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/cookie-hash": {
+      "get": {
+        "tags": [
+          "Cookie Groups"
+        ],
+        "summary": "Get cookie configuration hash",
+        "description": "Returns a hash representing the current cookie configuration. This hash changes whenever any cookie group or entry is modified, making it useful for detecting configuration changes.",
+        "operationId": "readCookieHash",
+        "responses": {
+          "200": {
+            "description": "Successful response with the cookie configuration hash.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CookieHashResponse"
                 }
               }
             }

--- a/tests/unit/Core/Content/Cookie/SalesChannel/CookieHashRouteResponseTest.php
+++ b/tests/unit/Core/Content/Cookie/SalesChannel/CookieHashRouteResponseTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cookie\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cookie\SalesChannel\CookieHashRouteResponse;
+use Shopware\Core\Content\Cookie\Struct\CookieHash;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CookieHashRouteResponse::class)]
+class CookieHashRouteResponseTest extends TestCase
+{
+    public function testConstructorAndGetter(): void
+    {
+        $hash = 'abc123def456';
+        $response = new CookieHashRouteResponse($hash);
+
+        static::assertSame($hash, $response->getCookieHash());
+    }
+
+    public function testResponseContainsCookieHashStruct(): void
+    {
+        $hash = 'test-hash-value';
+        $response = new CookieHashRouteResponse($hash);
+
+        $object = $response->getObject();
+        static::assertInstanceOf(CookieHash::class, $object);
+        static::assertSame($hash, $object->cookieHash);
+        static::assertSame('cookie_hash', $object->getApiAlias());
+    }
+}

--- a/tests/unit/Core/Content/Cookie/SalesChannel/CookieHashRouteTest.php
+++ b/tests/unit/Core/Content/Cookie/SalesChannel/CookieHashRouteTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cookie\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cookie\SalesChannel\CookieHashRoute;
+use Shopware\Core\Content\Cookie\Service\CookieService;
+use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Generator;
+use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CookieHashRoute::class)]
+class CookieHashRouteTest extends TestCase
+{
+    public function testGetCookieHashWithEmptyProvider(): void
+    {
+        $cookieProvider = $this->createMock(CookieProviderInterface::class);
+        $cookieProvider->method('getCookieGroups')->willReturn([]);
+
+        $cookieService = $this->createMock(CookieService::class);
+        $cookieService->method('calculateCookieHash')->willReturn('8739602554c7f3241958e3cc9b57fdecb474d508');
+
+        $route = new CookieHashRoute($cookieProvider, $cookieService);
+
+        $request = new Request();
+        $salesChannelContext = Generator::generateSalesChannelContext();
+
+        $response = $route->getCookieHash($request, $salesChannelContext);
+
+        static::assertIsString($response->getCookieHash());
+    }
+
+    public function testGetCookieHashCallsServiceMethods(): void
+    {
+        $cookieGroups = [
+            ['group' => 'test', 'cookie' => 'test-cookie'],
+        ];
+
+        $cookieProvider = $this->createMock(CookieProviderInterface::class);
+        $cookieProvider->method('getCookieGroups')->willReturn($cookieGroups);
+
+        $collection = new CookieGroupCollection();
+
+        $cookieService = $this->createMock(CookieService::class);
+        $cookieService->expects($this->once())
+            ->method('getCookieGroupCollection')
+            ->with($cookieGroups, static::anything(), true)
+            ->willReturn($collection);
+        $cookieService->expects($this->once())
+            ->method('calculateCookieHash')
+            ->with($collection)
+            ->willReturn('f1d2d2f924e986ac86fdf7b36c94bcdf32beec15');
+
+        $route = new CookieHashRoute($cookieProvider, $cookieService);
+
+        $request = new Request();
+        $salesChannelContext = Generator::generateSalesChannelContext();
+
+        $response = $route->getCookieHash($request, $salesChannelContext);
+
+        // Response is properly typed, no need to assert instance type
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    #[DataProvider('translateParameterProvider')]
+    public function testTranslateParameterHandling(array $queryParams, bool $expectedTranslate): void
+    {
+        $cookieGroups = [
+            ['group' => 'test', 'cookie' => 'test-cookie'],
+        ];
+
+        $cookieProvider = $this->createMock(CookieProviderInterface::class);
+        $cookieProvider->method('getCookieGroups')->willReturn($cookieGroups);
+
+        $collection = new CookieGroupCollection();
+
+        $cookieService = $this->createMock(CookieService::class);
+        $cookieService->expects($this->once())
+            ->method('getCookieGroupCollection')
+            ->with($cookieGroups, static::anything(), $expectedTranslate)
+            ->willReturn($collection);
+        $cookieService->method('calculateCookieHash')->willReturn('hash');
+
+        $route = new CookieHashRoute($cookieProvider, $cookieService);
+
+        $request = new Request($queryParams);
+        $salesChannelContext = Generator::generateSalesChannelContext();
+
+        $route->getCookieHash($request, $salesChannelContext);
+    }
+
+    /**
+     * @return array<string, array{array<string, string>, bool}>
+     */
+    public static function translateParameterProvider(): array
+    {
+        return [
+            'translate=true' => [['translate' => '1'], true],
+            'translate=false' => [['translate' => '0'], false],
+            'no translate param (defaults to true)' => [[], true],
+        ];
+    }
+}

--- a/tests/unit/Core/Content/Cookie/Service/CookieServiceTest.php
+++ b/tests/unit/Core/Content/Cookie/Service/CookieServiceTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cookie\Service\CookieService;
 use Shopware\Core\Content\Cookie\Struct\CookieEntry;
 use Shopware\Core\Content\Cookie\Struct\CookieGroup;
+use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics\SalesChannelAnalyticsCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
@@ -77,7 +79,6 @@ class CookieServiceTest extends TestCase
             ]),
         ];
 
-        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $translator = $this->createMock(TranslatorInterface::class);
@@ -131,7 +132,6 @@ class CookieServiceTest extends TestCase
             $cookieGroup,
         ];
 
-        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $translator = $this->createMock(TranslatorInterface::class);
@@ -180,11 +180,11 @@ class CookieServiceTest extends TestCase
             ]),
         ];
 
-        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $translator = $this->createMock(TranslatorInterface::class);
 
+        // @phpstan-ignore-next-line
         $cookieService = new CookieService($systemConfigService, $repository, $translator);
         $result = $cookieService->getCookieGroupCollection($cookieGroups, $salesChannelContext, false);
 
@@ -227,7 +227,6 @@ class CookieServiceTest extends TestCase
             ]),
         ];
 
-        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $translator = $this->createMock(TranslatorInterface::class);
@@ -254,5 +253,141 @@ class CookieServiceTest extends TestCase
 
         static::assertArrayHasKey('snippetName', $entryJson);
         static::assertArrayHasKey('hidden', $entryJson);
+    }
+
+    public function testCalculateCookieHashWithEmptyCollection(): void
+    {
+        $repository = $this->createMock(EntityRepository::class);
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $cookieService = new CookieService($systemConfigService, $repository, $translator);
+        $collection = new CookieGroupCollection();
+
+        $hash = $cookieService->calculateCookieHash($collection);
+
+        static::assertIsString($hash);
+        static::assertSame(40, \strlen($hash)); // SHA-1 produces 40 character hex string
+        static::assertMatchesRegularExpression('/^[a-f0-9]{40}$/', $hash);
+    }
+
+    public function testCalculateCookieHashConsistency(): void
+    {
+        $repository = $this->createMock(EntityRepository::class);
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $cookieService = new CookieService($systemConfigService, $repository, $translator);
+
+        // Create two identical collections
+        $collection1 = $this->createTestCollection();
+        $collection2 = $this->createTestCollection();
+
+        $hash1 = $cookieService->calculateCookieHash($collection1);
+        $hash2 = $cookieService->calculateCookieHash($collection2);
+
+        // Same data should produce same hash
+        static::assertSame($hash1, $hash2);
+    }
+
+    public function testCalculateCookieHashChangesWithDifferentData(): void
+    {
+        $repository = $this->createMock(EntityRepository::class);
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $cookieService = new CookieService($systemConfigService, $repository, $translator);
+
+        $collection1 = $this->createTestCollection();
+
+        // Create a different collection
+        $collection2 = new CookieGroupCollection();
+        $entry = new CookieEntry(hidden: false);
+        $entry->cookie = 'different-cookie';
+        $group = new CookieGroup(isRequired: false, entries: [$entry]);
+        $group->snippetName = 'different.group';
+        $collection2->add($group);
+
+        $hash1 = $cookieService->calculateCookieHash($collection1);
+        $hash2 = $cookieService->calculateCookieHash($collection2);
+
+        // Different data should produce different hashes
+        static::assertNotSame($hash1, $hash2);
+    }
+
+    public function testCalculateCookieHashHandlesNullValues(): void
+    {
+        $repository = $this->createMock(EntityRepository::class);
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $cookieService = new CookieService($systemConfigService, $repository, $translator);
+
+        $collection = new CookieGroupCollection();
+        $entry = new CookieEntry(hidden: true);
+        // Leave all optional fields as null
+        $group = new CookieGroup(isRequired: true, entries: [$entry]);
+        $collection->add($group);
+
+        $hash = $cookieService->calculateCookieHash($collection);
+
+        static::assertIsString($hash);
+        static::assertSame(40, \strlen($hash));
+        static::assertMatchesRegularExpression('/^[a-f0-9]{40}$/', $hash);
+    }
+
+    public function testCalculateCookieHashOrderIndependent(): void
+    {
+        $repository = $this->createMock(EntityRepository::class);
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $cookieService = new CookieService($systemConfigService, $repository, $translator);
+
+        // Create collections with same groups but in different order
+        $collection1 = new CookieGroupCollection();
+        $collection2 = new CookieGroupCollection();
+
+        $group1 = new CookieGroup(isRequired: true, entries: []);
+        $group1->snippetName = 'group1';
+
+        $group2 = new CookieGroup(isRequired: false, entries: []);
+        $group2->snippetName = 'group2';
+
+        // Add in different order
+        $collection1->add($group1);
+        $collection1->add($group2);
+
+        $collection2->add($group2);
+        $collection2->add($group1);
+
+        $hash1 = $cookieService->calculateCookieHash($collection1);
+        $hash2 = $cookieService->calculateCookieHash($collection2);
+
+        // Order should not matter due to sorting in the algorithm
+        static::assertSame($hash1, $hash2);
+    }
+
+    private function createTestCollection(): CookieGroupCollection
+    {
+        $collection = new CookieGroupCollection();
+
+        $entry = new CookieEntry(hidden: false);
+        $entry->cookie = 'test-cookie';
+        $entry->snippetName = 'test.cookie';
+        $entry->snippetDescription = 'Test Cookie Description';
+        $entry->value = '1';
+        $entry->expiration = '30';
+
+        $group = new CookieGroup(isRequired: true, entries: [$entry]);
+        $group->snippetName = 'test.group';
+        $group->snippetDescription = 'Test Group Description';
+        $group->cookie = 'test-group-cookie';
+        $group->value = 'group-value';
+        $group->expiration = '60';
+
+        $collection->add($group);
+
+        return $collection;
     }
 }

--- a/tests/unit/Core/Content/Cookie/Service/CookieServiceTest.php
+++ b/tests/unit/Core/Content/Cookie/Service/CookieServiceTest.php
@@ -79,6 +79,7 @@ class CookieServiceTest extends TestCase
             ]),
         ];
 
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $translator = $this->createMock(TranslatorInterface::class);
@@ -132,6 +133,7 @@ class CookieServiceTest extends TestCase
             $cookieGroup,
         ];
 
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $translator = $this->createMock(TranslatorInterface::class);
@@ -180,11 +182,11 @@ class CookieServiceTest extends TestCase
             ]),
         ];
 
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $translator = $this->createMock(TranslatorInterface::class);
 
-        // @phpstan-ignore-next-line
         $cookieService = new CookieService($systemConfigService, $repository, $translator);
         $result = $cookieService->getCookieGroupCollection($cookieGroups, $salesChannelContext, false);
 
@@ -227,6 +229,7 @@ class CookieServiceTest extends TestCase
             ]),
         ];
 
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $translator = $this->createMock(TranslatorInterface::class);

--- a/tests/unit/Core/Content/Cookie/Struct/CookieGroupCollectionTest.php
+++ b/tests/unit/Core/Content/Cookie/Struct/CookieGroupCollectionTest.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cookie\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cookie\Struct\CookieGroup;
+use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CookieGroupCollection::class)]
+class CookieGroupCollectionTest extends TestCase
+{
+    public function testGetApiAlias(): void
+    {
+        $collection = new CookieGroupCollection();
+        static::assertSame('cookie_group_collection', $collection->getApiAlias());
+    }
+
+    public function testCanAddCookieGroup(): void
+    {
+        $collection = new CookieGroupCollection();
+        $group = new CookieGroup(isRequired: true);
+
+        // This should not throw an exception, confirming the expected class is correct
+        $collection->add($group);
+        static::assertCount(1, $collection);
+    }
+
+    public function testCollectionFunctionality(): void
+    {
+        $collection = new CookieGroupCollection();
+
+        $group1 = new CookieGroup(isRequired: true);
+        $group1->snippetName = 'group1';
+
+        $group2 = new CookieGroup(isRequired: false);
+        $group2->snippetName = 'group2';
+
+        // Test add
+        $collection->add($group1);
+        static::assertCount(1, $collection);
+
+        // Test set
+        $collection->set('key', $group2);
+        static::assertCount(2, $collection);
+
+        // Test get
+        static::assertSame($group2, $collection->get('key'));
+
+        // Test has
+        static::assertTrue($collection->has('key'));
+        static::assertFalse($collection->has('nonexistent'));
+
+        // Test remove
+        $collection->remove('key');
+        static::assertCount(1, $collection);
+        static::assertFalse($collection->has('key'));
+
+        // Test clear
+        $collection->clear();
+        static::assertCount(0, $collection);
+    }
+
+    public function testGetElements(): void
+    {
+        $collection = new CookieGroupCollection();
+
+        $group1 = new CookieGroup(isRequired: true);
+        $group2 = new CookieGroup(isRequired: false);
+
+        $collection->add($group1);
+        $collection->add($group2);
+
+        $elements = $collection->getElements();
+        static::assertCount(2, $elements);
+        static::assertSame($group1, $elements[0]);
+        static::assertSame($group2, $elements[1]);
+    }
+
+    public function testFirst(): void
+    {
+        $collection = new CookieGroupCollection();
+
+        // Empty collection
+        static::assertNull($collection->first());
+
+        $group1 = new CookieGroup(isRequired: true);
+        $group2 = new CookieGroup(isRequired: false);
+
+        $collection->add($group1);
+        $collection->add($group2);
+
+        static::assertSame($group1, $collection->first());
+    }
+
+    public function testLast(): void
+    {
+        $collection = new CookieGroupCollection();
+
+        // Empty collection
+        static::assertNull($collection->last());
+
+        $group1 = new CookieGroup(isRequired: true);
+        $group2 = new CookieGroup(isRequired: false);
+
+        $collection->add($group1);
+        $collection->add($group2);
+
+        static::assertSame($group2, $collection->last());
+    }
+}

--- a/tests/unit/Core/Content/Cookie/Struct/CookieHashTest.php
+++ b/tests/unit/Core/Content/Cookie/Struct/CookieHashTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cookie\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cookie\Struct\CookieHash;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CookieHash::class)]
+class CookieHashTest extends TestCase
+{
+    public function testConstructorAndGetter(): void
+    {
+        $hash = 'abc123def456';
+        $struct = new CookieHash($hash);
+
+        static::assertSame($hash, $struct->cookieHash);
+    }
+
+    public function testGetApiAlias(): void
+    {
+        $struct = new CookieHash('test-hash');
+        static::assertSame('cookie_hash', $struct->getApiAlias());
+    }
+
+    public function testSha1Hash(): void
+    {
+        $hash = 'd1311937c9f21d5724151afe1ab26876bbe6e6b2'; // SHA-1 hash
+        $struct = new CookieHash($hash);
+
+        static::assertSame($hash, $struct->cookieHash);
+        static::assertSame(40, \strlen($struct->cookieHash)); // SHA-1 produces 40 character hex string
+        static::assertMatchesRegularExpression('/^[a-f0-9]{40}$/', $struct->cookieHash);
+    }
+
+    public function testEmptyHash(): void
+    {
+        $hash = '';
+        $struct = new CookieHash($hash);
+
+        static::assertSame($hash, $struct->cookieHash);
+    }
+
+    public function testJsonSerialization(): void
+    {
+        $hash = 'abc123def456789';
+        $struct = new CookieHash($hash);
+
+        $serialized = $struct->jsonSerialize();
+
+        static::assertIsArray($serialized);
+        static::assertArrayHasKey('cookieHash', $serialized);
+        static::assertSame($hash, $serialized['cookieHash']);
+
+        // API alias is not included in jsonSerialize, but available via getApiAlias()
+        static::assertSame('cookie_hash', $struct->getApiAlias());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Adds an endpoint that gives you the current hash of all present cookie configurations.
The idea is to save this as a cookie and compare it with the result from the endpoint.
If the hash from the cookie and the hash from the endpoint are different, the cookie process needs to be restarted.

Related: #9451

### 2. What does this change do, exactly?
It introduced the new store API endpoint.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
