### PR TITLE
fix: Attribute entities work with autoconfigure attribute

### DIFF
--- a/changelog/_unreleased/2025-08-15-allow-autoconfigure-attribute-on-attribute-entities.md
+++ b/changelog/_unreleased/2025-08-15-allow-autoconfigure-attribute-on-attribute-entities.md
@@ -1,0 +1,6 @@
+---
+title: Allow autoconfigure attribute on attribute entities
+issue: #11915
+---
+# Core
+* Changed CompilerPass priority of `\Shopware\Core\Framework\DependencyInjection\CompilerPass\AttributeEntityCompilerPass` to 99, to only run after symfony's `\Symfony\Component\DependencyInjection\Compiler\RegisterAutoconfigureAttributesPass` tag, that way services with the `AutoconfigureTag` attribute are correctly picked up by our compiler pass.

--- a/config/services_test.xml
+++ b/config/services_test.xml
@@ -7,6 +7,8 @@
     </parameters>
 
     <services>
+        <defaults autoconfigure="true"/>
+
         <service id="Shopware\Tests\Integration\Core\Framework\Api\EventListener\FixturesPhp\SalesChannelAuthenticationListenerTestRoute">
             <tag name="controller.service_arguments"/>
         </service>
@@ -52,9 +54,7 @@
             <tag name="shopware.entity"/>
         </service>
 
-        <service id="Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntityAgg">
-            <tag name="shopware.entity"/>
-        </service>
+        <service id="Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntityAgg"/>
 
         <service id="Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntityWithHydrator">
             <tag name="shopware.entity"/>

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -100,8 +100,9 @@ class Framework extends Bundle
             $loader->load('app_test.xml');
         }
 
+        /** Needs to run after @see RegisterAutoconfigureAttributesPass (priority 100) to include all services that are autoconfigured */
+        $container->addCompilerPass(new AttributeEntityCompilerPass(new AttributeEntityCompiler()), PassConfig::TYPE_BEFORE_OPTIMIZATION, 99);
         // make sure to remove services behind a feature flag, before some other compiler passes may reference them, therefore the high priority
-        $container->addCompilerPass(new AttributeEntityCompilerPass(new AttributeEntityCompiler()), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new FeatureFlagCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new EntityCompilerPass());
         $container->addCompilerPass(new DisableTwigCacheWarmerCompilerPass());

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntityAgg.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntityAgg.php
@@ -9,11 +9,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ForeignKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ManyToOne;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity as EntityStruct;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**
  * @internal
  */
 #[Entity('attribute_entity_agg', parent: 'attribute_entity', since: '6.6.3.0')]
+// Test that autoconfigure works with attribute entities, do not add the tag in service declaration in service_test.xml
+#[AutoconfigureTag('shopware.entity')]
 class AttributeEntityAgg extends EntityStruct
 {
     #[PrimaryKey]


### PR DESCRIPTION
see issue https://github.com/shopware/shopware/issues/11915, our compiler pass did run before symfonys autoconfigure pass, thus the autoconfigured services where not yet resolved, by executing our compiler pass after symfonys the tags are correctly resolved