### PR TITLE
Adds `EntityCriteriaEvent` to `EntityRepository`

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer;
 use Shopware\Core\Framework\Adapter\Database\ReplicaConnection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityAggregationResultLoadedEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityCriteriaEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityIdSearchResultLoadedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntitySearchedEvent;
@@ -222,7 +223,10 @@ class EntityRepository
      */
     private function _search(Criteria $criteria, Context $context): EntitySearchResult
     {
-        $criteria = clone $criteria;
+        $criteriaEvent = new EntityCriteriaEvent($this->definition, $criteria, $context);
+        $this->eventDispatcher->dispatch($criteriaEvent, $criteriaEvent->getEventName());
+
+        $criteria = clone $criteriaEvent->getCriteria();
         $aggregations = null;
         if ($criteria->getAggregations()) {
             $aggregations = $this->aggregate($criteria, $context);

--- a/src/Core/Framework/DataAbstractionLayer/Event/EntityCriteriaEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/EntityCriteriaEvent.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\GenericEvent;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class EntityCriteriaEvent extends Event implements ShopwareEvent, GenericEvent
+{
+    public function __construct(
+        private readonly EntityDefinition $definition,
+        private readonly Criteria $criteria,
+        private readonly Context $context
+    ) {
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    public function getEntityName(): string
+    {
+        return $this->definition->getEntityName();
+    }
+
+    public function getEventName(): string
+    {
+        return $this->definition->getEntityName() . '.criteria';
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- Make plugin developers happy
- A lot of plugins use event like "customer.loaded", "order.loaded" or any other generic events to extend or delete some data, which can cause a big problem in perfomance. With "%entity%.criteria", shopware plugin can now delete, include or filter more easlier and better

### 2. What does this change do, exactly?
- The code dispatches certain events on for changing criteria

### 3. Describe each step to reproduce the issue or behaviour.
- Register event subscriber for "product.criteria"
- Change title to test
- Now criteria is cutomizeable to extend in shopware plugins.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
