### PR TITLE
refactor: Make navbar template extendable

### DIFF
--- a/changelog/_unreleased/2025-08-17-make-navbar-template-extendable.md
+++ b/changelog/_unreleased/2025-08-17-make-navbar-template-extendable.md
@@ -1,0 +1,9 @@
+---
+title: Make navbar template extendable
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed content of the `layout_navbar_menu_item` block of the `@Storefront/storefront/layout/navbar/navbar.html.twig` template, to unify the handling of folder and product categories
+* Added blocks `layout_navbar_menu_item_link`, `layout_navbar_menu_item_link_content` `layout_navbar_menu_item_children` to the `@Storefront/storefront/layout/navbar/navbar.html.twig` template

--- a/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
@@ -37,40 +37,25 @@
                                 {% set name = category.translated.name %}
                                 {% set hasChildren = treeItem.children|length > 0 %}
 
-                                {% block layout_navbar_menu_item %}
-                                    {% if category.type == 'folder' %}
-                                        <li class="nav-item nav-item-{{ id }}">
-                                            <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2{% if hasChildren %} dropdown-toggle{% endif %}"
-                                               href="#"
-                                               {% if hasChildren %}data-bs-toggle="dropdown"{% endif %}
-                                               data-flyout-menu-trigger="{{ id }}"
-                                               itemprop="url"
-                                               title="{{ name }}">
-                                                <span itemprop="name" class="main-navigation-link-text">{{ name }}</span>
-                                            </a>
 
-                                            {% if hasChildren %}
-                                                <div class="dropdown-menu w-100 p-4">
-                                                    {% sw_include '@Storefront/storefront/layout/navbar/content.html.twig' with {
-                                                        themeIconConfig: themeIconConfig,
-                                                        navigationTree: treeItem,
-                                                        level: level+1,
-                                                        page: page
-                                                    } only %}
-                                                </div>
-                                            {% endif %}
-                                        </li>
-                                    {% else %}
-                                        <li class="nav-item nav-item-{{ id }} {% if hasChildren %}dropdown position-static{% endif %}">
+                                {% block layout_navbar_menu_item %}
+                                    <li class="nav-item nav-item-{{ id }} {% if hasChildren %}dropdown position-static{% endif %}">
+                                        {% block layout_navbar_menu_item_link %}
                                             <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2{% if hasChildren %} dropdown-toggle{% endif %}"
-                                               href="{{ category.seoUrl }}"
+                                               href="{{ category.seoUrl ?: '#' }}"
                                                {% if hasChildren %}data-bs-toggle="dropdown"{% endif %}
-                                               {% if category.shouldOpenInNewTab %}target="_blank"{% endif %}
+                                               {% if category.type != 'folder' && category.shouldOpenInNewTab %}target="_blank"{% endif %}
                                                itemprop="url"
-                                               title="{{ name }}">
-                                                <span itemprop="name" class="main-navigation-link-text">{{ name }}</span>
+                                               title="{{ name }}"
+                                            >
+                                                {% block layout_navbar_menu_item_link_content %}
+                                                    <span itemprop="name" class="main-navigation-link-text">{{ name }}</span>
+                                                {% endblock %}
                                             </a>
-                                            {% if hasChildren %}
+                                        {% endblock %}
+
+                                        {% if hasChildren %}
+                                            {% block layout_navbar_menu_item_children %}
                                                 <div class="dropdown-menu w-100 p-4">
                                                     {% sw_include '@Storefront/storefront/layout/navbar/content.html.twig' with {
                                                         themeIconConfig: themeIconConfig,
@@ -79,9 +64,9 @@
                                                         page: page
                                                     } only %}
                                                 </div>
-                                            {% endif %}
-                                        </li>
-                                    {% endif %}
+                                            {% endblock %}
+                                        {% endif %}
+                                    </li>
                                 {% endblock %}
                             {% endfor %}
                         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
@@ -37,14 +37,13 @@
                                 {% set name = category.translated.name %}
                                 {% set hasChildren = treeItem.children|length > 0 %}
 
-
                                 {% block layout_navbar_menu_item %}
                                     <li class="nav-item nav-item-{{ id }} {% if hasChildren %}dropdown position-static{% endif %}">
                                         {% block layout_navbar_menu_item_link %}
                                             <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2{% if hasChildren %} dropdown-toggle{% endif %}"
                                                href="{{ category.seoUrl ?: '#' }}"
                                                {% if hasChildren %}data-bs-toggle="dropdown"{% endif %}
-                                               {% if category.type != 'folder' && category.shouldOpenInNewTab %}target="_blank"{% endif %}
+                                               {% if category.type != 'folder' and category.shouldOpenInNewTab %}target="_blank"{% endif %}
                                                itemprop="url"
                                                title="{{ name }}"
                                             >


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is quite hard to extend the navbar template, as there are almost no blocks. Furthermore the distinction between the folder and product categories is not needed. Also the `data-flyout-menu-trigger="{{ id }}"` has been missed to remove, when the "old navigation" has been removed.

### 2. What does this change do, exactly?
Address the issues mentioned in the previous section.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
