### PR TITLE
fix: sidebar renderer width reset on close

### DIFF
--- a/changelog/_unreleased/2025-08-18-fix-sidebar-renderer-width-update.md
+++ b/changelog/_unreleased/2025-08-18-fix-sidebar-renderer-width-update.md
@@ -1,0 +1,5 @@
+---
+title: Fix sidebar renderer width reset on close
+---
+# Administration
+* Changed `sw-sidebar-renderer` not to reset width when it is closed.

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
@@ -84,7 +84,7 @@ export default Shopware.Component.wrapComponentConfig({
         };
 
         onUpdated(() => {
-            if (!activeSidebar.value?.resizable && sidebarSetWidth.value !== MIN_SIDEBAR_WIDTH) {
+            if (activeSidebar.value && !activeSidebar.value?.resizable && sidebarSetWidth.value !== MIN_SIDEBAR_WIDTH) {
                 sidebarSetWidth.value = MIN_SIDEBAR_WIDTH;
             }
         });

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -116,7 +116,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             mockLocalStorage.getItem.mockReturnValue('600');
 
             const wrapper = await createWrapper();
-            
+
             expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('600px');
             expect(mockLocalStorage.getItem).toHaveBeenCalledWith('sw-sidebar-width');
         });
@@ -125,7 +125,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             mockLocalStorage.getItem.mockReturnValue('600');
 
             const wrapper = await createWrapper();
-            
+
             await ui.sidebar.add({
                 title: 'Test sidebar',
                 locationId: 'test-sidebar',

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -116,8 +116,31 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             mockLocalStorage.getItem.mockReturnValue('600');
 
             const wrapper = await createWrapper();
+            
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('600px');
+            expect(mockLocalStorage.getItem).toHaveBeenCalledWith('sw-sidebar-width');
+        });
+
+        it('should reset width to minimum when sidebar becomes non-resizable', async () => {
+            mockLocalStorage.getItem.mockReturnValue('600');
+
+            const wrapper = await createWrapper();
+            
+            await ui.sidebar.add({
+                title: 'Test sidebar',
+                locationId: 'test-sidebar',
+                resizable: true,
+            });
+            Shopware.Store.get('sidebar').sidebars[0].active = true;
+            await wrapper.vm.$nextTick();
 
             expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('600px');
+
+            Shopware.Store.get('sidebar').sidebars[0].resizable = false;
+            await wrapper.vm.$forceUpdate();
+            await wrapper.vm.$nextTick();
+
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('480px');
             expect(mockLocalStorage.getItem).toHaveBeenCalledWith('sw-sidebar-width');
         });
 
@@ -253,29 +276,6 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
 
             // Restore original method
             window.addEventListener = originalAddEventListener;
-        });
-
-        it('should reset width to minimum when sidebar becomes non-resizable', async () => {
-            const wrapper = await createWrapper();
-
-            await ui.sidebar.add({
-                title: 'Test sidebar',
-                locationId: 'test-sidebar',
-                resizable: true,
-            });
-            Shopware.Store.get('sidebar').sidebars[0].active = true;
-            await wrapper.vm.$nextTick();
-
-            await dragSidebarToWidth(wrapper, 1000);
-
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('920px'); // 1920 - 1000
-
-            Shopware.Store.get('sidebar').sidebars[0].resizable = false;
-
-            await wrapper.vm.$forceUpdate();
-            await wrapper.vm.$nextTick();
-
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('480px');
         });
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Sidebar renderer resets the saved width each time it is closed by the user.

### 2. What does this change do, exactly?
Prevents the reset if there is no active sidebar.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
