### PR TITLE
feat: Email template validation POC

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
@@ -95,6 +95,31 @@ class MailApiService extends ApiService {
         );
     }
 
+    validateMailTemplate(
+        subject,
+        senderName,
+        contentHtml,
+        contentPlain,
+        mailTemplateType
+    ) {
+        const apiRoute = `/_action/${this.getApiBasePath()}/validate`;
+
+        return this.httpClient
+            .post(
+                apiRoute,
+                {
+                    subject: subject,
+                    senderName: senderName,
+                    contentHtml: contentHtml,
+                    contentPlain: contentPlain,
+                    mailTemplateType: mailTemplateType,
+                },
+                { headers: this.getBasicHeaders() },
+            ).then((response) => {
+                return ApiService.handleResponse(response);
+            });
+    }
+
     buildRenderPreview(mailTemplateType, mailTemplate) {
         const apiRoute = `/_action/${this.getApiBasePath()}/build`;
 

--- a/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
@@ -96,11 +96,8 @@ class MailApiService extends ApiService {
     }
 
     validateMailTemplate(
-        subject,
-        senderName,
-        contentHtml,
-        contentPlain,
-        mailTemplateType
+        flowEventClass,
+        mailTemplateContent,
     ) {
         const apiRoute = `/_action/${this.getApiBasePath()}/validate`;
 
@@ -108,11 +105,8 @@ class MailApiService extends ApiService {
             .post(
                 apiRoute,
                 {
-                    subject: subject,
-                    senderName: senderName,
-                    contentHtml: contentHtml,
-                    contentPlain: contentPlain,
-                    mailTemplateType: mailTemplateType,
+                    flowEventClass: flowEventClass,
+                    mailTemplateContent: mailTemplateContent,
                 },
                 { headers: this.getBasicHeaders() },
             ).then((response) => {

--- a/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
@@ -95,10 +95,7 @@ class MailApiService extends ApiService {
         );
     }
 
-    validateMailTemplate(
-        flowEventClass,
-        mailTemplateContent,
-    ) {
+    validateMailTemplate(flowEventClass, mailTemplateContent) {
         const apiRoute = `/_action/${this.getApiBasePath()}/validate`;
 
         return this.httpClient
@@ -109,7 +106,8 @@ class MailApiService extends ApiService {
                     mailTemplateContent: mailTemplateContent,
                 },
                 { headers: this.getBasicHeaders() },
-            ).then((response) => {
+            )
+            .then((response) => {
                 return ApiService.handleResponse(response);
             });
     }

--- a/src/Administration/Resources/app/administration/src/core/service/entity-mapping.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/entity-mapping.service.ts
@@ -78,6 +78,7 @@ function getEntityMapping(entityName?: string, entityNameMapping?: EntityNameMap
         // Handle entity mapping
         if (property?.entity) {
             const entityDef = Shopware.EntityDefinition.getDefinitionRegistry().get(property.entity) as EntitySchema;
+            console.log(entityDef);
             schema = entityDef;
             lastEntityName = dubbedVal;
 

--- a/src/Administration/Resources/app/administration/src/core/service/entity-mapping.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/entity-mapping.service.ts
@@ -78,7 +78,6 @@ function getEntityMapping(entityName?: string, entityNameMapping?: EntityNameMap
         // Handle entity mapping
         if (property?.entity) {
             const entityDef = Shopware.EntityDefinition.getDefinitionRegistry().get(property.entity) as EntitySchema;
-            console.log(entityDef);
             schema = entityDef;
             lastEntityName = dubbedVal;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-header-footer-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-header-footer-list/index.js
@@ -200,7 +200,7 @@ export default {
 
         showDeleteErrorNotification(item) {
             return this.createNotificationError({
-                message: this.$tc('sw-mail-header-footer.list.messageDeleteError', { name: item.name }, 0),
+                message: this.$t('sw-mail-header-footer.list.messageDeleteError', { name: item.name }, 0),
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-header-footer-list/sw-mail-header-footer-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-header-footer-list/sw-mail-header-footer-list.html.twig
@@ -1,20 +1,20 @@
 {% block sw_mail_header_footer_list_grid %}
 <mt-card
-    :title="$tc('sw-mail-header-footer.list.textMailHeaderFooterOverview')"
+    :title="$t('sw-mail-header-footer.list.textMailHeaderFooterOverview')"
     position-identifier="sw-mail-header-footer-list"
 >
     {% block sw_mail_header_footer_list_grid_empty_state %}
     <sw-empty-state
         v-if="!isLoading && !showListing"
-        :title="$tc('sw-mail-header-footer.list.emptyStateTitle')"
-        :subline="$tc('sw-mail-header-footer.list.emptyStateSubTitle')"
+        :title="$t('sw-mail-header-footer.list.emptyStateTitle')"
+        :subline="$t('sw-mail-header-footer.list.emptyStateSubTitle')"
         :absolute="false"
     >
         {% block sw_mail_header_footer_list_grid_empty_state_icon %}
         <template #icon>
             <img
                 :src="assetFilter('/administration/administration/static/img/empty-states/settings-empty-state.svg')"
-                :alt="$tc('sw-mail-header-footer.list.emptyStateTitle')"
+                :alt="$t('sw-mail-header-footer.list.emptyStateTitle')"
             >
         </template>
         {% endblock %}
@@ -55,7 +55,7 @@
                     size="small"
                     @click="onMultipleDelete"
                 >
-                    {{ $tc('global.default.delete') }}
+                    {{ $t('global.default.delete') }}
                 </mt-button>
             </template>
 
@@ -65,7 +65,7 @@
                     size="small"
                     @click="onDelete(item)"
                 >
-                    {{ $tc('global.default.delete') }}
+                    {{ $t('global.default.delete') }}
                 </mt-button>
             </template>
 
@@ -76,7 +76,7 @@
                     :disabled="!acl.can('mail_templates.creator') || undefined"
                     @click="onDuplicate(item.id)"
                 >
-                    {{ $tc('sw-mail-header-footer.list.contextMenuDuplicate') }}
+                    {{ $t('sw-mail-header-footer.list.contextMenuDuplicate') }}
                 </sw-context-menu-item>
                 {% endblock %}
             </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/sw-mail-template-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/sw-mail-template-list.html.twig
@@ -1,13 +1,13 @@
 {% block sw_mail_template_list_grid %}
 <mt-card
-    :title="$tc('sw-mail-template.list.titleMailTemplateList')"
+    :title="$t('sw-mail-template.list.titleMailTemplateList')"
     position-identifier="sw-mail-template-list"
 >
     {% block sw_mail_template_list_grid_empty_state %}
     <sw-empty-state
         v-if="!isLoading && !showListing"
-        :title="$tc('sw-mail-template.list.emptyStateTitle')"
-        :subline="$tc('sw-mail-template.list.emptyStateSubTitle')"
+        :title="$t('sw-mail-template.list.emptyStateTitle')"
+        :subline="$t('sw-mail-template.list.emptyStateSubTitle')"
         :absolute="false"
     >
         {% block sw_mail_template_list_grid_empty_state_icon %}
@@ -52,7 +52,7 @@
                     :disabled="!acl.can('mail_templates.creator') || undefined"
                     @click="onDuplicate(item.id)"
                 >
-                    {{ $tc('sw-mail-template.list.contextMenuDuplicate') }}
+                    {{ $t('sw-mail-template.list.contextMenuDuplicate') }}
                 </sw-context-menu-item>
                 {% endblock %}
             </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/sw-mail-template-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/sw-mail-template-list.scss
@@ -1,5 +1,5 @@
 .sw-mail-template-list {
     .sw-empty-state {
-        padding: 40px 0;
+        padding: var(--scale-size-40) 0;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-validation-result/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-validation-result/index.ts
@@ -1,0 +1,52 @@
+import template from './sw-mail-template-validation-result.html.twig';
+import './sw-mail-template-validation-result.scss';
+
+/**
+ * @sw-package after-sales
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export default {
+    template,
+
+    props: {
+        title: {
+            type: String,
+            required: false,
+            default: '',
+        },
+        hint: {
+            type: String,
+            required: false,
+            default: '',
+        },
+        type: {
+            type: String,
+            required: false,
+            default: '',
+        },
+    },
+
+    computed: {
+        icon() {
+            switch (this.type) {
+                case 'error':
+                    return 'solid-exclamation-circle';
+                case 'warning':
+                    return 'solid-exclamation-triangle';
+                default:
+                    return 'solid-exclamation-circle';
+            }
+        },
+
+        iconColor() {
+            switch (this.type) {
+                case 'error':
+                    return 'var(--color-icon-critical-default)';
+                case 'warning':
+                    return 'var(--color-icon-attention-default)';
+                default:
+                    return 'var(--color-icon-critical-default)';
+            }
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-validation-result/sw-mail-template-validation-result.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-validation-result/sw-mail-template-validation-result.html.twig
@@ -1,0 +1,20 @@
+<mt-banner
+    class="sw-mail-template-validation-result"
+    :title="title"
+>
+    <template #customIcon>
+        <mt-icon
+            class="sw-mail-template-validation-result__icon"
+            size="16"
+            :name="icon"
+            :color="iconColor"
+        />
+    </template>
+
+    <p class="sw-mail-template-validation-result__hint">
+        {{ hint }}
+    </p>
+    <p class="sw-mail-template-validation-result__content">
+        <slot></slot>
+    </p>
+</mt-banner>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-validation-result/sw-mail-template-validation-result.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-validation-result/sw-mail-template-validation-result.scss
@@ -1,0 +1,20 @@
+.sw-mail-template-validation-result {
+    position: relative;
+    width: 100%;
+
+    &__icon {
+        margin-top: var(--scale-size-2);
+    }
+
+    &__hint {
+        position: absolute;
+        top: var(--scale-size-8);
+        right: var(--scale-size-8);
+        color: var(--color-text-secondary-default);
+        font-size: var(--font-size-2xs);
+    }
+
+    .mt-banner__body {
+        overflow-x: auto;
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-validation-result/sw-mail-template-validation-result.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-validation-result/sw-mail-template-validation-result.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @sw-package after-sales
+ */
+import { mount } from '@vue/test-utils';
+
+async function createWrapper(props: object = {}) {
+    return mount(await wrapTestComponent('sw-mail-template-validation-result', { sync: true }), {
+        props: {
+            ...props,
+        },
+    });
+}
+
+describe('modules/sw-mail-template/component/sw-mail-template-validation-result', () => {
+    it('should show red warning icon when no type given', async () => {
+        const wrapper = await createWrapper();
+
+        const icon = wrapper.findComponent('.sw-mail-template-validation-result__icon');
+
+        expect(icon.props('name')).toBe('solid-exclamation-circle');
+        expect(icon.props('color')).toBe('var(--color-icon-critical-default)');
+    });
+
+    it('should show red warning icon when type error given', async () => {
+        const wrapper = await createWrapper({ type: 'error' });
+
+        const icon = wrapper.findComponent('.sw-mail-template-validation-result__icon');
+
+        expect(icon.props('name')).toBe('solid-exclamation-circle');
+        expect(icon.props('color')).toBe('var(--color-icon-critical-default)');
+    });
+
+    it('should show red warning icon when type warning given', async () => {
+        const wrapper = await createWrapper({ type: 'warning' });
+
+        const icon = wrapper.findComponent('.sw-mail-template-validation-result__icon');
+
+        expect(icon.props('name')).toBe('solid-exclamation-triangle');
+        expect(icon.props('color')).toBe('var(--color-icon-attention-default)');
+    });
+
+    it('should show given title', async () => {
+        const wrapper = await createWrapper({ title: 'foo' });
+
+        const title = wrapper.find('.mt-banner__title');
+
+        expect(title.text()).toBe('foo');
+    });
+
+    it('should show given hint', async () => {
+        const wrapper = await createWrapper({ hint: 'bar' });
+
+        const hint = wrapper.find('.sw-mail-template-validation-result__hint');
+
+        expect(hint.text()).toBe('bar');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/index.js
@@ -5,6 +5,10 @@ const { Module, Feature } = Shopware;
 /* eslint-disable max-len, sw-deprecation-rules/private-feature-declarations */
 Shopware.Component.register('sw-mail-template-list', () => import('./component/sw-mail-template-list'));
 Shopware.Component.register('sw-mail-header-footer-list', () => import('./component/sw-mail-header-footer-list'));
+Shopware.Component.register(
+    'sw-mail-template-validation-result',
+    () => import('./component/sw-mail-template-validation-result'),
+);
 Shopware.Component.register('sw-mail-template-detail', () => import('./page/sw-mail-template-detail'));
 Shopware.Component.extend(
     'sw-mail-template-create',

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/index.js
@@ -111,7 +111,7 @@ export default {
         tooltipSave() {
             if (!this.allowSave) {
                 return {
-                    message: this.$tc('sw-privileges.tooltip.warning'),
+                    message: this.$t('sw-privileges.tooltip.warning'),
                     disabled: this.allowSave,
                     showOnDisabledElements: true,
                 };
@@ -211,7 +211,7 @@ export default {
                 this.isSaveSuccessful = true;
             } catch (error) {
                 const notificationError = {
-                    message: this.$tc('global.notification.notificationSaveErrorMessageRequiredFieldsInvalid'),
+                    message: this.$t('global.notification.notificationSaveErrorMessageRequiredFieldsInvalid'),
                 };
 
                 this.createNotificationError(notificationError);

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/sw-mail-header-footer-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/sw-mail-header-footer-detail.html.twig
@@ -2,7 +2,7 @@
 <sw-page class="sw-mail-header-footer-detail">
     {% block sw_mail_header_footer_detail_header %}
     <template #smart-bar-header>
-        <h2>{{ placeholder(mailHeaderFooter, 'name', $tc('sw-mail-header-footer.detail.textHeadline')) }}</h2>
+        <h2>{{ placeholder(mailHeaderFooter, 'name', $t('sw-mail-header-footer.detail.textHeadline')) }}</h2>
     </template>
     {% endblock %}
 
@@ -19,7 +19,7 @@
             size="default"
             @click="onCancel"
         >
-            {{ $tc('global.default.cancel') }}
+            {{ $t('global.default.cancel') }}
         </mt-button>
         {% endblock %}
 
@@ -34,7 +34,7 @@
             @update:process-success="saveFinish"
             @click.prevent="onSave"
         >
-            {{ $tc('sw-mail-header-footer.detail.buttonSave') }}
+            {{ $t('sw-mail-header-footer.detail.buttonSave') }}
         </sw-button-process>
         {% endblock %}
     </template>
@@ -60,13 +60,13 @@
             <template v-else-if="mailHeaderFooter">
                 {% block sw_mail_header_footer_detail_content_language_info %}
                 <sw-language-info
-                    :entity-description="placeholder(mailHeaderFooter, 'name', $tc('sw-mail-header-footer.detail.textHeadline'))"
+                    :entity-description="placeholder(mailHeaderFooter, 'name', $t('sw-mail-header-footer.detail.textHeadline'))"
                 />
                 {% endblock %}
 
                 {% block sw_mail_header_footer_detail_basic_info %}
                 <mt-card
-                    :title="$tc('sw-mail-header-footer.detail.basic.titleCard')"
+                    :title="$t('sw-mail-header-footer.detail.basic.titleCard')"
                     position-identifier="sw-mail-header-footer-detail-basic-info"
                 >
                     {% block sw_mail_header_footer_basic_form_name_field %}
@@ -75,8 +75,8 @@
                         name="sw-field--mailHeaderFooter-name"
                         validation="required"
                         required
-                        :label="$tc('sw-mail-header-footer.detail.basic.labelName')"
-                        :placeholder="placeholder(mailHeaderFooter, 'name', $tc('sw-mail-header-footer.detail.basic.placeholderName'))"
+                        :label="$t('sw-mail-header-footer.detail.basic.labelName')"
+                        :placeholder="placeholder(mailHeaderFooter, 'name', $t('sw-mail-header-footer.detail.basic.placeholderName'))"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
                         :error="mailHeaderFooterNameError"
                     />
@@ -86,8 +86,8 @@
                     <mt-textarea
                         v-model="mailHeaderFooter.description"
                         name="sw-field--mailHeaderFooter-description"
-                        :label="$tc('sw-mail-header-footer.detail.basic.labelDescription')"
-                        :placeholder="placeholder(mailHeaderFooter, 'description', $tc('sw-mail-header-footer.detail.basic.placeholderDescription'))"
+                        :label="$t('sw-mail-header-footer.detail.basic.labelDescription')"
+                        :placeholder="placeholder(mailHeaderFooter, 'description', $t('sw-mail-header-footer.detail.basic.placeholderDescription'))"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
                     />
                     {% endblock %}
@@ -97,8 +97,8 @@
                         id="salesChannels"
                         v-model:entity-collection="mailHeaderFooter.salesChannels"
                         class="sw-mail-header-footer-detail__sales-channel"
-                        :label="$tc('sw-mail-header-footer.detail.basic.labelSalesChannels')"
-                        :placeholder="$tc('sw-mail-header-footer.detail.basic.placeholderSalesChannels')"
+                        :label="$t('sw-mail-header-footer.detail.basic.labelSalesChannels')"
+                        :placeholder="$t('sw-mail-header-footer.detail.basic.placeholderSalesChannels')"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
                         required
                     />
@@ -108,7 +108,7 @@
 
                 {% block sw_mail_header_footer_detail_content_header %}
                 <mt-card
-                    :title="$tc('sw-mail-header-footer.detail.header.titleCard')"
+                    :title="$t('sw-mail-header-footer.detail.header.titleCard')"
                     position-identifier="sw-mail-header-footer-detail-content-header"
                 >
                     {% block sw_mail_header_footer_detail_content_header_plain_field %}
@@ -118,8 +118,8 @@
                         identifier="header_plain"
                         name="header_plain"
                         completion-mode="entity"
-                        :label="$tc('sw-mail-header-footer.detail.header.labelPlain')"
-                        :placeholder="placeholder(mailHeaderFooter, 'headerPlain', $tc('sw-mail-header-footer.detail.header.placeholderPlain'))"
+                        :label="$t('sw-mail-header-footer.detail.header.labelPlain')"
+                        :placeholder="placeholder(mailHeaderFooter, 'headerPlain', $t('sw-mail-header-footer.detail.header.placeholderPlain'))"
                         :completer-function="completerFunction"
                         :editor-config="editorConfig"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
@@ -133,8 +133,8 @@
                         identifier="header_html"
                         name="header_html"
                         completion-mode="entity"
-                        :label="$tc('sw-mail-header-footer.detail.header.labelHtml')"
-                        :placeholder="placeholder(mailHeaderFooter, 'headerHtml', $tc('sw-mail-header-footer.detail.header.placeholderHtml'))"
+                        :label="$t('sw-mail-header-footer.detail.header.labelHtml')"
+                        :placeholder="placeholder(mailHeaderFooter, 'headerHtml', $t('sw-mail-header-footer.detail.header.placeholderHtml'))"
                         :completer-function="completerFunction"
                         :editor-config="editorConfig"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
@@ -145,7 +145,7 @@
 
                 {% block sw_mail_header_footer_detail_content_footer %}
                 <mt-card
-                    :title="$tc('sw-mail-header-footer.detail.footer.titleCard')"
+                    :title="$t('sw-mail-header-footer.detail.footer.titleCard')"
                     position-identifier="sw-mail-header-footer-detail-content-footer"
                 >
                     {% block sw_mail_header_footer_detail_content_footer_plain_field %}
@@ -155,8 +155,8 @@
                         identifier="footer_plain"
                         name="footer_plain"
                         completion-mode="entity"
-                        :label="$tc('sw-mail-header-footer.detail.footer.labelPlain')"
-                        :placeholder="placeholder(mailHeaderFooter, 'footerPlain', $tc('sw-mail-header-footer.detail.footer.placeholderPlain'))"
+                        :label="$t('sw-mail-header-footer.detail.footer.labelPlain')"
+                        :placeholder="placeholder(mailHeaderFooter, 'footerPlain', $t('sw-mail-header-footer.detail.footer.placeholderPlain'))"
                         :completer-function="completerFunction"
                         :editor-config="editorConfig"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
@@ -170,8 +170,8 @@
                         identifier="footer_html"
                         name="footer_html"
                         completion-mode="entity"
-                        :label="$tc('sw-mail-header-footer.detail.footer.labelHtml')"
-                        :placeholder="placeholder(mailHeaderFooter, 'footerHtml', $tc('sw-mail-header-footer.detail.footer.placeholderHtml'))"
+                        :label="$t('sw-mail-header-footer.detail.footer.labelHtml')"
+                        :placeholder="placeholder(mailHeaderFooter, 'footerHtml', $t('sw-mail-header-footer.detail.footer.placeholderHtml'))"
                         :completer-function="completerFunction"
                         :editor-config="editorConfig"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
@@ -184,10 +184,10 @@
 
         <sw-modal
             v-if="showModal"
-            :title="$tc('sw-mail-header-footer.modal.title')"
+            :title="$t('sw-mail-header-footer.modal.title')"
             @modal-close="onClose"
         >
-            <p>{{ $tc('sw-mail-header-footer.modal.mainContent') }}</p>
+            <p>{{ $t('sw-mail-header-footer.modal.mainContent') }}</p>
 
             <div class="sw-mail-header-footer-detail__sales-channel-list">
                 <p class="sw-mail-header-footer-detail__sales-channel-list-label">
@@ -208,7 +208,7 @@
                     variant="secondary"
                     @click="onClose"
                 >
-                    {{ $tc('global.default.cancel') }}
+                    {{ $t('global.default.cancel') }}
                 </mt-button>
 
                 <mt-button
@@ -216,7 +216,7 @@
                     variant="critical"
                     @click="confirmSave"
                 >
-                    {{ $tc('sw-mail-header-footer.modal.confirmButton') }}
+                    {{ $t('sw-mail-header-footer.modal.confirmButton') }}
                 </mt-button>
             </template>
         </sw-modal>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-create/index.js
@@ -30,6 +30,7 @@ export default {
             }
 
             this.mailTemplateId = this.mailTemplate.id;
+            this.loadTriggerEvents();
         },
 
         saveFinish() {

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -446,33 +446,24 @@ export default {
                 .validateMailTemplate(this.triggerEvent.class, {
                     subject: this.mailTemplate.subject,
                     senderName: this.mailTemplate.senderName,
-                    contentHtml: this.mailTemplate.contentHtml,
                     contentPlain: this.mailTemplate.contentPlain,
+                    contentHtml: this.mailTemplate.contentHtml,
                 })
                 .then((response) => {
-                    this.validationErrors = [];
-
-                    Object.entries(response).forEach((entry) => {
-                        const field = entry[0];
-                        const validationErrors = entry[1];
-
-                        this.validationErrors = [
-                            ...this.validationErrors,
-                            ...validationErrors.map((e) => this.translateValidationError(e, field)),
-                        ];
-                    });
-
-                    this.validationErrors = this.validationErrors.sort((a, b) => {
-                        return (a.level === 'error' ? 1 : 0) - (b.level === 'error' ? 1 : 0);
-                    });
+                    this.validationErrors = response
+                        .map((entry) => this.translateValidationError(entry))
+                        .sort((a, b) => {
+                            return (a.level === 'error' ? 1 : 0) - (b.level === 'error' ? 1 : 0);
+                        });
                 })
                 .catch((exception) => {
                     this.createNotificationError(exception.message);
                 });
         },
 
-        translateValidationError(validationError, field) {
-            switch (field) {
+        translateValidationError(validationError) {
+            let field;
+            switch (validationError.field) {
                 case 'subject':
                     field = 'options.labelSubject';
                     break;

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -248,6 +248,14 @@ export default {
                     .map(event => ({
                     ...event,
                     label: event.name.split('.').map(eventName => this.getEventNameTranslated(eventName)).join(' / '),
+                    data: {
+                        ...event.data,
+                        'salesChannel': {
+                            nullable: true,
+                            type: 'entity',
+                            entityName: 'sales_channel',
+                        },
+                    },
                 }));
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -442,6 +442,8 @@ export default {
         },
 
         onClickValidateMailTemplate() {
+            this.isLoading = true;
+
             this.mailService
                 .validateMailTemplate(this.triggerEvent.class, {
                     subject: this.mailTemplate.subject ?? '',
@@ -450,15 +452,17 @@ export default {
                     contentHtml: this.mailTemplate.contentHtml ?? '',
                 })
                 .then((response) => {
-                    this.validationErrors = response
-                        .map((entry) => this.translateValidationError(entry))
-                        .sort((a, b) => {
-                            return (a.level === 'error' ? 1 : 0) - (b.level === 'error' ? 1 : 0);
-                        });
+                    this.mailPreview = '';
+                    this.mailPreview += `<h3>${this.$t(`sw-mail-template.detail.options.labelSubject`)}</h3><br/><br/>${response.subject}<br/><hr/><br/><br/>`;
+                    this.mailPreview += `<h3>${this.$t(`sw-mail-template.detail.options.labelSenderName`)}</h3><br/><br/>${response.senderName}<br/><hr/><br/><br/>`;
+                    this.mailPreview += `<h3>${this.$t(`sw-mail-template.detail.mailText.labelContentPlain`)}</h3><br/><br/>${response.contentPlain.replace(/\n/g, () => '<br/>')}<br/><hr/><br/><br/>`;
+                    this.mailPreview += `<h3>${this.$t(`sw-mail-template.detail.options.labelContentHtml`)}</h3><br/><br/>${response.contentHtml}<br/><hr/><br/><br/>`;
                 })
                 .catch((exception) => {
                     this.createNotificationError(exception.message);
                 });
+
+            this.isLoading = false;
         },
 
         translateValidationError(validationError) {

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -307,11 +307,25 @@ export default {
         },
 
         onSave() {
-            const updatePromises = [];
-            const mailTemplateSubject = this.mailTemplate.subject || this.placeholder(this.mailTemplate, 'subject');
-
             this.isSaveSuccessful = false;
             this.isLoading = true;
+
+            console.log(this.mailTemplate);
+            this.mailService.validateMailTemplate(
+                this.mailTemplate.subject,
+                this.mailTemplate.senderName,
+                this.mailTemplate.contentHtml,
+                this.mailTemplate.contentPlain,
+                this.mailTemplateType.technicalName,
+            ).then((response) => {
+                console.log(response);
+            }).catch((error) => {
+                console.log(error);
+                this.isLoading = false;
+            });
+
+            const updatePromises = [];
+            const mailTemplateSubject = this.mailTemplate.subject || this.placeholder(this.mailTemplate, 'subject');
 
             updatePromises.push(
                 this.mailTemplateRepository

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -476,7 +476,7 @@ export default {
                 case 'arrayAccess':
                 case 'unknownVariable':
                 case 'complexElement':
-                    message = {'variable': validationError.variable, 'path': validationError.path};
+                    message = {'variable': validationError.variable};
                     break;
                 case 'syntax':
                     message = {'message': validationError.message};

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -452,7 +452,7 @@ export default {
                 .then((response) => {
                     this.validationErrors = [];
 
-                    Object.entries(response).forEach(entry => {
+                    Object.entries(response).forEach((entry) => {
                         const field = entry[0];
                         const validationErrors = entry[1];
 

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -2,7 +2,7 @@ import { dom } from 'src/core/service/util.service';
 import template from './sw-mail-template-detail.html.twig';
 import './sw-mail-template-detail.scss';
 
-const { Mixin, Context, Service } = Shopware;
+const { Mixin, Context} = Shopware;
 const { Criteria, EntityCollection } = Shopware.Data;
 const { warn } = Shopware.Utils.debug;
 const { camelCase } = Shopware.Utils.string;
@@ -61,6 +61,8 @@ export default {
             showLanguageNotAssignedToSalesChannelWarning: false,
             triggerEvent: null,
             triggerEvents: [],
+            isValidationLoading: false,
+            validationErrors: null,
         };
     },
 
@@ -79,7 +81,7 @@ export default {
         ]),
 
         loadedAvailableVariables() {
-            if (!this.mailTemplateType || !this.mailTemplateType.templateData) {
+            if (!this.triggerEvent) {
                 return [];
             }
             if (Object.values(this.availableVariables).length === 0) {
@@ -242,11 +244,12 @@ export default {
                 this.loadEntityData();
             }
             this.businessEventService.getBusinessEvents().then(events => {
-                this.triggerEvents = events.map(event => ({
+                this.triggerEvents = events
+                    .filter(event => event.aware.includes("mailAware"))
+                    .map(event => ({
                     ...event,
                     label: event.name.split('.').map(eventName => this.getEventNameTranslated(eventName)).join(' / '),
                 }));
-                console.log(this.triggerEvents);
             });
         },
 
@@ -423,8 +426,8 @@ export default {
         },
 
         onClickValidateMailTemplate() {
-            console.log(this.mailTemplate);
-            console.log(this.triggerEvent);
+            this.isValidationLoading = true;
+            this.validationErrors = [];
             this.mailService.validateMailTemplate(
                 this.triggerEvent.class,
                 {
@@ -434,15 +437,65 @@ export default {
                     contentPlain: this.mailTemplate.contentPlain,
                 },
             ).then((response) => {
-                console.log(response);
-            }).catch((error) => {
-                console.log(error);
-                this.isLoading = false;
+                this.validationErrors = [
+                    ...response.subject.map(e => this.translateValidationError(e, 'subject')),
+                    ...response.senderName.map(e => this.translateValidationError(e, 'senderName')),
+                    ...response.contentHtml.map(e => this.translateValidationError(e, 'contentHtml')),
+                    ...response.contentPlain.map(e => this.translateValidationError(e, 'contentPlain')),
+                ];
+            }).catch((exception) => {
+                this.createNotificationError(exception.message);
+            }).finally(() => {
+                this.isValidationLoading = false;
             });
         },
 
+        translateValidationError(validationError, field) {
+            switch (field) {
+                case 'subject':
+                    field = 'options.labelSubject';
+                    break;
+                case 'senderName':
+                    field = 'options.labelSenderName';
+                    break;
+                case 'contentHtml':
+                    field = 'mailText.labelContentHtml';
+                    break;
+                case 'contentPlain':
+                    field = 'mailText.labelContentPlain';
+                    break;
+                default:
+                    break;
+            }
+
+            let message;
+            switch (validationError.type) {
+                case 'arrayAccess':
+                case 'unknownVariable':
+                    message = {'variable': validationError.variable, 'path': validationError.path};
+                    break;
+                case 'syntax':
+                    message = {'message': validationError.message};
+                    break;
+
+                default:
+                    message = {};
+            }
+
+            return {
+                level: validationError.level,
+                message: this.$tc(
+                    `sw-mail-template.validation.${validationError.level}.${validationError.type}`,
+                    message,
+                    message.path ? 2 : 1,
+                ),
+                hint: (validationError.line > 0 ? `Line ${validationError.line} / ` : "")
+                    + this.$tc(`sw-mail-template.detail.${field}`),
+                name: this.$tc(`sw-mail-template.validation.${validationError.level}.name`),
+            };
+        },
+
         onTriggerEventChange(eventName) {
-            console.log(eventName);
             this.triggerEvent = this.triggerEvents.find(event => event.name === eventName);
         },
 
@@ -638,57 +691,71 @@ export default {
         },
 
         loadAvailableVariables(variable, variableEntitySchema) {
-            if (!this.mailTemplateType || !this.mailTemplateType.availableEntities) {
-                return [];
+            if (!this.triggerEvent) {
+                return;
             }
 
-            const variablePath = variable.concat('.');
-            const variableEntitySchemaPath = variableEntitySchema.concat('.');
+            const variablePathParts = variable.split('.');
 
-            const foundVariables = Object.keys(Shopware.Utils.get(this.mailTemplateType.templateData, variable));
+            let entityPath = '';
 
-            const keys = foundVariables.map((val) => {
-                const availableVariable = Shopware.Utils.get(this.mailTemplateType.templateData, variablePath.concat(val));
-                const isObject = typeof availableVariable === 'object' && availableVariable !== null;
-                const length = isObject ? Object.values(availableVariable).length : 0;
+            let currentField = null;
+            let skip = false;
 
-                // the pattern for schema is `.at(0)` or `.at(1)` instead of `.0` or `.1`
-                const schema = this.isToManyAssociationVariable(variable)
-                    ? `${variableEntitySchemaPath}at(${parseInt(val, 10)})`
-                    : variableEntitySchemaPath + val;
+            variablePathParts.forEach(variablePathPart => {
+                if (skip) {
+                    return;
+                }
 
-                return {
-                    id: variablePath + val,
-                    schema,
-                    name: val,
-                    childCount: length,
-                    parentId: variable,
-                    afterId: null,
-                };
+                if (!currentField && !this.triggerEvent.data[variablePathPart]) {
+                    skip = true;
+                    return;
+                }
+
+                currentField = this.triggerEvent.data[variablePathPart];
+                entityPath += `${variablePathPart}.`;
+
+                if (currentField.type === 'entity') {
+                    skip = true;
+                }
             });
 
-            this.addVariables(keys);
-
-            return true;
-        },
-
-        isToManyAssociationVariable(variable) {
-            if (!variable) {
-                return false;
+            if (!currentField) {
+                return;
             }
 
-            const variables = variable.split('.');
-            variables.splice(1, 0, 'properties');
-            const field = Shopware.Utils.get(this.entitySchema, `${variables.join('.')}`);
+            if (currentField.type === 'object') {
+                this.addVariables(Object.keys(currentField.data).sort().map(key => ({
+                    id: `${variable}.${key}`,
+                    schema: variableEntitySchema,
+                    name: key,
+                    childCount: (['object', 'entity'].includes(currentField.data[key]) ? 1 : 0),
+                    parentId: variable,
+                    afterId: null,
+                })));
 
-            return (
-                field &&
-                field.type === 'association' &&
-                [
-                    'one_to_many',
-                    'many_to_many',
-                ].includes(field.relation)
-            );
+                return;
+            }
+
+            if (currentField.type === 'entity') {
+                const mapping = [];
+                mapping[currentField.entityName] = currentField.entityName;
+
+                const entityMappingPath = variable.split(entityPath)[1] ?
+                        `${currentField.entityName}.${variable.split(entityPath)[1]}.` : `${currentField.entityName}.`;
+
+                const entitySchema = this.entityMappingService.getEntityMapping(entityMappingPath, mapping);
+
+                this.addVariables(Object.keys(entitySchema).sort().map(key => ({
+                    id: `${variable}.${key}`,
+                    schema: variableEntitySchema,
+                    name: key,
+                    childCount: (entitySchema[key].type === 'association' ? 1 : 0),
+                    parentId: variable,
+                    afterId: null,
+                })));
+
+            }
         },
 
         onGetTreeItems(parent, schema) {
@@ -704,28 +771,18 @@ export default {
         loadInitialAvailableVariables() {
             this.availableVariables = {};
 
-            if (!this.hasTemplateData) {
+            if (!this.triggerEvent) {
                 return;
             }
 
-            Object.keys(this.mailTemplateType.templateData).forEach((variable) => {
-                const availableVariable = Shopware.Utils.get(this.mailTemplateType.templateData, variable);
-                let length = 0;
-                if (typeof availableVariable === 'object' && availableVariable !== null) {
-                    length = Object.values(availableVariable).length;
-                }
-
-                this.addVariables([
-                    {
-                        id: variable,
-                        schema: variable,
-                        name: variable,
-                        childCount: length,
-                        parentId: null,
-                        afterId: null,
-                    },
-                ]);
-            });
+            this.addVariables(Object.keys(this.triggerEvent.data).sort().map((variable) => ({
+                id: variable,
+                schema: variable,
+                name: variable,
+                childCount: ['entity', 'object'].includes(this.triggerEvent.data[variable].type) ? 1 : 0,
+                parentId: null,
+                afterId: null,
+            })));
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -444,10 +444,10 @@ export default {
         onClickValidateMailTemplate() {
             this.mailService
                 .validateMailTemplate(this.triggerEvent.class, {
-                    subject: this.mailTemplate.subject,
-                    senderName: this.mailTemplate.senderName,
-                    contentPlain: this.mailTemplate.contentPlain,
-                    contentHtml: this.mailTemplate.contentHtml,
+                    subject: this.mailTemplate.subject ?? '',
+                    senderName: this.mailTemplate.senderName ?? '',
+                    contentPlain: this.mailTemplate.contentPlain ?? '',
+                    contentHtml: this.mailTemplate.contentHtml ?? '',
                 })
                 .then((response) => {
                     this.validationErrors = response

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -2,7 +2,7 @@ import { dom } from 'src/core/service/util.service';
 import template from './sw-mail-template-detail.html.twig';
 import './sw-mail-template-detail.scss';
 
-const { Mixin, Context} = Shopware;
+const { Mixin, Context } = Shopware;
 const { Criteria, EntityCollection } = Shopware.Data;
 const { warn } = Shopware.Utils.debug;
 const { camelCase } = Shopware.Utils.string;
@@ -238,29 +238,16 @@ export default {
                 path: 'testerMail',
                 scope: this,
             });
+
             if (this.$route.params.id) {
                 this.mailTemplateId = this.$route.params.id.toLowerCase();
                 this.loadEntityData();
             }
-            this.businessEventService.getBusinessEvents().then(events => {
-                this.triggerEvents = events
-                    .filter(event => event.aware.includes("mailAware"))
-                    .map(event => ({
-                    ...event,
-                    label: event.name.split('.').map(eventName => this.getEventNameTranslated(eventName)).join(' / '),
-                    data: {
-                        ...event.data,
-                        'salesChannel': {
-                            nullable: true,
-                            type: 'entity',
-                            entityName: 'sales_channel',
-                        },
-                    },
-                }));
-            });
+
+            this.loadTriggerEvents();
         },
 
-        getEventNameTranslated(eventName) {
+        getTriggerEventNameTranslated(eventName) {
             const eventNameCamelCase = camelCase(eventName);
             const translatedEventName = [
                 `sw-flow-app.triggers-app.${eventNameCamelCase}`,
@@ -269,6 +256,28 @@ export default {
             ].find((key) => this.$te(key));
 
             return translatedEventName ? this.$t(translatedEventName) : eventName.replace(/_|-/g, ' ');
+        },
+
+        loadTriggerEvents() {
+            this.businessEventService.getBusinessEvents().then((events) => {
+                this.triggerEvents = events
+                    .filter((event) => event.aware.includes('mailAware'))
+                    .map((event) => ({
+                        ...event,
+                        label: event.name
+                            .split('.')
+                            .map((eventName) => this.getTriggerEventNameTranslated(eventName))
+                            .join(' / '),
+                        data: {
+                            ...event.data,
+                            salesChannel: {
+                                nullable: true,
+                                type: 'entity',
+                                entityName: 'sales_channel',
+                            },
+                        },
+                    }));
+            });
         },
 
         loadEntityData() {
@@ -433,32 +442,33 @@ export default {
         },
 
         onClickValidateMailTemplate() {
-            this.mailService.validateMailTemplate(
-                this.triggerEvent.class,
-                {
+            this.mailService
+                .validateMailTemplate(this.triggerEvent.class, {
                     subject: this.mailTemplate.subject,
                     senderName: this.mailTemplate.senderName,
                     contentHtml: this.mailTemplate.contentHtml,
                     contentPlain: this.mailTemplate.contentPlain,
-                },
-            ).then((response) => {
-                this.validationErrors = [
-                    ...response.subject.map(e => this.translateValidationError(e, 'subject')),
-                    ...response.senderName.map(e => this.translateValidationError(e, 'senderName')),
-                    ...response.contentPlain.map(e => this.translateValidationError(e, 'contentPlain')),
-                    ...response.contentHtml.map(e => this.translateValidationError(e, 'contentHtml')),
-                ].sort((a, b) => {
-                    if (a.level === b.level) {
-                        return 0;
-                    }
-                    if (a.level === 'error') {
-                        return -1;
-                    }
-                    return 1;
+                })
+                .then((response) => {
+                    this.validationErrors = [];
+
+                    Object.entries(response).forEach(entry => {
+                        const field = entry[0];
+                        const validationErrors = entry[1];
+
+                        this.validationErrors = [
+                            ...this.validationErrors,
+                            ...validationErrors.map((e) => this.translateValidationError(e, field)),
+                        ];
+                    });
+
+                    this.validationErrors = this.validationErrors.sort((a, b) => {
+                        return (a.level === 'error' ? 1 : 0) - (b.level === 'error' ? 1 : 0);
+                    });
+                })
+                .catch((exception) => {
+                    this.createNotificationError(exception.message);
                 });
-            }).catch((exception) => {
-                this.createNotificationError(exception.message);
-            });
         },
 
         translateValidationError(validationError, field) {
@@ -479,35 +489,34 @@ export default {
                     break;
             }
 
-            let message;
+            const content = {};
             switch (validationError.type) {
                 case 'arrayAccess':
                 case 'unknownVariable':
                 case 'complexElement':
-                    message = {'variable': validationError.variable};
+                    content.variable = validationError.variable;
                     break;
                 case 'syntax':
-                    message = {'message': validationError.message};
+                    content.message = validationError.message;
                     break;
                 default:
-                    message = {};
+                    break;
             }
 
             return {
                 level: validationError.level,
-                message: this.$t(
-                    `sw-mail-template.validation.${validationError.level}.${validationError.type}`,
-                    message,
-                    message.path ? 2 : 1,
+                message: this.$t(`sw-mail-template.validation.${validationError.level}.${validationError.type}`, content),
+                hint: this.$t(
+                    'sw-mail-template.validation.hint',
+                    { line: validationError.line, field: this.$t(`sw-mail-template.detail.${field}`) },
+                    validationError.line === 0 ? 1 : 2,
                 ),
-                hint: (validationError.line > 0 ? `Line ${validationError.line} / ` : "")
-                    + this.$t(`sw-mail-template.detail.${field}`),
                 name: this.$t(`sw-mail-template.validation.${validationError.level}.levelName`),
             };
         },
 
         onTriggerEventChange(eventName) {
-            this.triggerEvent = this.triggerEvents.find(event => event.name === eventName);
+            this.triggerEvent = this.triggerEvents.find((event) => event.name === eventName);
         },
 
         onClickShowPreview() {
@@ -713,7 +722,7 @@ export default {
             let currentField = null;
             let skip = false;
 
-            variablePathParts.forEach(variablePathPart => {
+            variablePathParts.forEach((variablePathPart) => {
                 if (skip) {
                     return;
                 }
@@ -736,14 +745,23 @@ export default {
             }
 
             if (currentField.type === 'object') {
-                this.addVariables(Object.keys(currentField.data).sort().map(key => ({
-                    id: `${variable}.${key}`,
-                    schema: variableEntitySchema,
-                    name: key,
-                    childCount: (['object', 'entity'].includes(currentField.data[key]) ? 1 : 0),
-                    parentId: variable,
-                    afterId: null,
-                })));
+                this.addVariables(
+                    Object.keys(currentField.data)
+                        .sort()
+                        .map((key) => ({
+                            id: `${variable}.${key}`,
+                            schema: variableEntitySchema,
+                            name: key,
+                            childCount: [
+                                'object',
+                                'entity',
+                            ].includes(currentField.data[key])
+                                ? 1
+                                : 0,
+                            parentId: variable,
+                            afterId: null,
+                        })),
+                );
 
                 return;
             }
@@ -752,20 +770,24 @@ export default {
                 const mapping = [];
                 mapping[currentField.entityName] = currentField.entityName;
 
-                const entityMappingPath = variable.split(entityPath)[1] ?
-                        `${currentField.entityName}.${variable.split(entityPath)[1]}.` : `${currentField.entityName}.`;
+                const entityMappingPath = variable.split(entityPath)[1]
+                    ? `${currentField.entityName}.${variable.split(entityPath)[1]}.`
+                    : `${currentField.entityName}.`;
 
                 const entitySchema = this.entityMappingService.getEntityMapping(entityMappingPath, mapping);
 
-                this.addVariables(Object.keys(entitySchema).sort().map(key => ({
-                    id: `${variable}.${key}`,
-                    schema: variableEntitySchema,
-                    name: key,
-                    childCount: (entitySchema[key].type === 'association' ? 1 : 0),
-                    parentId: variable,
-                    afterId: null,
-                })));
-
+                this.addVariables(
+                    Object.keys(entitySchema)
+                        .sort()
+                        .map((key) => ({
+                            id: `${variable}.${key}`,
+                            schema: variableEntitySchema,
+                            name: key,
+                            childCount: entitySchema[key].type === 'association' ? 1 : 0,
+                            parentId: variable,
+                            afterId: null,
+                        })),
+                );
             }
         },
 
@@ -786,14 +808,23 @@ export default {
                 return;
             }
 
-            this.addVariables(Object.keys(this.triggerEvent.data).sort().map((variable) => ({
-                id: variable,
-                schema: variable,
-                name: variable,
-                childCount: ['entity', 'object'].includes(this.triggerEvent.data[variable].type) ? 1 : 0,
-                parentId: null,
-                afterId: null,
-            })));
+            this.addVariables(
+                Object.keys(this.triggerEvent.data)
+                    .sort()
+                    .map((variable) => ({
+                        id: variable,
+                        schema: variable,
+                        name: variable,
+                        childCount: [
+                            'entity',
+                            'object',
+                        ].includes(this.triggerEvent.data[variable].type)
+                            ? 1
+                            : 0,
+                        parentId: null,
+                        afterId: null,
+                    })),
+            );
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -2,9 +2,10 @@ import { dom } from 'src/core/service/util.service';
 import template from './sw-mail-template-detail.html.twig';
 import './sw-mail-template-detail.scss';
 
-const { Mixin, Context } = Shopware;
+const { Mixin, Context, Service } = Shopware;
 const { Criteria, EntityCollection } = Shopware.Data;
 const { warn } = Shopware.Utils.debug;
+const { camelCase } = Shopware.Utils.string;
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 
 /**
@@ -20,6 +21,7 @@ export default {
         'repositoryFactory',
         'acl',
         'feature',
+        'businessEventService',
     ],
 
     mixins: [
@@ -57,6 +59,8 @@ export default {
             availableVariables: {},
             entitySchema: Object.fromEntries(Shopware.EntityDefinition.getDefinitionRegistry()),
             showLanguageNotAssignedToSalesChannelWarning: false,
+            triggerEvent: null,
+            triggerEvents: [],
         };
     },
 
@@ -237,6 +241,24 @@ export default {
                 this.mailTemplateId = this.$route.params.id.toLowerCase();
                 this.loadEntityData();
             }
+            this.businessEventService.getBusinessEvents().then(events => {
+                this.triggerEvents = events.map(event => ({
+                    ...event,
+                    label: event.name.split('.').map(eventName => this.getEventNameTranslated(eventName)).join(' / '),
+                }));
+                console.log(this.triggerEvents);
+            });
+        },
+
+        getEventNameTranslated(eventName) {
+            const eventNameCamelCase = camelCase(eventName);
+            const translatedEventName = [
+                `sw-flow-app.triggers-app.${eventNameCamelCase}`,
+                `sw-flow-custom-event.event-tree.${eventNameCamelCase}`,
+                `sw-flow.triggers.${eventNameCamelCase}`,
+            ].find((key) => this.$te(key));
+
+            return translatedEventName ? this.$tc(translatedEventName) : eventName.replace(/_|-/g, ' ');
         },
 
         loadEntityData() {
@@ -309,20 +331,6 @@ export default {
         onSave() {
             this.isSaveSuccessful = false;
             this.isLoading = true;
-
-            console.log(this.mailTemplate);
-            this.mailService.validateMailTemplate(
-                this.mailTemplate.subject,
-                this.mailTemplate.senderName,
-                this.mailTemplate.contentHtml,
-                this.mailTemplate.contentPlain,
-                this.mailTemplateType.technicalName,
-            ).then((response) => {
-                console.log(response);
-            }).catch((error) => {
-                console.log(error);
-                this.isLoading = false;
-            });
 
             const updatePromises = [];
             const mailTemplateSubject = this.mailTemplate.subject || this.placeholder(this.mailTemplate, 'subject');
@@ -412,6 +420,30 @@ export default {
                     this.createNotificationError(notificationTestMailError);
                     warn(this._name, exception.message, exception.response);
                 });
+        },
+
+        onClickValidateMailTemplate() {
+            console.log(this.mailTemplate);
+            console.log(this.triggerEvent);
+            this.mailService.validateMailTemplate(
+                this.triggerEvent.class,
+                {
+                    subject: this.mailTemplate.subject,
+                    senderName: this.mailTemplate.senderName,
+                    contentHtml: this.mailTemplate.contentHtml,
+                    contentPlain: this.mailTemplate.contentPlain,
+                },
+            ).then((response) => {
+                console.log(response);
+            }).catch((error) => {
+                console.log(error);
+                this.isLoading = false;
+            });
+        },
+
+        onTriggerEventChange(eventName) {
+            console.log(eventName);
+            this.triggerEvent = this.triggerEvents.find(event => event.name === eventName);
         },
 
         onClickShowPreview() {

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -61,7 +61,6 @@ export default {
             showLanguageNotAssignedToSalesChannelWarning: false,
             triggerEvent: null,
             triggerEvents: [],
-            isValidationLoading: false,
             validationErrors: null,
         };
     },
@@ -154,7 +153,7 @@ export default {
         tooltipSave() {
             if (!this.allowSave) {
                 return {
-                    message: this.$tc('sw-privileges.tooltip.warning'),
+                    message: this.$t('sw-privileges.tooltip.warning'),
                     disabled: this.allowSave,
                     showOnDisabledElements: true,
                 };
@@ -261,7 +260,7 @@ export default {
                 `sw-flow.triggers.${eventNameCamelCase}`,
             ].find((key) => this.$te(key));
 
-            return translatedEventName ? this.$tc(translatedEventName) : eventName.replace(/_|-/g, ' ');
+            return translatedEventName ? this.$t(translatedEventName) : eventName.replace(/_|-/g, ' ');
         },
 
         loadEntityData() {
@@ -275,7 +274,7 @@ export default {
                 if (!this.mailTemplate.mailTemplateType?.id) {
                     this.isLoading = false;
                     this.createNotificationError({
-                        message: this.$tc('sw-mail-template.general.missingMailTemplateTypeErrorMessage'),
+                        message: this.$t('sw-mail-template.general.missingMailTemplateTypeErrorMessage'),
                     });
                 } else {
                     this.onChangeType(this.mailTemplate.mailTemplateType.id);
@@ -353,12 +352,12 @@ export default {
 
                         if (error.response.data.errors.length > 0) {
                             const errorDetailMsg = error.response.data.errors[0].detail;
-                            errormsg = `<br/> ${this.$tc('sw-mail-template.detail.textErrorMessage')}: "${errorDetailMsg}"`;
+                            errormsg = `<br/> ${this.$t('sw-mail-template.detail.textErrorMessage')}: "${errorDetailMsg}"`;
                         }
 
                         this.createNotificationError({
                             message:
-                                this.$tc('sw-mail-template.detail.messageSaveError', { subject: mailTemplateSubject }, 0) +
+                                this.$t('sw-mail-template.detail.messageSaveError', { subject: mailTemplateSubject }, 0) +
                                 errormsg,
                         });
                     }),
@@ -369,15 +368,15 @@ export default {
 
         onClickTestMailTemplate() {
             const notificationTestMailSuccess = {
-                message: this.$tc('sw-mail-template.general.notificationTestMailSuccessMessage'),
+                message: this.$t('sw-mail-template.general.notificationTestMailSuccessMessage'),
             };
 
             const notificationTestMailError = {
-                message: this.$tc('sw-mail-template.general.notificationTestMailErrorMessage'),
+                message: this.$t('sw-mail-template.general.notificationTestMailErrorMessage'),
             };
 
             const notificationTestMailErrorSalesChannel = {
-                message: this.$tc('sw-mail-template.general.notificationTestMailSalesChannelErrorMessage'),
+                message: this.$t('sw-mail-template.general.notificationTestMailSalesChannelErrorMessage'),
             };
 
             if (!this.testMailSalesChannelId) {
@@ -412,7 +411,7 @@ export default {
                     const isMailSent = response?.size !== 0;
                     if (!isMailSent) {
                         this.createNotificationError({
-                            message: this.$tc('sw-mail-template.general.notificationGeneralSyntaxValidationErrorMessage'),
+                            message: this.$t('sw-mail-template.general.notificationGeneralSyntaxValidationErrorMessage'),
                         });
                         return;
                     }
@@ -426,8 +425,6 @@ export default {
         },
 
         onClickValidateMailTemplate() {
-            this.isValidationLoading = true;
-            this.validationErrors = [];
             this.mailService.validateMailTemplate(
                 this.triggerEvent.class,
                 {
@@ -440,13 +437,19 @@ export default {
                 this.validationErrors = [
                     ...response.subject.map(e => this.translateValidationError(e, 'subject')),
                     ...response.senderName.map(e => this.translateValidationError(e, 'senderName')),
-                    ...response.contentHtml.map(e => this.translateValidationError(e, 'contentHtml')),
                     ...response.contentPlain.map(e => this.translateValidationError(e, 'contentPlain')),
-                ];
+                    ...response.contentHtml.map(e => this.translateValidationError(e, 'contentHtml')),
+                ].sort((a, b) => {
+                    if (a.level === b.level) {
+                        return 0;
+                    }
+                    if (a.level === 'error') {
+                        return -1;
+                    }
+                    return 1;
+                });
             }).catch((exception) => {
                 this.createNotificationError(exception.message);
-            }).finally(() => {
-                this.isValidationLoading = false;
             });
         },
 
@@ -472,26 +475,26 @@ export default {
             switch (validationError.type) {
                 case 'arrayAccess':
                 case 'unknownVariable':
+                case 'complexElement':
                     message = {'variable': validationError.variable, 'path': validationError.path};
                     break;
                 case 'syntax':
                     message = {'message': validationError.message};
                     break;
-
                 default:
                     message = {};
             }
 
             return {
                 level: validationError.level,
-                message: this.$tc(
+                message: this.$t(
                     `sw-mail-template.validation.${validationError.level}.${validationError.type}`,
                     message,
                     message.path ? 2 : 1,
                 ),
                 hint: (validationError.line > 0 ? `Line ${validationError.line} / ` : "")
-                    + this.$tc(`sw-mail-template.detail.${field}`),
-                name: this.$tc(`sw-mail-template.validation.${validationError.level}.name`),
+                    + this.$t(`sw-mail-template.detail.${field}`),
+                name: this.$t(`sw-mail-template.validation.${validationError.level}.levelName`),
             };
         },
 
@@ -511,11 +514,11 @@ export default {
                     this.mailPreview = null;
                     if (!error.response?.data?.errors?.[0]?.detail) {
                         this.createNotificationError({
-                            message: this.$tc('sw-mail-template.general.notificationGeneralSyntaxValidationErrorMessage'),
+                            message: this.$t('sw-mail-template.general.notificationGeneralSyntaxValidationErrorMessage'),
                         });
                     } else {
                         this.createNotificationError({
-                            message: this.$tc(
+                            message: this.$t(
                                 'sw-mail-template.general.notificationSyntaxValidationErrorMessage',
                                 {
                                     errorMsg: error.response?.data?.errors?.[0]?.detail,
@@ -573,7 +576,7 @@ export default {
                 let errormsg = '';
                 if (error.response.data.errors.length > 0) {
                     const errorDetailMsg = error.response.data.errors[0].detail;
-                    errormsg = `<br/> ${this.$tc('sw-mail-template.detail.textErrorMessage')}: "${errorDetailMsg}"`;
+                    errormsg = `<br/> ${this.$t('sw-mail-template.detail.textErrorMessage')}: "${errorDetailMsg}"`;
                 }
 
                 this.createNotificationError({
@@ -598,7 +601,7 @@ export default {
                 let errormsg = e.message ?? '';
                 if (e.response?.data?.errors?.length > 0) {
                     const errorDetailMsg = e.response.data.errors[0].detail;
-                    errormsg = `<br/> ${this.$tc('sw-mail-template.detail.textErrorMessage')}: "${errorDetailMsg}"`;
+                    errormsg = `<br/> ${this.$t('sw-mail-template.detail.textErrorMessage')}: "${errorDetailMsg}"`;
                 }
 
                 this.createNotificationError({
@@ -681,7 +684,7 @@ export default {
         onAddItemToAttachment(mediaItem) {
             if (this._checkIfMediaIsAlreadyUsed(mediaItem.id)) {
                 this.createNotificationInfo({
-                    message: this.$tc('sw-mail-template.list.errorMediaItemDuplicated'),
+                    message: this.$t('sw-mail-template.list.errorMediaItemDuplicated'),
                 });
                 return false;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -362,21 +362,49 @@
                 class="sw-mail-template-detail__show-available-variables"
             >
                 <div class="sw-mail-template-detail__available-variables-sidebar-container">
-                    {% block sw_mail_template_available_variables_tree %}
-                    <sw-tree
-                        class="sw-mail-template-detail__available-variables-sidebar-container__tree"
-                        :searchable="false"
-                        :disable-context-menu="true"
-                        :on-change-route="() => { return false; }"
-                        :items="loadedAvailableVariables"
-                        :sortable="false"
-                        @get-tree-items="onGetTreeItems"
+                    <mt-select
+                        value-property="name"
+                        class="sw-mail-template-detail__available-variables-sidebar-trigger-select"
+                        :label="$tc('sw-mail-template.detail.sidebar.buttonValidation')"
+                        :model-value="triggerEvent"
+                        :options="triggerEvents"
+                        @update:model-value="onTriggerEventChange"
                     >
-                        {% block sw_mail_template_available_variables_tree_headline %}
-                        <template #headline>
-                            <span></span>
+                        <template #hint>
+                            <div class="sw-mail-template-detail__field-hint">
+                                <div class="sw-mail-template-detail__field-hint-icon-container">
+                                    <mt-icon
+                                        size="12"
+                                        name="solid-info-circle"
+                                        class="sw-mail-template-detail__field-hint-icon"
+                                    />
+                                </div>
+                                <p>{{ $tc('sw-mail-template.detail.sidebar.hintAvailableVariables') }}</p>
+                            </div>
                         </template>
-                        {% endblock %}
+                    </mt-select>
+
+                    <div
+                        v-if="loadedAvailableVariables.length > 0"
+                        class="sw-mail-template-detail__available-variables-sidebar-tree-container"
+                    >
+                        <hr class="sw-mail-template-detail__available-variables-sidebar-divider">
+
+                        {% block sw_mail_template_available_variables_tree %}
+                            <sw-tree
+                                class="sw-mail-template-detail__available-variables-sidebar-container__tree"
+                                :searchable="false"
+                                :disable-context-menu="true"
+                                :on-change-route="() => { return false; }"
+                                :items="loadedAvailableVariables"
+                                :sortable="false"
+                                @get-tree-items="onGetTreeItems"
+                            >
+                                {% block sw_mail_template_available_variables_tree_headline %}
+                                    <template #headline>
+                                        <span></span>
+                                    </template>
+                                {% endblock %}
 
                         {% block sw_mail_template_available_variables_tree_items %}
                         <template
@@ -398,27 +426,28 @@
                                 </template>
                                 {% endblock %}
 
-                                {% block sw_mail_template_available_variables_tree_items_item_actions %}
-                                <template #actions="{ item }">
-                                    <mt-icon
-                                        v-if="item.childCount === 0"
-                                        v-tooltip="{
+                                                {% block sw_mail_template_available_variables_tree_items_item_actions %}
+                                                    <template #actions="{ item }">
+                                                        <mt-icon
+                                                            v-if="item.childCount === 0"
+                                                            v-tooltip="{
                                             message: $tc('sw-mail-template.detail.sidebar.copyTooltip'),
                                             width: 150,
                                             position: 'bottom'
                                         }"
-                                        name="regular-products-s"
-                                        class="sw-mail-template-detail__copy_icon"
-                                        @click="onCopyVariable(item.id)"
-                                    />
-                                </template>
+                                                            name="regular-products-s"
+                                                            class="sw-mail-template-detail__copy_icon"
+                                                            @click="onCopyVariable(item.id)"
+                                                        />
+                                                    </template>
+                                                {% endblock %}
+                                            </sw-tree-item>
+                                        {% endblock %}
+                                    </template>
                                 {% endblock %}
-                            </sw-tree-item>
-                            {% endblock %}
-                        </template>
+                            </sw-tree>
                         {% endblock %}
-                    </sw-tree>
-                    {% endblock %}
+                    </div>
                 </div>
             </sw-sidebar-item>
             {% endblock %}
@@ -480,7 +509,7 @@
                         </mt-select>
 
                         <mt-button
-                            class="sw-mail-template-detail__send-test-mail"
+                            class="sw-mail-template-detail__validate-mail-template"
                             variant="secondary"
                             :disabled="!isValidationLoading && !triggerEvent"
                             @click="onClickValidateMailTemplate"
@@ -490,7 +519,7 @@
                     </div>
 
                     <div
-                        v-if="!isValidationLoading && validationErrors !== null"
+                        v-if="validationErrors !== null"
                         class="sw-mail-template-detail__validation-sidebar-result"
                     >
                         <hr class="sw-mail-template-detail__validation-sidebar-result-divider">
@@ -523,7 +552,11 @@
                                 >
                                     ({{ error.hint }})
                                 </p>
-                                {{ error.message }}
+                                <p
+                                    class="sw-mail-template-detail__validation-sidebar-result-error-element-message"
+                                >
+                                    {{ error.message }}
+                                </p>
                             </mt-banner>
                         </div>
                         <div

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -450,6 +450,30 @@
             </sw-sidebar-media-item>
             {% endblock %}
             {% endblock %}
+
+            <sw-sidebar-item
+                icon="regular-eye"
+                title="Validate Email Template"
+                class="sw-mail-template-detail__show-validation-sidebar"
+            >
+                <div>
+                    <mt-select
+                        valueProperty="name"
+                        label="Flow Event Trigger Context"
+                        :model-value="triggerEvent"
+                        :options="triggerEvents"
+                        @update:model-value="onTriggerEventChange"
+                    />
+                </div>
+                <mt-button
+                    class="sw-mail-template-detail__send-test-mail"
+                    variant="secondary"
+                    :disabled="!triggerEvent"
+                    @click="onClickValidateMailTemplate"
+                >
+                    Validate
+                </mt-button>
+            </sw-sidebar-item>
         </sw-sidebar>
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -365,7 +365,7 @@
                     <mt-select
                         value-property="name"
                         class="sw-mail-template-detail__available-variables-sidebar-trigger-select"
-                        :label="$t('sw-mail-template.detail.sidebar.buttonValidation')"
+                        :label="$t('sw-mail-template.detail.sidebar.selectValidation')"
                         :model-value="triggerEvent"
                         :options="triggerEvents"
                         @update:model-value="onTriggerEventChange"
@@ -489,7 +489,7 @@
                     <div>
                         <mt-select
                             value-property="name"
-                            :label="$t('sw-mail-template.detail.sidebar.buttonValidation')"
+                            :label="$t('sw-mail-template.detail.sidebar.selectValidation')"
                             :model-value="triggerEvent"
                             :options="triggerEvents"
                             @update:model-value="onTriggerEventChange"

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -391,20 +391,20 @@
                         <hr class="sw-mail-template-detail__available-variables-sidebar-divider">
 
                         {% block sw_mail_template_available_variables_tree %}
-                            <sw-tree
-                                class="sw-mail-template-detail__available-variables-sidebar-container__tree"
-                                :searchable="false"
-                                :disable-context-menu="true"
-                                :on-change-route="() => { return false; }"
-                                :items="loadedAvailableVariables"
-                                :sortable="false"
-                                @get-tree-items="onGetTreeItems"
-                            >
-                                {% block sw_mail_template_available_variables_tree_headline %}
-                                    <template #headline>
-                                        <span></span>
-                                    </template>
-                                {% endblock %}
+                        <sw-tree
+                            class="sw-mail-template-detail__available-variables-sidebar-container__tree"
+                            :searchable="false"
+                            :disable-context-menu="true"
+                            :on-change-route="() => { return false; }"
+                            :items="loadedAvailableVariables"
+                            :sortable="false"
+                            @get-tree-items="onGetTreeItems"
+                        >
+                            {% block sw_mail_template_available_variables_tree_headline %}
+                            <template #headline>
+                                <span></span>
+                            </template>
+                            {% endblock %}
 
                         {% block sw_mail_template_available_variables_tree_items %}
                         <template
@@ -426,26 +426,26 @@
                                 </template>
                                 {% endblock %}
 
-                                                {% block sw_mail_template_available_variables_tree_items_item_actions %}
-                                                    <template #actions="{ item }">
-                                                        <mt-icon
-                                                            v-if="item.childCount === 0"
-                                                            v-tooltip="{
-                                            message: $tc('sw-mail-template.detail.sidebar.copyTooltip'),
-                                            width: 150,
-                                            position: 'bottom'
-                                        }"
-                                                            name="regular-products-s"
-                                                            class="sw-mail-template-detail__copy_icon"
-                                                            @click="onCopyVariable(item.id)"
-                                                        />
-                                                    </template>
-                                                {% endblock %}
-                                            </sw-tree-item>
-                                        {% endblock %}
+                                    {% block sw_mail_template_available_variables_tree_items_item_actions %}
+                                    <template #actions="{ item }">
+                                        <mt-icon
+                                            v-if="item.childCount === 0"
+                                            v-tooltip="{
+                                                message: $tc('sw-mail-template.detail.sidebar.copyTooltip'),
+                                                width: 150,
+                                                position: 'bottom'
+                                            }"
+                                            name="regular-products-s"
+                                            class="sw-mail-template-detail__copy_icon"
+                                            @click="onCopyVariable(item.id)"
+                                        />
                                     </template>
+                                    {% endblock %}
+                                </sw-tree-item>
                                 {% endblock %}
-                            </sw-tree>
+                            </template>
+                            {% endblock %}
+                        </sw-tree>
                         {% endblock %}
                     </div>
                 </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -511,7 +511,7 @@
                         <mt-button
                             class="sw-mail-template-detail__validate-mail-template"
                             variant="secondary"
-                            :disabled="!isValidationLoading && !triggerEvent"
+                            :disabled="!triggerEvent"
                             @click="onClickValidateMailTemplate"
                         >
                             Validate

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -532,32 +532,15 @@
                                 {{ $t('sw-mail-template.validation.result.error.title', {'number': validationErrors.length}, validationErrors.length) }}
                             </h4>
 
-                            <mt-banner
+                            <sw-mail-template-validation-result
                                 v-for="error in validationErrors"
-                                :key="error.id"
                                 :title="error.name"
-                                class="sw-mail-template-detail__validation-sidebar-result-error-element"
+                                :hint="error.hint"
+                                :type="error.level"
                             >
-                                <template #customIcon>
-                                    <mt-icon
-                                        size="16"
-                                        :name="error.level === 'error' ? 'solid-exclamation-circle' : 'solid-exclamation-triangle'"
-                                        class="sw-mail-template-detail__validation-sidebar-result-error-element-icon"
-                                        :color="error.level === 'error' ? 'var(--color-icon-critical-default)' : 'var(--color-icon-attention-default)'"
-                                    />
-                                </template>
+                                {{ error.message }}
+                            </sw-mail-template-validation-result>
 
-                                <p
-                                    class="sw-mail-template-detail__validation-sidebar-result-error-element-hint"
-                                >
-                                    ({{ error.hint }})
-                                </p>
-                                <p
-                                    class="sw-mail-template-detail__validation-sidebar-result-error-element-message"
-                                >
-                                    {{ error.message }}
-                                </p>
-                            </mt-banner>
                         </div>
                         <div
                             v-else

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -463,7 +463,10 @@
             {% endblock %}
 
             {% block sw_mail_template_detail_sidebar_inner_media %}
-            <sw-sidebar-media-item ref="mediaSidebarItem">
+            <sw-sidebar-media-item
+                ref="mediaSidebarItem"
+                class="sw-mail-template-detail__media-sidebar"
+            >
                 <template
                     #context-menu-items="media"
                 >
@@ -485,77 +488,74 @@
                 :disabled="isLoading"
                 :title="$t('sw-mail-template.detail.sidebar.titleValidation')"
             >
-                <div class="sw-mail-template-detail__validation-sidebar-container">
-                    <div>
-                        <mt-select
-                            value-property="name"
-                            :label="$t('sw-mail-template.detail.sidebar.selectValidation')"
-                            :model-value="triggerEvent"
-                            :options="triggerEvents"
-                            @update:model-value="onTriggerEventChange"
-                        >
-                            <template #hint>
-                                <div class="sw-mail-template-detail__field-hint">
-                                    <div class="sw-mail-template-detail__field-hint-icon-container">
-                                        <mt-icon
-                                            size="12"
-                                            name="solid-info-circle"
-                                            class="sw-mail-template-detail__field-hint-icon"
-                                        />
-                                    </div>
-                                    <p>{{ $t('sw-mail-template.detail.sidebar.hintValidation') }}</p>
+                <div>
+                    <mt-select
+                        value-property="name"
+                        :label="$t('sw-mail-template.detail.sidebar.selectValidation')"
+                        :model-value="triggerEvent"
+                        :options="triggerEvents"
+                        @update:model-value="onTriggerEventChange"
+                    >
+                        <template #hint>
+                            <div class="sw-mail-template-detail__field-hint">
+                                <div class="sw-mail-template-detail__field-hint-icon-container">
+                                    <mt-icon
+                                        size="12"
+                                        name="solid-info-circle"
+                                        class="sw-mail-template-detail__field-hint-icon"
+                                    />
                                 </div>
-                            </template>
-                        </mt-select>
+                                <p>{{ $t('sw-mail-template.detail.sidebar.hintValidation') }}</p>
+                            </div>
+                        </template>
+                    </mt-select>
 
-                        <mt-button
-                            class="sw-mail-template-detail__validate-mail-template"
-                            variant="secondary"
-                            :disabled="!triggerEvent"
-                            @click="onClickValidateMailTemplate"
-                        >
-                            Validate
-                        </mt-button>
-                    </div>
+                    <mt-button
+                        variant="secondary"
+                        :disabled="!triggerEvent"
+                        @click="onClickValidateMailTemplate"
+                    >
+                        Validate
+                    </mt-button>
+                </div>
+
+                <div
+                    v-if="validationErrors !== null"
+                    class="sw-mail-template-detail__validation-sidebar-result"
+                >
+                    <hr class="sw-mail-template-detail__validation-sidebar-result-divider">
 
                     <div
-                        v-if="validationErrors !== null"
-                        class="sw-mail-template-detail__validation-sidebar-result"
+                        v-if="validationErrors?.length > 0"
+                        class="sw-mail-template-detail__validation-sidebar-result-error"
                     >
-                        <hr class="sw-mail-template-detail__validation-sidebar-result-divider">
+                        <h4 class="sw-mail-template-detail__validation-sidebar-result-error-title">
+                            {{ $t('sw-mail-template.validation.result.error.title', {'number': validationErrors.length}, validationErrors.length) }}
+                        </h4>
 
-                        <div
-                            v-if="validationErrors?.length > 0"
-                            class="sw-mail-template-detail__validation-sidebar-result-error"
+                        <sw-mail-template-validation-result
+                            v-for="error in validationErrors"
+                            :title="error.name"
+                            :hint="error.hint"
+                            :type="error.level"
                         >
-                            <h4 class="sw-mail-template-detail__validation-sidebar-result-error-title">
-                                {{ $t('sw-mail-template.validation.result.error.title', {'number': validationErrors.length}, validationErrors.length) }}
-                            </h4>
+                            {{ error.message }}
+                        </sw-mail-template-validation-result>
 
-                            <sw-mail-template-validation-result
-                                v-for="error in validationErrors"
-                                :title="error.name"
-                                :hint="error.hint"
-                                :type="error.level"
-                            >
-                                {{ error.message }}
-                            </sw-mail-template-validation-result>
-
-                        </div>
-                        <div
-                            v-else
-                            class="sw-mail-template-detail__validation-sidebar-result-success"
-                        >
-                            <mt-icon
-                                size="16"
-                                name="solid-check-circle"
-                                class="sw-mail-template-detail__validation-sidebar-result-success-icon"
-                                color="var(--color-icon-positive-default)"
-                            />
-                            <h4 class="sw-mail-template-detail__validation-sidebar-result-success-title">
-                                {{ $t('sw-mail-template.validation.result.success.title') }}
-                            </h4>
-                        </div>
+                    </div>
+                    <div
+                        v-else
+                        class="sw-mail-template-detail__validation-sidebar-result-success"
+                    >
+                        <mt-icon
+                            size="16"
+                            name="solid-check-circle"
+                            class="sw-mail-template-detail__validation-sidebar-result-success-icon"
+                            color="var(--color-icon-positive-default)"
+                        />
+                        <h4 class="sw-mail-template-detail__validation-sidebar-result-success-title">
+                            {{ $t('sw-mail-template.validation.result.success.title') }}
+                        </h4>
                     </div>
                 </div>
             </sw-sidebar-item>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -3,13 +3,13 @@
     {% block sw_mail_template_detail_header %}
     <template #smart-bar-header>
         <h2 v-if="mailTemplate">
-            {{ $tc('sw-mail-template.detail.textHeadlineEdit') }}
+            {{ $t('sw-mail-template.detail.textHeadlineEdit') }}
         </h2>
         <h2
             v-else
             class="sw-mail-template-detail__empty-title"
         >
-            {{ $tc('sw-mail-template.detail.textHeadline') }}
+            {{ $t('sw-mail-template.detail.textHeadline') }}
         </h2>
     </template>
     {% endblock %}
@@ -27,7 +27,7 @@
             size="default"
             @click="onCancel"
         >
-            {{ $tc('global.default.cancel') }}
+            {{ $t('global.default.cancel') }}
         </mt-button>
         {% endblock %}
 
@@ -42,7 +42,7 @@
             @update:process-success="saveFinish"
             @click.prevent="onSave"
         >
-            {{ $tc('sw-mail-template.detail.buttonSave') }}
+            {{ $t('sw-mail-template.detail.buttonSave') }}
         </sw-button-process>
         {% endblock %}
     </template>
@@ -69,13 +69,13 @@
             <template v-else>
                 {% block sw_mail_template_detail_content_language_info %}
                 <sw-language-info
-                    :entity-description="placeholder(mailTemplate.mailTemplateType, 'name', $tc('sw-mail-template.detail.textHeadline'))"
+                    :entity-description="placeholder(mailTemplate.mailTemplateType, 'name', $t('sw-mail-template.detail.textHeadline'))"
                 />
                 {% endblock %}
 
                 {% block sw_mail_template_detail_basic_info %}
                 <mt-card
-                    :title="$tc('sw-mail-template.detail.basic.titleCard')"
+                    :title="$t('sw-mail-template.detail.basic.titleCard')"
                     position-identifier="sw-mail-template-detail-basic-info"
                 >
                     {% block sw_mail_template_basic_form_mail_type_field %}
@@ -86,8 +86,8 @@
                         entity="mail_template_type"
                         required
                         show-clearable-button
-                        :label="$tc('sw-mail-template.detail.basic.labelMailType')"
-                        :placeholder="$tc('sw-mail-template.detail.basic.placeholderMailType')"
+                        :label="$t('sw-mail-template.detail.basic.labelMailType')"
+                        :placeholder="$t('sw-mail-template.detail.basic.placeholderMailType')"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
                         :error="mailTemplateMailTemplateTypeIdError"
                         @update:value="onChangeType"
@@ -99,8 +99,8 @@
                         v-model="mailTemplate.description"
                         class="sw-mail-template-detail__description-field"
                         name="sw-field--mailTemplate-description"
-                        :label="$tc('sw-mail-template.detail.basic.labelDescription')"
-                        :placeholder="$tc('sw-mail-template.detail.basic.placeholderDescription')"
+                        :label="$t('sw-mail-template.detail.basic.labelDescription')"
+                        :placeholder="$t('sw-mail-template.detail.basic.placeholderDescription')"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
                     />
                     {% endblock %}
@@ -110,7 +110,7 @@
                 {% block sw_mail_template_detail_options_info %}
                 <mt-card
                     position-identifier="sw-mail-template-detail-options-info"
-                    :title="$tc('sw-mail-template.detail.options.titleCard')"
+                    :title="$t('sw-mail-template.detail.options.titleCard')"
                 >
                     <sw-container
                         columns="repeat(auto-fit, minmax(250px, 1fr))"
@@ -124,8 +124,8 @@
                                 class="sw-mail-template-detail__subject-field"
                                 name="sw-field--mailTemplate-subject"
                                 required
-                                :label="$tc('sw-mail-template.detail.options.labelSubject')"
-                                :placeholder="placeholder(mailTemplate, 'subject', $tc('sw-mail-template.detail.options.placeholderSubject'))"
+                                :label="$t('sw-mail-template.detail.options.labelSubject')"
+                                :placeholder="placeholder(mailTemplate, 'subject', $t('sw-mail-template.detail.options.placeholderSubject'))"
                                 :disabled="!acl.can('mail_templates.editor') || undefined"
                                 :error="mailTemplateSubjectError"
                             />
@@ -137,8 +137,8 @@
                             v-model="mailTemplate.senderName"
                             class="sw-mail-template-detail__sender-name-field"
                             name="sw-field--mailTemplate-senderName"
-                            :label="$tc('sw-mail-template.detail.options.labelSenderName')"
-                            :placeholder="placeholder(mailTemplate, 'senderName', $tc('sw-mail-template.detail.options.placeholderSenderName'))"
+                            :label="$t('sw-mail-template.detail.options.labelSenderName')"
+                            :placeholder="placeholder(mailTemplate, 'senderName', $t('sw-mail-template.detail.options.placeholderSenderName'))"
                             :disabled="!acl.can('mail_templates.editor') || undefined"
                         />
                         {% endblock %}
@@ -148,7 +148,7 @@
 
                 {% block sw_mail_template_detail_attachments_info %}
                 <mt-card
-                    :title="$tc('sw-mail-template.detail.media.titleCard')"
+                    :title="$t('sw-mail-template.detail.media.titleCard')"
                     position-identifier="sw-mail-template-detail-atttachments-info"
                 >
                     {% block sw_mail_template_detail_attachments_info_upload %}
@@ -195,7 +195,7 @@
                             {% block sw_mail_template_detail_attachments_info_grid_actions %}
                             <sw-context-menu-item
                                 v-tooltip.bottom="{
-                                    message: $tc('sw-privileges.tooltip.warning'),
+                                    message: $t('sw-privileges.tooltip.warning'),
                                     disabled: acl.can('mail_templates.editor') || undefined,
                                     showOnDisabledElements: true
                                 }"
@@ -203,7 +203,7 @@
                                 :disabled="!acl.can('mail_templates.editor') || undefined"
                                 @click="onDeleteMedia(item.id)"
                             >
-                                {{ $tc('global.default.delete') }}
+                                {{ $t('global.default.delete') }}
                             </sw-context-menu-item>
                             {% endblock %}
                         </template>
@@ -216,7 +216,7 @@
                                 @click="onDeleteSelectedMedia"
                                 @keydown.enter="onDeleteSelectedMedia"
                             >
-                                {{ $tc('global.default.delete') }}
+                                {{ $t('global.default.delete') }}
                             </mt-link>
                             {% endblock %}
                         </template>
@@ -227,7 +227,7 @@
 
                 {% block sw_mail_template_detail_mail_text_info %}
                 <mt-card
-                    :title="$tc('sw-mail-template.detail.mailText.titleCard')"
+                    :title="$t('sw-mail-template.detail.mailText.titleCard')"
                     position-identifier="sw-mail-template-detail-text-info"
                 >
                     {% block sw_mail_template_mail_text_form_content_plain_field %}
@@ -238,8 +238,8 @@
                         class="sw-mail-template-detail__plain-editor"
                         name="content_plain"
                         completion-mode="entity"
-                        :label="$tc('sw-mail-template.detail.mailText.labelContentPlain')"
-                        :placeholder="placeholder(mailTemplate, 'contentPlain', $tc('sw-mail-template.detail.mailText.placeholderPlain'))"
+                        :label="$t('sw-mail-template.detail.mailText.labelContentPlain')"
+                        :placeholder="placeholder(mailTemplate, 'contentPlain', $t('sw-mail-template.detail.mailText.placeholderPlain'))"
                         :completer-function="outerCompleterFunction"
                         :editor-config="editorConfig"
                         :disabled="!acl.can('mail_templates.editor')"
@@ -256,8 +256,8 @@
                         class="sw-mail-template-detail__html-editor"
                         name="content_html"
                         completion-mode="entity"
-                        :label="$tc('sw-mail-template.detail.mailText.labelContentHtml')"
-                        :placeholder="placeholder(mailTemplate, 'contentHtml', $tc('sw-mail-template.detail.mailText.placeholderHtml'))"
+                        :label="$t('sw-mail-template.detail.mailText.labelContentHtml')"
+                        :placeholder="placeholder(mailTemplate, 'contentHtml', $t('sw-mail-template.detail.mailText.placeholderHtml'))"
                         :completer-function="outerCompleterFunction"
                         :editor-config="editorConfig"
                         :disabled="!acl.can('mail_templates.editor')"
@@ -270,7 +270,7 @@
                 <sw-modal
                     v-if="mailPreview"
                     class="sw-mail-template-preview-modal"
-                    :title="$tc('sw-mail-template.detail.previewModalTitle')"
+                    :title="$t('sw-mail-template.detail.previewModalTitle')"
                     :is-loading="isLoading"
                     @modal-close="onCancelShowPreview"
                 >
@@ -286,7 +286,7 @@
                             variant="secondary"
                             @click="onCancelShowPreview"
                         >
-                            {{ $tc('global.default.close') }}
+                            {{ $t('global.default.close') }}
                         </mt-button>
                         {% endblock %}
                     </template>
@@ -307,7 +307,7 @@
             {% block sw_mail_template_detail_sidebar_inner_test_mail %}
             <sw-sidebar-item
                 icon="regular-paper-plane"
-                :title="$tc('sw-mail-template.detail.sidebar.titleTestMail')"
+                :title="$t('sw-mail-template.detail.sidebar.titleTestMail')"
                 class="sw-mail-template-detail__test-mail-sidebar"
             >
                 <div class="sw-mail-template-detail__test-mail-sidebar-container">
@@ -315,7 +315,7 @@
                         v-if="showLanguageNotAssignedToSalesChannelWarning"
                         variant="attention"
                     >
-                        {{ $tc('sw-mail-template.detail.sidebar.languageNotAssignedToSalesChannel') }}
+                        {{ $t('sw-mail-template.detail.sidebar.languageNotAssignedToSalesChannel') }}
                     </mt-banner>
 
                     {% block sw_mail_template_mail_text_form_test_mail_field %}
@@ -323,8 +323,8 @@
                     <mt-text-field
                         v-model="testerMail"
                         name="sw-field--testerMail"
-                        :placeholder="$tc('sw-mail-template.detail.sidebar.placeholderTestMail')"
-                        :label="$tc('sw-mail-template.detail.sidebar.labelTestMail')"
+                        :placeholder="$t('sw-mail-template.detail.sidebar.placeholderTestMail')"
+                        :label="$t('sw-mail-template.detail.sidebar.labelTestMail')"
                         :disabled="!acl.can('mail_templates.editor') || undefined"
                     />
                     {% endblock %}
@@ -334,8 +334,8 @@
                         v-model:value="testMailSalesChannelId"
                         name="sw-field--testMailSalesChannelId"
                         entity="sales_channel"
-                        :label="$tc('sw-mail-template.detail.basic.labelSalesChannels')"
-                        :placeholder="$tc('sw-mail-template.detail.basic.placeholderSalesChannels')"
+                        :label="$t('sw-mail-template.detail.basic.labelSalesChannels')"
+                        :placeholder="$t('sw-mail-template.detail.basic.placeholderSalesChannels')"
                         show-clearable-button
                     />
                     {% endblock %}
@@ -347,7 +347,7 @@
                         variant="secondary"
                         @click="onClickTestMailTemplate"
                     >
-                        {{ $tc('sw-mail-template.detail.sidebar.buttonTestMail') }}
+                        {{ $t('sw-mail-template.detail.sidebar.buttonTestMail') }}
                     </mt-button>
                     {% endblock %}
                 </div>
@@ -357,7 +357,7 @@
             {% block sw_mail_template_detail_sidebar_inner_variables %}
             <sw-sidebar-item
                 icon="regular-code"
-                :title="$tc('sw-mail-template.detail.sidebar.titleShowAvailableVariables')"
+                :title="$t('sw-mail-template.detail.sidebar.titleShowAvailableVariables')"
                 :disabled="isLoading || !hasTemplateData"
                 class="sw-mail-template-detail__show-available-variables"
             >
@@ -365,7 +365,7 @@
                     <mt-select
                         value-property="name"
                         class="sw-mail-template-detail__available-variables-sidebar-trigger-select"
-                        :label="$tc('sw-mail-template.detail.sidebar.buttonValidation')"
+                        :label="$t('sw-mail-template.detail.sidebar.buttonValidation')"
                         :model-value="triggerEvent"
                         :options="triggerEvents"
                         @update:model-value="onTriggerEventChange"
@@ -379,7 +379,7 @@
                                         class="sw-mail-template-detail__field-hint-icon"
                                     />
                                 </div>
-                                <p>{{ $tc('sw-mail-template.detail.sidebar.hintAvailableVariables') }}</p>
+                                <p>{{ $t('sw-mail-template.detail.sidebar.hintAvailableVariables') }}</p>
                             </div>
                         </template>
                     </mt-select>
@@ -392,10 +392,10 @@
 
                         {% block sw_mail_template_available_variables_tree %}
                         <sw-tree
-                            class="sw-mail-template-detail__available-variables-sidebar-container__tree"
+                            class="sw-mail-template-detail__available-variables-sidebar-container-tree"
                             :searchable="false"
                             :disable-context-menu="true"
-                            :on-change-route="() => { return false; }"
+                            :on-change-route="() => false"
                             :items="loadedAvailableVariables"
                             :sortable="false"
                             @get-tree-items="onGetTreeItems"
@@ -431,12 +431,12 @@
                                         <mt-icon
                                             v-if="item.childCount === 0"
                                             v-tooltip="{
-                                                message: $tc('sw-mail-template.detail.sidebar.copyTooltip'),
+                                                message: $t('sw-mail-template.detail.sidebar.copyTooltip'),
                                                 width: 150,
                                                 position: 'bottom'
                                             }"
                                             name="regular-products-s"
-                                            class="sw-mail-template-detail__copy_icon"
+                                            class="sw-mail-template-detail__copy-icon"
                                             @click="onCopyVariable(item.id)"
                                         />
                                     </template>
@@ -455,7 +455,7 @@
             {% block sw_mail_template_detail_sidebar_inner_preview %}
             <sw-sidebar-item
                 icon="regular-eye"
-                :title="$tc('sw-mail-template.detail.sidebar.titleShowPreview')"
+                :title="$t('sw-mail-template.detail.sidebar.titleShowPreview')"
                 :disabled="isLoading || showPreview || !hasTemplateData"
                 class="sw-mail-template-detail__show-preview-sidebar"
                 @click="onClickShowPreview"
@@ -472,7 +472,7 @@
                         :disabled="!acl.can('mail_templates.editor') || undefined"
                         @click="onAddItemToAttachment(media.mediaItem)"
                     >
-                        {{ $tc('sw-mail-template.detail.sidebar.labelContextMenuAddToMailTemplate') }}
+                        {{ $t('sw-mail-template.detail.sidebar.labelContextMenuAddToMailTemplate') }}
                     </sw-context-menu-item>
                     {% endblock %}
                 </template>
@@ -483,13 +483,13 @@
                 icon="check-circle"
                 class="sw-mail-template-detail__validation-sidebar"
                 :disabled="isLoading"
-                :title="$tc('sw-mail-template.detail.sidebar.titleValidation')"
+                :title="$t('sw-mail-template.detail.sidebar.titleValidation')"
             >
                 <div class="sw-mail-template-detail__validation-sidebar-container">
                     <div>
                         <mt-select
                             value-property="name"
-                            :label="$tc('sw-mail-template.detail.sidebar.buttonValidation')"
+                            :label="$t('sw-mail-template.detail.sidebar.buttonValidation')"
                             :model-value="triggerEvent"
                             :options="triggerEvents"
                             @update:model-value="onTriggerEventChange"
@@ -503,7 +503,7 @@
                                             class="sw-mail-template-detail__field-hint-icon"
                                         />
                                     </div>
-                                    <p>{{ $tc('sw-mail-template.detail.sidebar.hintValidation') }}</p>
+                                    <p>{{ $t('sw-mail-template.detail.sidebar.hintValidation') }}</p>
                                 </div>
                             </template>
                         </mt-select>
@@ -529,7 +529,7 @@
                             class="sw-mail-template-detail__validation-sidebar-result-error"
                         >
                             <h4 class="sw-mail-template-detail__validation-sidebar-result-error-title">
-                                {{ $tc('sw-mail-template.validation.result.error.title', {'number': validationErrors.length}, validationErrors.length) }}
+                                {{ $t('sw-mail-template.validation.result.error.title', {'number': validationErrors.length}, validationErrors.length) }}
                             </h4>
 
                             <mt-banner
@@ -570,7 +570,7 @@
                                 color="var(--color-icon-positive-default)"
                             />
                             <h4 class="sw-mail-template-detail__validation-sidebar-result-success-title">
-                                {{ $tc('sw-mail-template.validation.result.success.title') }}
+                                {{ $t('sw-mail-template.validation.result.success.title') }}
                             </h4>
                         </div>
                     </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -409,7 +409,7 @@
                                         }"
                                         name="regular-products-s"
                                         class="sw-mail-template-detail__copy_icon"
-                                        @click="onCopyVariable(item.schema)"
+                                        @click="onCopyVariable(item.id)"
                                     />
                                 </template>
                                 {% endblock %}
@@ -449,31 +449,101 @@
                 </template>
             </sw-sidebar-media-item>
             {% endblock %}
-            {% endblock %}
 
             <sw-sidebar-item
-                icon="regular-eye"
-                title="Validate Email Template"
-                class="sw-mail-template-detail__show-validation-sidebar"
+                icon="check-circle"
+                class="sw-mail-template-detail__validation-sidebar"
+                :disabled="isLoading"
+                :title="$tc('sw-mail-template.detail.sidebar.titleValidation')"
             >
-                <div>
-                    <mt-select
-                        valueProperty="name"
-                        label="Flow Event Trigger Context"
-                        :model-value="triggerEvent"
-                        :options="triggerEvents"
-                        @update:model-value="onTriggerEventChange"
-                    />
+                <div class="sw-mail-template-detail__validation-sidebar-container">
+                    <div>
+                        <mt-select
+                            value-property="name"
+                            :label="$tc('sw-mail-template.detail.sidebar.buttonValidation')"
+                            :model-value="triggerEvent"
+                            :options="triggerEvents"
+                            @update:model-value="onTriggerEventChange"
+                        >
+                            <template #hint>
+                                <div class="sw-mail-template-detail__field-hint">
+                                    <div class="sw-mail-template-detail__field-hint-icon-container">
+                                        <mt-icon
+                                            size="12"
+                                            name="solid-info-circle"
+                                            class="sw-mail-template-detail__field-hint-icon"
+                                        />
+                                    </div>
+                                    <p>{{ $tc('sw-mail-template.detail.sidebar.hintValidation') }}</p>
+                                </div>
+                            </template>
+                        </mt-select>
+
+                        <mt-button
+                            class="sw-mail-template-detail__send-test-mail"
+                            variant="secondary"
+                            :disabled="!isValidationLoading && !triggerEvent"
+                            @click="onClickValidateMailTemplate"
+                        >
+                            Validate
+                        </mt-button>
+                    </div>
+
+                    <div
+                        v-if="!isValidationLoading && validationErrors !== null"
+                        class="sw-mail-template-detail__validation-sidebar-result"
+                    >
+                        <hr class="sw-mail-template-detail__validation-sidebar-result-divider">
+
+                        <div
+                            v-if="validationErrors?.length > 0"
+                            class="sw-mail-template-detail__validation-sidebar-result-error"
+                        >
+                            <h4 class="sw-mail-template-detail__validation-sidebar-result-error-title">
+                                {{ $tc('sw-mail-template.validation.result.error.title', {'number': validationErrors.length}, validationErrors.length) }}
+                            </h4>
+
+                            <mt-banner
+                                v-for="error in validationErrors"
+                                :key="error.id"
+                                :title="error.name"
+                                class="sw-mail-template-detail__validation-sidebar-result-error-element"
+                            >
+                                <template #customIcon>
+                                    <mt-icon
+                                        size="16"
+                                        :name="error.level === 'error' ? 'solid-exclamation-circle' : 'solid-exclamation-triangle'"
+                                        class="sw-mail-template-detail__validation-sidebar-result-error-element-icon"
+                                        :color="error.level === 'error' ? 'var(--color-icon-critical-default)' : 'var(--color-icon-attention-default)'"
+                                    />
+                                </template>
+
+                                <p
+                                    class="sw-mail-template-detail__validation-sidebar-result-error-element-hint"
+                                >
+                                    ({{ error.hint }})
+                                </p>
+                                {{ error.message }}
+                            </mt-banner>
+                        </div>
+                        <div
+                            v-else
+                            class="sw-mail-template-detail__validation-sidebar-result-success"
+                        >
+                            <mt-icon
+                                size="16"
+                                name="solid-check-circle"
+                                class="sw-mail-template-detail__validation-sidebar-result-success-icon"
+                                color="var(--color-icon-positive-default)"
+                            />
+                            <h4 class="sw-mail-template-detail__validation-sidebar-result-success-title">
+                                {{ $tc('sw-mail-template.validation.result.success.title') }}
+                            </h4>
+                        </div>
+                    </div>
                 </div>
-                <mt-button
-                    class="sw-mail-template-detail__send-test-mail"
-                    variant="secondary"
-                    :disabled="!triggerEvent"
-                    @click="onClickValidateMailTemplate"
-                >
-                    Validate
-                </mt-button>
             </sw-sidebar-item>
+            {% endblock %}
         </sw-sidebar>
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
@@ -49,9 +49,78 @@
     }
 
     &__attachments-info-grid {
+    .sw-mail-template-detail__validation-sidebar {
+        &-container {
+            padding: 20px;
+            border-top: 1px solid $color-gray-300;
+            display: flex;
+            flex-direction: column;
+            gap: var(--scale-size-32);
+
+            .sw-mail-template-detail__validation-sidebar-result {
+                &-divider {
+                    border: none ;
+                    border-top: 1px solid var(--color-border-secondary-default);
+                }
+
+                &-error,&-success {
+                    display: flex;
+                    padding-top: var(--scale-size-32);
+                    flex-direction: column;
+                    align-items: flex-start;
+                    gap: var(--scale-size-16);
+                    align-self: stretch;
+
+                     &-title {
+                         color: var(--color-text-primary-default);
+                         font-size: var(--font-size-xs);
+                         margin: 0;
+                     }
+
+                    &-element {
+                        position: relative;
+                        margin: 0;
+                        width: 100%;
+                        background-color: var(--color-background-tertiary-default);
+                        padding: var(--scale-size-8);
+                        gap: var(--scale-size-6);
+
+                        &-icon {
+                            margin-top: var(--scale-size-2);
+                        }
+
+                        &-hint {
+                            position: absolute;
+                            top: var(--scale-size-8);
+                            right: var(--scale-size-8);
+                            color: var(--color-text-secondary-default);
+                            font-size: var(--font-size-2xs);
+                        }
+                    }
+                }
+                &-success {
+                    flex-direction: row;
+                    gap: var(--scale-size-6);
+                }
+            }
+        }
+    }
+
+    &__test-mail-sidebar-container {
         position: relative;
         margin-top: var(--scale-size-20);
         border: 1px solid var(--color-border-primary-default);
         border-radius: var(--border-radius-xs);
     }
+
+    &__field-hint {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--scale-size-4);
+
+        &-icon-container {
+            margin-top: -1px;
+        }
+    }
+
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
@@ -102,46 +102,15 @@
                     padding-top: var(--scale-size-32);
                     flex-direction: column;
                     align-items: flex-start;
-                    gap: var(--scale-size-16);
                     align-self: stretch;
 
-                     &-title {
-                         color: var(--color-text-primary-default);
-                         font-size: var(--font-size-xs);
-                         margin: 0;
-                     }
-
-                    &-element {
-                        position: relative;
-                        margin: 0;
-                        width: 100%;
-                        background-color: var(--color-background-tertiary-default);
-                        padding: var(--scale-size-8);
-                        gap: var(--scale-size-6);
-                        border: none;
-
-                        &-icon {
-                            margin-top: var(--scale-size-2);
-                        }
-
-                        &-hint {
-                            position: absolute;
-                            top: var(--scale-size-8);
-                            right: var(--scale-size-8);
-                            color: var(--color-text-secondary-default);
-                            font-size: var(--font-size-2xs);
-                        }
-
-                        .mt-banner__title {
-                            position: sticky;
-                            left: 0;
-                        }
-
-                        .mt-banner__body {
-                            overflow-x: auto;
-                        }
+                    &-title {
+                        color: var(--color-text-primary-default);
+                        font-size: var(--font-size-xs);
+                        margin-bottom: var(--scale-size-16);
                     }
                 }
+
                 &-success {
                     flex-direction: row;
                     gap: var(--scale-size-6);

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
@@ -10,14 +10,46 @@
         }
     }
 
-    &__available-variables-sidebar-container {
-        height: 100%;
+    .sw-sidebar-item {
+        &__headline {
+            align-items: center
+        }
+        &__title {
+            display: flex;
+            align-items: center;
+        }
+        &__close-button {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
     }
 
-    .sw-tree {
-        .sw-tree__content {
-            max-height: 100%;
+    &__available-variables-sidebar-container {
+        &-container {
+            height: 100%;
+            border-top: 1px solid $color-gray-300;
         }
+
+        &-trigger-select {
+            padding: 20px;
+            margin-bottom: var(--scale-size-32);
+        }
+
+        &-divider {
+            margin: 0 20px;
+            border: none ;
+            border-top: 1px solid var(--color-border-secondary-default);
+        }
+
+        &-container__tree {
+            border: none;
+            height: calc(100% - 171px);
+
+            .sw-tree__content {
+                height: 100%;
+                //height: 427px;
+            }
 
         .icon--regular-circle-xxs,
         .sw-mail-template-detail__copy_icon,
@@ -84,6 +116,7 @@
                         background-color: var(--color-background-tertiary-default);
                         padding: var(--scale-size-8);
                         gap: var(--scale-size-6);
+                        border: none;
 
                         &-icon {
                             margin-top: var(--scale-size-2);
@@ -95,6 +128,15 @@
                             right: var(--scale-size-8);
                             color: var(--color-text-secondary-default);
                             font-size: var(--font-size-2xs);
+                        }
+
+                        .mt-banner__title {
+                            position: sticky;
+                            left: 0;
+                        }
+
+                        .mt-banner__body {
+                            overflow-x: auto;
                         }
                     }
                 }

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
@@ -42,9 +42,12 @@
             border-top: 1px solid var(--color-border-secondary-default);
         }
 
+        &-tree-container {
+            height: calc(100% - 171px);
+        }
+
         &-container__tree {
             border: none;
-            height: calc(100% - 171px);
 
             .sw-tree__content {
                 height: 100%;

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
@@ -46,12 +46,11 @@
             height: calc(100% - 171px);
         }
 
-        &-container__tree {
+        &-container-tree {
             border: none;
 
             .sw-tree__content {
                 height: 100%;
-                //height: 427px;
             }
 
         .icon--regular-circle-xxs,
@@ -62,7 +61,7 @@
         }
 
         .sw-tree-item__children {
-            .sw-mail-template-detail__copy_icon {
+            .sw-mail-template-detail__copy-icon {
                 display: block;
                 max-width: var(--scale-size-14);
                 color: var(--color-icon-secondary-default);

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
@@ -10,48 +10,25 @@
         }
     }
 
-    .sw-sidebar-item {
-        &__headline {
-            align-items: center
-        }
-        &__title {
-            display: flex;
-            align-items: center;
-        }
-        &__close-button {
-            display: flex;
-            align-items: center;
-            justify-content: center;
+    &__show-available-variables {
+        .sw-sidebar-item__content {
+            border-top: 1px solid var(--color-border-secondary-default);
+
+            .sw-mail-template-detail__available-variables-sidebar-container {
+                height: 100%;
+                padding: var(--scale-size-20);
+
+                &-tree {
+                    border: none;
+                }
+            }
         }
     }
 
-    &__available-variables-sidebar-container {
-        &-container {
-            height: 100%;
-            border-top: 1px solid $color-gray-300;
+    .sw-tree {
+        .sw-tree__content {
+            max-height: 100%;
         }
-
-        &-trigger-select {
-            padding: 20px;
-            margin-bottom: var(--scale-size-32);
-        }
-
-        &-divider {
-            margin: 0 20px;
-            border: none ;
-            border-top: 1px solid var(--color-border-secondary-default);
-        }
-
-        &-tree-container {
-            height: calc(100% - 171px);
-        }
-
-        &-container-tree {
-            border: none;
-
-            .sw-tree__content {
-                height: 100%;
-            }
 
         .icon--regular-circle-xxs,
         .sw-mail-template-detail__copy_icon,
@@ -61,7 +38,7 @@
         }
 
         .sw-tree-item__children {
-            .sw-mail-template-detail__copy-icon {
+            .sw-mail-template-detail__copy_icon {
                 display: block;
                 max-width: var(--scale-size-14);
                 color: var(--color-icon-secondary-default);
@@ -77,63 +54,65 @@
         }
     }
 
-    &__test-mail-sidebar-container {
-        padding: var(--scale-size-20);
-        border-top: 1px solid var(--color-border-primary-default);
-    }
+    &__validation-sidebar {
+        .sw-sidebar-item {
+            &__content {
+                border-top: 1px solid var(--color-border-secondary-default);
+            }
 
-    &__attachments-info-grid {
-    .sw-mail-template-detail__validation-sidebar {
-        &-container {
-            padding: 20px;
-            border-top: 1px solid $color-gray-300;
-            display: flex;
-            flex-direction: column;
-            gap: var(--scale-size-32);
+            &__scrollable-container {
+                padding: var(--scale-size-20);
+                display: flex;
+                flex-direction: column;
+                gap: var(--scale-size-32);
 
-            .sw-mail-template-detail__validation-sidebar-result {
-                &-divider {
-                    border: none ;
-                    border-top: 1px solid var(--color-border-secondary-default);
-                }
-
-                &-error,&-success {
-                    display: flex;
-                    padding-top: var(--scale-size-32);
-                    flex-direction: column;
-                    align-items: flex-start;
-                    align-self: stretch;
-
-                    &-title {
-                        color: var(--color-text-primary-default);
-                        font-size: var(--font-size-xs);
-                        margin-bottom: var(--scale-size-16);
+                .sw-mail-template-detail__validation-sidebar-result {
+                    &-divider {
+                        border: none;
+                        border-top: 1px solid var(--color-border-secondary-default);
                     }
-                }
 
-                &-success {
-                    flex-direction: row;
-                    gap: var(--scale-size-6);
+                    &-error, &-success {
+                        display: flex;
+                        padding-top: var(--scale-size-32);
+                        flex-direction: column;
+                        align-items: flex-start;
+                        align-self: stretch;
+
+                        &-title {
+                            color: var(--color-text-secondary-default);
+                            font-size: var(--font-size-xs);
+                            margin-bottom: var(--scale-size-16);
+                        }
+                    }
+
+                    &-success {
+                        flex-direction: row;
+                        gap: var(--scale-size-6);
+                    }
                 }
             }
         }
     }
 
     &__test-mail-sidebar-container {
+        padding: var(--scale-size-20);
+        border-top: 1px solid var(--color-border-secondary-default);
+    }
+
+    &__media-sidebar {
+        .sw-sidebar-item__content {
+            border-top: 1px solid var(--color-border-secondary-default);
+        }
+        .sw-sidebar-item__scrollable-container {
+            padding-top: var(--scale-size-20);
+        }
+    }
+
+    &__attachments-info-grid {
         position: relative;
         margin-top: var(--scale-size-20);
         border: 1px solid var(--color-border-primary-default);
         border-radius: var(--border-radius-xs);
     }
-
-    &__field-hint {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--scale-size-4);
-
-        &-icon-container {
-            margin-top: -1px;
-        }
-    }
-
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
@@ -131,6 +131,9 @@ async function createWrapper(privileges = []) {
                         return privileges.includes(identifier);
                     },
                 },
+                businessEventService: {
+                    getBusinessEvents: () => Promise.resolve([]),
+                }
             },
             mocks: {
                 $route: { params: { id: Shopware.Utils.createId() } },
@@ -844,7 +847,7 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
 
         expect(notificationMock).toHaveBeenCalledTimes(1);
         expect(notificationMock).toHaveBeenCalledWith({
-            message: wrapper.vm.$tc('sw-mail-template.general.missingMailTemplateTypeErrorMessage'),
+            message: wrapper.vm.$t('sw-mail-template.general.missingMailTemplateTypeErrorMessage'),
         });
 
         wrapper.vm.createNotificationError.mockRestore();

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
@@ -133,7 +133,7 @@ async function createWrapper(privileges = []) {
                 },
                 businessEventService: {
                     getBusinessEvents: () => Promise.resolve([]),
-                }
+                },
             },
             mocks: {
                 $route: { params: { id: Shopware.Utils.createId() } },

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-index/sw-mail-template-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-index/sw-mail-template-index.html.twig
@@ -15,14 +15,14 @@
         {% block sw_mail_template_list_smart_bar_header_title %}
         <h2>
             {% block sw_mail_template_list_smart_bar_header_title_text %}
-            <span>{{ $tc('sw-settings.index.title') }}</span>
+            <span>{{ $t('sw-settings.index.title') }}</span>
 
             <mt-icon
                 name="regular-chevron-right-xs"
                 size="12px"
             />
 
-            <span>{{ $tc('sw-mail-template.list.textMailTemplateOverview') }}</span>
+            <span>{{ $t('sw-mail-template.list.textMailTemplateOverview') }}</span>
             {% endblock %}
         </h2>
         {% endblock %}
@@ -33,7 +33,7 @@
     <template #smart-bar-actions>
         <sw-context-button
             v-tooltip.bottom="{
-                message: $tc('sw-privileges.tooltip.warning'),
+                message: $t('sw-privileges.tooltip.warning'),
                 disabled: acl.can('mail_templates.creator'),
                 showOnDisabledElements: true
             }"
@@ -46,7 +46,7 @@
                     :disabled="!acl.can('mail_templates.creator') || undefined"
                     size="default"
                 >
-                    <span>{{ $tc('global.default.add') }}</span>
+                    <span>{{ $t('global.default.add') }}</span>
 
                     <template #iconBack>
                         <mt-icon
@@ -59,13 +59,13 @@
 
             {% block sw_mail_template_list_smart_bar_actions_add %}
             <sw-context-menu-item :router-link="{ name: 'sw.mail.template.create' }">
-                {{ $tc('sw-mail-template.list.buttonAddMailTemplate') }}
+                {{ $t('sw-mail-template.list.buttonAddMailTemplate') }}
             </sw-context-menu-item>
             {% endblock %}
 
             {% block sw_mail_header_footer_list_smart_bar_actions_add %}
             <sw-context-menu-item :router-link="{ name: 'sw.mail.template.create_head_foot' }">
-                {{ $tc('sw-mail-header-footer.list.buttonAddMailHeaderFooter') }}
+                {{ $t('sw-mail-header-footer.list.buttonAddMailHeaderFooter') }}
             </sw-context-menu-item>
             {% endblock %}
         </sw-context-button>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/snippet/en.json
@@ -11,6 +11,26 @@
       "notificationGeneralSyntaxValidationErrorMessage": "Invalid template, check syntax.",
       "missingMailTemplateTypeErrorMessage": "A required mail template type is not available."
     },
+    "validation": {
+      "result": {
+        "error": {
+          "title": "{number} issue found | {number} issues found"
+        },
+        "success": {
+          "title": "Validation successful"
+        }
+      },
+      "error": {
+        "levelName": "Error",
+        "unknownVariable": "Unknown variable: \"{variable}\".",
+        "syntax": "Syntax error found: {message}",
+        "arrayAccess": "Unable to access array: \"{variable}\"."
+      },
+      "warning": {
+        "levelName": "Warning",
+        "complexElement": "Complex element found: \"{variable}\". Verify output manually."
+      }
+    },
     "list": {
       "textMailTemplateOverview": "Email templates",
       "tabMailTemplates": "Templates",
@@ -71,7 +91,11 @@
         "titleShowPreview": "Show preview",
         "titleShowAvailableVariables": "Variables",
         "copyTooltip": "Copy to clipboard.",
-        "languageNotAssignedToSalesChannel": "The current language is not assigned to the selected sales channel."
+        "hintAvailableVariables": "Please select a flow trigger to show available variables.",
+        "languageNotAssignedToSalesChannel": "The current language is not assigned to the selected sales channel.",
+        "titleValidation": "Validate email template",
+        "buttonValidation": "Flow trigger",
+        "hintValidation": "Validation may not be fully accurate. Please review the resulting email."
       },
       "previewModalTitle": "Preview",
       "buttonSave": "Save",

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/snippet/en.json
@@ -29,7 +29,8 @@
       "warning": {
         "levelName": "Warning",
         "complexElement": "Complex element found: \"{variable}\". Verify output manually."
-      }
+      },
+      "hint": "{field} | Line {line} / {field}"
     },
     "list": {
       "textMailTemplateOverview": "Email templates",

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/snippet/en.json
@@ -94,7 +94,7 @@
         "hintAvailableVariables": "Please select a flow trigger to show available variables.",
         "languageNotAssignedToSalesChannel": "The current language is not assigned to the selected sales channel.",
         "titleValidation": "Validate email template",
-        "buttonValidation": "Flow trigger",
+        "selectValidation": "Flow trigger",
         "hintValidation": "Validation may not be fully accurate. Please review the resulting email."
       },
       "previewModalTitle": "Preview",

--- a/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
@@ -4,6 +4,13 @@ namespace Shopware\Core\Checkout\Cart\Event;
 
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerGroupStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\OrderStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
+use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
 use Shopware\Core\Framework\Event\CustomerAware;

--- a/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
@@ -3,15 +3,11 @@
 namespace Shopware\Core\Checkout\Cart\Event;
 
 use Shopware\Core\Checkout\Cart\CartException;
-use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
-use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
-use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\CustomerGroupAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -53,7 +49,11 @@ class CheckoutOrderPlacedEvent extends Event implements SalesChannelAware, Sales
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('order', new EntityType(OrderDefinition::class));
+            ->merge(OrderStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(CustomerGroupStorer::getAvailableData());
     }
 
     public function getContext(): Context

--- a/src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
@@ -2,16 +2,17 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\Aggregate\CustomerRecovery\CustomerRecoveryDefinition;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerRecovery\CustomerRecoveryEntity;
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\CustomerRecoveryAware;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerRecoveryStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
@@ -74,10 +75,12 @@ class CustomerAccountRecoverRequestEvent extends Event implements SalesChannelAw
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customerRecovery', new EntityType(CustomerRecoveryDefinition::class))
-            ->add('customer', new EntityType(CustomerDefinition::class))
-            ->add('resetUrl', new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add('shopName', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(CustomerRecoveryStorer::getAvailableData())
+            ->add(FlowMailVariables::RESET_URL, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(FlowMailVariables::SHOP_NAME, (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable());
     }
 
     public function getMailStruct(): MailRecipientStruct

--- a/src/Core/Checkout/Customer/Event/CustomerBeforeLoginEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerBeforeLoginEvent.php
@@ -38,6 +38,11 @@ class CustomerBeforeLoginEvent extends Event implements SalesChannelAware, Shopw
         ];
     }
 
+    public static function getScalarKeys(): array
+    {
+        // TODO: Implement getScalarKeys() method.
+    }
+
     public function getName(): string
     {
         return self::EVENT_NAME;

--- a/src/Core/Checkout/Customer/Event/CustomerBeforeLoginEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerBeforeLoginEvent.php
@@ -4,13 +4,10 @@ namespace Shopware\Core\Checkout\Customer\Event;
 
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
-use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
-use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
-use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\SalesChannelAware;
 use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
@@ -18,7 +15,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CustomerBeforeLoginEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, MailAware, ScalarValuesAware, FlowEventAware
+class CustomerBeforeLoginEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, ScalarValuesAware, FlowEventAware
 {
     final public const EVENT_NAME = 'checkout.customer.before.login';
 
@@ -66,11 +63,6 @@ class CustomerBeforeLoginEvent extends Event implements SalesChannelAware, Shopw
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('email', new ScalarValueType(ScalarValueType::TYPE_STRING));
-    }
-
-    public function getMailStruct(): MailRecipientStruct
-    {
-        throw new MailEventConfigurationException('Data for mailRecipientStruct not available.', self::class);
+            ->add(FlowMailVariables::EMAIL, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 }

--- a/src/Core/Checkout/Customer/Event/CustomerBeforeLoginEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerBeforeLoginEvent.php
@@ -38,11 +38,6 @@ class CustomerBeforeLoginEvent extends Event implements SalesChannelAware, Shopw
         ];
     }
 
-    public static function getScalarKeys(): array
-    {
-        // TODO: Implement getScalarKeys() method.
-    }
-
     public function getName(): string
     {
         return self::EVENT_NAME;

--- a/src/Core/Checkout/Customer/Event/CustomerDeletedEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDeletedEvent.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
+use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
 use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
 use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;

--- a/src/Core/Checkout/Customer/Event/CustomerDeletedEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDeletedEvent.php
@@ -2,12 +2,11 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
-use Shopware\Core\Checkout\Customer\CustomerEntity;
-use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -18,7 +17,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CustomerDeletedEvent extends Event implements ShopwareSalesChannelEvent, CustomerAware, MailAware, ScalarValuesAware, FlowEventAware
+class CustomerDeletedEvent extends Event implements ShopwareSalesChannelEvent, CustomerAware, MailAware, FlowEventAware
 {
     final public const EVENT_NAME = 'checkout.customer.deleted';
 
@@ -78,13 +77,8 @@ class CustomerDeletedEvent extends Event implements ShopwareSalesChannelEvent, C
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class));
-    }
-
-    public function getValues(): array
-    {
-        return [
-            'customer' => $this->serializedCustomer,
-        ];
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData());
     }
 }

--- a/src/Core/Checkout/Customer/Event/CustomerDoubleOptInRegistrationEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDoubleOptInRegistrationEvent.php
@@ -2,13 +2,14 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
@@ -36,8 +37,10 @@ class CustomerDoubleOptInRegistrationEvent extends Event implements SalesChannel
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class))
-            ->add('confirmUrl', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->add(FlowMailVariables::CONFIRM_URL, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     public function getName(): string

--- a/src/Core/Checkout/Customer/Event/CustomerGroupRegistrationAccepted.php
+++ b/src/Core/Checkout/Customer/Event/CustomerGroupRegistrationAccepted.php
@@ -2,14 +2,15 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupDefinition;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerGroupStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\CustomerGroupAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -37,8 +38,10 @@ class CustomerGroupRegistrationAccepted extends Event implements SalesChannelAwa
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class))
-            ->add('customerGroup', new EntityType(CustomerGroupDefinition::class));
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(CustomerGroupStorer::getAvailableData());
     }
 
     public function getName(): string

--- a/src/Core/Checkout/Customer/Event/CustomerGroupRegistrationDeclined.php
+++ b/src/Core/Checkout/Customer/Event/CustomerGroupRegistrationDeclined.php
@@ -2,14 +2,15 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupDefinition;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerGroupStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\CustomerGroupAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -37,8 +38,10 @@ class CustomerGroupRegistrationDeclined extends Event implements SalesChannelAwa
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class))
-            ->add('customerGroup', new EntityType(CustomerGroupDefinition::class));
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(CustomerGroupStorer::getAvailableData());
     }
 
     public function getName(): string

--- a/src/Core/Checkout/Customer/Event/CustomerLoginEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerLoginEvent.php
@@ -42,11 +42,6 @@ class CustomerLoginEvent extends Event implements SalesChannelAware, ShopwareSal
         ];
     }
 
-    public static function getScalarKeys(): array
-    {
-        // TODO: Implement getScalarKeys() method.
-    }
-
     public function getName(): string
     {
         return self::EVENT_NAME;

--- a/src/Core/Checkout/Customer/Event/CustomerLoginEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerLoginEvent.php
@@ -42,6 +42,11 @@ class CustomerLoginEvent extends Event implements SalesChannelAware, ShopwareSal
         ];
     }
 
+    public static function getScalarKeys(): array
+    {
+        // TODO: Implement getScalarKeys() method.
+    }
+
     public function getName(): string
     {
         return self::EVENT_NAME;

--- a/src/Core/Checkout/Customer/Event/CustomerLoginEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerLoginEvent.php
@@ -2,13 +2,14 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
@@ -47,11 +48,6 @@ class CustomerLoginEvent extends Event implements SalesChannelAware, ShopwareSal
         return self::EVENT_NAME;
     }
 
-    public function getCustomer(): CustomerEntity
-    {
-        return $this->customer;
-    }
-
     public function getSalesChannelContext(): SalesChannelContext
     {
         return $this->salesChannelContext;
@@ -75,8 +71,10 @@ class CustomerLoginEvent extends Event implements SalesChannelAware, ShopwareSal
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class))
-            ->add('contextToken', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->add(FlowMailVariables::CONTEXT_TOKEN, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     public function getCustomerId(): string

--- a/src/Core/Checkout/Customer/Event/CustomerLogoutEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerLogoutEvent.php
@@ -2,11 +2,12 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -56,7 +57,9 @@ class CustomerLogoutEvent extends Event implements SalesChannelAware, ShopwareSa
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class));
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData());
     }
 
     public function getCustomerId(): string

--- a/src/Core/Checkout/Customer/Event/CustomerRegisterEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerRegisterEvent.php
@@ -2,11 +2,12 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -53,7 +54,9 @@ class CustomerRegisterEvent extends Event implements SalesChannelAware, Shopware
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class));
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData());
     }
 
     public function getMailStruct(): MailRecipientStruct

--- a/src/Core/Checkout/Customer/Event/CustomerSetDefaultBillingAddressEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerSetDefaultBillingAddressEvent.php
@@ -2,10 +2,11 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -16,9 +17,10 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CustomerSetDefaultBillingAddressEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, FlowEventAware
+class CustomerSetDefaultBillingAddressEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, CustomerAware, ScalarValuesAware, FlowEventAware
 {
     final public const EVENT_NAME = 'checkout.customer.default.billing.address.event';
+    final public const ADDRESS_ID = 'addressId';
 
     public function __construct(
         private readonly SalesChannelContext $salesChannelContext,
@@ -30,6 +32,11 @@ class CustomerSetDefaultBillingAddressEvent extends Event implements SalesChanne
     public function getName(): string
     {
         return self::EVENT_NAME;
+    }
+
+    public function getCustomerId(): string
+    {
+        return $this->customer->getId();
     }
 
     public function getCustomer(): CustomerEntity
@@ -55,8 +62,8 @@ class CustomerSetDefaultBillingAddressEvent extends Event implements SalesChanne
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class))
-            ->add('contextToken', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->merge(CustomerStorer::getAvailableData())
+            ->add(self::ADDRESS_ID, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     public function getAddressId(): string
@@ -67,5 +74,12 @@ class CustomerSetDefaultBillingAddressEvent extends Event implements SalesChanne
     public function setAddressId(string $addressId): void
     {
         $this->addressId = $addressId;
+    }
+
+    public function getValues(): array
+    {
+        return [
+            self::ADDRESS_ID => $this->addressId,
+        ];
     }
 }

--- a/src/Core/Checkout/Customer/Event/CustomerSetDefaultShippingAddressEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerSetDefaultShippingAddressEvent.php
@@ -2,10 +2,11 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -16,9 +17,10 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CustomerSetDefaultShippingAddressEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, FlowEventAware
+class CustomerSetDefaultShippingAddressEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, CustomerAware, ScalarValuesAware, FlowEventAware
 {
     final public const EVENT_NAME = 'checkout.customer.default.shipping.address.event';
+    final public const ADDRESS_ID = 'addressId';
 
     public function __construct(
         private readonly SalesChannelContext $salesChannelContext,
@@ -30,6 +32,11 @@ class CustomerSetDefaultShippingAddressEvent extends Event implements SalesChann
     public function getName(): string
     {
         return self::EVENT_NAME;
+    }
+
+    public function getCustomerId(): string
+    {
+        return $this->customer->getId();
     }
 
     public function getCustomer(): CustomerEntity
@@ -55,8 +62,8 @@ class CustomerSetDefaultShippingAddressEvent extends Event implements SalesChann
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class))
-            ->add('contextToken', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->merge(CustomerStorer::getAvailableData())
+            ->add(self::ADDRESS_ID, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     public function getAddressId(): string
@@ -67,5 +74,12 @@ class CustomerSetDefaultShippingAddressEvent extends Event implements SalesChann
     public function setAddressId(string $addressId): void
     {
         $this->addressId = $addressId;
+    }
+
+    public function getValues(): array
+    {
+        return [
+            self::ADDRESS_ID => $this->addressId,
+        ];
     }
 }

--- a/src/Core/Checkout/Customer/Event/DoubleOptInGuestOrderEvent.php
+++ b/src/Core/Checkout/Customer/Event/DoubleOptInGuestOrderEvent.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
+use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
 use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;

--- a/src/Core/Checkout/Customer/Event/DoubleOptInGuestOrderEvent.php
+++ b/src/Core/Checkout/Customer/Event/DoubleOptInGuestOrderEvent.php
@@ -2,13 +2,13 @@
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
-use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
@@ -36,8 +36,10 @@ class DoubleOptInGuestOrderEvent extends Event implements SalesChannelAware, Cus
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('customer', new EntityType(CustomerDefinition::class))
-            ->add('confirmUrl', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->add(FlowMailVariables::CONFIRM_URL, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     /**

--- a/src/Core/Checkout/Order/Event/OrderPaymentMethodChangedEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderPaymentMethodChangedEvent.php
@@ -2,15 +2,17 @@
 
 namespace Shopware\Core\Checkout\Order\Event;
 
-use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
-use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderException;
 use Shopware\Core\Content\Flow\Dispatching\Aware\OrderTransactionAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\OrderStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\OrderTransactionStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -83,8 +85,11 @@ class OrderPaymentMethodChangedEvent extends Event implements SalesChannelAware,
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('order', new EntityType(OrderDefinition::class))
-            ->add('orderTransaction', new EntityType(OrderTransactionDefinition::class));
+            ->merge(OrderStorer::getAvailableData())
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(OrderTransactionStorer::getAvailableData());
     }
 
     public function getCustomerId(): string

--- a/src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
@@ -2,23 +2,21 @@
 
 namespace Shopware\Core\Checkout\Order\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
-use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderException;
 use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
+use Shopware\Core\Content\Flow\Dispatching\Storer\A11yRenderedDocumentStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\OrderStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\ArrayType;
-use Shopware\Core\Framework\Event\EventData\AssociativeArrayType;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
-use Shopware\Core\Framework\Event\EventData\ObjectType;
-use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
@@ -46,29 +44,11 @@ class OrderStateMachineStateChangeEvent extends Event implements SalesChannelAwa
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add(self::ORDER_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add(self::ORDER, new EntityType(OrderDefinition::class))
-            ->add(
-                self::MAIL_STRUCT,
-                (new ObjectType())
-                    ->add('bcc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
-                    ->add('cc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
-                    ->add('recipients', new AssociativeArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING), new ScalarValueType(ScalarValueType::TYPE_STRING)))
-            )
-            ->add(self::SALES_CHANNEL_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add(self::TIMEZONE, new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add(self::CUSTOMER_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add(self::CUSTOMER, new EntityType(CustomerDefinition::class))
-            ->add(self::A11Y_DOCUMENT_IDS, new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)))
-            ->add(
-                self::A11Y_DOCUMENTS,
-                new ArrayType(
-                    (new ObjectType())
-                        ->add('documentId', new ScalarValueType(ScalarValueType::TYPE_STRING))
-                        ->add('deepLinkCode', new ScalarValueType(ScalarValueType::TYPE_STRING))
-                        ->add('fileExtension', new ScalarValueType(ScalarValueType::TYPE_STRING))
-                )
-            );
+            ->merge(OrderStorer::getAvailableData())
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(CustomerStorer::getAvailableData())
+            ->merge(A11yRenderedDocumentStorer::getAvailableData());
     }
 
     public function getMailStruct(): MailRecipientStruct

--- a/src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Order\Event;
 
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderException;
@@ -11,9 +12,13 @@ use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
 use Shopware\Core\Framework\Event\CustomerAware;
+use Shopware\Core\Framework\Event\EventData\ArrayType;
+use Shopware\Core\Framework\Event\EventData\AssociativeArrayType;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
+use Shopware\Core\Framework\Event\EventData\ObjectType;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
@@ -41,7 +46,29 @@ class OrderStateMachineStateChangeEvent extends Event implements SalesChannelAwa
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('order', new EntityType(OrderDefinition::class));
+            ->add(self::ORDER_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(self::ORDER, new EntityType(OrderDefinition::class))
+            ->add(
+                self::MAIL_STRUCT,
+                (new ObjectType())
+                    ->add('bcc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
+                    ->add('cc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
+                    ->add('recipients', new AssociativeArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING), new ScalarValueType(ScalarValueType::TYPE_STRING)))
+            )
+            ->add(self::SALES_CHANNEL_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(self::TIMEZONE, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(self::CUSTOMER_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(self::CUSTOMER, new EntityType(CustomerDefinition::class))
+            ->add(self::A11Y_DOCUMENT_IDS, new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)))
+            ->add(
+                self::A11Y_DOCUMENTS,
+                new ArrayType(
+                    (new ObjectType())
+                        ->add('documentId', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                        ->add('deepLinkCode', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                        ->add('fileExtension', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                )
+            );
     }
 
     public function getMailStruct(): MailRecipientStruct

--- a/src/Core/Content/ContactForm/Event/ContactFormEvent.php
+++ b/src/Core/Content/ContactForm/Event/ContactFormEvent.php
@@ -9,13 +9,17 @@ use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\EventData\ArrayType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ForeignKeyType;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\MixedType;
+use Shopware\Core\Framework\Event\EventData\ObjectType;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\SalesChannelAware;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
+use Shopware\Core\System\Salutation\SalutationDefinition;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('discovery')]
@@ -42,7 +46,17 @@ final class ContactFormEvent extends Event implements SalesChannelAware, MailAwa
         return (new EventDataCollection())
             ->merge(MailStorer::getAvailableData())
             ->merge(TimezoneStorer::getAvailableData())
-            ->add(FlowMailVariables::CONTACT_FORM_DATA, new ArrayType(new MixedType()));
+            ->add(
+                FlowMailVariables::CONTACT_FORM_DATA,
+                (new ObjectType())
+                    ->add('salutationId', new ForeignKeyType(SalutationDefinition::class))
+                    ->add('email', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('subject', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('comment', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('firstName', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('lastName', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('phone', new ScalarValueType(ScalarValueType::TYPE_STRING))
+            );
     }
 
     /**

--- a/src/Core/Content/ContactForm/Event/ContactFormEvent.php
+++ b/src/Core/Content/ContactForm/Event/ContactFormEvent.php
@@ -4,10 +4,13 @@ namespace Shopware\Core\Content\ContactForm\Event;
 
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\EventData\ArrayType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
-use Shopware\Core\Framework\Event\EventData\ObjectType;
+use Shopware\Core\Framework\Event\EventData\MixedType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\SalesChannelAware;
@@ -37,7 +40,9 @@ final class ContactFormEvent extends Event implements SalesChannelAware, MailAwa
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('contactFormData', new ObjectType());
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->add(FlowMailVariables::CONTACT_FORM_DATA, new ArrayType(new MixedType()));
     }
 
     /**

--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -38,9 +38,17 @@
         <service id="Shopware\Core\Content\MailTemplate\Api\MailActionController" public="true">
             <argument type="service" id="Shopware\Core\Content\Mail\Service\MailService"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer"/>
+            <argument type="service" id="Shopware\Core\Content\MailTemplate\Service\MailTemplateService"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
+        </service>
+
+        <!-- Service -->
+        <service id="Shopware\Core\Content\MailTemplate\Service\MailTemplateService">
+            <argument type="service" id="twig"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
         </service>
 
         <!-- Sending -->

--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -49,6 +49,7 @@
             <argument type="service" id="twig"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer"/>
         </service>
 
         <!-- Sending -->

--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -49,7 +49,6 @@
             <argument type="service" id="twig"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
-            <argument type="service" id="Shopware\Core\Framework\Validation\DataValidator"/>
         </service>
 
         <!-- Sending -->

--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -49,6 +49,7 @@
             <argument type="service" id="twig"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Framework\Validation\DataValidator"/>
         </service>
 
         <!-- Sending -->

--- a/src/Core/Content/Flow/Dispatching/Aware/ScalarValuesAware.php
+++ b/src/Core/Content/Flow/Dispatching/Aware/ScalarValuesAware.php
@@ -15,4 +15,6 @@ interface ScalarValuesAware
      * @return array<string, scalar|array<mixed>|null>
      */
     public function getValues(): array;
+
+    public static function getScalarKeys(): array;
 }

--- a/src/Core/Content/Flow/Dispatching/Aware/ScalarValuesAware.php
+++ b/src/Core/Content/Flow/Dispatching/Aware/ScalarValuesAware.php
@@ -15,6 +15,4 @@ interface ScalarValuesAware
      * @return array<string, scalar|array<mixed>|null>
      */
     public function getValues(): array;
-
-    public static function getScalarKeys(): array;
 }

--- a/src/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorer.php
@@ -11,6 +11,10 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
+use Shopware\Core\Framework\Event\EventData\ArrayType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ObjectType;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Log\Package;
@@ -32,6 +36,21 @@ class A11yRenderedDocumentStorer extends FlowStorer
         private readonly EventDispatcherInterface $dispatcher,
         private readonly MailAttachmentsBuilder $mailAttachmentsBuilder
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS, new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)))
+            ->add(
+                A11yRenderedDocumentAware::A11Y_DOCUMENTS,
+                new ArrayType(
+                    (new ObjectType())
+                        ->add('documentId', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                        ->add('deepLinkCode', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                        ->add('fileExtension', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                )
+            );
     }
 
     public function store(FlowEventAware $event, array $stored): array

--- a/src/Core/Content/Flow/Dispatching/Storer/CustomAppStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/CustomAppStorer.php
@@ -5,12 +5,18 @@ namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 use Shopware\Core\Content\Flow\Dispatching\Aware\CustomAppAware;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
 class CustomAppStorer extends FlowStorer
 {
+    public static function getAvailableData(): EventDataCollection
+    {
+        return new EventDataCollection();
+    }
+
     /**
      * @param array<string, mixed> $stored
      *

--- a/src/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorer.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\CustomerGroupAware;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -27,6 +30,13 @@ class CustomerGroupStorer extends FlowStorer
         private readonly EntityRepository $customerGroupRepository,
         private readonly EventDispatcherInterface $dispatcher
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(CustomerGroupAware::CUSTOMER_GROUP_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(CustomerGroupAware::CUSTOMER_GROUP, new EntityType(CustomerGroupDefinition::class));
     }
 
     /**

--- a/src/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorer.php
@@ -11,6 +11,9 @@ use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -27,6 +30,13 @@ class CustomerRecoveryStorer extends FlowStorer
         private readonly EntityRepository $customerRecoveryRepository,
         private readonly EventDispatcherInterface $dispatcher
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(CustomerRecoveryAware::CUSTOMER_RECOVERY_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(CustomerRecoveryAware::CUSTOMER_RECOVERY, (new EntityType(CustomerRecoveryDefinition::class))->setNullable());
     }
 
     /**

--- a/src/Core/Content/Flow/Dispatching/Storer/CustomerStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/CustomerStorer.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\CustomerAware;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -28,6 +31,13 @@ class CustomerStorer extends FlowStorer
         private readonly EntityRepository $customerRepository,
         private readonly EventDispatcherInterface $dispatcher
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(CustomerAware::CUSTOMER_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(CustomerAware::CUSTOMER, (new EntityType(CustomerDefinition::class))->setNullable());
     }
 
     /**

--- a/src/Core/Content/Flow/Dispatching/Storer/FlowStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/FlowStorer.php
@@ -3,12 +3,15 @@
 namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
 abstract class FlowStorer
 {
+    abstract public static function getAvailableData(): EventDataCollection;
+
     /**
      * @param array<string, mixed> $stored
      *

--- a/src/Core/Content/Flow/Dispatching/Storer/LanguageStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/LanguageStorer.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\LanguageAware;
 use Shopware\Core\Framework\Log\Package;
@@ -10,6 +12,12 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('after-sales')]
 class LanguageStorer extends FlowStorer
 {
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(LanguageAware::LANGUAGE_ID, (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable());
+    }
+
     /**
      * @param array<string, mixed> $stored
      *

--- a/src/Core/Content/Flow/Dispatching/Storer/MailStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/MailStorer.php
@@ -7,7 +7,11 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
 use Shopware\Core\Framework\Event\CustomerAware;
+use Shopware\Core\Framework\Event\EventData\AssociativeArrayType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
+use Shopware\Core\Framework\Event\EventData\ObjectType;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
@@ -16,6 +20,19 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('after-sales')]
 class MailStorer extends FlowStorer
 {
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(
+                MailAware::MAIL_STRUCT,
+                (new ObjectType())
+                    ->add('recipients', new AssociativeArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING), new ScalarValueType(ScalarValueType::TYPE_STRING)))
+                    ->add('bcc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
+                    ->add('cc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
+            )
+            ->add(MailAware::SALES_CHANNEL_ID, (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable());
+    }
+
     /**
      * @param array<string, mixed> $stored
      *

--- a/src/Core/Content/Flow/Dispatching/Storer/MessageStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/MessageStorer.php
@@ -4,12 +4,20 @@ namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
 use Shopware\Core\Content\Flow\Dispatching\Aware\MessageAware;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
 class MessageStorer extends FlowStorer
 {
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(MessageAware::MESSAGE, new ScalarValueType(ScalarValueType::TYPE_STRING));
+    }
+
     /**
      * @param array<mixed> $stored
      *

--- a/src/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorer.php
@@ -11,6 +11,9 @@ use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRec
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -18,6 +21,13 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[Package('after-sales')]
 class NewsletterRecipientStorer extends FlowStorer
 {
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(NewsletterRecipientAware::NEWSLETTER_RECIPIENT_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(NewsletterRecipientAware::NEWSLETTER_RECIPIENT, (new EntityType(NewsletterRecipientDefinition::class))->setNullable());
+    }
+
     /**
      * @internal
      *

--- a/src/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorer.php
@@ -21,13 +21,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[Package('after-sales')]
 class NewsletterRecipientStorer extends FlowStorer
 {
-    public static function getAvailableData(): EventDataCollection
-    {
-        return (new EventDataCollection())
-            ->add(NewsletterRecipientAware::NEWSLETTER_RECIPIENT_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add(NewsletterRecipientAware::NEWSLETTER_RECIPIENT, (new EntityType(NewsletterRecipientDefinition::class))->setNullable());
-    }
-
     /**
      * @internal
      *
@@ -37,6 +30,13 @@ class NewsletterRecipientStorer extends FlowStorer
         private readonly EntityRepository $newsletterRecipientRepository,
         private readonly EventDispatcherInterface $dispatcher
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(NewsletterRecipientAware::NEWSLETTER_RECIPIENT_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(NewsletterRecipientAware::NEWSLETTER_RECIPIENT, (new EntityType(NewsletterRecipientDefinition::class))->setNullable());
     }
 
     /**

--- a/src/Core/Content/Flow/Dispatching/Storer/OrderStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/OrderStorer.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Log\Package;
@@ -28,6 +31,13 @@ class OrderStorer extends FlowStorer
         private readonly EntityRepository $orderRepository,
         private readonly EventDispatcherInterface $dispatcher
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(OrderAware::ORDER_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(OrderAware::ORDER, (new EntityType(OrderDefinition::class))->setNullable());
     }
 
     public function store(FlowEventAware $event, array $stored): array

--- a/src/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorer.php
@@ -11,6 +11,9 @@ use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -27,6 +30,13 @@ class OrderTransactionStorer extends FlowStorer
         private readonly EntityRepository $orderTransactionRepository,
         private readonly EventDispatcherInterface $dispatcher
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(OrderTransactionAware::ORDER_TRANSACTION_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(OrderTransactionAware::ORDER_TRANSACTION, (new EntityType(OrderTransactionDefinition::class))->setNullable());
     }
 
     /**

--- a/src/Core/Content/Flow/Dispatching/Storer/ProductStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/ProductStorer.php
@@ -10,6 +10,9 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\ProductAware;
 use Shopware\Core\Framework\Log\Package;
@@ -27,6 +30,13 @@ class ProductStorer extends FlowStorer
         private readonly EntityRepository $productRepository,
         private readonly EventDispatcherInterface $dispatcher
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(ProductAware::PRODUCT_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(ProductAware::PRODUCT, (new EntityType(ProductDefinition::class))->setNullable());
     }
 
     public function store(FlowEventAware $event, array $stored): array

--- a/src/Core/Content/Flow/Dispatching/Storer/ScalarValuesStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/ScalarValuesStorer.php
@@ -47,14 +47,4 @@ class ScalarValuesStorer extends FlowStorer
             $storable->setData($key, $value);
         }
     }
-
-    private function filterValues(array $values, array $valueMapping): array
-    {
-        $filteredValues = [];
-
-        for ($idx = 0; $idx < \count($values); ++$idx) {
-            if (\is_array($value)) {
-            }
-        }
-    }
 }

--- a/src/Core/Content/Flow/Dispatching/Storer/ScalarValuesStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/ScalarValuesStorer.php
@@ -41,4 +41,14 @@ class ScalarValuesStorer extends FlowStorer
             $storable->setData($key, $value);
         }
     }
+
+    private function filterValues(array $values, array $valueMapping): array
+    {
+        $filteredValues = [];
+
+        for ($idx = 0; $idx < \count($values); ++$idx) {
+            if (\is_array($value)) {
+            }
+        }
+    }
 }

--- a/src/Core/Content/Flow/Dispatching/Storer/ScalarValuesStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/ScalarValuesStorer.php
@@ -4,12 +4,18 @@ namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
 class ScalarValuesStorer extends FlowStorer
 {
+    public static function getAvailableData(): EventDataCollection
+    {
+        return new EventDataCollection();
+    }
+
     /**
      * @param array<string, mixed> $stored
      *

--- a/src/Core/Content/Flow/Dispatching/Storer/TimezoneStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/TimezoneStorer.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Log\Package;
@@ -19,6 +21,12 @@ class TimezoneStorer extends FlowStorer
     public function __construct(
         private readonly RequestStack $requestStack,
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(MailAware::TIMEZONE, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     /**

--- a/src/Core/Content/Flow/Dispatching/Storer/UserStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/UserStorer.php
@@ -7,6 +7,9 @@ use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\UserAware;
 use Shopware\Core\Framework\Log\Package;
@@ -27,6 +30,13 @@ class UserStorer extends FlowStorer
         private readonly EntityRepository $userRecoveryRepository,
         private readonly EventDispatcherInterface $dispatcher
     ) {
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add(UserAware::USER_RECOVERY_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(UserAware::USER_RECOVERY, (new EntityType(UserRecoveryEntity::class))->setNullable());
     }
 
     public function store(FlowEventAware $event, array $stored): array

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -85,11 +85,7 @@ class MailActionController extends AbstractController
             $errors[$name] = $this->mailTemplateService->validateTemplate($content, $vars);
         }
 
-        if (!empty($errors)) {
-            return new JsonResponse($errors, Response::HTTP_BAD_REQUEST);
-        }
-
-        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+        return new JsonResponse($errors, Response::HTTP_OK);
     }
 
     #[Route(

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -12,10 +12,13 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,9 +33,9 @@ class MailActionController extends AbstractController
      * @internal
      */
     public function __construct(
-        private readonly AbstractMailService $mailService,
+        private readonly AbstractMailService    $mailService,
         private readonly StringTemplateRenderer $templateRenderer,
-        private readonly MailTemplateService $mailTemplateService,
+        private readonly MailTemplateService    $mailTemplateService,
     ) {
     }
 
@@ -74,30 +77,12 @@ class MailActionController extends AbstractController
     )]
     public function validate(RequestDataBag $post, Context $context): JsonResponse
     {
-        /*
-         * Example call for version 1
-         */
-        $availableVariables = $this->mailTemplateService->getMailTemplateAvailableVariablesV1(
-            $this->mailTemplateService->getFlowEventClass($post->get('mailTemplateType'))
-        );
+        $vars = $post->get('flowEventClass')::getAvailableData()
+            ->add('salesChannel', new EntityType(SalesChannelDefinition::class));
 
-        $this->mailTemplateService->validateMailTemplateV1($post->get('subject', ''), $availableVariables);
-        $this->mailTemplateService->validateMailTemplateV1($post->get('senderName', ''), $availableVariables);
-        $this->mailTemplateService->validateMailTemplateV1($post->get('contentPlain', ''), $availableVariables);
-        $this->mailTemplateService->validateMailTemplateV1($post->get('contentHtml', ''), $availableVariables);
-
-
-        /*
-         * Example call for version 2
-         */
-        $availableVariables = $this->mailTemplateService->getMailTemplateAvailableVariablesV2(
-            $this->mailTemplateService->getFlowEventClass($post->get('mailTemplateType'))
-        );
-
-        $this->mailTemplateService->validateMailTemplateV2($post->get('subject', ''), $availableVariables);
-        $this->mailTemplateService->validateMailTemplateV2($post->get('senderName', ''), $availableVariables);
-        $this->mailTemplateService->validateMailTemplateV2($post->get('contentPlain', ''), $availableVariables);
-        $this->mailTemplateService->validateMailTemplateV2($post->get('contentHtml', ''), $availableVariables);
+        foreach ($post->get('mailTemplateContent') as $name => $content) {
+            $this->mailTemplateService->validateTemplate($content, $vars);
+        }
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -8,12 +8,9 @@ use Shopware\Core\Content\MailTemplate\MailTemplateEntity;
 use Shopware\Core\Content\MailTemplate\MailTemplateException;
 use Shopware\Core\Content\MailTemplate\Service\MailTemplateService;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
-use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\Event\EventData\EntityType;
-use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -33,9 +30,9 @@ class MailActionController extends AbstractController
      * @internal
      */
     public function __construct(
-        private readonly AbstractMailService    $mailService,
+        private readonly AbstractMailService $mailService,
         private readonly StringTemplateRenderer $templateRenderer,
-        private readonly MailTemplateService    $mailTemplateService,
+        private readonly MailTemplateService $mailTemplateService,
     ) {
     }
 

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -81,6 +81,7 @@ class MailActionController extends AbstractController
         $validationResponses = new MailTemplateValidationResponseCollection();
 
         foreach ($post->get('mailTemplateContent') as $mailTemplateField => $content) {
+            $this->mailTemplateService->render($content, $post->get('flowEventClass'), $context);
             $this->mailTemplateService->validateTemplate($mailTemplateField, $content, $vars, $validationResponses);
         }
 

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -6,9 +6,12 @@ use Shopware\Core\Content\Mail\Service\AbstractMailService;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsConfig;
 use Shopware\Core\Content\MailTemplate\MailTemplateEntity;
 use Shopware\Core\Content\MailTemplate\MailTemplateException;
+use Shopware\Core\Content\MailTemplate\Service\MailTemplateService;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
+use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -28,7 +31,8 @@ class MailActionController extends AbstractController
      */
     public function __construct(
         private readonly AbstractMailService $mailService,
-        private readonly StringTemplateRenderer $templateRenderer
+        private readonly StringTemplateRenderer $templateRenderer,
+        private readonly MailTemplateService $mailTemplateService,
     ) {
     }
 
@@ -70,9 +74,30 @@ class MailActionController extends AbstractController
     )]
     public function validate(RequestDataBag $post, Context $context): JsonResponse
     {
-        $this->templateRenderer->initialize();
-        $this->templateRenderer->render($post->get('contentHtml', ''), [], $context);
-        $this->templateRenderer->render($post->get('contentPlain', ''), [], $context);
+        /*
+         * Example call for version 1
+         */
+        $availableVariables = $this->mailTemplateService->getMailTemplateAvailableVariablesV1(
+            $this->mailTemplateService->getFlowEventClass($post->get('mailTemplateType'))
+        );
+
+        $this->mailTemplateService->validateMailTemplateV1($post->get('subject', ''), $availableVariables);
+        $this->mailTemplateService->validateMailTemplateV1($post->get('senderName', ''), $availableVariables);
+        $this->mailTemplateService->validateMailTemplateV1($post->get('contentPlain', ''), $availableVariables);
+        $this->mailTemplateService->validateMailTemplateV1($post->get('contentHtml', ''), $availableVariables);
+
+
+        /*
+         * Example call for version 2
+         */
+        $availableVariables = $this->mailTemplateService->getMailTemplateAvailableVariablesV2(
+            $this->mailTemplateService->getFlowEventClass($post->get('mailTemplateType'))
+        );
+
+        $this->mailTemplateService->validateMailTemplateV2($post->get('subject', ''), $availableVariables);
+        $this->mailTemplateService->validateMailTemplateV2($post->get('senderName', ''), $availableVariables);
+        $this->mailTemplateService->validateMailTemplateV2($post->get('contentPlain', ''), $availableVariables);
+        $this->mailTemplateService->validateMailTemplateV2($post->get('contentHtml', ''), $availableVariables);
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\MailTemplate\MailTemplateEntity;
 use Shopware\Core\Content\MailTemplate\MailTemplateException;
 use Shopware\Core\Content\MailTemplate\Service\MailTemplateService;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseCollection;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\EventData\EntityType;
@@ -77,12 +78,13 @@ class MailActionController extends AbstractController
         $vars = $post->get('flowEventClass')::getAvailableData()
             ->add('salesChannel', new EntityType(SalesChannelDefinition::class));
 
-        $errors = [];
-        foreach ($post->get('mailTemplateContent') as $name => $content) {
-            $errors[$name] = $this->mailTemplateService->validateTemplate($content, $vars);
+        $validationResponses = new MailTemplateValidationResponseCollection();
+
+        foreach ($post->get('mailTemplateContent') as $mailTemplateField => $content) {
+            $this->mailTemplateService->validateTemplate($mailTemplateField, $content, $vars, $validationResponses);
         }
 
-        return new JsonResponse($errors, Response::HTTP_OK);
+        return new JsonResponse($validationResponses, Response::HTTP_OK);
     }
 
     #[Route(

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -80,8 +80,13 @@ class MailActionController extends AbstractController
         $vars = $post->get('flowEventClass')::getAvailableData()
             ->add('salesChannel', new EntityType(SalesChannelDefinition::class));
 
+        $errors = [];
         foreach ($post->get('mailTemplateContent') as $name => $content) {
-            $this->mailTemplateService->validateTemplate($content, $vars);
+            $errors[$name] = $this->mailTemplateService->validateTemplate($content, $vars);
+        }
+
+        if (!empty($errors)) {
+            return new JsonResponse($errors, Response::HTTP_BAD_REQUEST);
         }
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -78,14 +78,13 @@ class MailActionController extends AbstractController
         $vars = $post->get('flowEventClass')::getAvailableData()
             ->add('salesChannel', new EntityType(SalesChannelDefinition::class));
 
-        $validationResponses = new MailTemplateValidationResponseCollection();
+        $renderResult = [];
 
         foreach ($post->get('mailTemplateContent') as $mailTemplateField => $content) {
-            $this->mailTemplateService->render($content, $post->get('flowEventClass'), $context);
-            $this->mailTemplateService->validateTemplate($mailTemplateField, $content, $vars, $validationResponses);
+            $renderResult[$mailTemplateField] = $this->mailTemplateService->render($content, $post->get('flowEventClass'), $context);
         }
 
-        return new JsonResponse($validationResponses, Response::HTTP_OK);
+        return new JsonResponse($renderResult, Response::HTTP_OK);
     }
 
     #[Route(

--- a/src/Core/Content/MailTemplate/MailTemplateException.php
+++ b/src/Core/Content/MailTemplate/MailTemplateException.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 class MailTemplateException extends HttpException
 {
     public const MAIL_INVALID_TEMPLATE_CONTENT = 'CONTENT__INVALID_MAIL_TEMPLATE_CONTENT';
+    public const MAIL_INVALID_VALIDATION_RESPONSE_LINE = 'CONTENT__INVALID_MAIL_TEMPLATE_VALIDATION_RESPONSE_LINE';
 
     public static function invalidMailTemplateContent(): self
     {
@@ -17,6 +18,15 @@ class MailTemplateException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::MAIL_INVALID_TEMPLATE_CONTENT,
             'Invalid Mail Template content under "mailTemplate.contentHtml" parameter, please send the plain template as string.'
+        );
+    }
+
+    public static function invalidMailTemplateValidationResponseLineNumber(): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::MAIL_INVALID_VALIDATION_RESPONSE_LINE,
+            'Invalid email template validation response line number.'
         );
     }
 }

--- a/src/Core/Content/MailTemplate/Service/Event/MailBeforeSentEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailBeforeSentEvent.php
@@ -41,11 +41,6 @@ class MailBeforeSentEvent extends Event implements LogAware, MessageAware, Scala
         return [FlowMailVariables::DATA => $this->data];
     }
 
-    public static function getScalarKeys(): array
-    {
-        // TODO: Implement getScalarKeys() method.
-    }
-
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())

--- a/src/Core/Content/MailTemplate/Service/Event/MailBeforeSentEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailBeforeSentEvent.php
@@ -6,10 +6,10 @@ use Monolog\Level;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\MessageAware;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MessageStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\EventData\ArrayType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
-use Shopware\Core\Framework\Event\EventData\ObjectType;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Log\LogAware;
@@ -44,8 +44,8 @@ class MailBeforeSentEvent extends Event implements LogAware, MessageAware, Scala
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('data', new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)))
-            ->add('message', new ObjectType());
+            ->merge(MessageStorer::getAvailableData())
+            ->add(FlowMailVariables::DATA, new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)));
     }
 
     public function getName(): string

--- a/src/Core/Content/MailTemplate/Service/Event/MailBeforeSentEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailBeforeSentEvent.php
@@ -41,6 +41,11 @@ class MailBeforeSentEvent extends Event implements LogAware, MessageAware, Scala
         return [FlowMailVariables::DATA => $this->data];
     }
 
+    public static function getScalarKeys(): array
+    {
+        // TODO: Implement getScalarKeys() method.
+    }
+
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())

--- a/src/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEvent.php
@@ -33,8 +33,8 @@ class MailBeforeValidateEvent extends Event implements LogAware, ScalarValuesAwa
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('data', new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)))
-            ->add('templateData', new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)));
+            ->add(FlowMailVariables::DATA, new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)))
+            ->add(FlowMailVariables::TEMPLATE_DATA, new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)));
     }
 
     public function getName(): string

--- a/src/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEvent.php
@@ -53,6 +53,11 @@ class MailBeforeValidateEvent extends Event implements LogAware, ScalarValuesAwa
         ];
     }
 
+    public static function getScalarKeys(): array
+    {
+        // TODO: Implement getScalarKeys() method.
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/src/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEvent.php
@@ -53,11 +53,6 @@ class MailBeforeValidateEvent extends Event implements LogAware, ScalarValuesAwa
         ];
     }
 
-    public static function getScalarKeys(): array
-    {
-        // TODO: Implement getScalarKeys() method.
-    }
-
     /**
      * @return array<string, mixed>
      */

--- a/src/Core/Content/MailTemplate/Service/Event/MailErrorEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailErrorEvent.php
@@ -97,7 +97,7 @@ class MailErrorEvent extends Event implements LogAware, ScalarValuesAware, FlowE
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('name', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->add(FlowMailVariables::EVENT_NAME, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     public function getTemplate(): ?string

--- a/src/Core/Content/MailTemplate/Service/Event/MailErrorEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailErrorEvent.php
@@ -42,11 +42,6 @@ class MailErrorEvent extends Event implements LogAware, ScalarValuesAware, FlowE
         return [FlowMailVariables::EVENT_NAME => self::NAME];
     }
 
-    public static function getScalarKeys(): array
-    {
-        // TODO: Implement getScalarKeys() method.
-    }
-
     public function getThrowable(): ?\Throwable
     {
         return $this->throwable;

--- a/src/Core/Content/MailTemplate/Service/Event/MailErrorEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailErrorEvent.php
@@ -42,6 +42,11 @@ class MailErrorEvent extends Event implements LogAware, ScalarValuesAware, FlowE
         return [FlowMailVariables::EVENT_NAME => self::NAME];
     }
 
+    public static function getScalarKeys(): array
+    {
+        // TODO: Implement getScalarKeys() method.
+    }
+
     public function getThrowable(): ?\Throwable
     {
         return $this->throwable;

--- a/src/Core/Content/MailTemplate/Service/Event/MailSentEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailSentEvent.php
@@ -35,9 +35,9 @@ class MailSentEvent extends Event implements LogAware, ScalarValuesAware, FlowEv
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('subject', new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add('contents', new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add('recipients', new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)));
+            ->add(FlowMailVariables::SUBJECT, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(FlowMailVariables::CONTENTS, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(FlowMailVariables::RECIPIENTS, new ArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING)));
     }
 
     public function getName(): string

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -1,0 +1,262 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate\Service;
+
+use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\Review\Event\ReviewFormEvent;
+use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
+use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
+use Shopware\Core\Framework\DataAbstractionLayer\CompiledFieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ParentAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\Event\ProductAware;
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\ArrayNormalizer;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
+use Twig\Environment;
+
+#[Package('after-sales')]
+class MailTemplateService
+{
+    private readonly TwigVariableParser $twigVariableParser;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        Environment $twig,
+        private readonly TwigVariableParserFactory $twigVariableParserFactory,
+        private readonly DefinitionInstanceRegistry $definitionRegistry,
+    ) {
+        $this->twigVariableParser = $this->twigVariableParserFactory->getParser($twig);
+    }
+
+    /**
+     * Utility to provide the context for the mail template (only works for FlowEvents)
+     */
+    public function getFlowEventClass($mailTemplateType): ?string
+    {
+        return match ($mailTemplateType) {
+            MailTemplateTypes::MAILTYPE_REVIEW_FORM => ReviewFormEvent::class,
+            // ... (other mail template types)
+            default => null,
+        };
+    }
+
+    /**
+     * Utility where the twig template is parsed and which returns the used variables.
+     * This is the location, where we could catch twig syntax errors.
+     */
+    private function parseMailTemplate(string $mailTemplate): array
+    {
+        return $this->twigVariableParser->parse($mailTemplate);
+    }
+
+    /*
+     * #####################
+     * ##    Version 1    ##
+     * #####################
+     *
+     * Will be called multiple times (once per mail template) so that the provided $availableVariables gets updated accordingly.
+     * This way we only need to resolve the fields for the entities once and not multiple times.
+     */
+    public function validateMailTemplateV1(string $mailTemplate, array &$availableVariables): void
+    {
+        $variables = ArrayNormalizer::expand(array_flip($this->parseMailTemplate($mailTemplate)));
+        $this->validateMailTemplateVariables($variables, $availableVariables);
+    }
+
+    private function validateMailTemplateVariables(array $variables, array &$availableVariables): void
+    {
+        for ($idx = 0; $idx < \count($variables); ++$idx) {
+            $key = array_keys($variables)[$idx];
+            $variable = $variables[$key];
+            if (!\array_key_exists($key, $availableVariables)) {
+                dd('Mail template variable ' . $key . ' does not exist');
+
+                return;
+            }
+
+            if (\is_array($variable)) {
+                array_walk($variable, function ($sub_value, $sub_key) use ($key, &$variables): void {
+                    $variables[$key . '.' . $sub_key] = $sub_value;
+                });
+            }
+
+            if (\is_callable($availableVariables[$key])) {
+                $availableVariables[$key] = $availableVariables[$key]();
+            }
+
+            if (\is_array($availableVariables[$key])) {
+                array_walk($availableVariables[$key], function ($sub_value, $sub_key) use ($key, &$availableVariables): void {
+                    if (\is_array($sub_value) || \is_callable($sub_value)) {
+                        $availableVariables[$key . '.' . $sub_key] = $sub_value;
+
+                        return;
+                    }
+                    $availableVariables[$key . '.' . $sub_value] = $sub_key;
+                });
+            }
+        }
+    }
+
+    public function getMailTemplateAvailableVariablesV1(string $flowEventClass): array
+    {
+        $entityAwares = class_implements($flowEventClass);
+
+        $templateData = [];
+
+        foreach ($entityAwares as $entityAware) {
+            switch ($entityAware) {
+                case ScalarValuesAware::class:
+                    /*
+                     * Expects the $flowEventClass::getScalarKeys() to be in a structure like
+                     *
+                     * [
+                     *    'a' => [
+                     *       'b',
+                     *       'c',
+                     *    ],
+                     *    'd',
+                     * ]
+                     */
+                    $templateData = array_merge($templateData, $flowEventClass::getScalarKeys());
+                    break;
+                case ProductAware::class:
+                    $templateData[ProductAware::PRODUCT_ID] = '';
+                    $productDefinition = $this->definitionRegistry->get(ProductDefinition::class);
+                    $templateData[ProductAware::PRODUCT] = fn () => $this->lazyLoadVariables($productDefinition, $productDefinition->getFields());
+                    break;
+                case SalesChannelAware::class:
+                    $templateData['salesChannelId'] = '';
+                    $salesChannelDefinition = $this->definitionRegistry->get(SalesChannelDefinition::class);
+                    $templateData['salesChannel'] = fn () => $this->lazyLoadVariables($salesChannelDefinition, $salesChannelDefinition->getFields());
+                    break;
+            }
+        }
+
+        return $templateData;
+    }
+
+    /**
+     * Tries to mimic the selective behavior of a query with an empty criteria.
+     * Refer EntityReader::joinBasic(...)
+     */
+    private function lazyLoadVariables(EntityDefinition $entityDefinition, CompiledFieldCollection $fields): array
+    {
+        $variables = [];
+
+        foreach ($fields as $field) {
+            if (!$field instanceof ParentAssociationField && $field instanceof AssociationField && $field->getAutoload() && $field->getReferenceDefinition() === $entityDefinition) {
+                continue;
+            }
+
+            if ($field instanceof ManyToManyAssociationField || $field->is(Runtime::class)) {
+                continue;
+            }
+
+            if ($field instanceof ManyToOneAssociationField || $field instanceof OneToOneAssociationField) {
+                $subEntityDefinition = $this->definitionRegistry->get($field->getReferenceClass());
+                $variables[$field->getPropertyName()] = fn () => $this->lazyLoadVariables($subEntityDefinition, $subEntityDefinition->getFields()->getBasicFields());
+                continue;
+            }
+
+            if ($field instanceof TranslatedField) {
+                $variables[] = $field->getPropertyName();
+
+                if (!isset($variables['translated'])) {
+                    $variables['translated'] = [];
+                }
+
+                $variables['translated'][] = $field->getPropertyName();
+                continue;
+            }
+
+            if ($field instanceof StorageAware) {
+                $variables[] = $field->getPropertyName();
+                continue;
+            }
+        }
+
+        return $variables;
+    }
+
+    /*
+     * #####################
+     * ##    Version 2    ##
+     * #####################
+     */
+    public function validateMailTemplateV2(array $usedVariables, array $availableVariables): void
+    {
+        foreach ($usedVariables as $usedVariable) {
+            if (\array_key_exists($usedVariable, $availableVariables)) {
+                continue;
+            }
+
+            $prefix = explode('.', $usedVariable)[0];
+
+            if (\is_callable($availableVariables[$prefix])) {
+                $pos = mb_strpos($usedVariable, '.');
+                if (!$pos) {
+                    dd('Entity ' . $prefix . ' cannot be processed as a whole!');
+                }
+                $fieldName = mb_substr($usedVariable, $pos + 1);
+                $field = $availableVariables[$prefix]($fieldName, $prefix);
+                if ($field) {
+                    continue;
+                }
+            }
+
+            dd('Unknown variable: ' . $usedVariable);
+        }
+    }
+
+    /*
+     * In this version I just go via the EntityDefinitionQueryHelper to look if a field could exist behind a certain path.
+     */
+    public function getMailTemplateAvailableVariablesV2(string $flowEventClass): array
+    {
+        $entityAwares = class_implements(ReviewFormEvent::class);
+
+        $templateData = [];
+
+        foreach ($entityAwares as $entityAware) {
+            switch ($entityAware) {
+                case ScalarValuesAware::class:
+                    /*
+                     * Expects the $flowEventClass::getScalarKeys() to be in a structure like
+                     *
+                     * [
+                     *    'a' => [],
+                     *    'a.b' => '',
+                     *    'c' => 0,      <- Idea: Provided datatype should hint to the actual data type
+                     * ]
+                     */
+                    $templateData = array_merge($templateData, ReviewFormEvent::getScalarKeys());
+                    break;
+                case ProductAware::class:
+                    $templateData[ProductAware::PRODUCT_ID] = '';
+                    $templateData[ProductAware::PRODUCT] = fn ($field, $prefix) => EntityDefinitionQueryHelper::getField($field, $this->definitionRegistry->get(ProductDefinition::class), $prefix);
+                    break;
+                case SalesChannelAware::class:
+                    $templateData['salesChannelId'] = '';
+                    $templateData['salesChannel'] = fn ($field, $prefix) => EntityDefinitionQueryHelper::getField($field, $this->definitionRegistry->get(SalesChannelDefinition::class), $prefix);
+                    break;
+            }
+        }
+
+        return $templateData;
+    }
+}

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -2,29 +2,17 @@
 
 namespace Shopware\Core\Content\MailTemplate\Service;
 
-use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
-use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
-use Shopware\Core\Content\Product\ProductDefinition;
-use Shopware\Core\Content\Product\SalesChannel\Review\Event\ReviewFormEvent;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
-use Shopware\Core\Framework\DataAbstractionLayer\CompiledFieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\ParentAssociationField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
-use Shopware\Core\Framework\Event\ProductAware;
-use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\Event\EventData\ArrayType;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\ArrayNormalizer;
-use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Twig\Environment;
 
 #[Package('after-sales')]
@@ -43,220 +31,91 @@ class MailTemplateService
         $this->twigVariableParser = $this->twigVariableParserFactory->getParser($twig);
     }
 
-    /**
-     * Utility to provide the context for the mail template (only works for FlowEvents)
-     */
-    public function getFlowEventClass($mailTemplateType): ?string
+    public function validateTemplate(string $mailTemplate, EventDataCollection $availableVariables): void
     {
-        return match ($mailTemplateType) {
-            MailTemplateTypes::MAILTYPE_REVIEW_FORM => ReviewFormEvent::class,
-            // ... (other mail template types)
-            default => null,
-        };
+        $usedVariables = $this->twigVariableParser->parse($mailTemplate);
+        $this->validateVariables($usedVariables, $availableVariables);
     }
 
-    /**
-     * Utility where the twig template is parsed and which returns the used variables.
-     * This is the location, where we could catch twig syntax errors.
-     */
-    private function parseMailTemplate(string $mailTemplate): array
+    public function validateVariables(array $usedVariables, EventDataCollection $availableVariables): void
     {
-        return $this->twigVariableParser->parse($mailTemplate);
-    }
-
-    /*
-     * #####################
-     * ##    Version 1    ##
-     * #####################
-     *
-     * Will be called multiple times (once per mail template) so that the provided $availableVariables gets updated accordingly.
-     * This way we only need to resolve the fields for the entities once and not multiple times.
-     */
-    public function validateMailTemplateV1(string $mailTemplate, array &$availableVariables): void
-    {
-        $variables = ArrayNormalizer::expand(array_flip($this->parseMailTemplate($mailTemplate)));
-        $this->validateMailTemplateVariables($variables, $availableVariables);
-    }
-
-    private function validateMailTemplateVariables(array $variables, array &$availableVariables): void
-    {
-        for ($idx = 0; $idx < \count($variables); ++$idx) {
-            $key = array_keys($variables)[$idx];
-            $variable = $variables[$key];
-            if (!\array_key_exists($key, $availableVariables)) {
-                dd('Mail template variable ' . $key . ' does not exist');
-
-                return;
+        foreach ($usedVariables as $var) {
+            if ($availableVariables->get($var)) {
+                continue;
             }
 
-            if (\is_array($variable)) {
-                array_walk($variable, function ($sub_value, $sub_key) use ($key, &$variables): void {
-                    $variables[$key . '.' . $sub_key] = $sub_value;
-                });
+            $varParts = explode('.', $var);
+
+            if (\count($varParts) < 2) {
+                dd('Unknown var: ' . $var);
             }
 
-            if (\is_callable($availableVariables[$key])) {
-                $availableVariables[$key] = $availableVariables[$key]();
-            }
+            $nestedAvVars = $availableVariables;
 
-            if (\is_array($availableVariables[$key])) {
-                array_walk($availableVariables[$key], function ($sub_value, $sub_key) use ($key, &$availableVariables): void {
-                    if (\is_array($sub_value) || \is_callable($sub_value)) {
-                        $availableVariables[$key . '.' . $sub_key] = $sub_value;
+            for ($i = 0; $i < \count($varParts); ++$i) {
+                $nestedAvVars = $nestedAvVars->get($varParts[$i]);
 
-                        return;
+                if (!$nestedAvVars) {
+                    dd('Unknown var: ' . $var);
+                }
+
+                if ($i === \count($varParts) - 1) {
+                    break;
+                }
+
+                if ($nestedAvVars instanceof EntityType) {
+                    $prefix = $varParts[$i];
+                    for ($j = 0; $j <= $i; ++$j) {
+                        unset($varParts[$j]);
                     }
-                    $availableVariables[$key . '.' . $sub_value] = $sub_key;
-                });
-            }
-        }
-    }
 
-    public function getMailTemplateAvailableVariablesV1(string $flowEventClass): array
-    {
-        $entityAwares = class_implements($flowEventClass);
+                    $path = \implode('.', $varParts);
 
-        $templateData = [];
+                    $field = $this->validateEntityField($path, $prefix, $nestedAvVars->getDefinitionClass());
 
-        foreach ($entityAwares as $entityAware) {
-            switch ($entityAware) {
-                case ScalarValuesAware::class:
-                    /*
-                     * Expects the $flowEventClass::getScalarKeys() to be in a structure like
-                     *
-                     * [
-                     *    'a' => [
-                     *       'b',
-                     *       'c',
-                     *    ],
-                     *    'd',
-                     * ]
-                     */
-                    $templateData = array_merge($templateData, $flowEventClass::getScalarKeys());
+                    if (!$field) {
+                        dd('Unknown var: ' . $var);
+                    }
+
                     break;
-                case ProductAware::class:
-                    $templateData[ProductAware::PRODUCT_ID] = '';
-                    $productDefinition = $this->definitionRegistry->get(ProductDefinition::class);
-                    $templateData[ProductAware::PRODUCT] = fn () => $this->lazyLoadVariables($productDefinition, $productDefinition->getFields());
-                    break;
-                case SalesChannelAware::class:
-                    $templateData['salesChannelId'] = '';
-                    $salesChannelDefinition = $this->definitionRegistry->get(SalesChannelDefinition::class);
-                    $templateData['salesChannel'] = fn () => $this->lazyLoadVariables($salesChannelDefinition, $salesChannelDefinition->getFields());
-                    break;
-            }
-        }
-
-        return $templateData;
-    }
-
-    /**
-     * Tries to mimic the selective behavior of a query with an empty criteria.
-     * Refer EntityReader::joinBasic(...)
-     */
-    private function lazyLoadVariables(EntityDefinition $entityDefinition, CompiledFieldCollection $fields): array
-    {
-        $variables = [];
-
-        foreach ($fields as $field) {
-            if (!$field instanceof ParentAssociationField && $field instanceof AssociationField && $field->getAutoload() && $field->getReferenceDefinition() === $entityDefinition) {
-                continue;
-            }
-
-            if ($field instanceof ManyToManyAssociationField || $field->is(Runtime::class)) {
-                continue;
-            }
-
-            if ($field instanceof ManyToOneAssociationField || $field instanceof OneToOneAssociationField) {
-                $subEntityDefinition = $this->definitionRegistry->get($field->getReferenceClass());
-                $variables[$field->getPropertyName()] = fn () => $this->lazyLoadVariables($subEntityDefinition, $subEntityDefinition->getFields()->getBasicFields());
-                continue;
-            }
-
-            if ($field instanceof TranslatedField) {
-                $variables[] = $field->getPropertyName();
-
-                if (!isset($variables['translated'])) {
-                    $variables['translated'] = [];
                 }
 
-                $variables['translated'][] = $field->getPropertyName();
-                continue;
-            }
+                if ($nestedAvVars instanceof ArrayType) {
+                    if (!($varParts[$i + 1] !== 'first' || $varParts[$i + 1] !== 'last' || \is_numeric($varParts[$i + 1]))) {
+                        dd('Invalid access on array: ' . $var);
+                    }
 
-            if ($field instanceof StorageAware) {
-                $variables[] = $field->getPropertyName();
-                continue;
-            }
-        }
-
-        return $variables;
-    }
-
-    /*
-     * #####################
-     * ##    Version 2    ##
-     * #####################
-     */
-    public function validateMailTemplateV2(array $usedVariables, array $availableVariables): void
-    {
-        foreach ($usedVariables as $usedVariable) {
-            if (\array_key_exists($usedVariable, $availableVariables)) {
-                continue;
-            }
-
-            $prefix = explode('.', $usedVariable)[0];
-
-            if (\is_callable($availableVariables[$prefix])) {
-                $pos = mb_strpos($usedVariable, '.');
-                if (!$pos) {
-                    dd('Entity ' . $prefix . ' cannot be processed as a whole!');
-                }
-                $fieldName = mb_substr($usedVariable, $pos + 1);
-                $field = $availableVariables[$prefix]($fieldName, $prefix);
-                if ($field) {
-                    continue;
+                    // Skipping the array access
+                    unset($varParts[$i + 1]);
+                    $varParts = \array_values($varParts);
+                    $nestedAvVars = $nestedAvVars->getType();
                 }
             }
-
-            dd('Unknown variable: ' . $usedVariable);
         }
     }
 
-    /*
-     * In this version I just go via the EntityDefinitionQueryHelper to look if a field could exist behind a certain path.
-     */
-    public function getMailTemplateAvailableVariablesV2(string $flowEventClass): array
+    private function validateEntityField(string $fieldName, string $prefix, string $entityDefinition): ?Field
     {
-        $entityAwares = class_implements(ReviewFormEvent::class);
+        // find every occurrence of an array accessor (number, ".first", ".last")
+        $parts = \preg_split('/(\.?\d+(\.|$))|(\.?first(\.|$))|(\.?last(\.|$))/', $fieldName);
 
-        $templateData = [];
+        $currentFieldName = '';
+        $field = null;
 
-        foreach ($entityAwares as $entityAware) {
-            switch ($entityAware) {
-                case ScalarValuesAware::class:
-                    /*
-                     * Expects the $flowEventClass::getScalarKeys() to be in a structure like
-                     *
-                     * [
-                     *    'a' => [],
-                     *    'a.b' => '',
-                     *    'c' => 0,      <- Idea: Provided datatype should hint to the actual data type
-                     * ]
-                     */
-                    $templateData = array_merge($templateData, ReviewFormEvent::getScalarKeys());
-                    break;
-                case ProductAware::class:
-                    $templateData[ProductAware::PRODUCT_ID] = '';
-                    $templateData[ProductAware::PRODUCT] = fn ($field, $prefix) => EntityDefinitionQueryHelper::getField($field, $this->definitionRegistry->get(ProductDefinition::class), $prefix);
-                    break;
-                case SalesChannelAware::class:
-                    $templateData['salesChannelId'] = '';
-                    $templateData['salesChannel'] = fn ($field, $prefix) => EntityDefinitionQueryHelper::getField($field, $this->definitionRegistry->get(SalesChannelDefinition::class), $prefix);
-                    break;
+        for ($i = 0; $i < \count($parts); ++$i) {
+            // an empty part at the end could be used for a warning -> "requested an array, should be handled accordingly"
+            if (empty($parts[$i])) {
+                continue;
+            }
+
+            $currentFieldName .= (empty($currentFieldName) ? '' : '.') . $parts[$i];
+            $field = EntityDefinitionQueryHelper::getField($currentFieldName, $this->definitionRegistry->get($entityDefinition), $prefix);
+
+            if (!($field instanceof ManyToManyAssociationField || $field instanceof OneToManyAssociationField || $field instanceof ListField) && $i !== \count($parts) - 1) {
+                return null;
             }
         }
 
-        return $templateData;
+        return $field;
     }
 }

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\MailTemplate\Service;
 
 use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationError;
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponse;
 use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationWarning;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
@@ -14,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\Event\EventData\ArrayType;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ObjectType;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataValidator;
@@ -38,7 +40,7 @@ class MailTemplateService
     }
 
     /**
-     * @return MailTemplateValidationError[]
+     * @return MailTemplateValidationResponse[]
      */
     public function validateTemplate(string $mailTemplate, EventDataCollection $availableVariables): array
     {
@@ -57,7 +59,9 @@ class MailTemplateService
     }
 
     /**
-     * @return MailTemplateValidationError[]
+     * @param array<string, string> $usedVariables
+     *
+     * @return MailTemplateValidationResponse[]
      */
     public function validateVariables(array $usedVariables, EventDataCollection $availableVariables): array
     {
@@ -86,11 +90,9 @@ class MailTemplateService
                 continue;
             }
 
-            $nestedAvVars = $availableVariables;
+            $nestedAvVars = $availableVariables->get($varParts[0]);
 
             for ($i = 0; $i < \count($varParts); ++$i) {
-                $nestedAvVars = $nestedAvVars->get($varParts[$i]);
-
                 if (!$nestedAvVars) {
                     $errors[] = new MailTemplateValidationError(
                         $this->dataValidator,
@@ -100,7 +102,7 @@ class MailTemplateService
                     break;
                 }
 
-                if ($i === \count($varParts) - 1) {
+                if ($nestedAvVars instanceof ScalarValueType && $i === \count($varParts) - 1) {
                     break;
                 }
 
@@ -118,6 +120,16 @@ class MailTemplateService
                 }
 
                 if ($nestedAvVars instanceof ArrayType) {
+                    if ($i === \count($varParts) - 1) {
+                        if (!($nestedAvVars->getType() instanceof ScalarValueType)) {
+                            $errors[] = new MailTemplateValidationWarning(
+                                $this->dataValidator,
+                                MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
+                                ['variable' => $var]
+                            );
+                        }
+                        break;
+                    }
                     if (!($varParts[$i + 1] === 'first' || $varParts[$i + 1] === 'last' || \is_numeric($varParts[$i + 1]))) {
                         $errors[] = new MailTemplateValidationError(
                             $this->dataValidator,
@@ -132,12 +144,29 @@ class MailTemplateService
                     $varParts = \array_values($varParts);
                     $nestedAvVars = $nestedAvVars->getType();
                 }
+
+                if ($nestedAvVars instanceof ObjectType) {
+                   $nestedAvVars = $nestedAvVars->get($varParts[$i + 1]);
+                   continue;
+                }
+
+                $errors[] = new MailTemplateValidationError(
+                    $this->dataValidator,
+                    MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
+                    ['variable' => $var]
+                );
+                break;
             }
         }
 
         return $errors;
     }
 
+    /**
+     * @param MailTemplateValidationResponse[] $errors
+     *
+     * @return MailTemplateValidationResponse[]
+     */
     private function validateEntityField(string $fieldName, string $prefix, string $entityDefinition, array $errors): array
     {
         $parts = \explode('.', $fieldName);

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -52,6 +52,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Twig\Environment;
+use Twig\Error\Error;
 use Twig\Error\SyntaxError;
 
 #[Package('after-sales')]
@@ -83,9 +84,15 @@ class MailTemplateService
         }
     }
 
-    public function render(string $mailTemplate, string $flowEventClass, Context $context): void
+    public function render(string $mailTemplate, string $flowEventClass, Context $context): string
     {
-        $result = $this->templateRenderer->render($mailTemplate, $this->generateTemplateData($flowEventClass), $context, false);
+        try {
+            return $this->templateRenderer->render($mailTemplate, $this->generateTemplateData($flowEventClass), $context, false);
+        } catch (Error $exception) {
+            $errorResponse = \json_encode(['message' => $exception->getRawMessage(), 'line' => $exception->getTemplateLine()]);
+            \assert(\is_string($errorResponse));
+            return $errorResponse;
+        }
     }
 
     public function generateTemplateData(string $flowEventClass): array
@@ -163,24 +170,12 @@ class MailTemplateService
             return $this->generateEntityData($dataType->getDefinitionClass(), $referenceData);
         }
 
-        if ($dataType::class === EntityType::class) {
-            return $this->generateEntityData($dataType->getDefinitionClass(), $referenceData);
-        }
-
         if ($dataType::class === ForeignKeyType::class) {
             if (!\array_key_exists($dataType->getReferenceClass() . '.id', $referenceData)) {
                 $referenceData[$dataType->getReferenceClass() . '.id'] = Uuid::randomHex();
             }
 
             return $referenceData[$dataType->getReferenceClass() . '.id'];
-        }
-
-        if ($dataType::class === MailRecipientStruct::class) {
-            return [
-                'recipients' => 'testing@shopware.com',
-                'bcc' => null,
-                'cc' => null,
-            ];
         }
 
         if ($dataType::class === ObjectType::class) {
@@ -202,7 +197,7 @@ class MailTemplateService
                 case ScalarValueType::TYPE_INT:
                     return 42;
                 case ScalarValueType::TYPE_STRING:
-                    return 'foobar';
+                    return '[some text]';
             }
         }
 

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -2,9 +2,11 @@
 
 namespace Shopware\Core\Content\MailTemplate\Service;
 
-use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationError;
-use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponse;
-use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationWarning;
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseArrayAccess;
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseCollection;
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseComplexElement;
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseSyntax;
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseUnknownVariable;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
@@ -34,80 +36,49 @@ class MailTemplateService
         Environment $twig,
         private readonly TwigVariableParserFactory $twigVariableParserFactory,
         private readonly DefinitionInstanceRegistry $definitionRegistry,
-        private readonly DataValidator $dataValidator,
     ) {
         $this->twigVariableParser = $this->twigVariableParserFactory->getParser($twig);
     }
 
-    /**
-     * @return MailTemplateValidationResponse[]
-     */
-    public function validateTemplate(string $mailTemplate, EventDataCollection $availableVariables): array
+    public function validateTemplate(string $mailTemplateField, string $mailTemplate, EventDataCollection $availableVariables, MailTemplateValidationResponseCollection $validationResponses): void
     {
         try {
             $usedVariables = $this->twigVariableParser->parse($mailTemplate);
+            $this->validateVariables($mailTemplateField, $usedVariables, $availableVariables, $validationResponses);
         } catch (SyntaxError $exception) {
-            return [new MailTemplateValidationError(
-                $this->dataValidator,
-                MailTemplateValidationError::TYPE_SYNTAX,
-                ['message' => $exception->getRawMessage()],
-                $exception->getTemplateLine(),
-            )];
+            $validationResponses->add(
+                new MailTemplateValidationResponseSyntax($mailTemplateField, $exception->getRawMessage(), $exception->getTemplateLine())
+            );
         }
-
-        return $this->validateVariables($usedVariables, $availableVariables);
     }
 
     /**
      * @param array<string, string> $usedVariables
-     *
-     * @return MailTemplateValidationResponse[]
      */
-    public function validateVariables(array $usedVariables, EventDataCollection $availableVariables): array
+    public function validateVariables(string $mailTemplateField, array $usedVariables, EventDataCollection $availableVariables, MailTemplateValidationResponseCollection $validationResponses): void
     {
-        $errors = [];
-
         foreach ($usedVariables as $var) {
-            if ($this->isKnownVariable($var, $availableVariables, $errors)) {
+            if ($field = $availableVariables->get($var)) {
+                if (!($field instanceof ScalarValueType)) {
+                    $validationResponses->add(
+                        new MailTemplateValidationResponseUnknownVariable(
+                            $mailTemplateField,
+                            $var
+                        )
+                    );
+                }
                 continue;
             }
 
-            $this->validateComplexVariable($var, $availableVariables, $errors);
+            $this->validateComplexVariable($mailTemplateField, $var, $availableVariables, $validationResponses);
         }
-
-        return $errors;
     }
 
-    /**
-     * @param MailTemplateValidationResponse[] $errors
-     */
-    private function isKnownVariable(string $var, EventDataCollection $availableVariables, array &$errors): bool
-    {
-        if ($field = $availableVariables->get($var)) {
-            if (!($field instanceof ScalarValueType)) {
-                $errors[] = new MailTemplateValidationWarning(
-                    $this->dataValidator,
-                    MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
-                    ['variable' => $var]
-                );
-            }
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @param MailTemplateValidationResponse[] $errors
-     */
-    private function validateComplexVariable(string $var, EventDataCollection $availableVariables, array &$errors): void
+    private function validateComplexVariable(string $mailTemplateField, string $var, EventDataCollection $availableVariables, MailTemplateValidationResponseCollection $validationResponses): void
     {
         if (!str_contains($var, '.')) {
-            $errors[] = new MailTemplateValidationError(
-                $this->dataValidator,
-                MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
-                ['variable' => $var]
-            );
+            $validationResponses->add(new MailTemplateValidationResponseUnknownVariable($mailTemplateField, $var));
+
             return;
         }
 
@@ -117,11 +88,7 @@ class MailTemplateService
 
         for ($i = 0; $i < \count($varParts); ++$i) {
             if (!$nestedAvVars) {
-                $errors[] = new MailTemplateValidationError(
-                    $this->dataValidator,
-                    MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
-                    ['variable' => $var]
-                );
+                $validationResponses->add(new MailTemplateValidationResponseUnknownVariable($mailTemplateField, $var));
                 break;
             }
 
@@ -137,7 +104,7 @@ class MailTemplateService
 
                 $path = \implode('.', $varParts);
 
-                $errors = $this->validateEntityField($path, $prefix, $nestedAvVars->getDefinitionClass(), $errors);
+                $this->validateEntityField($mailTemplateField, $path, $prefix, $nestedAvVars->getDefinitionClass(), $validationResponses);
 
                 break;
             }
@@ -145,20 +112,12 @@ class MailTemplateService
             if ($nestedAvVars instanceof ArrayType) {
                 if ($i === \count($varParts) - 1) {
                     if (!($nestedAvVars->getType() instanceof ScalarValueType)) {
-                        $errors[] = new MailTemplateValidationWarning(
-                            $this->dataValidator,
-                            MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
-                            ['variable' => $var]
-                        );
+                        $validationResponses->add(new MailTemplateValidationResponseComplexElement($mailTemplateField, $var));
                     }
                     break;
                 }
                 if (!($varParts[$i + 1] === 'first' || $varParts[$i + 1] === 'last' || \is_numeric($varParts[$i + 1]))) {
-                    $errors[] = new MailTemplateValidationError(
-                        $this->dataValidator,
-                        MailTemplateValidationError::TYPE_INVALID_ARRAY_ACCESS,
-                        ['variable' => $var]
-                    );
+                    $validationResponses->add(new MailTemplateValidationResponseArrayAccess($mailTemplateField, $var));
                     break;
                 }
 
@@ -173,21 +132,12 @@ class MailTemplateService
                 continue;
             }
 
-            $errors[] = new MailTemplateValidationError(
-                $this->dataValidator,
-                MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
-                ['variable' => $var]
-            );
+            $validationResponses->add(new MailTemplateValidationResponseUnknownVariable($mailTemplateField, $var));
             break;
         }
     }
 
-    /**
-     * @param MailTemplateValidationResponse[] $errors
-     *
-     * @return MailTemplateValidationResponse[]
-     */
-    private function validateEntityField(string $fieldName, string $prefix, string $entityDefinition, array $errors): array
+    private function validateEntityField(string $mailTemplateField, string $fieldName, string $prefix, string $entityDefinition, MailTemplateValidationResponseCollection $validationResponses): void
     {
         $parts = \explode('.', $fieldName);
 
@@ -205,23 +155,15 @@ class MailTemplateService
 
             if ($field instanceof ManyToManyAssociationField || $field instanceof OneToManyAssociationField || $field instanceof ListField) {
                 if ($i === \count($parts) - 1) {
-                    $errors[] = new MailTemplateValidationWarning(
-                        $this->dataValidator,
-                        MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
-                        ['variable' => $currentFieldName]
-                    );
+                    $validationResponses->add(new MailTemplateValidationResponseComplexElement($mailTemplateField, $currentFieldName));
 
-                    return $errors;
+                    return;
                 }
 
                 if (!($parts[$i + 1] === 'first' || $parts[$i + 1] === 'last' || \is_numeric($parts[$i + 1]))) {
-                    $errors[] = new MailTemplateValidationError(
-                        $this->dataValidator,
-                        MailTemplateValidationError::TYPE_INVALID_ARRAY_ACCESS,
-                        ['variable' => $currentFieldName]
-                    );
+                    $validationResponses->add(new MailTemplateValidationResponseArrayAccess($mailTemplateField, $currentFieldName));
 
-                    return $errors;
+                    return;
                 }
 
                 ++$i;
@@ -229,13 +171,7 @@ class MailTemplateService
         }
 
         if (!$field) {
-            $errors[] = new MailTemplateValidationError(
-                $this->dataValidator,
-                MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
-                ['variable' => $currentFieldName]
-            );
+            $validationResponses->add(new MailTemplateValidationResponseUnknownVariable($mailTemplateField, $currentFieldName));
         }
-
-        return $errors;
     }
 }

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -68,88 +68,55 @@ class MailTemplateService
         $errors = [];
 
         foreach ($usedVariables as $var) {
-            if ($field = $availableVariables->get($var)) {
-                if (!($field instanceof ScalarValueType)) {
-                    $errors[] = new MailTemplateValidationWarning(
-                        $this->dataValidator,
-                        MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
-                        ['variable' => $var]
-                    );
-                }
+            if ($this->isKnownVariable($var, $availableVariables, $errors)) {
                 continue;
             }
 
-            $varParts = explode('.', $var);
+            $this->validateComplexVariable($var, $availableVariables, $errors);
+        }
 
-            if (\count($varParts) < 2) {
-                $errors[] = new MailTemplateValidationError(
+        return $errors;
+    }
+
+    /**
+     * @param MailTemplateValidationResponse[] $errors
+     */
+    private function isKnownVariable(string $var, EventDataCollection $availableVariables, array &$errors): bool
+    {
+        if ($field = $availableVariables->get($var)) {
+            if (!($field instanceof ScalarValueType)) {
+                $errors[] = new MailTemplateValidationWarning(
                     $this->dataValidator,
-                    MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
+                    MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
                     ['variable' => $var]
                 );
-                continue;
             }
+            return true;
+        }
 
-            $nestedAvVars = $availableVariables->get($varParts[0]);
+        return false;
+    }
 
-            for ($i = 0; $i < \count($varParts); ++$i) {
-                if (!$nestedAvVars) {
-                    $errors[] = new MailTemplateValidationError(
-                        $this->dataValidator,
-                        MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
-                        ['variable' => $var]
-                    );
-                    break;
-                }
+    /**
+     * @param MailTemplateValidationResponse[] $errors
+     */
+    private function validateComplexVariable(string $var, EventDataCollection $availableVariables, array &$errors): void
+    {
+        if (!str_contains($var, '.')) {
+            $errors[] = new MailTemplateValidationError(
+                $this->dataValidator,
+                MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
+                ['variable' => $var]
+            );
+            return;
+        }
 
-                if ($nestedAvVars instanceof ScalarValueType && $i === \count($varParts) - 1) {
-                    break;
-                }
+        $varParts = explode('.', $var);
 
-                if ($nestedAvVars instanceof EntityType) {
-                    $prefix = $varParts[$i];
-                    for ($j = 0; $j <= $i; ++$j) {
-                        unset($varParts[$j]);
-                    }
+        $nestedAvVars = $availableVariables->get($varParts[0]);
 
-                    $path = \implode('.', $varParts);
-
-                    $errors = $this->validateEntityField($path, $prefix, $nestedAvVars->getDefinitionClass(), $errors);
-
-                    break;
-                }
-
-                if ($nestedAvVars instanceof ArrayType) {
-                    if ($i === \count($varParts) - 1) {
-                        if (!($nestedAvVars->getType() instanceof ScalarValueType)) {
-                            $errors[] = new MailTemplateValidationWarning(
-                                $this->dataValidator,
-                                MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
-                                ['variable' => $var]
-                            );
-                        }
-                        break;
-                    }
-                    if (!($varParts[$i + 1] === 'first' || $varParts[$i + 1] === 'last' || \is_numeric($varParts[$i + 1]))) {
-                        $errors[] = new MailTemplateValidationError(
-                            $this->dataValidator,
-                            MailTemplateValidationError::TYPE_INVALID_ARRAY_ACCESS,
-                            ['variable' => $var]
-                        );
-                        break;
-                    }
-
-                    // Skipping the array access
-                    unset($varParts[$i + 1]);
-                    $varParts = \array_values($varParts);
-                    $nestedAvVars = $nestedAvVars->getType();
-                }
-
-                if ($nestedAvVars instanceof ObjectType) {
-                   $nestedAvVars = $nestedAvVars->get($varParts[$i + 1]);
-                   continue;
-                }
-
+        for ($i = 0; $i < \count($varParts); ++$i) {
+            if (!$nestedAvVars) {
                 $errors[] = new MailTemplateValidationError(
                     $this->dataValidator,
                     MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
@@ -157,9 +124,62 @@ class MailTemplateService
                 );
                 break;
             }
-        }
 
-        return $errors;
+            if ($nestedAvVars instanceof ScalarValueType && $i === \count($varParts) - 1) {
+                break;
+            }
+
+            if ($nestedAvVars instanceof EntityType) {
+                $prefix = $varParts[$i];
+                for ($j = 0; $j <= $i; ++$j) {
+                    unset($varParts[$j]);
+                }
+
+                $path = \implode('.', $varParts);
+
+                $errors = $this->validateEntityField($path, $prefix, $nestedAvVars->getDefinitionClass(), $errors);
+
+                break;
+            }
+
+            if ($nestedAvVars instanceof ArrayType) {
+                if ($i === \count($varParts) - 1) {
+                    if (!($nestedAvVars->getType() instanceof ScalarValueType)) {
+                        $errors[] = new MailTemplateValidationWarning(
+                            $this->dataValidator,
+                            MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
+                            ['variable' => $var]
+                        );
+                    }
+                    break;
+                }
+                if (!($varParts[$i + 1] === 'first' || $varParts[$i + 1] === 'last' || \is_numeric($varParts[$i + 1]))) {
+                    $errors[] = new MailTemplateValidationError(
+                        $this->dataValidator,
+                        MailTemplateValidationError::TYPE_INVALID_ARRAY_ACCESS,
+                        ['variable' => $var]
+                    );
+                    break;
+                }
+
+                // Skipping the array access
+                unset($varParts[$i + 1]);
+                $varParts = \array_values($varParts);
+                $nestedAvVars = $nestedAvVars->getType();
+            }
+
+            if ($nestedAvVars instanceof ObjectType) {
+                $nestedAvVars = $nestedAvVars->get($varParts[$i + 1]);
+                continue;
+            }
+
+            $errors[] = new MailTemplateValidationError(
+                $this->dataValidator,
+                MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
+                ['variable' => $var]
+            );
+            break;
+        }
     }
 
     /**

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\Event\EventData\ArrayType;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Twig\Environment;
@@ -63,7 +64,14 @@ class MailTemplateService
         $errors = [];
 
         foreach ($usedVariables as $var) {
-            if ($availableVariables->get($var)) {
+            if ($field = $availableVariables->get($var)) {
+                if (!($field instanceof ScalarValueType)) {
+                    $errors[] = new MailTemplateValidationWarning(
+                        $this->dataValidator,
+                        MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
+                        ['variable' => $var]
+                    );
+                }
                 continue;
             }
 
@@ -84,7 +92,7 @@ class MailTemplateService
                 $nestedAvVars = $nestedAvVars->get($varParts[$i]);
 
                 if (!$nestedAvVars) {
-                    $errors[] = $errors[] = new MailTemplateValidationError(
+                    $errors[] = new MailTemplateValidationError(
                         $this->dataValidator,
                         MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
                         ['variable' => $var]

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -31,14 +31,20 @@ class MailTemplateService
         $this->twigVariableParser = $this->twigVariableParserFactory->getParser($twig);
     }
 
-    public function validateTemplate(string $mailTemplate, EventDataCollection $availableVariables): void
+    public function validateTemplate(string $mailTemplate, EventDataCollection $availableVariables): array
     {
-        $usedVariables = $this->twigVariableParser->parse($mailTemplate);
-        $this->validateVariables($usedVariables, $availableVariables);
+        try {
+            $usedVariables = $this->twigVariableParser->parse($mailTemplate);
+        } catch (\Throwable $exception) {
+            return [$exception->getMessage()];
+        }
+        return $this->validateVariables($usedVariables, $availableVariables);
     }
 
-    public function validateVariables(array $usedVariables, EventDataCollection $availableVariables): void
+    public function validateVariables(array $usedVariables, EventDataCollection $availableVariables): array
     {
+        $errors = [];
+
         foreach ($usedVariables as $var) {
             if ($availableVariables->get($var)) {
                 continue;
@@ -47,7 +53,8 @@ class MailTemplateService
             $varParts = explode('.', $var);
 
             if (\count($varParts) < 2) {
-                dd('Unknown var: ' . $var);
+                $errors[] = 'Unknown var: ' . $var;
+                continue;
             }
 
             $nestedAvVars = $availableVariables;
@@ -56,7 +63,8 @@ class MailTemplateService
                 $nestedAvVars = $nestedAvVars->get($varParts[$i]);
 
                 if (!$nestedAvVars) {
-                    dd('Unknown var: ' . $var);
+                    $errors[] = 'Unknown var: ' . $var;
+                    break;
                 }
 
                 if ($i === \count($varParts) - 1) {
@@ -74,7 +82,8 @@ class MailTemplateService
                     $field = $this->validateEntityField($path, $prefix, $nestedAvVars->getDefinitionClass());
 
                     if (!$field) {
-                        dd('Unknown var: ' . $var);
+                        $errors[] = 'Unknown var: ' . $var;
+                        break;
                     }
 
                     break;
@@ -82,7 +91,8 @@ class MailTemplateService
 
                 if ($nestedAvVars instanceof ArrayType) {
                     if (!($varParts[$i + 1] !== 'first' || $varParts[$i + 1] !== 'last' || \is_numeric($varParts[$i + 1]))) {
-                        dd('Invalid access on array: ' . $var);
+                        $errors[] = 'Invalid access on array: ' . $var;
+                        break;
                     }
 
                     // Skipping the array access
@@ -92,6 +102,8 @@ class MailTemplateService
                 }
             }
         }
+
+        return $errors;
     }
 
     private function validateEntityField(string $fieldName, string $prefix, string $entityDefinition): ?Field

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -2,18 +2,22 @@
 
 namespace Shopware\Core\Content\MailTemplate\Service;
 
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationError;
+use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationWarning;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\Event\EventData\ArrayType;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\DataValidator;
 use Twig\Environment;
+use Twig\Error\SyntaxError;
 
 #[Package('after-sales')]
 class MailTemplateService
@@ -27,20 +31,33 @@ class MailTemplateService
         Environment $twig,
         private readonly TwigVariableParserFactory $twigVariableParserFactory,
         private readonly DefinitionInstanceRegistry $definitionRegistry,
+        private readonly DataValidator $dataValidator,
     ) {
         $this->twigVariableParser = $this->twigVariableParserFactory->getParser($twig);
     }
 
+    /**
+     * @return MailTemplateValidationError[]
+     */
     public function validateTemplate(string $mailTemplate, EventDataCollection $availableVariables): array
     {
         try {
             $usedVariables = $this->twigVariableParser->parse($mailTemplate);
-        } catch (\Throwable $exception) {
-            return [$exception->getMessage()];
+        } catch (SyntaxError $exception) {
+            return [new MailTemplateValidationError(
+                $this->dataValidator,
+                MailTemplateValidationError::TYPE_SYNTAX,
+                ['message' => $exception->getRawMessage()],
+                $exception->getTemplateLine(),
+            )];
         }
+
         return $this->validateVariables($usedVariables, $availableVariables);
     }
 
+    /**
+     * @return MailTemplateValidationError[]
+     */
     public function validateVariables(array $usedVariables, EventDataCollection $availableVariables): array
     {
         $errors = [];
@@ -53,7 +70,11 @@ class MailTemplateService
             $varParts = explode('.', $var);
 
             if (\count($varParts) < 2) {
-                $errors[] = 'Unknown var: ' . $var;
+                $errors[] = new MailTemplateValidationError(
+                    $this->dataValidator,
+                    MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
+                    ['variable' => $var]
+                );
                 continue;
             }
 
@@ -63,7 +84,11 @@ class MailTemplateService
                 $nestedAvVars = $nestedAvVars->get($varParts[$i]);
 
                 if (!$nestedAvVars) {
-                    $errors[] = 'Unknown var: ' . $var;
+                    $errors[] = $errors[] = new MailTemplateValidationError(
+                        $this->dataValidator,
+                        MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
+                        ['variable' => $var]
+                    );
                     break;
                 }
 
@@ -79,19 +104,18 @@ class MailTemplateService
 
                     $path = \implode('.', $varParts);
 
-                    $field = $this->validateEntityField($path, $prefix, $nestedAvVars->getDefinitionClass());
-
-                    if (!$field) {
-                        $errors[] = 'Unknown var: ' . $var;
-                        break;
-                    }
+                    $errors = $this->validateEntityField($path, $prefix, $nestedAvVars->getDefinitionClass(), $errors);
 
                     break;
                 }
 
                 if ($nestedAvVars instanceof ArrayType) {
-                    if (!($varParts[$i + 1] !== 'first' || $varParts[$i + 1] !== 'last' || \is_numeric($varParts[$i + 1]))) {
-                        $errors[] = 'Invalid access on array: ' . $var;
+                    if (!($varParts[$i + 1] === 'first' || $varParts[$i + 1] === 'last' || \is_numeric($varParts[$i + 1]))) {
+                        $errors[] = new MailTemplateValidationError(
+                            $this->dataValidator,
+                            MailTemplateValidationError::TYPE_INVALID_ARRAY_ACCESS,
+                            ['variable' => $var]
+                        );
                         break;
                     }
 
@@ -106,10 +130,9 @@ class MailTemplateService
         return $errors;
     }
 
-    private function validateEntityField(string $fieldName, string $prefix, string $entityDefinition): ?Field
+    private function validateEntityField(string $fieldName, string $prefix, string $entityDefinition, array $errors): array
     {
-        // find every occurrence of an array accessor (number, ".first", ".last")
-        $parts = \preg_split('/(\.?\d+(\.|$))|(\.?first(\.|$))|(\.?last(\.|$))/', $fieldName);
+        $parts = \explode('.', $fieldName);
 
         $currentFieldName = '';
         $field = null;
@@ -123,11 +146,39 @@ class MailTemplateService
             $currentFieldName .= (empty($currentFieldName) ? '' : '.') . $parts[$i];
             $field = EntityDefinitionQueryHelper::getField($currentFieldName, $this->definitionRegistry->get($entityDefinition), $prefix);
 
-            if (!($field instanceof ManyToManyAssociationField || $field instanceof OneToManyAssociationField || $field instanceof ListField) && $i !== \count($parts) - 1) {
-                return null;
+            if ($field instanceof ManyToManyAssociationField || $field instanceof OneToManyAssociationField || $field instanceof ListField) {
+                if ($i === \count($parts) - 1) {
+                    $errors[] = new MailTemplateValidationWarning(
+                        $this->dataValidator,
+                        MailTemplateValidationWarning::TYPE_COMPLEX_ELEMENT,
+                        ['variable' => $currentFieldName]
+                    );
+
+                    return $errors;
+                }
+
+                if (!($parts[$i + 1] === 'first' || $parts[$i + 1] === 'last' || \is_numeric($parts[$i + 1]))) {
+                    $errors[] = new MailTemplateValidationError(
+                        $this->dataValidator,
+                        MailTemplateValidationError::TYPE_INVALID_ARRAY_ACCESS,
+                        ['variable' => $currentFieldName]
+                    );
+
+                    return $errors;
+                }
+
+                ++$i;
             }
         }
 
-        return $field;
+        if (!$field) {
+            $errors[] = new MailTemplateValidationError(
+                $this->dataValidator,
+                MailTemplateValidationError::TYPE_UNKNOWN_VARIABLE,
+                ['variable' => $currentFieldName]
+            );
+        }
+
+        return $errors;
     }
 }

--- a/src/Core/Content/MailTemplate/Service/MailTemplateService.php
+++ b/src/Core/Content/MailTemplate/Service/MailTemplateService.php
@@ -7,20 +7,50 @@ use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponse
 use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseComplexElement;
 use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseSyntax;
 use Shopware\Core\Content\MailTemplate\Validation\MailTemplateValidationResponseUnknownVariable;
+use Shopware\Core\Content\MeasurementSystem\Field\MeasurementUnitsField;
+use Shopware\Core\Content\MeasurementSystem\MeasurementUnits;
+use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BlobField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyIdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\Event\EventData\ArrayType;
+use Shopware\Core\Framework\Event\EventData\AssociativeArrayType;
+use Shopware\Core\Framework\Event\EventData\EntityCollectionType;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\EventDataType;
+use Shopware\Core\Framework\Event\EventData\ForeignKeyType;
+use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ObjectType;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Validation\DataValidator;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Twig\Environment;
 use Twig\Error\SyntaxError;
 
@@ -36,6 +66,7 @@ class MailTemplateService
         Environment $twig,
         private readonly TwigVariableParserFactory $twigVariableParserFactory,
         private readonly DefinitionInstanceRegistry $definitionRegistry,
+        private readonly StringTemplateRenderer $templateRenderer,
     ) {
         $this->twigVariableParser = $this->twigVariableParserFactory->getParser($twig);
     }
@@ -50,6 +81,50 @@ class MailTemplateService
                 new MailTemplateValidationResponseSyntax($mailTemplateField, $exception->getRawMessage(), $exception->getTemplateLine())
             );
         }
+    }
+
+    public function render(string $mailTemplate, string $flowEventClass, Context $context): void
+    {
+        $result = $this->templateRenderer->render($mailTemplate, $this->generateTemplateData($flowEventClass), $context, false);
+    }
+
+    public function generateTemplateData(string $flowEventClass): array
+    {
+        $templateData = [];
+        $referenceData = [];
+
+        try {
+            $flowEvent = new \ReflectionClass($flowEventClass);
+
+            if (!$flowEvent->implementsInterface(FlowEventAware::class)) {
+                return [];
+            }
+
+            $eventDataCollection = $flowEvent->getMethod('getAvailableData')->invoke(null);
+            \assert($eventDataCollection instanceof EventDataCollection);
+            $eventData = $eventDataCollection->getData();
+        } catch (\ReflectionException $e) {
+            return [];
+        }
+
+        if (!$flowEvent->implementsInterface(MailAware::class)) {
+            return [];
+        }
+
+        $templateData[MailAware::TIMEZONE] = 'UTC';
+
+        $templateData['salesChannel'] = $this->generateEntityData(SalesChannelDefinition::class, $referenceData);
+        $templateData['salesChannelId'] = $templateData['salesChannel']['id'];
+
+        foreach ($eventData as $name => $type) {
+            if (\array_key_exists($name, $templateData)) {
+                continue;
+            }
+
+            $templateData[$name] = $this->generateEventDataTypeData($type, $referenceData);
+        }
+
+        return $templateData;
     }
 
     /**
@@ -72,6 +147,175 @@ class MailTemplateService
 
             $this->validateComplexVariable($mailTemplateField, $var, $availableVariables, $validationResponses);
         }
+    }
+
+    private function generateEventDataTypeData(EventDataType $dataType, array &$referenceData): mixed
+    {
+        if ($dataType::class === AssociativeArrayType::class || $dataType::class === ArrayType::class) {
+            return [];
+        }
+
+        if ($dataType::class === EntityCollectionType::class) {
+            return [$this->generateEntityData($dataType->getDefinitionClass(), $referenceData)];
+        }
+
+        if ($dataType::class === EntityType::class) {
+            return $this->generateEntityData($dataType->getDefinitionClass(), $referenceData);
+        }
+
+        if ($dataType::class === EntityType::class) {
+            return $this->generateEntityData($dataType->getDefinitionClass(), $referenceData);
+        }
+
+        if ($dataType::class === ForeignKeyType::class) {
+            if (!\array_key_exists($dataType->getReferenceClass() . '.id', $referenceData)) {
+                $referenceData[$dataType->getReferenceClass() . '.id'] = Uuid::randomHex();
+            }
+
+            return $referenceData[$dataType->getReferenceClass() . '.id'];
+        }
+
+        if ($dataType::class === MailRecipientStruct::class) {
+            return [
+                'recipients' => 'testing@shopware.com',
+                'bcc' => null,
+                'cc' => null,
+            ];
+        }
+
+        if ($dataType::class === ObjectType::class) {
+            $object = [];
+
+            foreach ($dataType->getData() as $key => $value) {
+                $object[$key] = $this->generateEventDataTypeData($value, $referenceData);
+            }
+
+            return $object;
+        }
+
+        if ($dataType::class === ScalarValueType::class) {
+            switch ($dataType->getType()) {
+                case ScalarValueType::TYPE_BOOL:
+                    return false;
+                case ScalarValueType::TYPE_FLOAT:
+                    return 42.24;
+                case ScalarValueType::TYPE_INT:
+                    return 42;
+                case ScalarValueType::TYPE_STRING:
+                    return 'foobar';
+            }
+        }
+
+        throw new \InvalidArgumentException('Unknown event data type: ' . $dataType::class);
+    }
+
+    private function generateEntityData(string $class, array &$referenceData): array
+    {
+        $entity = [];
+        $unresolvedTranslatedFields = [];
+
+        $fields = $this->definitionRegistry->get($class)->getFields();
+
+        foreach ($fields as $field) {
+            if (\array_key_exists($field->getPropertyName(), $entity)) {
+                continue;
+            }
+
+            if ($field::class === TranslationsAssociationField::class) {
+                $referenceData[$field->getReferenceClass()] = $this->generateEntityData($field->getReferenceClass(), $referenceData);
+                $entity[EntityDefinition::TRANSLATED_FIELD] = $referenceData[$field->getReferenceClass()];
+            }
+
+            if ($field instanceof AssociationField && !$field->getAutoload()) {
+                continue;
+            }
+
+            switch ($field::class) {
+                case BlobField::class:
+                    $entity[$field->getPropertyName()] = $field->getPropertyName();
+                    break;
+                case BoolField::class:
+                    $entity[$field->getPropertyName()] = false;
+                    break;
+                case CreatedAtField::class:
+                case UpdatedAtField::class:
+                    $entity[$field->getPropertyName()] = new \DateTimeImmutable();
+                    break;
+                case CustomFields::class:
+                case JsonField::class:
+                case ListField::class:
+                    $entity[$field->getPropertyName()] = null;
+                    break;
+                case FkField::class:
+                    if (!\array_key_exists($field->getReferenceClass() . '.' . $field->getReferenceField(), $referenceData)) {
+                        $referenceData[$field->getReferenceClass() . '.' . $field->getReferenceField()] = Uuid::randomHex();
+                    }
+                    $entity[$field->getPropertyName()] = $referenceData[$field->getReferenceClass() . '.' . $field->getReferenceField()];
+                    break;
+                case IdField::class:
+                    if (!\array_key_exists($class . '.id', $referenceData)) {
+                        $referenceData[$class . '.id'] = Uuid::randomHex();
+                    }
+                    $entity[$field->getPropertyName()] = $referenceData[$class . '.id'];
+                    break;
+                case IntField::class:
+                    $entity[$field->getPropertyName()] = 42;
+                    break;
+                case ManyToManyIdField::class:
+                    $associationField = $fields->get($field->getAssociationName());
+                    \assert($associationField instanceof ManyToManyAssociationField);
+                    if (!\array_key_exists($associationField->getReferenceClass(), $referenceData)) {
+                        $referenceData[$associationField->getReferenceClass()] = $this->generateEntityData($associationField->getReferenceClass(), $referenceData);
+                    }
+                    $fkField =
+                        $this->definitionRegistry
+                            ->get($associationField->getReferenceClass())
+                            ->getFields()
+                            ->filter(fn (Field $field) => $field instanceof FkField && $field->getStorageName() === $associationField->getMappingReferenceColumn())
+                            ->first();
+                    \assert($fkField instanceof FkField);
+
+                    if (!\array_key_exists($fkField->getReferenceClass(), $referenceData)) {
+                        $referenceData[$fkField->getReferenceClass()] = $this->generateEntityData($fkField->getReferenceClass(), $referenceData);
+                    }
+
+                    $entity[$field->getPropertyName()] = [$referenceData[$fkField->getReferenceClass()][$fkField->getReferenceField()]];
+                    break;
+                case MeasurementUnitsField::class:
+                    if (!\array_key_exists(MeasurementUnits::class, $referenceData)) {
+                        $referenceData[MeasurementUnits::class] = MeasurementUnits::createDefaultUnits();
+                    }
+                    $entity[$field->getPropertyName()] = $referenceData[MeasurementUnits::class];
+                    break;
+                case ReferenceVersionField::class:
+                    if (!\array_key_exists($field->getVersionReferenceClass() . '.' . $field->getReferenceField(), $referenceData)) {
+                        $referenceData[$field->getVersionReferenceClass() . '.' . $field->getReferenceField()] = Uuid::randomHex();
+                    }
+                    $entity[$field->getPropertyName()] = $referenceData[$field->getVersionReferenceClass() . '.' . $field->getReferenceField()];
+                    break;
+                case StringField::class:
+                    $entity[$field->getPropertyName()] = 'foobar';
+                    break;
+                case TranslatedField::class:
+                    $unresolvedTranslatedFields[] = $field;
+                    break;
+                case TranslationsAssociationField::class:
+                    if (!\array_key_exists(LanguageEntity::class . '.id', $referenceData)) {
+                        $referenceData[LanguageEntity::class . '.id'] = Uuid::randomHex();
+                    }
+                    $entity[$field->getPropertyName()] = [$referenceData[LanguageEntity::class . '.id'] => $referenceData[$field->getReferenceClass()]];
+                    break;
+                default:
+                    $entity[$field->getPropertyName()] = '## ERROR - UNKNOWN FIELD TYPE "' . $field::class . '" ##';
+                    break;
+            }
+        }
+
+        foreach ($unresolvedTranslatedFields as $field) {
+            $entity[$field->getPropertyName()] = $entity[EntityDefinition::TRANSLATED_FIELD][$field->getPropertyName()];
+        }
+
+        return $entity;
     }
 
     private function validateComplexVariable(string $mailTemplateField, string $var, EventDataCollection $availableVariables, MailTemplateValidationResponseCollection $validationResponses): void

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationError.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationError.php
@@ -2,18 +2,22 @@
 
 namespace Shopware\Core\Content\MailTemplate\Validation;
 
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Type;
 
+#[Package('after-sales')]
 class MailTemplateValidationError extends MailTemplateValidationResponse
 {
     final public const TYPE_UNKNOWN_VARIABLE = 'unknownVariable';
     final public const TYPE_SYNTAX = 'syntax';
     final public const TYPE_INVALID_ARRAY_ACCESS = 'arrayAccess';
 
+    /**
+     * @param array<string, string> $config
+     */
     public function __construct(
         private readonly DataValidator $dataValidator,
         private readonly string $type,

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationError.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationError.php
@@ -52,7 +52,6 @@ class MailTemplateValidationError extends MailTemplateValidationResponse
         $definition = new DataValidationDefinition('variable');
 
         $definition->add('variable', new NotBlank(), new Type('string'));
-        $definition->add('path', new Optional([new NotBlank(), new Type('string')]));
 
         return $definition;
     }

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationError.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationError.php
@@ -3,69 +3,24 @@
 namespace Shopware\Core\Content\MailTemplate\Validation;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Validation\DataValidationDefinition;
-use Shopware\Core\Framework\Validation\DataValidator;
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Type;
 
 #[Package('after-sales')]
-class MailTemplateValidationError extends MailTemplateValidationResponse
+abstract class MailTemplateValidationError extends MailTemplateValidationResponse
 {
-    final public const TYPE_UNKNOWN_VARIABLE = 'unknownVariable';
-    final public const TYPE_SYNTAX = 'syntax';
-    final public const TYPE_INVALID_ARRAY_ACCESS = 'arrayAccess';
+    private const LEVEL = 'error';
 
-    /**
-     * @param array<string, string> $config
-     */
     public function __construct(
-        private readonly DataValidator $dataValidator,
-        private readonly string $type,
-        private readonly array $config,
+        private readonly string $field,
         private readonly int $line = 0,
     ) {
-        parent::__construct(self::LEVEL_ERROR);
-
-        if (!($type === self::TYPE_UNKNOWN_VARIABLE || $type === self::TYPE_SYNTAX || $type === self::TYPE_INVALID_ARRAY_ACCESS)) {
-            throw new \Exception('Mail template validation error type is not valid');
-        }
-
-        switch ($type) {
-            case self::TYPE_SYNTAX:
-                $this->dataValidator->validate($config, $this->getSyntaxConfigValidation());
-                break;
-            case self::TYPE_UNKNOWN_VARIABLE:
-            case self::TYPE_INVALID_ARRAY_ACCESS:
-                $this->dataValidator->validate($config, $this->getVariableConfigValidation());
-                break;
-        }
+        parent::__construct($this->field, $this->line);
     }
 
     public function jsonSerialize(): array
     {
         return [
             ...parent::jsonSerialize(),
-            ...$this->config,
-            'type' => $this->type,
-            'line' => $this->line,
+            'level' => self::LEVEL,
         ];
-    }
-
-    private function getVariableConfigValidation(): DataValidationDefinition
-    {
-        $definition = new DataValidationDefinition('variable');
-
-        $definition->add('variable', new NotBlank(), new Type('string'));
-
-        return $definition;
-    }
-
-    private function getSyntaxConfigValidation(): DataValidationDefinition
-    {
-        $definition = new DataValidationDefinition('syntax');
-
-        $definition->add('message', new NotBlank(), new Type('string'));
-
-        return $definition;
     }
 }

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationError.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationError.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate\Validation;
+
+use Shopware\Core\Framework\Validation\DataValidationDefinition;
+use Shopware\Core\Framework\Validation\DataValidator;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Optional;
+use Symfony\Component\Validator\Constraints\Type;
+
+class MailTemplateValidationError extends MailTemplateValidationResponse
+{
+    final public const TYPE_UNKNOWN_VARIABLE = 'unknownVariable';
+    final public const TYPE_SYNTAX = 'syntax';
+    final public const TYPE_INVALID_ARRAY_ACCESS = 'arrayAccess';
+
+    public function __construct(
+        private readonly DataValidator $dataValidator,
+        private readonly string $type,
+        private readonly array $config,
+        private readonly int $line = 0,
+    ) {
+        parent::__construct(self::LEVEL_ERROR);
+
+        if (!($type === self::TYPE_UNKNOWN_VARIABLE || $type === self::TYPE_SYNTAX || $type === self::TYPE_INVALID_ARRAY_ACCESS)) {
+            throw new \Exception('Mail template validation error type is not valid');
+        }
+
+        switch ($type) {
+            case self::TYPE_SYNTAX:
+                $this->dataValidator->validate($config, $this->getSyntaxConfigValidation());
+                break;
+            case self::TYPE_UNKNOWN_VARIABLE:
+            case self::TYPE_INVALID_ARRAY_ACCESS:
+                $this->dataValidator->validate($config, $this->getVariableConfigValidation());
+                break;
+        }
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            ...parent::jsonSerialize(),
+            ...$this->config,
+            'type' => $this->type,
+            'line' => $this->line,
+        ];
+    }
+
+    private function getVariableConfigValidation(): DataValidationDefinition
+    {
+        $definition = new DataValidationDefinition('variable');
+
+        $definition->add('variable', new NotBlank(), new Type('string'));
+        $definition->add('path', new Optional([new NotBlank(), new Type('string')]));
+
+        return $definition;
+    }
+
+    private function getSyntaxConfigValidation(): DataValidationDefinition
+    {
+        $definition = new DataValidationDefinition('syntax');
+
+        $definition->add('message', new NotBlank(), new Type('string'));
+
+        return $definition;
+    }
+}

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponse.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponse.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Content\MailTemplate\Validation;
 
-use Shopware\Core\Framework\Struct\JsonSerializableTrait;
 use Shopware\Core\Framework\Struct\Struct;
 
 abstract class MailTemplateValidationResponse extends Struct

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponse.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponse.php
@@ -2,33 +2,28 @@
 
 namespace Shopware\Core\Content\MailTemplate\Validation;
 
+use Shopware\Core\Content\MailTemplate\MailTemplateException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
 #[Package('after-sales')]
 abstract class MailTemplateValidationResponse extends Struct
 {
-    final public const LEVEL_ERROR = 'error';
-    final public const LEVEL_WARNING = 'warning';
-
     public function __construct(
-        private readonly string $level,
+        private readonly string $field,
+        private readonly int $line = 0,
     ) {
-        if (!($level === self::LEVEL_ERROR || $level === self::LEVEL_WARNING)) {
-            throw new \Exception('Mail template validation response level is not valid');
+        if ($line < 0) {
+            MailTemplateException::invalidMailTemplateValidationResponseLineNumber();
         }
-    }
-
-    public function getLevel(): string
-    {
-        return $this->level;
     }
 
     public function jsonSerialize(): array
     {
         return [
             ...parent::jsonSerialize(),
-            'level' => $this->level,
+            'field' => $this->field,
+            'line' => $this->line,
         ];
     }
 }

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponse.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponse.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate\Validation;
+
+use Shopware\Core\Framework\Struct\JsonSerializableTrait;
+use Shopware\Core\Framework\Struct\Struct;
+
+abstract class MailTemplateValidationResponse extends Struct
+{
+    final public const LEVEL_ERROR = 'error';
+    final public const LEVEL_WARNING = 'warning';
+
+    public function __construct(
+        private readonly string $level,
+    ) {
+        if (!($level === self::LEVEL_ERROR || $level === self::LEVEL_WARNING)) {
+            throw new \Exception('Mail template validation response level is not valid');
+        }
+    }
+
+    public function getLevel(): string
+    {
+        return $this->level;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            ...parent::jsonSerialize(),
+            'level' => $this->level,
+        ];
+    }
+}

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponse.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponse.php
@@ -2,8 +2,10 @@
 
 namespace Shopware\Core\Content\MailTemplate\Validation;
 
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+#[Package('after-sales')]
 abstract class MailTemplateValidationResponse extends Struct
 {
     final public const LEVEL_ERROR = 'error';

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseArrayAccess.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseArrayAccess.php
@@ -5,12 +5,13 @@ namespace Shopware\Core\Content\MailTemplate\Validation;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
-abstract class MailTemplateValidationWarning extends MailTemplateValidationResponse
+class MailTemplateValidationResponseArrayAccess extends MailTemplateValidationError
 {
-    private const LEVEL = 'warning';
+    private const TYPE = 'arrayAccess';
 
     public function __construct(
         private readonly string $field,
+        private readonly string $variable,
         private readonly int $line = 0,
     ) {
         parent::__construct($this->field, $this->line);
@@ -20,7 +21,8 @@ abstract class MailTemplateValidationWarning extends MailTemplateValidationRespo
     {
         return [
             ...parent::jsonSerialize(),
-            'level' => self::LEVEL,
+            'variable' => $this->variable,
+            'type' => self::TYPE,
         ];
     }
 }

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseCollection.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseCollection.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate\Validation;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Collection;
+
+/**
+ * @extends Collection<MailTemplateValidationResponse>
+ */
+#[Package('after-sales')]
+class MailTemplateValidationResponseCollection extends Collection
+{
+    public function jsonSerialize(): array
+    {
+        return array_map(fn(MailTemplateValidationResponse $el) => $el->jsonSerialize(), $this->elements);
+    }
+}

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseComplexElement.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseComplexElement.php
@@ -5,12 +5,13 @@ namespace Shopware\Core\Content\MailTemplate\Validation;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
-abstract class MailTemplateValidationWarning extends MailTemplateValidationResponse
+class MailTemplateValidationResponseComplexElement extends MailTemplateValidationWarning
 {
-    private const LEVEL = 'warning';
+    private const TYPE = 'complexElement';
 
     public function __construct(
         private readonly string $field,
+        private readonly string $variable,
         private readonly int $line = 0,
     ) {
         parent::__construct($this->field, $this->line);
@@ -20,7 +21,8 @@ abstract class MailTemplateValidationWarning extends MailTemplateValidationRespo
     {
         return [
             ...parent::jsonSerialize(),
-            'level' => self::LEVEL,
+            'variable' => $this->variable,
+            'type' => self::TYPE,
         ];
     }
 }

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseSyntax.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseSyntax.php
@@ -5,12 +5,13 @@ namespace Shopware\Core\Content\MailTemplate\Validation;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
-abstract class MailTemplateValidationWarning extends MailTemplateValidationResponse
+class MailTemplateValidationResponseSyntax extends MailTemplateValidationError
 {
-    private const LEVEL = 'warning';
+    private const TYPE = 'syntax';
 
     public function __construct(
         private readonly string $field,
+        private readonly string $message,
         private readonly int $line = 0,
     ) {
         parent::__construct($this->field, $this->line);
@@ -20,7 +21,8 @@ abstract class MailTemplateValidationWarning extends MailTemplateValidationRespo
     {
         return [
             ...parent::jsonSerialize(),
-            'level' => self::LEVEL,
+            'message' => $this->message,
+            'type' => self::TYPE,
         ];
     }
 }

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseUnknownVariable.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationResponseUnknownVariable.php
@@ -5,12 +5,13 @@ namespace Shopware\Core\Content\MailTemplate\Validation;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
-abstract class MailTemplateValidationWarning extends MailTemplateValidationResponse
+class MailTemplateValidationResponseUnknownVariable extends MailTemplateValidationError
 {
-    private const LEVEL = 'warning';
+    private const TYPE = 'unknownVariable';
 
     public function __construct(
         private readonly string $field,
+        private readonly string $variable,
         private readonly int $line = 0,
     ) {
         parent::__construct($this->field, $this->line);
@@ -20,7 +21,9 @@ abstract class MailTemplateValidationWarning extends MailTemplateValidationRespo
     {
         return [
             ...parent::jsonSerialize(),
-            'level' => self::LEVEL,
+            'variable' => $this->variable,
+            'type' => self::TYPE,
         ];
     }
+
 }

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationWarning.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationWarning.php
@@ -2,16 +2,20 @@
 
 namespace Shopware\Core\Content\MailTemplate\Validation;
 
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Type;
 
+#[Package('after-sales')]
 class MailTemplateValidationWarning extends MailTemplateValidationResponse
 {
     final public const TYPE_COMPLEX_ELEMENT = 'complexElement';
 
+    /**
+     * @param array<string, string> $config
+     */
     public function __construct(
         private readonly DataValidator $dataValidator,
         private readonly string $type,

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationWarning.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationWarning.php
@@ -18,7 +18,7 @@ class MailTemplateValidationWarning extends MailTemplateValidationResponse
         private readonly array $config,
         private readonly int $line = 0,
     ) {
-        parent::__construct(self::LEVEL_ERROR);
+        parent::__construct(self::LEVEL_WARNING);
 
         if (!($type === self::TYPE_COMPLEX_ELEMENT)) {
             throw new \Exception('Mail template validation error type is not valid');

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationWarning.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationWarning.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate\Validation;
+
+use Shopware\Core\Framework\Validation\DataValidationDefinition;
+use Shopware\Core\Framework\Validation\DataValidator;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Optional;
+use Symfony\Component\Validator\Constraints\Type;
+
+class MailTemplateValidationWarning extends MailTemplateValidationResponse
+{
+    final public const TYPE_COMPLEX_ELEMENT = 'complexElement';
+
+    public function __construct(
+        private readonly DataValidator $dataValidator,
+        private readonly string $type,
+        private readonly array $config,
+        private readonly int $line = 0,
+    ) {
+        parent::__construct(self::LEVEL_ERROR);
+
+        if (!($type === self::TYPE_COMPLEX_ELEMENT)) {
+            throw new \Exception('Mail template validation error type is not valid');
+        }
+
+        $this->dataValidator->validate($config, $this->getVariableConfigValidation());
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            ...parent::jsonSerialize(),
+            ...$this->config,
+            'type' => $this->type,
+            'line' => $this->line,
+        ];
+    }
+
+    private function getVariableConfigValidation(): DataValidationDefinition
+    {
+        $definition = new DataValidationDefinition('variable');
+
+        $definition->add('variable', new NotBlank(), new Type('string'));
+        $definition->add('path', new Optional([new NotBlank(), new Type('string')]));
+
+        return $definition;
+    }
+}

--- a/src/Core/Content/MailTemplate/Validation/MailTemplateValidationWarning.php
+++ b/src/Core/Content/MailTemplate/Validation/MailTemplateValidationWarning.php
@@ -42,7 +42,6 @@ class MailTemplateValidationWarning extends MailTemplateValidationResponse
         $definition = new DataValidationDefinition('variable');
 
         $definition->add('variable', new NotBlank(), new Type('string'));
-        $definition->add('path', new Optional([new NotBlank(), new Type('string')]));
 
         return $definition;
     }

--- a/src/Core/Content/Media/Event/MediaUploadedEvent.php
+++ b/src/Core/Content/Media/Event/MediaUploadedEvent.php
@@ -33,7 +33,7 @@ class MediaUploadedEvent extends Event implements ScalarValuesAware, FlowEventAw
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('mediaId', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->add(FlowMailVariables::MEDIA_ID, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     public function getValues(): array

--- a/src/Core/Content/Media/Event/MediaUploadedEvent.php
+++ b/src/Core/Content/Media/Event/MediaUploadedEvent.php
@@ -43,6 +43,11 @@ class MediaUploadedEvent extends Event implements ScalarValuesAware, FlowEventAw
         ];
     }
 
+    public static function getScalarKeys(): array
+    {
+        // TODO: Implement getScalarKeys() method.
+    }
+
     public function getMediaId(): string
     {
         return $this->mediaId;

--- a/src/Core/Content/Media/Event/MediaUploadedEvent.php
+++ b/src/Core/Content/Media/Event/MediaUploadedEvent.php
@@ -43,11 +43,6 @@ class MediaUploadedEvent extends Event implements ScalarValuesAware, FlowEventAw
         ];
     }
 
-    public static function getScalarKeys(): array
-    {
-        // TODO: Implement getScalarKeys() method.
-    }
-
     public function getMediaId(): string
     {
         return $this->mediaId;

--- a/src/Core/Content/Newsletter/Event/NewsletterConfirmEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterConfirmEvent.php
@@ -3,10 +3,11 @@
 namespace Shopware\Core\Content\Newsletter\Event;
 
 use Shopware\Core\Content\Flow\Dispatching\Aware\NewsletterRecipientAware;
-use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\NewsletterRecipientStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -45,7 +46,9 @@ class NewsletterConfirmEvent extends Event implements SalesChannelAware, MailAwa
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('newsletterRecipient', new EntityType(NewsletterRecipientDefinition::class));
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(NewsletterRecipientStorer::getAvailableData());
     }
 
     public function getNewsletterRecipient(): NewsletterRecipientEntity

--- a/src/Core/Content/Newsletter/Event/NewsletterRegisterEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterRegisterEvent.php
@@ -5,10 +5,11 @@ namespace Shopware\Core\Content\Newsletter\Event;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\NewsletterRecipientAware;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
-use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\NewsletterRecipientStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
@@ -36,8 +37,10 @@ class NewsletterRegisterEvent extends Event implements SalesChannelAware, MailAw
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('newsletterRecipient', new EntityType(NewsletterRecipientDefinition::class))
-            ->add('url', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(NewsletterRecipientStorer::getAvailableData())
+            ->add(FlowMailVariables::URL, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     /**

--- a/src/Core/Content/Newsletter/Event/NewsletterUnsubscribeEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterUnsubscribeEvent.php
@@ -3,10 +3,11 @@
 namespace Shopware\Core\Content\Newsletter\Event;
 
 use Shopware\Core\Content\Flow\Dispatching\Aware\NewsletterRecipientAware;
-use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\NewsletterRecipientStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\FlowEventAware;
@@ -45,7 +46,9 @@ class NewsletterUnsubscribeEvent extends Event implements SalesChannelAware, Mai
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('newsletterRecipient', new EntityType(NewsletterRecipientDefinition::class));
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(NewsletterRecipientStorer::getAvailableData());
     }
 
     public function getNewsletterRecipient(): NewsletterRecipientEntity

--- a/src/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEvent.php
@@ -55,6 +55,27 @@ final class ReviewFormEvent extends Event implements SalesChannelAware, MailAwar
         return [FlowMailVariables::REVIEW_FORM_DATA => $this->reviewFormData];
     }
 
+    /**
+     * @return array<string>
+     */
+    public static function getScalarKeys(): array
+    {
+        return [
+            FlowMailVariables::REVIEW_FORM_DATA . '.forwardTo' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.parentId' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.forwardParameters' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.id' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.points' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.title' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.content' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.name' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.lastName' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.email' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.customerId' => '',
+            FlowMailVariables::REVIEW_FORM_DATA . '.productId' => '',
+        ];
+    }
+
     public function getName(): string
     {
         return self::EVENT_NAME;

--- a/src/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEvent.php
@@ -2,15 +2,19 @@
 
 namespace Shopware\Core\Content\Product\SalesChannel\Review\Event;
 
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
+use Shopware\Core\Framework\Event\EventData\ArrayType;
+use Shopware\Core\Framework\Event\EventData\AssociativeArrayType;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ObjectType;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\ProductAware;
@@ -43,8 +47,34 @@ final class ReviewFormEvent extends Event implements SalesChannelAware, MailAwar
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add(FlowMailVariables::REVIEW_FORM_DATA, new ObjectType())
-            ->add(ProductAware::PRODUCT, new EntityType(ProductDefinition::class));
+            ->add(
+                MailAware::MAIL_STRUCT,
+                (new ObjectType())
+                    ->add('bcc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
+                    ->add('cc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
+                    ->add('recipients', new AssociativeArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING), new ScalarValueType(ScalarValueType::TYPE_STRING)))
+            )
+            ->add(MailAware::SALES_CHANNEL_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(MailAware::TIMEZONE, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(ProductAware::PRODUCT, new EntityType(ProductDefinition::class))
+            ->add(CustomerAware::CUSTOMER_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
+            ->add(CustomerAware::CUSTOMER, new EntityType(CustomerDefinition::class))
+            ->add(
+                FlowMailVariables::REVIEW_FORM_DATA,
+                (new ObjectType())
+                    ->add('forwardTo', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('parentId', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('forwardParameters', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('id', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('points', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('title', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('content', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('name', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('lastName', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('email', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('customerId', new ScalarValueType(ScalarValueType::TYPE_STRING))
+                    ->add('productId', new ScalarValueType(ScalarValueType::TYPE_STRING))
+            );
     }
 
     /**
@@ -53,27 +83,6 @@ final class ReviewFormEvent extends Event implements SalesChannelAware, MailAwar
     public function getValues(): array
     {
         return [FlowMailVariables::REVIEW_FORM_DATA => $this->reviewFormData];
-    }
-
-    /**
-     * @return array<string>
-     */
-    public static function getScalarKeys(): array
-    {
-        return [
-            FlowMailVariables::REVIEW_FORM_DATA . '.forwardTo' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.parentId' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.forwardParameters' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.id' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.points' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.title' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.content' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.name' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.lastName' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.email' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.customerId' => '',
-            FlowMailVariables::REVIEW_FORM_DATA . '.productId' => '',
-        ];
     }
 
     public function getName(): string

--- a/src/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEvent.php
@@ -2,15 +2,14 @@
 
 namespace Shopware\Core\Content\Product\SalesChannel\Review\Event;
 
-use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
-use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\ProductStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\CustomerAware;
-use Shopware\Core\Framework\Event\EventData\ArrayType;
-use Shopware\Core\Framework\Event\EventData\AssociativeArrayType;
-use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ObjectType;
@@ -47,18 +46,10 @@ final class ReviewFormEvent extends Event implements SalesChannelAware, MailAwar
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add(
-                MailAware::MAIL_STRUCT,
-                (new ObjectType())
-                    ->add('bcc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
-                    ->add('cc', (new ScalarValueType(ScalarValueType::TYPE_STRING))->setNullable())
-                    ->add('recipients', new AssociativeArrayType(new ScalarValueType(ScalarValueType::TYPE_STRING), new ScalarValueType(ScalarValueType::TYPE_STRING)))
-            )
-            ->add(MailAware::SALES_CHANNEL_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add(MailAware::TIMEZONE, new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add(ProductAware::PRODUCT, new EntityType(ProductDefinition::class))
-            ->add(CustomerAware::CUSTOMER_ID, new ScalarValueType(ScalarValueType::TYPE_STRING))
-            ->add(CustomerAware::CUSTOMER, new EntityType(CustomerDefinition::class))
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->merge(ProductStorer::getAvailableData())
+            ->merge(CustomerStorer::getAvailableData())
             ->add(
                 FlowMailVariables::REVIEW_FORM_DATA,
                 (new ObjectType())

--- a/src/Core/Content/ProductExport/Event/ProductExportLoggingEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportLoggingEvent.php
@@ -5,6 +5,8 @@ namespace Shopware\Core\Content\ProductExport\Event;
 use Monolog\Level;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowMailVariables;
 use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MailStorer;
+use Shopware\Core\Content\Flow\Dispatching\Storer\TimezoneStorer;
 use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
@@ -88,7 +90,9 @@ class ProductExportLoggingEvent extends Event implements LogAware, MailAware, Sc
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())
-            ->add('name', new ScalarValueType(ScalarValueType::TYPE_STRING));
+            ->merge(MailStorer::getAvailableData())
+            ->merge(TimezoneStorer::getAvailableData())
+            ->add(FlowMailVariables::EVENT_NAME, new ScalarValueType(ScalarValueType::TYPE_STRING));
     }
 
     public function getMailStruct(): MailRecipientStruct

--- a/src/Core/Framework/Adapter/Twig/StringTemplateRenderer.php
+++ b/src/Core/Framework/Adapter/Twig/StringTemplateRenderer.php
@@ -80,15 +80,7 @@ class StringTemplateRenderer
             $coreExtension->setTimezone($data['timezone']);
         }
 
-        try {
-            return $this->twig->render($name, $data);
-        } catch (Error $error) {
-            if ($error instanceof SyntaxError) {
-                throw AdapterException::invalidTemplateSyntax($error->getMessage());
-            }
-
-            throw AdapterException::renderingTemplateFailed($error->getMessage());
-        }
+        return $this->twig->render($name, $data);
     }
 
     public function enableTestMode(): void

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -5,13 +5,17 @@ namespace Shopware\Core\Framework\Adapter\Twig;
 use Shopware\Core\Framework\Log\Package;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use Twig\Node\Expression\AssignNameExpression;
+use Twig\Node\EmptyNode;
 use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\FilterExpression;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\NameExpression;
+use Twig\Node\Expression\Variable\AssignContextVariable;
 use Twig\Node\ForNode;
 use Twig\Node\Node;
+use Twig\Node\Nodes;
 use Twig\Node\SetNode;
+use Twig\Node\TextNode;
 
 #[Package('framework')]
 class TwigVariableParser
@@ -40,66 +44,79 @@ class TwigVariableParser
     }
 
     /**
-     * @param array<Node> $nodes
-     * @param array<mixed> $aliases
+     * @param array<Nodes> $nodes
+     * @param array<string, string> $aliases
      *
-     * @return array<mixed>
+     * @return array<string,string>
      */
-    private function getVariables(iterable $nodes, array $aliases = [], bool $excludeAssignNameExpression = true): array
+    private function getVariables(iterable $nodes, array $aliases = []): array
     {
         $variables = [];
+
         foreach ($nodes as $node) {
-            if ($excludeAssignNameExpression && $node instanceof AssignNameExpression) {
+            if ($node instanceof EmptyNode || $node instanceof TextNode) {
                 continue;
             }
 
-            if ($node instanceof NameExpression) {
+            if ($node instanceof NameExpression || $nodes instanceof AssignContextVariable) {
                 $name = $node->getAttribute('name');
-
-                if (isset($aliases[$name])) {
-                    $name = $aliases[$name];
-                }
-
-                $variables[$name] = $name;
-
+                $variables[$name] = $aliases[$name] ?? $name;
                 continue;
-            }
-
-            if ($node instanceof SetNode) {
-                $target = implode('.', $this->getVariables([$node->getNode('names')], $aliases, false));
-                $aliases[$target] = '';
             }
 
             if ($node instanceof ConstantExpression && $nodes instanceof GetAttrExpression) {
                 $value = $node->getAttribute('value');
-                if (!empty($value)) {
+                $variables[$value] = $value;
+                continue;
+            }
+
+            if ($node instanceof ConstantExpression && $nodes instanceof FilterExpression) {
+                $value = $node->getAttribute('value');
+                if ($value === 'first' || $value === 'last') {
                     $variables[$value] = $value;
                 }
-
                 continue;
             }
 
             if ($node instanceof GetAttrExpression) {
-                $path = implode('.', $this->getVariables($node, $aliases, $excludeAssignNameExpression));
+                $path = implode('.', $this->getVariables($node, $aliases));
                 if (!empty($path)) {
                     $variables[$path] = $path;
                 }
+                continue;
+            }
 
+            if ($node instanceof SetNode) {
+                $i = 0;
+                $names = $node->getNode('names');
+                $values = $node->getNode('values');
+                while ($names->hasNode((string) $i)) {
+                    $alias = implode('.', $this->getVariables([$names->getNode((string) $i)], $aliases));
+                    $valueNode = $values->getNode((string) $i);
+                    if ($valueNode instanceof GetAttrExpression || $valueNode instanceof NameExpression) {
+                        $aliases[$alias] = implode('.', $this->getVariables([$valueNode], $aliases));
+                    } else {
+                        $variables = array_merge($variables, $this->getVariables($valueNode, $aliases));
+                        $aliases[$alias] = '';
+                    }
+                    $i++;
+                }
                 continue;
             }
 
             if ($node instanceof ForNode) {
-                $target = implode('.', $this->getVariables([$node->getNode('seq')], $aliases, $excludeAssignNameExpression));
-                $source = $node->getNode('value_target')->getAttribute('name');
-
-                $aliases[$source] = $target . '.0';
+                $path = implode('.', $this->getVariables([$node->getNode('seq')], $aliases));
+                $loopAliases = [...$aliases];
+                $loopAliases[$node->getNode('value_target')->getAttribute('name')] = $path . '.0';
+                $variables = array_merge($variables, $this->getVariables([$node->getNode('body')], $loopAliases));
+                continue;
             }
 
             if ($node instanceof Node) {
-                $variables += $this->getVariables($node, $aliases, $excludeAssignNameExpression);
+                $variables = array_merge($variables, $this->getVariables($node, $aliases));
             }
         }
 
-        return array_filter($variables);
+        return array_filter($variables, fn (string $variable) => !empty($variable) && !\str_starts_with($variable, '.'));
     }
 }

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -12,9 +12,7 @@ use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\Expression\Variable\AssignContextVariable;
 use Twig\Node\ForNode;
-use Twig\Node\ModuleNode;
 use Twig\Node\Node;
-use Twig\Node\Nodes;
 use Twig\Node\SetNode;
 use Twig\Node\TextNode;
 

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -117,6 +117,6 @@ class TwigVariableParser
             }
         }
 
-        return array_filter($variables, fn (string $variable) => !empty($variable) && !\str_starts_with($variable, '.'));
+        return array_filter($variables, fn (string $variable) => $variable !== '' && !\str_starts_with($variable, '.'));
     }
 }

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -9,8 +9,10 @@ use Twig\Node\Expression\AssignNameExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\NameExpression;
+use Twig\Node\Expression\Variable\ContextVariable;
 use Twig\Node\ForNode;
 use Twig\Node\Node;
+use Twig\Node\SetNode;
 
 #[Package('framework')]
 class TwigVariableParser
@@ -44,11 +46,11 @@ class TwigVariableParser
      *
      * @return array<mixed>
      */
-    private function getVariables(iterable $nodes, array $aliases = []): array
+    private function getVariables(iterable $nodes, array $aliases = [], bool $excludeAssignNameExpression = true): array
     {
         $variables = [];
         foreach ($nodes as $node) {
-            if ($node instanceof AssignNameExpression) {
+            if ($excludeAssignNameExpression && $node instanceof AssignNameExpression) {
                 continue;
             }
 
@@ -64,9 +66,14 @@ class TwigVariableParser
                 continue;
             }
 
+            if ($node instanceof SetNode) {
+                $target = implode('.', $this->getVariables([$node->getNode('names')], $aliases, false));
+                $aliases[$target] = '';
+            }
+
             if ($node instanceof ConstantExpression && $nodes instanceof GetAttrExpression) {
                 $value = $node->getAttribute('value');
-                if (!empty($value) && \is_string($value)) {
+                if (!empty($value)) {
                     $variables[$value] = $value;
                 }
 
@@ -74,7 +81,7 @@ class TwigVariableParser
             }
 
             if ($node instanceof GetAttrExpression) {
-                $path = implode('.', $this->getVariables($node, $aliases));
+                $path = implode('.', $this->getVariables($node, $aliases, $excludeAssignNameExpression));
                 if (!empty($path)) {
                     $variables[$path] = $path;
                 }
@@ -83,17 +90,17 @@ class TwigVariableParser
             }
 
             if ($node instanceof ForNode) {
-                $target = implode('.', $this->getVariables($node->getNode('seq'), $aliases));
+                $target = implode('.', $this->getVariables([$node->getNode('seq')], $aliases, $excludeAssignNameExpression));
                 $source = $node->getNode('value_target')->getAttribute('name');
 
-                $aliases[$source] = $target;
+                $aliases[$source] = $target . '.0';
             }
 
             if ($node instanceof Node) {
-                $variables += $this->getVariables($node, $aliases);
+                $variables += $this->getVariables($node, $aliases, $excludeAssignNameExpression);
             }
         }
 
-        return $variables;
+        return array_filter($variables);
     }
 }

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -9,7 +9,6 @@ use Twig\Node\Expression\AssignNameExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\NameExpression;
-use Twig\Node\Expression\Variable\ContextVariable;
 use Twig\Node\ForNode;
 use Twig\Node\Node;
 use Twig\Node\SetNode;

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -12,6 +12,7 @@ use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\Expression\Variable\AssignContextVariable;
 use Twig\Node\ForNode;
+use Twig\Node\ModuleNode;
 use Twig\Node\Node;
 use Twig\Node\Nodes;
 use Twig\Node\SetNode;
@@ -28,7 +29,7 @@ class TwigVariableParser
     }
 
     /**
-     * @return array<mixed>
+     * @return string[]
      */
     public function parse(string $template): array
     {
@@ -44,7 +45,7 @@ class TwigVariableParser
     }
 
     /**
-     * @param array<Nodes> $nodes
+     * @param Node|Node[]|array<int, Node> $nodes
      * @param array<string, string> $aliases
      *
      * @return array<string,string>

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -88,19 +88,19 @@ class TwigVariableParser
             }
 
             if ($node instanceof SetNode) {
-                $i = 0;
                 $names = $node->getNode('names');
                 $values = $node->getNode('values');
-                while ($names->hasNode((string) $i)) {
+
+                for ($i = 0; $names->hasNode((string) $i); $i++) {
                     $alias = implode('.', $this->getVariables([$names->getNode((string) $i)], $aliases));
                     $valueNode = $values->getNode((string) $i);
+
                     if ($valueNode instanceof GetAttrExpression || $valueNode instanceof NameExpression) {
                         $aliases[$alias] = implode('.', $this->getVariables([$valueNode], $aliases));
                     } else {
                         $variables = array_merge($variables, $this->getVariables($valueNode, $aliases));
                         $aliases[$alias] = '';
                     }
-                    $i++;
                 }
                 continue;
             }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
@@ -271,10 +271,16 @@ class EntityDefinitionQueryHelper
             $referenceDefinition = $field->getToManyReferenceDefinition();
         }
 
+        $root = $root . '.' . $field->getPropertyName();
+
+        if ($root === $original) {
+            return $field;
+        }
+
         return static::getField(
             $original,
             $referenceDefinition,
-            $root . '.' . $field->getPropertyName(),
+            $root,
             $resolveTranslated
         );
     }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
@@ -233,6 +233,7 @@ class EntityDefinitionQueryHelper
             if ($isAssociation) {
                 return null;
             }
+
             return self::getTranslatedField($definition, $field);
         }
         // This logic handles the fields behind the 'translated' property
@@ -246,12 +247,14 @@ class EntityDefinitionQueryHelper
             unset($fieldNameParts[0]);
             $test = \implode('.', $fieldNameParts);
             $translationDefinition = $definition->getTranslationDefinition();
+
             return self::getField($test, $translationDefinition, $translationDefinition::ENTITY_NAME ?? '');
         }
         if ($field instanceof TranslatedField) {
             if ($isAssociation) {
                 return null;
             }
+
             return $field;
         }
 
@@ -263,6 +266,7 @@ class EntityDefinitionQueryHelper
             if ($isAssociation) {
                 return null;
             }
+
             return $field;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
@@ -26,6 +27,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\Validator\Constraints\Json;
 
 /**
  * This class acts only as helper/common class for all dbal operations for entity definitions.
@@ -228,13 +230,39 @@ class EntityDefinitionQueryHelper
         }
 
         if ($field instanceof TranslatedField && $resolveTranslated) {
+            if ($isAssociation) {
+                return null;
+            }
             return self::getTranslatedField($definition, $field);
         }
+        // This logic handles the fields behind the 'translated' property
+        if ($field instanceof JsonField && $field->getPropertyName() === EntityDefinition::TRANSLATED_FIELD && $resolveTranslated) {
+            if (!$isAssociation) {
+                return $field;
+            }
+
+            $fieldNameParts = \explode('.', $fieldName);
+
+            unset($fieldNameParts[0]);
+            $test = \implode('.', $fieldNameParts);
+            $translationDefinition = $definition->getTranslationDefinition();
+            return self::getField($test, $translationDefinition, $translationDefinition::ENTITY_NAME ?? '');
+        }
         if ($field instanceof TranslatedField) {
+            if ($isAssociation) {
+                return null;
+            }
             return $field;
         }
 
         if (!$field instanceof AssociationField) {
+            /*
+             * I added these if statements because fields like product.translated.foobar (doesn't exist)  were handled incorrectly.
+             * In this case the JsonField value of 'translated' was returned.
+             */
+            if ($isAssociation) {
+                return null;
+            }
             return $field;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
@@ -248,7 +248,11 @@ class EntityDefinitionQueryHelper
             $test = \implode('.', $fieldNameParts);
             $translationDefinition = $definition->getTranslationDefinition();
 
-            return self::getField($test, $translationDefinition, $translationDefinition::ENTITY_NAME ?? '');
+            if (!$translationDefinition) {
+                return null;
+            }
+
+            return self::getField($test, $translationDefinition, $translationDefinition->getEntityName());
         }
         if ($field instanceof TranslatedField) {
             if ($isAssociation) {

--- a/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
@@ -31,6 +31,8 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 #[Package('framework')]
 abstract class EntityDefinition
 {
+    final public const TRANSLATED_FIELD = 'translated';
+
     protected ?CompiledFieldCollection $fields = null;
 
     /**
@@ -184,7 +186,7 @@ abstract class EntityDefinition
             if ($field instanceof TranslationsAssociationField) {
                 $this->translationField = $field;
                 $fields->add(
-                    (new JsonField('translated', 'translated'))->addFlags(new ApiAware(), new Computed(), new Runtime())
+                    (new JsonField(self::TRANSLATED_FIELD, self::TRANSLATED_FIELD))->addFlags(new ApiAware(), new Computed(), new Runtime())
                 );
 
                 break;

--- a/src/Core/Framework/DataAbstractionLayer/Field/FkField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/FkField.php
@@ -53,6 +53,11 @@ class FkField extends Field implements StorageAware
         return $this->referenceDefinition;
     }
 
+    public function getReferenceClass(): string
+    {
+        return $this->referenceClass;
+    }
+
     public function getReferenceField(): string
     {
         return $this->referenceField;

--- a/src/Core/Framework/Event/EventData/AssociativeArrayType.php
+++ b/src/Core/Framework/Event/EventData/AssociativeArrayType.php
@@ -5,12 +5,17 @@ namespace Shopware\Core\Framework\Event\EventData;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('fundamentals@after-sales')]
-class ArrayType extends EventDataType
+class AssociativeArrayType extends EventDataType
 {
-    final public const TYPE = 'array';
+    final public const TYPE = 'associative_array';
 
-    public function __construct(private readonly EventDataType $type)
+    public function __construct(private readonly ScalarValueType $key, private readonly EventDataType $type)
     {
+    }
+
+    public function getKey(): ScalarValueType
+    {
+        return $this->key;
     }
 
     public function getType(): EventDataType
@@ -24,6 +29,7 @@ class ArrayType extends EventDataType
             ...parent::toArray(),
             'type' => self::TYPE,
             'of' => $this->type->toArray(),
+            'key' => $this->key->toArray(),
         ];
     }
 }

--- a/src/Core/Framework/Event/EventData/EntityCollectionType.php
+++ b/src/Core/Framework/Event/EventData/EntityCollectionType.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Event\EventData;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('fundamentals@after-sales')]
-class EntityCollectionType implements EventDataType
+class EntityCollectionType extends EventDataType
 {
     final public const TYPE = 'collection';
 
@@ -13,9 +13,15 @@ class EntityCollectionType implements EventDataType
     {
     }
 
+    public function getDefinitionClass(): string
+    {
+        return $this->definitionClass;
+    }
+
     public function toArray(): array
     {
         return [
+            ...parent::toArray(),
             'type' => self::TYPE,
             'entityClass' => $this->definitionClass,
         ];

--- a/src/Core/Framework/Event/EventData/EntityType.php
+++ b/src/Core/Framework/Event/EventData/EntityType.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('fundamentals@after-sales')]
-class EntityType implements EventDataType
+class EntityType extends EventDataType
 {
     final public const TYPE = 'entity';
 
@@ -35,9 +35,20 @@ class EntityType implements EventDataType
         $this->entityName = $entityDefinition->getEntityName();
     }
 
+    public function getDefinitionClass(): string
+    {
+        return $this->definitionClass;
+    }
+
+    public function getEntityName(): string
+    {
+        return $this->entityName;
+    }
+
     public function toArray(): array
     {
         return [
+            ...parent::toArray(),
             'type' => self::TYPE,
             'entityClass' => $this->definitionClass,
             'entityName' => $this->entityName,

--- a/src/Core/Framework/Event/EventData/EventDataCollection.php
+++ b/src/Core/Framework/Event/EventData/EventDataCollection.php
@@ -31,4 +31,11 @@ class EventDataCollection
     {
         return array_map(fn ($type) => $type->toArray(), $this->data);
     }
+
+    public function merge(EventDataCollection $collection): EventDataCollection
+    {
+        $this->data = \array_merge($this->data, $collection->data);
+
+        return $this;
+    }
 }

--- a/src/Core/Framework/Event/EventData/EventDataCollection.php
+++ b/src/Core/Framework/Event/EventData/EventDataCollection.php
@@ -8,15 +8,20 @@ use Shopware\Core\Framework\Log\Package;
 class EventDataCollection
 {
     /**
-     * @var array<string, array<string, mixed>>
+     * @var array<string, EventDataType>
      */
     private array $data = [];
 
     public function add(string $name, EventDataType $type): self
     {
-        $this->data[$name] = $type->toArray();
+        $this->data[$name] = $type;
 
         return $this;
+    }
+
+    public function get(string $name): ?EventDataType
+    {
+        return $this->data[$name] ?? null;
     }
 
     /**
@@ -24,6 +29,6 @@ class EventDataCollection
      */
     public function toArray(): array
     {
-        return $this->data;
+        return array_map(fn ($type) => $type->toArray(), $this->data);
     }
 }

--- a/src/Core/Framework/Event/EventData/EventDataCollection.php
+++ b/src/Core/Framework/Event/EventData/EventDataCollection.php
@@ -25,6 +25,14 @@ class EventDataCollection
     }
 
     /**
+     * @return array<string, EventDataType>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
      * @return array<string, array<string, mixed>>
      */
     public function toArray(): array

--- a/src/Core/Framework/Event/EventData/EventDataType.php
+++ b/src/Core/Framework/Event/EventData/EventDataType.php
@@ -5,10 +5,24 @@ namespace Shopware\Core\Framework\Event\EventData;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('fundamentals@after-sales')]
-interface EventDataType
+abstract class EventDataType
 {
+    private bool $nullable = false;
+
     /**
      * @return array<string, mixed>
      */
-    public function toArray(): array;
+    public function toArray(): array
+    {
+        return [
+            'nullable' => $this->nullable,
+        ];
+    }
+
+    public function setNullable(): self
+    {
+        $this->nullable = true;
+
+        return $this;
+    }
 }

--- a/src/Core/Framework/Event/EventData/ForeignKeyType.php
+++ b/src/Core/Framework/Event/EventData/ForeignKeyType.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Event\EventData;
+
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+
+class ForeignKeyType extends ScalarValueType
+{
+    public function __construct(
+        private readonly string $referenceClass,
+    ) {
+        parent::__construct(self::TYPE_STRING);
+    }
+
+    public function getReferenceClass(): string
+    {
+        return $this->referenceClass;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            ...parent::toArray(),
+            'referenceClass' => $this->referenceClass,
+        ];
+    }
+}

--- a/src/Core/Framework/Event/EventData/MixedType.php
+++ b/src/Core/Framework/Event/EventData/MixedType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Shopware\Core\Framework\Event\EventData;
+
+class MixedType extends EventDataType
+{
+    final public const TYPE = 'mixed';
+
+    public function toArray(): array
+    {
+        return [
+            ...parent::toArray(),
+            'type' => self::TYPE,
+        ];
+    }
+}

--- a/src/Core/Framework/Event/EventData/MixedType.php
+++ b/src/Core/Framework/Event/EventData/MixedType.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\Framework\Event\EventData;
 

--- a/src/Core/Framework/Event/EventData/MixedType.php
+++ b/src/Core/Framework/Event/EventData/MixedType.php
@@ -2,6 +2,9 @@
 
 namespace Shopware\Core\Framework\Event\EventData;
 
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('fundamentals@after-sales')]
 class MixedType extends EventDataType
 {
     final public const TYPE = 'mixed';

--- a/src/Core/Framework/Event/EventData/ObjectType.php
+++ b/src/Core/Framework/Event/EventData/ObjectType.php
@@ -12,7 +12,7 @@ class ObjectType extends EventDataType
     /**
      * @var array<string, EventDataType>
      */
-    private ?array $data = [];
+    private array $data = [];
 
     public function add(string $name, EventDataType $type): self
     {

--- a/src/Core/Framework/Event/EventData/ObjectType.php
+++ b/src/Core/Framework/Event/EventData/ObjectType.php
@@ -26,6 +26,14 @@ class ObjectType extends EventDataType
         return $this->data[$name] ?? null;
     }
 
+    /**
+     * @return array<string, EventDataType>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
     public function toArray(): array
     {
         return [

--- a/src/Core/Framework/Event/EventData/ObjectType.php
+++ b/src/Core/Framework/Event/EventData/ObjectType.php
@@ -5,27 +5,33 @@ namespace Shopware\Core\Framework\Event\EventData;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('fundamentals@after-sales')]
-class ObjectType implements EventDataType
+class ObjectType extends EventDataType
 {
     final public const TYPE = 'object';
 
     /**
-     * @var array<string, mixed>|null
+     * @var array<string, EventDataType>
      */
-    private ?array $data = null;
+    private ?array $data = [];
 
     public function add(string $name, EventDataType $type): self
     {
-        $this->data[$name] = $type->toArray();
+        $this->data[$name] = $type;
 
         return $this;
+    }
+
+    public function get(string $name): ?EventDataType
+    {
+        return $this->data[$name] ?? null;
     }
 
     public function toArray(): array
     {
         return [
+            ...parent::toArray(),
             'type' => self::TYPE,
-            'data' => $this->data,
+            'data' => array_map(fn ($type) => $type->toArray(), $this->data),
         ];
     }
 }

--- a/src/Core/Framework/Event/EventData/ScalarValueType.php
+++ b/src/Core/Framework/Event/EventData/ScalarValueType.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Event\EventData;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('fundamentals@after-sales')]
-class ScalarValueType implements EventDataType
+class ScalarValueType extends EventDataType
 {
     final public const TYPE_STRING = 'string';
     final public const TYPE_INT = 'int';
@@ -30,9 +30,15 @@ class ScalarValueType implements EventDataType
         $this->type = $type;
     }
 
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
     public function toArray(): array
     {
         return [
+            ...parent::toArray(),
             'type' => $this->type,
         ];
     }


### PR DESCRIPTION
This is my current POC for the email template validation (#11563)

The validation itself should idealy contain three steps:
1. Validate twig syntax and extract used variables (easily done via `TwigVariableParser::parse(...)`)
2. Check used variables if they would be available when sending the email
3. Fill the variables with minimal content ('Lorem ipsum' strings and such) and render the template to see if it would handle the data correctly (especially array access, etc.) <--- this step would currently be a nice to have but not mandatory

Known issues:
- Currently nothing hinders a user to send a mail with custom context. So it maybe would make sense to provide this context via a selection (existing or custom) as we for example could get information about the available data for a flow event (cf. `ReviewFormEvent`)