### PR TITLE
chore: remove extra assertions from database transaction behaviour

### DIFF
--- a/tests/integration/Core/Framework/TestCaseBase/DatabaseTransactionBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/DatabaseTransactionBehaviourTest.php
@@ -39,6 +39,14 @@ class DatabaseTransactionBehaviourTest extends TestCase
         }
     }
 
+    public function testNoAssertionIsPerformedInTheTrait(): void
+    {
+        // This test is to ensure that the DatabaseTransactionBehaviour trait does not perform any assertions
+        // during its execution, which could interfere with testing behaviour, as test suites consuming this trait
+        // may hide risky tests.
+        static::expectNotToPerformAssertions();
+    }
+
     public function testInTransaction(): void
     {
         $connection = KernelLifecycleManager::getKernel()


### PR DESCRIPTION
### 1. Why is this change necessary?
Following up https://github.com/shopware/shopware/pull/11942 with some dead code removal initiative, some integration tests have been discovered with zero direct assertions in their body, while 2 assertions were always performed.
[tests/integration/Storefront/Controller/CookieControllerTest.php](https://github.com/shopware/shopware/pull/11942/files/80e69bba43f9214f9ea3b25b4ff7b759c9b0e2be#diff-3a99413abae48939b978ec51ef2ff2003c2629f32c53b55bc963f5bd1de3d46a)
[tests/integration/Storefront/Theme/ThemeLifecycleHandlerTest.php](https://github.com/shopware/shopware/pull/11942/files/80e69bba43f9214f9ea3b25b4ff7b759c9b0e2be#diff-c19da04794a45b342b5bf807542ad80b425fd0929c812fba48f00617e96c4944)


This is due to DatabaseTransactionBehaviour (embedded within IntegrationTestBehaviour), which is doing 2 PHPUnit assertions when simple if statement would suffice.

It is a bad practice as it will hide any integration test consuming these traits, and not performing any other assertions, marking them as "passed" while they are asserting nothing, which is `risky` with the letter `R` in PHPUnit result.
This is misleading anyone relying on integration test.

### 2. What does this change do, exactly?
(first commit) Create a test expecting no assertion done within pure usage of DatabaseTransactionBehaviour, in DatabaseTransactionBehaviourTest => the result for `testNoAssertionIsPerformedInTheTrait` will be a risky test

(second commit) Fix this test by removing assertions in DatabaseTransactionBehaviour by if statement, and still throwing PHPUnit expectation failure exception to stay compatible with our suites => `testNoAssertionIsPerformedInTheTrait` is no longer marked as risky test (no assertion is expected)

Additionally, after this, more integration tests using these DatabaseTransactionBehaviour trait might appear as `risky` and should be fixed


### 3. Describe each step to reproduce the issue or behaviour.
- Run the new test on local (first commit)
```
composer run phpunit -- --testsuite integration --filter DatabaseTransactionBehaviourTest
> phpunit '--testsuite' 'integration' '--filter' 'DatabaseTransactionBehaviourTest'
PHPUnit 11.5.32 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.29
Configuration: /Users/nfortier/Dev/platform/phpunit.xml.dist
Random Seed:   1755641298

..R..                                                               5 / 5 (100%)

Time: 00:00.542, Memory: 144.50 MB

There was 1 risky test:

1) Shopware\Tests\Integration\Core\Framework\TestCaseBase\DatabaseTransactionBehaviourTest::testNoAssertionIsPerformedInTheTrait
This test is not expected to perform assertions but performed 1 assertion

/Users/nfortier/Dev/platform/tests/integration/Core/Framework/TestCaseBase/DatabaseTransactionBehaviourTest.php:42

OK, but there were issues!
```
- Rerun on local (second commit) => no more risky test

- Check the pipeline on the first commit => https://github.com/shopware/shopware/actions/runs/17083170430/job/48441780737?pr=11995#step:6:56 
- Check the pipeline on the second commit => 
  - no more risky test for testNoAssertionIsPerformedInTheTrait
  - all hidden risky tests are showing up in every sub integration test suites (to be fixed in another PR)


### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/11998

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
