### PR TITLE
fix: Allow product detail endpoint to use criteria fields

### DIFF
--- a/changelog/_unreleased/2025-08-20-allow-product-detail-endpoint-to-use-criteria-fields.md
+++ b/changelog/_unreleased/2025-08-20-allow-product-detail-endpoint-to-use-criteria-fields.md
@@ -1,0 +1,8 @@
+---
+title: Allow product detail endpoint to use criteria fields
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute` to allow the criteria to accept `fields`

--- a/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
+++ b/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
@@ -16,6 +16,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Seo\MainCategory\MainCategoryEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
@@ -77,15 +78,15 @@ class CategoryBreadcrumbBuilder
         return $category;
     }
 
-    public function getProductSeoCategory(ProductEntity $product, SalesChannelContext $context): ?CategoryEntity
+    public function getProductSeoCategory(ProductEntity|PartialEntity $product, SalesChannelContext $context): ?CategoryEntity
     {
         $category = $this->getMainCategory($product, $context);
         if ($category !== null) {
             return $category;
         }
 
-        $categoryIds = $product->getCategoryIds() ?? [];
-        $productStreamIds = $product->getStreamIds() ?? [];
+        $categoryIds = $product->get('categoryIds') ?? [];
+        $productStreamIds = $product->get('streamIds') ?? [];
 
         if (empty($productStreamIds) && empty($categoryIds)) {
             return null;
@@ -198,14 +199,14 @@ class CategoryBreadcrumbBuilder
         return $this->getProductSeoCategory($product, $salesChannelContext);
     }
 
-    private function getMainCategory(ProductEntity $product, SalesChannelContext $context): ?CategoryEntity
+    private function getMainCategory(ProductEntity|PartialEntity $product, SalesChannelContext $context): ?CategoryEntity
     {
         $criteria = new Criteria();
         $criteria->setLimit(1);
         $criteria->setTitle('breadcrumb-builder::main-category');
 
-        if (($product->getMainCategories() === null || $product->getMainCategories()->count() <= 0) && $product->getParentId() !== null) {
-            $criteria->addFilter($this->getMainCategoryFilter($product->getParentId(), $context));
+        if (($product->get('mainCategories') === null || \count($product->get('mainCategories')) <= 0) && $product->get('parentId') !== null) {
+            $criteria->addFilter($this->getMainCategoryFilter($product->get('parentId'), $context));
         } else {
             $criteria->addFilter($this->getMainCategoryFilter($product->getId(), $context));
         }
@@ -219,7 +220,7 @@ class CategoryBreadcrumbBuilder
 
         $entity = $firstCategory instanceof MainCategoryEntity ? $firstCategory->getCategory() : $firstCategory;
 
-        return $product->getCategoryIds() !== null && $entity !== null && \in_array($entity->getId(), $product->getCategoryIds(), true) ? $entity : null;
+        return $product->get('categoryIds') !== null && $entity !== null && \in_array($entity->getId(), $product->get('categoryIds'), true) ? $entity : null;
     }
 
     private function getMainCategoryFilter(string $productId, SalesChannelContext $context): AndFilter

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Product\SalesChannel\Detail;
 
 use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingCollection;
+use Shopware\Core\Content\Product\DataAbstractionLayer\VariantListingConfig;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
@@ -11,6 +12,7 @@ use Shopware\Core\Content\Property\PropertyGroupDefinition;
 use Shopware\Core\Content\Property\PropertyGroupEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
@@ -34,10 +36,10 @@ class ProductConfiguratorLoader
      * @throws InconsistentCriteriaIdsException
      */
     public function load(
-        SalesChannelProductEntity $product,
+        SalesChannelProductEntity|PartialEntity $product,
         SalesChannelContext $context
     ): PropertyGroupCollection {
-        $parentId = $product->getParentId();
+        $parentId = $product->get('parentId');
         if (!$parentId) {
             return new PropertyGroupCollection();
         }
@@ -134,7 +136,7 @@ class ProductConfiguratorLoader
     /**
      * @param array<string, PropertyGroupEntity>|null $groups
      */
-    private function sortSettings(?array $groups, SalesChannelProductEntity $product): PropertyGroupCollection
+    private function sortSettings(?array $groups, SalesChannelProductEntity|PartialEntity $product): PropertyGroupCollection
     {
         if (!$groups) {
             return new PropertyGroupCollection();
@@ -180,7 +182,11 @@ class ProductConfiguratorLoader
         $collection = new PropertyGroupCollection($sorted);
 
         // check if product has an individual sorting configuration for property groups
-        $config = $product->getVariantListingConfig()?->getConfiguratorGroupConfig();
+        $variantListingConfig = $product->get('variantListingConfig');
+        $config = null;
+        if ($variantListingConfig instanceof VariantListingConfig) {
+            $config = $variantListingConfig->getConfiguratorGroupConfig();
+        }
 
         if (!$config) {
             $collection->sortByPositions();
@@ -225,9 +231,9 @@ class ProductConfiguratorLoader
     /**
      * @return array<int|string, string>
      */
-    private function buildCurrentOptions(SalesChannelProductEntity $product, PropertyGroupCollection $groups): array
+    private function buildCurrentOptions(SalesChannelProductEntity|PartialEntity $product, PropertyGroupCollection $groups): array
     {
-        if (empty($product->getOptionIds())) {
+        if (empty($product->get('optionIds'))) {
             return [];
         }
 
@@ -235,7 +241,7 @@ class ProductConfiguratorLoader
 
         $current = [];
 
-        foreach ($product->getOptionIds() as $optionId) {
+        foreach ($product->get('optionIds') as $optionId) {
             $groupId = $keyMap[$optionId] ?? null;
             if ($groupId === null) {
                 continue;

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -38,6 +39,9 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Package('inventory')]
 class ProductDetailRoute extends AbstractProductDetailRoute
 {
+    private const SKIP_CONFIGURATOR = 'skipConfigurator';
+    private const SKIP_CMS_PAGE = 'skipCmsPage';
+
     /**
      * @internal
      *
@@ -94,24 +98,24 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             $criteria->setIds([$productId]);
             $criteria->setTitle('product-detail-route');
 
+            /** @var SalesChannelProductEntity|PartialEntity|null $product */
             $product = $this->productRepository->search($criteria, $context)->getEntities()->first();
-            if (!($product instanceof SalesChannelProductEntity)) {
+            if (!$product) {
                 throw ProductException::productNotFound($productId);
             }
 
-            $parent = $product->getParentId() ?? $product->getId();
+            $parent = $product->get('parentId') ?? $product->getId();
 
             $this->cacheTagCollector->addTag(EntityCacheKeyGenerator::buildProductTag($parent));
 
-            $product->setSeoCategory(
-                $this->breadcrumbBuilder->getProductSeoCategory($product, $context)
-            );
+            $product->assign(['seoCategory' => $this->breadcrumbBuilder->getProductSeoCategory($product, $context)]);
 
-            $configurator = $this->configuratorLoader->load($product, $context);
+            $skipConfigurator = $request->query->getBoolean(self::SKIP_CONFIGURATOR);
+            $configurator = !$skipConfigurator ? $this->configuratorLoader->load($product, $context) : null;
 
-            $pageId = $product->getCmsPageId();
-
-            if ($pageId) {
+            $skipCmsPage = $request->query->getBoolean(self::SKIP_CMS_PAGE);
+            $pageId = $product->get('cmsPageId');
+            if (!$skipCmsPage && $pageId) {
                 // clone product to prevent recursion encoding (see NEXT-17603)
                 $resolverContext = new EntityResolverContext($context, $request, $this->productDefinition, clone $product);
 
@@ -119,13 +123,13 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                     $request,
                     $this->createCriteria($pageId, $request),
                     $context,
-                    $product->getTranslation('slotConfig'),
+                    $product->get('slotConfig') ?? ($product->get('translated') ?? [])['slotConfig'] ?? null,
                     $resolverContext
                 );
 
-                $cmsPage = $pages->first();
+                $cmsPage = $pages->getEntities()->first();
                 if ($cmsPage !== null) {
-                    $product->setCmsPage($cmsPage);
+                    $product->assign(['cmsPage' => $cmsPage]);
                 }
             }
 

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteResponse.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteResponse.php
@@ -4,18 +4,19 @@ namespace Shopware\Core\Content\Product\SalesChannel\Detail;
 
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 
 /**
- * @extends StoreApiResponse<ArrayStruct<array{product: SalesChannelProductEntity, configurator: PropertyGroupCollection|null}>>
+ * @extends StoreApiResponse<ArrayStruct<array{product: SalesChannelProductEntity|PartialEntity, configurator: PropertyGroupCollection|null}>>
  */
 #[Package('inventory')]
 class ProductDetailRouteResponse extends StoreApiResponse
 {
     public function __construct(
-        SalesChannelProductEntity $product,
+        SalesChannelProductEntity|PartialEntity $product,
         ?PropertyGroupCollection $configurator,
     ) {
         parent::__construct(new ArrayStruct([
@@ -29,7 +30,7 @@ class ProductDetailRouteResponse extends StoreApiResponse
         return $this->object;
     }
 
-    public function getProduct(): SalesChannelProductEntity
+    public function getProduct(): SalesChannelProductEntity|PartialEntity
     {
         return $this->object->get('product');
     }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product.json
@@ -103,7 +103,7 @@
                             "schema": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/components/schemas/NoneFieldsCriteria"
+                                        "$ref": "#/components/schemas/Criteria"
                                     }
                                 ]
                             }

--- a/src/Storefront/Controller/CmsController.php
+++ b/src/Storefront/Controller/CmsController.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractProductDetailRoute
 use Shopware\Core\Content\Product\SalesChannel\FindVariant\AbstractFindProductVariantRoute;
 use Shopware\Core\Content\Product\SalesChannel\Listing\AbstractProductListingRoute;
 use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewLoader;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
@@ -178,6 +179,7 @@ class CmsController extends StorefrontController
 
         $result = $this->productRoute->load($newProductId, $request, $context, new Criteria());
         $product = $result->getProduct();
+        \assert($product instanceof SalesChannelProductEntity);
         $configurator = $result->getConfigurator();
 
         $reviewTotal = 0;

--- a/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
+++ b/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
@@ -6,6 +6,7 @@ use Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -22,7 +23,7 @@ class ProductPageConfiguratorLoader extends ProductConfiguratorLoader
     /**
      * @throws InconsistentCriteriaIdsException
      */
-    public function load(SalesChannelProductEntity $product, SalesChannelContext $context): PropertyGroupCollection
+    public function load(SalesChannelProductEntity|PartialEntity $product, SalesChannelContext $context): PropertyGroupCollection
     {
         return $this->loader->load($product, $context);
     }

--- a/src/Storefront/Page/Product/ProductPageLoader.php
+++ b/src/Storefront/Page/Product/ProductPageLoader.php
@@ -6,6 +6,7 @@ use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
 use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaCollection;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractProductDetailRoute;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
@@ -62,6 +63,7 @@ class ProductPageLoader
 
         $result = $this->productDetailRoute->load($productId, $request, $context, $criteria);
         $product = $result->getProduct();
+        \assert($product instanceof SalesChannelProductEntity);
 
         if ($product->getMedia() && $product->getCover()) {
             $product->setMedia(new ProductMediaCollection(array_merge(

--- a/src/Storefront/Page/Product/QuickView/MinimalQuickViewPageLoader.php
+++ b/src/Storefront/Page/Product/QuickView/MinimalQuickViewPageLoader.php
@@ -3,6 +3,7 @@
 namespace Shopware\Storefront\Page\Product\QuickView;
 
 use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractProductDetailRoute;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
@@ -50,6 +51,7 @@ class MinimalQuickViewPageLoader
 
         $result = $this->productRoute->load($productId, $request->duplicate(), $salesChannelContext, $criteria);
         $product = $result->getProduct();
+        \assert($product instanceof SalesChannelProductEntity);
 
         $page = new MinimalQuickViewPage($product);
 

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -22,6 +22,8 @@ use Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -115,8 +117,41 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load('1', new Request(), $this->context, new Criteria());
 
+        static::assertInstanceOf(SalesChannelProductEntity::class, $result->getProduct());
         static::assertSame('4', $result->getProduct()->getCmsPageId());
         static::assertSame('mainVariant', $result->getProduct()->getUniqueIdentifier());
+    }
+
+    public function testLoadWithFields(): void
+    {
+        $productEntity = new PartialEntity();
+        $productEntity->assign([
+            'id' => Uuid::randomHex(),
+            'cmsPageId' => '4',
+            'uniqueIdentifier' => 'mainVariant',
+        ]);
+
+        $criteria = new Criteria()
+            ->addFields(['cmsPageId']);
+
+        $this->productRepository->expects($this->exactly(1))
+            ->method('search')
+            ->willReturn(
+                new EntitySearchResult(
+                    'product',
+                    1,
+                    new EntityCollection([$productEntity]),
+                    null,
+                    $criteria,
+                    $this->context->getContext()
+                )
+            );
+
+        $result = $this->route->load('1', new Request(), $this->context, $criteria);
+
+        static::assertInstanceOf(PartialEntity::class, $result->getProduct());
+        static::assertSame('4', $result->getProduct()->get('cmsPageId'));
+        static::assertSame('mainVariant', $result->getProduct()->get('uniqueIdentifier'));
     }
 
     public function testLoadBestVariant(): void
@@ -150,6 +185,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load($this->idsCollection->get('product1'), new Request(), $this->context, new Criteria());
 
+        static::assertInstanceOf(SalesChannelProductEntity::class, $result->getProduct());
         static::assertSame('4', $result->getProduct()->getCmsPageId());
         static::assertSame('BestVariant', $result->getProduct()->getUniqueIdentifier());
         static::assertTrue($result->getProduct()->getAvailable());
@@ -188,6 +224,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load($this->idsCollection->get('product1'), $request, $this->context, new Criteria());
 
+        static::assertInstanceOf(SalesChannelProductEntity::class, $result->getProduct());
         static::assertSame('term', $result->getProduct()->getCmsPageId());
         static::assertSame('term', $result->getProduct()->getUniqueIdentifier());
     }
@@ -228,6 +265,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load($productId, new Request(), $this->context, new Criteria());
 
+        static::assertInstanceOf(SalesChannelProductEntity::class, $result->getProduct());
         static::assertSame('2', $result->getProduct()->getUniqueIdentifier());
         static::assertTrue($result->getProduct()->getAvailable());
     }
@@ -273,6 +311,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load(Uuid::randomHex(), new Request(), $this->context, new Criteria());
 
+        static::assertInstanceOf(SalesChannelProductEntity::class, $result->getProduct());
         static::assertSame($variantId, $result->getProduct()->getUniqueIdentifier());
         static::assertTrue($result->getProduct()->getAvailable());
     }
@@ -314,6 +353,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load($productId, new Request(), $this->context, new Criteria());
 
+        static::assertInstanceOf(SalesChannelProductEntity::class, $result->getProduct());
         static::assertSame('2', $result->getProduct()->getUniqueIdentifier());
         static::assertTrue($result->getProduct()->getAvailable());
     }
@@ -346,6 +386,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->route->load($this->idsCollection->get('product2'), new Request(), $this->context, new Criteria());
 
+        static::assertInstanceOf(SalesChannelProductEntity::class, $result->getProduct());
         static::assertSame('4', $result->getProduct()->getCmsPageId());
         static::assertSame('BestVariant', $result->getProduct()->getUniqueIdentifier());
     }

--- a/tests/unit/Storefront/Controller/CmsControllerTest.php
+++ b/tests/unit/Storefront/Controller/CmsControllerTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Cms\CmsPageEntity;
 use Shopware\Core\Content\Cms\SalesChannel\CmsRoute;
 use Shopware\Core\Content\Cms\SalesChannel\CmsRouteResponse;
 use Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute;
+use Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRouteResponse;
 use Shopware\Core\Content\Product\SalesChannel\FindVariant\FindProductVariantRoute;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
@@ -45,6 +46,8 @@ class CmsControllerTest extends TestCase
 
     private MockObject&ProductListingRoute $productListingRouteMock;
 
+    private MockObject&ProductDetailRoute $productDetailRouteMock;
+
     private CmsControllerTestClass $controller;
 
     protected function setUp(): void
@@ -53,12 +56,13 @@ class CmsControllerTest extends TestCase
         $this->cmsRouteMock = $this->createMock(CmsRoute::class);
         $this->categoryRouteMock = $this->createMock(CategoryRoute::class);
         $this->productListingRouteMock = $this->createMock(ProductListingRoute::class);
+        $this->productDetailRouteMock = $this->createMock(ProductDetailRoute::class);
 
         $this->controller = new CmsControllerTestClass(
             $this->cmsRouteMock,
             $this->categoryRouteMock,
             $this->productListingRouteMock,
-            $this->createMock(ProductDetailRoute::class),
+            $this->productDetailRouteMock,
             $this->createMock(ProductReviewLoader::class),
             $this->createMock(FindProductVariantRoute::class),
             $eventDispatcherMock,
@@ -180,6 +184,13 @@ class CmsControllerTest extends TestCase
             ]
         );
 
+        $salesChannelProduct = new SalesChannelProductEntity();
+        $salesChannelProduct->setId($ids->get('product'));
+
+        $this->productDetailRouteMock->expects($this->once())
+            ->method('load')
+            ->willReturn(new ProductDetailRouteResponse($salesChannelProduct, null));
+
         $this->controller->switchBuyBoxVariant($ids->get('product'), $request, $this->createMock(SalesChannelContext::class));
 
         static::assertInstanceOf(SalesChannelProductEntity::class, $this->controller->renderStorefrontParameters['product']);
@@ -205,6 +216,13 @@ class CmsControllerTest extends TestCase
                 'options' => 'invalidJsonString',
             ]
         );
+
+        $salesChannelProduct = new SalesChannelProductEntity();
+        $salesChannelProduct->setId($ids->get('product'));
+
+        $this->productDetailRouteMock->expects($this->once())
+            ->method('load')
+            ->willReturn(new ProductDetailRouteResponse($salesChannelProduct, null));
 
         $response = $this->controller->switchBuyBoxVariant(
             $ids->get('product'),


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently if you request the `/store-api/product/{productId}` endpoint with `fields` there will be a product not found exception because it checks for a SalesChannelProductEntity
- This PR allows the endpoint to accept the `fields` in the criteria

### 2. What does this change do, exactly?
* Changed `Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute` to allow the criteria to accept `fields`

### 3. Describe each step to reproduce the issue or behaviour.
- Request the `/store-api/product/{productId}` with `fields`

### 4. Please link to the relevant issues (if any).
- Fixes #9779 

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
