### PR TITLE
chore: Use correct EntityRepository types for phpstan in core (Test)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -174,7 +174,6 @@ parameters:
         - # WIP implementation (See NEXT-29041 - https://github.com/shopware/shopware/issues/6175)
             message: '#.* generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityRepository.*not specify its types: TEntityCollection#'
             paths:
-                - src/Core/Test/**
                 - tests/integration/Core/Content/**
                 - tests/integration/Core/Framework/**
                 - tests/unit/Core/**

--- a/src/Core/Test/Integration/Builder/Promotion/PromotionFixtureBuilder.php
+++ b/src/Core/Test/Integration/Builder/Promotion/PromotionFixtureBuilder.php
@@ -2,6 +2,9 @@
 
 namespace Shopware\Core\Test\Integration\Builder\Promotion;
 
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountCollection;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionSetGroup\PromotionSetGroupCollection;
+use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -29,6 +32,11 @@ class PromotionFixtureBuilder
      */
     private array $dataDiscounts = [];
 
+    /**
+     * @param EntityRepository<PromotionCollection> $promotionRepository
+     * @param EntityRepository<PromotionSetGroupCollection> $promotionSetgroupRepository
+     * @param EntityRepository<PromotionDiscountCollection> $promotionDiscountRepository
+     */
     public function __construct(
         private readonly string $promotionId,
         AbstractSalesChannelContextFactory $salesChannelContextFactory,

--- a/src/Core/Test/Integration/Traits/EntityFixturesBase.php
+++ b/src/Core/Test/Integration/Traits/EntityFixturesBase.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Before;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -31,6 +32,9 @@ trait EntityFixturesBase
         $this->entityFixtureContext = $context;
     }
 
+    /**
+     * @return EntityRepository<covariant EntityCollection<covariant Entity>>
+     */
     public static function getFixtureRepository(string $fixtureName): EntityRepository
     {
         $container = KernelLifecycleManager::getKernel()->getContainer();
@@ -45,6 +49,7 @@ trait EntityFixturesBase
 
     /**
      * @param array<string, array<string, mixed>> $fixtureData
+     * @param EntityRepository<covariant EntityCollection<covariant Entity>> $repository
      */
     public function createFixture(string $fixtureName, array $fixtureData, EntityRepository $repository): Entity
     {

--- a/src/Core/Test/Integration/Traits/OrderFixture.php
+++ b/src/Core/Test/Integration/Traits/OrderFixture.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
 use Shopware\Core\Test\TestDefaults;
@@ -46,14 +47,14 @@ trait OrderFixture
         $orderNumber = Uuid::randomHex();
         $deliveryId = Uuid::randomHex();
 
-        /** @var EntityRepository $salesChannelRepository */
+        /** @var EntityRepository<SalesChannelCollection> $salesChannelRepository */
         $salesChannelRepository = static::getContainer()->get('sales_channel.repository');
 
-        /** @var SalesChannelEntity $salesChannel */
         $salesChannel = $salesChannelRepository->search(
             (new Criteria())->addFilter(new EqualsFilter('id', TestDefaults::SALES_CHANNEL)),
             $context
-        )->first();
+        )->getEntities()->first();
+        static::assertInstanceOf(SalesChannelEntity::class, $salesChannel);
 
         $paymentMethodId = $salesChannel->getPaymentMethodId();
         $shippingMethodId = $salesChannel->getShippingMethodId();


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently a few EntityRepository types are missing their phpstan type
- As in the past we group this updates to the EntityRepository types by areas to keep the PR size reasonable
- This PR includes core Test area

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the EntityRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
