### PR TITLE
fix: Navigation routes properly invalidated

### DIFF
--- a/changelog/_unreleased/2025-08-20-navigation-cache-invalidation.md
+++ b/changelog/_unreleased/2025-08-20-navigation-cache-invalidation.md
@@ -1,0 +1,15 @@
+---
+title: Fix navigation cache invalidation
+issue: 11420
+---
+# Core
+* Changed `\Shopware\Core\Content\Category\SalesChannel\NavigationRoute::load()` and `\Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber::invalidateNavigationRoute()` to tag all navigation routes with the same tag and invalidate the cached navigations when navigation relevant data changes.
+* Deprecated `\Shopware\Core\Content\Category\SalesChannel\NavigationRoute::buildName()` as navigation routes won't be tagged with dynamic tags anymore, use `NavigationRoute::ALL_TAG` instead.
+___ 
+# Upgrade Information
+## Deprecated `NavigationRoute::buildName()`
+The method `\Shopware\Core\Content\Category\SalesChannel\NavigationRoute::buildName()` is deprecated and will be removed in the next major version. It was used to build a dynamic tag name for navigation routes, but now all navigation routes are tagged with the same tag `NavigationRoute::ALL_TAG`.
+___ 
+# Next Major Version Changes
+## Removal of `NavigationRoute::buildName()`
+The method `\Shopware\Core\Content\Category\SalesChannel\NavigationRoute::buildName()` was removed, navigation routes are now only tagged with `NavigationRoute::ALL`.

--- a/src/Core/Content/Category/SalesChannel/NavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/NavigationRoute.php
@@ -89,7 +89,7 @@ class NavigationRoute extends AbstractNavigationRoute
         // Navigation route will be tagged & invalidated globally only in 6.8
         Feature::callSilentIfInactive(
             'v6.8.0.0',
-            static function () use ($context, $activeId, &$tags) {
+            static function () use ($context, $activeId, &$tags): void {
                 $tags[] = self::buildName($context->getSalesChannelId());
                 $tags[] = self::buildName($activeId);
             }

--- a/src/Core/Content/Category/SalesChannel/NavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/NavigationRoute.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\StoreApiRouteScope;
@@ -51,8 +52,16 @@ class NavigationRoute extends AbstractNavigationRoute
     ) {
     }
 
+    /**
+     * @deprecated - tag:v6.8.0 - will be removed, navigation route will only be tagged globally, use NavigationRoute::ALL_TAG instead
+     */
     public static function buildName(string $id): string
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0', ' NavigationRoute::ALL_TAG')
+        );
+
         return 'navigation-route-' . $id;
     }
 
@@ -75,10 +84,16 @@ class NavigationRoute extends AbstractNavigationRoute
 
         $active = $this->getMetaInfoById($activeId, $metaInfo);
 
-        $tags = [
-            self::buildName($context->getSalesChannelId()),
-            self::buildName($activeId),
-        ];
+        $tags = [self::ALL_TAG];
+
+        // Navigation route will be tagged & invalidated globally only in 6.8
+        Feature::callSilentIfInactive(
+            'v6.8.0.0',
+            static function () use ($context, $activeId, &$tags) {
+                $tags[] = self::buildName($context->getSalesChannelId());
+                $tags[] = self::buildName($activeId);
+            }
+        );
 
         $this->cacheTagCollector->addTag(...$tags);
 

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
@@ -250,6 +250,7 @@ class CacheInvalidationSubscriber
         if (!empty($changedSalesChannelSettings)) {
             // if the sales channel settings changed, we invalidate the complete navigation route
             $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
+
             return;
         }
 
@@ -260,6 +261,7 @@ class CacheInvalidationSubscriber
         if (!empty($changedCategoryData)) {
             // if category data that has impact on navigation changes, we invalidate the complete navigation route
             $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
+
             return;
         }
 
@@ -267,6 +269,7 @@ class CacheInvalidationSubscriber
         if (!empty($deletedCategories)) {
             // if the category is deleted, we invalidate the complete navigation route
             $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
+
             return;
         }
 

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
 use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute;
 use Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRoute;
 use Shopware\Core\Checkout\Shipping\ShippingMethodDefinition;
+use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationDefinition;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\Event\CategoryIndexerEvent;
 use Shopware\Core\Content\Category\SalesChannel\CategoryRoute;
@@ -242,9 +243,41 @@ class CacheInvalidationSubscriber
     public function invalidateNavigationRoute(EntityWrittenContainerEvent $event): void
     {
         // invalidates the navigation route when a category changed or the entry point configuration of an sales channel changed
-        $logs = [...$this->getChangedCategories($event), ...$this->getChangedEntryPoints($event)];
+        $changedSalesChannelSettings = $event->getPrimaryKeysWithPropertyChange(
+            SalesChannelDefinition::ENTITY_NAME,
+            ['navigationCategoryId', 'navigationCategoryDepth', 'serviceCategoryId', 'footerCategoryId']
+        );
+        if (!empty($changedSalesChannelSettings)) {
+            // if the sales channel settings changed, we invalidate the complete navigation route
+            $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
+            return;
+        }
 
-        $this->cacheInvalidator->invalidate($logs);
+        $changedCategoryData = $event->getPrimaryKeysWithPropertyChange(
+            CategoryDefinition::ENTITY_NAME,
+            ['parentId', 'afterCategoryId', 'visible', 'active']
+        );
+        if (!empty($changedCategoryData)) {
+            // if category data that has impact on navigation changes, we invalidate the complete navigation route
+            $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
+            return;
+        }
+
+        $deletedCategories = $event->getDeletedPrimaryKeys(CategoryDefinition::ENTITY_NAME);
+        if (!empty($deletedCategories)) {
+            // if the category is deleted, we invalidate the complete navigation route
+            $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
+            return;
+        }
+
+        $changedCategoryTranslationData = $event->getPrimaryKeysWithPropertyChange(
+            CategoryTranslationDefinition::ENTITY_NAME,
+            ['name']
+        );
+        if (!empty($changedCategoryTranslationData)) {
+            // if translated category data that has impact on navigation changes, we invalidate the complete navigation route
+            $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
+        }
     }
 
     public function invalidatePaymentMethodRoute(EntityWrittenContainerEvent $event): void
@@ -556,37 +589,6 @@ class CacheInvalidationSubscriber
         $ids = array_column($ids, 'salesChannelId');
 
         return array_map(PaymentMethodRoute::buildName(...), $ids);
-    }
-
-    /**
-     * @return string[]
-     */
-    private function getChangedCategories(EntityWrittenContainerEvent $event): array
-    {
-        $ids = $event->getPrimaryKeysWithPayload(CategoryDefinition::ENTITY_NAME);
-
-        if (empty($ids)) {
-            return [];
-        }
-
-        return array_map(NavigationRoute::buildName(...), $ids);
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function getChangedEntryPoints(EntityWrittenContainerEvent $event): array
-    {
-        $ids = $event->getPrimaryKeysWithPropertyChange(
-            SalesChannelDefinition::ENTITY_NAME,
-            ['navigationCategoryId', 'navigationCategoryDepth', 'serviceCategoryId', 'footerCategoryId']
-        );
-
-        if (empty($ids)) {
-            return [];
-        }
-
-        return [NavigationRoute::ALL_TAG];
     }
 
     /**

--- a/tests/unit/Core/Content/Category/SalesChannel/NavigationRouteTest.php
+++ b/tests/unit/Core/Content/Category/SalesChannel/NavigationRouteTest.php
@@ -1,0 +1,220 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Category\SalesChannel;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
+use Shopware\Core\Content\Category\SalesChannel\NavigationRoute;
+use Shopware\Core\Content\Category\Tree\CategoryTreePathResolver;
+use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Core\Test\Generator;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(NavigationRoute::class)]
+class NavigationRouteTest extends TestCase
+{
+    private NavigationRoute $navigationRoute;
+
+    private Connection&MockObject $connection;
+
+    /**
+     * @var SalesChannelRepository<CategoryCollection>&MockObject
+     */
+    private SalesChannelRepository&MockObject $categoryRepository;
+
+    private CacheTagCollector&MockObject $cacheTagCollector;
+
+    private CategoryTreePathResolver&MockObject $categoryTreePathResolver;
+
+    private SalesChannelContext $salesChannelContext;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->categoryRepository = $this->createMock(SalesChannelRepository::class);
+        $this->cacheTagCollector = $this->createMock(CacheTagCollector::class);
+        $this->categoryTreePathResolver = $this->createMock(CategoryTreePathResolver::class);
+
+        $this->navigationRoute = new NavigationRoute(
+            $this->connection,
+            $this->categoryRepository,
+            $this->cacheTagCollector,
+            $this->categoryTreePathResolver
+        );
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+        $salesChannel->setNavigationCategoryId(Uuid::randomHex());
+
+        $this->salesChannelContext = Generator::generateSalesChannelContext(
+            salesChannel: $salesChannel
+        );
+    }
+
+    public function testLoadAddsCacheTagsCorrectly(): void
+    {
+        $activeId = Uuid::randomHex();
+        $rootId = Uuid::randomHex();
+        $request = new Request();
+        $criteria = new Criteria();
+
+        // Configure the sales channel to use our rootId as navigation category
+        $this->salesChannelContext->getSalesChannel()->setNavigationCategoryId($rootId);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'LOWER(HEX(`id`))' => $activeId,
+                    'path' => '|' . $rootId . '|' . $activeId . '|',
+                    'level' => 2,
+                ],
+                [
+                    'LOWER(HEX(`id`))' => $rootId,
+                    'path' => '|' . $rootId . '|',
+                    'level' => 1,
+                ],
+            ]);
+
+        $categories = new CategoryCollection();
+        $searchResult = new EntitySearchResult(
+            'category',
+            0,
+            $categories,
+            null,
+            $criteria,
+            $this->salesChannelContext->getContext()
+        );
+
+        $this->categoryRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn($searchResult);
+
+        $this->categoryTreePathResolver
+            ->expects($this->once())
+            ->method('getAdditionalPathsToLoad')
+            ->willReturn([]);
+
+        $this->cacheTagCollector
+            ->expects($this->once())
+            ->method('addTag')
+            ->with(NavigationRoute::ALL_TAG);
+
+        $this->navigationRoute->load(
+            $activeId,
+            $rootId,
+            $request,
+            $this->salesChannelContext,
+            $criteria
+        );
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testLoadAddsDeprecatedCacheTagsCorrectly(): void
+    {
+        $activeId = Uuid::randomHex();
+        $rootId = Uuid::randomHex();
+        $request = new Request();
+        $criteria = new Criteria();
+
+        // Configure the sales channel to use our rootId as navigation category
+        $this->salesChannelContext->getSalesChannel()->setNavigationCategoryId($rootId);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'LOWER(HEX(`id`))' => $activeId,
+                    'path' => '|' . $rootId . '|' . $activeId . '|',
+                    'level' => 2,
+                ],
+                [
+                    'LOWER(HEX(`id`))' => $rootId,
+                    'path' => '|' . $rootId . '|',
+                    'level' => 1,
+                ],
+            ]);
+
+        $categories = new CategoryCollection();
+        $searchResult = new EntitySearchResult(
+            'category',
+            0,
+            $categories,
+            null,
+            $criteria,
+            $this->salesChannelContext->getContext()
+        );
+
+        $this->categoryRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn($searchResult);
+
+        $this->categoryTreePathResolver
+            ->expects($this->once())
+            ->method('getAdditionalPathsToLoad')
+            ->willReturn([]);
+
+        $this->cacheTagCollector
+            ->expects($this->once())
+            ->method('addTag')
+            ->with(
+                NavigationRoute::ALL_TAG,
+                NavigationRoute::buildName($this->salesChannelContext->getSalesChannelId()),
+                NavigationRoute::buildName($activeId)
+            );
+
+        $this->navigationRoute->load(
+            $activeId,
+            $rootId,
+            $request,
+            $this->salesChannelContext,
+            $criteria
+        );
+    }
+
+    public function testLoadWithInvalidCategoryThrowsException(): void
+    {
+        $activeId = Uuid::randomHex();
+        $rootId = Uuid::randomHex();
+        $request = new Request();
+        $criteria = new Criteria();
+
+        $this->connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
+
+        $this->expectException(CategoryNotFoundException::class);
+        $this->expectExceptionMessage(
+            \sprintf('Category "%s" not found.', $activeId)
+        );
+
+        $this->navigationRoute->load(
+            $activeId,
+            $rootId,
+            $request,
+            $this->salesChannelContext,
+            $criteria
+        );
+    }
+}

--- a/tests/unit/Core/Content/Category/SalesChannel/NavigationRouteTest.php
+++ b/tests/unit/Core/Content/Category/SalesChannel/NavigationRouteTest.php
@@ -17,7 +17,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 use Symfony\Component\HttpFoundation\Request;
@@ -58,24 +57,15 @@ class NavigationRouteTest extends TestCase
             $this->categoryTreePathResolver
         );
 
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId(Uuid::randomHex());
-        $salesChannel->setNavigationCategoryId(Uuid::randomHex());
-
-        $this->salesChannelContext = Generator::generateSalesChannelContext(
-            salesChannel: $salesChannel
-        );
+        $this->salesChannelContext = Generator::generateSalesChannelContext();
     }
 
     public function testLoadAddsCacheTagsCorrectly(): void
     {
         $activeId = Uuid::randomHex();
-        $rootId = Uuid::randomHex();
+        $rootId = Generator::NAVIGATION_CATEGORY;
         $request = new Request();
         $criteria = new Criteria();
-
-        // Configure the sales channel to use our rootId as navigation category
-        $this->salesChannelContext->getSalesChannel()->setNavigationCategoryId($rootId);
 
         $this->connection
             ->expects($this->once())
@@ -131,12 +121,9 @@ class NavigationRouteTest extends TestCase
     public function testLoadAddsDeprecatedCacheTagsCorrectly(): void
     {
         $activeId = Uuid::randomHex();
-        $rootId = Uuid::randomHex();
+        $rootId = Generator::NAVIGATION_CATEGORY;
         $request = new Request();
         $criteria = new Criteria();
-
-        // Configure the sales channel to use our rootId as navigation category
-        $this->salesChannelContext->getSalesChannel()->setNavigationCategoryId($rootId);
 
         $this->connection
             ->expects($this->once())

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationDefinition;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\SalesChannel\NavigationRoute;
 use Shopware\Core\Content\Media\Event\MediaIndexerEvent;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
@@ -138,6 +141,270 @@ class CacheInvalidationSubscriberTest extends TestCase
             );
 
         $subscriber->invalidateMedia($event);
+    }
+
+    public function testInvalidateNavigationRouteWithSalesChannelSettings(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $subscriber = new CacheInvalidationSubscriber(
+            $this->cacheInvalidator,
+            $this->connection,
+            true
+        );
+
+        // Test when sales channel navigation settings change
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    SalesChannelDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $salesChannelId,
+                            [
+                                'navigationCategoryId' => Uuid::randomHex(),
+                                'navigationCategoryDepth' => 3,
+                            ],
+                            SalesChannelDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        $this->cacheInvalidator
+            ->expects($this->once())
+            ->method('invalidate')
+            ->with([NavigationRoute::ALL_TAG]);
+
+        $subscriber->invalidateNavigationRoute($event);
+    }
+
+    public function testInvalidateNavigationRouteWithCategoryStructuralChanges(): void
+    {
+        $categoryId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $subscriber = new CacheInvalidationSubscriber(
+            $this->cacheInvalidator,
+            $this->connection,
+            true
+        );
+
+        // Test when category structural data changes (parentId, visible, active, afterCategoryId)
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    CategoryDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $categoryId,
+                            [
+                                'parentId' => Uuid::randomHex(),
+                                'visible' => true,
+                                'active' => false,
+                            ],
+                            CategoryDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        $this->cacheInvalidator
+            ->expects($this->once())
+            ->method('invalidate')
+            ->with([NavigationRoute::ALL_TAG]);
+
+        $subscriber->invalidateNavigationRoute($event);
+    }
+
+    public function testInvalidateNavigationRouteWithDeletedCategories(): void
+    {
+        $categoryId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $subscriber = new CacheInvalidationSubscriber(
+            $this->cacheInvalidator,
+            $this->connection,
+            true
+        );
+
+        // Test when categories are deleted
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    CategoryDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $categoryId,
+                            [],
+                            CategoryDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_DELETE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        $this->cacheInvalidator
+            ->expects($this->once())
+            ->method('invalidate')
+            ->with([NavigationRoute::ALL_TAG]);
+
+        $subscriber->invalidateNavigationRoute($event);
+    }
+
+    public function testInvalidateNavigationRouteWithCategoryTranslationChanges(): void
+    {
+        $categoryTranslationId = ['categoryId' => Uuid::randomHex(), 'languageId' => Uuid::randomHex()];
+        $context = Context::createDefaultContext();
+
+        $subscriber = new CacheInvalidationSubscriber(
+            $this->cacheInvalidator,
+            $this->connection,
+            true
+        );
+
+        // Test when category translation name changes
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    CategoryTranslationDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $categoryTranslationId,
+                            [
+                                'name' => 'New Category Name',
+                            ],
+                            CategoryTranslationDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        $this->cacheInvalidator
+            ->expects($this->once())
+            ->method('invalidate')
+            ->with([NavigationRoute::ALL_TAG]);
+
+        $subscriber->invalidateNavigationRoute($event);
+    }
+
+    public function testInvalidateNavigationRouteWithMultipleTriggers(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $categoryId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $subscriber = new CacheInvalidationSubscriber(
+            $this->cacheInvalidator,
+            $this->connection,
+            true
+        );
+
+        // Test when both sales channel settings and category data change
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    SalesChannelDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $salesChannelId,
+                            [
+                                'footerCategoryId' => Uuid::randomHex(),
+                            ],
+                            SalesChannelDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+                new EntityWrittenEvent(
+                    CategoryDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $categoryId,
+                            [
+                                'active' => true,
+                            ],
+                            CategoryDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        // Should still only invalidate once with the ALL_TAG when sales channel settings change
+        $this->cacheInvalidator
+            ->expects($this->once())
+            ->method('invalidate')
+            ->with([NavigationRoute::ALL_TAG]);
+
+        $subscriber->invalidateNavigationRoute($event);
+    }
+
+    public function testInvalidateNavigationRouteWithNoRelevantChanges(): void
+    {
+        $categoryId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $subscriber = new CacheInvalidationSubscriber(
+            $this->cacheInvalidator,
+            $this->connection,
+            true
+        );
+
+        // Test when category data changes that don't affect navigation (e.g., description)
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    CategoryDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $categoryId,
+                            [
+                                'description' => 'New description',
+                                'metaTitle' => 'New meta title',
+                            ],
+                            CategoryDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        // Should not invalidate anything
+        $this->cacheInvalidator
+            ->expects($this->never())
+            ->method('invalidate');
+
+        $subscriber->invalidateNavigationRoute($event);
     }
 
     public function createSnippetEvent(): EntityWrittenContainerEvent


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/11420

Navigation route was only tagged by active id, so changing any other category would not lead to category invalidation

to prevent adding to many tags per entry (as depending per cache store there is a upper limit) we only tag navigations generally and as soon as navigation relevant data in the category entity changes we invalidate all navigations

the reason is that figuring out exactly which navigation needs to be invalidated when a given category changes is not that easy, and category is an entity that should not be updated constantly
