### PR TITLE
chore: Use correct EntityRepository types for phpstan in unit core tests

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -176,7 +176,6 @@ parameters:
             paths:
                 - tests/integration/Core/Content/**
                 - tests/integration/Core/Framework/**
-                - tests/unit/Core/**
 
         - # Needs a proper class-string annotation in `\Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition::getCollectionClass` and all child classes
             message: '#PHPDoc tag @var with type .*Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityCollection.* is not subtype of native type string#'

--- a/tests/unit/Core/Checkout/Cart/Address/AddressValidator2Test.php
+++ b/tests/unit/Core/Checkout/Cart/Address/AddressValidator2Test.php
@@ -12,6 +12,8 @@ use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
@@ -83,6 +85,9 @@ class AddressValidator2Test extends TestCase
         return new IdSearchResult(0, [], new Criteria(), Context::createDefaultContext());
     }
 
+    /**
+     * @return EntityRepository<EntityCollection<Entity>>&MockObject
+     */
     private function getRepositoryMock(?IdSearchResult $result): EntityRepository&MockObject
     {
         $repository = $this->createMock(EntityRepository::class);

--- a/tests/unit/Core/Checkout/Cart/Address/AddressValidatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Address/AddressValidatorTest.php
@@ -16,6 +16,8 @@ use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEnt
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Product\State;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
@@ -33,6 +35,7 @@ use Shopware\Core\Test\Generator;
 #[Package('checkout')]
 class AddressValidatorTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<EntityCollection<Entity>> */
     private MockObject&EntityRepository $repository;
 
     private AddressValidator $validator;

--- a/tests/unit/Core/Checkout/Cart/Order/LineItemDownloadLoaderTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/LineItemDownloadLoaderTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Order\LineItemDownloadLoader;
 use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductDownload\ProductDownloadCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductDownload\ProductDownloadEntity;
 use Shopware\Core\Content\Product\State;
 use Shopware\Core\Framework\Context;
@@ -23,6 +24,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('checkout')]
 class LineItemDownloadLoaderTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<ProductDownloadCollection> */
     private MockObject&EntityRepository $productDownloadRepository;
 
     private LineItemDownloadLoader $loader;

--- a/tests/unit/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
@@ -48,6 +48,7 @@ class CartOrderRouteTest extends TestCase
 {
     private CartCalculator&MockObject $cartCalculator;
 
+    /** @var EntityRepository<OrderCollection>&MockObject */
     private EntityRepository&MockObject $orderRepository;
 
     private OrderPersister&MockObject $orderPersister;

--- a/tests/unit/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionControllerTest.php
+++ b/tests/unit/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionControllerTest.php
@@ -34,8 +34,10 @@ class CustomerGroupRegistrationActionControllerTest extends TestCase
 {
     private CustomerGroupRegistrationActionController $controllerMock;
 
+    /** @var MockObject&EntityRepository<CustomerCollection> */
     private MockObject&EntityRepository $customerRepositoryMock;
 
+    /** @var MockObject&EntityRepository<CustomerGroupCollection> */
     private MockObject&EntityRepository $customerGroupRepositoryMock;
 
     private MockObject&SalesChannelContextRestorer $contextRestorerMock;

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/DownloadRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/DownloadRouteTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('checkout')]
 class DownloadRouteTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<OrderLineItemDownloadCollection> */
     private MockObject&EntityRepository $downloadRepository;
 
     private MockObject&DownloadResponseGenerator $downloadResponseGenerator;

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
@@ -38,6 +38,7 @@ class RegisterConfirmRouteTest extends TestCase
 
     protected EventDispatcherInterface&MockObject $eventDispatcher;
 
+    /** @var EntityRepository<CustomerCollection>&MockObject */
     protected EntityRepository&MockObject $customerRepository;
 
     protected DataValidator&MockObject $validator;

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRouteTest.php
@@ -33,8 +33,10 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(SendPasswordRecoveryMailRoute::class)]
 class SendPasswordRecoveryMailRouteTest extends TestCase
 {
+    /** @var EntityRepository<CustomerCollection>&MockObject */
     protected EntityRepository&MockObject $customerRepository;
 
+    /** @var EntityRepository<CustomerRecoveryCollection>&MockObject */
     protected EntityRepository&MockObject $customerRecoveryRepository;
 
     protected EventDispatcherInterface&MockObject $eventDispatcher;

--- a/tests/unit/Core/Checkout/Customer/Validation/CustomerZipcodeValidatorTest.php
+++ b/tests/unit/Core/Checkout/Customer/Validation/CustomerZipcodeValidatorTest.php
@@ -30,7 +30,7 @@ class CustomerZipcodeValidatorTest extends TestCase
     private CustomerZipCode $constraint;
 
     /**
-     * @var EntityRepository&MockObject
+     * @var EntityRepository<CountryCollection>&MockObject
      */
     private EntityRepository $countryRepository;
 

--- a/tests/unit/Core/Checkout/Order/SalesChannel/OrderServiceTest.php
+++ b/tests/unit/Core/Checkout/Order/SalesChannel/OrderServiceTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Checkout\Order\Validation\OrderValidationFactory;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Content\Product\State;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -33,6 +34,7 @@ class OrderServiceTest extends TestCase
 {
     private MockObject&CartService $cartService;
 
+    /** @var MockObject&EntityRepository<PaymentMethodCollection> */
     private MockObject&EntityRepository $paymentMethodRepository;
 
     private OrderService $orderService;

--- a/tests/unit/Core/Checkout/Payment/Cart/PaymentRecurringProcessorTest.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/PaymentRecurringProcessorTest.php
@@ -19,7 +19,6 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentTransactionStructFactory;
 use Shopware\Core\Checkout\Payment\PaymentException;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -219,7 +218,10 @@ class PaymentRecurringProcessorTest extends TestCase
         $processor->processRecurring('foo', Context::createDefaultContext());
     }
 
-    private function getOrderTransactionRepository(bool $returnEntity): EntityRepository
+    /**
+     * @return StaticEntityRepository<OrderTransactionCollection>
+     */
+    private function getOrderTransactionRepository(bool $returnEntity): StaticEntityRepository
     {
         $entity = new OrderTransactionEntity();
         $entity->setId('foo');

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryEntity;
@@ -340,8 +341,10 @@ class CategoryBreadcrumbBuilderTest extends TestCase
     /**
      * @param array<CategoryEntity> $categoryEntityCollection1
      * @param array<CategoryEntity> $categoryEntityCollection2
+     *
+     * @return EntityRepository<CategoryCollection>&MockObject
      */
-    private function getCategoryRepositoryMock(array $categoryEntityCollection1, array $categoryEntityCollection2): EntityRepository
+    private function getCategoryRepositoryMock(array $categoryEntityCollection1, array $categoryEntityCollection2): EntityRepository&MockObject
     {
         $categoryRepositoryMock = $this->createMock(EntityRepository::class);
         $categoryRepositoryMock->method('search')->willReturnOnConsecutiveCalls(

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeActionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddCustomerAffiliateAndCampaignCodeAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -24,6 +25,7 @@ class AddCustomerAffiliateAndCampaignCodeActionTest extends TestCase
 {
     private Connection&MockObject $connection;
 
+    /** @var MockObject&EntityRepository<CustomerCollection> */
     private MockObject&EntityRepository $repository;
 
     private AddCustomerAffiliateAndCampaignCodeAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerTagActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerTagActionTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddCustomerTagAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -22,6 +23,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 #[CoversClass(AddCustomerTagAction::class)]
 class AddCustomerTagActionTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<CustomerCollection> */
     private MockObject&EntityRepository $repository;
 
     private AddCustomerTagAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeActionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderAffiliateAndCampaignCodeAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -24,6 +25,7 @@ class AddOrderAffiliateAndCampaignCodeActionTest extends TestCase
 {
     private Connection&MockObject $connection;
 
+    /** @var MockObject&EntityRepository<OrderCollection> */
     private MockObject&EntityRepository $repository;
 
     private AddOrderAffiliateAndCampaignCodeAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderTagActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderTagActionTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderTagAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -22,6 +23,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 #[CoversClass(AddOrderTagAction::class)]
 class AddOrderTagActionTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<OrderCollection> */
     private MockObject&EntityRepository $repository;
 
     private AddOrderTagAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupActionTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Action;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Flow\Dispatching\Action\ChangeCustomerGroupAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -20,6 +21,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[CoversClass(ChangeCustomerGroupAction::class)]
 class ChangeCustomerGroupActionTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<CustomerCollection> */
     private MockObject&EntityRepository $repository;
 
     private ChangeCustomerGroupAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusActionTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Action;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Flow\Dispatching\Action\ChangeCustomerStatusAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
@@ -20,6 +21,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[CoversClass(ChangeCustomerStatusAction::class)]
 class ChangeCustomerStatusActionTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<CustomerCollection> */
     private MockObject&EntityRepository $repository;
 
     private ChangeCustomerStatusAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagActionTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\RemoveCustomerTagAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Log\Package;
@@ -22,6 +24,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 #[CoversClass(RemoveCustomerTagAction::class)]
 class RemoveCustomerTagActionTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<EntityCollection<Entity>> */
     private MockObject&EntityRepository $repository;
 
     private RemoveCustomerTagAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/RemoveOrderTagActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/RemoveOrderTagActionTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\RemoveOrderTagAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Log\Package;
@@ -22,6 +24,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 #[CoversClass(RemoveOrderTagAction::class)]
 class RemoveOrderTagActionTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<EntityCollection<Entity>> */
     private MockObject&EntityRepository $repository;
 
     private RemoveOrderTagAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/SendMailActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/SendMailActionTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Dispatching\Struct\Sequence;
 use Shopware\Core\Content\Mail\Service\AbstractMailService;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsConfig;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeCollection;
 use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
 use Shopware\Core\Content\MailTemplate\MailTemplateCollection;
 use Shopware\Core\Content\MailTemplate\MailTemplateEntity;
@@ -53,12 +54,12 @@ class SendMailActionTest extends TestCase
     private AbstractMailService $mailService;
 
     /**
-     * @var EntityRepository&MockObject
+     * @var EntityRepository<MailTemplateCollection>&MockObject
      */
     private EntityRepository $mailTemplateRepository;
 
     /**
-     * @var EntityRepository&MockObject
+     * @var EntityRepository<MailTemplateTypeCollection>&MockObject
      */
     private EntityRepository $mailTemplateTypeRepository;
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/SetCustomerCustomFieldActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/SetCustomerCustomFieldActionTest.php
@@ -29,6 +29,7 @@ class SetCustomerCustomFieldActionTest extends TestCase
 {
     private Connection&MockObject $connection;
 
+    /** @var MockObject&EntityRepository<CustomerCollection> */
     private MockObject&EntityRepository $repository;
 
     private SetCustomerCustomFieldAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/SetCustomerGroupCustomFieldActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/SetCustomerGroupCustomFieldActionTest.php
@@ -29,6 +29,7 @@ class SetCustomerGroupCustomFieldActionTest extends TestCase
 {
     private Connection&MockObject $connection;
 
+    /** @var MockObject&EntityRepository<CustomerGroupCollection> */
     private MockObject&EntityRepository $repository;
 
     private SetCustomerGroupCustomFieldAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/SetOrderCustomFieldActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/SetOrderCustomFieldActionTest.php
@@ -29,6 +29,7 @@ class SetOrderCustomFieldActionTest extends TestCase
 {
     private Connection&MockObject $connection;
 
+    /** @var MockObject&EntityRepository<OrderCollection> */
     private MockObject&EntityRepository $repository;
 
     private SetOrderCustomFieldAction $action;

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerGroupStorerTest.php
@@ -28,6 +28,7 @@ class CustomerGroupStorerTest extends TestCase
 {
     private CustomerGroupStorer $storer;
 
+    /** @var MockObject&EntityRepository<CustomerGroupCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerRecoveryStorerTest.php
@@ -28,6 +28,7 @@ class CustomerRecoveryStorerTest extends TestCase
 {
     private CustomerRecoveryStorer $storer;
 
+    /** @var MockObject&EntityRepository<CustomerRecoveryCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/CustomerStorerTest.php
@@ -30,6 +30,7 @@ class CustomerStorerTest extends TestCase
 {
     private CustomerStorer $storer;
 
+    /** @var MockObject&EntityRepository<CustomerCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/NewsletterRecipientStorerTest.php
@@ -28,6 +28,7 @@ class NewsletterRecipientStorerTest extends TestCase
 {
     private NewsletterRecipientStorer $storer;
 
+    /** @var MockObject&EntityRepository<NewsletterRecipientCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderStorerTest.php
@@ -28,6 +28,7 @@ class OrderStorerTest extends TestCase
 {
     private OrderStorer $storer;
 
+    /** @var MockObject&EntityRepository<OrderCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/OrderTransactionStorerTest.php
@@ -28,6 +28,7 @@ class OrderTransactionStorerTest extends TestCase
 {
     private OrderTransactionStorer $storer;
 
+    /** @var MockObject&EntityRepository<OrderTransactionCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/ProductStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/ProductStorerTest.php
@@ -30,6 +30,7 @@ class ProductStorerTest extends TestCase
 {
     private ProductStorer $storer;
 
+    /** @var MockObject&EntityRepository<ProductCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/UserStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/UserStorerTest.php
@@ -28,6 +28,7 @@ class UserStorerTest extends TestCase
 {
     private UserStorer $storer;
 
+    /** @var MockObject&EntityRepository<UserRecoveryCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/tests/unit/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/PriceSerializerTest.php
+++ b/tests/unit/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/PriceSerializerTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Field\PriceSerializer;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\Log\Package;
@@ -394,9 +393,12 @@ class PriceSerializerTest extends TestCase
 
     /**
      * @param array<CurrencyCollection<CurrencyEntity>|array<string>> $results
+     *
+     * @return StaticEntityRepository<CurrencyCollection>
      */
-    private function getCurrencyRepository(array $results): EntityRepository
+    private function getCurrencyRepository(array $results): StaticEntityRepository
     {
+        /** @var StaticEntityRepository<CurrencyCollection> */
         return new StaticEntityRepository($results, new CurrencyDefinition());
     }
 }

--- a/tests/unit/Core/Content/ImportExport/Strategy/Import/ImportStrategyTestCase.php
+++ b/tests/unit/Core/Content/ImportExport/Strategy/Import/ImportStrategyTestCase.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ImportExport\Struct\Config;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -19,6 +20,7 @@ abstract class ImportStrategyTestCase extends TestCase
 {
     protected EventDispatcherInterface&MockObject $eventDispatcher;
 
+    /** @var EntityRepository<MediaCollection>&MockObject */
     protected EntityRepository&MockObject $repository;
 
     protected function setUp(): void

--- a/tests/unit/Core/Content/Mail/Service/MailAttachmentsBuilderTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailAttachmentsBuilderTest.php
@@ -31,6 +31,7 @@ class MailAttachmentsBuilderTest extends TestCase
 {
     private MockObject&MediaService $mediaService;
 
+    /** @var MockObject&EntityRepository<MediaCollection> */
     private MockObject&EntityRepository $mediaRepository;
 
     private MockObject&DocumentGenerator $documentGenerator;

--- a/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailServiceTest.php
@@ -56,7 +56,7 @@ class MailServiceTest extends TestCase
     private MailService $mailService;
 
     /**
-     * @var MockObject&EntityRepository
+     * @var MockObject&EntityRepository<SalesChannelCollection>
      */
     private EntityRepository $salesChannelRepository;
 

--- a/tests/unit/Core/Content/Mail/Transport/MailerTransportDecoratorTest.php
+++ b/tests/unit/Core/Content/Mail/Transport/MailerTransportDecoratorTest.php
@@ -6,6 +6,7 @@ use League\Flysystem\Filesystem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Content\Mail\Service\Mail;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsBuilder;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsConfig;
@@ -32,6 +33,7 @@ class MailerTransportDecoratorTest extends TestCase
 
     private Filesystem $filesystem;
 
+    /** @var MockObject&EntityRepository<DocumentCollection> */
     private MockObject&EntityRepository $documentRepository;
 
     private MailerTransportDecorator $decorator;

--- a/tests/unit/Core/Content/MeasurementSystem/Unit/MeasurementUnitProviderTest.php
+++ b/tests/unit/Core/Content/MeasurementSystem/Unit/MeasurementUnitProviderTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[CoversClass(MeasurementUnitProvider::class)]
 class MeasurementUnitProviderTest extends TestCase
 {
+    /** @var EntityRepository<EntityCollection<MeasurementDisplayUnitEntity>>&MockObject */
     private EntityRepository&MockObject $repository;
 
     private MeasurementUnitProvider $provider;

--- a/tests/unit/Core/Content/Media/SalesChannel/MediaRouteTest.php
+++ b/tests/unit/Core/Content/Media/SalesChannel/MediaRouteTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(MediaRoute::class)]
 class MediaRouteTest extends TestCase
 {
+    /** @var EntityRepository<MediaCollection>&MockObject */
     private EntityRepository&MockObject $mediaRepository;
 
     private MediaRoute $mediaRoute;

--- a/tests/unit/Core/Content/Product/Cart/ProductFeatureBuilderTest.php
+++ b/tests/unit/Core/Content/Product/Cart/ProductFeatureBuilderTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductFeatureSet\ProductFeatureSetCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductFeatureSet\ProductFeatureSetDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductFeatureSet\ProductFeatureSetEntity;
 use Shopware\Core\Content\Product\Cart\ProductFeatureBuilder;
@@ -34,6 +35,7 @@ class ProductFeatureBuilderTest extends TestCase
 {
     private ProductFeatureBuilder $productFeatureBuilder;
 
+    /** @var MockObject&EntityRepository<ProductFeatureSetCollection> */
     private MockObject&EntityRepository $customFieldRepository;
 
     private MockObject&LanguageLocaleCodeProvider $languageLocaleProvider;

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewRouteTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewCollection;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRoute;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
@@ -25,6 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(ProductReviewRoute::class)]
 class ProductReviewRouteTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<ProductReviewCollection> */
     private MockObject&EntityRepository $repository;
 
     private StaticSystemConfigService $config;

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRouteTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewCollection;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Review\Event\ReviewFormEvent;
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewSaveRoute;
@@ -28,6 +29,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(ProductReviewSaveRoute::class)]
 class ProductReviewSaveRouteTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<ProductReviewCollection> */
     private MockObject&EntityRepository $repository;
 
     private MockObject&DataValidator $validator;

--- a/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Content\ProductExport\ScheduledTask;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\ProductExport\ProductExportCollection;
@@ -14,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\MessageBus\CollectingMessageBus;
@@ -99,7 +101,10 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         return $productExportEntity;
     }
 
-    private function getProductExportRepositoryMock(ProductExportEntity $productExportEntity): EntityRepository
+    /**
+     * @return EntityRepository<ProductExportCollection>&MockObject
+     */
+    private function getProductExportRepositoryMock(ProductExportEntity $productExportEntity): EntityRepository&MockObject
     {
         $productEntitySearchResult = new EntitySearchResult(
             'product',
@@ -116,8 +121,12 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         return $productExportRepositoryMock;
     }
 
-    private function getSalesChannelRepositoryMock(): EntityRepository
+    /**
+     * @return StaticEntityRepository<SalesChannelCollection>
+     */
+    private function getSalesChannelRepositoryMock(): StaticEntityRepository
     {
+        /** @var StaticEntityRepository<SalesChannelCollection> */
         return new StaticEntityRepository([['8fdd4e21be6b4ad59656fb856d0375e7']]);
     }
 

--- a/tests/unit/Core/Framework/App/Command/AppListCommandTest.php
+++ b/tests/unit/Core/Framework/App/Command/AppListCommandTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(AppListCommand::class)]
 class AppListCommandTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<AppCollection> */
     private MockObject&EntityRepository $appRepoMock;
 
     private AppListCommand $command;

--- a/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -75,7 +75,10 @@ class AppLifecycleTest extends TestCase
         $appRepository = $this->createMock(EntityRepository::class);
         $appRepository->expects($this->never())->method('upsert');
 
-        $appLifecycle = $this->getAppLifecycle($appRepository, new StaticEntityRepository([]), null, new StaticSourceResolver());
+        /** @var StaticEntityRepository<LanguageCollection> */
+        $languageRepository = new StaticEntityRepository([]);
+
+        $appLifecycle = $this->getAppLifecycle($appRepository, $languageRepository, null, new StaticSourceResolver());
 
         $this->expectException(AppException::class);
         $this->expectExceptionMessage('App test is not compatible with this Shopware version');
@@ -90,7 +93,10 @@ class AppLifecycleTest extends TestCase
         $appRepository = $this->createMock(EntityRepository::class);
         $appRepository->expects($this->never())->method('upsert');
 
-        $appLifecycle = $this->getAppLifecycle($appRepository, new StaticEntityRepository([]), null, new StaticSourceResolver());
+        /** @var StaticEntityRepository<LanguageCollection> */
+        $languageRepository = new StaticEntityRepository([]);
+
+        $appLifecycle = $this->getAppLifecycle($appRepository, $languageRepository, null, new StaticSourceResolver());
 
         $this->expectException(AppException::class);
         $this->expectExceptionMessage('App test is not compatible with this Shopware version');
@@ -99,6 +105,7 @@ class AppLifecycleTest extends TestCase
 
     public function testInstallSavesSnippetsGiven(): void
     {
+        /** @var StaticEntityRepository<LanguageCollection> */
         $languageRepository = new StaticEntityRepository([$this->getLanguageCollection([
             [
                 'id' => Uuid::randomHex(),
@@ -154,6 +161,7 @@ class AppLifecycleTest extends TestCase
 
     public function testInstallSavesNoSnippetsGiven(): void
     {
+        /** @var StaticEntityRepository<LanguageCollection> */
         $languageRepository = new StaticEntityRepository([$this->getLanguageCollection([
             [
                 'id' => Uuid::randomHex(),
@@ -200,6 +208,7 @@ class AppLifecycleTest extends TestCase
 
     public function testUpdateSavesNoSnippetsGiven(): void
     {
+        /** @var StaticEntityRepository<LanguageCollection> */
         $languageRepository = new StaticEntityRepository([$this->getLanguageCollection([
             [
                 'id' => Uuid::randomHex(),
@@ -244,6 +253,7 @@ class AppLifecycleTest extends TestCase
 
     public function testUpdateSavesSnippets(): void
     {
+        /** @var StaticEntityRepository<LanguageCollection> */
         $languageRepository = new StaticEntityRepository([$this->getLanguageCollection([
             [
                 'id' => Uuid::randomHex(),
@@ -300,6 +310,7 @@ class AppLifecycleTest extends TestCase
     {
         $this->io->rename(__DIR__ . '/../_fixtures/Resources/config', __DIR__ . '/../_fixtures/Resources/noconfighere');
 
+        /** @var StaticEntityRepository<LanguageCollection> */
         $languageRepository = new StaticEntityRepository([$this->getLanguageCollection([
             [
                 'id' => Uuid::randomHex(),
@@ -344,6 +355,10 @@ class AppLifecycleTest extends TestCase
         $this->io->rename(__DIR__ . '/../_fixtures/Resources/noconfighere', __DIR__ . '/../_fixtures/Resources/config');
     }
 
+    /**
+     * @param EntityRepository<AppCollection> $appRepository
+     * @param EntityRepository<LanguageCollection> $languageRepository
+     */
     private function getAppLifecycle(
         EntityRepository $appRepository,
         EntityRepository $languageRepository,

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/FlowEventPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/FlowEventPersisterTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventCollection;
 use Shopware\Core\Framework\App\Flow\Event\Event;
 use Shopware\Core\Framework\App\Flow\Event\Xml\CustomEvents;
 use Shopware\Core\Framework\App\Lifecycle\Persister\FlowEventPersister;
@@ -23,6 +24,7 @@ class FlowEventPersisterTest extends TestCase
 {
     private FlowEventPersister $flowEventPersister;
 
+    /** @var EntityRepository<AppFlowEventCollection>&MockObject */
     private EntityRepository&MockObject $flowEventsRepositoryMock;
 
     private Connection&MockObject $connectionMock;

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/ShippingMethodPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/ShippingMethodPersisterTest.php
@@ -5,7 +5,9 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Persister;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\App\Aggregate\AppShippingMethod\AppShippingMethodEntity;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ShippingMethodPersister;
@@ -82,11 +84,18 @@ class ShippingMethodPersisterTest extends TestCase
         );
     }
 
-    private function createShippingMethodRepositoryMock(): EntityRepository
+    /**
+     * @return StaticEntityRepository<ShippingMethodCollection>
+     */
+    private function createShippingMethodRepositoryMock(): StaticEntityRepository
     {
+        /** @var StaticEntityRepository<ShippingMethodCollection> */
         return new StaticEntityRepository([]);
     }
 
+    /**
+     * @return EntityRepository<EntityCollection<AppShippingMethodEntity>>
+     */
     private function createAppShippingMethodRepositoryMock(): EntityRepository
     {
         $appShippingMethodMock = $this->createMock(EntityRepository::class);
@@ -104,6 +113,9 @@ class ShippingMethodPersisterTest extends TestCase
         return $appShippingMethodMock;
     }
 
+    /**
+     * @return EntityRepository<MediaCollection>
+     */
     private function createMediaRepositoryMock(): EntityRepository
     {
         $mediaRepositoryMock = $this->createMock(EntityRepository::class);
@@ -134,6 +146,9 @@ class ShippingMethodPersisterTest extends TestCase
         return Manifest::createFromXmlFile($file);
     }
 
+    /**
+     * @return EntityRepository<EntityCollection<AppShippingMethodEntity>>
+     */
     private function createAppShippingMethodRepositoryMockWithExistingAppShippingMethods(): EntityRepository|MockObject
     {
         $shippingMethodOne = new ShippingMethodEntity();

--- a/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistryTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistryTest.php
@@ -27,7 +27,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 class TaskRegistryTest extends TestCase
 {
     /**
-     * @var EntityRepository&MockObject
+     * @var EntityRepository<ScheduledTaskCollection>&MockObject
      */
     private EntityRepository $scheduleTaskRepository;
 

--- a/tests/unit/Core/Framework/Plugin/Command/PluginListCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/PluginListCommandTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(PluginListCommand::class)]
 class PluginListCommandTest extends TestCase
 {
+    /** @var MockObject&EntityRepository<PluginCollection> */
     private MockObject&EntityRepository $pluginRepoMock;
 
     private MockObject&ComposerPluginLoader $composerPluginLoaderMock;

--- a/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -33,6 +33,7 @@ use Shopware\Core\Framework\Plugin\Exception\PluginNotActivatedException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotInstalledException;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
+use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
@@ -58,6 +59,7 @@ class PluginLifecycleServiceTest extends TestCase
 {
     private PluginLifecycleService $pluginLifecycleService;
 
+    /** @var MockObject&EntityRepository<PluginCollection> */
     private MockObject&EntityRepository $pluginRepoMock;
 
     private MockObject&KernelPluginCollection $kernelPluginCollectionMock;

--- a/tests/unit/Core/Framework/Store/Authentication/StoreRequestOptionsProviderTest.php
+++ b/tests/unit/Core/Framework/Store/Authentication/StoreRequestOptionsProviderTest.php
@@ -231,6 +231,9 @@ class StoreRequestOptionsProviderTest extends TestCase
         static::assertSame('locale-from-provider', $queries['language']);
     }
 
+    /**
+     * @return EntityRepository<UserCollection>&MockObject
+     */
     private function configureUserRepositorySearchMock(
         UserCollection $collection,
         InvokedCount $invokedCount

--- a/tests/unit/Core/Framework/Store/Services/FirstRunWizardServiceTest.php
+++ b/tests/unit/Core/Framework/Store/Services/FirstRunWizardServiceTest.php
@@ -35,6 +35,7 @@ use Shopware\Core\Framework\Store\Struct\ShopUserTokenStruct;
 use Shopware\Core\Framework\Store\Struct\StorePluginStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -893,6 +894,9 @@ class FirstRunWizardServiceTest extends TestCase
         static::assertCount(1, $demodataPlugins);
     }
 
+    /**
+     * @param ?EntityRepository<UserConfigCollection> $userConfigRepository
+     */
     private function createFirstRunWizardService(
         ?StoreService $storeService = null,
         ?SystemConfigService $systemConfigService = null,


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently a few EntityRepository types are missing their phpstan type
- As in the past we group this updates to the EntityRepository types by areas to keep the PR size reasonable
- This PR includes core unit tests area

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the EntityRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
