### PR TITLE
chore: Use correct EntityRepository types for phpstan in integration core framework tests

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -175,7 +175,6 @@ parameters:
             message: '#.* generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityRepository.*not specify its types: TEntityCollection#'
             paths:
                 - tests/integration/Core/Content/**
-                - tests/integration/Core/Framework/**
                 - tests/unit/Core/**
 
         - # Needs a proper class-string annotation in `\Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition::getCollectionClass` and all child classes

--- a/tests/integration/Core/Framework/Adapter/Twig/AppTemplateIteratorTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/AppTemplateIteratorTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\AppTemplateIterator;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -28,7 +29,7 @@ class AppTemplateIteratorTest extends TestCase
 
     public function testItAddsAppDatabaseTemplates(): void
     {
-        /** @var EntityRepository $appRepository */
+        /** @var EntityRepository<AppCollection> $appRepository */
         $appRepository = static::getContainer()->get('app.repository');
 
         $appRepository->create([

--- a/tests/integration/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\EntityTemplateLoader;
+use Shopware\Core\Framework\App\Template\TemplateCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -31,6 +32,9 @@ class EntityTemplateLoaderTest extends TestCase
         {% endblock %}
     ';
 
+    /**
+     * @var EntityRepository<TemplateCollection>
+     */
     private EntityRepository $templateRepository;
 
     private EntityTemplateLoader $templateLoader;

--- a/tests/integration/Core/Framework/Adapter/Twig/NamespaceHierarchy/BundleHierarchyBuilderTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/NamespaceHierarchy/BundleHierarchyBuilderTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig\NamespaceHierar
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\BundleHierarchyBuilder;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -15,6 +16,9 @@ class BundleHierarchyBuilderTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<AppCollection>
+     */
     private EntityRepository $appRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/Adapter/Twig/NamespaceHierarchy/NamespaceHierarchyBuilderTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/NamespaceHierarchy/NamespaceHierarchyBuilderTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig\NamespaceHierar
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -17,7 +18,7 @@ class NamespaceHierarchyBuilderTest extends TestCase
 
     public function testItAddsAppTemplateNamespaces(): void
     {
-        /** @var EntityRepository $appRepository */
+        /** @var EntityRepository<AppCollection> $appRepository */
         $appRepository = static::getContainer()->get('app.repository');
 
         $appRepository->create([

--- a/tests/integration/Core/Framework/Api/Acl/AclAnnotationValidatorTest.php
+++ b/tests/integration/Core/Framework/Api/Acl/AclAnnotationValidatorTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Acl\AclAnnotationValidator;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Test\Api\Acl\fixtures\AclTestController;
@@ -26,6 +27,9 @@ class AclAnnotationValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<AppCollection>
+     */
     private EntityRepository $appRepository;
 
     private Connection $connection;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlDefinition;
@@ -30,6 +31,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\FilesystemBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestUser;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
@@ -596,7 +598,7 @@ EOF;
 
         $this->assertEntityExists($browser, 'product', $id);
 
-        /** @var EntityRepository $productRepo */
+        /** @var EntityRepository<ProductCollection> $productRepo */
         $productRepo = static::getContainer()->get(ProductDefinition::ENTITY_NAME . '.repository');
         $criteria = new Criteria([$id]);
         $criteria->addFilter(
@@ -2477,7 +2479,7 @@ EOF;
 
     private function getNonSystemLanguageId(): string
     {
-        /** @var EntityRepository $languageRepository */
+        /** @var EntityRepository<LanguageCollection> $languageRepository */
         $languageRepository = static::getContainer()->get('language.repository');
         $criteria = new Criteria();
         $criteria->addFilter(new NotFilter(

--- a/tests/integration/Core/Framework/Api/Controller/AuthControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/AuthControllerTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestUser;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Integration\IntegrationCollection;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\HttpFoundation\Response;
@@ -712,7 +713,7 @@ class AuthControllerTest extends TestCase
 
     private function setAccessTokenForIntegration(string $integrationId, string $accessKey, string $secret): void
     {
-        /** @var EntityRepository $integrationRepository */
+        /** @var EntityRepository<IntegrationCollection> $integrationRepository */
         $integrationRepository = static::getContainer()->get('integration.repository');
 
         $integrationRepository->update([

--- a/tests/integration/Core/Framework/Api/OAuth/ClientRepositoryTest.php
+++ b/tests/integration/Core/Framework/Api/OAuth/ClientRepositoryTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\Integration\IntegrationCollection;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -69,7 +70,7 @@ class ClientRepositoryTest extends TestCase
 
     private function setAccessTokenForIntegration(string $integrationId, string $accessKey, string $secret): void
     {
-        /** @var EntityRepository $integrationRepository */
+        /** @var EntityRepository<IntegrationCollection> $integrationRepository */
         $integrationRepository = static::getContainer()->get('integration.repository');
 
         $integrationRepository->update([

--- a/tests/integration/Core/Framework/Api/Serializer/JsonApiEncoderTest.php
+++ b/tests/integration/Core/Framework/Api/Serializer/JsonApiEncoderTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderDefinition;
 use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Rule\RuleDefinition;
 use Shopware\Core\Defaults;
@@ -53,6 +54,9 @@ class JsonApiEncoderTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/App/ActionButton/ActionButtonLoaderTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/ActionButtonLoaderTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App\ActionButton;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\ActionButton\ActionButtonLoader;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -16,6 +17,9 @@ class ActionButtonLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<AppCollection>
+     */
     private EntityRepository $appRepository;
 
     private ActionButtonLoader $actionButtonLoader;

--- a/tests/integration/Core/Framework/App/AppLocaleProviderTest.php
+++ b/tests/integration/Core/Framework/App/AppLocaleProviderTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -21,6 +22,9 @@ class AppLocaleProviderTest extends TestCase
 
     private AppLocaleProvider $localeProvider;
 
+    /**
+     * @var EntityRepository<UserCollection>
+     */
     private EntityRepository $userRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/App/AppServiceTest.php
+++ b/tests/integration/Core/Framework/App/AppServiceTest.php
@@ -3,7 +3,9 @@
 namespace Shopware\Tests\Integration\Core\Framework\App;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonCollection;
 use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonEntity;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppService;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
@@ -29,10 +31,16 @@ class AppServiceTest extends TestCase
 
     private AppService $appService;
 
+    /**
+     * @var EntityRepository<AppCollection>
+     */
     private EntityRepository $appRepository;
 
     private Context $context;
 
+    /**
+     * @var EntityRepository<ActionButtonCollection>
+     */
     private EntityRepository $actionButtonRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/App/Command/InstallAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/InstallAppCommandTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Command;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\Command\AppPrinter;
 use Shopware\Core\Framework\App\Command\InstallAppCommand;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
@@ -21,6 +22,9 @@ class InstallAppCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<AppCollection>
+     */
     private EntityRepository $appRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/App/Command/RefreshAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/RefreshAppCommandTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\App\Command;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppService;
 use Shopware\Core\Framework\App\Command\AppPrinter;
 use Shopware\Core\Framework\App\Command\RefreshAppCommand;
@@ -24,6 +25,9 @@ class RefreshAppCommandTest extends TestCase
     use AppSystemTestBehaviour;
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<AppCollection>
+     */
     private EntityRepository $appRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -51,6 +51,7 @@ use Shopware\Core\Framework\Script\Execution\Script;
 use Shopware\Core\Framework\Script\Execution\ScriptLoader;
 use Shopware\Core\Framework\Script\ScriptCollection;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\CustomEntity\CustomEntityCollection;
 use Shopware\Core\System\CustomEntity\CustomEntityEntity;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetCollection;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSetRelation\CustomFieldSetRelationEntity;
@@ -86,6 +87,9 @@ class AppLifecycleTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<CustomEntityCollection>
+     */
     private EntityRepository $customEntityRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\App\Manifest;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\Manifest\ModuleLoader;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\App\ShopId\ShopId;
@@ -26,6 +27,9 @@ class ModuleLoaderTest extends TestCase
     use DatabaseTransactionBehaviour;
     use KernelTestBehaviour;
 
+    /**
+     * @var EntityRepository<AppCollection>
+     */
     private EntityRepository $appRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/App/Payment/AbstractAppPaymentHandlerTestCase.php
+++ b/tests/integration/Core/Framework/App/Payment/AbstractAppPaymentHandlerTestCase.php
@@ -9,13 +9,16 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCaptureRefund\OrderTransactionCaptureRefundCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCaptureRefund\OrderTransactionCaptureRefundStates;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Checkout\Payment\Cart\PaymentRefundProcessor;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentProcessor;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\App\AppCollection;
@@ -75,8 +78,14 @@ abstract class AbstractAppPaymentHandlerTestCase extends TestCase
      */
     protected EntityRepository $orderTransactionRepository;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
+    /**
+     * @var EntityRepository<PaymentMethodCollection>
+     */
     private EntityRepository $paymentMethodRepository;
 
     private StateMachineRegistry $stateMachineRegistry;
@@ -85,6 +94,9 @@ abstract class AbstractAppPaymentHandlerTestCase extends TestCase
 
     private AbstractSalesChannelContextFactory $salesChannelContextFactory;
 
+    /**
+     * @var EntityRepository<OrderTransactionCaptureCollection>
+     */
     private EntityRepository $orderTransactionCaptureRepository;
 
     /**

--- a/tests/integration/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandlerTest.php
+++ b/tests/integration/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandlerTest.php
@@ -6,14 +6,17 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
 use Shopware\Core\Framework\App\ScheduledTask\DeleteCascadeAppsHandler;
 use Shopware\Core\Framework\App\ScheduledTask\DeleteCascadeAppsTask;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Integration\IntegrationCollection;
 
 /**
  * @internal
@@ -24,10 +27,19 @@ class DeleteCascadeAppsHandlerTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<ScheduledTaskCollection>
+     */
     private EntityRepository $scheduledTaskRepo;
 
+    /**
+     * @var EntityRepository<AclRoleCollection>
+     */
     private EntityRepository $aclRoleRepo;
 
+    /**
+     * @var EntityRepository<IntegrationCollection>
+     */
     private EntityRepository $integrationRepo;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\AttributeEntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeMappingDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -898,6 +899,9 @@ class AttributeEntityIntegrationTest extends TestCase
         static::assertSame('code-number', $record->number);
     }
 
+    /**
+     * @return EntityRepository<EntityCollection<Entity>>
+     */
     private function repository(string $entity): EntityRepository
     {
         $repository = static::getContainer()->get($entity . '.repository');

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\Tax\TaxCollection;
 
 /**
  * @internal
@@ -26,7 +27,7 @@ class CriteriaQueryHelperTest extends TestCase
     public function testInvalidSortingDirection(): void
     {
         $context = Context::createDefaultContext();
-        /** @var EntityRepository $taxRepository */
+        /** @var EntityRepository<TaxCollection> $taxRepository */
         $taxRepository = static::getContainer()->get('tax.repository');
 
         $criteria = new Criteria();

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Rule\RuleDefinition;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
@@ -45,7 +46,7 @@ class EntityForeignKeyResolverTest extends TestCase
 
         $productId = Uuid::randomHex();
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
         $context = Context::createDefaultContext();
 
@@ -191,7 +192,7 @@ class EntityForeignKeyResolverTest extends TestCase
         $builder = new ProductBuilder($ids, 'product');
         $builder->price(100);
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
 
         $productRepository->create([$builder->build()], $context);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGatewayTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGatewayTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -46,6 +47,9 @@ class EntityWriteGatewayTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private IdsCollection $ids;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Dbal\Fi
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeDefinition;
+use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Checkout\Document\DocumentDefinition;
 use Shopware\Core\Checkout\Document\DocumentEntity;
 use Shopware\Core\Checkout\Order\OrderCollection;
@@ -55,6 +56,9 @@ class ManyToOneAssociationFieldResolverTest extends TestCase
      */
     protected EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<DocumentCollection>
+     */
     protected EntityRepository $documentRepository;
 
     protected Connection $connection;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
@@ -4,11 +4,13 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Dbal;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationDefinition;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturerTranslation\ProductManufacturerTranslationDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -28,10 +30,16 @@ class ManyToManyAssociationFieldTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private Context $context;
 
+    /**
+     * @var EntityRepository<CategoryCollection>
+     */
     private EntityRepository $categoryRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/TranslatedVersionsTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/TranslatedVersionsTest.php
@@ -229,6 +229,9 @@ class TranslatedVersionsTest extends TestCase
         static::assertSame('THIS_SHOULD_BE_RETURNED', $result);
     }
 
+    /**
+     * @param EntityRepository<ProductManufacturerCollection> $productManufacturerRepository
+     */
     private function createManufacturer(EntityRepository $productManufacturerRepository, string $productManufacturerId, Context $context): void
     {
         $translations = $this->getTestTranslations();

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtectionValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtectionValidatorTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayer
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigDefinition;
 use Shopware\Core\System\User\Aggregate\UserAccessKey\UserAccessKeyDefinition;
 use Shopware\Core\Test\TestDefaults;
@@ -188,7 +189,7 @@ class EntityProtectionValidatorTest extends TestCase
 
     public function testItDoesNotValidateCascadeDeletes(): void
     {
-        /** @var EntityRepository $salesChannelRepository */
+        /** @var EntityRepository<SalesChannelCollection> $salesChannelRepository */
         $salesChannelRepository = static::getContainer()->get('sales_channel.repository');
         $countBefore = $salesChannelRepository->search(new Criteria(), Context::createDefaultContext())->getTotal();
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
@@ -26,6 +26,8 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
@@ -70,7 +72,10 @@ class EntityRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->categoryRepository = $this->createRepository(CategoryDefinition::class);
+        /** @var EntityRepository<CategoryCollection> */
+        $categoryRepository = $this->createRepository(CategoryDefinition::class);
+
+        $this->categoryRepository = $categoryRepository;
     }
 
     protected function tearDown(): void
@@ -1648,6 +1653,8 @@ class EntityRepositoryTest extends TestCase
 
     /**
      * @param class-string<EntityDefinition> $definitionClass
+     *
+     * @return EntityRepository<covariant EntityCollection<covariant Entity>>
      */
     private function createRepository(
         string $definitionClass,
@@ -1656,6 +1663,7 @@ class EntityRepositoryTest extends TestCase
         $definition = static::getContainer()->get($definitionClass);
         static::assertInstanceOf(EntityDefinition::class, $definition);
 
+        /** @var EntityRepository<covariant EntityCollection<covariant Entity>> */
         return new EntityRepository(
             $definition,
             static::getContainer()->get(EntityReaderInterface::class),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEventSerializationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEventSerializationTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Event;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -34,7 +35,7 @@ class EntityWrittenEventSerializationTest extends TestCase
 
     private function writeTestProduct(): EntityWrittenContainerEvent
     {
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
 
         return $productRepository->create(

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryWriterFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryWriterFacadeTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\Script\Execution\ScriptAppInformation;
 use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Framework\Test\Script\Execution\TestHook;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\Tax\TaxCollection;
 use Shopware\Core\System\Tax\TaxEntity;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -371,7 +372,7 @@ class RepositoryWriterFacadeTest extends TestCase
 
     private function getExistingTaxId(): string
     {
-        /** @var EntityRepository $taxRepository */
+        /** @var EntityRepository<TaxCollection> $taxRepository */
         $taxRepository = static::getContainer()->get('tax.repository');
 
         $criteria = new Criteria();

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreateAtAndUpdatedAtFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreateAtAndUpdatedAtFieldTest.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
@@ -31,6 +33,9 @@ class CreateAtAndUpdatedAtFieldTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<EntityCollection<Entity>>
+     */
     private EntityRepository $entityRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
@@ -25,6 +25,7 @@ use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\Custo
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\CustomField\CustomFieldCollection;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -1132,6 +1133,9 @@ class CustomFieldTest extends TestCase
         $attributeRepo->create($attributes, Context::createDefaultContext());
     }
 
+    /**
+     * @return EntityRepository<CustomFieldCollection>
+     */
     private function getTestRepository(): EntityRepository
     {
         $definition = $this->registerDefinition(
@@ -1139,6 +1143,7 @@ class CustomFieldTest extends TestCase
             CustomFieldTestTranslationDefinition::class
         );
 
+        /** @var EntityRepository<CustomFieldCollection> */
         return new EntityRepository(
             $definition,
             static::getContainer()->get(EntityReaderInterface::class),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTranslationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTranslationTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\CustomField\CustomFieldCollection;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -575,6 +576,9 @@ class CustomFieldTranslationTest extends TestCase
         );
     }
 
+    /**
+     * @return EntityRepository<CustomFieldCollection>
+     */
     protected function getTestRepository(): EntityRepository
     {
         $definition = $this->registerDefinition(
@@ -582,6 +586,7 @@ class CustomFieldTranslationTest extends TestCase
             CustomFieldTestTranslationDefinition::class
         );
 
+        /** @var EntityRepository<CustomFieldCollection> */
         return new EntityRepository(
             $definition,
             static::getContainer()->get(EntityReaderInterface::class),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAwareFlagTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAwareFlagTest.php
@@ -3,7 +3,9 @@
 namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Field\Flag;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -21,8 +23,14 @@ class ApiAwareFlagTest extends TestCase
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
+    /**
+     * @var EntityRepository<MediaCollection>
+     */
     private EntityRepository $mediaRepository;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/OneToOneAssociationFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/OneToOneAssociationFieldTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Field;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeletedEvent;
@@ -40,8 +41,14 @@ class OneToOneAssociationFieldTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<EntityCollection<Entity>>
+     */
     private EntityRepository $repository;
 
+    /**
+     * @var EntityRepository<EntityCollection<Entity>>
+     */
     private EntityRepository $subRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/StateMachineSateFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/StateMachineSateFieldSerializerTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -27,6 +28,9 @@ class StateMachineSateFieldSerializerTest extends TestCase
     use DatabaseTransactionBehaviour;
     use KernelTestBehaviour;
 
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldIndexerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldIndexerTest.php
@@ -7,6 +7,8 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -19,6 +21,9 @@ class ManyToManyIdFieldIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<EntityCollection<Entity>>
+     */
     private EntityRepository $productPropertyRepository;
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -29,6 +29,7 @@ use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\ParentAssociationCanNotBeFetched;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
@@ -2234,7 +2235,7 @@ class EntityReaderTest extends TestCase
             ],
         ];
 
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<EntityCollection<Entity>> $repository */
         $repository = static::getContainer()->get('non_id_primary_key_test.repository');
 
         $repository->create($data, Context::createDefaultContext());
@@ -2273,7 +2274,7 @@ class EntityReaderTest extends TestCase
             ],
         ];
 
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<EntityCollection<Entity>> $repository */
         $repository = static::getContainer()->get('non_id_primary_key_test.repository');
 
         $repository->create($data, Context::createDefaultContext());

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search\
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -23,6 +24,9 @@ class RangeAggregationTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $repository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/AntiJoinSearchTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/AntiJoinSearchTest.php
@@ -4,6 +4,8 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerCollection;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
@@ -50,7 +52,7 @@ class AntiJoinSearchTest extends TestCase
 
         $ids = array_column($products, 'id');
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $productRepository->create($products, Context::createDefaultContext());
 
@@ -109,7 +111,7 @@ class AntiJoinSearchTest extends TestCase
 
         $ids = array_column($products, 'id');
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $productRepository->create($products, Context::createDefaultContext());
 
@@ -141,7 +143,7 @@ class AntiJoinSearchTest extends TestCase
             $this->getTaggedProduct($greenBlueId, 'green blue', ['blue', 'green']),
         ];
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $productRepository->create($products, Context::createDefaultContext());
 
@@ -195,7 +197,7 @@ class AntiJoinSearchTest extends TestCase
             ],
         ];
 
-        /** @var EntityRepository $categoryRepository */
+        /** @var EntityRepository<CategoryCollection> $categoryRepository */
         $categoryRepository = static::getContainer()->get('category.repository');
         $categoryRepository->create($categories, Context::createDefaultContext());
 
@@ -269,7 +271,7 @@ class AntiJoinSearchTest extends TestCase
             ],
         ];
 
-        /** @var EntityRepository $manufacturerRepository */
+        /** @var EntityRepository<ProductManufacturerCollection> $manufacturerRepository */
         $manufacturerRepository = static::getContainer()->get('product_manufacturer.repository');
         $manufacturerRepository->create($manufacturers, Context::createDefaultContext());
 
@@ -387,7 +389,7 @@ class AntiJoinSearchTest extends TestCase
             $this->getTaggedProduct($withTagId, 'green', ['green']),
         ];
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $productRepository->create($products, Context::createDefaultContext());
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntitySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntitySearcherTest.php
@@ -5,13 +5,17 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\CriteriaQueryBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntitySearcher;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
@@ -31,8 +35,14 @@ class EntitySearcherTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<PropertyGroupCollection>
+     */
     private EntityRepository $groupRepository;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     protected function setUp(): void
@@ -567,7 +577,7 @@ class EntitySearcherTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsAnyFilter('productId', array_values($ids->getList(['product-1', 'product-2']))));
 
-        /** @var EntityRepository $productCategoryRepository */
+        /** @var EntityRepository<EntityCollection<Entity>> $productCategoryRepository */
         $productCategoryRepository = static::getContainer()->get('product_category.repository');
         $result = $productCategoryRepository
             ->searchIds($criteria, Context::createDefaultContext());

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/FkFieldPrimarySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/FkFieldPrimarySearcherTest.php
@@ -5,9 +5,12 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationCollection;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
@@ -29,6 +32,9 @@ class FkFieldPrimarySearcherTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private string $productId;
@@ -69,7 +75,7 @@ class FkFieldPrimarySearcherTest extends TestCase
             Context::createDefaultContext()
         );
 
-        /** @var EntityRepository $fkFieldPrimaryRepository */
+        /** @var EntityRepository<EntityCollection<Entity>> $fkFieldPrimaryRepository */
         $fkFieldPrimaryRepository = static::getContainer()->get($definition->getEntityName() . '.repository');
 
         $fkFieldPrimaryRepository->create(
@@ -83,7 +89,7 @@ class FkFieldPrimarySearcherTest extends TestCase
         );
 
         $criteria = new Criteria([$this->productId]);
-        /** @var EntityRepository $fkFieldPrimaryRepository */
+        /** @var EntityRepository<EntityCollection<Entity>> $fkFieldPrimaryRepository */
         $fkFieldPrimaryRepository = static::getContainer()->get('fk_field_primary.repository');
         /** @var array<string, ArrayEntity> $fkFieldPrimaryTupel */
         $fkFieldPrimaryTupel = $fkFieldPrimaryRepository->search($criteria, Context::createDefaultContext())->getElements();
@@ -96,7 +102,7 @@ class FkFieldPrimarySearcherTest extends TestCase
     {
         $this->addMultiPrimaryFkField();
 
-        /** @var EntityRepository $multiPrimaryRepository */
+        /** @var EntityRepository<EntityCollection<Entity>> $multiPrimaryRepository */
         $multiPrimaryRepository = static::getContainer()->get('multi_fk_field_primary.repository');
         $firstId = Uuid::randomHex();
         $secondId = Uuid::randomHex();
@@ -139,9 +145,9 @@ class FkFieldPrimarySearcherTest extends TestCase
 
         $criteria = new Criteria([['productId' => $this->productId, 'languageId' => Defaults::LANGUAGE_SYSTEM]]);
 
+        /** @var EntityRepository<ProductTranslationCollection> */
         $productTranslationRepository = static::getContainer()->get('product_translation.repository');
-        /** @var ProductTranslationCollection $productTranslation */
-        $productTranslation = $productTranslationRepository->search($criteria, Context::createDefaultContext());
+        $productTranslation = $productTranslationRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
         $key = $this->productId . '-' . Defaults::LANGUAGE_SYSTEM;
         static::assertArrayHasKey($key, $productTranslation->getElements());

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -5,6 +5,8 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search\
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerCollection;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
@@ -31,8 +33,14 @@ class SqlQueryParserTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $repository;
 
+    /**
+     * @var EntityRepository<ProductManufacturerCollection>
+     */
     private EntityRepository $manufacturerRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityExistsValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityExistsValidatorTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Locale\LocaleCollection;
 use Shopware\Core\System\Locale\LocaleDefinition;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -119,11 +120,15 @@ class EntityExistsValidatorTest extends TestCase
         static::assertCount(1, $violations);
     }
 
+    /**
+     * @return EntityRepository<LocaleCollection>
+     */
     protected function createRepository(): EntityRepository
     {
         $definition = static::getContainer()->get(LocaleDefinition::class);
         static::assertInstanceOf(LocaleDefinition::class, $definition);
 
+        /** @var EntityRepository<LocaleCollection> */
         return new EntityRepository(
             $definition,
             static::getContainer()->get(EntityReaderInterface::class),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Locale\LocaleCollection;
 use Shopware\Core\System\Locale\LocaleDefinition;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -146,11 +147,15 @@ class EntityNotExistsValidatorTest extends TestCase
         static::assertCount(2, $violations);
     }
 
+    /**
+     * @return EntityRepository<LocaleCollection>
+     */
     protected function createRepository(): EntityRepository
     {
         $definition = static::getContainer()->get(LocaleDefinition::class);
         static::assertInstanceOf(LocaleDefinition::class, $definition);
 
+        /** @var EntityRepository<LocaleCollection> */
         return new EntityRepository(
             $definition,
             static::getContainer()->get(EntityReaderInterface::class),

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
@@ -16,6 +16,8 @@ use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTax;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRule;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceCollection;
@@ -84,8 +86,14 @@ class VersioningTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
     private AbstractSalesChannelContextFactory $salesChannelContextFactory;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/EntityWriterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/EntityWriterTest.php
@@ -7,10 +7,12 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerEntity;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
@@ -838,7 +840,7 @@ class EntityWriterTest extends TestCase
 
     public function testCanUpdateEntitiesToAddCustomFields(): void
     {
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
         $productId = Uuid::randomHex();
 
@@ -965,6 +967,9 @@ class EntityWriterTest extends TestCase
         return static::getContainer()->get(EntityWriter::class);
     }
 
+    /**
+     * @return EntityRepository<MediaCollection>
+     */
     private function getMediaRepository(): EntityRepository
     {
         return static::getContainer()->get('media.repository');

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/ParentChildTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/ParentChildTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Write;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\ExpectedArrayException;
@@ -18,6 +19,9 @@ class ParentChildTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<CategoryCollection>
+     */
     private EntityRepository $categoryRepository;
 
     private Connection $connection;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/SetNullOnDeleteTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/SetNullOnDeleteTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
@@ -34,6 +36,9 @@ class SetNullOnDeleteTest extends TestCase
 
     private EntityWriter $writer;
 
+    /**
+     * @var EntityRepository<EntityCollection<Entity>>
+     */
     private EntityRepository $repository;
 
     private Connection $connection;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/TranslationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/TranslationTest.php
@@ -10,12 +10,14 @@ use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotDefinition;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturerTranslation\ProductManufacturerTranslationDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
@@ -29,7 +31,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\Aggregate\CurrencyTranslation\CurrencyTranslationDefinition;
+use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Currency\CurrencyDefinition;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\Tax\TaxDefinition;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -41,10 +45,19 @@ class TranslationTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<CurrencyCollection>
+     */
     private EntityRepository $currencyRepository;
 
+    /**
+     * @var EntityRepository<LanguageCollection>
+     */
     private EntityRepository $languageRepository;
 
     /**
@@ -52,6 +65,9 @@ class TranslationTest extends TestCase
      */
     private EntityRepository $categoryRepository;
 
+    /**
+     * @var EntityRepository<CmsPageCollection>
+     */
     private EntityRepository $pageRepository;
 
     /**

--- a/tests/integration/Core/Framework/Language/LanguageValidatorTest.php
+++ b/tests/integration/Core/Framework/Language/LanguageValidatorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageValidator;
 
 /**
@@ -21,6 +22,9 @@ class LanguageValidatorTest extends TestCase
 
     private Context $defaultContext;
 
+    /**
+     * @var EntityRepository<LanguageCollection>
+     */
     private EntityRepository $languageRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
@@ -31,6 +32,9 @@ class ScheduledTaskHandlerTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<ScheduledTaskCollection>
+     */
     private EntityRepository $scheduledTaskRepo;
 
     private LoggerInterface&MockObject $logger;

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Scheduler\TaskScheduler;
@@ -30,6 +31,9 @@ class TaskSchedulerTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ScheduledTaskCollection>
+     */
     private EntityRepository $scheduledTaskRepo;
 
     private MockObject&MessageBusInterface $messageBus;

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/TaskRegistryTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/TaskRegistryTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
 use Shopware\Core\Framework\Test\MessageQueue\fixtures\FooMessage;
@@ -22,6 +23,9 @@ class TaskRegistryTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ScheduledTaskCollection>
+     */
     private EntityRepository $scheduledTaskRepo;
 
     private TaskRegistry $registry;

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\Plugin\Exception\PluginHasActiveDependantsException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotActivatedException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotInstalledException;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
@@ -63,6 +64,9 @@ class PluginLifecycleServiceTest extends TestCase
 
     private ContainerInterface $container;
 
+    /**
+     * @var EntityRepository<PluginCollection>
+     */
     private EntityRepository $pluginRepo;
 
     private PluginService $pluginService;

--- a/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\ShopwareHttpException;
 use Shopware\Core\Framework\Test\Plugin\PluginTestsHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Locale\LocaleCollection;
 use Shopware\Core\System\Locale\LocaleEntity;
 use SwagTestNoDefaultLang\SwagTestNoDefaultLang;
 use SwagTestPlugin\SwagTestPlugin;
@@ -368,7 +369,7 @@ class PluginServiceTest extends TestCase
 
     private function getIsoId(string $iso): string
     {
-        /** @var EntityRepository $localeRepository */
+        /** @var EntityRepository<LocaleCollection> $localeRepository */
         $localeRepository = static::getContainer()->get('locale.repository');
 
         $criteria = new Criteria();

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverAppTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverAppTest.php
@@ -3,7 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Routing;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\App\AppCollection;
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Integration\IntegrationCollection;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
@@ -95,7 +96,7 @@ class ApiRequestContextResolverAppTest extends TestCase
 
     public function testCanWriteWithPermissionsSet(): void
     {
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
         $productId = Uuid::randomHex();
         $context = Context::createDefaultContext();
@@ -123,7 +124,7 @@ class ApiRequestContextResolverAppTest extends TestCase
 
     public function testItCanUpdateAnExistingProduct(): void
     {
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
         $productId = Uuid::randomHex();
         $newName = 'i got a new name';
@@ -149,7 +150,6 @@ class ApiRequestContextResolverAppTest extends TestCase
 
         static::assertSame(204, $browser->getResponse()->getStatusCode());
 
-        /** @var ProductEntity $product */
         $product = $productRepository->search(new Criteria(), $context)->getEntities()->get($productId);
 
         static::assertNotNull($product);
@@ -231,7 +231,7 @@ class ApiRequestContextResolverAppTest extends TestCase
 
     private function setAccessTokenForIntegration(string $integrationId, string $accessKey, string $secret): void
     {
-        /** @var EntityRepository $integrationRepository */
+        /** @var EntityRepository<IntegrationCollection> $integrationRepository */
         $integrationRepository = static::getContainer()->get('integration.repository');
 
         $integrationRepository->update([

--- a/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
+use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
@@ -42,6 +43,9 @@ class SalesChannelRequestContextResolverTest extends TestCase
 
     private IdsCollection $ids;
 
+    /**
+     * @var EntityRepository<CurrencyCollection>
+     */
     private EntityRepository $currencyRepository;
 
     private SalesChannelContextServiceInterface $contextService;

--- a/tests/integration/Core/Framework/Rule/AndRuleTest.php
+++ b/tests/integration/Core/Framework/Rule/AndRuleTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Rule\Aggregate\RuleCondition\RuleConditionCollection;
 use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Context;
@@ -30,6 +31,9 @@ class AndRuleTest extends TestCase
      */
     private EntityRepository $ruleRepository;
 
+    /**
+     * @var EntityRepository<RuleConditionCollection>
+     */
     private EntityRepository $conditionRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
+++ b/tests/integration/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Rule\Container;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Rule\LineItemInCategoryRule;
+use Shopware\Core\Content\Rule\Aggregate\RuleCondition\RuleConditionCollection;
 use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Context;
@@ -34,6 +35,9 @@ class MatchAllLineItemsRuleTest extends TestCase
      */
     private EntityRepository $ruleRepository;
 
+    /**
+     * @var EntityRepository<RuleConditionCollection>
+     */
     private EntityRepository $conditionRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/integration/Core/Framework/Rule/DateRangeRuleTest.php
@@ -3,6 +3,8 @@
 namespace Shopware\Tests\Integration\Core\Framework\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Rule\Aggregate\RuleCondition\RuleConditionCollection;
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -26,8 +28,14 @@ class DateRangeRuleTest extends TestCase
     use DatabaseTransactionBehaviour;
     use KernelTestBehaviour;
 
+    /**
+     * @var EntityRepository<RuleCollection>
+     */
     private EntityRepository $ruleRepository;
 
+    /**
+     * @var EntityRepository<RuleConditionCollection>
+     */
     private EntityRepository $conditionRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/Rule/NotRuleTest.php
+++ b/tests/integration/Core/Framework/Rule/NotRuleTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Rule\Aggregate\RuleCondition\RuleConditionCollection;
 use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Context;
@@ -31,6 +32,9 @@ class NotRuleTest extends TestCase
      */
     private EntityRepository $ruleRepository;
 
+    /**
+     * @var EntityRepository<RuleConditionCollection>
+     */
     private EntityRepository $conditionRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/Rule/OrRuleTest.php
+++ b/tests/integration/Core/Framework/Rule/OrRuleTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Rule\Aggregate\RuleCondition\RuleConditionCollection;
 use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Context;
@@ -31,6 +32,9 @@ class OrRuleTest extends TestCase
      */
     private EntityRepository $ruleRepository;
 
+    /**
+     * @var EntityRepository<RuleConditionCollection>
+     */
     private EntityRepository $conditionRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/Rule/ScriptRuleTest.php
+++ b/tests/integration/Core/Framework/Rule/ScriptRuleTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\CheckoutRuleScope;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Rule\Aggregate\RuleCondition\RuleConditionCollection;
 use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\App\Aggregate\AppScriptCondition\AppScriptConditionCollection;
@@ -51,6 +52,9 @@ class ScriptRuleTest extends TestCase
      */
     private EntityRepository $ruleRepository;
 
+    /**
+     * @var EntityRepository<RuleConditionCollection>
+     */
     private EntityRepository $conditionRepository;
 
     /**

--- a/tests/integration/Core/Framework/Rule/XorRuleTest.php
+++ b/tests/integration/Core/Framework/Rule/XorRuleTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Rule\Aggregate\RuleCondition\RuleConditionCollection;
 use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Context;
@@ -31,6 +32,9 @@ class XorRuleTest extends TestCase
      */
     private EntityRepository $ruleRepository;
 
+    /**
+     * @var EntityRepository<RuleConditionCollection>
+     */
     private EntityRepository $conditionRepository;
 
     private Context $context;

--- a/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
@@ -42,6 +43,9 @@ class SeoUrlPersisterTest extends TestCase
 
     private SeoUrlPersister $seoUrlPersister;
 
+    /**
+     * @var EntityRepository<CategoryCollection>
+     */
     private EntityRepository $categoryRepository;
 
     private SeoUrlGenerator $seoUrlGenerator;

--- a/tests/integration/Core/Framework/Seo/SeoUrlPlaceholderHandlerTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrlPlaceholderHandlerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Seo;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandler;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Defaults;
@@ -183,7 +184,7 @@ class SeoUrlPlaceholderHandlerTest extends TestCase
             ],
         ];
 
-        /** @var EntityRepository $repo */
+        /** @var EntityRepository<SeoUrlCollection> $repo */
         $repo = static::getContainer()->get('seo_url.repository');
         $repo->create($seoUrls, Context::createDefaultContext());
 

--- a/tests/integration/Core/Framework/Store/Api/StoreControllerTest.php
+++ b/tests/integration/Core/Framework/Store/Api/StoreControllerTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\Store\Struct\PluginDownloadDataStruct;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserEntity;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -34,6 +35,9 @@ class StoreControllerTest extends TestCase
 
     private Context $defaultContext;
 
+    /**
+     * @var EntityRepository<UserCollection>
+     */
     private EntityRepository $userRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
+++ b/tests/integration/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Store\Authentication\FrwRequestOptionsProvider;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardService;
 use Shopware\Core\Framework\Test\Store\StoreClientBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
 
 /**
  * @internal
@@ -26,6 +27,9 @@ class FrwRequestOptionsProviderTest extends TestCase
 
     private FrwRequestOptionsProvider $optionsProvider;
 
+    /**
+     * @var EntityRepository<UserConfigCollection>
+     */
     private EntityRepository $userConfigRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/Store/Authentication/LocaleProviderTest.php
+++ b/tests/integration/Core/Framework/Store/Authentication/LocaleProviderTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Authentication\LocaleProvider;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -20,6 +21,9 @@ class LocaleProviderTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<UserCollection>
+     */
     private EntityRepository $userRepository;
 
     private LocaleProvider $localeProvider;

--- a/tests/integration/Core/Framework/Store/Services/ExtensionLoaderTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionLoaderTest.php
@@ -181,7 +181,7 @@ class ExtensionLoaderTest extends TestCase
 
         $time = new \DateTime();
 
-        /** @var EntityRepository $pluginRepository */
+        /** @var EntityRepository<PluginCollection> $pluginRepository */
         $pluginRepository = static::getContainer()->get('plugin.repository');
         $pluginRepository->update([
             [

--- a/tests/integration/Core/Framework/Store/Subscriber/LicenseHostChangedSubscriberTest.php
+++ b/tests/integration/Core/Framework/Store/Subscriber/LicenseHostChangedSubscriberTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserEntity;
 use Shopware\Core\Test\TestDefaults;
 
@@ -29,7 +30,7 @@ class LicenseHostChangedSubscriberTest extends TestCase
         $systemConfigService->set('core.store.licenseHost', 'host');
         $systemConfigService->set('core.store.shopSecret', 'shop-s3cr3t');
 
-        /** @var EntityRepository $userRepository */
+        /** @var EntityRepository<UserCollection> $userRepository */
         $userRepository = static::getContainer()->get('user.repository');
 
         /** @var UserEntity $adminUser */

--- a/tests/integration/Core/Framework/Translation/TranslatorTest.php
+++ b/tests/integration/Core/Framework/Translation/TranslatorTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
+use Shopware\Core\System\Snippet\SnippetCollection;
 use Shopware\Core\System\Snippet\SnippetDefinition;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Core\Test\TestDefaults;
@@ -41,6 +42,9 @@ class TranslatorTest extends TestCase
 
     private Translator $translator;
 
+    /**
+     * @var EntityRepository<SnippetCollection>
+     */
     private EntityRepository $snippetRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Framework/Webhook/Hookable/HookableEventFactoryTest.php
+++ b/tests/integration/Core/Framework/Webhook/Hookable/HookableEventFactoryTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
 use Shopware\Core\Content\Flow\Dispatching\FlowFactory;
 use Shopware\Core\Content\Flow\Dispatching\FlowState;
+use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceCollection;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Flow\TestFlowBusinessEvent;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -17,7 +19,9 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\Hookable\HookableBusinessEvent;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEventFactory;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\Tax\TaxCollection;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -62,7 +66,7 @@ class HookableEventFactoryTest extends TestCase
     {
         $id = Uuid::randomHex();
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $writtenEvent = $this->insertProduct($id, $productRepository);
 
@@ -113,7 +117,7 @@ class HookableEventFactoryTest extends TestCase
     {
         $id = Uuid::randomHex();
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $this->insertProduct($id, $productRepository);
 
@@ -166,7 +170,7 @@ class HookableEventFactoryTest extends TestCase
     {
         $id = Uuid::randomHex();
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $this->insertProduct($id, $productRepository);
 
@@ -188,7 +192,7 @@ class HookableEventFactoryTest extends TestCase
     public function testDoesNotCreateHookableNotHookableEntity(): void
     {
         $id = Uuid::randomHex();
-        /** @var EntityRepository $taxRepository */
+        /** @var EntityRepository<TaxCollection> */
         $taxRepository = static::getContainer()->get('tax.repository');
 
         $createdEvent = $taxRepository->upsert([
@@ -225,7 +229,7 @@ class HookableEventFactoryTest extends TestCase
     {
         $id = Uuid::randomHex();
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $this->insertProduct($id, $productRepository);
 
@@ -268,7 +272,7 @@ class HookableEventFactoryTest extends TestCase
         $id = Uuid::randomHex();
         $productPriceId = Uuid::randomHex();
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $this->insertProduct($id, $productRepository);
 
@@ -347,14 +351,14 @@ class HookableEventFactoryTest extends TestCase
     {
         $id = Uuid::randomHex();
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $this->insertProduct($id, $productRepository);
 
         $ruleRepository = static::getContainer()->get('rule.repository');
         $ruleId = $ruleRepository->searchIds(new Criteria(), Context::createDefaultContext())->firstId();
 
-        /** @var EntityRepository $productPriceRepository */
+        /** @var EntityRepository<ProductPriceCollection> */
         $productPriceRepository = static::getContainer()->get('product_price.repository');
         $writtenEvent = $productPriceRepository->upsert([
             [
@@ -401,7 +405,7 @@ class HookableEventFactoryTest extends TestCase
     {
         $id = Uuid::randomHex();
 
-        /** @var EntityRepository $salesChannelDomainRepository */
+        /** @var EntityRepository<SalesChannelDomainCollection> */
         $salesChannelDomainRepository = static::getContainer()->get('sales_channel_domain.repository');
         $writtenEvent = $this->insertSalesChannelDomain($id, $salesChannelDomainRepository);
 
@@ -436,6 +440,9 @@ class HookableEventFactoryTest extends TestCase
         }
     }
 
+    /**
+     * @param EntityRepository<ProductCollection> $productRepository
+     */
     private function insertProduct(string $id, EntityRepository $productRepository): EntityWrittenContainerEvent
     {
         return $productRepository->upsert([
@@ -463,6 +470,9 @@ class HookableEventFactoryTest extends TestCase
         ], Context::createDefaultContext());
     }
 
+    /**
+     * @param EntityRepository<SalesChannelDomainCollection> $salesChannelDomainRepository
+     */
     private function insertSalesChannelDomain(
         string $id,
         EntityRepository $salesChannelDomainRepository


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently a few EntityRepository types are missing their phpstan type
- As in the past we group this updates to the EntityRepository types by areas to keep the PR size reasonable
- This PR includes core integration framework tests area

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the EntityRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
