### PR TITLE
chore: Use correct EntityRepository types for phpstan in integration core content tests

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -171,11 +171,6 @@ parameters:
                 - tests/integration/Core/Framework/Store/_fixtures/AppStoreTestPlugin/*
                 - tests/integration/Core/Framework/Plugin/_fixtures/*
 
-        - # WIP implementation (See NEXT-29041 - https://github.com/shopware/shopware/issues/6175)
-            message: '#.* generic class Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityRepository.*not specify its types: TEntityCollection#'
-            paths:
-                - tests/integration/Core/Content/**
-
         - # Needs a proper class-string annotation in `\Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition::getCollectionClass` and all child classes
             message: '#PHPDoc tag @var with type .*Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityCollection.* is not subtype of native type string#'
             paths:

--- a/tests/integration/Core/Content/Category/SalesChannel/CategoryRouteTest.php
+++ b/tests/integration/Core/Content/Category/SalesChannel/CategoryRouteTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Tests\Integration\Core\Content\Category\SalesChannel\fixtures\CategoryRouteInheritanceFixtures;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -149,7 +150,7 @@ class CategoryRouteTest extends TestCase
     {
         $this->createListingData();
 
-        /** @var EntityRepository $salesChannelRepository */
+        /** @var EntityRepository<SalesChannelCollection> $salesChannelRepository */
         $salesChannelRepository = $this->getContainer()->get('sales_channel.repository');
         $salesChannelRepository->upsert([[
             'id' => $this->ids->get('sales-channel'),

--- a/tests/integration/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/integration/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
@@ -38,6 +39,9 @@ class CategoryBreadcrumbBuilderTest extends TestCase
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
+    /**
+     * @var EntityRepository<CategoryCollection>
+     */
     private EntityRepository $categoryRepository;
 
     private SalesChannelContext $salesChannelContext;
@@ -48,6 +52,9 @@ class CategoryBreadcrumbBuilderTest extends TestCase
 
     private CategoryBreadcrumbBuilder $breadcrumbBuilder;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private KernelBrowser $browser;

--- a/tests/integration/Core/Content/Category/Service/NavigationLoaderTest.php
+++ b/tests/integration/Core/Content/Category/Service/NavigationLoaderTest.php
@@ -27,6 +27,9 @@ class NavigationLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<CategoryCollection>
+     */
     private EntityRepository $repository;
 
     private NavigationLoaderInterface $navigationLoader;

--- a/tests/integration/Core/Content/Cms/CmsEntityTest.php
+++ b/tests/integration/Core/Content/Cms/CmsEntityTest.php
@@ -14,6 +14,8 @@ use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\CmsPageDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\CompiledFieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
@@ -59,7 +61,7 @@ class CmsEntityTest extends TestCase
     {
         $definition = static::getContainer()->get($entityDefinitionClass);
         static::assertInstanceOf(EntityDefinition::class, $definition);
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<EntityCollection<Entity>> $repository */
         $repository = static::getContainer()->get($definition->getEntityName() . '.repository');
         $result = $repository->search(new Criteria(), Context::createDefaultContext());
 

--- a/tests/integration/Core/Content/Cms/Subscriber/CmsPageBeforeDefaultChangeSubscriberTest.php
+++ b/tests/integration/Core/Content/Cms/Subscriber/CmsPageBeforeDefaultChangeSubscriberTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsException;
+use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\Exception\PageNotFoundException;
 use Shopware\Core\Content\Cms\Subscriber\CmsPageDefaultChangeSubscriber;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -27,6 +28,9 @@ class CmsPageBeforeDefaultChangeSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<CmsPageCollection>
+     */
     private EntityRepository $cmsPageRepository;
 
     private SystemConfigService $systemConfigService;

--- a/tests/integration/Core/Content/Cms/Subscriber/CmsPageBeforeDeleteSubscriberTest.php
+++ b/tests/integration/Core/Content/Cms/Subscriber/CmsPageBeforeDeleteSubscriberTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Cms\Subscriber;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsException;
+use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\Subscriber\CmsPageDefaultChangeSubscriber;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
@@ -25,6 +26,9 @@ class CmsPageBeforeDeleteSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<CmsPageCollection>
+     */
     private EntityRepository $cmsPageRepository;
 
     private SystemConfigService $systemConfigService;

--- a/tests/integration/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php
+++ b/tests/integration/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php
@@ -4,8 +4,12 @@ namespace Shopware\Tests\Integration\Core\Content\Cms\Subscriber;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\Subscriber\UnusedMediaSubscriber;
 use Shopware\Core\Content\Media\Event\UnusedMediaSearchEvent;
+use Shopware\Core\Content\Media\MediaCollection;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Category\CategoryBuilder;
 use Shopware\Core\Content\Test\Cms\LayoutBuilder;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
@@ -23,12 +27,24 @@ class UnusedMediaSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<CmsPageCollection>
+     */
     private EntityRepository $cmsPageRepository;
 
+    /**
+     * @var EntityRepository<MediaCollection>
+     */
     private EntityRepository $mediaRepository;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<CategoryCollection>
+     */
     private EntityRepository $categoryRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/AddCustomerAffiliateAndCampaignCodeActionTest.php
+++ b/tests/integration/Core/Content/Flow/AddCustomerAffiliateAndCampaignCodeActionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddCustomerAffiliateAndCampaignCodeAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -25,6 +26,9 @@ class AddCustomerAffiliateAndCampaignCodeActionTest extends TestCase
     use CacheTestBehaviour;
     use OrderActionTrait;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/AddCustomerTagActionTest.php
+++ b/tests/integration/Core/Content/Flow/AddCustomerTagActionTest.php
@@ -6,8 +6,10 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddCustomerTagAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
@@ -30,6 +32,9 @@ class AddCustomerTagActionTest extends TestCase
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     private Connection $connection;
@@ -38,6 +43,9 @@ class AddCustomerTagActionTest extends TestCase
 
     private IdsCollection $ids;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/AddOrderAffiliateAndCampaignCodeActionTest.php
+++ b/tests/integration/Core/Content/Flow/AddOrderAffiliateAndCampaignCodeActionTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderAffiliateAndCampaignCodeAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -22,6 +23,9 @@ class AddOrderAffiliateAndCampaignCodeActionTest extends TestCase
 {
     use OrderActionTrait;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/AddOrderTagActionTest.php
+++ b/tests/integration/Core/Content/Flow/AddOrderTagActionTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
 use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderTagAction;
 use Shopware\Core\Content\Flow\Dispatching\Action\RemoveOrderTagAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -26,6 +27,9 @@ class AddOrderTagActionTest extends TestCase
 {
     use OrderActionTrait;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/Flow/ChangeCustomerGroupActionTest.php
+++ b/tests/integration/Core/Content/Flow/ChangeCustomerGroupActionTest.php
@@ -5,9 +5,11 @@ namespace Shopware\Tests\Integration\Core\Content\Flow;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Content\Flow\Dispatching\Action\ChangeCustomerGroupAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -32,12 +34,18 @@ class ChangeCustomerGroupActionTest extends TestCase
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     private KernelBrowser $browser;
 
     private IdsCollection $ids;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/ChangeCustomerStatusActionTest.php
+++ b/tests/integration/Core/Content/Flow/ChangeCustomerStatusActionTest.php
@@ -4,9 +4,11 @@ namespace Shopware\Tests\Integration\Core\Content\Flow;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Content\Flow\Dispatching\Action\ChangeCustomerStatusAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -30,12 +32,18 @@ class ChangeCustomerStatusActionTest extends TestCase
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     private KernelBrowser $browser;
 
     private IdsCollection $ids;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessActionTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessActionTest.php
@@ -12,16 +12,20 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractDownloadRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\DownloadRoute;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\Struct\ActionSequence;
 use Shopware\Core\Content\Flow\Events\FlowSendMailActionEvent;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeEntity;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailBeforeSentEvent;
 use Shopware\Core\Content\Media\File\FileFetcher;
 use Shopware\Core\Content\Media\File\FileSaver;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\State;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
@@ -56,12 +60,24 @@ class GrantDownloadAccessActionTest extends TestCase
 
     private CartService $cartService;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
+    /**
+     * @var EntityRepository<OrderTransactionCollection>
+     */
     private EntityRepository $orderTransactionRepository;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     private SalesChannelContext $salesChannelContext;

--- a/tests/integration/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
@@ -8,12 +8,15 @@ use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryStates;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderStateAction;
 use Shopware\Core\Content\Flow\Dispatching\FlowFactory;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -33,10 +36,19 @@ class SetOrderStateActionTest extends TestCase
 {
     use OrderActionTrait;
 
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
+    /**
+     * @var EntityRepository<OrderDeliveryCollection>
+     */
     private EntityRepository $orderDeliveryRepository;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/Flow/Dispatching/FlowExecutorTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/FlowExecutorTest.php
@@ -11,12 +11,16 @@ use Shopware\Core\Checkout\Cart\Rule\LineItemRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemTotalPriceRule;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Customer\Rule\LastNameRule;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderTagAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Flow\Rule\OrderTagRule;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -45,14 +49,29 @@ class FlowExecutorTest extends TestCase
 
     private CartService $cartService;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
+    /**
+     * @var EntityRepository<OrderTransactionCollection>
+     */
     private EntityRepository $orderTransactionRepository;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
+    /**
+     * @var EntityRepository<TagCollection>
+     */
     private EntityRepository $tagRepository;
 
     private OrderTransactionStateHandler $orderTransactionStateHandler;

--- a/tests/integration/Core/Content/Flow/GenerateDocumentActionTest.php
+++ b/tests/integration/Core/Content/Flow/GenerateDocumentActionTest.php
@@ -28,6 +28,7 @@ use Shopware\Core\Checkout\Document\Renderer\StornoRenderer;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Checkout\Order\Event\OrderStateMachineStateChangeEvent;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Content\Flow\Dispatching\Action\GenerateDocumentAction;
@@ -63,6 +64,9 @@ class GenerateDocumentActionTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
     private DocumentGenerator $documentGenerator;

--- a/tests/integration/Core/Content/Flow/RemoveCustomerTagActionTest.php
+++ b/tests/integration/Core/Content/Flow/RemoveCustomerTagActionTest.php
@@ -5,9 +5,11 @@ namespace Shopware\Tests\Integration\Core\Content\Flow;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderTagAction;
 use Shopware\Core\Content\Flow\Dispatching\Action\RemoveCustomerTagAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
@@ -30,6 +32,9 @@ class RemoveCustomerTagActionTest extends TestCase
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     private Connection $connection;
@@ -38,6 +43,9 @@ class RemoveCustomerTagActionTest extends TestCase
 
     private IdsCollection $ids;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/RemoveOrderTagActionTest.php
+++ b/tests/integration/Core/Content/Flow/RemoveOrderTagActionTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Content\Flow\Dispatching\Action\RemoveOrderTagAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -31,6 +32,9 @@ class RemoveOrderTagActionTest extends TestCase
 {
     use OrderActionTrait;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/Flow/SetCustomerCustomFieldActionTest.php
+++ b/tests/integration/Core/Content/Flow/SetCustomerCustomFieldActionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Content\Flow\Dispatching\Action\SetCustomerCustomFieldAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -25,6 +26,9 @@ class SetCustomerCustomFieldActionTest extends TestCase
     use CacheTestBehaviour;
     use OrderActionTrait;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/SetCustomerGroupCustomFieldActionTest.php
+++ b/tests/integration/Core/Content/Flow/SetCustomerGroupCustomFieldActionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerGroupRegistrationAccepted;
 use Shopware\Core\Content\Flow\Dispatching\Action\SetCustomerGroupCustomFieldAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -27,6 +28,9 @@ class SetCustomerGroupCustomFieldActionTest extends TestCase
     use CacheTestBehaviour;
     use OrderActionTrait;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Flow/SetOrderCustomFieldActionTest.php
+++ b/tests/integration/Core/Content/Flow/SetOrderCustomFieldActionTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderCustomFieldAction;
+use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -22,6 +23,9 @@ class SetOrderCustomFieldActionTest extends TestCase
 {
     use OrderActionTrait;
 
+    /**
+     * @var EntityRepository<FlowCollection>
+     */
     private EntityRepository $flowRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportFileApiTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportFileApiTest.php
@@ -4,7 +4,9 @@ namespace Shopware\Tests\Integration\Core\Content\ImportExport\Api;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
@@ -24,6 +26,9 @@ class ImportExportFileApiTest extends TestCase
     use DatabaseTransactionBehaviour;
     use KernelTestBehaviour;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportFileEntity>>
+     */
     private EntityRepository $repository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportLogApiTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportLogApiTest.php
@@ -4,7 +4,11 @@ namespace Shopware\Tests\Integration\Core\Content\ImportExport\Api;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogCollection;
+use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
@@ -13,6 +17,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,12 +32,24 @@ class ImportExportLogApiTest extends TestCase
     use DatabaseTransactionBehaviour;
     use KernelTestBehaviour;
 
+    /**
+     * @var EntityRepository<ImportExportLogCollection>
+     */
     private EntityRepository $logRepository;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportProfileEntity>>
+     */
     private EntityRepository $profileRepository;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportFileEntity>>
+     */
     private EntityRepository $fileRepository;
 
+    /**
+     * @var EntityRepository<UserCollection>
+     */
     private EntityRepository $userRepository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportProfileApiTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportProfileApiTest.php
@@ -4,7 +4,9 @@ namespace Shopware\Tests\Integration\Core\Content\ImportExport\Api;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
@@ -23,6 +25,9 @@ class ImportExportProfileApiTest extends TestCase
     use DatabaseTransactionBehaviour;
     use KernelTestBehaviour;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportProfileEntity>>
+     */
     private EntityRepository $repository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/ImportExport/Commands/DeleteExpiredFilesCommandTest.php
+++ b/tests/integration/Core/Content/ImportExport/Commands/DeleteExpiredFilesCommandTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
 use Shopware\Core\Content\ImportExport\Command\DeleteExpiredFilesCommand;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -25,6 +26,9 @@ class DeleteExpiredFilesCommandTest extends TestCase
     use IntegrationTestBehaviour;
     use QueueTestBehaviour;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportFileEntity>>
+     */
     private EntityRepository $fileRepository;
 
     private DeleteExpiredFilesCommand $deleteExpiredFilesCommand;

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryDefinition;
 
 /**
@@ -21,6 +22,9 @@ class CountrySerializerTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<CountryCollection>
+     */
     private EntityRepository $countryRepository;
 
     private CountrySerializer $serializer;

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializerTest.php
@@ -4,6 +4,8 @@ namespace Shopware\Tests\Integration\Core\Content\ImportExport\DataAbstractionLa
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupCollection;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Entity\CustomerSerializer;
 use Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\SerializerRegistry;
@@ -14,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
 /**
  * @internal
@@ -25,10 +28,19 @@ class CustomerSerializerTest extends TestCase
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
 
+    /**
+     * @var EntityRepository<CustomerGroupCollection>
+     */
     private EntityRepository $customerGroupRepository;
 
+    /**
+     * @var EntityRepository<SalesChannelCollection>
+     */
     private EntityRepository $salesChannelRepository;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
     private EntityRepository $customerRepository;
 
     private CustomerSerializer $serializer;

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageDefinition;
 
 /**
@@ -22,6 +23,9 @@ class LanguageSerializerTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<LanguageCollection>
+     */
     private EntityRepository $languageRepository;
 
     private LanguageSerializer $serializer;

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/OrderSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/OrderSerializerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\ImportExport\DataAbstractionLa
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Entity\OrderSerializer;
@@ -32,6 +33,9 @@ class OrderSerializerTest extends TestCase
 
     private OrderSerializer $serializer;
 
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
     private Context $context;

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializerTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductCrossSellingAssignedProducts\ProductCrossSellingAssignedProductsCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSellingAssignedProducts\ProductCrossSellingAssignedProductsEntity;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
@@ -31,7 +32,7 @@ class ProductCrossSellingSerializerTest extends TestCase
 
     public function testOnlySupportsProductCrossSelling(): void
     {
-        /** @var EntityRepository $assignedProductsRepository */
+        /** @var EntityRepository<ProductCrossSellingAssignedProductsCollection> $assignedProductsRepository */
         $assignedProductsRepository = static::getContainer()->get('product_cross_selling_assigned_products.repository');
 
         $serializer = new ProductCrossSellingSerializer($assignedProductsRepository);

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializerTest.php
@@ -12,7 +12,11 @@ use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Content\Media\File\FileSaver;
 use Shopware\Core\Content\Media\File\MediaFile;
 use Shopware\Core\Content\Media\MediaService;
+use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
@@ -24,6 +28,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Framework\Twig\Extension\UrlEncodingTwigFilter;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,12 +41,24 @@ class ProductSerializerTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductVisibilityCollection>
+     */
     private EntityRepository $visibilityRepository;
 
+    /**
+     * @var EntityRepository<SalesChannelCollection>
+     */
     private EntityRepository $salesChannelRepository;
 
+    /**
+     * @var EntityRepository<ProductMediaCollection>
+     */
     private EntityRepository $productMediaRepository;
 
+    /**
+     * @var EntityRepository<ProductConfiguratorSettingCollection>
+     */
     private EntityRepository $productConfiguratorSettingRepository;
 
     protected function setUp(): void
@@ -322,7 +339,7 @@ class ProductSerializerTest extends TestCase
             ],
         ];
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
         $productRepository->create([$product], Context::createDefaultContext());
 

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/PromotionIndividualCodeSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/PromotionIndividualCodeSerializerTest.php
@@ -3,7 +3,9 @@
 namespace Shopware\Tests\Integration\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Entity;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionIndividualCode\PromotionIndividualCodeCollection;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionIndividualCode\PromotionIndividualCodeDefinition;
+use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Checkout\Promotion\PromotionDefinition;
 use Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Entity\PromotionIndividualCodeSerializer;
 use Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\SerializerRegistry;
@@ -22,8 +24,14 @@ class PromotionIndividualCodeSerializerTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<PromotionCollection>
+     */
     private EntityRepository $promoRepository;
 
+    /**
+     * @var EntityRepository<PromotionIndividualCodeCollection>
+     */
     private EntityRepository $promoCodeRepository;
 
     private PromotionIndividualCodeSerializer $serializer;

--- a/tests/integration/Core/Content/ImportExport/Repository/ImportExportFileRepositoryTest.php
+++ b/tests/integration/Core/Content/ImportExport/Repository/ImportExportFileRepositoryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
@@ -24,6 +25,9 @@ class ImportExportFileRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportFileEntity>>
+     */
     private EntityRepository $repository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/ImportExport/Repository/ImportExportLogRepositoryTest.php
+++ b/tests/integration/Core/Content/ImportExport/Repository/ImportExportLogRepositoryTest.php
@@ -4,8 +4,12 @@ namespace Shopware\Tests\Integration\Core\Content\ImportExport\Repository;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogCollection;
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogEntity;
+use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
@@ -14,6 +18,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -25,12 +30,24 @@ class ImportExportLogRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ImportExportLogCollection>
+     */
     private EntityRepository $logRepository;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportProfileEntity>>
+     */
     private EntityRepository $profileRepository;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportFileEntity>>
+     */
     private EntityRepository $fileRepository;
 
+    /**
+     * @var EntityRepository<UserCollection>
+     */
     private EntityRepository $userRepository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/ImportExport/Repository/ImportExportProfileRepositoryTest.php
+++ b/tests/integration/Core/Content/ImportExport/Repository/ImportExportProfileRepositoryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ImportExport\Exception\DeleteDefaultProfileException;
 use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
@@ -23,6 +24,9 @@ class ImportExportProfileRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportProfileEntity>>
+     */
     private EntityRepository $repository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/ImportExport/ScheduledTask/CleanupImportExportFileTaskHandlerTest.php
+++ b/tests/integration/Core/Content/ImportExport/ScheduledTask/CleanupImportExportFileTaskHandlerTest.php
@@ -3,11 +3,14 @@
 namespace Shopware\Tests\Integration\Core\Content\ImportExport\ScheduledTask;
 
 use League\Flysystem\FilesystemOperator;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogCollection;
 use Shopware\Core\Content\ImportExport\Message\DeleteFileHandler;
 use Shopware\Core\Content\ImportExport\Message\DeleteFileMessage;
 use Shopware\Core\Content\ImportExport\ScheduledTask\CleanupImportExportFileTaskHandler;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -21,8 +24,14 @@ use Symfony\Component\Messenger\TraceableMessageBus;
 #[Package('fundamentals@after-sales')]
 class CleanupImportExportFileTaskHandlerTest extends AbstractImportExportTestCase
 {
+    /**
+     * @var EntityRepository<ImportExportLogCollection>
+     */
     private EntityRepository $logRepository;
 
+    /**
+     * @var EntityRepository<EntityCollection<ImportExportFileEntity>>
+     */
     private EntityRepository $fileRepository;
 
     private FilesystemOperator $filesystem;

--- a/tests/integration/Core/Content/ImportExport/Service/FileServiceTest.php
+++ b/tests/integration/Core/Content/ImportExport/Service/FileServiceTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFi
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogEntity;
 use Shopware\Core\Content\ImportExport\Service\FileService;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -49,7 +50,7 @@ class FileServiceTest extends TestCase
 
     public function testStoreFile(): void
     {
-        /** @var EntityRepository $fileRepository */
+        /** @var EntityRepository<EntityCollection<ImportExportFileEntity>> $fileRepository */
         $fileRepository = static::getContainer()->get('import_export_file.repository');
         $fileService = new FileService(
             static::getContainer()->get('shopware.filesystem.private'),

--- a/tests/integration/Core/Content/ImportExport/Subscriber/ProductCategoryPathsSubscriberTest.php
+++ b/tests/integration/Core/Content/ImportExport/Subscriber/ProductCategoryPathsSubscriberTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Content\ImportExport\Subscriber;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\ImportExport\Event\ImportExportBeforeImportRecordEvent;
 use Shopware\Core\Content\ImportExport\Event\Subscriber\ProductCategoryPathsSubscriber;
 use Shopware\Core\Content\ImportExport\Struct\Config;
@@ -23,6 +24,9 @@ class ProductCategoryPathsSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<CategoryCollection>
+     */
     private EntityRepository $categoryRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/MailTemplate/Api/MailHeaderFooterApiTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Api/MailHeaderFooterApiTest.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
@@ -20,6 +22,9 @@ class MailHeaderFooterApiTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;
 
+    /**
+     * @var EntityRepository<EntityCollection<Entity>>
+     */
     private EntityRepository $repository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/MailTemplate/Repository/MailHeaderFooterRepositoryTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Repository/MailHeaderFooterRepositoryTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooter\MailHeaderFooterEntity;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -22,6 +24,9 @@ class MailHeaderFooterRepositoryTest extends TestCase
     use IntegrationTestBehaviour;
     use MediaFixtures;
 
+    /**
+     * @var EntityRepository<EntityCollection<Entity>>
+     */
     private EntityRepository $repository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Api\MediaUploadController;
 use Shopware\Core\Content\Media\Event\MediaUploadedEvent;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaType\ImageType;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
@@ -31,6 +32,9 @@ class MediaUploadControllerTest extends TestCase
 
     final public const TEST_IMAGE = __DIR__ . '/../fixtures/shopware-logo.png';
 
+    /**
+     * @var EntityRepository<MediaCollection>
+     */
     private EntityRepository $mediaRepository;
 
     private string $mediaId;

--- a/tests/integration/Core/Content/Media/File/FileLoaderTest.php
+++ b/tests/integration/Core/Content/Media/File/FileLoaderTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\File\FileFetcher;
 use Shopware\Core\Content\Media\File\FileLoader;
 use Shopware\Core\Content\Media\File\FileSaver;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -28,6 +29,9 @@ final class FileLoaderTest extends TestCase
 
     private FileSaver $fileSaver;
 
+    /**
+     * @var EntityRepository<MediaCollection>
+     */
     private EntityRepository $mediaRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Media/Subscriber/CustomFieldsUnusedMediaSubscriberTest.php
+++ b/tests/integration/Core/Content/Media/Subscriber/CustomFieldsUnusedMediaSubscriberTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Event\UnusedMediaSearchEvent;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\Subscriber\CustomFieldsUnusedMediaSubscriber;
 use Shopware\Core\Content\Test\Category\CategoryBuilder;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
@@ -15,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetCollection;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
@@ -27,8 +29,14 @@ class CustomFieldsUnusedMediaSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<MediaCollection>
+     */
     private EntityRepository $mediaRepository;
 
+    /**
+     * @var EntityRepository<CustomFieldSetCollection>
+     */
     private EntityRepository $customFieldSetRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -47,8 +47,14 @@ class ThumbnailServiceTest extends TestCase
 
     private ThumbnailService $thumbnailService;
 
+    /**
+     * @var EntityRepository<MediaCollection>
+     */
     private EntityRepository $mediaRepository;
 
+    /**
+     * @var EntityRepository<MediaThumbnailCollection>
+     */
     private EntityRepository $thumbnailRepository;
 
     private bool $remoteThumbnailsEnable = false;

--- a/tests/integration/Core/Content/Newsletter/ScheduledTask/NewsletterRecipientTaskHandlerTest.php
+++ b/tests/integration/Core/Content/Newsletter/ScheduledTask/NewsletterRecipientTaskHandlerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Newsletter\ScheduledTask;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientCollection;
 use Shopware\Core\Content\Newsletter\ScheduledTask\NewsletterRecipientTaskHandler;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -53,7 +54,7 @@ class NewsletterRecipientTaskHandlerTest extends TestCase
         $taskHandler = $this->getTaskHandler();
         $taskHandler->run();
 
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<NewsletterRecipientCollection> */
         $repository = static::getContainer()->get('newsletter_recipient.repository');
         $result = $repository->searchIds(new Criteria(), Context::createDefaultContext());
 

--- a/tests/integration/Core/Content/Newsletter/Service/NewsletterRecipientServiceTest.php
+++ b/tests/integration/Core/Content/Newsletter/Service/NewsletterRecipientServiceTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Newsletter\Service;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientCollection;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Content\Newsletter\NewsletterException;
 use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterConfirmRoute;
@@ -140,12 +141,11 @@ class NewsletterRecipientServiceTest extends TestCase
             ->get(NewsletterSubscribeRoute::class)
             ->subscribe($dataBag, $context, false);
 
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<NewsletterRecipientCollection> */
         $repository = static::getContainer()->get('newsletter_recipient.repository');
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('email', $email));
 
-        /** @var NewsletterRecipientEntity $result */
         $result = $repository->search($criteria, $context->getContext())->getEntities()->first();
 
         static::assertInstanceOf(NewsletterRecipientEntity::class, $result);
@@ -198,13 +198,12 @@ class NewsletterRecipientServiceTest extends TestCase
             ->get(NewsletterConfirmRoute::class)
             ->confirm($dataBag, $context);
 
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<NewsletterRecipientCollection> */
         $repository = static::getContainer()->get('newsletter_recipient.repository');
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('email', $email));
 
-        /** @var NewsletterRecipientEntity $result */
         $result = $repository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(NewsletterRecipientEntity::class, $result);
@@ -249,13 +248,12 @@ class NewsletterRecipientServiceTest extends TestCase
             ->get(NewsletterUnsubscribeRoute::class)
             ->unsubscribe($dataBag, $context);
 
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<NewsletterRecipientCollection> $repository */
         $repository = static::getContainer()->get('newsletter_recipient.repository');
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('email', $email));
 
-        /** @var NewsletterRecipientEntity $result */
         $result = $repository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(NewsletterRecipientEntity::class, $result);

--- a/tests/integration/Core/Content/Product/Cart/ProductCartProcessorTest.php
+++ b/tests/integration/Core/Content/Product/Cart/ProductCartProcessorTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
@@ -902,7 +903,7 @@ class ProductCartProcessorTest extends TestCase
      */
     private function getCountryIds(): array
     {
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<CountryCollection> $repository */
         $repository = static::getContainer()->get('country.repository');
 
         $criteria = (new Criteria())->setLimit(2)

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/VariantListingIndexerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/VariantListingIndexerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Product\DataAbstractionLayer\I
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -21,6 +22,9 @@ class VariantListingIndexerTest extends TestCase
     use IntegrationTestBehaviour;
     use QueueTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $repository;
 
     private string $productId;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizerTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductCategoryDenormalizer;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
@@ -30,6 +31,9 @@ class ProductCategoryDenormalizerTest extends TestCase
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     protected function setUp(): void

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamIndexer;
 use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamIndexingMessage;
+use Shopware\Core\Content\ProductStream\ProductStreamCollection;
 use Shopware\Core\Content\ProductStream\ProductStreamEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -36,6 +37,9 @@ class ProductStreamUpdaterTest extends TestCase
      */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<ProductStreamCollection>
+     */
     private EntityRepository $productStreamRepository;
 
     private SalesChannelContext $salesChannel;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -6,9 +6,12 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\DataAbstractionLayer\SearchKeywordUpdater;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -24,8 +27,14 @@ class SearchKeywordUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<EntityCollection<Entity>>
+     */
     private EntityRepository $salesChannelLanguageRepository;
 
     private Connection $connection;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/StatesUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/StatesUpdaterTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexer;
 use Shopware\Core\Content\Product\DataAbstractionLayer\StatesUpdater;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\State;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
@@ -28,6 +29,9 @@ class StatesUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private StatesUpdater $statesUpdater;

--- a/tests/integration/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Events\ProductCrossSellingIdsCriteriaEvent;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\CrossSelling\AbstractProductCrossSellingRoute;
@@ -46,6 +47,9 @@ class CrossSellingRouteTest extends TestCase
 
     private SalesChannelContext $salesChannelContext;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private AbstractProductCrossSellingRoute $route;

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\Detail;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractAvailableCombinationLoader;
 use Shopware\Core\Content\Product\SalesChannel\Detail\AvailableCombinationLoader;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
@@ -28,6 +29,9 @@ class AvailableCombinationLoaderTest extends TestCase
 
     private AbstractAvailableCombinationLoader $loader;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private IdsCollection $ids;

--- a/tests/integration/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\FindVaria
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Exception\VariantNotFoundException;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\FindVariant\FindProductVariantRoute;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
@@ -24,6 +25,9 @@ class FindProductVariantRouteTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $repository;
 
     private SalesChannelContext $context;

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderTest.php
@@ -43,6 +43,9 @@ class ProductListingLoaderTest extends TestCase
     use SalesChannelApiTestBehaviour;
     use TaxAddToSalesChannelTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private ProductListingLoader $productListingLoader;

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
@@ -7,7 +7,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Defaults;
@@ -57,8 +59,14 @@ class ProductListingRouteTest extends TestCase
      */
     private array $variantIds;
 
+    /**
+     * @var EntityRepository<CategoryCollection>
+     */
     private EntityRepository $categoryRepository;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     protected function setUp(): void
@@ -66,11 +74,11 @@ class ProductListingRouteTest extends TestCase
         $this->ids = new IdsCollection();
         $this->createSalesChannelContext(['id' => $this->ids->create('sales-channel')]);
 
-        /** @var EntityRepository $categoryRepository */
+        /** @var EntityRepository<CategoryCollection> */
         $categoryRepository = static::getContainer()->get('category.repository');
         $this->categoryRepository = $categoryRepository;
 
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $this->productRepository = $productRepository;
     }

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
@@ -8,7 +8,9 @@ use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductSearchConfig\ProductSearchConfigCollection;
 use Shopware\Core\Content\Product\DataAbstractionLayer\SearchKeywordUpdater;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute;
 use Shopware\Core\Content\Product\SalesChannel\Suggest\ProductSuggestRoute;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
@@ -44,6 +46,9 @@ class ProductSearchRouteTest extends TestCase
 
     private string $productSearchConfigId;
 
+    /**
+     * @var EntityRepository<ProductSearchConfigCollection>
+     */
     private EntityRepository $productSearchConfigRepository;
 
     private SearchKeywordUpdater $searchKeywordUpdater;
@@ -664,7 +669,7 @@ class ProductSearchRouteTest extends TestCase
 
     private function setupProductsForImplementSearch(IdsCollection $ids): void
     {
-        /** @var EntityRepository $productRepository */
+        /** @var EntityRepository<ProductCollection> $productRepository */
         $productRepository = static::getContainer()->get('product.repository');
         $productIds = [];
         $productsNames = [

--- a/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
+++ b/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductSearchConfig\ProductSearchConfigCollection;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreter;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreterInterface;
 use Shopware\Core\Defaults;
@@ -31,6 +32,9 @@ class ProductSearchTermInterpreterTest extends TestCase
 
     private ProductSearchTermInterpreterInterface $interpreter;
 
+    /**
+     * @var EntityRepository<ProductSearchConfigCollection>
+     */
     private EntityRepository $productSearchConfigRepository;
 
     private string $productSearchConfigId;

--- a/tests/integration/Core/Content/Product/Stock/StockStorageTest.php
+++ b/tests/integration/Core/Content/Product/Stock/StockStorageTest.php
@@ -11,7 +11,9 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItemFactoryHandler\ProductLineItemFactory;
 use Shopware\Core\Checkout\Cart\PriceDefinitionFactory;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
+use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Events\ProductNoLongerAvailableEvent;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -52,8 +54,14 @@ class StockStorageTest extends TestCase
     use IntegrationTestBehaviour;
     use TaxAddToSalesChannelTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<OrderLineItemCollection>
+     */
     private EntityRepository $lineItemRepository;
 
     private CartService $cartService;
@@ -62,14 +70,14 @@ class StockStorageTest extends TestCase
 
     private SalesChannelContext $context;
 
-    private EntityRepository $orderLineItemRepository;
-
+    /**
+     * @var EntityRepository<OrderCollection>
+     */
     private EntityRepository $orderRepository;
 
     protected function setUp(): void
     {
         $this->productRepository = static::getContainer()->get('product.repository');
-        $this->orderLineItemRepository = static::getContainer()->get('order_line_item.repository');
         $this->cartService = static::getContainer()->get(CartService::class);
         $this->contextFactory = static::getContainer()->get(SalesChannelContextFactory::class);
         $this->lineItemRepository = static::getContainer()->get('order_line_item.repository');
@@ -540,10 +548,10 @@ class StockStorageTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('orderId', $orderId));
 
-        $orderLineItem = $this->orderLineItemRepository->search($criteria, $context)->first();
+        $orderLineItem = $this->lineItemRepository->search($criteria, $context)->first();
         static::assertInstanceOf(OrderLineItemEntity::class, $orderLineItem);
 
-        $this->orderLineItemRepository->delete([
+        $this->lineItemRepository->delete([
             [
                 'id' => $orderLineItem->getId(),
             ],
@@ -578,10 +586,10 @@ class StockStorageTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('orderId', $orderId));
 
-        $orderLineItem = $this->orderLineItemRepository->search($criteria, $context)->first();
+        $orderLineItem = $this->lineItemRepository->search($criteria, $context)->first();
         static::assertInstanceOf(OrderLineItemEntity::class, $orderLineItem);
 
-        $this->orderLineItemRepository->update([
+        $this->lineItemRepository->update([
             [
                 'id' => $orderLineItem->getId(),
                 'referencedId' => $newProduct->getId(),
@@ -629,10 +637,10 @@ class StockStorageTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('orderId', $orderId));
 
-        $orderLineItem = $this->orderLineItemRepository->search($criteria, $context)->first();
+        $orderLineItem = $this->lineItemRepository->search($criteria, $context)->first();
         static::assertInstanceOf(OrderLineItemEntity::class, $orderLineItem);
 
-        $this->orderLineItemRepository->update([
+        $this->lineItemRepository->update([
             [
                 'id' => $orderLineItem->getId(),
                 'referencedId' => $newProduct->getId(),
@@ -671,10 +679,10 @@ class StockStorageTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('orderId', $orderId));
 
-        $orderLineItem = $this->orderLineItemRepository->search($criteria, $context)->first();
+        $orderLineItem = $this->lineItemRepository->search($criteria, $context)->first();
         static::assertInstanceOf(OrderLineItemEntity::class, $orderLineItem);
 
-        $this->orderLineItemRepository->update([
+        $this->lineItemRepository->update([
             [
                 'id' => $orderLineItem->getId(),
                 'quantity' => 2,

--- a/tests/integration/Core/Content/ProductExport/Command/ProductExportGenerateCommandTest.php
+++ b/tests/integration/Core/Content/ProductExport/Command/ProductExportGenerateCommandTest.php
@@ -7,6 +7,7 @@ use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\ProductExport\Command\ProductExportGenerateCommand;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Defaults;
@@ -33,6 +34,9 @@ class ProductExportGenerateCommandTest extends TestCase
 
     private ProductExportGenerateCommand $productExportGenerateCommand;
 
+    /**
+     * @var EntityRepository<ProductExportCollection>
+     */
     private EntityRepository $repository;
 
     private Context $context;

--- a/tests/integration/Core/Content/ProductExport/SalesChannel/ProductExportControllerTest.php
+++ b/tests/integration/Core/Content/ProductExport/SalesChannel/ProductExportControllerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\ProductExport\SalesChannel;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
@@ -15,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Core\Test\TestDefaults;
@@ -30,6 +32,9 @@ class ProductExportControllerTest extends TestCase
     use AppSystemTestBehaviour;
     use SalesChannelFunctionalTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductExportCollection>
+     */
     private EntityRepository $repository;
 
     private Context $context;
@@ -276,7 +281,7 @@ class ProductExportControllerTest extends TestCase
 
     protected function getSalesChannelDomain(): SalesChannelDomainEntity
     {
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<SalesChannelDomainCollection> $repository */
         $repository = static::getContainer()->get('sales_channel_domain.repository');
 
         /** @var SalesChannelDomainEntity $salesChannelDomain */

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\ProductExport\Event\ProductExportChangeEncodingEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportProductCriteriaEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportRenderBodyContextEvent;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Content\ProductExport\Service\ProductExportGenerator;
@@ -31,9 +32,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 /**
@@ -43,6 +46,9 @@ class ProductExportGeneratorTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductExportCollection>
+     */
     private EntityRepository $repository;
 
     private Context $context;
@@ -289,7 +295,7 @@ class ProductExportGeneratorTest extends TestCase
 
     private function getSalesChannelId(): string
     {
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<SalesChannelCollection> $repository */
         $repository = static::getContainer()->get('sales_channel.repository');
 
         $salesChannel = $repository->search(new Criteria(), $this->context)->first();
@@ -300,7 +306,7 @@ class ProductExportGeneratorTest extends TestCase
 
     private function getSalesChannelDomain(): SalesChannelDomainEntity
     {
-        /** @var EntityRepository $repository */
+        /** @var EntityRepository<SalesChannelDomainCollection> $repository */
         $repository = static::getContainer()->get('sales_channel_domain.repository');
 
         $salesChannelDomain = $repository->search(new Criteria(), $this->context)->first();

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExporterTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExporterTest.php
@@ -7,6 +7,7 @@ use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\ProductExport\Exception\ExportNotFoundException;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Service\ProductExporter;
 use Shopware\Core\Content\ProductExport\Service\ProductExporterInterface;
@@ -31,6 +32,9 @@ class ProductExporterTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductExportCollection>
+     */
     private EntityRepository $repository;
 
     private Context $context;

--- a/tests/integration/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
+++ b/tests/integration/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
@@ -4,7 +4,9 @@ namespace Shopware\Tests\Integration\Core\Content\ProductStream\DataAbstractionL
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamIndexer;
+use Shopware\Core\Content\ProductStream\ProductStreamCollection;
 use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
 use Shopware\Core\Content\ProductStream\ProductStreamEntity;
 use Shopware\Core\Defaults;
@@ -32,12 +34,18 @@ class ProductStreamIndexerTest extends TestCase
     use DatabaseTransactionBehaviour;
     use KernelTestBehaviour;
 
+    /**
+     * @var EntityRepository<ProductStreamCollection>
+     */
     private EntityRepository $productStreamRepository;
 
     private ProductStreamIndexer $indexer;
 
     private Connection $connection;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepo;
 
     private Context $context;

--- a/tests/integration/Core/Content/Seo/HreflangLoaderTest.php
+++ b/tests/integration/Core/Content/Seo/HreflangLoaderTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\MeasurementSystem\MeasurementUnits;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Seo\HreflangLoaderInterface;
 use Shopware\Core\Content\Seo\HreflangLoaderParameter;
+use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Test\TestProductSeoUrlRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -32,8 +33,14 @@ class HreflangLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    /**
+     * @var EntityRepository<SeoUrlCollection>
+     */
     private EntityRepository $seoUrlRepository;
 
+    /**
+     * @var EntityRepository<SalesChannelDomainCollection>
+     */
     private EntityRepository $salesChannelDomainRepository;
 
     private SalesChannelContext $salesChannelContext;

--- a/tests/integration/Core/Content/Seo/SeoResolverTest.php
+++ b/tests/integration/Core/Content/Seo/SeoResolverTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\AbstractSeoResolver;
 use Shopware\Core\Content\Seo\SeoResolver;
+use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -23,6 +24,9 @@ class SeoResolverTest extends TestCase
     use IntegrationTestBehaviour;
     use StorefrontSalesChannelTestHelper;
 
+    /**
+     * @var EntityRepository<SeoUrlCollection>
+     */
     private EntityRepository $seoUrlRepository;
 
     private AbstractSeoResolver $seoResolver;

--- a/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Sitemap\Provider;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
@@ -42,6 +43,9 @@ class ProductUrlProviderTest extends TestCase
 
     private SalesChannelContext $salesChannelContext;
 
+    /**
+     * @var EntityRepository<ProductCollection>
+     */
     private EntityRepository $productRepository;
 
     private SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler;

--- a/tests/integration/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandlerTest.php
+++ b/tests/integration/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandlerTest.php
@@ -18,6 +18,8 @@ use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\Messenger\Envelope;
@@ -35,8 +37,14 @@ class SitemapGenerateTaskHandlerTest extends TestCase
 
     private SitemapGenerateTaskHandler $sitemapHandler;
 
+    /**
+     * @var EntityRepository<SalesChannelDomainCollection>
+     */
     private EntityRepository $salesChannelDomainRepository;
 
+    /**
+     * @var EntityRepository<SalesChannelCollection>
+     */
     private EntityRepository $salesChannelRepository;
 
     private MockObject&MessageBusInterface $messageBusMock;


### PR DESCRIPTION
### 1. Why is this change necessary?

**NOTE**
  - **This is the last PR which should completly remove the phpstan ignore part for EntityRepository types**
  - **All other EntityRepository type PR's have to be merged first, so this one can cleanup the last types**

:
- Currently a few EntityRepository types are missing their phpstan type
- As in the past we group this updates to the EntityRepository types by areas to keep the PR size reasonable
- This PR includes core integration content tests area

### 2. What does this change do, exactly?
- Changed several phpstan types to add the correct entity collection to the EntityRepository type

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
