### PR TITLE
feat: Improve sw-extension-domains-modal stylings

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-domains-modal/sw-extension-domains-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-domains-modal/sw-extension-domains-modal.html.twig
@@ -3,6 +3,7 @@
     class="sw-extension-domains-modal"
     :title="modalTitle"
     variant="small"
+    @modal-close="close"
 >
 
     {% block sw_extension_domains_modal_description %}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-domains-modal/sw-extension-domains-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-domains-modal/sw-extension-domains-modal.scss
@@ -1,30 +1,24 @@
-@import "~scss/variables";
-
 .sw-extension-domains-modal {
-    color: $color-darkgray-200;
-
     &__description {
-        font-size: $font-size-xs;
-        padding: 12px 0 29px;
+        font-size: var(--font-size-xs);
+        margin-bottom: var(--scale-size-24);
     }
 
     &__list-title {
-        font-size: $font-size-xs;
-        margin-bottom: 20px;
+        font-size: var(--font-size-xs);
     }
 
     &__list {
         list-style: none;
-        margin: 0 -30px;
     }
 
-    &__list-item {
-        border-bottom: 1px solid $color-gray-300;
-        padding: 10px 30px;
-        font-size: $font-size-xs;
+    .sw-extension-domains-modal__list-item {
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
+        padding: var(--scale-size-10) 0;
 
-        &:first-child {
-            border-top: 1px solid $color-gray-300;
+        &:not(:last-child) {
+            border-bottom: 1px solid var(--color-border-primary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-details-modal/sw-extension-permissions-details-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-details-modal/sw-extension-permissions-details-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-modal.sw-extension-permissions-details-modal {
     .sw-modal__body {
         padding: 0;
@@ -8,12 +6,12 @@
 }
 
 .sw-extension-permissions-details-modal__table {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     border-spacing: unset;
     border-collapse: collapse;
 
     .sw-extension-permissions-details-modal__operations {
-        border-bottom: 1px solid $color-gray-300;
+        border-bottom: 1px solid var(--color-border-primary-default);
         box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 10%);
         display: block;
         top: 0;
@@ -22,16 +20,16 @@
     }
 
     tr {
-        padding: 16px 36px;
+        padding: var(--scale-size-16) var(--scale-size-36);
 
         &:not(:last-child) {
-            border-bottom: 1px solid $color-gray-300;
+            border-bottom: 1px solid var(--color-border-primary-default);
         }
 
         &.sw-extension-permissions-details-modal__category {
             display: grid;
-            font-weight: $font-weight-semi-bold;
-            background: $color-gray-100;
+            font-weight: var(--font-weight-semi-bold);
+            background: var(--color-elevation-surface-sunken);
         }
 
         &.sw-extension-permissions-details-modal__grid-columns {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.html.twig
@@ -47,17 +47,14 @@
             {% endblock %}
 
             {% block sw_extension_permissions_modal_link %}
-            <mt-button
-                class="sw-extension-permissions-modal__link"
-                variant="secondary"
+            <mt-link
+                class="sw-extension-permissions-modal__detail-link"
+                as="button"
+                type="internal"
                 @click="openDetailsModal(key)"
             >
                 {{ $tc('sw-extension-store.component.sw-extension-permissions-modal.textEntities') }}
-                <mt-icon
-                    name="regular-long-arrow-right"
-                    size="12px"
-                />
-            </mt-button>
+            </mt-link>
             {% endblock %}
             {% endblock %}
         </div>
@@ -72,18 +69,14 @@
                 {{ $tc('sw-extension-store.component.sw-extension-permissions-modal.domains') }}
             </span>
 
-            <mt-button
-                class="sw-extension-permissions-modal__link"
-                variant="secondary"
+            <mt-link
+                class="sw-extension-permissions-modal__detail-link"
+                as="button"
+                type="internal"
                 @click="toggleDomainsModal(true)"
             >
                 {{ $tc('sw-extension-store.component.sw-extension-permissions-modal.showDomains') }}
-
-                <mt-icon
-                    name="regular-long-arrow-right"
-                    size="12px"
-                />
-            </mt-button>
+            </mt-link>
         </div>
         {% endblock %}
     </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.scss
@@ -1,23 +1,21 @@
-@import "~scss/variables";
-
 .sw-extension-permissions-modal {
     .sw-modal__body {
-        padding: 36px 0 0;
+        padding: var(--scale-size-36) 0 0;
     }
 
     .sw-extension-permissions-modal__intro {
         text-align: center;
-        font-size: $font-size-xs;
-        margin-bottom: 24px;
-        padding: 0 24px;
+        font-size: var(--font-size-xs);
+        margin-bottom: var(--scale-size-24);
+        padding: 0 var(--scale-size-24);
 
         img {
-            margin-bottom: 28px;
+            margin-bottom: var(--scale-size-24);
         }
     }
 
     &__domain-hint {
-        margin-top: 22px;
+        margin-top: var(--scale-size-24);
     }
 }
 
@@ -25,39 +23,19 @@
     .sw-extension-permissions-modal__category {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        padding: 22px 32px;
+        padding: var(--scale-size-24) var(--scale-size-32);
 
         &:not(:last-child) {
-            border-bottom: 1px solid $color-gray-300;
+            border-bottom: 1px solid var(--color-border-primary-default);
         }
 
         .sw-extension-permissions-modal__category-label {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
         }
 
-        .sw-extension-permissions-modal__link {
-            border: none;
-            outline: none;
-            background: none;
-            color: $color-shopware-brand-500;
+        .sw-extension-permissions-modal__detail-link {
             justify-self: end;
-            text-decoration: underline;
-            font-weight: $font-weight-regular;
-            line-height: inherit;
-            padding: 0;
-
-            &:hover {
-                color: $color-shopware-brand-800;
-                background: none;
-
-                .mt-icon {
-                    color: $color-shopware-brand-800;
-                }
-            }
-
-            .mt-icon {
-                color: $color-shopware-brand-500;
-            }
+            font-size: var(--font-size-2xs);
         }
     }
 }


### PR DESCRIPTION
Fixes open discussions from https://github.com/shopware/shopware/pull/11914

* fixed a bug where the `sw-extension-domains-modal` could only be closed with the primary button
* Replaced scss variables with style token
* Replaced custom links in the overview with `mt-link` components
* Restyled domain modal

before:  
<img width="540" height="450" alt="image" src="https://github.com/user-attachments/assets/b94f4b35-0fc5-4317-b63f-d48cfdcb0d54" />

after:  
<img width="555" height="429" alt="image" src="https://github.com/user-attachments/assets/bd316609-aa07-4fe3-a574-a6be9bf30cee" />

