### PR TITLE
fix: Add loading of active category in category tree on change

### DIFF
--- a/changelog/_unreleased/2025-08-21-add-loading-of-active-category-in-category-tree-on-change.md
+++ b/changelog/_unreleased/2025-08-21-add-loading-of-active-category-in-category-tree-on-change.md
@@ -1,0 +1,9 @@
+---
+title: Add loading of active category in category tree on change
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Added new `loadActiveCategory` method to `sw-category-tree` component which is called on `category` change to open the new category tree.
+* Removed active category loading logic from `openInitialTree` method of `sw-category-tree` component and added a `loadActiveCategory` method call instead.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In the category module of the Administration, if you search for and select a category which is not already loaded and visible in the category tree, the new active category does not get loaded in the tree and therefore no category is selected.

### 2. What does this change do, exactly?
* Added new `loadActiveCategory` method to `sw-category-tree` component which is called on `category` change to open the new category tree.
* Removed active category loading logic from `openInitialTree` method of `sw-category-tree` component and added a `loadActiveCategory` method call instead.

### 3. Describe each step to reproduce the issue or behaviour.
Create a category tree with some deeply nested categories > reopen the category module (root categories will be loaded) > in the search bar, search for a nested category which is not visible in the category tree already and select it

Expected result: Category tree for the selected category will be loaded and the selected category will be marked as active.
Actual result: Category tree does not load any additional categories and there is no category marked active.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
