### PR TITLE
feat: make AsyncAws batch size configurable

### DIFF
--- a/changelog/_unreleased/2025-08-21-make-asyncawss3writebatchadapter-batch-size-configurable.md
+++ b/changelog/_unreleased/2025-08-21-make-asyncawss3writebatchadapter-batch-size-configurable.md
@@ -1,0 +1,18 @@
+---
+title: Make AsyncAwsS3WriteBatchAdapter batch size configurable
+---
+# Core
+* Added configurable batch size for `AsyncAwsS3WriteBatchAdapter` via the `shopware.filesystem.batch_write_size` configuration with a default value of 250
+* Changed `AwsS3v3Factory` to inject the batch size parameter from configuration
+___
+# Upgrade Information
+## Configuration
+You can now configure the batch size for S3 file writing operations in your `config/packages/shopware.yaml`:
+
+```yaml
+shopware:
+    filesystem:
+        batch_write_size: 100  # Default is 250
+```
+
+This controls how many files are processed in a single batch when using the AsyncAwsS3WriteBatchAdapter, which helps prevent "Too many open files" errors and allows for performance tuning based on your infrastructure.

--- a/config-schema.json
+++ b/config-schema.json
@@ -1022,6 +1022,11 @@
                 "private_local_path_prefix": {
                     "type": "string",
                     "description": "Path prefix to be prepended to the path when using a local download strategy"
+                },
+                "batch_write_size": {
+                    "type": "integer",
+                    "default": 250,
+                    "description": "Batch size for writing files simultaneously using AsyncAwsS3WriteBatchAdapter"
                 }
             },
             "title": "Filesystem"

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
@@ -16,12 +16,7 @@ class AsyncAwsS3WriteBatchAdapter extends AsyncAwsS3Adapter implements WriteBatc
     /**
      * @var int<1, max>
      */
-    private int $batchSize = 250;
-
-    public function setBatchSize(int $batchSize): void
-    {
-        $this->batchSize = $batchSize;
-    }
+    public int $batchSize = 250;
 
     public function writeBatch(CopyBatchInput ...$files): void
     {

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
@@ -14,17 +14,13 @@ use Shopware\Core\Framework\Log\Package;
 class AsyncAwsS3WriteBatchAdapter extends AsyncAwsS3Adapter implements WriteBatchInterface
 {
     /**
-     * @param S3Client $client // needs to be defined, because parent constructor also allows unknown type
-     * @param int<1, max> $batchSize
+     * @var int<1, max>
      */
-    public function __construct(
-        S3Client $client,
-        string $bucket,
-        string $prefix = '',
-        ?PortableVisibilityConverter $visibility = null,
-        private readonly int $batchSize = 250
-    ) {
-        parent::__construct($client, $bucket, $prefix, $visibility);
+    private int $batchSize = 250;
+
+    public function setBatchSize(int $batchSize): void
+    {
+        $this->batchSize = $batchSize;
     }
 
     public function writeBatch(CopyBatchInput ...$files): void

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
@@ -13,6 +13,20 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 class AsyncAwsS3WriteBatchAdapter extends AsyncAwsS3Adapter implements WriteBatchInterface
 {
+    /**
+     * @param S3Client $client // needs to be defined, because parent constructor also allows unknown type
+     * @param int<1, max> $batchSize
+     */
+    public function __construct(
+        S3Client $client,
+        string $bucket,
+        string $prefix = '',
+        ?PortableVisibilityConverter $visibility = null,
+        private readonly int $batchSize = 250
+    ) {
+        parent::__construct($client, $bucket, $prefix, $visibility);
+    }
+
     public function writeBatch(CopyBatchInput ...$files): void
     {
         /** @var S3Client $s3Client */
@@ -28,8 +42,8 @@ class AsyncAwsS3WriteBatchAdapter extends AsyncAwsS3Adapter implements WriteBatc
         /** @var PortableVisibilityConverter $visibilityConverter */
         $visibilityConverter = \Closure::bind(fn () => $this->visibility, $this, parent::class)();
 
-        // Copy the files in batches of 250 files. This is necessary to have open sockets and not run into the "Too many open files" error.
-        foreach (array_chunk($files, 250) as $filesBatch) {
+        // Copy the files in batches. This is necessary to have open sockets and not run into the "Too many open files" error.
+        foreach (array_chunk($files, $this->batchSize) as $filesBatch) {
             $requests = [];
 
             foreach ($filesBatch as $file) {

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
@@ -55,7 +55,7 @@ class AwsS3v3Factory implements AdapterFactoryInterface
         $client = new S3Client($s3Opts);
 
         $adapter = new AsyncAwsS3WriteBatchAdapter($client, $options['bucket'], $options['root'], new PortableVisibilityConverter());
-        $adapter->setBatchSize($this->batchWriteSize);
+        $adapter->batchSize = $this->batchWriteSize;
 
         return $adapter;
     }

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
@@ -17,6 +17,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class AwsS3v3Factory implements AdapterFactoryInterface
 {
     /**
+     * @param int<1, max> $batchWriteSize
+     */
+    public function __construct(
+        private readonly int $batchWriteSize = 250
+    ) {}
+
+    /**
      * @param array<string, mixed> $config
      */
     public function create(array $config): FilesystemAdapter
@@ -44,7 +51,7 @@ class AwsS3v3Factory implements AdapterFactoryInterface
 
         $client = new S3Client($s3Opts);
 
-        return new AsyncAwsS3WriteBatchAdapter($client, $options['bucket'], $options['root'], new PortableVisibilityConverter());
+        return new AsyncAwsS3WriteBatchAdapter($client, $options['bucket'], $options['root'], new PortableVisibilityConverter(), $this->batchWriteSize);
     }
 
     public function getType(): string

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
@@ -17,11 +17,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class AwsS3v3Factory implements AdapterFactoryInterface
 {
     /**
+     * @internal
+     *
      * @param int<1, max> $batchWriteSize
      */
     public function __construct(
         private readonly int $batchWriteSize = 250
-    ) {}
+    ) {
+    }
 
     /**
      * @param array<string, mixed> $config
@@ -51,7 +54,10 @@ class AwsS3v3Factory implements AdapterFactoryInterface
 
         $client = new S3Client($s3Opts);
 
-        return new AsyncAwsS3WriteBatchAdapter($client, $options['bucket'], $options['root'], new PortableVisibilityConverter(), $this->batchWriteSize);
+        $adapter = new AsyncAwsS3WriteBatchAdapter($client, $options['bucket'], $options['root'], new PortableVisibilityConverter());
+        $adapter->setBatchSize($this->batchWriteSize);
+
+        return $adapter;
     }
 
     public function getType(): string

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -128,6 +128,11 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('')
                     ->info('Path prefix to be prepended to the path when using a local download strategy')
                 ->end()
+                ->integerNode('batch_write_size')
+                    ->defaultValue(250)
+                    ->min(1)
+                    ->info('Batch size for writing files simultaneously using AsyncAwsS3WriteBatchAdapter')
+                ->end()
             ->end();
 
         return $rootNode;

--- a/src/Core/Framework/DependencyInjection/filesystem.xml
+++ b/src/Core/Framework/DependencyInjection/filesystem.xml
@@ -45,6 +45,7 @@
         </service>
 
         <service class="Shopware\Core\Framework\Adapter\Filesystem\Adapter\AwsS3v3Factory" id="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory.amazon_s3">
+            <argument>%shopware.filesystem.batch_write_size%</argument>
             <tag name="shopware.filesystem.factory"/>
         </service>
 

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -159,6 +159,7 @@ shopware:
         private_allowed_extensions: ["jpg", "jpeg", "png", "webp", "avif", "gif", "svg", "bmp", "tiff", "tif", "eps", "webm", "mkv", "flv", "ogv", "ogg", "mov", "mp4", "avi", "wmv", "pdf", "aac", "mp3", "wav", "flac", "oga", "wma", "txt", "doc", "ico", "glb", "zip", "rar", "csv", "xls", "xlsx", "html", "xml"]
         private_local_download_strategy: "php"
         private_local_path_prefix: ""
+        batch_write_size: 250
 
     cdn:
         url: ''

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
@@ -78,4 +78,28 @@ class AsyncAwsS3WriteBatchAdapterTest extends TestCase
         $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test', '', new PortableVisibilityConverter());
         $adapter->writeBatch(new CopyBatchInput('invalid', ['test.txt']));
     }
+
+    public function testConfigurableBatchSize(): void
+    {
+        $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
+        file_put_contents($tmpFile, 'test');
+
+        $s3Client = $this->createMock(S3Client::class);
+        $result = ResultMockFactory::create(PutObjectOutput::class);
+
+        $batchSize = 2;
+        $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test', '', new PortableVisibilityConverter(), $batchSize);
+
+        $files = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $files[] = new CopyBatchInput($tmpFile, ["test{$i}.txt"]);
+        }
+
+        $s3Client
+            ->expects($this->exactly(5))
+            ->method('putObject')
+            ->willReturn($result);
+
+        $adapter->writeBatch(...$files);
+    }
 }

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AsyncAwsS3WriteBatchAdapter;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -19,8 +20,9 @@ class AsyncAwsS3WriteBatchAdapterTest extends TestCase
 {
     public function testS3(): void
     {
-        $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
-        file_put_contents($tmpFile, 'test');
+        $fs = new Filesystem();
+        $tmpFile = $fs->tempnam(sys_get_temp_dir(), 'test');
+        $fs->dumpFile($tmpFile, 'test');
 
         $sourceFile = fopen($tmpFile, 'rb');
         static::assertIsResource($sourceFile);
@@ -45,8 +47,9 @@ class AsyncAwsS3WriteBatchAdapterTest extends TestCase
 
     public function testS3UsingPath(): void
     {
-        $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
-        file_put_contents($tmpFile, 'test');
+        $fs = new Filesystem();
+        $tmpFile = $fs->tempnam(sys_get_temp_dir(), 'test');
+        $fs->dumpFile($tmpFile, 'test');
 
         $s3Client = $this->createMock(S3Client::class);
 
@@ -81,14 +84,15 @@ class AsyncAwsS3WriteBatchAdapterTest extends TestCase
 
     public function testConfigurableBatchSize(): void
     {
-        $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
-        file_put_contents($tmpFile, 'test');
+        $fs = new Filesystem();
+        $tmpFile = $fs->tempnam(sys_get_temp_dir(), 'test');
+        $fs->dumpFile($tmpFile, 'test');
 
         $s3Client = $this->createMock(S3Client::class);
         $result = ResultMockFactory::create(PutObjectOutput::class);
 
-        $batchSize = 2;
-        $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test', '', new PortableVisibilityConverter(), $batchSize);
+        $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test', '', new PortableVisibilityConverter());
+        $adapter->setBatchSize(2);
 
         $files = [];
         for ($i = 0; $i < 5; ++$i) {

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
@@ -92,7 +92,7 @@ class AsyncAwsS3WriteBatchAdapterTest extends TestCase
         $result = ResultMockFactory::create(PutObjectOutput::class);
 
         $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test', '', new PortableVisibilityConverter());
-        $adapter->setBatchSize(2);
+        $adapter->batchSize = 2;
 
         $files = [];
         for ($i = 0; $i < 5; ++$i) {

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
@@ -46,7 +46,7 @@ class AwsS3v3FactoryTest extends TestCase
         ]);
 
         static::assertEquals(
-            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter(), 250),
+            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter()),
             (new AwsS3v3Factory())->create($config)
         );
     }
@@ -76,7 +76,7 @@ class AwsS3v3FactoryTest extends TestCase
         ]);
 
         static::assertEquals(
-            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter(), 250),
+            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter()),
             (new AwsS3v3Factory())->create($config)
         );
     }
@@ -96,8 +96,11 @@ class AwsS3v3FactoryTest extends TestCase
             'region' => 'local',
         ]);
 
+        $adapter = new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter());
+        $adapter->setBatchSize($customBatchSize);
+
         static::assertEquals(
-            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter(), $customBatchSize),
+            $adapter,
             $factory->create($config)
         );
     }

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
@@ -97,7 +97,7 @@ class AwsS3v3FactoryTest extends TestCase
         ]);
 
         $adapter = new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter());
-        $adapter->setBatchSize($customBatchSize);
+        $adapter->batchSize = $customBatchSize;
 
         static::assertEquals(
             $adapter,

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
@@ -46,7 +46,7 @@ class AwsS3v3FactoryTest extends TestCase
         ]);
 
         static::assertEquals(
-            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter()),
+            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter(), 250),
             (new AwsS3v3Factory())->create($config)
         );
     }
@@ -76,8 +76,29 @@ class AwsS3v3FactoryTest extends TestCase
         ]);
 
         static::assertEquals(
-            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter()),
+            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter(), 250),
             (new AwsS3v3Factory())->create($config)
+        );
+    }
+
+    public function testCreateWithCustomBatchSize(): void
+    {
+        $config = [
+            'bucket' => 'private',
+            'region' => 'local',
+            'root' => 'foobar',
+        ];
+
+        $customBatchSize = 100;
+        $factory = new AwsS3v3Factory($customBatchSize);
+
+        $client = new S3Client([
+            'region' => 'local',
+        ]);
+
+        static::assertEquals(
+            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter(), $customBatchSize),
+            $factory->create($config)
         );
     }
 }


### PR DESCRIPTION
The value was hardcoded and we assume it makes problems during cloud deploys
