### PR TITLE
fix: fix permission issues with Meteor SDK in plugin usage

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/application.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/application.spec.js
@@ -154,4 +154,45 @@ describe('core/application.js', () => {
             iframeSrc: 'http://localhost:8000/bundles/testplugin/administration/',
         });
     });
+
+    it('should load plugins correctly in watch with all permissions', async () => {
+        process.env.NODE_ENV = 'development';
+
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => ({
+                    'test-plugin': {
+                        html: 'http://localhost:8000/bundles/testplugin/administration/',
+                    },
+                }),
+            }),
+        );
+
+        // Mock plugins
+        Shopware.Context.app.config.bundles = {
+            'test-plugin': {
+                baseUrl: 'http://localhost:8000/bundles/testplugin/administration/',
+            },
+        };
+
+        // Load plugins
+        await Shopware.Application.loadPlugins();
+
+        // Check if new plugin added the correct extension to the store
+        expect(Shopware.Store.get('extensions').extensionsState['test-plugin']).toEqual({
+            name: 'test-plugin',
+            baseUrl: 'http://localhost:8000/bundles/testplugin/administration/',
+            permissions: {
+                additional: ['*'],
+                create: ['*'],
+                read: ['*'],
+                update: ['*'],
+                delete: ['*'],
+            },
+            version: undefined,
+            type: 'plugin',
+            integrationId: undefined,
+            active: undefined,
+        });
+    });
 });

--- a/src/Administration/Resources/app/administration/src/core/application.ts
+++ b/src/Administration/Resources/app/administration/src/core/application.ts
@@ -852,6 +852,17 @@ class ApplicationBootstrapper {
         // To keep permissions reactive no matter if empty or not
         extension.permissions = permissions ?? reactive({});
 
+        // Check if extension is a plugin, then it has full permissions access
+        if (extension.type === 'plugin') {
+            extension.permissions = {
+                additional: ['*'],
+                create: ['*'],
+                read: ['*'],
+                update: ['*'],
+                delete: ['*'],
+            };
+        }
+
         Shopware.Store.get('extensions').addExtension(extension);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Closes https://github.com/shopware/shopware/issues/11186

### 2. What does this change do, exactly?

Add explicit "all" privileges to plugins. Beforehand it was checked by the whole URL origin. But this isn't working anymore because the new Vite watcher creates separate ports for each plugin
