### PR TITLE
feat: remove usage of imagedestroy

### DIFF
--- a/changelog/_unreleased/2025-08-22-remove-usage-of-imagedestroy.md
+++ b/changelog/_unreleased/2025-08-22-remove-usage-of-imagedestroy.md
@@ -1,0 +1,17 @@
+---
+title: Remove usage of imagedestroy
+issue: 
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Removed usage of `imagedestroy` in ThumbnailService.
+
+___
+# Storefront
+
+* Removed usage of `imagedestroy` in BasicCaptchaGenerator.
+

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -277,8 +277,6 @@ class ThumbnailService
                     $fileSystem->write($path, $fileSystem->read($media->getPath()));
                 }
 
-                imagedestroy($thumbnail);
-
                 $event->thumbnail(
                     mediaId: $media->getId(),
                     thumbnailId: $id,
@@ -287,8 +285,6 @@ class ThumbnailService
             }
 
             $this->dispatcher->dispatch($event);
-
-            imagedestroy($image);
         } finally {
             return $records;
         }

--- a/src/Storefront/Framework/Captcha/BasicCaptcha/BasicCaptchaGenerator.php
+++ b/src/Storefront/Framework/Captcha/BasicCaptcha/BasicCaptchaGenerator.php
@@ -41,7 +41,6 @@ class BasicCaptchaGenerator extends AbstractBasicCaptchaGenerator
         ob_start();
         imagepng($img, null, 9);
         $image = (string) ob_get_clean();
-        imagedestroy($img);
         $image = base64_encode($image);
 
         return new BasicCaptchaImage($code, $image);


### PR DESCRIPTION
### 1. Why is this change necessary?
https://www.php.net/manual/en/function.imagedestroy.php
the function does nothing since PHP 8.0

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
