### PR TITLE
refactor: use bs gutter instead of hardcoded spacing in listing

### DIFF
--- a/changelog/_unreleased/2025-08-22-use-bootstrap-gutter-variables-for-product-listing-grid.md
+++ b/changelog/_unreleased/2025-08-22-use-bootstrap-gutter-variables-for-product-listing-grid.md
@@ -1,0 +1,5 @@
+---
+title: Use bootstrap gutter variables for product-listing grid
+---
+# Storefront
+* Changed `.cms-listing-row` CSS to use `--bs-gutter-x` and `--bs-gutter-y` variables instead of hardcoded negative margins and also remove hardcoded paddings from `.cms-listing-col`.

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
@@ -151,12 +151,6 @@ General styling for cms elements
     }
 }
 
-.cms-element-product-listing {
-    .cms-listing-col {
-        margin-bottom: $spacer-lg;
-    }
-}
-
 .cms-element-product-listing-actions {
     display: flex;
     align-items: center;

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_cms-element.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_cms-element.scss
@@ -6,14 +6,9 @@ Skin styling for cms elements
 
 .cms-element-product-listing {
     .cms-listing-row {
-        margin-right: -$cms-element-product-listing-gutter-width / 2;
-        margin-left: -$cms-element-product-listing-gutter-width / 2;
-    }
-
-    .cms-listing-col {
-        padding-right: $cms-element-product-listing-gutter-width / 2;
-        padding-left: $cms-element-product-listing-gutter-width / 2;
-        margin-bottom: $cms-element-product-listing-gutter-width;
+        --#{$prefix}gutter-x: #{$cms-element-product-listing-gutter-width};
+        --#{$prefix}gutter-y: #{$cms-element-product-listing-gutter-width};
+        margin-bottom: $spacer-lg;
     }
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

- The `cms-listing-row` and `cms-listing-col` uses hardcoded spacing with manual negative margins and paddings.
- This should be handled by the bootstrap grid.
- It is harder to overwrite / change.

### 2. What does this change do, exactly?

- Use the bootstrap gutter config variables instead `--bs-gutter-x` and `--bs-gutter-y`.
- No more need for the `/ 2` calculation because bootstrap does it already.
- No more manual bottom spacing on the individual product box columns. Bootstrap gutter is used instead.
- Give the listing itself the bottom spacing instead.

### 3. Describe each step to reproduce the issue or behaviour.

- Inspect the `.cms-listing-row` element in your dev tools.
- You can easily change the gutters by using the variables `--bs-gutter-x` and `--bs-gutter-y`.
- The spacing (visually) is the same as before.
