### PR TITLE
fix: Error when creating user in admin

### DIFF
--- a/changelog/_unreleased/2025-08-22-fix-confusing-error-on-user-create.md
+++ b/changelog/_unreleased/2025-08-22-fix-confusing-error-on-user-create.md
@@ -1,0 +1,6 @@
+---
+title: Fix confusing error on user create in admin
+issue: #12040
+---
+# Administration
+* Changed `sw-users-permissions-user-detail` component, to only reauthenticate user with the new password if the changed user is the actually logged-in user, thus fixing an error when creating new users.

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
@@ -411,10 +411,13 @@ export default {
             try {
                 await this.userRepository.save(this.user, context);
 
-                if (this.user.password) {
-                    await this.updateAuthToken();
+                if (this.currentUser.id === this.user.id) {
+                    if (this.user.password) {
+                        await this.updateAuthToken();
+                    }
+                    await this.updateCurrentUser();
                 }
-                await this.updateCurrentUser();
+
                 this.createdComponent();
 
                 this.confirmPasswordModal = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.spec.js
@@ -564,4 +564,16 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-detail', (
         expect(mockedLoginService.verifyUserToken).not.toHaveBeenCalled();
         expect(mockedLoginService.setBearerAuthentication).not.toHaveBeenCalled();
     });
+
+    it('should not update the auth token if user a different user then the currently logged in user is changed', async () => {
+        Shopware.Application.$container.resetProviders();
+        Shopware.Application.addServiceProvider('localeHelper', () => ({ setLocaleWithId: () => Promise.resolve() }));
+        wrapper.vm.user.password = 'newPassword';
+        wrapper.vm.user.id = 'randomId';
+        await wrapper.vm.saveUser();
+        await flushPromises();
+
+        expect(mockedLoginService.verifyUserToken).not.toHaveBeenCalled();
+        expect(mockedLoginService.setBearerAuthentication).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/shopware/shopware/issues/12040

we tried to reuthenticate the current user with the password that was set on the user in the detail page, that lead to errors when you created a new user (or changed the password of an existing user that is not the logged in user)
