### PR TITLE
fix: Use dynamic navigation depth in offcanvas menu

### DIFF
--- a/changelog/_unreleased/2025-08-23-fix-offcanvas-navigation-depth.md
+++ b/changelog/_unreleased/2025-08-23-fix-offcanvas-navigation-depth.md
@@ -1,0 +1,9 @@
+---
+title: Fix offcanvas menu navigation depth configuration
+issue: NEXT-9471
+author: Martin Bens
+author_email: m.bens@shopware.com
+author_github: @SpiGAndromeda
+---
+# Storefront
+* Fixed the mobile/offcanvas navigation menu to display the same category depth as configured in the sales channel settings, instead of always showing only one level of categories.

--- a/changelog/_unreleased/2025-08-23-fix-offcanvas-navigation-depth.md
+++ b/changelog/_unreleased/2025-08-23-fix-offcanvas-navigation-depth.md
@@ -6,4 +6,4 @@ author_email: m.bens@shopware.com
 author_github: @SpiGAndromeda
 ---
 # Storefront
-* Fixed the mobile/offcanvas navigation menu to display the same category depth as configured in the sales channel settings, instead of always showing only one level of categories.
+* Changed the mobile/offcanvas navigation menu to display the same category depth as configured in the sales channel settings, instead of always showing only one level of categories.

--- a/src/Storefront/Pagelet/Menu/Offcanvas/MenuOffcanvasPageletLoader.php
+++ b/src/Storefront/Pagelet/Menu/Offcanvas/MenuOffcanvasPageletLoader.php
@@ -38,7 +38,12 @@ class MenuOffcanvasPageletLoader implements MenuOffcanvasPageletLoaderInterface
             throw RoutingException::missingRequestParameter('navigationId');
         }
 
-        $navigation = $this->navigationLoader->load($navigationId, $context, $navigationId, 1);
+        $navigation = $this->navigationLoader->load(
+            $navigationId,
+            $context,
+            $navigationId,
+            $context->getSalesChannel()->getNavigationCategoryDepth()
+        );
 
         $pagelet = new MenuOffcanvasPagelet($navigation);
 

--- a/tests/unit/Storefront/Pagelet/Menu/Offcanvas/MenuOffcanvasPageletLoaderTest.php
+++ b/tests/unit/Storefront/Pagelet/Menu/Offcanvas/MenuOffcanvasPageletLoaderTest.php
@@ -39,7 +39,7 @@ class MenuOffcanvasPageletLoaderTest extends TestCase
                     $categoryId2,
                     $salesChannelContext,
                     $categoryId2,
-                    1,
+                    $salesChannelContext->getSalesChannel()->getNavigationCategoryDepth(),
                     new Tree($category2, [new TreeItem($category1, []), new TreeItem($category2, [])]),
                 ],
             ]

--- a/tests/unit/Storefront/Pagelet/Menu/Offcanvas/MenuOffcanvasPageletLoaderTest.php
+++ b/tests/unit/Storefront/Pagelet/Menu/Offcanvas/MenuOffcanvasPageletLoaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopware\Tests\Unit\Storefront\Pagelet\Menu\Offcanvas;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Service\NavigationLoaderInterface;
@@ -22,28 +23,32 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(MenuOffcanvasPageletLoader::class)]
 class MenuOffcanvasPageletLoaderTest extends TestCase
 {
-    public function testLoad(): void
+    #[DataProvider('loadProvider')]
+    public function testLoad(int $navigationCategoryDepth): void
     {
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $salesChannelContext = Generator::generateSalesChannelContext();
+        $salesChannelContext->getSalesChannel()->setNavigationCategoryDepth($navigationCategoryDepth);
 
         $navigationLoader = $this->createMock(NavigationLoaderInterface::class);
         $categoryId1 = Uuid::randomHex();
         $categoryId2 = Uuid::randomHex();
         $category1 = (new CategoryEntity())->assign(['id' => $categoryId1]);
         $category2 = (new CategoryEntity())->assign(['id' => $categoryId2]);
-        $navigationLoader->method('load')->willReturnMap(
-            [
-                [
-                    $categoryId2,
-                    $salesChannelContext,
-                    $categoryId2,
-                    $salesChannelContext->getSalesChannel()->getNavigationCategoryDepth(),
-                    new Tree($category2, [new TreeItem($category1, []), new TreeItem($category2, [])]),
-                ],
-            ]
-        );
+        $navigationLoader->expects($this->once())
+            ->method('load')
+            /**
+             * Regression test/assumption for PR #12061: Ensures navigation depth is dynamically
+             * retrieved from sales channel configuration.
+             */
+            ->with(
+                $categoryId2,
+                $salesChannelContext,
+                $categoryId2,
+                $salesChannelContext->getSalesChannel()->getNavigationCategoryDepth()
+            )
+            ->willReturn(new Tree($category2, [new TreeItem($category1, []), new TreeItem($category2, [])]));
 
         $loader = new MenuOffcanvasPageletLoader($eventDispatcher, $navigationLoader);
         $menuOffcanvas = $loader->load(new Request(['navigationId' => $categoryId2]), $salesChannelContext);
@@ -56,5 +61,12 @@ class MenuOffcanvasPageletLoaderTest extends TestCase
         static::assertCount(2, $tree);
         static::assertSame($categoryId1, $tree[0]->getCategory()->getId());
         static::assertSame($categoryId2, $tree[1]->getCategory()->getId());
+    }
+
+    public static function loadProvider(): \Generator
+    {
+        for ($depth = 1; $depth <= 4; ++$depth) {
+            yield \sprintf('navigation category depth %d', $depth) => [$depth];
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The mobile/offcanvas navigation menu was hardcoded to only show 1 level of categories, ignoring the configured `navigationCategoryDepth` setting from the sales channel configuration. This meant that merchants who configured their navigation to show multiple levels (e.g., 3 levels) would see the full hierarchy in the desktop navigation but only the first level in the mobile menu.

This inconsistency created a poor user experience on mobile devices and prevented merchants from properly utilizing the navigation depth configuration.

### 2. What does this change do, exactly?

- Changes `MenuOffcanvasPageletLoader::load()` to dynamically retrieve the navigation depth from `$context->getSalesChannel()->getNavigationCategoryDepth()` instead of using a hardcoded value of `1`
- Updates the corresponding unit test to expect the dynamic depth value from the sales channel context
- Ensures the mobile/offcanvas navigation menu displays the same category depth as configured in the administration

### 3. Describe each step to reproduce the issue or behaviour.

See issue #9471 for detailed reproduction steps.

### 4. Please link to the relevant issues (if any).

- Fixes #9471

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them