### PR TITLE
feat(storefront): use service subscribers for controllers

### DIFF
--- a/changelog/_unreleased/2025-01-24-storefront-controller-service-subscriber.md
+++ b/changelog/_unreleased/2025-01-24-storefront-controller-service-subscriber.md
@@ -1,0 +1,100 @@
+---
+title: Implement Service Subscriber pattern for Storefront controllers
+issue: NEXT-3462
+author: Martin Bens
+author_email: m.bens@shopware.com
+author_github: @SpiGAndromeda
+---
+# Storefront
+* Changed `Shopware\Storefront\Controller\StorefrontController` to implement `Symfony\Contracts\Service\ServiceSubscriberInterface`
+* Changed `getSubscribedServices()` method to declare all framework services with optional markers (`?` prefix)
+* Added service locator pattern for lazy-loading of services in controllers
+* Added `Shopware\Storefront\Controller\DeprecatedContainerAccessTrait` for backward compatibility
+* Changed all 30 controller service definitions in `controller.xml` to use service subscriber pattern
+* Added `controller.service_arguments` and `container.service_subscriber` tags to controller services
+* Changed container injection from `service_container` to `Psr\Container\ContainerInterface`
+* Deprecated direct container access via `$this->container->get()` without service subscription
+___
+# Upgrade Information
+## Service Subscriber Pattern for Storefront Controllers
+
+Storefront controllers now use Symfony's ServiceSubscriberInterface for improved performance and memory efficiency. Services are lazy-loaded through a service locator instead of injecting the full container.
+
+### Migration for Custom Controllers
+
+If you have controllers extending `StorefrontController`, declare additional service dependencies:
+
+#### Before
+```php
+class MyController extends StorefrontController
+{
+    public function myAction(): Response
+    {
+        // Direct container access - still works but deprecated
+        $myService = $this->container->get('my.custom.service');
+        return $this->renderStorefront('...');
+    }
+}
+```
+
+#### After
+```php
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+class MyController extends StorefrontController implements ServiceSubscriberInterface
+{
+    public static function getSubscribedServices(): array
+    {
+        return array_merge(parent::getSubscribedServices(), [
+            'my.custom.service' => '?App\Service\MyCustomService',
+        ]);
+    }
+    
+    public function myAction(): Response
+    {
+        // Service properly declared and lazy-loaded
+        $myService = $this->container->get('my.custom.service');
+        return $this->renderStorefront('...');
+    }
+}
+```
+
+### Service Configuration Update
+
+Update your controller service definitions:
+
+```xml
+<service id="MyPlugin\Controller\MyController">
+    <!-- Constructor arguments for specific dependencies -->
+    <argument type="service" id="my.specific.service"/>
+    
+    <!-- Add these tags for service subscription -->
+    <tag name="controller.service_arguments"/>
+    <tag name="container.service_subscriber"/>
+    
+    <!-- Use service locator instead of full container -->
+    <call method="setContainer">
+        <argument type="service" id="Psr\Container\ContainerInterface"/>
+    </call>
+</service>
+```
+
+### Pre-Subscribed Services
+
+The following services are already available in `StorefrontController`:
+- `twig` (`Twig\Environment`)
+- `event_dispatcher` (`Symfony\Contracts\EventDispatcher\EventDispatcherInterface`)
+- `translator` (`Symfony\Contracts\Translation\TranslatorInterface`)
+- `router` (`Symfony\Component\Routing\RouterInterface`)
+- `request_stack` (`Symfony\Component\HttpFoundation\RequestStack`)
+- `Shopware\Core\System\SystemConfig\SystemConfigService`
+- `Shopware\Core\Framework\Adapter\Twig\TemplateFinder`
+- `Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface`
+- `Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface`
+- `Shopware\Core\Framework\Script\Execution\ScriptExecutor`
+- `Shopware\Core\Framework\Routing\RequestTransformerInterface`
+
+### Backward Compatibility
+
+- Direct container access continues to work with deprecation warnings
+- Use `DeprecatedContainerAccessTrait` for gradual migration

--- a/changelog/_unreleased/2025-08-23-storefront-controller-service-subscriber.md
+++ b/changelog/_unreleased/2025-08-23-storefront-controller-service-subscriber.md
@@ -7,12 +7,10 @@ author_github: @SpiGAndromeda
 ---
 # Storefront
 * Changed `Shopware\Storefront\Controller\StorefrontController` to implement `Symfony\Contracts\Service\ServiceSubscriberInterface`
-* Changed `getSubscribedServices()` method to declare all framework services with optional markers (`?` prefix)
-* Added service locator pattern for lazy-loading of services in controllers
-* Added `Shopware\Storefront\Controller\DeprecatedContainerAccessTrait` for backward compatibility
-* Changed all 30 controller service definitions in `controller.xml` to use service subscriber pattern
-* Added `controller.service_arguments` and `container.service_subscriber` tags to controller services
-* Changed container injection from `service_container` to `Psr\Container\ContainerInterface`
+* Added autoconfigure and autowire support for modern controller configuration in `services_controller.xml`
+* Added `Shopware\Storefront\DependencyInjection\Compiler\StorefrontControllerCompilerPass` for backward compatibility
+* Added `Shopware\Storefront\Controller\DeprecatedContainerAccessTrait` for gradual migration
+* Changed container injection from `service_container` to `Psr\Container\ContainerInterface` service locator
 * Deprecated direct container access via `$this->container->get()` without service subscription
 ___
 # Upgrade Information
@@ -59,20 +57,26 @@ class MyController extends StorefrontController implements ServiceSubscriberInte
 }
 ```
 
-### Service Configuration Update
+### Service Configuration Options
 
-Update your controller service definitions:
+#### Option 1: Modern Autoconfigure (Recommended)
+```xml
+<services>
+    <defaults public="true" autoconfigure="true" autowire="true" />
+    
+    <service id="MyPlugin\Controller\MyController">
+        <!-- Only specific dependencies needed -->
+        <argument type="service" id="my.specific.service"/>
+    </service>
+</services>
+```
 
+#### Option 2: Manual Configuration (Legacy)
 ```xml
 <service id="MyPlugin\Controller\MyController">
-    <!-- Constructor arguments for specific dependencies -->
     <argument type="service" id="my.specific.service"/>
-    
-    <!-- Add these tags for service subscription -->
     <tag name="controller.service_arguments"/>
     <tag name="container.service_subscriber"/>
-    
-    <!-- Use service locator instead of full container -->
     <call method="setContainer">
         <argument type="service" id="Psr\Container\ContainerInterface"/>
     </call>
@@ -96,5 +100,6 @@ The following services are already available in `StorefrontController`:
 
 ### Backward Compatibility
 
-- Direct container access continues to work with deprecation warnings
-- Use `DeprecatedContainerAccessTrait` for gradual migration
+- Existing controller configurations continue to work through the compiler pass
+- Direct container access works with deprecation warnings until 6.9.0
+- Both autoconfigure and manual configuration are supported

--- a/changelog/_unreleased/2025-08-23-storefront-controller-service-subscriber.md
+++ b/changelog/_unreleased/2025-08-23-storefront-controller-service-subscriber.md
@@ -1,6 +1,6 @@
 ---
 title: Implement Service Subscriber pattern for Storefront controllers
-issue: NEXT-3462
+issue: 3462
 author: Martin Bens
 author_email: m.bens@shopware.com
 author_github: @SpiGAndromeda

--- a/src/Storefront/Controller/DeprecatedContainerAccessTrait.php
+++ b/src/Storefront/Controller/DeprecatedContainerAccessTrait.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Storefront\Controller;
 
-use Psr\Container\ContainerInterface;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -12,15 +11,13 @@ use Shopware\Core\Framework\Log\Package;
  *
  * @property ContainerInterface $container
  *
- * This trait provides backward compatibility for controllers that directly access
- * services from the container without declaring them in getSubscribedServices().
- * All usages should be migrated to proper service subscription.
+ * Bridge for legacy code accessing undeclared services.
  */
 #[Package('framework')]
 trait DeprecatedContainerAccessTrait
 {
     /**
-     * @deprecated tag:v6.8.0 - Use service subscription instead
+     * @deprecated tag:v6.8.0 - Declare services in getSubscribedServices()
      */
     protected function getServiceDeprecated(string $id): ?object
     {
@@ -41,13 +38,13 @@ trait DeprecatedContainerAccessTrait
     }
 
     /**
-     * @deprecated tag:v6.8.0 - Use service subscription instead
+     * @deprecated tag:v6.8.0 - Use optional service subscription
      */
     protected function hasServiceDeprecated(string $id): bool
     {
         trigger_deprecation(
             'shopware/storefront',
-            '6.6.0',
+            '6.8.0',
             'Checking service availability via hasServiceDeprecated("%s") in %s is deprecated. '
             . 'Declare the service as optional in getSubscribedServices() method instead.',
             $id,

--- a/src/Storefront/Controller/DeprecatedContainerAccessTrait.php
+++ b/src/Storefront/Controller/DeprecatedContainerAccessTrait.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Controller;
+
+use Psr\Container\ContainerInterface;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @deprecated tag:v6.8.0 - Will be removed in 6.9.0
+ *
+ * @property ContainerInterface $container
+ *
+ * This trait provides backward compatibility for controllers that directly access
+ * services from the container without declaring them in getSubscribedServices().
+ * All usages should be migrated to proper service subscription.
+ */
+#[Package('framework')]
+trait DeprecatedContainerAccessTrait
+{
+    /**
+     * @deprecated tag:v6.8.0 - Use service subscription instead
+     */
+    protected function getServiceDeprecated(string $id): ?object
+    {
+        trigger_deprecation(
+            'shopware/storefront',
+            '6.8.0',
+            'Direct container access via $this->container->get("%s") in %s is deprecated. '
+            . 'Declare the service in getSubscribedServices() method instead.',
+            $id,
+            static::class
+        );
+
+        if (!$this->container->has($id)) {
+            return null;
+        }
+
+        return $this->container->get($id);
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - Use service subscription instead
+     */
+    protected function hasServiceDeprecated(string $id): bool
+    {
+        trigger_deprecation(
+            'shopware/storefront',
+            '6.6.0',
+            'Checking service availability via hasServiceDeprecated("%s") in %s is deprecated. '
+            . 'Declare the service as optional in getSubscribedServices() method instead.',
+            $id,
+            static::class
+        );
+
+        return $this->container->has($id);
+    }
+}

--- a/src/Storefront/Controller/DeprecatedContainerAccessTrait.php
+++ b/src/Storefront/Controller/DeprecatedContainerAccessTrait.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Storefront\Controller;
 
+use Psr\Container\ContainerInterface;
 use Shopware\Core\Framework\Log\Package;
 
 /**

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -24,9 +24,12 @@ use Shopware\Storefront\Framework\Twig\Extension\IconCacheTwigFilter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Error\LoaderError;
@@ -34,28 +37,31 @@ use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 
 #[Package('framework')]
-abstract class StorefrontController extends AbstractController
+abstract class StorefrontController extends AbstractController implements ServiceSubscriberInterface
 {
     public const SUCCESS = 'success';
     public const DANGER = 'danger';
     public const INFO = 'info';
     public const WARNING = 'warning';
 
+    /**
+     * {@inheritdoc}
+     */
     public static function getSubscribedServices(): array
     {
-        $services = parent::getSubscribedServices();
-
-        $services['twig'] = Environment::class;
-        $services['event_dispatcher'] = EventDispatcherInterface::class;
-        $services[SystemConfigService::class] = SystemConfigService::class;
-        $services[TemplateFinder::class] = TemplateFinder::class;
-        $services[SeoUrlPlaceholderHandlerInterface::class] = SeoUrlPlaceholderHandlerInterface::class;
-        $services[MediaUrlPlaceholderHandlerInterface::class] = MediaUrlPlaceholderHandlerInterface::class;
-        $services[ScriptExecutor::class] = ScriptExecutor::class;
-        $services['translator'] = TranslatorInterface::class;
-        $services[RequestTransformerInterface::class] = RequestTransformerInterface::class;
-
-        return $services;
+        return array_merge(parent::getSubscribedServices(), [
+            'twig' => '?' . Environment::class,
+            'event_dispatcher' => '?' . EventDispatcherInterface::class,
+            SystemConfigService::class => '?' . SystemConfigService::class,
+            TemplateFinder::class => '?' . TemplateFinder::class,
+            SeoUrlPlaceholderHandlerInterface::class => '?' . SeoUrlPlaceholderHandlerInterface::class,
+            MediaUrlPlaceholderHandlerInterface::class => '?' . MediaUrlPlaceholderHandlerInterface::class,
+            ScriptExecutor::class => '?' . ScriptExecutor::class,
+            'translator' => '?' . TranslatorInterface::class,
+            RequestTransformerInterface::class => '?' . RequestTransformerInterface::class,
+            'request_stack' => '?' . RequestStack::class,
+            'router' => '?' . RouterInterface::class,
+        ]);
     }
 
     /**

--- a/src/Storefront/DependencyInjection/Compiler/StorefrontControllerCompilerPass.php
+++ b/src/Storefront/DependencyInjection/Compiler/StorefrontControllerCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Storefront\DependencyInjection\Compiler;
 
+use Psr\Container\ContainerInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -32,9 +33,11 @@ class StorefrontControllerCompilerPass implements CompilerPassInterface
                 continue;
             }
 
-            // Use is_subclass_of with autoload=false to prevent triggering file-level deprecations
-            // that Symfony places before class declarations (avoids loading unnecessary files)
-            if (!is_subclass_of($class, StorefrontController::class, false)) {
+            // Skip if class isn't a StorefrontController
+            // Note: This may trigger autoloading which can trigger deprecation warnings
+            // if the file itself has a deprecation trigger (Symfony likes to do that to deprecate classes).
+            // As this point only controller classes are checked which shouldn't have such a trigger.
+            if (!is_subclass_of($class, StorefrontController::class)) {
                 continue;
             }
 
@@ -59,7 +62,7 @@ class StorefrontControllerCompilerPass implements CompilerPassInterface
                 // PSR interface provides service locator, not full container
                 if (!$hasSetContainer && !$definition->isAutowired()) {
                     $definition->addMethodCall('setContainer', [
-                        new Reference('Psr\Container\ContainerInterface'),
+                        new Reference(ContainerInterface::class),
                     ]);
                 }
             }

--- a/src/Storefront/DependencyInjection/Compiler/StorefrontControllerCompilerPass.php
+++ b/src/Storefront/DependencyInjection/Compiler/StorefrontControllerCompilerPass.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\DependencyInjection\Compiler;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Controller\StorefrontController;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Ensures backward compatibility for controllers not using autoconfigure.
+ * Plugins may still use manual configuration.
+ */
+#[Package('framework')]
+class StorefrontControllerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        // Process tagged controllers to avoid loading all classes
+        $taggedControllers = $container->findTaggedServiceIds('controller.service_arguments');
+
+        foreach (array_keys($taggedControllers) as $id) {
+            if (!$container->hasDefinition($id)) {
+                continue;
+            }
+
+            $definition = $container->getDefinition($id);
+            $class = $definition->getClass();
+
+            if ($class === null) {
+                continue;
+            }
+
+            // Use is_subclass_of with autoload=false to prevent triggering file-level deprecations
+            // that Symfony places before class declarations (avoids loading unnecessary files)
+            if (!is_subclass_of($class, StorefrontController::class, false)) {
+                continue;
+            }
+
+            // Legacy controllers need manual configuration
+            if (!$definition->isAutoconfigured()) {
+                if (!$definition->hasTag('controller.service_arguments')) {
+                    $definition->addTag('controller.service_arguments');
+                }
+
+                if (!$definition->hasTag('container.service_subscriber')) {
+                    $definition->addTag('container.service_subscriber');
+                }
+
+                $hasSetContainer = false;
+                foreach ($definition->getMethodCalls() as $methodCall) {
+                    if ($methodCall[0] === 'setContainer') {
+                        $hasSetContainer = true;
+                        break;
+                    }
+                }
+
+                // PSR interface provides service locator, not full container
+                if (!$hasSetContainer && !$definition->isAutowired()) {
+                    $definition->addMethodCall('setContainer', [
+                        new Reference('Psr\Container\ContainerInterface'),
+                    ]);
+                }
+            }
+
+            // Controllers must be public for routing
+            if (!$definition->isPublic()) {
+                $definition->setPublic(true);
+            }
+        }
+    }
+}

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -9,8 +9,10 @@
 
         <service id="Shopware\Storefront\Controller\Api\CaptchaController" public="true">
             <argument type="tagged_iterator" tag="shopware.storefront.captcha"/>
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -30,8 +32,10 @@
             <argument type="service" id="Shopware\Storefront\Pagelet\Header\HeaderPageletLoader"/>
             <argument type="service" id="Shopware\Storefront\Pagelet\Footer\FooterPageletLoader"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -43,8 +47,10 @@
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ChangeEmailRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\DeleteCustomerRoute"/>
             <argument type="service" id="logger"/>
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -57,8 +63,10 @@
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\DeleteAddressRoute"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -71,8 +79,10 @@
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ImitateCustomerRoute"/>
             <argument type="service" id="Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade"/>
             <argument type="service" id="Shopware\Storefront\Page\Account\RecoverPassword\AccountRecoverPasswordPageLoader"/>
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -87,8 +97,10 @@
             <argument type="service" id="Shopware\Core\Framework\Util\HtmlSanitizer"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\ProductListRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItemFactoryRegistry"/>
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -105,8 +117,10 @@
             <argument type="service" id="Shopware\Storefront\Pagelet\Header\HeaderPageletLoader"/>
             <argument type="service" id="Shopware\Storefront\Pagelet\Footer\FooterPageletLoader"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -114,8 +128,10 @@
             <argument type="service" id="Shopware\Core\Framework\Gateway\Context\SalesChannel\ContextGatewayRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -124,8 +140,10 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="sales_channel_analytics.repository"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -139,8 +157,10 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -149,8 +169,10 @@
             <argument type="service" id="Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute"/>
             <argument type="service" id="Shopware\Core\Content\Newsletter\SalesChannel\NewsletterUnsubscribeRoute"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -159,8 +181,10 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="router.default"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -169,8 +193,10 @@
             <argument type="service" id="Shopware\Storefront\Page\Maintenance\MaintenancePageLoader"/>
             <argument type="service" id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -179,8 +205,10 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Storefront\Page\Navigation\Error\ErrorPageLoader"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -192,8 +220,10 @@
             <argument type="service" id="Shopware\Core\Content\Category\Service\CategoryUrlGenerator"/>
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -202,8 +232,10 @@
             <argument type="service" id="Shopware\Core\Content\Newsletter\SalesChannel\NewsletterConfirmRoute"/>
             <argument type="service" id="Shopware\Storefront\Pagelet\Newsletter\Account\NewsletterAccountPageletLoader"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -215,16 +247,20 @@
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
         <service id="Shopware\Storefront\Controller\LandingPageController">
             <argument type="service" id="Shopware\Storefront\Page\LandingPage\LandingPageLoader"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -241,8 +277,10 @@
             <argument type="service" id="Shopware\Storefront\Pagelet\Header\HeaderPageletLoader"/>
             <argument type="service" id="Shopware\Storefront\Pagelet\Footer\FooterPageletLoader"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -250,8 +288,10 @@
             <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
             <argument type="service" id="Shopware\Core\Framework\Script\Api\ScriptResponseEncoder"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -260,8 +300,10 @@
             <argument type="service" id="Shopware\Storefront\Page\Suggest\SuggestPageLoader"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -269,15 +311,19 @@
             <argument type="service" id="Shopware\Storefront\Page\Sitemap\SitemapPageLoader"/>
             <argument type="service" id="Shopware\Core\Content\Sitemap\SalesChannel\SitemapFileRoute"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
         <service id="Shopware\Storefront\Controller\CountryStateController" public="true">
             <argument type="service" id="Shopware\Storefront\Pagelet\Country\CountryStateDataPageletLoader"/>
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -285,22 +331,28 @@
             <argument type="service" id="Shopware\Core\Checkout\Document\SalesChannel\DocumentRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
         <service id="Shopware\Storefront\Controller\DownloadController" public="true">
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\DownloadRoute"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
         <service id="Shopware\Storefront\Controller\WellKnownController" public="true">
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -314,8 +366,10 @@
             <argument type="service" id="Shopware\Storefront\Pagelet\Wishlist\GuestWishlistPageletLoader"/>
             <argument type="service" id="event_dispatcher"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
@@ -323,23 +377,29 @@
             <argument type="service" id="Shopware\Storefront\Pagelet\Captcha\BasicCaptchaPageletLoader"/>
             <argument type="service" id="Shopware\Storefront\Framework\Captcha\BasicCaptcha"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
         <service id="Shopware\Storefront\Controller\VerificationHashController" public="true">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
 
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
 
         <service id="Shopware\Storefront\Controller\RobotsController" public="true">
             <argument type="service" id="Shopware\Storefront\Page\Robots\RobotsPageLoader"/>
+            <tag name="controller.service_arguments"/>
+            <tag name="container.service_subscriber"/>
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface"/>
             </call>
         </service>
     </services>

--- a/src/Storefront/Resources/config/services_controller.xml
+++ b/src/Storefront/Resources/config/services_controller.xml
@@ -8,6 +8,16 @@
         <!-- Symfony detects controller interfaces and applies tags automatically -->
         <defaults public="true" autoconfigure="true" autowire="true" />
 
+        <!-- 
+            Alias for PSR ContainerInterface to support autowiring of setContainer().
+            For ServiceSubscriberInterface controllers, this gets replaced with a service locator
+            containing only the subscribed services during compilation.
+        -->
+        <service id="Psr\Container\ContainerInterface" class="Symfony\Component\DependencyInjection\ServiceLocator">
+            <argument type="collection" />
+            <tag name="container.service_locator" />
+        </service>
+
         <service id="Shopware\Storefront\Controller\Api\CaptchaController">
             <argument type="tagged_iterator" tag="shopware.storefront.captcha"/>
         </service>

--- a/src/Storefront/Resources/config/services_controller.xml
+++ b/src/Storefront/Resources/config/services_controller.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Symfony detects controller interfaces and applies tags automatically -->
+        <defaults public="true" autoconfigure="true" autowire="true" />
+
+        <service id="Shopware\Storefront\Controller\Api\CaptchaController">
+            <argument type="tagged_iterator" tag="shopware.storefront.captcha"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\AccountOrderController">
+            <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountOrderPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountEditOrderPageLoader"/>
+            <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\CancelOrderRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\HandlePaymentMethodRoute"/>
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountOrderDetailPageLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderRoute"/>
+            <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderService"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Header\HeaderPageletLoader"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Footer\FooterPageletLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\AccountProfileController">
+            <argument type="service" id="Shopware\Storefront\Page\Account\Overview\AccountOverviewPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Page\Account\Profile\AccountProfilePageLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ChangeCustomerProfileRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ChangePasswordRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ChangeEmailRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\DeleteCustomerRoute"/>
+            <argument type="service" id="logger"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\AddressController">
+            <argument type="service" id="Shopware\Storefront\Page\Address\Listing\AddressListingPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Page\Address\Detail\AddressDetailPageLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\AccountService"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ListAddressRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\UpsertAddressRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\DeleteAddressRoute"/>
+            <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
+            <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\AuthController">
+            <argument type="service" id="Shopware\Storefront\Page\Account\Login\AccountLoginPageLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\SendPasswordRecoveryMailRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ResetPasswordRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LoginRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ImitateCustomerRoute"/>
+            <argument type="service" id="Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade"/>
+            <argument type="service" id="Shopware\Storefront\Page\Account\RecoverPassword\AccountRecoverPasswordPageLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\AppController">
+            <argument type="service" id="Shopware\Core\Framework\App\Api\AppJWTGenerateRoute"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\CartLineItemController">
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\LineItemFactoryHandler\ProductLineItemFactory"/>
+            <argument type="service" id="Shopware\Core\Framework\Util\HtmlSanitizer"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\ProductListRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\LineItemFactoryRegistry"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\CheckoutController">
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPageLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderService"/>
+            <argument type="service" id="Shopware\Core\Checkout\Payment\PaymentProcessor"/>
+            <argument type="service" id="Shopware\Storefront\Page\Checkout\Offcanvas\OffcanvasCartPageLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Header\HeaderPageletLoader"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Footer\FooterPageletLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\ContextGatewayController">
+            <argument type="service" id="Shopware\Core\Framework\Gateway\Context\SalesChannel\ContextGatewayRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\CookieController">
+            <argument type="service" id="Shopware\Storefront\Framework\Cookie\CookieProviderInterface"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="sales_channel_analytics.repository"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\CmsController">
+            <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\CmsRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\CategoryRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\FindVariant\FindProductVariantRoute"/>
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\FormController">
+            <argument type="service" id="Shopware\Core\Content\ContactForm\SalesChannel\ContactFormRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Newsletter\SalesChannel\NewsletterUnsubscribeRoute"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\ContextController">
+            <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="router.default"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\MaintenanceController">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="Shopware\Storefront\Page\Maintenance\MaintenancePageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\ErrorController">
+            <argument type="service" id="Shopware\Storefront\Framework\Twig\ErrorTemplateResolver"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="Shopware\Storefront\Page\Navigation\Error\ErrorPageLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\NavigationController">
+            <argument type="service" id="Shopware\Storefront\Page\Navigation\NavigationPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Menu\Offcanvas\MenuOffcanvasPageletLoader"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Header\HeaderPageletLoader"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Footer\FooterPageletLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Category\Service\CategoryUrlGenerator"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\NewsletterController">
+            <argument type="service" id="Shopware\Storefront\Page\Newsletter\Subscribe\NewsletterSubscribePageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Newsletter\SalesChannel\NewsletterConfirmRoute"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Newsletter\Account\NewsletterAccountPageletLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\ProductController">
+            <argument type="service" id="Shopware\Storefront\Page\Product\ProductPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\FindVariant\FindProductVariantRoute"/>
+            <argument type="service" id="Shopware\Storefront\Page\Product\QuickView\MinimalQuickViewPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewSaveRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\LandingPageController">
+            <argument type="service" id="Shopware\Storefront\Page\LandingPage\LandingPageLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\RegisterController">
+            <argument type="service" id="Shopware\Storefront\Page\Account\Login\AccountLoginPageLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="Shopware\Storefront\Page\Checkout\Register\CheckoutRegisterPageLoader"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="customer.repository"/>
+            <argument type="service" id="Shopware\Storefront\Page\Account\CustomerGroupRegistration\CustomerGroupRegistrationPageLoader"/>
+            <argument type="service" id="sales_channel_domain.repository"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Header\HeaderPageletLoader"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Footer\FooterPageletLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\ScriptController">
+            <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
+            <argument type="service" id="Shopware\Core\Framework\Script\Api\ScriptResponseEncoder"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\SearchController">
+            <argument type="service" id="Shopware\Storefront\Page\Search\SearchPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Page\Suggest\SuggestPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\SitemapController">
+            <argument type="service" id="Shopware\Storefront\Page\Sitemap\SitemapPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Sitemap\SalesChannel\SitemapFileRoute"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\CountryStateController">
+            <argument type="service" id="Shopware\Storefront\Pagelet\Country\CountryStateDataPageletLoader"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\DocumentController">
+            <argument type="service" id="Shopware\Core\Checkout\Document\SalesChannel\DocumentRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LogoutRoute"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\DownloadController">
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\DownloadRoute"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\WellKnownController" />
+
+        <service id="Shopware\Storefront\Controller\WishlistController">
+            <argument type="service" id="Shopware\Storefront\Page\Wishlist\WishlistPageLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LoadWishlistRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\AddWishlistProductRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\RemoveWishlistProductRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\MergeWishlistProductRoute"/>
+            <argument type="service" id="Shopware\Storefront\Page\Wishlist\GuestWishlistPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Pagelet\Wishlist\GuestWishlistPageletLoader"/>
+            <argument type="service" id="event_dispatcher"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\CaptchaController">
+            <argument type="service" id="Shopware\Storefront\Pagelet\Captcha\BasicCaptchaPageletLoader"/>
+            <argument type="service" id="Shopware\Storefront\Framework\Captcha\BasicCaptcha"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\VerificationHashController">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+        </service>
+
+        <service id="Shopware\Storefront\Controller\RobotsController">
+            <argument type="service" id="Shopware\Storefront\Page\Robots\RobotsPageLoader"/>
+        </service>
+    </services>
+</container>

--- a/src/Storefront/Storefront.php
+++ b/src/Storefront/Storefront.php
@@ -4,6 +4,7 @@ namespace Shopware\Storefront;
 
 use Shopware\Core\Framework\Bundle;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\DependencyInjection\Compiler\StorefrontControllerCompilerPass;
 use Shopware\Storefront\DependencyInjection\DisableTemplateCachePass;
 use Shopware\Storefront\DependencyInjection\StorefrontMigrationReplacementCompilerPass;
 use Shopware\Storefront\Framework\ThemeInterface;
@@ -31,9 +32,16 @@ class Storefront extends Bundle implements ThemeInterface
         $loader->load('controller.xml');
         $loader->load('theme.xml');
 
+        // Autoconfigured controllers for gradual migration
+        $resourcesLoader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/Resources/config'));
+        if (is_file(__DIR__ . '/Resources/config/services_controller.xml')) {
+            $resourcesLoader->load('services_controller.xml');
+        }
+
         $container->setParameter('storefrontRoot', $this->getPath());
 
         $container->addCompilerPass(new DisableTemplateCachePass());
         $container->addCompilerPass(new StorefrontMigrationReplacementCompilerPass());
+        $container->addCompilerPass(new StorefrontControllerCompilerPass());
     }
 }

--- a/tests/unit/Storefront/Controller/DeprecatedContainerAccessTraitTest.php
+++ b/tests/unit/Storefront/Controller/DeprecatedContainerAccessTraitTest.php
@@ -1,0 +1,252 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Shopware\Storefront\Controller\DeprecatedContainerAccessTrait;
+use Shopware\Storefront\Controller\StorefrontController;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ *
+ * @phpstan-ignore classConstant.deprecatedTrait
+ */
+#[CoversClass(DeprecatedContainerAccessTrait::class)]
+class DeprecatedContainerAccessTraitTest extends TestCase
+{
+    private TestControllerWithDeprecatedTrait $controller;
+
+    /**
+     * @var MockObject&ContainerInterface
+     */
+    private MockObject $container;
+
+    protected function setUp(): void
+    {
+        $this->controller = new TestControllerWithDeprecatedTrait();
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->controller->setContainer($this->container);
+    }
+
+    public function testGetServiceDeprecatedReturnsService(): void
+    {
+        $mockService = new \stdClass();
+        $mockService->test = 'value';
+
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('test.service')
+            ->willReturn(true);
+
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->with('test.service')
+            ->willReturn($mockService);
+
+        // Capture deprecation warning
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            if ($errno === \E_USER_DEPRECATED) {
+                $deprecations[] = $errstr;
+            }
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        $result = $this->controller->getTestService('test.service');
+
+        restore_error_handler();
+
+        static::assertSame($mockService, $result);
+        static::assertEquals('value', $result->test);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('Direct container access via $this->container->get("test.service")', $deprecations[0]);
+    }
+
+    public function testGetServiceDeprecatedReturnsNullWhenServiceNotExists(): void
+    {
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('non.existent.service')
+            ->willReturn(false);
+
+        $this->container
+            ->expects($this->never())
+            ->method('get');
+
+        // Capture deprecation warning
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            if ($errno === \E_USER_DEPRECATED) {
+                $deprecations[] = $errstr;
+            }
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        $result = $this->controller->getTestService('non.existent.service');
+
+        restore_error_handler();
+
+        static::assertNull($result);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('Direct container access via $this->container->get("non.existent.service")', $deprecations[0]);
+    }
+
+    public function testHasServiceDeprecatedReturnsTrueWhenServiceExists(): void
+    {
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('existing.service')
+            ->willReturn(true);
+
+        // Capture deprecation warning
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            if ($errno === \E_USER_DEPRECATED) {
+                $deprecations[] = $errstr;
+            }
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        $result = $this->controller->hasTestService('existing.service');
+
+        restore_error_handler();
+
+        static::assertTrue($result);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('Checking service availability via hasServiceDeprecated("existing.service")', $deprecations[0]);
+    }
+
+    public function testHasServiceDeprecatedReturnsFalseWhenServiceNotExists(): void
+    {
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('non.existent.service')
+            ->willReturn(false);
+
+        // Capture deprecation warning
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            if ($errno === \E_USER_DEPRECATED) {
+                $deprecations[] = $errstr;
+            }
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        $result = $this->controller->hasTestService('non.existent.service');
+
+        restore_error_handler();
+
+        static::assertFalse($result);
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('Checking service availability via hasServiceDeprecated("non.existent.service")', $deprecations[0]);
+    }
+
+    public function testDeprecationMessageIncludesClassName(): void
+    {
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('test.service')
+            ->willReturn(true);
+
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->with('test.service')
+            ->willReturn(new \stdClass());
+
+        // Capture deprecation warning
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            if ($errno === \E_USER_DEPRECATED) {
+                $deprecations[] = $errstr;
+            }
+
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        $this->controller->getTestService('test.service');
+
+        restore_error_handler();
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString(TestControllerWithDeprecatedTrait::class, $deprecations[0]);
+        static::assertStringContainsString('Declare the service in getSubscribedServices() method instead', $deprecations[0]);
+    }
+
+    public function testDeprecationVersionNumbers(): void
+    {
+        $this->container
+            ->expects($this->once())
+            ->method('has')
+            ->with('test.service')
+            ->willReturn(true);
+
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->with('test.service')
+            ->willReturn(new \stdClass());
+
+        // Use error handler to capture deprecation details
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            if ($errno === \E_USER_DEPRECATED) {
+                $deprecations[] = $errstr;
+            }
+
+            return true;
+        });
+
+        $this->controller->getTestService('test.service');
+
+        restore_error_handler();
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('6.8.0', $deprecations[0]);
+        static::assertStringContainsString('shopware/storefront', $deprecations[0]);
+    }
+}
+
+/**
+ * @internal
+ * Test controller that uses the deprecated trait for testing purposes
+ */
+class TestControllerWithDeprecatedTrait extends StorefrontController
+{
+    use DeprecatedContainerAccessTrait;
+
+    /**
+     * Public wrapper for testing protected method
+     */
+    public function getTestService(string $id): ?object
+    {
+        return $this->getServiceDeprecated($id);
+    }
+
+    /**
+     * Public wrapper for testing protected method
+     */
+    public function hasTestService(string $id): bool
+    {
+        return $this->hasServiceDeprecated($id);
+    }
+
+    public function testAction(): Response
+    {
+        return new Response('test');
+    }
+}

--- a/tests/unit/Storefront/Controller/DeprecatedContainerAccessTraitTest.php
+++ b/tests/unit/Storefront/Controller/DeprecatedContainerAccessTraitTest.php
@@ -49,24 +49,12 @@ class DeprecatedContainerAccessTraitTest extends TestCase
             ->with('test.service')
             ->willReturn($mockService);
 
-        // Capture deprecation warning
-        $deprecations = [];
-        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
-            if ($errno === \E_USER_DEPRECATED) {
-                $deprecations[] = $errstr;
-            }
-
-            return true;
-        }, \E_USER_DEPRECATED);
+        $this->expectUserDeprecationMessageMatches('/Since shopware\/storefront 6\.8\.0: Direct container access via \$this->container->get\("test\.service"\)/');
 
         $result = $this->controller->getTestService('test.service');
 
-        restore_error_handler();
-
         static::assertSame($mockService, $result);
         static::assertEquals('value', $result->test);
-        static::assertCount(1, $deprecations);
-        static::assertStringContainsString('Direct container access via $this->container->get("test.service")', $deprecations[0]);
     }
 
     public function testGetServiceDeprecatedReturnsNullWhenServiceNotExists(): void
@@ -81,23 +69,11 @@ class DeprecatedContainerAccessTraitTest extends TestCase
             ->expects($this->never())
             ->method('get');
 
-        // Capture deprecation warning
-        $deprecations = [];
-        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
-            if ($errno === \E_USER_DEPRECATED) {
-                $deprecations[] = $errstr;
-            }
-
-            return true;
-        }, \E_USER_DEPRECATED);
+        $this->expectUserDeprecationMessageMatches('/Since shopware\/storefront 6\.8\.0: Direct container access via \$this->container->get\("non\.existent\.service"\)/');
 
         $result = $this->controller->getTestService('non.existent.service');
 
-        restore_error_handler();
-
         static::assertNull($result);
-        static::assertCount(1, $deprecations);
-        static::assertStringContainsString('Direct container access via $this->container->get("non.existent.service")', $deprecations[0]);
     }
 
     public function testHasServiceDeprecatedReturnsTrueWhenServiceExists(): void
@@ -108,23 +84,11 @@ class DeprecatedContainerAccessTraitTest extends TestCase
             ->with('existing.service')
             ->willReturn(true);
 
-        // Capture deprecation warning
-        $deprecations = [];
-        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
-            if ($errno === \E_USER_DEPRECATED) {
-                $deprecations[] = $errstr;
-            }
-
-            return true;
-        }, \E_USER_DEPRECATED);
+        $this->expectUserDeprecationMessageMatches('/Since shopware\/storefront 6\.8\.0: Checking service availability via hasServiceDeprecated\("existing\.service"\)/');
 
         $result = $this->controller->hasTestService('existing.service');
 
-        restore_error_handler();
-
         static::assertTrue($result);
-        static::assertCount(1, $deprecations);
-        static::assertStringContainsString('Checking service availability via hasServiceDeprecated("existing.service")', $deprecations[0]);
     }
 
     public function testHasServiceDeprecatedReturnsFalseWhenServiceNotExists(): void
@@ -135,23 +99,11 @@ class DeprecatedContainerAccessTraitTest extends TestCase
             ->with('non.existent.service')
             ->willReturn(false);
 
-        // Capture deprecation warning
-        $deprecations = [];
-        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
-            if ($errno === \E_USER_DEPRECATED) {
-                $deprecations[] = $errstr;
-            }
-
-            return true;
-        }, \E_USER_DEPRECATED);
+        $this->expectUserDeprecationMessageMatches('/Since shopware\/storefront 6\.8\.0: Checking service availability via hasServiceDeprecated\("non\.existent\.service"\)/');
 
         $result = $this->controller->hasTestService('non.existent.service');
 
-        restore_error_handler();
-
         static::assertFalse($result);
-        static::assertCount(1, $deprecations);
-        static::assertStringContainsString('Checking service availability via hasServiceDeprecated("non.existent.service")', $deprecations[0]);
     }
 
     public function testDeprecationMessageIncludesClassName(): void
@@ -168,23 +120,9 @@ class DeprecatedContainerAccessTraitTest extends TestCase
             ->with('test.service')
             ->willReturn(new \stdClass());
 
-        // Capture deprecation warning
-        $deprecations = [];
-        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
-            if ($errno === \E_USER_DEPRECATED) {
-                $deprecations[] = $errstr;
-            }
-
-            return true;
-        }, \E_USER_DEPRECATED);
+        $this->expectUserDeprecationMessageMatches('/Since shopware\/storefront 6\.8\.0:.*' . preg_quote(TestControllerWithDeprecatedTrait::class, '/') . '.*Declare the service in getSubscribedServices\(\) method instead/');
 
         $this->controller->getTestService('test.service');
-
-        restore_error_handler();
-
-        static::assertCount(1, $deprecations);
-        static::assertStringContainsString(TestControllerWithDeprecatedTrait::class, $deprecations[0]);
-        static::assertStringContainsString('Declare the service in getSubscribedServices() method instead', $deprecations[0]);
     }
 
     public function testDeprecationVersionNumbers(): void
@@ -201,23 +139,9 @@ class DeprecatedContainerAccessTraitTest extends TestCase
             ->with('test.service')
             ->willReturn(new \stdClass());
 
-        // Use error handler to capture deprecation details
-        $deprecations = [];
-        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
-            if ($errno === \E_USER_DEPRECATED) {
-                $deprecations[] = $errstr;
-            }
-
-            return true;
-        });
+        $this->expectUserDeprecationMessageMatches('/Since shopware\/storefront 6\.8\.0:/');
 
         $this->controller->getTestService('test.service');
-
-        restore_error_handler();
-
-        static::assertCount(1, $deprecations);
-        static::assertStringContainsString('6.8.0', $deprecations[0]);
-        static::assertStringContainsString('shopware/storefront', $deprecations[0]);
     }
 }
 

--- a/tests/unit/Storefront/Controller/StorefrontControllerServiceSubscriberTest.php
+++ b/tests/unit/Storefront/Controller/StorefrontControllerServiceSubscriberTest.php
@@ -1,0 +1,165 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
+use Shopware\Core\Framework\Routing\RequestTransformerInterface;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Storefront\Controller\StorefrontController;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+
+/**
+ * @internal
+ */
+#[CoversClass(StorefrontController::class)]
+class StorefrontControllerServiceSubscriberTest extends TestCase
+{
+    public function testImplementsServiceSubscriberInterface(): void
+    {
+        // Verify that StorefrontController properly implements the interface
+        $interfaces = class_implements(StorefrontController::class);
+
+        static::assertIsArray($interfaces);
+        static::assertContains(ServiceSubscriberInterface::class, $interfaces);
+    }
+
+    public function testGetSubscribedServices(): void
+    {
+        $services = StorefrontController::getSubscribedServices();
+
+        // Assert required framework services are subscribed
+        static::assertArrayHasKey('twig', $services);
+        static::assertArrayHasKey('event_dispatcher', $services);
+        static::assertArrayHasKey('translator', $services);
+        static::assertArrayHasKey('router', $services);
+        static::assertArrayHasKey('request_stack', $services);
+
+        // Assert Shopware specific services are subscribed
+        static::assertArrayHasKey(SystemConfigService::class, $services);
+        static::assertArrayHasKey(TemplateFinder::class, $services);
+        static::assertArrayHasKey(SeoUrlPlaceholderHandlerInterface::class, $services);
+        static::assertArrayHasKey(MediaUrlPlaceholderHandlerInterface::class, $services);
+        static::assertArrayHasKey(ScriptExecutor::class, $services);
+        static::assertArrayHasKey(RequestTransformerInterface::class, $services);
+    }
+
+    public function testServicesAreOptional(): void
+    {
+        $services = StorefrontController::getSubscribedServices();
+
+        // All services should be optional (prefixed with ?)
+        static::assertIsString($services['twig']);
+        static::assertStringStartsWith('?', (string) $services['twig']);
+        static::assertIsString($services['event_dispatcher']);
+        static::assertStringStartsWith('?', (string) $services['event_dispatcher']);
+        static::assertIsString($services['translator']);
+        static::assertStringStartsWith('?', (string) $services['translator']);
+        static::assertIsString($services['router']);
+        static::assertStringStartsWith('?', (string) $services['router']);
+        static::assertIsString($services['request_stack']);
+        static::assertStringStartsWith('?', (string) $services['request_stack']);
+        static::assertIsString($services[SystemConfigService::class]);
+        static::assertStringStartsWith('?', (string) $services[SystemConfigService::class]);
+        static::assertIsString($services[TemplateFinder::class]);
+        static::assertStringStartsWith('?', (string) $services[TemplateFinder::class]);
+        static::assertIsString($services[SeoUrlPlaceholderHandlerInterface::class]);
+        static::assertStringStartsWith('?', (string) $services[SeoUrlPlaceholderHandlerInterface::class]);
+        static::assertIsString($services[MediaUrlPlaceholderHandlerInterface::class]);
+        static::assertStringStartsWith('?', (string) $services[MediaUrlPlaceholderHandlerInterface::class]);
+        static::assertIsString($services[ScriptExecutor::class]);
+        static::assertStringStartsWith('?', (string) $services[ScriptExecutor::class]);
+        static::assertIsString($services[RequestTransformerInterface::class]);
+        static::assertStringStartsWith('?', (string) $services[RequestTransformerInterface::class]);
+    }
+
+    public function testControllerWithServiceLocator(): void
+    {
+        $controller = new TestStorefrontController();
+
+        // Create mock service locator
+        $container = $this->createMock(ContainerInterface::class);
+
+        // Configure the mock to return services when requested
+        $container->method('has')->willReturn(true);
+        $container->method('get')->willReturnCallback(function (string $id) {
+            $services = [
+                'twig' => $this->createMock(Environment::class),
+                'event_dispatcher' => $this->createMock(EventDispatcherInterface::class),
+                'translator' => $this->createMock(TranslatorInterface::class),
+                'router' => $this->createMock(RouterInterface::class),
+                'request_stack' => $this->createMock(RequestStack::class),
+                SystemConfigService::class => $this->createMock(SystemConfigService::class),
+                TemplateFinder::class => $this->createMock(TemplateFinder::class),
+                SeoUrlPlaceholderHandlerInterface::class => $this->createMock(SeoUrlPlaceholderHandlerInterface::class),
+                MediaUrlPlaceholderHandlerInterface::class => $this->createMock(MediaUrlPlaceholderHandlerInterface::class),
+                ScriptExecutor::class => $this->createMock(ScriptExecutor::class),
+                RequestTransformerInterface::class => $this->createMock(RequestTransformerInterface::class),
+            ];
+
+            return $services[$id] ?? null;
+        });
+
+        $controller->setContainer($container);
+
+        // Test that the controller can use the trans method
+        $result = $controller->testTrans('test.key');
+        static::assertIsString($result);
+    }
+
+    public function testInheritancePreservesSubscriptions(): void
+    {
+        $parentServices = StorefrontController::getSubscribedServices();
+        $childServices = TestChildController::getSubscribedServices();
+
+        // Child should have all parent services
+        foreach ($parentServices as $key => $value) {
+            static::assertArrayHasKey($key, $childServices);
+        }
+
+        // Child should have additional services
+        static::assertArrayHasKey('custom.service', $childServices);
+    }
+}
+
+/**
+ * @internal
+ * Test controller implementation for unit tests
+ */
+class TestStorefrontController extends StorefrontController
+{
+    public function testTrans(string $key): string
+    {
+        return $this->trans($key);
+    }
+
+    public function testAction(): Response
+    {
+        return new Response('test');
+    }
+}
+
+/**
+ * @internal
+ * Test child controller with additional service subscriptions
+ */
+class TestChildController extends StorefrontController
+{
+    public static function getSubscribedServices(): array
+    {
+        return array_merge(parent::getSubscribedServices(), [
+            'custom.service' => '?stdClass',
+        ]);
+    }
+}

--- a/tests/unit/Storefront/DependencyInjection/Compiler/StorefrontControllerCompilerPassTest.php
+++ b/tests/unit/Storefront/DependencyInjection/Compiler/StorefrontControllerCompilerPassTest.php
@@ -1,0 +1,198 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Storefront\Controller\AccountOrderController;
+use Shopware\Storefront\DependencyInjection\Compiler\StorefrontControllerCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @internal
+ */
+#[CoversClass(StorefrontControllerCompilerPass::class)]
+class StorefrontControllerCompilerPassTest extends TestCase
+{
+    private StorefrontControllerCompilerPass $compilerPass;
+
+    protected function setUp(): void
+    {
+        $this->compilerPass = new StorefrontControllerCompilerPass();
+    }
+
+    public function testProcessSkipsAutoconfiguredControllers(): void
+    {
+        $container = new ContainerBuilder();
+
+        // Autoconfigured controllers already have everything they need from Symfony
+        $definition = new Definition(AccountOrderController::class);
+        $definition->setAutoconfigured(true);
+        $definition->addTag('controller.service_arguments');
+
+        $container->setDefinition('test.controller', $definition);
+        
+        // Capture initial state
+        $methodCallsBefore = count($definition->getMethodCalls());
+
+        $this->compilerPass->process($container);
+
+        // Verify no unnecessary configuration was added
+        static::assertCount($methodCallsBefore, $definition->getMethodCalls());
+        static::assertTrue($definition->isPublic());
+    }
+
+    public function testProcessConfiguresLegacyControllers(): void
+    {
+        $container = new ContainerBuilder();
+
+        // Legacy controllers need manual configuration
+        $definition = new Definition(AccountOrderController::class);
+        $definition->setAutoconfigured(false);
+        $definition->addTag('controller.service_arguments');
+
+        $container->setDefinition('test.controller', $definition);
+
+        $this->compilerPass->process($container);
+
+        // Verify the controller is properly configured for Symfony
+        static::assertTrue($definition->hasTag('controller.service_arguments'));
+        static::assertTrue($definition->hasTag('container.service_subscriber'));
+        static::assertTrue($definition->isPublic());
+    }
+
+    public function testProcessEnsuresNonAutowiredControllersHaveDependencies(): void
+    {
+        $container = new ContainerBuilder();
+
+        // Non-autowired controllers need explicit dependency configuration
+        $definition = new Definition(AccountOrderController::class);
+        $definition->setAutoconfigured(false);
+        $definition->setAutowired(false);
+        $definition->addTag('controller.service_arguments');
+
+        $container->setDefinition('test.controller', $definition);
+
+        $this->compilerPass->process($container);
+
+        // Verify the controller can access its dependencies
+        // Without being prescriptive about the exact mechanism
+        static::assertTrue($definition->hasTag('container.service_subscriber'));
+        
+        // Verify some form of dependency injection is configured
+        $hasDependencyInjection = 
+            $definition->isAutowired() || 
+            count($definition->getMethodCalls()) > 0 || 
+            count($definition->getArguments()) > 0;
+        
+        static::assertTrue($hasDependencyInjection);
+    }
+
+    public function testProcessIsIdempotent(): void
+    {
+        $container = new ContainerBuilder();
+
+        // Setup a controller with existing configuration
+        $definition = new Definition(AccountOrderController::class);
+        $definition->setAutoconfigured(false);
+        $definition->setAutowired(false);
+        $definition->addTag('controller.service_arguments');
+        $definition->addMethodCall('setContainer', [new Reference('Psr\Container\ContainerInterface')]);
+
+        $container->setDefinition('test.controller', $definition);
+        
+        // Run the compiler pass twice
+        $this->compilerPass->process($container);
+        $stateAfterFirst = [
+            'methodCalls' => count($definition->getMethodCalls()),
+            'tags' => count($definition->getTags()),
+        ];
+        
+        $this->compilerPass->process($container);
+        $stateAfterSecond = [
+            'methodCalls' => count($definition->getMethodCalls()),
+            'tags' => count($definition->getTags()),
+        ];
+
+        // Verify the compiler pass is idempotent (doesn't duplicate configuration)
+        static::assertEquals($stateAfterFirst, $stateAfterSecond);
+    }
+
+    public function testProcessEnsuresControllersAreRoutable(): void
+    {
+        $container = new ContainerBuilder();
+
+        // Controllers must be public to be routable by Symfony
+        $definition = new Definition(AccountOrderController::class);
+        $definition->setPublic(false); // Start as private
+        $definition->addTag('controller.service_arguments');
+
+        $container->setDefinition('test.controller', $definition);
+
+        $this->compilerPass->process($container);
+
+        static::assertTrue($definition->isPublic());
+    }
+
+    public function testProcessIgnoresNonStorefrontServices(): void
+    {
+        $container = new ContainerBuilder();
+
+        // Non-StorefrontController services should not be modified
+        $definition = new Definition(\stdClass::class);
+        $definition->addTag('controller.service_arguments');
+
+        $container->setDefinition('some.service', $definition);
+
+        $this->compilerPass->process($container);
+
+        // Verify non-StorefrontController services are not modified
+        static::assertFalse($definition->hasTag('container.service_subscriber'));
+    }
+
+    public function testProcessHandlesMissingClassGracefully(): void
+    {
+        $container = new ContainerBuilder();
+
+        // Service definition without a class should be skipped
+        $definition = new Definition();
+        $definition->addTag('controller.service_arguments');
+
+        $container->setDefinition('test.controller', $definition);
+
+        // Should not throw an exception
+        $this->compilerPass->process($container);
+
+        // Verify it was skipped
+        static::assertFalse($definition->hasTag('container.service_subscriber'));
+    }
+
+    public function testProcessOnlyAffectsTaggedServices(): void
+    {
+        $container = new ContainerBuilder();
+
+        // Service without controller tag should be ignored
+        $untaggedDefinition = new Definition(AccountOrderController::class);
+        $untaggedDefinition->setPublic(false);
+        
+        // Service with controller tag should be processed
+        $taggedDefinition = new Definition(AccountOrderController::class);
+        $taggedDefinition->setPublic(false);
+        $taggedDefinition->addTag('controller.service_arguments');
+        
+        $container->setDefinition('untagged.controller', $untaggedDefinition);
+        $container->setDefinition('tagged.controller', $taggedDefinition);
+
+        $this->compilerPass->process($container);
+
+        // Untagged should remain unchanged
+        static::assertFalse($untaggedDefinition->isPublic());
+        static::assertFalse($untaggedDefinition->hasTag('container.service_subscriber'));
+
+        // Tagged should be processed
+        static::assertTrue($taggedDefinition->isPublic());
+        static::assertTrue($taggedDefinition->hasTag('container.service_subscriber'));
+    }
+}

--- a/tests/unit/Storefront/DependencyInjection/Compiler/StorefrontControllerCompilerPassTest.php
+++ b/tests/unit/Storefront/DependencyInjection/Compiler/StorefrontControllerCompilerPassTest.php
@@ -33,9 +33,9 @@ class StorefrontControllerCompilerPassTest extends TestCase
         $definition->addTag('controller.service_arguments');
 
         $container->setDefinition('test.controller', $definition);
-        
+
         // Capture initial state
-        $methodCallsBefore = count($definition->getMethodCalls());
+        $methodCallsBefore = \count($definition->getMethodCalls());
 
         $this->compilerPass->process($container);
 
@@ -80,13 +80,13 @@ class StorefrontControllerCompilerPassTest extends TestCase
         // Verify the controller can access its dependencies
         // Without being prescriptive about the exact mechanism
         static::assertTrue($definition->hasTag('container.service_subscriber'));
-        
+
         // Verify some form of dependency injection is configured
-        $hasDependencyInjection = 
-            $definition->isAutowired() || 
-            count($definition->getMethodCalls()) > 0 || 
-            count($definition->getArguments()) > 0;
-        
+        $hasDependencyInjection =
+            $definition->isAutowired()
+            || \count($definition->getMethodCalls()) > 0
+            || \count($definition->getArguments()) > 0;
+
         static::assertTrue($hasDependencyInjection);
     }
 
@@ -102,18 +102,18 @@ class StorefrontControllerCompilerPassTest extends TestCase
         $definition->addMethodCall('setContainer', [new Reference('Psr\Container\ContainerInterface')]);
 
         $container->setDefinition('test.controller', $definition);
-        
+
         // Run the compiler pass twice
         $this->compilerPass->process($container);
         $stateAfterFirst = [
-            'methodCalls' => count($definition->getMethodCalls()),
-            'tags' => count($definition->getTags()),
+            'methodCalls' => \count($definition->getMethodCalls()),
+            'tags' => \count($definition->getTags()),
         ];
-        
+
         $this->compilerPass->process($container);
         $stateAfterSecond = [
-            'methodCalls' => count($definition->getMethodCalls()),
-            'tags' => count($definition->getTags()),
+            'methodCalls' => \count($definition->getMethodCalls()),
+            'tags' => \count($definition->getTags()),
         ];
 
         // Verify the compiler pass is idempotent (doesn't duplicate configuration)
@@ -176,12 +176,12 @@ class StorefrontControllerCompilerPassTest extends TestCase
         // Service without controller tag should be ignored
         $untaggedDefinition = new Definition(AccountOrderController::class);
         $untaggedDefinition->setPublic(false);
-        
+
         // Service with controller tag should be processed
         $taggedDefinition = new Definition(AccountOrderController::class);
         $taggedDefinition->setPublic(false);
         $taggedDefinition->addTag('controller.service_arguments');
-        
+
         $container->setDefinition('untagged.controller', $untaggedDefinition);
         $container->setDefinition('tagged.controller', $taggedDefinition);
 


### PR DESCRIPTION
## Why this change?
Storefront controllers currently inject the entire Symfony container, which goes against Symfony best practices. This makes it difficult to understand controller dependencies and prevents the use of modern Symfony features like autoconfigure/autowire.

## What does it do?
Implements Symfony's ServiceSubscriberInterface pattern to provide controllers with a service locator containing only declared services. This aligns with Symfony's recommended approach for controller service injection.

Key improvements:
- Controllers receive a service locator instead of the full container
- Services are explicitly declared via getSubscribedServices()
- Enables autoconfigure/autowire support for modern Symfony patterns
- Maintains full backward compatibility through compiler pass
- Provides PSR ContainerInterface service for autowiring support

## How to test
1. Load any storefront page - should work without errors
2. Verify existing plugins with custom controllers continue working
3. Test autowired controllers (e.g., SwagCommercial plugins)

## Resolves
#3462

## Breaking changes
Controllers extending StorefrontController must declare custom services in getSubscribedServices(). Direct container access still works with deprecation warnings until 6.9.0. See changelog for migration guide.