### PR TITLE
fix: add safety measure for empty passwords

### DIFF
--- a/src/Core/Framework/Api/OAuth/UserRepository.php
+++ b/src/Core/Framework/Api/OAuth/UserRepository.php
@@ -38,6 +38,11 @@ class UserRepository implements UserRepositoryInterface
             return null;
         }
 
+        if ($password === '' || (string) $user['password'] === '') {
+            // never allow login with empty password or empty hash
+            return null;
+        }
+
         if (!password_verify($password, (string) $user['password'])) {
             return null;
         }


### PR DESCRIPTION
In practice this point in the login code should never be reached with an empty password (it's validated to be non empty as request parameter). But for good measure and also to not run `password_verify` with empty hashes this change makes it a little more robust and obvious.