### PR TITLE
fix: Admin es search for "document number" doesn't return any results…

### DIFF
--- a/changelog/_unreleased/2025-08-20-fix-admin-es-search-for-document-number-does-not-return-any-result.md
+++ b/changelog/_unreleased/2025-08-20-fix-admin-es-search-for-document-number-does-not-return-any-result.md
@@ -1,0 +1,6 @@
+---
+title: Fix admin es search for document number does not return any result
+issue: 11074
+---
+# Core
+* Changed `fetch` method in `Shopware\Elasticsearch\Admin\Indexer\OrderAdminSearchIndexer` to fetch all document numbers for orders.

--- a/src/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexer.php
+++ b/src/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexer.php
@@ -142,7 +142,7 @@ final class OrderAdminSearchIndexer extends AbstractAdminIndexer
                 LEFT JOIN order_delivery
                     ON `order`.id = order_delivery.order_id AND order_delivery.order_version_id = :versionId
                 LEFT JOIN document
-                    ON `order`.id = document.order_id AND document.order_version_id = :versionId
+                    ON `order`.id = document.order_id
             WHERE order.id IN (:ids) AND `order`.version_id = :versionId
             GROUP BY order.id
         ',

--- a/tests/unit/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexerTest.php
@@ -141,7 +141,51 @@ class OrderAdminSearchIndexerTest extends TestCase
     {
         $connection = $this->createMock(Connection::class);
 
-        $connection->method('fetchAllAssociative')->willReturn(
+        $connection->method('fetchAllAssociative')->with(
+            '
+            SELECT LOWER(HEX(order.id)) as id,
+                   GROUP_CONCAT(DISTINCT tag.name SEPARATOR " ") as tags,
+                   GROUP_CONCAT(DISTINCT country_translation.name SEPARATOR " ") as country,
+                   GROUP_CONCAT(DISTINCT order_address.city SEPARATOR " ") as city,
+                   GROUP_CONCAT(DISTINCT order_address.street SEPARATOR " ") as street,
+                   GROUP_CONCAT(DISTINCT order_address.zipcode SEPARATOR " ") as zipcode,
+                   GROUP_CONCAT(DISTINCT order_address.phone_number SEPARATOR " ") as phone_number,
+                   GROUP_CONCAT(DISTINCT order_address.additional_address_line1 SEPARATOR " ") as additional_address_line1,
+                   GROUP_CONCAT(DISTINCT order_address.additional_address_line2 SEPARATOR " ") as additional_address_line2,
+                   GROUP_CONCAT(DISTINCT JSON_UNQUOTE(JSON_EXTRACT(document.config, "$.documentNumber")) SEPARATOR " ") as documentNumber,
+                   order_customer.first_name,
+                   order_customer.last_name,
+                   order_customer.email,
+                   order_customer.company,
+                   order_customer.customer_number,
+                   `order`.order_number,
+                   `order`.amount_total,
+                   order_delivery.tracking_codes
+            FROM `order`
+                LEFT JOIN order_customer
+                    ON `order`.id = order_customer.order_id AND order_customer.order_version_id = :versionId
+                LEFT JOIN order_address
+                    ON `order`.id = order_address.order_id AND order_address.order_version_id = :versionId
+                LEFT JOIN country
+                    ON order_address.country_id = country.id
+                LEFT JOIN country_translation
+                    ON country.id = country_translation.country_id
+                LEFT JOIN order_tag
+                    ON `order`.id = order_tag.order_id AND order_tag.order_version_id = :versionId
+                LEFT JOIN tag
+                    ON order_tag.tag_id = tag.id
+                LEFT JOIN order_delivery
+                    ON `order`.id = order_delivery.order_id AND order_delivery.order_version_id = :versionId
+                LEFT JOIN document
+                    ON `order`.id = document.order_id
+            WHERE order.id IN (:ids) AND `order`.version_id = :versionId
+            GROUP BY order.id
+        ',
+            [
+                'ids' => Uuid::fromHexToBytesList(['809c1844f4734243b6aa04aba860cd45']),
+                'versionId' => Uuid::fromHexToBytes('0fa91ce3e96a4bc2be4bd9ce752c3425'),
+            ]
+        )->willReturn(
             [
                 [
                     'id' => '809c1844f4734243b6aa04aba860cd45',


### PR DESCRIPTION
This pull request addresses an issue where searching for orders by document number in the admin Elasticsearch interface was not returning any results. The main fix ensures that all document numbers for orders are correctly fetched and indexed, improving search reliability for document numbers.

**Core functionality fix:**

* Updated the SQL query in the `fetch` method of `OrderAdminSearchIndexer` to remove the `order_version_id` condition from the join with the `document` table, ensuring all document numbers are fetched for each order.