### PR TITLE
chore: Add route attribute

### DIFF
--- a/src/Core/PlatformRequest.php
+++ b/src/Core/PlatformRequest.php
@@ -66,6 +66,7 @@ final class PlatformRequest
     public const ATTRIBUTE_ACL = '_acl';
     public const ATTRIBUTE_CAPTCHA = '_captcha';
     public const ATTRIBUTE_ROUTE_SCOPE = '_routeScope';
+    public const ATTRIBUTE_ROUTE = '_route';
     public const ATTRIBUTE_ENTITY = '_entity';
     public const ATTRIBUTE_NO_STORE = '_noStore';
     public const ATTRIBUTE_HTTP_CACHE = '_httpCache';


### PR DESCRIPTION
I noticed that there is no const for the `_route` attribute resulting in a bunch of "magic" strings in the code base. Would you mind considering this addition? If this get's accepted please also backport it to 6.6.x.
