### PR TITLE
feat: Add feature toggle for oder.transactions property in documents

### DIFF
--- a/src/Core/Framework/Resources/views/documents/includes/payment_shipping.html.twig
+++ b/src/Core/Framework/Resources/views/documents/includes/payment_shipping.html.twig
@@ -14,7 +14,11 @@ All blocks of this template are available in the template which renders this tem
         <div class="payment-shipping-container" tabindex="0">
             {% block document_payment_shipping_inner %}
                 {% block document_payment %}
-                    {{ 'document.paymentShippingInfo.paymentMethod'|trans({'%paymentMethod%': order.transactions.last.paymentMethod.translated.name})|sw_sanitize }}<br>
+                    {% if feature('v6.8.0.0') %}
+                        {{ 'document.paymentShippingInfo.paymentMethod'|trans({'%paymentMethod%': order.primaryOrderTransaction.paymentMethod.translated.name})|sw_sanitize }}<br>
+                    {% else %}
+                        {{ 'document.paymentShippingInfo.paymentMethod'|trans({'%paymentMethod%': order.transactions.last.paymentMethod.translated.name})|sw_sanitize }}<br>
+                    {% endif %}
                 {% endblock %}
                 {% block document_shipping %}
                     {{ 'document.paymentShippingInfo.shippingMethod'|trans({'%shippingMethod%': order.deliveries.first.shippingMethod.translated.name})|sw_sanitize }}<br><br>

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/credit_note_renderer_default.html
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/credit_note_renderer_default.html
@@ -525,8 +525,8 @@
     
 
                         <div class="payment-shipping-container" tabindex="0">
-                                                <strong>Payment method:</strong> Payment<br>
-                                                    <strong>Shipping method:</strong> test shipping method<br><br>
+                                                                        <strong>Payment method:</strong> Payment<br>
+                                                                        <strong>Shipping method:</strong> test shipping method<br><br>
                                                     Delivered goods remain our property until full payment has been made.<br>
                                                     Service date equivalent to invoice date<br>
                                                                                         </div>

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/delivery_note_renderer_default.html
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/delivery_note_renderer_default.html
@@ -503,8 +503,8 @@
                 
 
                         <div class="payment-shipping-container" tabindex="0">
-                                                <strong>Payment method:</strong> Cash on delivery<br>
-                                                    <strong>Shipping method:</strong> Standard<br><br>
+                                                                        <strong>Payment method:</strong> Cash on delivery<br>
+                                                                        <strong>Shipping method:</strong> Standard<br><br>
                                                     Delivered goods remain our property until full payment has been made.<br>
                                                     Service date equivalent to invoice date<br>
                                                                                         </div>

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/invoice_renderer_default.html
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/invoice_renderer_default.html
@@ -542,8 +542,8 @@
     
 
                         <div class="payment-shipping-container" tabindex="0">
-                                                <strong>Payment method:</strong> Cash on delivery<br>
-                                                    <strong>Shipping method:</strong> Standard<br><br>
+                                                                        <strong>Payment method:</strong> Cash on delivery<br>
+                                                                        <strong>Shipping method:</strong> Standard<br><br>
                                                     Delivered goods remain our property until full payment has been made.<br>
                                                     Service date equivalent to invoice date<br>
                                                                                         </div>

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/storno_renderer_default.html
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/storno_renderer_default.html
@@ -546,8 +546,8 @@
     
 
                         <div class="payment-shipping-container" tabindex="0">
-                                                <strong>Payment method:</strong> Cash on delivery<br>
-                                                    <strong>Shipping method:</strong> Standard<br><br>
+                                                                        <strong>Payment method:</strong> Cash on delivery<br>
+                                                                        <strong>Shipping method:</strong> Standard<br><br>
                                                     Delivered goods remain our property until full payment has been made.<br>
                                                     Service date equivalent to invoice date<br>
                                                                                         </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

This change is necessary, to ensure the major integration tests in commercial continue to succeed when testing documents.

### 2. What does this change do, exactly?

This change introduces a feature toggle around the `oder.transactions` property, which is used in document tempaltes and will be replaced with `order.primaryOrderTransation` in v6.8.0.0.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #12080 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
