### PR TITLE
chore: add natural sorting for property option list

### DIFF
--- a/changelog/_unreleased/2025-08-26-add-natural-sorting-for-property-option-list.md
+++ b/changelog/_unreleased/2025-08-26-add-natural-sorting-for-property-option-list.md
@@ -1,0 +1,8 @@
+---
+title: Add natural sorting for property option list
+author: Lee Nguyen
+author_email: nguyenquocdaile@gmail.com
+author_github: @nguyenquocdaile
+---
+# Administration
+* Added `useNaturalNameSorting` computed, which was computed to check whether a property option contains a number in `src/module/sw-property/component/sw-property-option-list/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
@@ -67,6 +67,19 @@ export default {
             return this.propertyGroup.isLoading || !this.isSystemLanguage || !this.acl.can('property.editor');
         },
 
+        useNaturalNameSorting() {
+            const options = this.propertyGroup?.options || [];
+
+            if (!options.length) {
+                return false;
+            }
+
+            return options.some((option) => {
+                const name = (option?.translated?.name ?? option?.name ?? '').toString();
+                return /\d/.test(name);
+            });
+        },
+
         /**
          * @deprecated tag:v6.8.0 - Will be removed
          */
@@ -183,6 +196,7 @@ export default {
                     routerLink: 'sw.property.detail',
                     inlineEdit: 'string',
                     primary: true,
+                    naturalSorting: this.useNaturalNameSorting,
                 },
                 {
                     property: 'colorHexCode',

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
@@ -203,4 +203,59 @@ describe('module/sw-property/component/sw-property-option-list', () => {
 
         expect(wrapper.find('.modal').exists()).toBe(false);
     });
+
+    it('should disable natural sorting when names are purely alphabetical', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        const columns = wrapper.vm.getGroupColumns();
+        const nameColumn = columns.find((c) => c.property === 'name');
+
+        expect(nameColumn).toBeTruthy();
+        expect(nameColumn.naturalSorting).toBe(false);
+    });
+
+    it('should enable natural sorting when at least one name contains digits', async () => {
+        const numericOptions = [
+            {
+                groupId: 'group-1',
+                name: '1mm',
+                position: 1,
+                colorHexCode: null,
+                translated: { name: '1mm', position: 1, customFields: [] },
+                id: 'opt-1',
+            },
+            {
+                groupId: 'group-1',
+                name: '10mm',
+                position: 2,
+                colorHexCode: null,
+                translated: { name: '10mm', position: 2, customFields: [] },
+                id: 'opt-2',
+            },
+            {
+                groupId: 'group-1',
+                name: '2mm',
+                position: 3,
+                colorHexCode: null,
+                translated: { name: '2mm', position: 3, customFields: [] },
+                id: 'opt-3',
+            },
+        ];
+
+        const wrapper = await createWrapper();
+        await wrapper.setProps({
+            propertyGroup: {
+                ...propertyGroup,
+                options: numericOptions,
+            },
+        });
+        await flushPromises();
+
+        const columns = wrapper.vm.getGroupColumns();
+        const nameColumn = columns.find((c) => c.property === 'name');
+
+        expect(nameColumn).toBeTruthy();
+        expect(nameColumn.naturalSorting).toBe(true);
+    });
 });


### PR DESCRIPTION
### Description
Sorting will not be correct if the property option contains text and numbers.

<img width="1073" height="626" alt="image" src="https://github.com/user-attachments/assets/fa196e61-4370-44a6-a5b1-cc5b96ecade4" />

Adding naturalSoting: true will not correct for case text only.

<img width="1005" height="589" alt="image" src="https://github.com/user-attachments/assets/5d4d5b64-4d2d-4ac2-aef6-1fa544a0708c" />
