### PR TITLE
fix: deny bulk delete of promotions if orderCount

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -370,7 +370,7 @@
         margin: 0;
         line-height: var(--font-line-height-xs);
         font-size: var(--font-size-xs);
-        padding: var(--scale-size-4) var(--scale-size-12);
+        padding: 0 var(--scale-size-12);
         text-decoration: none;
         color: var(--color-text-primary-default);
         cursor: pointer;

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/index.js
@@ -66,6 +66,10 @@ export default {
         dateFilter() {
             return Shopware.Filter.getByName('date');
         },
+
+        allowBulkDelete() {
+            return !this.selectionArray.some(item => item.orderCount > 0);
+        },
     },
 
     methods: {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/index.js
@@ -68,7 +68,7 @@ export default {
         },
 
         allowBulkDelete() {
-            return !this.selectionArray.some(item => item.orderCount > 0);
+            return !this.selectionArray.some((item) => item.orderCount > 0);
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.html.twig
@@ -79,6 +79,7 @@
                 :show-selection="acl.can('promotion.deleter') || undefined"
                 :allow-edit="acl.can('promotion.editor') || undefined"
                 :allow-view="acl.can('promotion.viewer') || undefined"
+                :allow-delete="allowBulkDelete"
                 allow-column-edit
                 full-page
                 @update-records="updateTotal"

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.spec.js
@@ -290,12 +290,12 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-list', () => {
         const promotionWithOrders = { orderCount: 1 };
         const promotionWithoutOrders = { orderCount: 0 };
 
-        wrapper.vm.updateSelection({0: promotionWithoutOrders});
+        wrapper.vm.updateSelection({ 0: promotionWithoutOrders });
         await flushPromises();
-        expect(wrapper.find('sw-entity-listing-stub').attributes()['allow-delete']).toBe("true");
+        expect(wrapper.find('sw-entity-listing-stub').attributes()['allow-delete']).toBe('true');
 
-        wrapper.vm.updateSelection({0: promotionWithoutOrders, 1: promotionWithOrders});
+        wrapper.vm.updateSelection({ 0: promotionWithoutOrders, 1: promotionWithOrders });
         await flushPromises();
-        expect(wrapper.find('sw-entity-listing-stub').attributes()['allow-delete']).toBe("false");
+        expect(wrapper.find('sw-entity-listing-stub').attributes()['allow-delete']).toBe('false');
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.spec.js
@@ -283,4 +283,19 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-list', () => {
             disabled: true,
         });
     });
+
+    it('should disable bulk delete with undeletable promotions', async () => {
+        const wrapper = await createWrapper();
+
+        const promotionWithOrders = { orderCount: 1 };
+        const promotionWithoutOrders = { orderCount: 0 };
+
+        wrapper.vm.updateSelection({0: promotionWithoutOrders});
+        await flushPromises();
+        expect(wrapper.find('sw-entity-listing-stub').attributes()['allow-delete']).toBe("true");
+
+        wrapper.vm.updateSelection({0: promotionWithoutOrders, 1: promotionWithOrders});
+        await flushPromises();
+        expect(wrapper.find('sw-entity-listing-stub').attributes()['allow-delete']).toBe("false");
+    });
 });

--- a/src/Core/Checkout/DependencyInjection/promotion.xml
+++ b/src/Core/Checkout/DependencyInjection/promotion.xml
@@ -214,6 +214,12 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>
 
+        <service id="Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionValidator">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\CartScopeDiscountPackager"/>
 
         <service id="Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\SetGroupScopeDiscountPackager">

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionValidator.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionValidator.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Promotion\DataAbstractionLayer;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Promotion\PromotionDefinition;
+use Shopware\Core\Checkout\Promotion\PromotionException;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class PromotionValidator implements EventSubscriberInterface
+{
+    /**
+     * @internal
+     */
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    /**
+     * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreWriteValidationEvent::class => 'validate',
+        ];
+    }
+
+    public function validate(PreWriteValidationEvent $event): void
+    {
+        $ids = $event->getDeletedPrimaryKeys(PromotionDefinition::ENTITY_NAME);
+
+        $ids = \array_column($ids, 'id');
+
+        if (empty($ids)) {
+            return;
+        }
+
+        $pluginIds = $this->connection->fetchOne(
+            'SELECT id FROM promotion WHERE id IN (:ids) AND order_count > 0',
+            ['ids' => $ids],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+
+        if (!empty($pluginIds)) {
+            throw PromotionException::promotionUsedDeleteRestriction();
+        }
+    }
+}

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionValidator.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionValidator.php
@@ -43,13 +43,13 @@ class PromotionValidator implements EventSubscriberInterface
             return;
         }
 
-        $pluginIds = $this->connection->fetchOne(
+        $promotionIds = $this->connection->fetchOne(
             'SELECT id FROM promotion WHERE id IN (:ids) AND order_count > 0',
             ['ids' => $ids],
             ['ids' => ArrayParameterType::BINARY]
         );
 
-        if (!empty($pluginIds)) {
+        if (!empty($promotionIds)) {
             throw PromotionException::promotionUsedDeleteRestriction();
         }
     }

--- a/src/Core/Checkout/Promotion/PromotionException.php
+++ b/src/Core/Checkout/Promotion/PromotionException.php
@@ -39,6 +39,7 @@ class PromotionException extends HttpException
     public const FILTER_SORTER_NOT_FOUND = 'CHECKOUT__FILTER_SORTER_NOT_FOUND';
     public const FILTER_PICKER_NOT_FOUND = 'CHECKOUT__FILTER_PICKER_NOT_FOUND';
     public const PROMOTION_USAGE_LOCKED = 'CHECKOUT__PROMOTION_USAGE_LOCKED';
+    public const PROMOTION_USED_DELETE_RESTRICTION = 'CHECKOUT__PROMOTION_USED_DELETE_RESTRICTION';
 
     public static function codeAlreadyRedeemed(string $code): self
     {
@@ -261,6 +262,16 @@ class PromotionException extends HttpException
             self::PROMOTION_USAGE_LOCKED,
             'Promotion {{ promotion }} is locked due to concurrent write operation. Please try again later.',
             ['promotion' => $promotionCodeOrId]
+        );
+    }
+
+    public static function promotionUsedDeleteRestriction(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::PROMOTION_USED_DELETE_RESTRICTION,
+            'Promotions cannot be deleted once they have been used in an order.',
+            [],
         );
     }
 }

--- a/tests/unit/Core/Checkout/Promotion/DataAbstractionLayer/PromotionValidatorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/DataAbstractionLayer/PromotionValidatorTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Promotion\DataAbstractionLayer;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionValidator;
+use Shopware\Core\Checkout\Promotion\PromotionDefinition;
+use Shopware\Core\Checkout\Promotion\PromotionException;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(PromotionValidator::class)]
+class PromotionValidatorTest extends TestCase
+{
+    private StaticDefinitionInstanceRegistry $definitionInstanceRegistry;
+
+    protected function setUp(): void
+    {
+        $this->definitionInstanceRegistry = new StaticDefinitionInstanceRegistry(
+            [PromotionDefinition::class],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        static::assertSame(
+            [
+                PreWriteValidationEvent::class => 'validate',
+            ],
+            PromotionValidator::getSubscribedEvents()
+        );
+    }
+
+    public function testValidate(): void
+    {
+        $promotionId = Uuid::randomBytes();
+
+        $context = Context::createDefaultContext();
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [new DeleteCommand(
+                $this->definitionInstanceRegistry->get(PromotionDefinition::class),
+                ['id' => $promotionId],
+                new EntityExistence(PromotionDefinition::ENTITY_NAME, ['id' => $promotionId], true, false, false, [])
+            )],
+        );
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchOne')
+            ->with(
+                'SELECT id FROM promotion WHERE id IN (:ids) AND order_count > 0',
+                ['ids' => [$promotionId]],
+                ['ids' => ArrayParameterType::BINARY]
+            )
+            ->willReturn(false);
+
+        $subscriber = new PromotionValidator($connection);
+        $subscriber->validate($event);
+    }
+
+    public function testValidateWithOrderCount(): void
+    {
+        $promotionId = Uuid::randomBytes();
+
+        $context = Context::createDefaultContext();
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [new DeleteCommand(
+                $this->definitionInstanceRegistry->get(PromotionDefinition::class),
+                ['id' => $promotionId],
+                new EntityExistence(PromotionDefinition::ENTITY_NAME, ['id' => $promotionId], true, false, false, [])
+            )],
+        );
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchOne')
+            ->with(
+                'SELECT id FROM promotion WHERE id IN (:ids) AND order_count > 0',
+                ['ids' => [$promotionId]],
+                ['ids' => ArrayParameterType::BINARY]
+            )
+            ->willReturn('someId');
+
+        $this->expectException(PromotionException::class);
+        $this->expectExceptionMessage('Promotions cannot be deleted once they have been used in an order.');
+        $subscriber = new PromotionValidator($connection);
+        $subscriber->validate($event);
+    }
+
+    public function testValidateWithoutCommand(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            []
+        );
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())
+            ->method('fetchOne');
+
+        $subscriber = new PromotionValidator($connection);
+        $subscriber->validate($event);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Promotions should not be deleteable, if they have already been used. But Bulk Delete is still possible, even if the singular delete is disabled.

### 2. What does this change do, exactly?
Toggles bulk delete when a promotion is used.

### 3. Describe each step to reproduce the issue or behaviour.
Create a promotion, use it in an order, try to delete via bulk edit.

### 4. Please link to the relevant issues (if any).
fixes #11946

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
