### PR TITLE
feat: add crud permission shortcut

### DIFF
--- a/changelog/_unreleased/2025-08-27-add-a-crud-permission-shortcut-to-manifest.md
+++ b/changelog/_unreleased/2025-08-27-add-a-crud-permission-shortcut-to-manifest.md
@@ -1,0 +1,7 @@
+---
+title: Add a crud permission shortcut to manifest
+---
+
+# Core
+
+* Added `<crud>` element to App manifest to allow requesting create/read/update/delete permission in one xml element

--- a/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
+++ b/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
@@ -213,6 +213,7 @@
             <xs:element name="create" maxOccurs="unbounded" type="xs:string"/>
             <xs:element name="update" maxOccurs="unbounded" type="xs:string"/>
             <xs:element name="delete" maxOccurs="unbounded" type="xs:string"/>
+            <xs:element name="crud" maxOccurs="unbounded" type="xs:string"/>
             <xs:element name="permission" maxOccurs="unbounded" type="xs:string"/>
         </xs:choice>
     </xs:complexType>

--- a/src/Core/Framework/App/Manifest/Xml/Permission/Permissions.php
+++ b/src/Core/Framework/App/Manifest/Xml/Permission/Permissions.php
@@ -95,6 +95,15 @@ class Permissions extends XmlElement
                 continue;
             }
 
+            if ($child->tagName === 'crud') {
+                $permissions[$child->nodeValue][] = AclRoleDefinition::PRIVILEGE_READ;
+                $permissions[$child->nodeValue][] = AclRoleDefinition::PRIVILEGE_CREATE;
+                $permissions[$child->nodeValue][] = AclRoleDefinition::PRIVILEGE_UPDATE;
+                $permissions[$child->nodeValue][] = AclRoleDefinition::PRIVILEGE_DELETE;
+
+                continue;
+            }
+
             $permissions[$child->nodeValue][] = $child->tagName;
         }
 

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Permission/PermissionsTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Permission/PermissionsTest.php
@@ -57,4 +57,22 @@ class PermissionsTest extends TestCase
             'user_change_me',
         ], $manifest->getPermissions()->asParsedPrivileges());
     }
+
+    public function testCrudPermission(): void
+    {
+        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../../_fixtures/test/manifest_crud.xml');
+
+        static::assertNotNull($manifest->getPermissions());
+        static::assertCount(8, $manifest->getPermissions()->asParsedPrivileges());
+        static::assertSame([
+            'product:create',
+            'product:read',
+            'product:update',
+            'product:delete',
+            'category:read',
+            'category:create',
+            'category:update',
+            'category:delete',
+        ], $manifest->getPermissions()->asParsedPrivileges());
+    }
 }

--- a/tests/unit/Core/Framework/App/Manifest/_fixtures/test/manifest_crud.xml
+++ b/tests/unit/Core/Framework/App/Manifest/_fixtures/test/manifest_crud.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>test</name>
+        <label>Swag App Test</label>
+        <label lang="de-DE">Swag App Test</label>
+        <description>Test for App System</description>
+        <description lang="de-DE">Test für das App System</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <icon>icon.png</icon>
+        <license>MIT</license>
+        <privacy>https://test.com/privacy</privacy>
+        <privacyPolicyExtensions></privacyPolicyExtensions>
+    </meta>
+    <permissions>
+        <create>product</create>
+        <update>product</update>
+        <delete>product</delete>
+        <crud>category</crud>
+    </permissions>
+</manifest>


### PR DESCRIPTION
### 1. Why is this change necessary?

Building an app with many permissions gets an hassle as you have a huge list of permissions:

```xml
<!-- Product-->
        <read>product</read>
        <create>product</create>
        <delete>product</delete>
        <update>product</update>

        <read>product_translation</read>
        <create>product_translation</create>
        <delete>product_translation</delete>
        <update>product_translation</update>

        <read>product_visibility</read>
        <create>product_visibility</create>
        <delete>product_visibility</delete>
        <update>product_visibility</update>

        <read>product_category</read>
        <create>product_category</create>
        <delete>product_category</delete>
        <update>product_category</update>

        <!-- Category -->
        <read>category</read>
        <create>category</create>
        <delete>category</delete>
        <update>category</update>

        <read>category_translation</read>
        <create>category_translation</create>
        <delete>category_translation</delete>
        <update>category_translation</update>
        
        <!-- Sales Channel -->
        <read>sales_channel</read>
        <create>sales_channel</create>
        <delete>sales_channel</delete>
        <update>sales_channel</update>

        <!-- Media -->
        <read>media</read>
        <create>media</create>
        <delete>media</delete>
        <update>media</update>

        <!-- Tax -->
        <read>tax</read>
        <create>tax</create>
        <delete>tax</delete>
        <update>tax</update>
```




### 2. What does this change do, exactly?

Introduce a shortcut `<crud>` element

replaces above with:

```xml
<crud>product</crud>
<crud>product_translation</crud>
<crud>product_visibility</crud>
<crud>product_category</crud>
<crud>category</crud>
<crud>category_translation</crud>
<crud>sales_channel</crud>
<crud>media</crud>
<crud>tax</crud>
```

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
