### PR TITLE
fix: production environment detection in extension API

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.spec.js
@@ -604,9 +604,11 @@ describe('core/service/extension-api-data.service.ts', () => {
         let envBefore;
         if (env === 'prod') {
             envBefore = process.env;
-            process.env = 'prod';
+            process.env = { NODE_ENV: 'production' };
             Shopware.Utils.debug.warn = mock;
         } else {
+            envBefore = process.env;
+            process.env = {};
             Shopware.Utils.debug.error = mock;
         }
 

--- a/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.ts
@@ -140,8 +140,7 @@ handleGet((data, additionalOptions) => {
             // eslint-disable-next-line max-len
             `The extension "${extension.name}" uses a deprecated data set "${data.id}". ${registeredDataSet.deprecationMessage}`,
         ];
-        // @ts-expect-error
-        if (process.env !== 'prod') {
+        if (process.env.NODE_ENV !== 'production') {
             Shopware.Utils.debug.error(...debugArgs);
         } else {
             Shopware.Utils.debug.warn(...debugArgs);


### PR DESCRIPTION
### 1. Why is this change necessary?

`process.env` is a collection of env variables, comparing it to a string does not make sense.

### 2. What does this change do, exactly?

The environment detection used here was implemented oddly and then covered up with a ts-expect-error .

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
