### PR TITLE
fix: Consider landing page assignments in CMS page list

### DIFF
--- a/changelog/_unreleased/2025-08-27-consider-landing-page-assignments-in-cms-page-list.md
+++ b/changelog/_unreleased/2025-08-27-consider-landing-page-assignments-in-cms-page-list.md
@@ -1,0 +1,9 @@
+---
+title: Consider landing page assignments in CMS page list
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `sw-cms-list` component to consider landing page assignments.
+* Deprecated `associatedCategoryBuckets` and `associatedProductBuckets` computed properties of `sw-cms-list` component.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
@@ -243,6 +243,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -253,6 +254,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 2',
                     },
@@ -263,6 +265,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 2',
                     },
@@ -305,6 +308,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -315,6 +319,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 2',
                     },
@@ -325,6 +330,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 2',
                     },
@@ -372,6 +378,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -434,6 +441,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                         sections: [],
                         categories: [],
                         products: [],
+                        landingPages: [],
                         translated: {
                             name: 'CMS Page 1',
                         },
@@ -460,6 +468,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -490,6 +499,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -511,6 +521,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -542,6 +553,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -583,6 +595,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -623,6 +636,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -663,6 +677,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -700,6 +715,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -732,6 +748,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -764,6 +781,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -796,6 +814,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -822,6 +841,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                 sections: [],
                 categories: [],
                 products: [{ id: 'abc' }],
+                landingPages: [],
                 translated: {
                     name: 'CMS Page 1',
                 },
@@ -864,6 +884,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -925,11 +946,23 @@ describe('module/sw-cms/page/sw-cms-list', () => {
             };
         });
 
+        const expectedLandingPages = [
+            'LandingPage 1',
+            'LandingPage 2',
+            'LandingPage 3',
+        ];
+        const landingPageObjects = expectedLandingPages.map((landingPage) => {
+            return {
+                name: landingPage,
+            };
+        });
+
         const mockPage = {
             id: '1',
             sections: [],
             categories: categoryObjects,
             products: [],
+            landingPages: [],
             translated: {
                 name: 'CMS Page 1',
             },
@@ -955,6 +988,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
             message: 'Category 1, Category 3, Category 2, Product 1, Product 2, Product 3',
             disabled: false,
         });
+
+        mockPage.landingPages = landingPageObjects;
+
+        expect(wrapper.vm.getPages(mockPage)).toStrictEqual([
+            ...expectedCategories,
+            ...expectedProducts,
+            ...expectedLandingPages,
+        ]);
+        expect(wrapper.vm.getPagesTooltip(mockPage)).toStrictEqual({
+            width: 300,
+            message:
+                'Category 1, Category 3, Category 2, Product 1, Product 2, Product 3, LandingPage 1, LandingPage 2, LandingPage 3',
+            disabled: false,
+        });
     });
 
     it('should indicate layouts already assigned to pages', async () => {
@@ -968,6 +1015,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 1',
                     },
@@ -977,6 +1025,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     translated: {
                         name: 'CMS Page 2',
                     },
@@ -1122,6 +1171,7 @@ describe('module/sw-cms/page/sw-cms-list', () => {
                     sections: [],
                     categories: [],
                     products: [],
+                    landingPages: [],
                     name: 'CMS Page 1',
                     translated: {
                         name: 'CMS Page 1',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -8,6 +8,7 @@
       "createNewLayout": "Neues Layout anlegen",
       "deleteDisabledToolTip": "Das Layout ist noch mindestens einer Kategorie zugewiesen.",
       "deleteDisabledProductToolTip": "Das Layout ist noch mindestens einem Produkt zugewiesen.",
+      "deleteDisabledLandingPageToolTip": "Das Layout ist noch mindestens einer Landingpage zugewiesen.",
       "disabledAddingBlocksToolTip": "Blöcke können nur in der System-Standardsprache hinzugefügt werden.",
       "privacyNotice": "Ich habe die <a href=\"%privacyUrl%\">Datenschutzbestimmungen</a> zur Kenntnis genommen und die <a href=\"%tosUrl%\">AGB</a> gelesen und bin mit ihnen einverstanden."
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -8,6 +8,7 @@
       "createNewLayout": "Create new layout",
       "deleteDisabledToolTip": "The layout you want to delete is still assigned to at least one category.",
       "deleteDisabledProductToolTip": "The layout you want to delete is still assigned to at least one product.",
+      "deleteDisabledLandingPageToolTip": "The layout you want to delete is still assigned to at least one landing page.",
       "disabledAddingBlocksToolTip": "Adding blocks only works in your default system language.",
       "privacyNotice": "By selecting continue you confirm that you have read our <a href=\"%privacyUrl%\">data protection information</a> and accepted our <a href=\"%tosUrl%\">general terms and conditions</a>."
     },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
CMS page assignments in landing pages are not considered in the CMS page listing.

### 2. What does this change do, exactly?
* Changed `sw-cms-list` component to consider landing page assignments.
* Deprecated `associatedCategoryBuckets` and `associatedProductBuckets` computed properties of `sw-cms-list` component.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new CMS page > assign it to a landing page > go to CMS pages > the assignment is not displayed

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
