### PR TITLE
feat: Add custom action button on media sidebar

### DIFF
--- a/changelog/_unreleased/2025-09-03-add-custom-action-in-media-sidebar.md
+++ b/changelog/_unreleased/2025-09-03-add-custom-action-in-media-sidebar.md
@@ -1,0 +1,13 @@
+---
+title: Add custom action in media sidebar
+author: Quynh Nguyen
+author_email: q.nguyen@shopware.com
+author_github: quynhnguyen68
+---
+# Administration
+* Added block `sw_media_quickinfo_quickactions_custom_action` in `src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig` to show action buttons in media sidebar.
+* Changed in `src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js`
+    * Added computed property `extensionSdkButtons` to show action buttons.
+    * Added method `runAppAction` to call action button's callback function.
+
+* Changed in `src/app/component/app/sw-app-action-button/sw-app-action-button.html.twig` to show meteor icon for action button.

--- a/src/Administration/Resources/app/administration/blocks-list.json
+++ b/src/Administration/Resources/app/administration/blocks-list.json
@@ -3238,6 +3238,7 @@
  "sw_media_quickinfo_quickactions",
  "sw_media_quickinfo_quickactions_content",
  "sw_media_quickinfo_quickactions_copy_link",
+ "sw_media_quickinfo_quickactions_custom_action",
  "sw_media_quickinfo_quickactions_delete",
  "sw_media_quickinfo_quickactions_download",
  "sw_media_quickinfo_quickactions_move",

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@amplitude/analytics-browser": "2.24.2",
-        "@shopware-ag/meteor-admin-sdk": "6.3.0",
+        "@shopware-ag/meteor-admin-sdk": "6.4.0",
         "@shopware-ag/meteor-component-library": "4.16.0",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",
@@ -4863,9 +4863,9 @@
       }
     },
     "node_modules/@shopware-ag/meteor-admin-sdk": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-admin-sdk/-/meteor-admin-sdk-6.3.0.tgz",
-      "integrity": "sha512-9kVXUSWcEOomD8WlSmaa4nVDBhSFp+dpdamNfHZaWwGSneFQn7hAr7QdMPEFGiRWd6yj4DaUP8ObpPRcvXzc2g==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-admin-sdk/-/meteor-admin-sdk-6.4.0.tgz",
+      "integrity": "sha512-Pyj6/LAhFNqlG5BWHHQRoyYignUTLCFZrK0+XTGJ5XRr2eQP1MhZg8Kn0zxnK26OclL4a23x2dDgaIki73AOig==",
       "license": "MIT",
       "dependencies": {
         "localforage": "^1.10.0",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@amplitude/analytics-browser": "2.24.2",
-    "@shopware-ag/meteor-admin-sdk": "6.3.0",
+    "@shopware-ag/meteor-admin-sdk": "6.4.0",
     "@shopware-ag/meteor-component-library": "4.16.0",
     "@shopware-ag/meteor-icon-kit": "5.4.0",
     "@swc/core": "1.10.7",

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-action-button/sw-app-action-button.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-action-button/sw-app-action-button.html.twig
@@ -21,6 +21,12 @@
         alt=""
     />
 
+    <mt-icon
+        v-if="action.meteorIcon && action.view !== 'item'"
+        :name="action.meteorIcon"
+        size="14px"
+    />
+
     <span class="sw-context-menu-item__text">
         {{ $tc(buttonLabel ?? '') }}
     </span>

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-action-button/sw-app-action-button.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-action-button/sw-app-action-button.scss
@@ -1,10 +1,5 @@
 .sw-app-action-button {
     .mt-icon {
-        margin-left: 4px;
-        vertical-align: baseline;
-    }
-
-    .mt-icon svg {
         vertical-align: baseline;
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-action-button/sw-app-action-button.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-action-button/sw-app-action-button.spec.js
@@ -86,4 +86,28 @@ describe('sw-app-action-button', () => {
             baseAction,
         ]);
     });
+
+    it('should show meteor icon if set and view is not item', async () => {
+        wrapper = await createWrapper({
+            ...baseAction,
+            meteorIcon: 'regular-star',
+            view: 'list',
+        });
+
+        const meteorIcon = wrapper.find('.mt-icon');
+
+        expect(meteorIcon.exists()).toBe(true);
+        expect(meteorIcon.classes()).toContain('icon--regular-star');
+    });
+
+    it('should not show meteor icon if view is item', async () => {
+        wrapper = await createWrapper({
+            ...baseAction,
+            meteorIcon: 'regular-star',
+            view: 'item',
+        });
+
+        const meteorIcon = wrapper.find('.mt-icon');
+        expect(meteorIcon.exists()).toBe(false);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
@@ -93,6 +93,12 @@ export default {
             // we need to check the media url since media.fileExtension is set directly after upload
             return this.item?.fileExtension === 'glb' || !!this.item?.url?.endsWith('.glb');
         },
+
+        extensionSdkButtons() {
+            return Shopware.Store.get('actionButtons').buttons.filter((button) => {
+                return button.entity === 'media' && button.view === 'item';
+            });
+        },
     },
 
     watch: {
@@ -358,6 +364,22 @@ export default {
             };
 
             this.$emit('update:item', { ...this.item, ...newItemConfig });
+        },
+
+        runAppAction(action) {
+            if (typeof action.callback !== 'function') {
+                return;
+            }
+
+            const { fileName, mimeType, fileSize, url, id } = this.item;
+
+            action.callback({
+                id,
+                url,
+                fileName,
+                mimeType,
+                fileSize,
+            });
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig
@@ -107,6 +107,28 @@
                 </li>
                 {% endblock %}
 
+                {% block sw_media_quickinfo_quickactions_custom_action %}
+                <template v-if="extensionSdkButtons.length > 0 && item.hasFile">
+                    <li
+                        v-for="action in extensionSdkButtons"
+                        :key="action.id"
+                        class="sw-media-sidebar__quickaction quickaction--custom"
+                        role="button"
+                        tabindex="0"
+                        @click="runAppAction(action)"
+                        @keydown.enter="runAppAction(action)"
+                    >
+                        <mt-icon
+                            v-if="action.meteorIcon"
+                            size="16px"
+                            :name="action.meteorIcon"
+                            class="sw-media-sidebar__quickactions-icon"
+                        />
+                        {{ $tc(action.label) }}
+                    </li>
+                </template>
+                {% endblock %}
+
                 {% block sw_media_quickinfo_quickactions_delete %}
                 <li
                     v-if="!item.private"

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.spec.js
@@ -191,6 +191,10 @@ describe('module/sw-media/components/sw-media-quickinfo', () => {
         global.activeAclRoles = [];
     });
 
+    afterEach(() => {
+        Shopware.Store.get('actionButtons').buttons = [];
+    });
+
     it('should not be able to delete', async () => {
         const wrapper = await createWrapper();
         await wrapper.vm.$nextTick();
@@ -452,5 +456,39 @@ describe('module/sw-media/components/sw-media-quickinfo', () => {
         await wrapper.vm.onSave();
 
         expect(eventBusEmitSpy).toHaveBeenCalledWith('sw-media-library-item-updated', wrapper.vm.item.id);
+    });
+
+    it('should show action button from apps', async () => {
+        Shopware.Store.get('actionButtons').add({
+            name: 'media-button',
+            entity: 'media',
+            view: 'item',
+            label: 'Navigate to app',
+        });
+
+        const wrapper = await createWrapper({ hasFile: true });
+
+        const actionButton = wrapper.find('.quickaction--custom');
+        expect(actionButton.exists()).toBeTruthy();
+    });
+
+    it('should call the action button method', async () => {
+        const actionButtonMethod = jest.fn();
+        const action = {
+            name: 'media-button',
+            entity: 'media',
+            view: 'item',
+            label: 'Navigate to app',
+            callback: actionButtonMethod,
+        };
+
+        Shopware.Store.get('actionButtons').add(action);
+
+        const wrapper = await createWrapper({ hasFile: true });
+        const actionButton = wrapper.find('.quickaction--custom');
+
+        await actionButton.trigger('click');
+
+        expect(actionButtonMethod).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The action button is available in the media item context menu but is missing from the image details sidebar. This inconsistency may confuse users who expect the same actions to be available in both locations.

<img width="805" height="579" alt="Screenshot 2025-09-03 at 16 10 14" src="https://github.com/user-attachments/assets/fada0f24-99f5-410c-9f6e-6e95f8c18179" />


### 2. What does this change do, exactly?
The media action buttons should be present in both the media context menu and the image details sidebar for consistency and improved user experience.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
