### PR TITLE
fix: order entities in search preferences

### DIFF
--- a/changelog/_unreleased/2025-08-28-fix-order-entities-in-search-preferences.md
+++ b/changelog/_unreleased/2025-08-28-fix-order-entities-in-search-preferences.md
@@ -1,0 +1,6 @@
+---
+title: fix order entities in search preferences
+issue: #12128
+---
+# Administration
+* Changed `processSearchPreferences` method in `search-preferences.service.js` module to provide a secondary sort by `entityName` for stability

--- a/src/Administration/Resources/app/administration/src/app/service/search-preferences.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/search-preferences.service.js
@@ -125,7 +125,16 @@ export default function SearchPreferencesService({ userConfigRepository: _userCo
                 searchPreferences.push({ entityName, _searchable, fields });
             },
         );
-        searchPreferences.sort((a, b) => b.fields.length - a.fields.length);
+
+        searchPreferences.sort((a, b) => {
+            const lengthDiff = b.fields.length - a.fields.length;
+
+            if (lengthDiff !== 0) {
+                return lengthDiff;
+            }
+
+            return a.entityName.localeCompare(b.entityName);
+        });
 
         return searchPreferences;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/12128

### 2. What does this change do, exactly?

Changed `processSearchPreferences` method in `search-preferences.service.js` module to provide a secondary sort by `entityName` for stability

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/shopware/shopware/issues/12128

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
_

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
