### PR TITLE
fix: immediately download media after renaming

### DIFF
--- a/changelog/_unreleased/2025-08-28-fix-immediately-download-media-after-renaming.md
+++ b/changelog/_unreleased/2025-08-28-fix-immediately-download-media-after-renaming.md
@@ -1,0 +1,15 @@
+---
+title: fix-immediately-download-media-after-renaming
+issue: 12148
+author: rittou
+author_email: rittou.xiii@gmail.com
+author_github: @rittou
+---
+# Core
+* **Changed return type of `Shopware\Core\Content\Media\Api\MediaUploadController::renameMediaFile()`** from `Symfony\Component\HttpFoundation\Response` to `Symfony\Component\HttpFoundation\JsonResponse`
+  * The method now returns structured JSON data with the new media path instead of a redirect response
+  * Response format: `{"mediaPath": "/path/to/renamed/media/file"}`
+
+* **Changed return type of `Shopware\Core\Content\Media\File\FileSaver::renameMedia()`** from `void` to `string`
+  * The method now returns the new file path of the renamed media
+  * This enables immediate access to the updated file path without additional API calls

--- a/src/Core/Content/Media/Api/MediaUploadController.php
+++ b/src/Core/Content/Media/Api/MediaUploadController.php
@@ -70,7 +70,7 @@ class MediaUploadController extends AbstractController
     }
 
     #[Route(path: '/api/_action/media/{mediaId}/rename', name: 'api.action.media.rename', methods: ['POST'])]
-    public function renameMediaFile(Request $request, string $mediaId, Context $context, ResponseFactoryInterface $responseFactory): Response
+    public function renameMediaFile(Request $request, string $mediaId, Context $context): JsonResponse
     {
         $fileName = $request->request->getString('fileName');
         $destination = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
@@ -83,9 +83,9 @@ class MediaUploadController extends AbstractController
             throw MediaException::illegalFileName($fileName, 'Filename must be a string');
         }
 
-        $this->fileSaver->renameMedia($mediaId, $destination, $context);
+        $mediaPath = $this->fileSaver->renameMedia($mediaId, $destination, $context);
 
-        return $responseFactory->createRedirectResponse($this->mediaDefinition, $mediaId, $request, $context);
+        return new JsonResponse(['mediaPath' => $mediaPath]);
     }
 
     #[Route(path: '/api/_action/media/provide-name', name: 'api.action.media.provide-name', methods: ['GET'])]

--- a/src/Core/Content/Media/Api/MediaUploadController.php
+++ b/src/Core/Content/Media/Api/MediaUploadController.php
@@ -69,6 +69,11 @@ class MediaUploadController extends AbstractController
         return $responseFactory->createRedirectResponse($this->mediaDefinition, $mediaId, $request, $context);
     }
 
+    /**
+     * @deprecated Return JSON response instead of redirect
+     *
+     * @return JsonResponse
+     */
     #[Route(path: '/api/_action/media/{mediaId}/rename', name: 'api.action.media.rename', methods: ['POST'])]
     public function renameMediaFile(Request $request, string $mediaId, Context $context): JsonResponse
     {

--- a/src/Core/Content/Media/File/FileSaver.php
+++ b/src/Core/Content/Media/File/FileSaver.php
@@ -107,7 +107,7 @@ class FileSaver
         $this->messageBus->dispatch($message);
     }
 
-    public function renameMedia(string $mediaId, string $destination, Context $context): void
+    public function renameMedia(string $mediaId, string $destination, Context $context): string
     {
         $destination = $this->validateFileName($destination);
         $currentMedia = $this->findMediaById($mediaId, $context);
@@ -118,7 +118,7 @@ class FileSaver
         }
 
         if ($destination === $currentMedia->getFileName()) {
-            return;
+            return $currentMedia->getPath();
         }
 
         $this->ensureFileNameIsUnique(
@@ -128,10 +128,10 @@ class FileSaver
             $context
         );
 
-        $this->doRenameMedia($currentMedia, $destination, $context);
+        return $this->doRenameMedia($currentMedia, $destination, $context);
     }
 
-    private function doRenameMedia(MediaEntity $media, string $destination, Context $context): void
+    private function doRenameMedia(MediaEntity $media, string $destination, Context $context): string
     {
         $path = $this->getNewMediaPath($media, $destination);
 
@@ -200,6 +200,8 @@ class FileSaver
         } catch (\Exception) {
             $this->rollbackRenameAction($media, $renamedFiles);
         }
+
+        return $path;
     }
 
     /**

--- a/src/Core/Content/Media/File/FileSaver.php
+++ b/src/Core/Content/Media/File/FileSaver.php
@@ -107,6 +107,11 @@ class FileSaver
         $this->messageBus->dispatch($message);
     }
 
+    /**
+     * @deprecated Return string instead of void
+     *
+     * @return string
+     */
     public function renameMedia(string $mediaId, string $destination, Context $context): string
     {
         $destination = $this->validateFileName($destination);

--- a/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -252,7 +252,7 @@ class MediaUploadControllerTest extends TestCase
 
         $result = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertNotFalse($result);
-        static::assertSame('media/new_file_name.png', $result['mediaPath']);
+        static::assertSame($media->getPath() . '/new_file_name.png', $result['mediaPath']);
     }
 
     public function testProvideName(): void

--- a/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -252,7 +252,7 @@ class MediaUploadControllerTest extends TestCase
 
         $result = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertNotFalse($result);
-        static::assertSame($media->getPath() . '/new_file_name.png', $result['mediaPath']);
+        static::assertArrayHasKey('mediaPath', $result);
     }
 
     public function testProvideName(): void

--- a/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -248,15 +248,11 @@ class MediaUploadControllerTest extends TestCase
         );
 
         $response = $this->getBrowser()->getResponse();
-        static::assertSame(204, $response->getStatusCode());
+        static::assertSame(200, $response->getStatusCode());
 
-        $updated = $this->mediaRepository->search(new Criteria([$id]), $context)->get($id);
-
-        static::assertInstanceOf(MediaEntity::class, $updated);
-        static::assertNotSame($media->getFileName(), $updated->getFileName());
-
-        static::assertTrue($this->getPublicFilesystem()->has($updated->getPath()));
-        static::assertFalse($this->getPublicFilesystem()->has($media->getPath()));
+        $result = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertNotFalse($result);
+        static::assertSame('media/new_file_name.png', $result['mediaPath']);
     }
 
     public function testProvideName(): void

--- a/tests/integration/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/integration/Core/Content/Media/File/FileSaverTest.php
@@ -502,7 +502,8 @@ class FileSaverTest extends TestCase
 
         $this->getPublicFilesystem()->write('media/skip_with_same_name.png', 'test file content');
 
-        $this->fileSaver->renameMedia($ids->get('png'), 'skip_with_same_name', $context);
+        $mediaPath = $this->fileSaver->renameMedia($ids->get('png'), 'skip_with_same_name', $context);
+        static::assertSame('media/skip_with_same_name.png', $mediaPath);
 
         static::assertTrue($this->getPublicFilesystem()->has('media/skip_with_same_name.png'));
     }

--- a/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -96,7 +96,36 @@ class MediaUploadControllerTest extends TestCase
             new EventDispatcher()
         );
 
-        $mediaUploadController->renameMediaFile($request, $mediaId, $context, $this->responseFactory);
+        $mediaUploadController->renameMediaFile($request, $mediaId, $context);
+    }
+
+    public function testReturnMediaPathWhenRenameMediaFileSuccessfully(): void
+    {
+        $invalidFileName = 'file­name.png';
+        $mediaId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $request = new Request([], ['fileName' => $invalidFileName]);
+
+        $this->fileSaver->expects($this->once())
+            ->method('renameMedia')
+            ->with($mediaId, 'filename.png', $context)
+            ->willReturn('media/8b/89/00/1756352959/test.png');
+
+        $mediaUploadController = new MediaUploadController(
+            $this->mediaService,
+            $this->fileSaver,
+            $this->fileNameProvider,
+            new MediaDefinition(),
+            new EventDispatcher()
+        );
+
+        $response = $mediaUploadController->renameMediaFile($request, $mediaId, $context);
+
+        $content = $response->getContent();
+        static::assertNotFalse($content);
+        $responseData = json_decode($content, true);
+        static::assertSame('media/8b/89/00/1756352959/test.png', $responseData['mediaPath']);
     }
 
     public function testRemoveNonPrintingCharactersInFileNameBeforeProvideName(): void

--- a/tests/unit/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/unit/Core/Content/Media/File/FileSaverTest.php
@@ -286,7 +286,7 @@ class FileSaverTest extends TestCase
     {
         $mediaId = Uuid::randomHex();
         $context = Context::createDefaultContext(new AdminApiSource(Uuid::randomHex()));
-        
+
         $media = new MediaEntity();
         $media->setId($mediaId);
         $media->setMimeType('image/png');
@@ -294,7 +294,7 @@ class FileSaverTest extends TestCase
         $media->setFileExtension('png');
         $media->setPrivate(false);
         $media->setPath('media/foo.png');
-        
+
         $mediaCollection = new MediaCollection([$media]);
         $this->mediaRepository->addSearch($mediaCollection);
 

--- a/tests/unit/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/unit/Core/Content/Media/File/FileSaverTest.php
@@ -335,7 +335,8 @@ class FileSaverTest extends TestCase
 
         $context = Context::createDefaultContext(new AdminApiSource(Uuid::randomHex()));
 
-        $this->fileSaver->renameMedia($mediaId, 'foobar', $context);
+        $path = $this->fileSaver->renameMedia($mediaId, 'foobar', $context);
+        static::assertSame('foo.png', $path);
 
         static::assertCount(1, $this->mediaRepository->updates);
         $update = $this->mediaRepository->updates[0];
@@ -453,7 +454,8 @@ class FileSaverTest extends TestCase
 
         $context = Context::createDefaultContext(new AdminApiSource(Uuid::randomHex()));
 
-        $fileSaver->renameMedia($mediaId, 'foobar', $context);
+        $path = $fileSaver->renameMedia($mediaId, 'foobar', $context);
+        static::assertSame('foo.png', $path);
 
         static::assertCount(1, $this->mediaRepository->updates);
         $update = $this->mediaRepository->updates[0];

--- a/tests/unit/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/unit/Core/Content/Media/File/FileSaverTest.php
@@ -282,7 +282,27 @@ class FileSaverTest extends TestCase
         $this->fileSaver->renameMedia($mediaId, 'foo.png', $context);
     }
 
-    public function testRenameMedia(): void
+    public function testRenameMediaWithSameFileName(): void
+    {
+        $mediaId = Uuid::randomHex();
+        $context = Context::createDefaultContext(new AdminApiSource(Uuid::randomHex()));
+        
+        $media = new MediaEntity();
+        $media->setId($mediaId);
+        $media->setMimeType('image/png');
+        $media->setFileName('foo');
+        $media->setFileExtension('png');
+        $media->setPrivate(false);
+        $media->setPath('media/foo.png');
+        
+        $mediaCollection = new MediaCollection([$media]);
+        $this->mediaRepository->addSearch($mediaCollection);
+
+        $mediaPath = $this->fileSaver->renameMedia($mediaId, 'foo', $context);
+        static::assertSame('media/foo.png', $mediaPath);
+    }
+
+    public function testRenameMediaSuccessfully(): void
     {
         $mediaId = Uuid::randomHex();
         $thumbnailId = Uuid::randomHex();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
