### PR TITLE
feat: Allow selecting pack unit for essential characteristics of products

### DIFF
--- a/changelog/_unreleased/2025-08-28-add-packuit-to-product-features.md
+++ b/changelog/_unreleased/2025-08-28-add-packuit-to-product-features.md
@@ -1,0 +1,6 @@
+---
+title: Allow selecting pack unit for essential characteristics of products
+issue: #12167
+---
+# Administration
+* Added `packUnit` to `sw-settings-product-feature-sets` module's modal

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-modal/index.js
@@ -88,6 +88,12 @@ export default {
                     label: this.$tc('sw-settings-product-feature-sets.modal.label.weight'),
                     name: 'weight',
                 },
+                {
+                    id: 'd6eb6d4fbd754b0e9958ecc77abee3de',
+                    type: 'product',
+                    label: this.$tc('sw-settings-product-feature-sets.modal.label.packUnit'),
+                    name: 'packUnit',
+                },
             ],
             isApplyingSelections: false,
         };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/snippet/de.json
@@ -60,7 +60,8 @@
         "description": "Beschreibung",
         "manufacturerNumber": "Herstellernummer",
         "ean": "GTIN/EAN",
-        "referencePrice": "Grundpreis"
+        "referencePrice": "Grundpreis",
+        "packUnit": "Verpackungseinheit"
       }
     }
   },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/snippet/en.json
@@ -60,7 +60,8 @@
         "description": "Description",
         "manufacturerNumber": "Manufacturer product number",
         "ean": "GTIN/EAN",
-        "referencePrice": "Unit price"
+        "referencePrice": "Unit price",
+        "packUnit": "Pack unit"
       }
     }
   },

--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -805,7 +805,8 @@
           "length": "Länge:",
           "releaseDate": "Veröffentlicht:",
           "description": "Beschreibung:",
-          "referencePrice": "Inhalt:"
+          "referencePrice": "Inhalt:",
+          "packUnit": "Verpackungseinheit:"
         },
         "customField": {
           "true": "Ja",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -805,7 +805,8 @@
           "length": "Length:",
           "releaseDate": "Release date:",
           "description": "Description:",
-          "referencePrice": "Content:"
+          "referencePrice": "Content:",
+          "packUnit": "Pack unit:"
         },
         "customField": {
           "true": "Yes",


### PR DESCRIPTION
### 1. Why is this change necessary?

Popular demand since more than 4 years in the forum.

### 2. What does this change do, exactly?

Adds pack unit to the selectable fields in essential characteristics. Allowing those to make them available in cart templates, for example.

### 3. Describe each step to reproduce the issue or behaviour.

* Try to include packUnit in the cart
* Information cannot be found

### 4. Please link to the relevant issues

https://forum.shopware.com/t/verpackungseinheit-packunit-im-warenkorb-ausgeben/86908/5

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

### 6. Screenshot

<img width="1816" height="1077" alt="image" src="https://github.com/user-attachments/assets/8b090a2d-c28c-4e0d-bae8-2a9d4623dc0d" />
