### PR TITLE
fix: Consider parent sources in api aware flag

### DIFF
--- a/changelog/_unreleased/2025-08-28-fix-api-aware-flag-for-proxy.md
+++ b/changelog/_unreleased/2025-08-28-fix-api-aware-flag-for-proxy.md
@@ -1,0 +1,6 @@
+---
+title: Fix API aware flag for proxied requests
+issue: #7156
+---
+# Core
+* Changed `\Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware::isSourceAllowed()` to also consider parent classes of the current source. 

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAware.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAware.php
@@ -50,7 +50,23 @@ class ApiAware extends Flag
             return true;
         }
 
-        return isset($this->whitelist[$source]);
+        if (isset($this->whitelist[$source])) {
+            return true;
+        }
+
+        $parentSources = class_parents($source);
+
+        if (!$parentSources) {
+            return false;
+        }
+
+        foreach ($parentSources as $parentSource) {
+            if (isset($this->whitelist[$parentSource])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function parse(): \Generator

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAwareTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAwareTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Field\Flag;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Api\Context\AdminSalesChannelApiSource;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Api\Context\ShopApiSource;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[CoversClass(ApiAware::class)]
+#[Package('framework')]
+class ApiAwareTest extends TestCase
+{
+    public function testDefaultAllowsBothApis(): void
+    {
+        $flag = new ApiAware();
+
+        static::assertTrue($flag->isBaseUrlAllowed('/api'));
+        static::assertTrue($flag->isBaseUrlAllowed('/store-api'));
+
+        static::assertTrue($flag->isSourceAllowed(AdminApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(SalesChannelApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(ShopApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(AdminSalesChannelApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(SystemSource::class));
+    }
+
+    public function testOnlyAdminApiAware(): void
+    {
+        $flag = new ApiAware(AdminApiSource::class);
+
+        static::assertTrue($flag->isBaseUrlAllowed('/api'));
+        static::assertFalse($flag->isBaseUrlAllowed('/store-api'));
+
+        static::assertTrue($flag->isSourceAllowed(AdminApiSource::class));
+        static::assertFalse($flag->isSourceAllowed(SalesChannelApiSource::class));
+        static::assertFalse($flag->isSourceAllowed(ShopApiSource::class));
+        static::assertFalse($flag->isSourceAllowed(AdminSalesChannelApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(SystemSource::class));
+    }
+
+    public function testOnlyStoreApiAware(): void
+    {
+        $flag = new ApiAware(SalesChannelApiSource::class);
+
+        static::assertFalse($flag->isBaseUrlAllowed('/api'));
+        static::assertTrue($flag->isBaseUrlAllowed('/store-api'));
+
+        static::assertFalse($flag->isSourceAllowed(AdminApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(SalesChannelApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(ShopApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(AdminSalesChannelApiSource::class));
+        static::assertTrue($flag->isSourceAllowed(SystemSource::class));
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/shopware/shopware/issues/7156

Special sources that subclass one of the two main where not considered by API-aware flag, now we also check parent classes, that way it should automatically work when we might add any more sources in the future
