### PR TITLE
fix: revert theme field name change

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
@@ -729,7 +729,7 @@ Component.register('sw-theme-manager-detail', {
                 return fieldName;
             }
 
-            return `${label} (${fieldName})`;
+            return label;
         },
 
         /**


### PR DESCRIPTION
### 1. Why is this change necessary?

This reverts my https://github.com/shopware/shopware/commit/0ab0217bbc4a32e1428b4243abcce0ee4dc637dd

see https://github.com/shopware/shopware/issues/11960


I created an issue for meteor, so we can future display it less prominent: https://github.com/shopware/meteor/issues/880

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
