### PR TITLE
fix: Remove load expensive administration order sorting

### DIFF
--- a/changelog/_unreleased/2025-08-29-remove-load-expensive-administration-order-sorting.md
+++ b/changelog/_unreleased/2025-08-29-remove-load-expensive-administration-order-sorting.md
@@ -1,0 +1,8 @@
+---
+title: Remove load expensive administration order sorting
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Removed `Criteria.sort('shippingCosts.unitPrice', 'DESC')` criteria sorting in `Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -113,16 +113,14 @@ export default {
                 .addAssociation('primaryOrderTransaction.stateMachineState')
                 .addAssociation('primaryOrderDelivery.shippingMethod')
                 .addAssociation('primaryOrderDelivery.stateMachineState')
-                .addAssociation('primaryOrderDelivery.shippingOrderAddress.country')
-                .addSorting(Criteria.sort('shippingCosts.unitPrice', 'DESC'));
+                .addAssociation('primaryOrderDelivery.shippingOrderAddress.country');
 
             if (!Shopware.Feature.isActive('v6.8.0.0')) {
                 criteria
                     .getAssociation('deliveries')
                     .addAssociation('stateMachineState')
                     .addAssociation('shippingOrderAddress')
-                    .addAssociation('shippingMethod')
-                    .addSorting(Criteria.sort('shippingCosts.unitPrice', 'DESC'));
+                    .addAssociation('shippingMethod');
             }
 
             return criteria;


### PR DESCRIPTION
### 1. Why is this change necessary?
– Currently, loading the order page in the administration can take a while in an environment with many orders.
– Loading is so slow because a criteria sort uses a json value from the shipping costs field from the database, which is extremely slow to access and sort.
– The sort is already extremely meaningless because it is applied after the table sort, e.g., `orderDateTime DESC`, where all orders already have a fixed sort order.

Before PR change:
<img width="909" height="223" alt="image" src="https://github.com/user-attachments/assets/77ee97ba-dfc4-4a31-84bd-6411d3b1a4b9" />
After PR change:
<img width="914" height="164" alt="image" src="https://github.com/user-attachments/assets/c9aa7086-532f-49dc-ac64-5a734f32e9cc" />

### 2. What does this change do, exactly?
* Removed `Criteria.sort('shippingCosts.unitPrice', 'DESC')` criteria sorting in `Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js`

### 3. Describe each step to reproduce the issue or behaviour.
- Open the order page in the administration in a environment with many orders
- Wait a while for the order loading to finish

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
