### PR TITLE
fix: Remove unused and unnecessary associations from administration order list

### DIFF
--- a/changelog/_unreleased/2025-08-29-remove-unused-and-unnecessary-associations-from-administration-order-list.md
+++ b/changelog/_unreleased/2025-08-29-remove-unused-and-unnecessary-associations-from-administration-order-list.md
@@ -1,0 +1,8 @@
+---
+title: Remove unused and unnecessary associations from administration order list
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Removed `addresses`, `primaryOrderTransaction` & `primaryOrderDelivery.shippingOrderAddress.country` unused and unnecessary associations in `Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -590,11 +590,11 @@ export default {
          * @deprecated tag:v6.8.0 - will be removed, use order.primaryOrderDelivery instead
          */
         getDelivery(order) {
-            if (Shopware.Feature.isActive('v6.8.0.0')) {
-                return order.primaryOrderDelivery;
+            if (!Shopware.Feature.isActive('v6.8.0.0')) {
+                return order.deliveries[0];
             }
 
-            return order.deliveries[0];
+            return order.primaryOrderDelivery;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -549,11 +549,10 @@ export default {
             await this.$nextTick();
 
             const ordersExcludeDelivery = Object.values(this.$refs.orderGrid.selection).filter((order) => {
-                if (Shopware.Feature.isActive('v6.8.0.0')) {
-                    return !order.primaryOrderDelivery;
-                } 
+                if (!Shopware.Feature.isActive('v6.8.0.0')) {
                     return !this.getDelivery(order);
-                
+                }
+                return !order.primaryOrderDelivery;
             });
             const excludeDelivery = ordersExcludeDelivery.length > 0 ? '1' : '0';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -93,29 +93,29 @@ export default {
                 criteria.addFilter(filter);
             });
 
-            criteria.addAssociation('addresses');
             criteria.addAssociation('billingAddress');
             criteria.addAssociation('salesChannel');
             criteria.addAssociation('orderCustomer');
             criteria.addAssociation('currency');
             criteria.addAssociation('documents');
-
             criteria.addAssociation('stateMachineState');
-
-            criteria
-                .getAssociation('transactions')
-                .addAssociation('stateMachineState')
-                .addSorting(Criteria.sort('createdAt'));
-
-            criteria
-                .addAssociation('primaryOrderTransaction')
-                .addAssociation('primaryOrderTransaction.paymentMethod')
-                .addAssociation('primaryOrderTransaction.stateMachineState')
-                .addAssociation('primaryOrderDelivery.shippingMethod')
-                .addAssociation('primaryOrderDelivery.stateMachineState')
-                .addAssociation('primaryOrderDelivery.shippingOrderAddress.country');
+            criteria.addAssociation('primaryOrderTransaction.stateMachineState');
+            criteria.addAssociation('primaryOrderDelivery.stateMachineState');
+            criteria.addAssociation('primaryOrderDelivery.shippingOrderAddress');
 
             if (!Shopware.Feature.isActive('v6.8.0.0')) {
+                criteria.addAssociation('addresses');
+
+                criteria
+                    .getAssociation('transactions')
+                    .addAssociation('stateMachineState')
+                    .addSorting(Criteria.sort('createdAt'));
+
+                criteria
+                    .addAssociation('primaryOrderTransaction.paymentMethod')
+                    .addAssociation('primaryOrderDelivery.shippingMethod')
+                    .addAssociation('primaryOrderDelivery.shippingOrderAddress.country');
+
                 criteria
                     .getAssociation('deliveries')
                     .addAssociation('stateMachineState')
@@ -236,12 +236,12 @@ export default {
                     optionNoCriteria: this.$tc('sw-order.filters.documentFilter.textNoCriteria'),
                 },
                 'payment-method-filter': {
-                    property: 'transactions.paymentMethod',
+                    property: 'primaryOrderTransaction.paymentMethod',
                     label: this.$tc('sw-order.filters.paymentMethodFilter.label'),
                     placeholder: this.$tc('sw-order.filters.paymentMethodFilter.placeholder'),
                 },
                 'shipping-method-filter': {
-                    property: 'deliveries.shippingMethod',
+                    property: 'primaryOrderDelivery.shippingMethod',
                     label: this.$tc('sw-order.filters.shippingMethodFilter.label'),
                     placeholder: this.$tc('sw-order.filters.shippingMethodFilter.placeholder'),
                 },
@@ -251,7 +251,7 @@ export default {
                     placeholder: this.$tc('sw-order.filters.billingCountryFilter.placeholder'),
                 },
                 'shipping-country-filter': {
-                    property: 'deliveries.shippingOrderAddress.country',
+                    property: 'primaryOrderDelivery.shippingOrderAddress.country',
                     label: this.$tc('sw-order.filters.shippingCountryFilter.label'),
                     placeholder: this.$tc('sw-order.filters.shippingCountryFilter.placeholder'),
                 },
@@ -313,6 +313,9 @@ export default {
     methods: {
         createdComponent() {},
 
+        /**
+         * @deprecated tag:v6.8.0 - will be removed, use order.primaryOrderDelivery instead
+         */
         deliveryTooltip(deliveries) {
             return deliveries
                 .map((delivery) => {
@@ -373,6 +376,9 @@ export default {
             }
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - will be removed, use order.billingAddress instead
+         */
         getBillingAddress(order) {
             return order.addresses.find((address) => {
                 return address.id === order.billingAddressId;
@@ -410,7 +416,6 @@ export default {
                 },
                 {
                     property: 'orderCustomer.company',
-                    dataIndex: 'orderCustomer.company',
                     label: 'sw-order.list.columnCustomerCompany',
                     allowResize: true,
                     visible: false,
@@ -423,8 +428,7 @@ export default {
                     visible: false,
                 },
                 {
-                    property: 'deliveries.id',
-                    dataIndex: 'deliveries.shippingOrderAddress.street',
+                    property: 'primaryOrderDelivery.shippingOrderAddress.street',
                     label: 'sw-order.list.columnDeliveryAddress',
                     allowResize: true,
                 },
@@ -440,14 +444,12 @@ export default {
                     allowResize: true,
                 },
                 {
-                    property: 'transactions.last().stateMachineState.name',
-                    dataIndex: 'transactions.stateMachineState.name',
+                    property: 'primaryOrderTransaction.stateMachineState.name',
                     label: 'sw-order.list.columnTransactionState',
                     allowResize: true,
                 },
                 {
-                    property: 'deliveries[0].stateMachineState.name',
-                    dataIndex: 'deliveries.stateMachineState.name',
+                    property: 'primaryOrderDelivery.stateMachineState.name',
                     label: 'sw-order.list.columnDeliveryState',
                     allowResize: true,
                 },
@@ -484,33 +486,32 @@ export default {
 
             if (!Shopware.Feature.isActive('v6.8.0.0')) {
                 technicalName = order.transactions.last().stateMachineState.technicalName;
-            }
 
-            // set the payment status to the first transaction that is not cancelled
-            for (let i = 0; i < order.transactions.length; i += 1) {
-                if (
-                    ![
-                        'cancelled',
-                        'failed',
-                    ].includes(order.transactions[i].stateMachineState.technicalName)
-                ) {
-                    technicalName = order.transactions[i].stateMachineState.technicalName;
-                    break;
+                // set the payment status to the first transaction that is not cancelled
+                for (let i = 0; i < order.transactions.length; i += 1) {
+                    if (
+                        ![
+                            'cancelled',
+                            'failed',
+                        ].includes(order.transactions[i].stateMachineState.technicalName)
+                    ) {
+                        technicalName = order.transactions[i].stateMachineState.technicalName;
+                        break;
+                    }
                 }
             }
 
-            const style = this.stateStyleDataProviderService.getStyle('order_transaction.state', technicalName);
-
-            return style.colorCode;
+            return this.stateStyleDataProviderService.getStyle('order_transaction.state', technicalName).colorCode;
         },
 
         getVariantFromDeliveryState(order) {
-            const style = this.stateStyleDataProviderService.getStyle(
-                'order_delivery.state',
-                this.getDelivery(order).stateMachineState.technicalName,
-            );
+            let technicalName = order.primaryOrderDelivery?.stateMachineState.technicalName;
 
-            return style.colorCode;
+            if (!Shopware.Feature.isActive('v6.8.0.0')) {
+                technicalName = this.getDelivery(order).stateMachineState.technicalName;
+            }
+
+            return this.stateStyleDataProviderService.getStyle('order_delivery.state', technicalName).colorCode;
         },
 
         onDelete(id) {
@@ -548,7 +549,11 @@ export default {
             await this.$nextTick();
 
             const ordersExcludeDelivery = Object.values(this.$refs.orderGrid.selection).filter((order) => {
-                return !this.getDelivery(order);
+                if (Shopware.Feature.isActive('v6.8.0.0')) {
+                    return !order.primaryOrderDelivery;
+                } 
+                    return !this.getDelivery(order);
+                
             });
             const excludeDelivery = ordersExcludeDelivery.length > 0 ? '1' : '0';
 
@@ -560,31 +565,37 @@ export default {
             });
         },
 
-        transaction(item) {
-            for (let i = 0; i < item.transactions.length; i += 1) {
+        /**
+         * @deprecated tag:v6.8.0 - will be removed, use order.primaryOrderTransaction instead
+         */
+        transaction(order) {
+            if (Shopware.Feature.isActive('v6.8.0.0')) {
+                return order.primaryOrderTransaction;
+            }
+
+            for (let i = 0; i < order.transactions.length; i += 1) {
                 if (
                     ![
                         'cancelled',
                         'failed',
-                    ].includes(item.transactions[i].stateMachineState.technicalName)
+                    ].includes(order.transactions[i].stateMachineState.technicalName)
                 ) {
-                    return item.transactions[i];
+                    return order.transactions[i];
                 }
             }
 
-            if (!Shopware.Feature.isActive('v6.8.0.0')) {
-                return item.transactions.last();
-            }
-
-            return item.primaryOrderTransaction;
+            return order.transactions.last();
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - will be removed, use order.primaryOrderDelivery instead
+         */
         getDelivery(order) {
-            if (!Shopware.Feature.isActive('v6.8.0.0')) {
-                return order.deliveries[0];
+            if (Shopware.Feature.isActive('v6.8.0.0')) {
+                return order.primaryOrderDelivery;
             }
 
-            return order.primaryOrderDelivery;
+            return order.deliveries[0];
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -148,22 +148,12 @@
                 {% endblock %}
 
                 {% block sw_order_list_grid_columns_delivery_address %}
-                <template #column-deliveries.id="{ item }">
-                    <template v-if="getDelivery(item) && getDelivery(item).shippingOrderAddress">
-                        <div
-                            v-tooltip="{
-                                showDelay: 300,
-                                width: 400,
-                                disabled: item.deliveries.length <= 1,
-                                message: deliveryTooltip(item.deliveries)
-                            }"
-                            class="sw-order-list__delivery_address"
-                        >
-                            <span v-if="getDelivery(item).shippingOrderAddress.company">{{ getDelivery(item).shippingOrderAddress.company }}<span v-if="getDelivery(item).shippingOrderAddress.department"> - {{ getDelivery(item).shippingOrderAddress.department }}</span>,</span>
-                            {{ getDelivery(item).shippingOrderAddress.street }},
-                            {{ getDelivery(item).shippingOrderAddress.zipcode }}
-                            {{ getDelivery(item).shippingOrderAddress.city }}
-                        </div>
+                <template #column-primaryOrderDelivery.shippingOrderAddress.street="{ item }">
+                    <template v-if="item.primaryOrderDelivery?.shippingOrderAddress">
+                        <span v-if="item.primaryOrderDelivery.shippingOrderAddress.company">{{ item.primaryOrderDelivery.shippingOrderAddress.company }}<span v-if="item.primaryOrderDelivery.shippingOrderAddress.department"> - {{ item.primaryOrderDelivery.shippingOrderAddress.department }}</span>,</span>
+                        {{ item.primaryOrderDelivery.shippingOrderAddress.street }},
+                        {{ item.primaryOrderDelivery.shippingOrderAddress.zipcode }}
+                        {{ item.primaryOrderDelivery.shippingOrderAddress.city }}
                     </template>
 
                 </template>
@@ -191,35 +181,33 @@
                 {% endblock %}
 
                 {% block sw_order_list_grid_columns_transaction_state %}
-                <template #column-transactions.last().stateMachineState.name="{ item }">
+                <template #column-primaryOrderTransaction.stateMachineState.name="{ item }">
                     <div
-                        v-if="item.transactions && item.transactions[0]"
+                        v-if="item.primaryOrderTransaction?.stateMachineState"
                         class="sw-order-list__state"
                     >
                         <sw-color-badge
-                            v-if="item.transactions && item.transactions[0]"
                             :color="getVariantFromPaymentState(item)"
                             rounded
                         />
 
-                        {{ transaction(item).stateMachineState.translated.name }}
+                        {{ item.primaryOrderTransaction.stateMachineState.translated.name }}
                     </div>
                 </template>
                 {% endblock %}
 
                 {% block sw_order_list_grid_columns_delivery_state %}
-                <template #column-deliveries[0].stateMachineState.name="{ item }">
+                <template #column-primaryOrderDelivery.stateMachineState.name="{ item }">
                     <div
-                        v-if="getDelivery(item)"
+                        v-if="item.primaryOrderDelivery?.stateMachineState"
                         class="sw-order-list__state"
                     >
                         <sw-color-badge
-                            v-if="getDelivery(item)"
                             :color="getVariantFromDeliveryState(item)"
                             rounded
                         />
 
-                        {{ getDelivery(item).stateMachineState.translated.name }}
+                        {{ item.primaryOrderDelivery.stateMachineState.translated.name }}
                     </div>
                 </template>
                 {% endblock %}
@@ -402,25 +390,25 @@
                         {% endblock %}
 
                         {% block sw_order_list_bulk_edit_grid_columns_transaction_state %}
-                        <template #column-transactions.last().stateMachineState.name="{ item }">
+                        <template #column-primaryOrderTransaction.stateMachineState.name="{ item }">
                             <sw-label
-                                v-if="item.transactions && item.transactions[0]"
+                                v-if="item.primaryOrderTransaction?.stateMachineState"
                                 :variant="getVariantFromPaymentState(item)"
                                 appearance="pill"
                             >
-                                {{ transaction(item).stateMachineState.translated.name }}
+                                {{ item.primaryOrderTransaction.stateMachineState.translated.name }}
                             </sw-label>
                         </template>
                         {% endblock %}
 
                         {% block sw_order_list_bulk_edit_grid_columns_delivery_state %}
-                        <template #column-getDelivery(item).stateMachineState.name="{ item }">
+                        <template #column-primaryOrderDelivery.stateMachineState.name="{ item }">
                             <sw-label
-                                v-if="getDelivery(item)"
+                                v-if="item.primaryOrderDelivery?.stateMachineState"
                                 :variant="getVariantFromDeliveryState(item)"
                                 appearance="pill"
                             >
-                                {{ getDelivery(item).stateMachineState.translated.name }}
+                                {{ item.primaryOrderDelivery.stateMachineState.translated.name }}
                             </sw-label>
                         </template>
                         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
@@ -1,5 +1,4 @@
 import { mount } from '@vue/test-utils';
-import EntityCollection from 'src/core/data/entity-collection.data';
 import Criteria from 'src/core/data/criteria.data';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
 
@@ -12,11 +11,6 @@ const mockItem = {
     orderCustomer: {
         customerId: '2',
     },
-    addresses: [
-        {
-            street: '123 Random street',
-        },
-    ],
     currency: {
         isoCode: 'EUR',
     },
@@ -27,26 +21,29 @@ const mockItem = {
     salesChannel: {
         name: 'Test',
     },
-    transactions: new EntityCollection(null, null, null, new Criteria(1, 25), [
-        {
-            stateMachineState: {
-                technicalName: 'open',
-                name: 'Open',
-                translated: { name: 'Open' },
-            },
+    primaryOrderTransaction: {
+        stateMachineState: {
+            technicalName: 'open',
+            name: 'Open',
+            translated: { name: 'Open' },
         },
-    ]),
-    deliveries: [
-        {
-            stateMachineState: {
-                technicalName: 'open',
-                name: 'Open',
-                translated: { name: 'Open' },
-            },
+    },
+    primaryOrderDelivery: {
+        stateMachineState: {
+            technicalName: 'open',
+            name: 'Open',
+            translated: { name: 'Open' },
         },
-    ],
+        shippingOrderAddress: {
+            street: '123 Random street',
+            zipcode: '12345',
+            city: 'Random City',
+        },
+    },
     billingAddress: {
         street: '123 Random street',
+        zipcode: '12345',
+        city: 'Random City',
     },
 };
 
@@ -298,29 +295,13 @@ describe('src/module/sw-order/page/sw-order-list', () => {
     it('should show correct label for payment status', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
-        mockItem.transactions = new EntityCollection(null, null, null, new Criteria(1, 25), [
-            {
-                stateMachineState: {
-                    technicalName: 'cancelled',
-                    name: 'Cancelled',
-                    translated: { name: 'Cancelled' },
-                },
+        mockItem.primaryOrderTransaction = {
+            stateMachineState: {
+                technicalName: 'paid',
+                name: 'Paid',
+                translated: { name: 'Paid' },
             },
-            {
-                stateMachineState: {
-                    technicalName: 'paid',
-                    name: 'Paid',
-                    translated: { name: 'Paid' },
-                },
-            },
-            {
-                stateMachineState: {
-                    technicalName: 'open',
-                    name: 'Open',
-                    translated: { name: 'Open' },
-                },
-            },
-        ]);
+        };
 
         await wrapper.setData({
             orders: [
@@ -364,14 +345,14 @@ describe('src/module/sw-order/page/sw-order-list', () => {
 
         expect(criteria.getLimit()).toBe(25);
         [
-            'addresses',
             'billingAddress',
             'salesChannel',
             'orderCustomer',
             'currency',
             'documents',
-            'deliveries',
-            'transactions',
+            'stateMachineState',
+            'primaryOrderTransaction',
+            'primaryOrderDelivery',
         ].forEach((association) => expect(criteria.hasAssociation(association)).toBe(true));
     });
 
@@ -380,9 +361,8 @@ describe('src/module/sw-order/page/sw-order-list', () => {
         wrapper = await createWrapper();
         const criteria = wrapper.vm.orderCriteria;
 
-        expect(criteria.hasAssociation('stateMachineState')).toBe(true);
-        expect(criteria.getAssociation('deliveries').hasAssociation('stateMachineState')).toBe(true);
-        expect(criteria.getAssociation('transactions').hasAssociation('stateMachineState')).toBe(true);
+        expect(criteria.getAssociation('primaryOrderDelivery').hasAssociation('stateMachineState')).toBe(true);
+        expect(criteria.getAssociation('primaryOrderTransaction').hasAssociation('stateMachineState')).toBe(true);
     });
 
     it('should contain a computed property, called: listFilterOptions', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import EntityCollection from 'src/core/data/entity-collection.data';
 import Criteria from 'src/core/data/criteria.data';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
 
@@ -46,6 +47,32 @@ const mockItem = {
         city: 'Random City',
     },
 };
+
+if (!Shopware.Feature.isActive('v6.8.0.0')) {
+    mockItem.addresses = [
+        {
+            street: '123 Random street',
+        },
+    ];
+    mockItem.transactions = new EntityCollection(null, null, null, new Criteria(1, 25), [
+        {
+            stateMachineState: {
+                technicalName: 'open',
+                name: 'Open',
+                translated: { name: 'Open' },
+            },
+        },
+    ]);
+    mockItem.deliveries = [
+        {
+            stateMachineState: {
+                technicalName: 'open',
+                name: 'Open',
+                translated: { name: 'Open' },
+            },
+        },
+    ];
+}
 
 async function createWrapper() {
     return mount(await wrapTestComponent('sw-order-list', { sync: true }), {
@@ -362,6 +389,7 @@ describe('src/module/sw-order/page/sw-order-list', () => {
         const criteria = wrapper.vm.orderCriteria;
 
         expect(criteria.getAssociation('primaryOrderDelivery').hasAssociation('stateMachineState')).toBe(true);
+        expect(criteria.getAssociation('primaryOrderDelivery').hasAssociation('shippingOrderAddress')).toBe(true);
         expect(criteria.getAssociation('primaryOrderTransaction').hasAssociation('stateMachineState')).toBe(true);
     });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently, there are some associations on the order list page of the administration that are loaded but never used or are loaded unnecessarily
- The associations  `paymentMethod` of `transactions` (`primaryOrderTransaction`), `shippingMethod` of `primaryOrderDelivery` & `shippingOrderAddress.country` of `primaryOrderDelivery` are unsed
- We can replace the loading of `addresses` & `primaryOrderTransaction` with a simple javascript array find on the already existing data of `addresses` & `transactions`

### 2. What does this change do, exactly?
* Removed `addresses`, `primaryOrderTransaction` & `primaryOrderDelivery.shippingOrderAddress.country` unused and unnecessary associations in `Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
