### PR TITLE
feat: Add `skipConfigurator` & `skipCmsPage` query parameter to ProductDetailRoute

### DIFF
--- a/changelog/_unreleased/2025-08-29-add-skip-query-parameter-to-product-detail-route.md
+++ b/changelog/_unreleased/2025-08-29-add-skip-query-parameter-to-product-detail-route.md
@@ -1,0 +1,8 @@
+---
+title: Add `skipConfigurator` & `skipCmsPage` query parameter to ProductDetailRoute
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Added `skipConfigurator` & `skipCmsPage` query parameter checks to `Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute`

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -38,6 +38,9 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Package('inventory')]
 class ProductDetailRoute extends AbstractProductDetailRoute
 {
+    private const SKIP_CONFIGURATOR = 'skipConfigurator';
+    private const SKIP_CMS_PAGE = 'skipCmsPage';
+
     /**
      * @internal
      *
@@ -107,11 +110,12 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                 $this->breadcrumbBuilder->getProductSeoCategory($product, $context)
             );
 
-            $configurator = $this->configuratorLoader->load($product, $context);
+            $skipConfigurator = $request->query->getBoolean(self::SKIP_CONFIGURATOR);
+            $configurator = !$skipConfigurator ? $this->configuratorLoader->load($product, $context) : null;
 
+            $skipCmsPage = $request->query->getBoolean(self::SKIP_CMS_PAGE);
             $pageId = $product->getCmsPageId();
-
-            if ($pageId) {
+            if (!$skipCmsPage && $pageId) {
                 // clone product to prevent recursion encoding (see NEXT-17603)
                 $resolverContext = new EntityResolverContext($context, $request, $this->productDefinition, clone $product);
 

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -110,12 +110,12 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                 $this->breadcrumbBuilder->getProductSeoCategory($product, $context)
             );
 
-            $skipConfigurator = $request->query->getBoolean(self::SKIP_CONFIGURATOR);
-            $configurator = !$skipConfigurator ? $this->configuratorLoader->load($product, $context) : null;
+            $loadConfigurator = !$request->query->getBoolean(self::SKIP_CONFIGURATOR);
+            $configurator = $loadConfigurator ? $this->configuratorLoader->load($product, $context) : null;
 
-            $skipCmsPage = $request->query->getBoolean(self::SKIP_CMS_PAGE);
+            $loadCmsPage = !$request->query->getBoolean(self::SKIP_CMS_PAGE);
             $pageId = $product->getCmsPageId();
-            if (!$skipCmsPage && $pageId) {
+            if ($loadCmsPage && $pageId) {
                 // clone product to prevent recursion encoding (see NEXT-17603)
                 $resolverContext = new EntityResolverContext($context, $request, $this->productDefinition, clone $product);
 

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product.json
@@ -94,6 +94,24 @@
                         "schema": {
                             "type": "boolean"
                         }
+                    },
+                    {
+                        "description": "Instructs Shopware to skip loading the configurator data",
+                        "in": "query",
+                        "name": "skipConfigurator",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "description": "Instructs Shopware to skip loading the CMS page data",
+                        "in": "query",
+                        "name": "skipCmsPage",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ],
                 "requestBody": {

--- a/tests/integration/Core/Framework/fixtures/QueryParameterAllowList.php
+++ b/tests/integration/Core/Framework/fixtures/QueryParameterAllowList.php
@@ -70,6 +70,7 @@ class QueryParameterAllowList
                 '/store-api/navigation/{activeId}/{rootId}' => ['@criteria', 'depth', 'buildTree'],
                 '/store-api/payment-method' => ['@criteria'],
                 '/store-api/product' => ['@criteria'],
+                '/store-api/product/{productId}' => ['skipConfigurator', 'skipCmsPage'],
                 '/store-api/salutation' => ['@criteria'],
                 '/store-api/seo-url' => ['@criteria'],
                 '/store-api/shipping-method' => ['@criteria', 'onlyAvailable'],


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently if you request the product detail route to get data via the store api there is always the configurator & cms data for the product
- You maybe don't need this data and want to exclude if for smaller payloads & after respond time
- This PR adds new query parameter to exclude the configurator or cms data from the response
- This PR is a extracted change from https://github.com/shopware/shopware/pull/12004

### 2. What does this change do, exactly?
* Added `skipConfigurator` & `skipCmsPage` query parameter checks to `Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute`

### 3. Describe each step to reproduce the issue or behaviour.
- Load a product via the store-api
- You get a huge amount of cms & configurator data, even tough you maybe don't want / need it

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/12004

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
