### PR TITLE
chore: Enable `reportWrongPhpDocTypeInVarTag` phpstan parameter

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -198,3 +198,8 @@ parameters:
             identifier: argument.type
             path: tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
 
+        - # tests are allowed to add dummy classes in the same file
+            message: '#PHPDoc tag @var with type .* is not subtype of type .*#'
+            paths:
+                - src/Core/**
+                - tests/**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -198,7 +198,7 @@ parameters:
             identifier: argument.type
             path: tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
 
-        - # tests are allowed to add dummy classes in the same file
+        - # With the active `reportWrongPhpDocTypeInVarTag` phpstan parameter we should resolve this issue per area
             message: '#PHPDoc tag @var with type .* is not subtype of type .*#'
             paths:
                 - src/Core/**

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -19,7 +19,6 @@ parameters:
 
     # For stricter testing those should be set to true at some point
     reportMaybesInMethodSignatures: false
-    reportWrongPhpDocTypeInVarTag: true
 
     # For stricter testing those should be set to true at some point
     strictRules:

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -19,7 +19,7 @@ parameters:
 
     # For stricter testing those should be set to true at some point
     reportMaybesInMethodSignatures: false
-    reportWrongPhpDocTypeInVarTag: false
+    reportWrongPhpDocTypeInVarTag: true
 
     # For stricter testing those should be set to true at some point
     strictRules:

--- a/src/Core/Framework/Test/TestCaseBase/SessionTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SessionTestBehaviour.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\Test\TestCaseBase;
 
 use PHPUnit\Framework\Attributes\After;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
-use Symfony\Component\HttpFoundation\Session\SessionFactory;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -25,7 +24,6 @@ trait SessionTestBehaviour
 
     public function getSession(): SessionInterface
     {
-        /** @var SessionFactory $factory */
         $factory = static::getContainer()->get('session.factory');
 
         return $factory->createSession();

--- a/src/Core/Framework/Test/TestCaseBase/SessionTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SessionTestBehaviour.php
@@ -4,9 +4,7 @@ namespace Shopware\Core\Framework\Test\TestCaseBase;
 
 use PHPUnit\Framework\Attributes\After;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionFactory;
-use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**

--- a/src/Core/Framework/Test/TestCaseBase/SessionTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SessionTestBehaviour.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Test\TestCaseBase;
 use PHPUnit\Framework\Attributes\After;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionFactory;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -26,7 +27,7 @@ trait SessionTestBehaviour
 
     public function getSession(): SessionInterface
     {
-        /** @var SessionFactoryInterface $factory */
+        /** @var SessionFactory $factory */
         $factory = static::getContainer()->get('session.factory');
 
         return $factory->createSession();

--- a/src/Elasticsearch/Framework/ElasticsearchHelper.php
+++ b/src/Elasticsearch/Framework/ElasticsearchHelper.php
@@ -94,7 +94,7 @@ class ElasticsearchHelper
             return;
         }
 
-        /** @var list<string> $ids */
+        /** @var non-empty-list<string> $ids */
         $ids = array_values($ids);
 
         $query = $this->parser->parseFilter(

--- a/src/Elasticsearch/Product/CustomFieldSetGateway.php
+++ b/src/Elasticsearch/Product/CustomFieldSetGateway.php
@@ -89,7 +89,7 @@ class CustomFieldSetGateway
      */
     public function fetchLanguageIds(): array
     {
-        /** @var array<string> $languageIds */
+        /** @var list<string> $languageIds */
         $languageIds = $this->connection->fetchFirstColumn('SELECT LOWER(HEX(`id`)) FROM language');
 
         return $languageIds;

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -210,7 +210,6 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
 
         $languageMapping = $this->getLanguageMapping();
 
-        /** @var array<string, string> $item */
         foreach ($data as $id => $item) {
             /** @var array<int|string, array<string, string|null>> $translation */
             $translation = $item['translation'] ?? [];
@@ -226,6 +225,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 context: $context
             );
 
+            /** @var array<string, string> $item */
             $visibilities = ElasticsearchIndexingUtils::parseJson($item, 'visibilities');
 
             $visibilitiesFlatten = [];
@@ -244,6 +244,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 continue;
             }
 
+            /** @var array<string, string> $item */
             $documents[$id] = [
                 'id' => $id,
                 'autoIncrement' => (float) $item['autoIncrement'],

--- a/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
+++ b/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
@@ -92,7 +92,7 @@ class MaintenanceModeResolver
         $main = $this->requestStack->getMainRequest();
         $whitelist = $main?->attributes->get(SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE_IP_WHITLELIST) ?? '';
 
-        /** @var string[] $allowedIps */
+        /** @var list<string> $allowedIps */
         $allowedIps = Json::decodeToList((string) $whitelist);
 
         return $this->maintenanceModeResolver->isClientAllowed($request, $allowedIps);

--- a/src/Storefront/Theme/Subscriber/UnusedMediaSubscriber.php
+++ b/src/Storefront/Theme/Subscriber/UnusedMediaSubscriber.php
@@ -38,7 +38,7 @@ class UnusedMediaSubscriber implements EventSubscriberInterface
     public function removeUsedMedia(UnusedMediaSearchEvent $event): void
     {
         $context = Context::createDefaultContext();
-        /** @var array<string> $allThemeIds */
+        /** @var list<string> $allThemeIds */
         $allThemeIds = $this->themeRepository->searchIds(new Criteria(), $context)->getIds();
 
         $mediaIds = [];

--- a/src/Storefront/Theme/ThemeLifecycleService.php
+++ b/src/Storefront/Theme/ThemeLifecycleService.php
@@ -198,7 +198,7 @@ class ThemeLifecycleService
         $criteria->addFilter(new EqualsFilter('media_folder.defaultFolder.entity', 'theme'));
         $criteria->setLimit(1);
 
-        /** @var array<string> $defaultFolderIds */
+        /** @var list<string> $defaultFolderIds */
         $defaultFolderIds = $this->mediaFolderRepository->searchIds($criteria, $context)->getIds();
 
         return \count($defaultFolderIds) === 1 ? $defaultFolderIds[0] : null;


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/pull/12018#discussion_r2291099433
- After this PR we can resolve the remaining ~100 issues from core & tests

### 2. What does this change do, exactly?
- Enable `reportWrongPhpDocTypeInVarTag` phpstan parameter

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/12018#discussion_r2291099433

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
