### PR TITLE
ci: use pull_request_target in milestone automation

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,7 +1,7 @@
 name: Update milestone
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
### 1. Why is this change necessary?
Externals doesn't have enough permissions to update a PR.

### 2. What does this change do, exactly?
Run the workflow in `pull_request_target` context.

### 4. Please link to the relevant issues (if any).
- closes #12201
