### PR TITLE
chore: Enable `overwriteVariablesWithLoop` phpstan parameter

### DIFF
--- a/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
@@ -61,8 +61,8 @@ final class DeliveryNoteRenderer extends AbstractDocumentRenderer
 
         $chunk = $this->getOrdersLanguageId(array_values($ids), $context->getVersionId(), $this->connection);
 
-        foreach ($chunk as ['language_id' => $languageId, 'ids' => $ids]) {
-            $criteria = OrderDocumentCriteriaFactory::create(\explode(',', (string) $ids), $rendererConfig->deepLinkCode, self::TYPE);
+        foreach ($chunk as ['language_id' => $languageId, 'ids' => $chunkIds]) {
+            $criteria = OrderDocumentCriteriaFactory::create(\explode(',', (string) $chunkIds), $rendererConfig->deepLinkCode, self::TYPE);
             $context = $context->assign([
                 'languageIdChain' => \array_values(\array_unique(\array_filter([$languageId, ...$languageIdChain]))),
             ]);

--- a/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
@@ -62,8 +62,8 @@ final class InvoiceRenderer extends AbstractDocumentRenderer
 
         $chunk = $this->getOrdersLanguageId(array_values($ids), $context->getVersionId(), $this->connection);
 
-        foreach ($chunk as ['language_id' => $languageId, 'ids' => $ids]) {
-            $criteria = OrderDocumentCriteriaFactory::create(\explode(',', (string) $ids), $rendererConfig->deepLinkCode, self::TYPE);
+        foreach ($chunk as ['language_id' => $languageId, 'ids' => $chunkIds]) {
+            $criteria = OrderDocumentCriteriaFactory::create(\explode(',', (string) $chunkIds), $rendererConfig->deepLinkCode, self::TYPE);
 
             $context = $context->assign([
                 'languageIdChain' => \array_values(\array_unique(\array_filter([$languageId, ...$languageIdChain]))),

--- a/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
@@ -61,8 +61,8 @@ class ZugferdRenderer extends AbstractDocumentRenderer
         $languageIdChain = $context->getLanguageIdChain();
 
         $chunk = $this->getOrdersLanguageId(array_values($ids), $context->getVersionId(), $this->connection);
-        foreach ($chunk as ['language_id' => $languageId, 'ids' => $ids]) {
-            $criteria = OrderDocumentCriteriaFactory::create(\explode(',', (string) $ids), $rendererConfig->deepLinkCode);
+        foreach ($chunk as ['language_id' => $languageId, 'ids' => $chunkIds]) {
+            $criteria = OrderDocumentCriteriaFactory::create(\explode(',', (string) $chunkIds), $rendererConfig->deepLinkCode);
             $criteria->addAssociation('lineItems.product.manufacturer');
 
             $context->assign([

--- a/src/Core/Checkout/Order/Api/OrderActionController.php
+++ b/src/Core/Checkout/Order/Api/OrderActionController.php
@@ -204,9 +204,9 @@ class OrderActionController extends AbstractController
         $documentsGroupByType = FetchModeHelper::group($documents);
         /** @var array<string, array<array{sent: int, doc_id: string}>> $documentsGroupByType */
         $documentIds = [];
-        foreach ($documentsGroupByType as $documents) {
+        foreach ($documentsGroupByType as $groupedDocuments) {
             // Latest document of type
-            $document = $documents[0];
+            $document = $groupedDocuments[0];
 
             if ($skipSentDocuments && $document['sent']) {
                 continue;

--- a/src/Core/Content/Media/Infrastructure/Command/UpdatePathCommand.php
+++ b/src/Core/Content/Media/Infrastructure/Command/UpdatePathCommand.php
@@ -50,9 +50,9 @@ class UpdatePathCommand extends Command
         $progressBar->start();
 
         $chunks = array_chunk($ids, 200);
-        foreach ($chunks as $ids) {
-            $this->updater->updateMedia($ids);
-            $progressBar->advance(\count($ids));
+        foreach ($chunks as $chunkIds) {
+            $this->updater->updateMedia($chunkIds);
+            $progressBar->advance(\count($chunkIds));
         }
 
         $progressBar->finish();
@@ -71,9 +71,9 @@ class UpdatePathCommand extends Command
 
         $progressBar->start();
         $chunks = array_chunk($ids, 200);
-        foreach ($chunks as $ids) {
-            $this->updater->updateThumbnails($ids);
-            $progressBar->advance(\count($ids));
+        foreach ($chunks as $chunkIds) {
+            $this->updater->updateThumbnails($chunkIds);
+            $progressBar->advance(\count($chunkIds));
         }
         $progressBar->finish();
 

--- a/src/Core/Content/Media/MediaFolderService.php
+++ b/src/Core/Content/Media/MediaFolderService.php
@@ -111,11 +111,11 @@ class MediaFolderService
 
         $payload[$folder->getId()]['useParentConfiguration'] = false;
 
-        foreach ($subFolders as $folder) {
+        foreach ($subFolders as $subFolder) {
             $configurationId = $config ? $this->cloneConfiguration($config->getId(), $context) : null;
 
-            $payload[$folder->getId()]['useParentConfiguration'] = false;
-            $payload[$folder->getId()]['configurationId'] = $configurationId;
+            $payload[$subFolder->getId()]['useParentConfiguration'] = false;
+            $payload[$subFolder->getId()]['configurationId'] = $configurationId;
         }
 
         return $payload;

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -401,9 +401,9 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
             return $this->buildPriceDefinition($product->getCalculatedPrice(), $quantity);
         }
 
-        // keep loop reference to $price variable to get last quantity price in case of "null"
         $price = $product->getCalculatedPrice();
-        foreach ($product->getCalculatedPrices() as $price) {
+        foreach ($product->getCalculatedPrices() as $calculatedPrice) {
+            $price = $calculatedPrice;
             if ($quantity <= $price->getQuantity()) {
                 break;
             }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -31,7 +31,6 @@ parameters:
         disallowedEmpty: false
         disallowedImplicitArrayCreation: false
         disallowedShortTernary: false
-        overwriteVariablesWithLoop: false
         closureUsesThis: false
         matchingInheritedMethodNames: false
         numericOperandsInArithmeticOperators: false

--- a/src/Core/Framework/Adapter/Filesystem/MemoryFilesystemAdapter.php
+++ b/src/Core/Framework/Adapter/Filesystem/MemoryFilesystemAdapter.php
@@ -111,8 +111,8 @@ class MemoryFilesystemAdapter implements FilesystemAdapter
         $prefix = $this->preparePath($path);
         $prefix = rtrim($prefix, '/') . '/';
 
-        foreach (array_keys($this->files) as $path) {
-            if (str_starts_with($path, $prefix)) {
+        foreach (array_keys($this->files) as $file) {
+            if (str_starts_with($file, $prefix)) {
                 return true;
             }
         }
@@ -187,9 +187,9 @@ class MemoryFilesystemAdapter implements FilesystemAdapter
         $prefixLength = \strlen($prefix);
         $listedDirectories = [];
 
-        foreach ($this->files as $path => $file) {
-            if (str_starts_with($path, $prefix)) {
-                $subPath = substr($path, $prefixLength);
+        foreach ($this->files as $filePath => $file) {
+            if (str_starts_with($filePath, $prefix)) {
+                $subPath = substr($filePath, $prefixLength);
                 $dirname = \dirname($subPath);
 
                 if ($dirname !== '.') {
@@ -211,12 +211,12 @@ class MemoryFilesystemAdapter implements FilesystemAdapter
                 }
 
                 $dummyFilename = self::DUMMY_FILE_FOR_FORCED_LISTING_IN_FLYSYSTEM_TEST;
-                if (str_ends_with($path, $dummyFilename)) {
+                if (str_ends_with($filePath, $dummyFilename)) {
                     continue;
                 }
 
                 if ($deep === true || !str_contains($subPath, '/')) {
-                    yield new FileAttributes(ltrim($path, '/'), $file->fileSize(), $file->visibility(), $file->lastModified(), $file->mimeType());
+                    yield new FileAttributes(ltrim($filePath, '/'), $file->fileSize(), $file->visibility(), $file->lastModified(), $file->mimeType());
                 }
             }
         }

--- a/src/Core/Framework/Adapter/Twig/TokenParser/FromTokenParser.php
+++ b/src/Core/Framework/Adapter/Twig/TokenParser/FromTokenParser.php
@@ -60,8 +60,8 @@ final class FromTokenParser extends AbstractTokenParser
         $internalRef = new AssignTemplateVariable(new TemplateVariable(null, $token->getLine()), $this->parser->isMainScope());
         $node = new ImportNode($macro, $internalRef, $token->getLine());
 
-        foreach ($targets as $name => $alias) {
-            $this->parser->addImportedSymbol('function', $alias->getAttribute('name'), 'macro_' . $name, $internalRef);
+        foreach ($targets as $targetName => $targetAlias) {
+            $this->parser->addImportedSymbol('function', $targetAlias->getAttribute('name'), 'macro_' . $targetName, $internalRef);
         }
 
         return $node;

--- a/src/Core/Framework/Api/Sync/SyncFkResolver.php
+++ b/src/Core/Framework/Api/Sync/SyncFkResolver.php
@@ -43,8 +43,8 @@ class SyncFkResolver
             return $payload;
         }
 
-        foreach ($map as $key => &$values) {
-            $values = $this->getResolver($key)->resolve($values);
+        foreach ($map as $fkKey => &$values) {
+            $values = $this->getResolver($fkKey)->resolve($values);
         }
 
         $exceptions = [];

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -158,8 +158,8 @@ class EntityHydrator
 
             $encoded = $field->getSerializer()->encode($field, $existence, $kvPair, $params);
 
-            foreach ($encoded as $key => $value) {
-                $mapped[$key] = $value;
+            foreach ($encoded as $key => $encodedValue) {
+                $mapped[$key] = $encodedValue;
             }
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
@@ -122,11 +122,11 @@ class CriteriaPartResolver
             $query->setParameter($key, $value, $parsed->getType($key));
         }
 
-        foreach ($filter->getQueries() as $filter) {
-            if (!$filter instanceof SingleFieldFilter) {
+        foreach ($filter->getQueries() as $queryFilter) {
+            if (!$queryFilter instanceof SingleFieldFilter) {
                 continue;
             }
-            $filter->setResolved(self::escape($alias) . '.id IS NOT NULL');
+            $queryFilter->setResolved(self::escape($alias) . '.id IS NOT NULL');
         }
 
         $query->andWhere(implode(' AND ', $parsed->getWheres()));

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilder.php
@@ -60,11 +60,11 @@ class JoinGroupBuilder
 
             unset($groups['operator'], $groups['negated']);
 
-            foreach ($groups as $path => $filters) {
+            foreach ($groups as $path => $groupFilters) {
                 $relevant = \in_array($path, $duplicates, true) || $negated;
 
                 if (!$relevant) {
-                    $new = array_merge($new, $filters);
+                    $new = array_merge($new, $groupFilters);
 
                     continue;
                 }
@@ -73,7 +73,7 @@ class JoinGroupBuilder
                     continue;
                 }
 
-                $new[] = new JoinGroup($filters, $path, '_' . $level, $operator);
+                $new[] = new JoinGroup($groupFilters, $path, '_' . $level, $operator);
                 ++$level;
             }
         }

--- a/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
@@ -272,8 +272,8 @@ class EntityWriteResultFactory
             // after resolving the mapping entities - we resolve the parent for related entity (maybe inherited for products, or sub domain entities)
             $nested = $this->resolveParents($fkField->getReferenceDefinition(), $mapped);
 
-            foreach ($nested as $entity => $primaryKeys) {
-                $mapping[$entity] = array_merge($mapping[$entity] ?? [], $primaryKeys);
+            foreach ($nested as $nestedEntity => $nestedPrimaryKeys) {
+                $mapping[$nestedEntity] = array_merge($mapping[$nestedEntity] ?? [], $nestedPrimaryKeys);
             }
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
@@ -449,8 +449,8 @@ class WriteCommandExtractor
         krsort($filtered, \SORT_NUMERIC);
 
         $sorted = [];
-        foreach ($filtered as $fields) {
-            foreach ($fields as $field) {
+        foreach ($filtered as $filteredFields) {
+            foreach ($filteredFields as $field) {
                 $sorted[] = $field;
             }
         }

--- a/src/Core/Framework/Demodata/Generator/PropertyGroupGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/PropertyGroupGenerator.php
@@ -59,8 +59,8 @@ class PropertyGroupGenerator implements DemodataGeneratorInterface
 
         $context->getConsole()->progressStart(\count($data));
 
-        foreach ($data as $group => $options) {
-            $mapped = array_map(fn ($option) => ['id' => Uuid::randomHex(), 'name' => $option], $options);
+        foreach ($data as $group => $groupOptions) {
+            $mapped = array_map(fn ($option) => ['id' => Uuid::randomHex(), 'name' => $option], $groupOptions);
 
             $this->propertyGroupRepository->create(
                 [

--- a/src/Core/Framework/Increment/ArrayIncrementer.php
+++ b/src/Core/Framework/Increment/ArrayIncrementer.php
@@ -39,8 +39,8 @@ class ArrayIncrementer extends AbstractIncrementer
         }
 
         if ($key === null) {
-            foreach ($this->logs[$cluster] as $key => $count) {
-                $this->logs[$cluster][$key] = 0;
+            foreach ($this->logs[$cluster] as $clusterKey => $count) {
+                $this->logs[$cluster][$clusterKey] = 0;
             }
 
             return;

--- a/src/Core/Framework/Increment/RedisIncrementer.php
+++ b/src/Core/Framework/Increment/RedisIncrementer.php
@@ -46,10 +46,10 @@ class RedisIncrementer extends AbstractIncrementer
             return;
         }
 
-        $keys = $this->getKeys($cluster);
+        $clusterKeys = $this->getKeys($cluster);
 
-        foreach ($keys as $key) {
-            $this->redis->del($key);
+        foreach ($clusterKeys as $clusterKey) {
+            $this->redis->del($clusterKey);
         }
     }
 

--- a/src/Core/Framework/MessageQueue/Middleware/RoutingOverwriteMiddleware.php
+++ b/src/Core/Framework/MessageQueue/Middleware/RoutingOverwriteMiddleware.php
@@ -69,8 +69,8 @@ class RoutingOverwriteMiddleware implements MiddlewareInterface
             return null;
         }
 
-        foreach ($overwrites as $class => $transports) {
-            if ($message instanceof $class) {
+        foreach ($overwrites as $overwriteClass => $transports) {
+            if ($message instanceof $overwriteClass) {
                 return $transports;
             }
         }

--- a/src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
+++ b/src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
@@ -258,11 +258,12 @@ EOD;
      */
     private function findForeignKeyDefinition(array $keyStructure): ForeignKeyConstraint
     {
-        $fks = $this->schemaManager->listTableForeignKeys($keyStructure['TABLE_NAME']);
+        $foreignKeys = $this->schemaManager->listTableForeignKeys($keyStructure['TABLE_NAME']);
         $fk = null;
 
-        foreach ($fks as $fk) {
-            if ($this->isEqualForeignKey($fk, $keyStructure['REFERENCED_TABLE_NAME'], $keyStructure['REFERENCED_COLUMN_NAME'])) {
+        foreach ($foreignKeys as $foreignKey) {
+            if ($this->isEqualForeignKey($foreignKey, $keyStructure['REFERENCED_TABLE_NAME'], $keyStructure['REFERENCED_COLUMN_NAME'])) {
+                $fk = $foreignKey;
                 break;
             }
         }

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -120,8 +120,8 @@ class AssetService
             $bundle = $this->getBundle($bundleName);
 
             if ($bundle instanceof Plugin) {
-                foreach ($this->getAdditionalBundles($bundle) as $bundle) {
-                    $this->removeAssets($bundle->getName());
+                foreach ($this->getAdditionalBundles($bundle) as $additionalBundle) {
+                    $this->removeAssets($additionalBundle->getName());
                 }
             }
         } catch (PluginNotFoundException) {

--- a/src/Core/Profiling/DependencyInjection/CompilerPass/CartServiceCompilerPass.php
+++ b/src/Core/Profiling/DependencyInjection/CompilerPass/CartServiceCompilerPass.php
@@ -30,9 +30,9 @@ class CartServiceCompilerPass implements CompilerPassInterface
     private function processTaggedServices(ContainerBuilder $container, string $tag): array
     {
         $services = [];
-        foreach ($container->findTaggedServiceIds($tag) as $serviceId => $tags) {
-            foreach ($tags as $tag) {
-                $priority = (int) ($tag['priority'] ?? 0);
+        foreach ($container->findTaggedServiceIds($tag) as $serviceId => $serviceTags) {
+            foreach ($serviceTags as $serviceTag) {
+                $priority = (int) ($serviceTag['priority'] ?? 0);
                 $services[$serviceId] = [
                     'serviceId' => $serviceId,
                     'priority' => $priority,

--- a/src/Core/System/SystemConfig/SystemConfigService.php
+++ b/src/Core/System/SystemConfig/SystemConfigService.php
@@ -244,10 +244,10 @@ class SystemConfigService implements ResetInterface
             }
         }
 
-        $event = new BeforeSystemConfigMultipleChangedEvent($values, $salesChannelId);
-        $this->dispatcher->dispatch($event);
+        $beforeChangedEvent = new BeforeSystemConfigMultipleChangedEvent($values, $salesChannelId);
+        $this->dispatcher->dispatch($beforeChangedEvent);
 
-        $values = $event->getConfig();
+        $values = $beforeChangedEvent->getConfig();
 
         $where = $salesChannelId ? 'sales_channel_id = :salesChannelId' : 'sales_channel_id IS NULL';
 

--- a/src/Elasticsearch/Admin/AdminSearcher.php
+++ b/src/Elasticsearch/Admin/AdminSearcher.php
@@ -93,13 +93,13 @@ class AdminSearcher
         }
 
         $mapped = [];
-        foreach ($result as $index => $values) {
+        foreach ($result as $idx => $values) {
             $entityName = $values['hits'][0]['entityName'];
             $indexer = $this->registry->getIndexer($entityName);
 
             $data = $indexer->globalData($values, $context);
             $data['indexer'] = $indexer->getName();
-            $data['index'] = (string) $index;
+            $data['index'] = (string) $idx;
 
             $mapped[$indexer->getEntity()] = $data;
         }

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearchHydrator.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearchHydrator.php
@@ -69,10 +69,10 @@ class ElasticsearchEntitySearchHydrator extends AbstractElasticsearchSearchHydra
             /** @var array{ hits: array{ hits: array<int, array<mixed>>}} $inner */
             $inner = $hit['inner_hits']['inner'];
 
-            $nested = $this->extractHits($inner);
+            $innerHits = $this->extractHits($inner);
 
-            foreach ($nested as $inner) {
-                $records[] = $inner;
+            foreach ($innerHits as $innerHit) {
+                $records[] = $innerHit;
             }
         }
 

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -220,8 +220,8 @@ abstract class StorefrontController extends AbstractController
         }
 
         /** @var array<string, Error[]> $groups */
-        foreach ($groups as $type => $errors) {
-            foreach ($errors as $error) {
+        foreach ($groups as $type => $errorGroup) {
+            foreach ($errorGroup as $error) {
                 $parameters = [];
 
                 foreach ($error->getParameters() as $key => $value) {

--- a/src/Storefront/Theme/Command/ThemePrepareIconsCommand.php
+++ b/src/Storefront/Theme/Command/ThemePrepareIconsCommand.php
@@ -104,9 +104,9 @@ class ThemePrepareIconsCommand extends Command
             $defs = $svg->getDocument()->getChild(0);
             if (!($defs instanceof SVGDefs)) {
                 $defs = new SVGDefs();
-                foreach ($this->getChildren($svg->getDocument()) as $child) {
-                    $svg->getDocument()->removeChild($child);
-                    $defs->addChild($child);
+                foreach ($this->getChildren($svg->getDocument()) as $documentChild) {
+                    $svg->getDocument()->removeChild($documentChild);
+                    $defs->addChild($documentChild);
                 }
                 $svg->getDocument()->addChild($defs);
             }
@@ -121,9 +121,9 @@ class ThemePrepareIconsCommand extends Command
             }
 
             $use = null;
-            foreach ($this->getChildren($svg->getDocument()) as $child) {
-                if ($child instanceof SVGUse) {
-                    $use = $child;
+            foreach ($this->getChildren($svg->getDocument()) as $documentChild) {
+                if ($documentChild instanceof SVGUse) {
+                    $use = $documentChild;
                 }
             }
 

--- a/tests/integration/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
@@ -130,8 +130,8 @@ class CrossSellingRouteTest extends TestCase
         static::assertSame('Test Cross Selling', $element->getCrossSelling()->getName());
 
         $lastPrice = 0;
-        foreach ($element->getProducts() as $product) {
-            $productPrice = $product->getCurrencyPrice(Defaults::CURRENCY);
+        foreach ($element->getProducts() as $crossSellingProduct) {
+            $productPrice = $crossSellingProduct->getCurrencyPrice(Defaults::CURRENCY);
             static::assertNotNull($productPrice);
             static::assertGreaterThanOrEqual($lastPrice, $productPrice->getGross());
             $lastPrice = $productPrice->getGross();
@@ -170,8 +170,8 @@ class CrossSellingRouteTest extends TestCase
         static::assertSame('Test Cross Selling', $element->getCrossSelling()->getName());
 
         $lastPrice = 0;
-        foreach ($element->getProducts() as $product) {
-            $productPrice = $product->getCurrencyPrice(Defaults::CURRENCY);
+        foreach ($element->getProducts() as $crossSellingProduct) {
+            $productPrice = $crossSellingProduct->getCurrencyPrice(Defaults::CURRENCY);
             static::assertNotNull($productPrice);
             static::assertGreaterThanOrEqual($lastPrice, $productPrice->getGross());
             $lastPrice = $productPrice->getGross();
@@ -210,8 +210,8 @@ class CrossSellingRouteTest extends TestCase
         static::assertSame('Test Cross Selling', $element->getCrossSelling()->getName());
 
         $lastPrice = 0;
-        foreach ($element->getProducts() as $product) {
-            $productPrice = $product->getCurrencyPrice(Defaults::CURRENCY);
+        foreach ($element->getProducts() as $crossSellingProduct) {
+            $productPrice = $crossSellingProduct->getCurrencyPrice(Defaults::CURRENCY);
             static::assertNotNull($productPrice);
             static::assertGreaterThanOrEqual($lastPrice, $productPrice->getGross());
             $lastPrice = $productPrice->getGross();

--- a/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
+++ b/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
@@ -87,8 +87,8 @@ class ApiRoutesHaveASchemaTest extends TestCase
         }
 
         if (!empty($schemaRoutes)) {
-            foreach ($schemaRoutes as $path => $schema) {
-                $routesFromPathParameter = $this->getRoutesFromSchemaDefinitionPath($path, $schema);
+            foreach ($schemaRoutes as $path => $routeSchema) {
+                $routesFromPathParameter = $this->getRoutesFromSchemaDefinitionPath($path, $routeSchema);
                 foreach ($routesFromPathParameter as $routeFromPathParameter) {
                     if (\in_array($routeFromPathParameter, $missingRoutes, true)) {
                         unset($schemaRoutes[$path], $missingRoutes[array_search($routeFromPathParameter, $missingRoutes, true)]);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
@@ -1497,8 +1497,8 @@ class EntityRepositoryTest extends TestCase
         static::assertCount(3, $folder->getChildren());
 
         $secondIds = $folder->getChildren()->getIds();
-        foreach ($firstIds as $id) {
-            static::assertNotContains($id, $secondIds);
+        foreach ($firstIds as $childrenId) {
+            static::assertNotContains($childrenId, $secondIds);
         }
     }
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntitySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntitySearcherTest.php
@@ -585,10 +585,10 @@ class EntitySearcherTest extends TestCase
         static::assertIsArray($result->getIds());
         static::assertNotEmpty($result->getIds());
 
-        foreach ($result->getIds() as $ids) {
-            static::assertIsArray($ids);
-            static::assertArrayHasKey('productId', $ids);
-            static::assertArrayHasKey('categoryId', $ids);
+        foreach ($result->getIds() as $resultIds) {
+            static::assertIsArray($resultIds);
+            static::assertArrayHasKey('productId', $resultIds);
+            static::assertArrayHasKey('categoryId', $resultIds);
         }
     }
 

--- a/tests/integration/Core/Framework/Store/Subscriber/LicenseHostChangedSubscriberTest.php
+++ b/tests/integration/Core/Framework/Store/Subscriber/LicenseHostChangedSubscriberTest.php
@@ -33,12 +33,12 @@ class LicenseHostChangedSubscriberTest extends TestCase
         /** @var EntityRepository<UserCollection> $userRepository */
         $userRepository = static::getContainer()->get('user.repository');
 
-        /** @var UserEntity $adminUser */
-        $adminUser = $userRepository->search(new Criteria(), $context)->first();
+        $user = $userRepository->search(new Criteria(), $context)->first();
+        static::assertInstanceOf(UserEntity::class, $user);
 
         $userRepository->create([
             [
-                'localeId' => $adminUser->getLocaleId(),
+                'localeId' => $user->getLocaleId(),
                 'username' => 'admin2',
                 'password' => TestDefaults::HASHED_PASSWORD,
                 'firstName' => 'admin2',
@@ -47,7 +47,7 @@ class LicenseHostChangedSubscriberTest extends TestCase
                 'storeToken' => null,
             ],
             [
-                'localeId' => $adminUser->getLocaleId(),
+                'localeId' => $user->getLocaleId(),
                 'username' => 'admin3',
                 'password' => TestDefaults::HASHED_PASSWORD,
                 'firstName' => 'admin3',

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Services/InAppPurchaseProviderTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Services/InAppPurchaseProviderTest.php
@@ -209,8 +209,8 @@ class InAppPurchaseProviderTest extends TestCase
                 'quantity' => 1,
             ];
         }
-        foreach ($formattedActivePurchases as $extensionName => $purchases) {
-            $formattedActivePurchases[$extensionName] = $this->generateJwt($purchases);
+        foreach ($formattedActivePurchases as $extensionName => $formattedActivePurchase) {
+            $formattedActivePurchases[$extensionName] = $this->generateJwt($formattedActivePurchase);
         }
 
         return \json_encode($formattedActivePurchases) ?: '';


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/pull/12204
- This PR enables the `overwriteVariablesWithLoop` phpstan parameter to improve phpstan type safety

### 2. What does this change do, exactly?
- Enable `overwriteVariablesWithLoop` phpstan parameter

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/12204

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
