### PR TITLE
chore: Enable `noVariableVariables` phpstan parameter

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -139,24 +139,6 @@ parameters:
         - identifier: staticMethod.alreadyNarrowedType
           path: tests/devops/Core/DefaultsTest.php
 
-        - # Classes that are allowed to use dynamic property name access
-            message: '#Use explicit names over dynamic ones#'
-            paths:
-                - src/Core/Checkout/Cart/LineItem/LineItem.php
-                - src/Core/Checkout/Document/DocumentConfiguration.php
-                - src/Core/Content/Product/Hook/Pricing/ProductProxy.php
-                - src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
-                - src/Core/Framework/Struct/AssignArrayTrait.php
-                - src/Core/Framework/Struct/CloneTrait.php
-                - src/Core/Framework/Struct/CreateFromTrait.php
-                - src/Core/Framework/App/Manifest/Xml/XmlElement.php
-                - src/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/SingleEntitySelectField.php
-                - src/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/SingleSelectField.php
-                - src/Core/Framework/App/Payment/Response/AbstractResponse.php
-                - src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
-                - src/Core/Framework/DataAbstractionLayer/Entity.php
-                - src/Core/Framework/DataAbstractionLayer/Util/AfterSort.php
-
         - # Can not be fixed currently. See https://github.com/phpstan/phpstan/discussions/9159
             message: '#Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Field::getFlag\(\) should return \(TFlag of Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Flag\\Flag\)\|null but returns Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Flag\\Flag\|null#'
             path: src/Core/Framework/DataAbstractionLayer/Field/Field.php

--- a/src/Core/Checkout/Cart/LineItem/LineItem.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItem.php
@@ -120,6 +120,7 @@ class LineItem extends Struct
         $self = new self($lineItem->id, $lineItem->type, $lineItem->getReferencedId(), $lineItem->quantity);
 
         foreach (get_object_vars($lineItem) as $property => $value) {
+            // @phpstan-ignore property.dynamicName (We have to use dynamic properties here to copy over all properties)
             $self->$property = $value;
         }
 

--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -115,6 +115,7 @@ class DocumentConfiguration extends Struct
      */
     public function __set($name, $value): void
     {
+        // @phpstan-ignore property.dynamicName (We allow all dynamic properties in the document configuration)
         $this->$name = $value;
     }
 
@@ -125,6 +126,7 @@ class DocumentConfiguration extends Struct
      */
     public function __get($name)
     {
+        // @phpstan-ignore property.dynamicName (We allow all dynamic properties in the document configuration)
         return $this->$name;
     }
 

--- a/src/Core/Checkout/Document/DocumentConfigurationFactory.php
+++ b/src/Core/Checkout/Document/DocumentConfigurationFactory.php
@@ -79,12 +79,12 @@ class DocumentConfigurationFactory
                  */
                 if (method_exists($baseConfig, $setterMethod)) {
                     if (is_subclass_of($typeName, Struct::class) && \is_array($value)) {
-                        // @phpstan-ignore symplify.noDynamicName
+                        // @phpstan-ignore method.dynamicName
                         $baseConfig->$setterMethod((new $typeName())->assign($value));
                         continue;
                     }
 
-                    // @phpstan-ignore symplify.noDynamicName
+                    // @phpstan-ignore method.dynamicName
                     $baseConfig->$setterMethod($value);
                     continue;
                 }
@@ -94,7 +94,7 @@ class DocumentConfigurationFactory
                     continue;
                 }
 
-                // @phpstan-ignore symplify.noDynamicName
+                // @phpstan-ignore property.dynamicName
                 $baseConfig->{$key} = (new $typeName())->assign($value);
             }
         }

--- a/src/Core/Content/Product/Hook/Pricing/ProductProxy.php
+++ b/src/Core/Content/Product/Hook/Pricing/ProductProxy.php
@@ -67,6 +67,7 @@ class ProductProxy implements \ArrayAccess
             'calculatedCheapestPrice' => $this->calculatedCheapestPrice(),
             'calculatedPrice' => $this->calculatedPrice(),
             'calculatedPrices' => $this->calculatedPrices(),
+            // @phpstan-ignore property.dynamicName (Allow the dynamic access for sales channel product fields)
             default => $this->product->$property,
         };
     }

--- a/src/Core/DevOps/Docs/Script/HooksReferenceGenerator.php
+++ b/src/Core/DevOps/Docs/Script/HooksReferenceGenerator.php
@@ -357,7 +357,7 @@ class HooksReferenceGenerator implements ScriptReferenceGenerator
         $hookData['interfaceHook'] = true;
         $hookData['interfaceDescription'] = "**Interface Hook**\n\n" . $hookData['trigger'];
 
-        foreach ($hook::FUNCTIONS as $functionName => $functionHook) { /* @phpstan-ignore-line */
+        foreach ($hook::FUNCTIONS as $functionName => $functionHook) {
             $hookData['functions'][$functionName] = $this->getDataForHook($functionHook);
         }
 

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -31,7 +31,6 @@ parameters:
         closureUsesThis: false
         numericOperandsInArithmeticOperators: false
         dynamicCallOnStaticMethod: false
-        noVariableVariables: false
         strictArrayFilter: false
 
     type_perfect:
@@ -53,9 +52,6 @@ rules:
     - Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule
 
     - Symplify\PHPStanRules\Rules\Complexity\ForbiddenArrayMethodCallRule
-
-    # complexity rules
-    - Symplify\PHPStanRules\Rules\NoDynamicNameRule
 
     # naming rules
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Symplify\NoReturnSetterMethodWithFluentSettersRule

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
@@ -193,6 +193,7 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
 
         foreach ($openApi->paths as $path) {
             foreach (self::OPERATION_KEYS as $key) {
+                // @phpstan-ignore property.dynamicName (We check the keys via OPERATION_KEYS)
                 $operation = $path->$key;
 
                 if (!$operation instanceof Operation) {

--- a/src/Core/Framework/App/Manifest/Xml/XmlElement.php
+++ b/src/Core/Framework/App/Manifest/Xml/XmlElement.php
@@ -26,6 +26,7 @@ abstract class XmlElement extends Struct
         $this->validateRequiredElements($data, static::REQUIRED_FIELDS);
 
         foreach ($data as $property => $value) {
+            // @phpstan-ignore property.dynamicName (The XML element is abstract dynamic so we allow all dynamic properties)
             $this->$property = $value;
         }
     }

--- a/src/Core/Framework/App/Payment/Response/AbstractResponse.php
+++ b/src/Core/Framework/App/Payment/Response/AbstractResponse.php
@@ -38,18 +38,4 @@ abstract class AbstractResponse extends Struct
 
         return $response;
     }
-
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function assign(array $options): static
-    {
-        foreach ($options as $key => $value) {
-            if (property_exists($this, $key)) {
-                $this->$key = $value;
-            }
-        }
-
-        return $this;
-    }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -328,6 +328,7 @@ class EntityHydrator
             $entity->addTranslated($field, $translation);
 
             $chainFieldValue = self::value($row, $chain[0], $field);
+            // @phpstan-ignore property.dynamicName (We have to dynamically set all translated field in the original entity)
             $entity->$field = $chainFieldValue !== null ? ($fieldValue === $chainFieldValue ? $translation : $typed->getSerializer()->decode($typed, $chainFieldValue)) : null;
         }
     }

--- a/src/Core/Framework/DataAbstractionLayer/Entity.php
+++ b/src/Core/Framework/DataAbstractionLayer/Entity.php
@@ -41,6 +41,7 @@ class Entity extends Struct
             $this->checkIfPropertyAccessIsAllowed($name);
         }
 
+        // @phpstan-ignore property.dynamicName (We have to use dynamic properties here to allow access to all entity properties)
         return $this->$name;
     }
 
@@ -50,6 +51,7 @@ class Entity extends Struct
      */
     public function __set($name, $value): void
     {
+        // @phpstan-ignore property.dynamicName (We have to use dynamic properties here to allow access to all entity properties)
         $this->$name = $value;
     }
 
@@ -64,6 +66,7 @@ class Entity extends Struct
             }
         }
 
+        // @phpstan-ignore property.dynamicName
         return isset($this->$name);
     }
 
@@ -100,6 +103,7 @@ class Entity extends Struct
         }
 
         if ($this->has($property)) {
+            // @phpstan-ignore property.dynamicName
             return $this->$property;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Util/AfterSort.php
+++ b/src/Core/Framework/DataAbstractionLayer/Util/AfterSort.php
@@ -25,7 +25,9 @@ class AfterSort
 
         // pre-sort elements to pull elements without an after id parent to the front
         uasort($elements, function (Struct $a, Struct $b) use ($propertyName) {
+            // @phpstan-ignore property.dynamicName (We can use any property to sort the elements)
             $aValue = $a->$propertyName;
+            // @phpstan-ignore property.dynamicName (We can use any property to sort the elements)
             $bValue = $b->$propertyName;
             if ($aValue === $bValue && $aValue === null) {
                 return 0;
@@ -55,6 +57,7 @@ class AfterSort
 
         while (\count($elements) > 0) {
             foreach ($elements as $index => $element) {
+                // @phpstan-ignore property.dynamicName
                 if ($lastId !== $element->$propertyName) {
                     continue;
                 }

--- a/src/Core/Framework/Gateway/Context/Command/Executor/ContextGatewayCommandExecutor.php
+++ b/src/Core/Framework/Gateway/Context/Command/Executor/ContextGatewayCommandExecutor.php
@@ -40,7 +40,6 @@ class ContextGatewayCommandExecutor
         $parameters = [];
 
         if ($tokenCommand = $commands->getSingleTokenCommand()) {
-            /** @phpstan-ignore symplify.noDynamicName */
             $this->registry->get($tokenCommand::COMMAND_KEY)->handle($tokenCommand, $context, $parameters);
 
             $token = $parameters['token'];

--- a/src/Core/Framework/Struct/AssignArrayTrait.php
+++ b/src/Core/Framework/Struct/AssignArrayTrait.php
@@ -22,6 +22,7 @@ trait AssignArrayTrait
             }
 
             try {
+                // @phpstan-ignore property.dynamicName (We allow dynamic assignment of all properties)
                 $this->$key = $value;
             } catch (\Error|\Exception) {
                 // nth

--- a/src/Core/Framework/Struct/CloneTrait.php
+++ b/src/Core/Framework/Struct/CloneTrait.php
@@ -13,8 +13,10 @@ trait CloneTrait
         $variables = get_object_vars($this);
         foreach ($variables as $key => $value) {
             if (\is_object($value) && !$value instanceof \UnitEnum) {
+                // @phpstan-ignore property.dynamicName, property.dynamicName (We have to allow dynamic properties here to copy all variables)
                 $this->$key = clone $this->$key;
             } elseif (\is_array($value)) {
+                // @phpstan-ignore property.dynamicName (We have to allow dynamic properties here to copy all variables)
                 $this->$key = $this->cloneArray($value);
             }
         }

--- a/src/Core/Framework/Struct/CreateFromTrait.php
+++ b/src/Core/Framework/Struct/CreateFromTrait.php
@@ -17,6 +17,7 @@ trait CreateFromTrait
         }
 
         foreach (get_object_vars($object) as $property => $value) {
+            // @phpstan-ignore property.dynamicName (We have to allow dynamic properties here to copy all variables)
             $self->$property = $value;
         }
 

--- a/src/Core/Test/Stub/Redis/RedisMultiWrapper.php
+++ b/src/Core/Test/Stub/Redis/RedisMultiWrapper.php
@@ -31,7 +31,7 @@ class RedisMultiWrapper extends \Redis
      */
     private function doCall(string $name, array $arguments)
     {
-        // @phpstan-ignore symplify.noDynamicName
+        // @phpstan-ignore method.dynamicName (We allow dynamic method calls to proxy all Redis methods)
         $this->results[] = $this->redis->$name(...$arguments);
 
         return $this;

--- a/tests/unit/Administration/Login/TokenService/ParsedIdTokenTest.php
+++ b/tests/unit/Administration/Login/TokenService/ParsedIdTokenTest.php
@@ -98,7 +98,7 @@ class ParsedIdTokenTest extends TestCase
 
         $tokenGenerator->setEmail($email);
         $setter = $this->getSetter($property);
-        // @phpstan-ignore symplify.noDynamicName
+        // @phpstan-ignore method.dynamicName
         $tokenGenerator->$setter($value);
 
         $token = $tokenGenerator->generate();
@@ -106,7 +106,7 @@ class ParsedIdTokenTest extends TestCase
         static::assertInstanceOf(Plain::class, $parsed);
 
         $result = ParsedIdToken::createFromDataSet($parsed->claims());
-        // @phpstan-ignore symplify.noDynamicName
+        // @phpstan-ignore property.dynamicName
         static::assertSame($email, $result->$property);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/pull/12204
- This PR enables the `noVariableVariables` phpstan parameter to improve phpstan type safety

### 2. What does this change do, exactly?
- Enable `noVariableVariables` phpstan parameter

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/12204

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
