### PR TITLE
chore: Explicitly requiring `symfony/web-profiler-bundle` in minimal version 7.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -206,6 +206,7 @@
         "symfony/expression-language": "~7.3.0",
         "symfony/phpunit-bridge": "~7.3.0",
         "symfony/var-dumper": "~7.3.0",
+        "symfony/web-profiler-bundle": "~7.3.0",
         "symplify/phpstan-rules": "14.0.2"
     },
     "suggest": {

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -167,6 +167,7 @@
         "symfony/browser-kit": "~7.3.0",
         "symfony/phpunit-bridge": "~7.3.0",
         "symfony/var-dumper": "~7.3.0",
+        "symfony/web-profiler-bundle": "~7.3.0",
         "symfony/dom-crawler": "~7.3.0",
         "brianium/paratest": "^7.3",
         "shopware/dev-tools": "^1.3"


### PR DESCRIPTION
### 1. Why is this change necessary?
The PR https://github.com/shopware/shopware/pull/11559 needs to be backported: https://github.com/FriendsOfShopware/platform-plugin-dev-docker/actions/runs/17366213609/job/49293465828#step:5:1460

### 2. What does this change do, exactly?
Backport the change which is only in trunk, as the 6.6 version is also affected.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
