### PR TITLE
fix: saas related permissions missing in test

### DIFF
--- a/tests/acceptance/tests/Settings/ShopwareServices.spec.ts
+++ b/tests/acceptance/tests/Settings/ShopwareServices.spec.ts
@@ -86,8 +86,38 @@ test(
         test.skip(satisfies(InstanceMeta.version, '<6.7.1'), 'Feature not available until version 6.7.1.0');
 
         await test.step('Verify insufficient permissions prevent access to services.', async () => {
+            let aclRole;
             // Create a role with insufficient permissions
-            const aclRole = await TestDataService.createAclRole();
+            // eslint-disable-next-line playwright/no-conditional-in-test
+            if (InstanceMeta.isSaaS) {
+                const privileges = [
+                    'cms_page:read',
+                    'custom_field:read',
+                    'custom_field_set_relation:read',
+                    'language:read',
+                    'locale:read',
+                    'log_entry:create',
+                    'message_queue_stats:read',
+                    'product_sorting:create',
+                    'product_sorting:delete',
+                    'product_sorting:read',
+                    'product_sorting:update',
+                    'sales_channel:read',
+                    'seo_url_template:create',
+                    'seo_url_template:read',
+                    'seo_url_template:update',
+                    'system.system_config',
+                    'system_config:create',
+                    'system_config:delete',
+                    'system_config:read',
+                    'system_config:update',
+                    'sales_channel_domain:read',
+                    'swag_language_pack_language:read',
+                ];
+                aclRole = await TestDataService.createAclRole({ privileges: privileges });
+            } else {
+                aclRole = await TestDataService.createAclRole();
+            }
             const user = await TestDataService.createUser();
             await TestDataService.assignAclRoleUser(aclRole.id, user.id);
 
@@ -95,33 +125,68 @@ test(
         });
 
         await test.step('Verify minimum permissions are enough to manage Shopware Services.', async () => {
+            let aclRole;
             // Basic permissions to access the services
-            const privileges = [
-                'cms_page:read',
-                'custom_field:read',
-                'custom_field_set_relation:read',
-                'language:read',
-                'locale:read',
-                'log_entry:create',
-                'message_queue_stats:read',
-                'plugin:update',
-                'product_sorting:create',
-                'product_sorting:delete',
-                'product_sorting:read',
-                'product_sorting:update',
-                'sales_channel:read',
-                'seo_url_template:create',
-                'seo_url_template:read',
-                'seo_url_template:update',
-                'system.plugin_maintain',
-                'system.system_config',
-                'system:clear:cache',
-                'system:plugin:maintain',
-                'system_config:create',
-                'system_config:delete',
-                'system_config:read',
-                'system_config:update'];
-            const aclRole = await TestDataService.createAclRole({privileges: privileges});
+            // eslint-disable-next-line playwright/no-conditional-in-test
+            if (InstanceMeta.isSaaS) {
+                const privileges = [
+                    'cms_page:read',
+                    'custom_field:read',
+                    'custom_field_set_relation:read',
+                    'language:read',
+                    'locale:read',
+                    'log_entry:create',
+                    'message_queue_stats:read',
+                    'plugin:update',
+                    'product_sorting:create',
+                    'product_sorting:delete',
+                    'product_sorting:read',
+                    'product_sorting:update',
+                    'sales_channel:read',
+                    'seo_url_template:create',
+                    'seo_url_template:read',
+                    'seo_url_template:update',
+                    'system.plugin_maintain',
+                    'system.system_config',
+                    'system:clear:cache',
+                    'system:plugin:maintain',
+                    'system_config:create',
+                    'system_config:delete',
+                    'system_config:read',
+                    'system_config:update',
+                    'sales_channel_domain:read',
+                    'swag_language_pack_language:read',
+                ];
+                aclRole = await TestDataService.createAclRole({ privileges: privileges });
+            } else {
+                const privileges = [
+                    'cms_page:read',
+                    'custom_field:read',
+                    'custom_field_set_relation:read',
+                    'language:read',
+                    'locale:read',
+                    'log_entry:create',
+                    'message_queue_stats:read',
+                    'plugin:update',
+                    'product_sorting:create',
+                    'product_sorting:delete',
+                    'product_sorting:read',
+                    'product_sorting:update',
+                    'sales_channel:read',
+                    'seo_url_template:create',
+                    'seo_url_template:read',
+                    'seo_url_template:update',
+                    'system.plugin_maintain',
+                    'system.system_config',
+                    'system:clear:cache',
+                    'system:plugin:maintain',
+                    'system_config:create',
+                    'system_config:delete',
+                    'system_config:read',
+                    'system_config:update',
+                ];
+                aclRole = await TestDataService.createAclRole({ privileges: privileges });
+            }
             const user = await TestDataService.createUser();
             await TestDataService.assignAclRoleUser(aclRole.id, user.id);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In shopware SaaS the user need more permissions to enter the administration by default. 

- 'sales_channel_domain:read',
- 'swag_language_pack_language:read' 


### 2. What does this change do, exactly?
It differ between SaaS and onPrem related permissions and added:

- 'sales_channel_domain:read',
- 'swag_language_pack_language:read' 

### 3. Describe each step to reproduce the issue or behaviour.
- run the test without the following permissions in SaaS. The test to validate the user behaviour with different permissions will fail:
- 'sales_channel_domain:read',
- 'swag_language_pack_language:read' 


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
