### PR TITLE
fix: Media thumbnail generation with null media thumbnail size

### DIFF
--- a/changelog/_unreleased/2025-09-02-fix-media-thumbnail-generation-check-with-null-size.md
+++ b/changelog/_unreleased/2025-09-02-fix-media-thumbnail-generation-check-with-null-size.md
@@ -1,0 +1,8 @@
+---
+title: Fix media thumbnail generation with null media thumbnail size
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Changed `Shopware\Core\Content\Media\Thumbnail\ThumbnailService` to correctly re-generate thumbnails with a null `mediaThumbnailSizeId`

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -24,7 +24,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -158,14 +157,8 @@ class ThumbnailService
 
         foreach ($toBeCreatedSizes as $thumbnailSize) {
             foreach ($toBeDeletedThumbnails as $thumbnail) {
-                if (Feature::isActive('v6.8.0.0')) {
-                    if ($thumbnailSize->getId() !== $thumbnail->getMediaThumbnailSizeId()) {
-                        continue;
-                    }
-                } else {
-                    if ($thumbnail->getMediaThumbnailSizeId() && $thumbnailSize->getId() !== $thumbnail->getMediaThumbnailSizeId()) {
-                        continue;
-                    }
+                if ($thumbnailSize->getId() !== $thumbnail->getMediaThumbnailSizeId()) {
+                    continue;
                 }
 
                 if ($strict === true && !$this->getFileSystem($media)->fileExists($thumbnail->getPath())) {


### PR DESCRIPTION
### 1. Why is this change necessary?
- We should already re-generate thumbnails with a null `mediaThumbnailSizeId` before the 6.8 update
- This will reduce the amount of invalid database rows as after the re-generation of the thumbnail there will be a filled `mediaThumbnailSizeId`

### 2. What does this change do, exactly?
* Changed `Shopware\Core\Content\Media\Thumbnail\ThumbnailService` to correctly re-generate thumbnails with a null `mediaThumbnailSizeId`

### 3. Describe each step to reproduce the issue or behaviour.
- 6.7 environment
- Have a media thumbnail row with a null mediaThumbnailSizeId
- Trigger the re-generation of thumbnails for this media

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
