### PR TITLE
fix: document content wrapping (backport)

### DIFF
--- a/changelog/_unreleased/2025-04-08-fix-invoice-empty-pages.md
+++ b/changelog/_unreleased/2025-04-08-fix-invoice-empty-pages.md
@@ -1,0 +1,8 @@
+---
+title: Fix invoice empty pages
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Changed styles in `src/Core/Framework/Resources/views/documents/style_base_portrait.css.twig` and `src/Core/Framework/Resources/views/documents/style_base_landscape.css.twig` to prevent empty pages in invoice document.

--- a/changelog/_unreleased/2025-08-01-document-styling.md
+++ b/changelog/_unreleased/2025-08-01-document-styling.md
@@ -1,0 +1,10 @@
+---
+title: Fixing document squished line item listing
+issue: 11654
+author: Simon Fiebranz
+author_email: s.fiebranz@shopware.com
+author_github: @CR0YD
+---
+# Core
+* Changed document styling to fix render issue with text blocks over multiple page breaks.
+* Changed document styling to fix squished text blocks.

--- a/src/Core/Framework/Resources/views/documents/style_base_landscape.css.twig
+++ b/src/Core/Framework/Resources/views/documents/style_base_landscape.css.twig
@@ -1,10 +1,15 @@
 <style type="text/css">
     {% block document_style %}
         body {
-            font-family: 'Source Sans Pro', sans-serif;
+            font-family: 'Source Sans Pro', "DejaVu Sans", sans-serif;
             font-size: 12px;
             line-height: 12px;
             width: 100%;
+        }
+
+        main {
+            width: 100%;
+            float: right;
         }
 
         .letter-header {
@@ -44,6 +49,7 @@
         /*Page */
         @page {
             margin-top: 200px;
+            margin-bottom: 50px;
         }
 
         /* Header */
@@ -217,9 +223,6 @@
 
         .payment-shipping-container, .shipping-address-container, .sum-container {
             page-break-inside: avoid;
-        }
-
-        .payment-shipping-container {
             clear: right;
         }
 
@@ -250,9 +253,8 @@
         /* Footer */
         footer {
             position: fixed;
-            bottom: 30px;
+            bottom: -10px;
             font-size: 8px;
-            padding-top: 30px;
             line-height: 9px;
             width: 100%;
         }

--- a/src/Core/Framework/Resources/views/documents/style_base_portrait.css.twig
+++ b/src/Core/Framework/Resources/views/documents/style_base_portrait.css.twig
@@ -1,10 +1,15 @@
 <style type="text/css">
     {% block document_style %}
         body {
-            font-family: 'Source Sans Pro', sans-serif;
+            font-family: 'Source Sans Pro', "DejaVu Sans", sans-serif;
             font-size: 12px;
             line-height: 12px;
             width: 100%;
+        }
+
+        main {
+            width: 100%;
+            float: right;
         }
 
         .letter-header {
@@ -48,6 +53,7 @@
         /*Page */
         @page {
             margin-top: 200px;
+            margin-bottom: 50px;
         }
 
         /* Header */
@@ -224,9 +230,6 @@
 
         .payment-shipping-container, .shipping-address-container, .sum-container {
             page-break-inside: avoid;
-        }
-
-        .payment-shipping-container {
             clear: right;
         }
 
@@ -257,9 +260,8 @@
         /* Footer */
         footer {
             position: fixed;
-            bottom: 30px;
+            bottom: -10px;
             font-size: 8px;
-            padding-top: 30px;
             line-height: 9px;
             width: 100%;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
During the document generation the content was wrongly merged with the document which resulted in many mostly blank pages with only a little bit text in the footer.

### 2. What does this change do, exactly?
This backports the fixes for the document generation already applied in 6.7.x.

### 3. Describe each step to reproduce the issue or behaviour.
cf.: [#11438](https://github.com/shopware/shopware/issues/11438)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #10730

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
