### PR TITLE
feat: improve languages admin ui resolves #11414

### DIFF
--- a/changelog/_unreleased/2025-09-03-improved-language-settings-ui.md
+++ b/changelog/_unreleased/2025-09-03-improved-language-settings-ui.md
@@ -1,0 +1,11 @@
+---
+title: Improved language settings UI
+issue: #11414
+author: Lukas Rump
+author_email: l.rump@shopware.com
+author_github: @lukasrump
+---
+# Administration
+* Added link to snippet settings in language list and detail page in `Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig` and `Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.html.twig`
+* Removed default column and added a label for the default language in `Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig`
+* Added card and changed title in `Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig`

--- a/src/Administration/Resources/app/administration/src/meta/position-identifiers.json
+++ b/src/Administration/Resources/app/administration/src/meta/position-identifiers.json
@@ -266,6 +266,7 @@
  "sw-settings-index-content",
  "sw-settings-language-detail-content",
  "sw-settings-language-detail-custom-field-sets",
+ "sw-settings-language-list",
  "sw-settings-listing-option-criteria-grid",
  "sw-settings-listing-option-general-info",
  "sw-settings-listing-sales-channel",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.html.twig
@@ -44,6 +44,18 @@
     {% block sw_settings_language_detail_content %}
     <template #content>
         <sw-card-view>
+            <div class="sw-settings-language-detail__snippet-link-wrapper">
+                <router-link
+                    class="sw-settings-language-detail__snippet-link"
+                    :to="{ name: 'sw.settings.snippet.index' }"
+                >
+                    {{ $tc('sw-settings-language.list.manageSnippets') }}
+                    <mt-icon
+                        name="long-arrow-right"
+                        size="12"
+                    />
+                </router-link>
+            </div>
             <sw-skeleton v-if="isLoading" />
 
             <template v-else>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.scss
@@ -18,7 +18,7 @@
         display: flex;
         justify-content: flex-end;
         margin-bottom: 8px;
-        max-width: 60rem;
+        max-width: $content-width;
         margin-left: auto;
         margin-right: auto;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.scss
@@ -1,3 +1,5 @@
+@import "~scss/variables";
+
 .sw-settings-language-detail {
     .sw-settings-language--alert-change-parent {
         margin-top: 30px;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.scss
@@ -13,4 +13,13 @@
             right: 18px;
         }
     }
+
+    .sw-settings-language-detail__snippet-link-wrapper {
+        display: flex;
+        justify-content: flex-end;
+        margin-bottom: 8px;
+        max-width: 60rem;
+        margin-left: auto;
+        margin-right: auto;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.spec.js
@@ -128,6 +128,7 @@ async function createWrapper(privileges = [], languageId = null, stubTranslation
                 'sw-ai-copilot-badge': true,
                 'sw-help-text': true,
                 'sw-field-error': true,
+                'router-link': true,
             },
         },
     };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/index.js
@@ -30,7 +30,7 @@ export default {
             filterRootLanguages: false,
             filterInheritedLanguages: false,
             isLoading: true,
-            sortBy: 'name',
+            sortBy: 'active',
             sortDirection: 'DESC',
         };
     },
@@ -73,25 +73,21 @@ export default {
                     label: 'sw-settings-language.list.columnName',
                     dataIndex: 'name',
                     inlineEdit: true,
-                    allowResize: true,
                 },
                 {
                     property: 'locale',
                     dataIndex: 'locale.id',
                     label: 'sw-settings-language.list.columnLocaleName',
-                    allowResize: true,
                 },
                 {
                     property: 'translationCode.code',
                     label: 'sw-settings-language.list.columnIsoCode',
-                    allowResize: true,
                 },
                 {
                     property: 'active',
                     dataIndex: 'active',
                     label: 'sw-settings-language.list.columnActive',
                     inlineEdit: 'boolean',
-                    allowResize: true,
                     align: 'center',
                 },
             ];

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/index.js
@@ -76,20 +76,6 @@ export default {
                     allowResize: true,
                 },
                 {
-                    property: 'id',
-                    label: 'sw-settings-language.list.columnDefault',
-                    align: 'center',
-                    allowResize: true,
-                },
-                {
-                    property: 'active',
-                    dataIndex: 'active',
-                    label: 'sw-settings-language.list.columnActive',
-                    inlineEdit: 'boolean',
-                    allowResize: true,
-                    align: 'center',
-                },
-                {
                     property: 'locale',
                     dataIndex: 'locale.id',
                     label: 'sw-settings-language.list.columnLocaleName',
@@ -101,10 +87,12 @@ export default {
                     allowResize: true,
                 },
                 {
-                    property: 'parent',
-                    dataIndex: 'parent.id',
-                    label: 'sw-settings-language.list.columnInherit',
+                    property: 'active',
+                    dataIndex: 'active',
+                    label: 'sw-settings-language.list.columnActive',
+                    inlineEdit: 'boolean',
                     allowResize: true,
+                    align: 'center',
                 },
             ];
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig
@@ -6,7 +6,7 @@
     <template #search-bar>
         <sw-search-bar
             initial-search-type="language"
-            :placeholder="$tc('sw-settings-language.general.placeholderSearchBar')"
+            :placeholder="$t('sw-settings-language.general.placeholderSearchBar')"
             :initial-search="term"
             @search="onSearch"
         />
@@ -20,11 +20,11 @@
         <h2>
 
             {% block sw_settings_language_list_smart_bar_header_title_text %}
-            {{ $tc('sw-settings.index.title') }}
+            {{ $t('sw-settings.index.title') }}
             <mt-icon
                 name="regular-chevron-right-xs"
                 size="12px"
-            /> {{ $tc('sw-settings-language.list.textHeadline') }}
+            /> {{ $t('sw-settings-language.list.textHeadline') }}
             {% endblock %}
 
             {# @deprecated tag:v6.8.0 - Block will be removed. #}
@@ -44,7 +44,7 @@
         {% block sw_settings_language_list_smart_bar_actions_add %}
         <mt-button
             v-tooltip.bottom="{
-                message: $tc('sw-privileges.tooltip.warning'),
+                message: $t('sw-privileges.tooltip.warning'),
                 disabled: allowCreate,
                 showOnDisabledElements: true
             }"
@@ -54,7 +54,7 @@
             size="default"
             @click="$router.push({ name: 'sw.settings.language.create' })"
         >
-            {{ $tc('sw-settings-language.list.buttonAddLanguage') }}
+            {{ $t('sw-settings-language.list.buttonAddLanguage') }}
         </mt-button>
         {% endblock %}
 
@@ -70,7 +70,7 @@
                     class="sw-settings-language-list__snippet-link"
                     :to="{ name: 'sw.settings.snippet.index' }"
                 >
-                    {{ $tc('sw-settings-language.list.manageSnippets') }}
+                    {{ $t('sw-settings-language.list.manageSnippets') }}
                     <mt-icon
                         name="long-arrow-right"
                         size="12"
@@ -84,10 +84,10 @@
                 <template #title>
                     <div class="sw-settings-language-list__card-title-wrapper">
                         <div class="sw-settings-language-list__card-title">
-                            {{ $tc('sw-settings-language.list.cardTitle') }} ({{ total }})
+                            {{ $t('sw-settings-language.list.cardTitle') }} ({{ total }})
                         </div>
                         <div class="sw-settings-language-list__card-subtitle">
-                            {{ $tc('sw-settings-language.list.cardSubtitle') }}
+                            {{ $t('sw-settings-language.list.cardSubtitle') }}
                         </div>
                     </div>
                 </template>
@@ -125,7 +125,7 @@
                             />
                             <router-link
                                 v-else
-                                :title="$tc('sw-settings-language.list.contextMenuEdit')"
+                                :title="$t('sw-settings-language.list.contextMenuEdit')"
                                 :to="{ name: 'sw.settings.language.detail', params: { id: item.id } }"
                             >
                                 {{ item.name }}
@@ -133,10 +133,9 @@
                                     v-if="isDefault(item.id)"
                                     variant="neutral"
                                     size="small"
-
                                     class="sw-settings-language-list__default-label"
                                 >
-                                    {{ $tc('sw-settings-language.list.defaultLabel') }}
+                                    {{ $t('sw-settings-language.list.defaultLabel') }}
                                 </sw-label>
                             </router-link>
                         </template>
@@ -200,14 +199,14 @@
                                 :disabled="isDefault(item.id) || !allowDelete || undefined"
                                 @click="showDelete(item.id)"
                             >
-                                {{ $tc('global.default.delete') }}
+                                {{ $t('global.default.delete') }}
                             </sw-context-menu-item>
                         </template>
                         {% endblock %}
 
                         {% block sw_settings_language_list_content_list_delete_confirm_action %}
                         <template #delete-confirm-text="{ item }">
-                            {{ $tc('sw-settings-language.list.textDeleteConfirm', { name: item.name }, 1 ) }}
+                            {{ $t('sw-settings-language.list.textDeleteConfirm', { name: item.name }, 1 ) }}
                         </template>
                         {% endblock %}
                         {% endblock %}
@@ -228,7 +227,7 @@
             {% block sw_settings_language_list_grid_sidebar_filter %}
             <sw-sidebar-item
                 icon="regular-filter"
-                :title="$tc('sw-settings-language.list.titleSidebarFilter')"
+                :title="$t('sw-settings-language.list.titleSidebarFilter')"
             >
                 <sw-collapse expand-on-loading>
 
@@ -238,7 +237,7 @@
 
                             {% block sw_settings_language_list_grid_sidebar_filter_header_title %}
                             <h4 class="sw-settings-language-list__collapse-title">
-                                {{ $tc('sw-settings-language.list.titleSidebarQuickFilter') }}
+                                {{ $t('sw-settings-language.list.titleSidebarQuickFilter') }}
                             </h4>
                             {% endblock %}
 
@@ -274,7 +273,7 @@
                         <mt-switch
                             v-model="filterRootLanguages"
                             class="sw-settings-language-list__filterField"
-                            :label="$tc('sw-settings-language.list.textFilterRootLanguages')"
+                            :label="$t('sw-settings-language.list.textFilterRootLanguages')"
                         />
                         {% endblock %}
 
@@ -283,7 +282,7 @@
                         <mt-switch
                             v-model="filterInheritedLanguages"
                             class="sw-settings-language-list__filterField"
-                            :label="$tc('sw-settings-language.list.textFilterInheritedLanguages')"
+                            :label="$t('sw-settings-language.list.textFilterInheritedLanguages')"
                         />
                         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig
@@ -27,13 +27,9 @@
             /> {{ $tc('sw-settings-language.list.textHeadline') }}
             {% endblock %}
 
+            {# @deprecated tag:v6.8.0 - Block will be removed. #}
             {% block sw_settings_language_list_smart_bar_header_amount %}
-            <span
-                v-if="!isLoading"
-                class="sw-page__smart-bar-amount"
-            >
-                ({{ total }})
-            </span>
+
             {% endblock %}
 
         </h2>
@@ -84,8 +80,18 @@
 
             <mt-card
                 position-identifier="sw-settings-language-list"
-                :title="$tc('sw-settings-language.list.cardTitle')"
             >
+                <template #title>
+                    <div class="sw-settings-language-list__card-title-wrapper">
+                        <div class="sw-settings-language-list__card-title">
+                            {{ $tc('sw-settings-language.list.cardTitle') }} ({{ total }})
+                        </div>
+                        <div class="sw-settings-language-list__card-subtitle">
+                            {{ $tc('sw-settings-language.list.cardSubtitle') }}
+                        </div>
+                    </div>
+                </template>
+
                 <template #grid>
                     <sw-entity-listing
                         key="language-listing"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.html.twig
@@ -67,118 +67,152 @@
 
     {% block sw_settings_language_list_content %}
     <template #content>
-        <sw-entity-listing
-            key="language-listing"
-            class="sw-settings-language-list-grid"
-            detail-route="sw.settings.language.detail"
-            :is-loading="isLoading"
-            :repository="languageRepository"
-            :columns="getColumns"
-            :items="languages"
-            :sort-by="sortBy"
-            :sort-direction="sortDirection"
-            :disable-data-fetching="true"
-            :allow-view="allowView || undefined"
-            :allow-edit="allowEdit || undefined"
-            :allow-inline-edit="allowInlineEdit || undefined"
-            :allow-delete="allowDelete || undefined"
-            @column-sort="onSortColumn"
-            @page-change="onPageChange"
-        >
 
-            {% block sw_settings_language_list_content_list_content %}
-            {% block sw_settings_language_list_content_list_columns %}
-            {% block sw_settings_language_list_content_list_column_name %}
-            <template #column-name="{ item, column, compact, isInlineEdit }">
-
-                <mt-text-field
-                    v-if="isInlineEdit"
-                    v-model="item.name"
-                    :size="compact ? 'small' : 'default'"
-                />
+        <sw-card-view>
+            <div class="sw-settings-language-list__snippet-link-wrapper">
                 <router-link
-                    v-else
-                    :title="$tc('sw-settings-language.list.contextMenuEdit')"
-                    :to="{ name: 'sw.settings.language.detail', params: { id: item.id } }"
+                    class="sw-settings-language-list__snippet-link"
+                    :to="{ name: 'sw.settings.snippet.index' }"
                 >
-                    {{ item.name }}
+                    {{ $tc('sw-settings-language.list.manageSnippets') }}
+                    <mt-icon
+                        name="long-arrow-right"
+                        size="12"
+                    />
                 </router-link>
-            </template>
-            {% endblock %}
+            </div>
 
-            <template #column-active="{ item, isInlineEdit }">
-                <template v-if="isInlineEdit && !isDefault(item.id)">
-                    <mt-checkbox
-                        v-model:checked="item.active"
-                    />
+            <mt-card
+                position-identifier="sw-settings-language-list"
+                :title="$tc('sw-settings-language.list.cardTitle')"
+            >
+                <template #grid>
+                    <sw-entity-listing
+                        key="language-listing"
+                        class="sw-settings-language-list-grid"
+                        detail-route="sw.settings.language.detail"
+                        :is-loading="isLoading"
+                        :repository="languageRepository"
+                        :columns="getColumns"
+                        :items="languages"
+                        :sort-by="sortBy"
+                        :sort-direction="sortDirection"
+                        :disable-data-fetching="true"
+                        :allow-view="allowView || undefined"
+                        :allow-edit="allowEdit || undefined"
+                        :allow-inline-edit="allowInlineEdit || undefined"
+                        :allow-delete="allowDelete || undefined"
+                        :full-page="false"
+                        @column-sort="onSortColumn"
+                        @page-change="onPageChange"
+                    >
+
+                        {% block sw_settings_language_list_content_list_content %}
+                        {% block sw_settings_language_list_content_list_columns %}
+                        {% block sw_settings_language_list_content_list_column_name %}
+                        <template #column-name="{ item, column, compact, isInlineEdit }">
+
+                            <mt-text-field
+                                v-if="isInlineEdit"
+                                v-model="item.name"
+                                :size="compact ? 'small' : 'default'"
+                            />
+                            <router-link
+                                v-else
+                                :title="$tc('sw-settings-language.list.contextMenuEdit')"
+                                :to="{ name: 'sw.settings.language.detail', params: { id: item.id } }"
+                            >
+                                {{ item.name }}
+                                <sw-label
+                                    v-if="isDefault(item.id)"
+                                    variant="neutral"
+                                    size="small"
+
+                                    class="sw-settings-language-list__default-label"
+                                >
+                                    {{ $tc('sw-settings-language.list.defaultLabel') }}
+                                </sw-label>
+                            </router-link>
+                        </template>
+                        {% endblock %}
+
+                        <template #column-active="{ item, isInlineEdit }">
+                            <template v-if="isInlineEdit && !isDefault(item.id)">
+                                <mt-checkbox
+                                    v-model:checked="item.active"
+                                />
+                            </template>
+
+                            <template v-else>
+                                <mt-icon
+                                    v-if="item.active"
+                                    name="regular-checkmark-xs"
+                                    size="16px"
+                                    class="is--active"
+                                />
+                                <mt-icon
+                                    v-else
+                                    name="regular-times-s"
+                                    size="16px"
+                                    class="is--inactive"
+                                />
+                            </template>
+                        </template>
+
+                        {% block sw_settings_language_list_content_list_column_locale %}
+                        <template #column-locale="{ item, column, compact, isInlineEdit }">
+                            {{ item.locale.translated.name }}, {{ item.locale.translated.territory }}
+                        </template>
+                        {% endblock %}
+                        {# @deprecated tag:v6.8.0 - Block will be removed. #}
+                        {% block sw_settings_language_list_content_list_column_id %}
+                        <template #column-id="{ item, column, compact, isInlineEdit }">
+                            <mt-icon
+                                v-if="isDefault(item.id)"
+                                name="regular-checkmark-xs"
+                                size="16px"
+                                class="is--active"
+                            />
+                            <div v-else></div>
+                        </template>
+                        {% endblock %}
+
+                        {% block sw_settings_language_list_content_list_column_parent %}
+                        <template #column-parent="{ item, column, compact, isInlineEdit }">
+                            {{ getParentName(item) }}
+                        </template>
+                        {% endblock %}
+                        {% endblock %}
+
+                        {% block sw_settings_language_list_content_list_delete %}
+                        {% block sw_settings_language_list_content_list_delete_action %}
+                        <template #delete-action="{ item, showDelete }">
+                            <sw-context-menu-item
+                                v-tooltip.bottom="tooltipDelete(item.id)"
+                                class="sw-settings-language-list__delete-action"
+                                variant="danger"
+                                :disabled="isDefault(item.id) || !allowDelete || undefined"
+                                @click="showDelete(item.id)"
+                            >
+                                {{ $tc('global.default.delete') }}
+                            </sw-context-menu-item>
+                        </template>
+                        {% endblock %}
+
+                        {% block sw_settings_language_list_content_list_delete_confirm_action %}
+                        <template #delete-confirm-text="{ item }">
+                            {{ $tc('sw-settings-language.list.textDeleteConfirm', { name: item.name }, 1 ) }}
+                        </template>
+                        {% endblock %}
+                        {% endblock %}
+                        {% endblock %}
+
+                    </sw-entity-listing>
                 </template>
-
-                <template v-else>
-                    <mt-icon
-                        v-if="item.active"
-                        name="regular-checkmark-xs"
-                        size="16px"
-                        class="is--active"
-                    />
-                    <mt-icon
-                        v-else
-                        name="regular-times-s"
-                        size="16px"
-                        class="is--inactive"
-                    />
-                </template>
-            </template>
-
-            {% block sw_settings_language_list_content_list_column_locale %}
-            <template #column-locale="{ item, column, compact, isInlineEdit }">
-                {{ item.locale.translated.name }}, {{ item.locale.translated.territory }}
-            </template>
-            {% endblock %}
-
-            {% block sw_settings_language_list_content_list_column_id %}
-            <template #column-id="{ item, column, compact, isInlineEdit }">
-                <mt-icon
-                    v-if="isDefault(item.id)"
-                    name="regular-checkmark-xs"
-                    size="16px"
-                    class="is--active"
-                />
-                <div v-else></div>
-            </template>
-            {% endblock %}
-
-            {% block sw_settings_language_list_content_list_column_parent %}
-            <template #column-parent="{ item, column, compact, isInlineEdit }">
-                {{ getParentName(item) }}
-            </template>
-            {% endblock %}
-            {% endblock %}
-
-            {% block sw_settings_language_list_content_list_delete %}
-            {% block sw_settings_language_list_content_list_delete_action %}
-            <template #delete-action="{ item, showDelete }">
-                <sw-context-menu-item
-                    v-tooltip.bottom="tooltipDelete(item.id)"
-                    class="sw-settings-language-list__delete-action"
-                    variant="danger"
-                    :disabled="isDefault(item.id) || !allowDelete || undefined"
-                    @click="showDelete(item.id)"
-                >
-                    {{ $tc('global.default.delete') }}
-                </sw-context-menu-item>
-            </template>
-            {% endblock %}
-
-            {% block sw_settings_language_list_content_list_delete_confirm_action %}
-            <template #delete-confirm-text="{ item }">
-                {{ $tc('sw-settings-language.list.textDeleteConfirm', { name: item.name }, 1 ) }}
-            </template>
-            {% endblock %}
-            {% endblock %}
-            {% endblock %}
-
-        </sw-entity-listing>
+            </mt-card>
+        </sw-card-view>
     </template>
+
     {% endblock %}
 
     {% block sw_settings_language_list_grid_sidebar %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.scss
@@ -58,4 +58,20 @@
         margin-left: auto;
         margin-right: auto;
     }
+
+    .sw-settings-language-list__card-title-wrapper {
+        margin-bottom: 8px;
+    }
+
+    .sw-settings-language-list__card-title {
+        font-size: $font-size-m;
+        font-weight: $font-weight-semi-bold;
+        margin-bottom: 4px;
+    }
+
+    .sw-settings-language-list__card-subtitle {
+        font-size: $font-size-xs;
+        color: var(--color-gray-800);
+        margin-bottom: 8px;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.scss
@@ -54,7 +54,7 @@
         display: flex;
         justify-content: flex-end;
         margin-bottom: 8px;
-        max-width: 60rem;
+        max-width: $content-width;
         margin-left: auto;
         margin-right: auto;
     }
@@ -64,8 +64,8 @@
     }
 
     .sw-settings-language-list__card-title {
-        font-size: $font-size-m;
-        font-weight: $font-weight-semi-bold;
+        font-size: var(--font-size-m);
+        font-weight: var(--font-weight-semibold);
         margin-bottom: 4px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.scss
@@ -42,4 +42,20 @@
             }
         }
     }
+
+    .sw-settings-language-list__default-label {
+        display: inline-flex;
+        align-items: center;
+        vertical-align: middle;
+        margin-left: 8px;
+    }
+
+    .sw-settings-language-list__snippet-link-wrapper {
+        display: flex;
+        justify-content: flex-end;
+        margin-bottom: 8px;
+        max-width: 60rem;
+        margin-left: auto;
+        margin-right: auto;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.spec.js
@@ -109,6 +109,9 @@ async function createWrapper(privileges = []) {
                     },
                     'sw-text-field': true,
                     'router-link': true,
+                    'sw-card-view': true,
+                    'sw-card': true,
+                    'sw-label': true,
                 },
             },
         },
@@ -224,5 +227,14 @@ describe('module/sw-settings-language/page/sw-settings-language-list', () => {
                 ]),
             }),
         );
+    });
+
+    it('should show a link to the snippets page', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        const snippetLink = wrapper.find('.sw-settings-language-list__snippet-link');
+        expect(snippetLink.exists()).toBe(true);
+        expect(snippetLink.text()).toContain('manageSnippets');
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/de.json
@@ -22,9 +22,9 @@
       "titleSidebarQuickFilter": "Quick Filter",
       "textFilterRootLanguages": "Zeige nur \"Root\"-Sprachen",
       "textFilterInheritedLanguages": "Zeige nur vererbte Sprachen",
-      "manageSnippets": "Snippets verwalten",
+      "manageSnippets": "Textbausteine verwalten",
       "cardTitle": "Sprachen",
-      "cardSubtitle": "Sprachen können Verkaufskanal-Domains zugeordnet werden. Sie ermöglichen die Übersetzung von Inhalten in Kategorien, Produkten, CMS-Seiten usw."
+      "cardSubtitle": "Sprachen können Verkaufskanal-Domains zugeordnet werden. Sie ermöglichen die Übersetzung von Inhalten in Kategorien, Produkten, Erlebniswelten usw."
     },
     "detail": {
       "textHeadline": "Neue Sprache",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/de.json
@@ -23,7 +23,8 @@
       "textFilterRootLanguages": "Zeige nur \"Root\"-Sprachen",
       "textFilterInheritedLanguages": "Zeige nur vererbte Sprachen",
       "manageSnippets": "Snippets verwalten",
-      "cardTitle": "Sprachen"
+      "cardTitle": "Sprachen",
+      "cardSubtitle": "Sprachen können Verkaufskanal-Domains zugeordnet werden. Sie ermöglichen die Übersetzung von Inhalten in Kategorien, Produkten, CMS-Seiten usw."
     },
     "detail": {
       "textHeadline": "Neue Sprache",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/de.json
@@ -13,6 +13,7 @@
       "columnIsoCode": "ISO-Code ",
       "columnInherit": "Erbt von",
       "columnDefault": "Standard",
+      "defaultLabel": "Standard",
       "buttonAddLanguage": "Sprache anlegen",
       "contextMenuEdit": "Bearbeiten",
       "messageDeleteSuccess": "Die Sprache \"{name}\" wurde erfolgreich gelöscht.",
@@ -20,7 +21,9 @@
       "titleSidebarFilter": "Filter",
       "titleSidebarQuickFilter": "Quick Filter",
       "textFilterRootLanguages": "Zeige nur \"Root\"-Sprachen",
-      "textFilterInheritedLanguages": "Zeige nur vererbte Sprachen"
+      "textFilterInheritedLanguages": "Zeige nur vererbte Sprachen",
+      "manageSnippets": "Snippets verwalten",
+      "cardTitle": "Sprachen"
     },
     "detail": {
       "textHeadline": "Neue Sprache",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/en.json
@@ -13,6 +13,7 @@
       "columnIsoCode": "ISO Code ",
       "columnInherit": "Inherit from",
       "columnDefault": "Default",
+      "defaultLabel": "Default",
       "buttonAddLanguage": "Add language",
       "contextMenuEdit": "Edit",
       "messageDeleteSuccess": "Language \"{name}\" has been deleted.",
@@ -20,7 +21,9 @@
       "titleSidebarFilter": "Filter",
       "titleSidebarQuickFilter": "Quick filter",
       "textFilterRootLanguages": "Show only \"root\" languages",
-      "textFilterInheritedLanguages": "Show only inherited languages"
+      "textFilterInheritedLanguages": "Show only inherited languages",
+      "manageSnippets": "Manage snippets",
+      "cardTitle": "Languages"
     },
     "detail": {
       "textHeadline": "New language",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/en.json
@@ -24,7 +24,7 @@
       "textFilterInheritedLanguages": "Show only inherited languages",
       "manageSnippets": "Manage snippets",
       "cardTitle": "Languages",
-      "cardSubtitle": "Languages can be assigned to Sales Channel domains in order to display the appropriate translations. They also enable the translation of content in categories, products, shopping experience pages, etc."
+      "cardSubtitle": "Languages can be assigned to Sales Channel domains in order to display the appropriate translations. They also enable the translation of content in categories, products, Shopping Experience pages, etc."
     },
     "detail": {
       "textHeadline": "New language",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/en.json
@@ -23,7 +23,8 @@
       "textFilterRootLanguages": "Show only \"root\" languages",
       "textFilterInheritedLanguages": "Show only inherited languages",
       "manageSnippets": "Manage snippets",
-      "cardTitle": "Languages"
+      "cardTitle": "Languages",
+      "cardSubtitle": "Languages can be assigned to Sales Channel domains in order to display the appropriate translations. They also enable the translation of content in categories, products, CMS pages, etc."
     },
     "detail": {
       "textHeadline": "New language",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/snippet/en.json
@@ -24,7 +24,7 @@
       "textFilterInheritedLanguages": "Show only inherited languages",
       "manageSnippets": "Manage snippets",
       "cardTitle": "Languages",
-      "cardSubtitle": "Languages can be assigned to Sales Channel domains in order to display the appropriate translations. They also enable the translation of content in categories, products, CMS pages, etc."
+      "cardSubtitle": "Languages can be assigned to Sales Channel domains in order to display the appropriate translations. They also enable the translation of content in categories, products, shopping experience pages, etc."
     },
     "detail": {
       "textHeadline": "New language",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This PR makes a few UI changes to the Language Settings module.

### 2. What does this change do, exactly?
* Added a link to the snippets module at the language list and detail page
* The list is no longer a full page and is now on a card.
* A label is used instead of a column for the default language.

<img width="3838" height="1814" alt="image" src="https://github.com/user-attachments/assets/dd17fc5c-22f7-4ae6-beb5-c10b02430f7f" />

