### PR TITLE
fix: change background color on even data grid rows

### DIFF
--- a/changelog/_unreleased/2025-09-02-fixed-background-color-on-even-data-grid-rows.md
+++ b/changelog/_unreleased/2025-09-02-fixed-background-color-on-even-data-grid-rows.md
@@ -1,0 +1,8 @@
+---
+title: Fixed background color on even data grid rows
+author: Fabian Hüske
+author_email: f.hueske@shopware.com
+author_github: @fabianhueske
+---
+# Administration
+* Fixed background color on even `sw-data-grid` rows.

--- a/changelog/_unreleased/2025-09-02-fixed-background-color-on-even-data-grid-rows.md
+++ b/changelog/_unreleased/2025-09-02-fixed-background-color-on-even-data-grid-rows.md
@@ -1,8 +1,0 @@
----
-title: Fixed background color on even data grid rows
-author: Fabian Hüske
-author_email: f.hueske@shopware.com
-author_github: @fabianhueske
----
-# Administration
-* Fixed background color on even `sw-data-grid` rows.

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -298,7 +298,7 @@
 
     .sw-data-grid__body .sw-data-grid__row {
         &:nth-child(even) .sw-data-grid__cell {
-            background-color: var(--color-background-primary-default);
+            background-color: var(--color-elevation-surface-sunken);
         }
 
         &:hover .sw-data-grid__cell {


### PR DESCRIPTION
### 1. Why is this change necessary?
Wrong Meteor color token assigned to even data grid rows resulting in invisible "zebra striping" (even rows are gray, odd are white).

### 2. What does this change do, exactly?
Applied the correct Meteor token to the background color of even rows.

### 3. Describe each step to reproduce the issue or behaviour.
Open a view with `sw-data-grid` in it like `Products overview`.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file]
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
