### PR TITLE
feat: interpret checkbox custom fields as bool in rules

### DIFF
--- a/changelog/_unreleased/2025-09-02-interpret-checkbox-custom-field-values-as-bool.md
+++ b/changelog/_unreleased/2025-09-02-interpret-checkbox-custom-field-values-as-bool.md
@@ -1,0 +1,9 @@
+---
+title: Interpret checkbox custom fields values as booleans
+issue: Ocarthon
+author: Philip Standt
+author_email: philip.standt@strix.net
+author_github: @Ocarthon
+---
+# Core
+- Changed `\Shopware\Core\Framework\Rule\CustomFieldRule` to interpret custom field values as a boolean when using a custom field of type `checkbox` in a rule.

--- a/src/Core/Framework/Rule/CustomFieldRule.php
+++ b/src/Core/Framework/Rule/CustomFieldRule.php
@@ -187,7 +187,7 @@ class CustomFieldRule
      */
     private static function isSwitchOrBoolField(array $renderedField): bool
     {
-        return \in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true);
+        return \in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH, CustomFieldTypes::CHECKBOX], true);
     }
 
     /**

--- a/tests/unit/Core/Framework/Rule/CustomFieldRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/CustomFieldRuleTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\CustomFieldRule;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\System\CustomField\CustomFieldTypes;
 
 /**
  * @internal
@@ -66,7 +67,11 @@ class CustomFieldRuleTest extends TestCase
      */
     public static function customFieldRuleMatchDataProvider(): iterable
     {
-        yield from self::boolTypeDataProvider();
+        // All boolean custom field types should behave the same
+        yield from self::boolTypeDataProvider(CustomFieldTypes::BOOL);
+        yield from self::boolTypeDataProvider(CustomFieldTypes::SWITCH);
+        yield from self::boolTypeDataProvider(CustomFieldTypes::CHECKBOX);
+
         yield from self::textTypeDataProvider();
         yield from self::stringTypeDataProvider();
         yield from self::floatTypeDataProvider();
@@ -78,188 +83,188 @@ class CustomFieldRuleTest extends TestCase
     /**
      * @return iterable<string, array<array<string, bool>|bool|string|null>>
      */
-    private static function boolTypeDataProvider(): iterable
+    private static function boolTypeDataProvider(string $boolCustomFieldType): iterable
     {
-        yield 'does not match missing value equals bool true' => [
+        yield $boolCustomFieldType . ': does not match missing value equals bool true' => [
             [],
             true,
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             false,
         ];
 
-        yield 'does match missing value equals bool false' => [
+        yield $boolCustomFieldType . ': does match missing value equals bool false' => [
             [],
             false,
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does not match bool false equals bool true' => [
+        yield $boolCustomFieldType . ': does not match bool false equals bool true' => [
             [self::CUSTOM_FIELD_NAME => false],
             true,
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             false,
         ];
 
-        yield 'does match bool false equals bool false' => [
+        yield $boolCustomFieldType . ': does match bool false equals bool false' => [
             [self::CUSTOM_FIELD_NAME => false],
             false,
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does not match bool true equals bool false' => [
+        yield $boolCustomFieldType . ': does not match bool true equals bool false' => [
             [self::CUSTOM_FIELD_NAME => true],
             false,
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             false,
         ];
 
-        yield 'does match bool true equals bool true' => [
+        yield $boolCustomFieldType . ': does match bool true equals bool true' => [
             [self::CUSTOM_FIELD_NAME => true],
             true,
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool true equals "yes"' => [
+        yield $boolCustomFieldType . ': does match bool true equals "yes"' => [
             [self::CUSTOM_FIELD_NAME => true],
             'yes',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool true equals "yes "' => [
+        yield $boolCustomFieldType . ': does match bool true equals "yes "' => [
             [self::CUSTOM_FIELD_NAME => true],
             'yes ',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool true equals "True"' => [
+        yield $boolCustomFieldType . ': does match bool true equals "True"' => [
             [self::CUSTOM_FIELD_NAME => true],
             'True',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool true equals "true"' => [
+        yield $boolCustomFieldType . ': does match bool true equals "true"' => [
             [self::CUSTOM_FIELD_NAME => true],
             'true',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool true equals "1"' => [
+        yield $boolCustomFieldType . ': does match bool true equals "1"' => [
             [self::CUSTOM_FIELD_NAME => true],
             '1',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does not match bool false equals "yes"' => [
+        yield $boolCustomFieldType . ': does not match bool false equals "yes"' => [
             [self::CUSTOM_FIELD_NAME => false],
             'yes',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             false,
         ];
 
-        yield 'does not match bool false with "yes "' => [
+        yield $boolCustomFieldType . ': does not match bool false with "yes "' => [
             [self::CUSTOM_FIELD_NAME => false],
             'yes ',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             false,
         ];
 
-        yield 'does not match bool false with "True"' => [
+        yield $boolCustomFieldType . ': does not match bool false with "True"' => [
             [self::CUSTOM_FIELD_NAME => false],
             'True',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             false,
         ];
 
-        yield 'does not match bool false with "true"' => [
+        yield $boolCustomFieldType . ': does not match bool false with "true"' => [
             [self::CUSTOM_FIELD_NAME => false],
             'true',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             false,
         ];
 
-        yield 'does not match bool false with "1"' => [
+        yield $boolCustomFieldType . ': does not match bool false with "1"' => [
             [self::CUSTOM_FIELD_NAME => false],
             '1',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             false,
         ];
 
-        yield 'does match bool false equals "no"' => [
+        yield $boolCustomFieldType . ': does match bool false equals "no"' => [
             [self::CUSTOM_FIELD_NAME => false],
             'no',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool false equals "no "' => [
+        yield $boolCustomFieldType . ': does match bool false equals "no "' => [
             [self::CUSTOM_FIELD_NAME => false],
             'no ',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool false equals "False"' => [
+        yield $boolCustomFieldType . ': does match bool false equals "False"' => [
             [self::CUSTOM_FIELD_NAME => false],
             'False',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool false equals "false"' => [
+        yield $boolCustomFieldType . ': does match bool false equals "false"' => [
             [self::CUSTOM_FIELD_NAME => false],
             'false',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool false equals "0"' => [
+        yield $boolCustomFieldType . ': does match bool false equals "0"' => [
             [self::CUSTOM_FIELD_NAME => false],
             '0',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool false equals "some string"' => [
+        yield $boolCustomFieldType . ': does match bool false equals "some string"' => [
             [self::CUSTOM_FIELD_NAME => false],
             'some string',
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];
 
-        yield 'does match bool false equals null' => [
+        yield $boolCustomFieldType . ': does match bool false equals null' => [
             [self::CUSTOM_FIELD_NAME => false],
             null,
-            'bool',
+            $boolCustomFieldType,
             Rule::OPERATOR_EQ,
             true,
         ];


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

There currently is an inconsistent treatment of the different boolean custom field types when evaluating rules.

The custom field types `bool`, `switch` and `checkbox` are all meant to contain boolean values (see https://github.com/shopware/shopware/blob/262ef0d544c0b4f3ec8ae9a8921202a5316d4018/src/Core/System/SalesChannel/StoreApiCustomFieldMapper.php#L79, where all three types are cast to a boolean in Store-API responses)

In the rule builder, a common case is to check whether a custom field is true or false. As custom fields on have generic choices, this can be done by checking if the custom field value is equal to `1`, `true` or any other value that php deems to be a boolean. This does work fine for `bool` and `switch` custom fields, but not for `checkbox` custom fields.

### 2. What does this change do, exactly?

This will treat custom fields of type `checkbox` as boolean fields when evaluating custom field rules. The `CustomFieldRule` will then make sure the custom field value and the expected value set in the rule are filtered as a bool before comparing them.

### 3. Describe each step to reproduce the issue or behaviour.

- Create custom field of type `checkbox` on the `customer` entity
- Create a customer and set the custom field to true
- Create a rule with a customer custom field condition where the created custom field is equal to `1`
- Login as the customer in the storefront and check with the webprofiler if the rule matches

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
