### PR TITLE
fix: load core snippets in Shopware 6.8.0

### DIFF
--- a/src/Administration/Snippet/SnippetFinder.php
+++ b/src/Administration/Snippet/SnippetFinder.php
@@ -4,7 +4,6 @@ namespace Shopware\Administration\Snippet;
 
 use Doctrine\DBAL\Connection;
 use League\Flysystem\Filesystem;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
 use Shopware\Core\Kernel;
@@ -68,17 +67,11 @@ class SnippetFinder implements SnippetFinderInterface
         $this->addInstalledPlatformPaths($paths, $locale);
 
         if ($paths->isEmpty()) {
-            // @deprecated tag:v6.8.0 - Will be removed and replaced with the new translation system.
-            if (!Feature::isActive('v6.8.0.0')) {
-                $this->addShopwareLegacyPaths($paths);
-            }
+            $this->addShopwareCorePaths($paths);
         }
 
         $snippetNames = ['administration.json'];
-        if (!Feature::isActive('v6.8.0.0')) {
-            // @deprecated tag:v6.8.0 - Will be removed and replaced with the new translation system.
-            $snippetNames[] = \sprintf('%s.json', $locale);
-        }
+        $snippetNames[] = \sprintf('%s.json', $locale);
 
         $this->addPluginPaths($paths, $locale);
         $this->addMeteorBundlePaths($paths);
@@ -168,11 +161,7 @@ class SnippetFinder implements SnippetFinderInterface
         }
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - Will be removed and replaced with the new translation system.
-     * The method `getInstalledSnippetPaths` will be used to fetch the paths.
-     */
-    private function addShopwareLegacyPaths(SnippetPathCollection $paths): void
+    private function addShopwareCorePaths(SnippetPathCollection $paths): void
     {
         $plugins = $this->kernel->getPluginLoader()->getPluginInstances()->all();
         $bundles = $this->kernel->getBundles();

--- a/tests/unit/Administration/Snippet/SnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/SnippetFinderTest.php
@@ -29,7 +29,6 @@ use Shopware\Core\System\Snippet\DataTransfer\PluginMapping\PluginMappingCollect
 use Shopware\Core\System\Snippet\Service\TranslationLoader;
 use Shopware\Core\System\Snippet\SnippetDefinition;
 use Shopware\Core\System\Snippet\Struct\TranslationConfig;
-use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Storefront\Storefront;
 use Shopware\Tests\Unit\Core\System\Snippet\Mock\TestPlugin;
@@ -39,7 +38,6 @@ use Symfony\Component\Validator\Validation;
  * @internal
  */
 #[CoversClass(SnippetFinder::class)]
-#[DisabledFeatures(['v6.8.0.0'])]
 class SnippetFinderTest extends TestCase
 {
     use SnippetFileTrait;


### PR DESCRIPTION
Don't deprecate core snippets with the release of the new translation system.

As core snippets are still needed and shipped with the Shopware installation, the system should not depend on additional translation files to be usable.

This fixes #12172 