### PR TITLE
feat: Add ScheduledTaskMessageInterface

### DIFF
--- a/changelog/_unreleased/2025-09-04-add-scheduled-task-message-interface.md
+++ b/changelog/_unreleased/2025-09-04-add-scheduled-task-message-interface.md
@@ -1,0 +1,8 @@
+---
+title: Add ScheduledTaskMessageInterface
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Added `Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskMessageInterface` to mark messages that are related to scheduled tasks

--- a/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTask.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTask.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\MessageQueue\AsyncMessageInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 #[Package('framework')]
-abstract class ScheduledTask implements AsyncMessageInterface
+abstract class ScheduledTask implements ScheduledTaskMessageInterface, AsyncMessageInterface
 {
     protected const MINUTELY = 60;
     protected const HOURLY = 3600;

--- a/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskMessageInterface.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskMessageInterface.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\MessageQueue\ScheduledTask;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+interface ScheduledTaskMessageInterface
+{
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
- If there is a huge amount of messages in the async queue the scheduled tasks may not be executed in time / get delayed because they share the same queue as nearly all other messages (async message queue)
- With this PR we add a new ScheduledTaskMessageInterface which can be used to route the scheduled task messages to a different queue

@Shopware Team:
- What do you thing of creating a new queue type `scheduled_task` and deprecating the `AsyncMessageInterface` for the scheduled task messages for 6.8?

### 2. What does this change do, exactly?
* Added `Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskMessageInterface` to mark messages that are related to scheduled tasks

### 3. Describe each step to reproduce the issue or behaviour.
- See `1. Why is this change necessary`

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
