### PR TITLE
fix: orders retrospectively affected by NEXT-14317

### DIFF
--- a/changelog/_unreleased/2025-09-04-fix-shopware-6-4-orders-with-cartLineItemsInCart.md
+++ b/changelog/_unreleased/2025-09-04-fix-shopware-6-4-orders-with-cartLineItemsInCart.md
@@ -1,0 +1,9 @@
+---
+title: Fix orders from Shopware 6.4 affected by NEXT-14317
+issue: NEXT-14317
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added migration `Migration1756812869MigrateLineItemsInCartRuleInOrderLineItems` to rewrite price definition rules in orders that used `cartLineItemsInCart` which is now called `cartLineItem`

--- a/src/Core/Migration/V6_6/Migration1756812869MigrateLineItemsInCartRuleInOrderLineItems.php
+++ b/src/Core/Migration/V6_6/Migration1756812869MigrateLineItemsInCartRuleInOrderLineItems.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1756812869MigrateLineItemsInCartRuleInOrderLineItems extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1756812869;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // migrate the rule condition types in order line items
+        $updateLimit = 1000;
+
+        do {
+            $ids = $connection->fetchFirstColumn(
+                'SELECT `id` FROM `order_line_item` WHERE JSON_VALUE(price_definition, \'$.filter\') LIKE \'%"cartLineItemsInCart"%\' LIMIT :limit',
+                ['limit' => $updateLimit],
+                ['limit' => ParameterType::INTEGER]
+            );
+
+            if (empty($ids)) {
+                break;
+            }
+
+            $connection->executeStatement(
+                'UPDATE `order_line_item` SET `price_definition` = REPLACE(`price_definition`, \'"cartLineItemsInCart"\', \'"cartLineItem"\') WHERE `id` IN (:ids)',
+                ['ids' => $ids],
+                ['ids' => ArrayParameterType::BINARY]
+            );
+        } while (\count($ids) === $updateLimit);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When you have orders from Shopware 6.4 with a price rule based on `cartLineItemsInCart` and want to open it up in a Shopware 6.5 admin but it won't open.

### 2. What does this change do, exactly?

Add a missing migration, that likely should've been part of https://github.com/shopware/shopware/commit/78dcfffbf257aa7ff1fc496f14b795cc4953a423#diff-5d07345a0d8a554732dbf23485605ba6f13ae6c56c1e99d1e2aae526e44abb8d

I am sure there are tests missing but I want to make sure first, that you would like to have this as a migration because it affects order tables, which tend to be bigger.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a well used shop using a lot of ootb features
2. Or create a rule with `cartLineItemsInCart` in a Shopware 6.4
3. Create a product with prices as upon this rule
4. Buy this product
5. Update Shopware to latest version
6. Try to export the order using the import/export module
7. Or try to open the order in the admin with this as API response
<img width="492" height="189" alt="grafik" src="https://github.com/user-attachments/assets/4d65bdf5-5ad8-4081-90e3-6c4ac21dc491" />

```json
{
    "exception": "Shopware\\Core\\Content\\Rule\\DataAbstractionLayer\\Indexing\\ConditionTypeNotFound",
    "message": "cartLineItemsInCart",
    "line": 229,
    "file": "vendor/shopware/core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php"
}
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
