### PR TITLE
feat: Add block type label in CMS sidebar

### DIFF
--- a/changelog/_unreleased/2025-09-04-add-block-type-in-cms.md
+++ b/changelog/_unreleased/2025-09-04-add-block-type-in-cms.md
@@ -1,0 +1,8 @@
+---
+title: Change CMS to show element type
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Administration
+* Changed cms element to show its type in configuration as a title addition

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -56,6 +56,14 @@ export default Shopware.Component.wrapComponentConfig({
             return this.cmsServiceState.elementRegistry[this.element.type];
         },
 
+        elementModalTitle() {
+            const title = this.$t('sw-cms.detail.title.elementSettingsModal');
+            if (this.elementConfig?.label !== undefined) {
+                return `${title} (${this.$t(this.elementConfig.label)})`;
+            }
+            return title;
+        },
+
         cmsElements() {
             const currentPageType = Shopware.Store.get('cmsPage').currentPageType;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
@@ -108,7 +108,7 @@
         v-show="showElementSettings"
         class="sw-cms-slot__config-modal"
         :variant="modalVariant"
-        :title="$tc('sw-cms.detail.title.elementSettingsModal')"
+        :title="elementModalTitle"
         @modal-close="onCloseSettingsModal"
     >
         {% block sw_cms_slot_content_settings_modal_component %}


### PR DESCRIPTION
### 1. Why is this change necessary?

It's usefull to see which type a block is, especially if many third party plugins are installed and there are many types of blocks

### 2. What does this change do, exactly?

Adds a (Type) to the title of the block editor side bar

<img width="1192" height="348" alt="image" src="https://github.com/user-attachments/assets/207cb31d-3574-4022-9774-3f44337af300" />

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a block in CMS
2. Click the block settings tab
3. see the ( ... ) text

### 4. Please link to the relevant issues (if any).
--

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
