### PR TITLE
chore: Enable `closureUsesThis` phpstan parameter

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -27,7 +27,6 @@ parameters:
         requireParentConstructorCall: false
         disallowedEmpty: false
         disallowedShortTernary: false
-        closureUsesThis: false
         numericOperandsInArithmeticOperators: false
         dynamicCallOnStaticMethod: false
         strictArrayFilter: false

--- a/tests/integration/Core/Checkout/Cart/SalesChannel/CartServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/SalesChannel/CartServiceTest.php
@@ -459,11 +459,10 @@ class CartServiceTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('Shipping costs: €0.00', $event->getContents()['text/html']);
+            static::assertStringContainsString('Shipping costs: €0.00', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -404,12 +404,11 @@ class OrderRouteTest extends TestCase
         }
 
         $dispatcher = static::getContainer()->get('event_dispatcher');
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('The payment for your order with Storefront is cancelled', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('Message: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('The payment for your order with Storefront is cancelled', $event->getContents()['text/html']);
+            static::assertStringContainsString('Message: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
@@ -444,12 +443,11 @@ class OrderRouteTest extends TestCase
     public function testSetSamePaymentMethodToOrder(): void
     {
         $dispatcher = static::getContainer()->get('event_dispatcher');
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('The payment for your order with Storefront is cancelled', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('Message: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('The payment for your order with Storefront is cancelled', $event->getContents()['text/html']);
+            static::assertStringContainsString('Message: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderServiceTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderServiceTest.php
@@ -155,11 +155,10 @@ class OrderServiceTest extends TestCase
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
         $url = $domain . '/account/order/' . $order->getDeepLinkCode();
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit, $url): void {
-            $phpunit->assertStringContainsString('The new status is as follows: Cancelled.', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString($url, $event->getContents()['text/html']);
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $url): void {
+            static::assertStringContainsString('The new status is as follows: Cancelled.', $event->getContents()['text/html']);
+            static::assertStringContainsString($url, $event->getContents()['text/html']);
             $eventDidRun = true;
         };
 
@@ -208,11 +207,10 @@ class OrderServiceTest extends TestCase
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
         $url = $domain . '/account/order/' . $order->getDeepLinkCode();
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit, $url): void {
-            $phpunit->assertStringContainsString('The new status is as follows: Cancelled.', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString($url, $event->getContents()['text/html']);
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $url): void {
+            static::assertStringContainsString('The new status is as follows: Cancelled.', $event->getContents()['text/html']);
+            static::assertStringContainsString($url, $event->getContents()['text/html']);
             $eventDidRun = true;
         };
 
@@ -364,11 +362,10 @@ class OrderServiceTest extends TestCase
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
         $url = $domain . '/account/order/' . $order->getDeepLinkCode();
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit, $url): void {
-            $phpunit->assertStringContainsString('The new status is as follows: Paid (partially).', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString($url, $event->getContents()['text/html']);
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $url): void {
+            static::assertStringContainsString('The new status is as follows: Paid (partially).', $event->getContents()['text/html']);
+            static::assertStringContainsString($url, $event->getContents()['text/html']);
             $eventDidRun = true;
         };
 
@@ -416,11 +413,10 @@ class OrderServiceTest extends TestCase
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
         $url = $domain . '/account/order/' . $order->getDeepLinkCode();
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit, $url): void {
-            $phpunit->assertStringContainsString('The new status is as follows: Paid (partially).', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString($url, $event->getContents()['text/html']);
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $url): void {
+            static::assertStringContainsString('The new status is as follows: Paid (partially).', $event->getContents()['text/html']);
+            static::assertStringContainsString($url, $event->getContents()['text/html']);
             $eventDidRun = true;
         };
 
@@ -566,11 +562,10 @@ class OrderServiceTest extends TestCase
         $order = $this->orderRepository->search($criteria, $this->salesChannelContext->getContext())->first();
 
         $url = $domain . '/account/order/' . $order->getDeepLinkCode();
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit, $url): void {
-            $phpunit->assertStringContainsString('The new status is as follows: Cancelled.', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString($url, $event->getContents()['text/html']);
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $url): void {
+            static::assertStringContainsString('The new status is as follows: Cancelled.', $event->getContents()['text/html']);
+            static::assertStringContainsString($url, $event->getContents()['text/html']);
             $eventDidRun = true;
         };
 
@@ -617,11 +612,10 @@ class OrderServiceTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit, $firstDomain, $secondDomain): void {
-            $phpunit->assertStringContainsString($firstDomain, $event->getContents()['text/html']);
-            $phpunit->assertThat($event->getContents()['text/html'], $this->logicalNot($this->stringContains($secondDomain)));
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $firstDomain, $secondDomain): void {
+            static::assertStringContainsString($firstDomain, $event->getContents()['text/html']);
+            static::assertThat($event->getContents()['text/html'], $this->logicalNot($this->stringContains($secondDomain)));
             $eventDidRun = true;
         };
 
@@ -651,10 +645,9 @@ class OrderServiceTest extends TestCase
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
         $url = $domain . '/account/order';
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit, $url): void {
-            $phpunit->assertStringContainsString($url, $event->getContents()['text/html']);
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $url): void {
+            static::assertStringContainsString($url, $event->getContents()['text/html']);
             $eventDidRun = true;
         };
 

--- a/tests/integration/Core/Content/ContactForm/ContactFormRouteTest.php
+++ b/tests/integration/Core/Content/ContactForm/ContactFormRouteTest.php
@@ -50,12 +50,11 @@ class ContactFormRouteTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            static::assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
@@ -97,14 +96,13 @@ class ContactFormRouteTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
         $recipients = [];
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, &$recipients, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, &$recipients): void {
             $eventDidRun = true;
             $recipients = $event->getRecipients();
-            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            static::assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
@@ -154,12 +152,11 @@ class ContactFormRouteTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            static::assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);

--- a/tests/integration/Core/Content/ContactForm/ContactFormServiceTest.php
+++ b/tests/integration/Core/Content/ContactForm/ContactFormServiceTest.php
@@ -40,12 +40,11 @@ class ContactFormServiceTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            static::assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
@@ -94,12 +93,11 @@ class ContactFormServiceTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            static::assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
@@ -135,12 +133,11 @@ class ContactFormServiceTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            static::assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
@@ -176,12 +173,11 @@ class ContactFormServiceTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            static::assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
@@ -217,12 +213,11 @@ class ContactFormServiceTest extends TestCase
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
-        $phpunit = $this;
         $eventDidRun = false;
-        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun): void {
             $eventDidRun = true;
-            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            $phpunit->assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            static::assertStringContainsString('Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);

--- a/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
@@ -62,7 +62,6 @@ class SalesChannelRequestContextResolverTest extends TestCase
         $this->createTestSalesChannel();
         $resolver = static::getContainer()->get(SalesChannelRequestContextResolver::class);
 
-        $phpunit = $this;
         $currencyId = $this->getCurrencyId('USD');
 
         $request = new Request();
@@ -73,10 +72,10 @@ class SalesChannelRequestContextResolverTest extends TestCase
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
         $eventDidRun = false;
-        $listenerContextEventClosure = function (SalesChannelContextResolvedEvent $event) use (&$eventDidRun, $phpunit, $currencyId): void {
+        $listenerContextEventClosure = function (SalesChannelContextResolvedEvent $event) use (&$eventDidRun, $currencyId): void {
             $eventDidRun = true;
-            $phpunit->assertSame($currencyId, $event->getSalesChannelContext()->getContext()->getCurrencyId());
-            $phpunit->assertInstanceOf(SalesChannelApiSource::class, $event->getSalesChannelContext()->getContext()->getSource());
+            static::assertSame($currencyId, $event->getSalesChannelContext()->getContext()->getCurrencyId());
+            static::assertInstanceOf(SalesChannelApiSource::class, $event->getSalesChannelContext()->getContext()->getSource());
         };
 
         $this->addEventListener($dispatcher, SalesChannelContextResolvedEvent::class, $listenerContextEventClosure);
@@ -176,10 +175,10 @@ class SalesChannelRequestContextResolverTest extends TestCase
         $dispatcher = static::getContainer()->get('event_dispatcher');
 
         $eventDidRun = false;
-        $listenerContextEventClosure = function (SalesChannelContextResolvedEvent $event) use (&$eventDidRun, $phpunit, $currencyId): void {
+        $listenerContextEventClosure = function (SalesChannelContextResolvedEvent $event) use (&$eventDidRun, $currencyId): void {
             $eventDidRun = true;
-            $phpunit->assertSame($currencyId, $event->getSalesChannelContext()->getContext()->getCurrencyId());
-            $phpunit->assertInstanceOf(AdminSalesChannelApiSource::class, $event->getSalesChannelContext()->getContext()->getSource());
+            static::assertSame($currencyId, $event->getSalesChannelContext()->getContext()->getCurrencyId());
+            static::assertInstanceOf(AdminSalesChannelApiSource::class, $event->getSalesChannelContext()->getContext()->getSource());
         };
 
         $this->addEventListener($dispatcher, SalesChannelContextResolvedEvent::class, $listenerContextEventClosure);


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/pull/12204
- This PR enables the `closureUsesThis` phpstan parameter to improve phpstan type safety

### 2. What does this change do, exactly?
- Enable `closureUsesThis` phpstan parameter

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/12204

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
