### PR TITLE
chore: remove DOD from bug_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,18 +59,3 @@ body:
           description: Tell us how the bug can be reproduced
       validations:
           required: true
-    - type: checkboxes
-      id: def-of-done
-      attributes:
-        label: Definition of Done
-        description: Please use this checklist to indicate that the deliverable meets Shopware standards.
-        options:
-          - label: An automated test covers the fix.
-          - label: Integration/E2E testing in staging is done.
-          - label: Changelog markdown file created or updated in /changelog/_unreleased directory.
-          - label: Developer documentation written/updated.
-          - label: End user and/or developer documentation written or updated with clarification.
-          - label: Regression test created to ensure bug does not reappear, and automated regression tests pass.
-          - label: Code changes resolve the reported bug without introducing new issues.
-      validations:
-        required: false


### PR DESCRIPTION
When creating a bug report, these checkboxes are displayed. I assume that the definition of done checkboxes should be placed in the [PULL_REQUEST_TEMPLATE.md](https://github.com/shopware/shopware/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md) rather than in the [bug_report.yml](https://github.com/shopware/shopware/blob/trunk/.github/ISSUE_TEMPLATE/bug_report.yml).

This behaviour was introduced in [PR #9656](https://github.com/shopware/shopware/pull/9656).

<img width="1314" height="532" alt="image" src="https://github.com/user-attachments/assets/fc61c561-c485-4c90-87b2-3c14e2336c44" />




<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
DOD in a bug report is confusing

### 2. What does this change do, exactly?
Revert https://github.com/shopware/shopware/pull/9656


### 3. Describe each step to reproduce the issue or behaviour.
Create a GitHub bug report.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
