### PR TITLE
chore: add missing assertions in tests of core/framework integration suite

### DIFF
--- a/tests/integration/Core/Framework/Api/Sync/SyncServiceTest.php
+++ b/tests/integration/Core/Framework/Api/Sync/SyncServiceTest.php
@@ -113,6 +113,12 @@ class SyncServiceTest extends TestCase
         ];
 
         $this->service->sync($operations, Context::createDefaultContext(), new SyncBehavior());
+        $exists = $this->connection->fetchAllAssociative(
+            'SELECT id FROM product_media WHERE id IN (:ids)',
+            ['ids' => Uuid::fromHexToBytesList($ids->getList(['media-2']))],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+        static::assertEmpty($exists);
     }
 
     public function testSingleOperationWithDeletesAndWrites(): void

--- a/tests/integration/Core/Framework/App/Validation/HookableValidatorTest.php
+++ b/tests/integration/Core/Framework/App/Validation/HookableValidatorTest.php
@@ -31,7 +31,8 @@ class HookableValidatorTest extends TestCase
     public function testValidateDoesNotThrowIfNoWebhooksExist(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../../App/Manifest/_fixtures/minimal/manifest.xml');
-        $this->hookableValidator->validate($manifest, Context::createDefaultContext());
+        $validations = $this->hookableValidator->validate($manifest, Context::createDefaultContext());
+        static::assertCount(0, $validations);
     }
 
     public function testValidateDoesNotThrowIfWebhooksAreValid(): void

--- a/tests/integration/Core/Framework/App/Validation/ManifestValidatorTest.php
+++ b/tests/integration/Core/Framework/App/Validation/ManifestValidatorTest.php
@@ -27,8 +27,15 @@ class ManifestValidatorTest extends TestCase
     public function testValidate(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
-
-        $this->manifestValidator->validate($manifest, Context::createDefaultContext());
+        $error = null;
+        $message = '';
+        try {
+            $this->manifestValidator->validate($manifest, Context::createDefaultContext());
+        } catch (\Throwable $e) {
+            $error = $e;
+            $message = \sprintf('No error expected, got "%s" with: %s', $error->getMessage(), $error->getTraceAsString());
+        }
+        static::assertNull($error, $message);
     }
 
     #[DataProvider('invalidManifestProvider')]

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
@@ -1945,8 +1945,17 @@ class VersioningTest extends TestCase
 
         $this->productRepository->update([$update->build()], $version);
 
-        // when the version is merged - the manufacturer should be created first
-        static::getContainer()->get('product.repository')->merge($versionId, $live);
+        $error = null;
+        $message = '';
+
+        try {
+            // when the version is merged - the manufacturer should be created first
+            static::getContainer()->get('product.repository')->merge($versionId, $live);
+        } catch (\Throwable $e) {
+            $error = $e;
+            $message = \sprintf('No error expected, got "%s" with: %s', $error->getMessage(), $error->getTraceAsString());
+        }
+        static::assertNull($error, $message);
     }
 
     private function getReviewCount(string $productId, string $versionId): int

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/EntityWriterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/EntityWriterTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefin
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerEntity;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -856,6 +857,8 @@ class EntityWriterTest extends TestCase
         $productRepository = static::getContainer()->get('product.repository');
         $productId = Uuid::randomHex();
 
+        $context = Context::createDefaultContext();
+
         $productRepository->create(
             [
                 [
@@ -867,7 +870,7 @@ class EntityWriterTest extends TestCase
                     'stock' => 0,
                 ],
             ],
-            Context::createDefaultContext(),
+            $context,
         );
 
         $productRepository->update(
@@ -877,8 +880,13 @@ class EntityWriterTest extends TestCase
                     'customFields' => ['foo' => 'bar'],
                 ],
             ],
-            Context::createDefaultContext(),
+            $context,
         );
+
+        $product = $productRepository->search(new Criteria([$productId]), $context)->first();
+
+        static::assertInstanceOf(ProductEntity::class, $product);
+        static::assertIsArray($product->getCustomFields());
     }
 
     public function testCloneVariantTranslation(): void

--- a/tests/integration/Core/Framework/Routing/RouteScopeListenerTest.php
+++ b/tests/integration/Core/Framework/Routing/RouteScopeListenerTest.php
@@ -51,7 +51,16 @@ class RouteScopeListenerTest extends TestCase
         $profilerController = static::getContainer()->get('web_profiler.controller.profiler');
         $event->setController($profilerController->panelAction(...));
 
-        $listener->checkScope($event);
+        $error = null;
+        $message = '';
+
+        try {
+            $listener->checkScope($event);
+        } catch (\Throwable $e) {
+            $error = $e;
+            $message = \sprintf('No error expected, got "%s" with: %s', $error->getMessage(), $error->getTraceAsString());
+        }
+        static::assertNull($error, $message);
     }
 
     public function testRouteScopeListenerFailsHardWithoutAnnotation(): void
@@ -76,8 +85,16 @@ class RouteScopeListenerTest extends TestCase
 
         $stack->push($request);
         $event = $this->createEvent($request);
+        $error = null;
+        $message = '';
 
-        $listener->checkScope($event);
+        try {
+            $listener->checkScope($event);
+        } catch (\Throwable $e) {
+            $error = $e;
+            $message = \sprintf('No error expected, got "%s" with: %s', $error->getMessage(), $error->getTraceAsString());
+        }
+        static::assertNull($error, $message);
     }
 
     public function testRouteScopeListenerDeniesInvalidAdminRequest(): void
@@ -106,8 +123,16 @@ class RouteScopeListenerTest extends TestCase
         $stack->push($requestSub);
 
         $event = $this->createEvent($requestSub);
+        $error = null;
+        $message = '';
 
-        $listener->checkScope($event);
+        try {
+            $listener->checkScope($event);
+        } catch (\Throwable $e) {
+            $error = $e;
+            $message = \sprintf('No error expected, got "%s" with: %s', $error->getMessage(), $error->getTraceAsString());
+        }
+        static::assertNull($error, $message);
     }
 
     private function createEvent(Request $request): ControllerEvent

--- a/tests/integration/Core/Framework/Store/Services/ExtensionLifecycleServiceTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionLifecycleServiceTest.php
@@ -85,9 +85,22 @@ class ExtensionLifecycleServiceTest extends TestCase
         static::assertFalse($testApp->isActive());
     }
 
+    /**
+     * When trying to uninstall an extension (app not a plugin) that does not exist,
+     * no error should be thrown. It is caught and returned within uninstallExtension
+     */
     public function testUninstallWithInvalidNameWithout(): void
     {
-        $this->lifecycleService->uninstall('app', 'notExisting', false, $this->context);
+        $error = null;
+        $message = '';
+
+        try {
+            $this->lifecycleService->uninstall('app', 'notExisting', false, $this->context);
+        } catch (\Throwable $e) {
+            $error = $e;
+            $message = \sprintf('No error expected, got "%s" with: %s', $error->getMessage(), $error->getTraceAsString());
+        }
+        static::assertNull($error, $message);
     }
 
     public function testInstallAppNotExisting(): void

--- a/tests/integration/Core/Framework/Store/Services/ExtensionStoreLicensesServiceTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionStoreLicensesServiceTest.php
@@ -66,6 +66,13 @@ class ExtensionStoreLicensesServiceTest extends TestCase
         $review = new ReviewStruct();
         $review->setExtensionId(5);
         $this->extensionLicensesService->rateLicensedExtension($review, $this->getContextWithStoreToken());
+
+        $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
+        static::assertNotNull($lastRequest);
+        static::assertSame(
+            '/swplatform/extensionstore/extensions/5/ratings',
+            $lastRequest->getUri()->getPath()
+        );
     }
 
     private function getContextWithStoreToken(): Context


### PR DESCRIPTION
### 1. Why is this change necessary?
Tests should not be marked as 'risky' and always assert something

### 2. What does this change do, exactly?
Adds missing assertions in tests of framework suite

### 3. Describe each step to reproduce the issue or behaviour.
- Run `vendor/bin/phpunit  -- tests/integration/Core/Framework`
- Check the pipeline ()

=> no test is marked with `R` anymore


### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/11998

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
