### PR TITLE
chore: add missing assertions in tests of core/content integration suite

### DIFF
--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -132,6 +132,9 @@ class SearchKeywordUpdaterTest extends TestCase
 
         static::getContainer()->get(SearchKeywordUpdater::class)
             ->update($ids->getList(['p1', 'p2']), Context::createDefaultContext());
+
+        $this->assertKeywords($ids->get('p1'), Defaults::LANGUAGE_SYSTEM, []);
+        $this->assertKeywords($ids->get('p2'), Defaults::LANGUAGE_SYSTEM, []);
     }
 
     public function testItSkipsKeywordGenerationForNotUsedLanguages(): void
@@ -318,7 +321,7 @@ class SearchKeywordUpdaterTest extends TestCase
             ]
         );
 
-        static::assertEquals($expectedKeywords, $keywords);
+        static::assertEquals($expectedKeywords, $keywords, 'no match: ' . print_r($keywords, true));
     }
 
     private function assertLanguageHasNoKeywords(string $languageId): void

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
@@ -112,6 +112,10 @@ class AvailableCombinationLoaderTest extends TestCase
         foreach ($result->getCombinations() as $combination) {
             static::assertSame($expected, $result->isAvailable($combination));
         }
+
+        if ($differentChannel) {
+            static::assertCount(0, $result->getCombinations());
+        }
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Tests should not be marked as 'risky' and always assert something

### 2. What does this change do, exactly?
Adds missing assertions in tests of content suite

### 3. Describe each step to reproduce the issue or behaviour.
- Run `vendor/bin/phpunit  -- tests/integration/Core/Content`
- Check the pipeline ()

=> no test is marked with `R` anymore


### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/11998

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
