### PR TITLE
chore: add missing assertions in tests of core/system integration suite

### DIFF
--- a/tests/integration/Core/System/SalesChannel/Subscriber/SalesChannelTypeValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Subscriber/SalesChannelTypeValidatorTest.php
@@ -66,13 +66,15 @@ class SalesChannelTypeValidatorTest extends TestCase
     public function testDeleteSalesChannel(): void
     {
         $id = $this->createSalesChannel()['id'];
+        $context = Context::createDefaultContext();
 
         $repo = static::getContainer()->get('sales_channel.repository');
         $repo->delete([
             [
                 'id' => $id,
             ],
-        ], Context::createDefaultContext());
+        ], $context);
+        static::assertNull($repo->searchIds(new Criteria([$id]), $context)->firstId());
     }
 
     /**

--- a/tests/integration/Core/System/SystemConfig/SystemConfigServiceTest.php
+++ b/tests/integration/Core/System/SystemConfig/SystemConfigServiceTest.php
@@ -322,7 +322,12 @@ class SystemConfigServiceTest extends TestCase
     public function testDeleteNonExisting(): void
     {
         $this->systemConfigService->delete('not.found');
+        $actual = $this->systemConfigService->get('not.found');
+        static::assertNull($actual);
+
         $this->systemConfigService->delete('not.found', TestDefaults::SALES_CHANNEL);
+        $actual = $this->systemConfigService->get('not.found', TestDefaults::SALES_CHANNEL);
+        static::assertNull($actual);
     }
 
     public function testDelete(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Tests should not be marked as 'risky' and always assert something

### 2. What does this change do, exactly?
- Adds missing assertions in tests of system suite
- Replaces old usage of catching exception + static::fail(), with expectExceptionObject()

### 3. Describe each step to reproduce the issue or behaviour.
- Run `vendor/bin/phpunit  -- tests/integration/Core/System`
- Check the pipeline ()

=> no test is marked with `R` anymore


### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/11998

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
