### PR TITLE
refactor: Add ProductListingLoader ids and aggregations cache

### DIFF
--- a/changelog/_unreleased/2025-09-08-add-product-listing-loader-ids-and-aggregations-cache.md
+++ b/changelog/_unreleased/2025-09-08-add-product-listing-loader-ids-and-aggregations-cache.md
@@ -1,0 +1,9 @@
+---
+title: Add ProductListingLoader ids and aggregations cache
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Core
+* Added `Shopware\Core\Content\Product\Extension\ResolveListingAggregationsExtension` to allow overriding the product listing aggregations result
+* Changed `Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader` to cache the ids and aggregations results per criteria & sales channel context hash to improve performance

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -461,6 +461,8 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory"/>
             <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
+            <argument type="service" id="cache.object"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute" public="true">

--- a/src/Core/Content/Product/Extension/ResolveListingAggregationsExtension.php
+++ b/src/Core/Content/Product/Extension/ResolveListingAggregationsExtension.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Extension;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @public this class is used as type-hint for all event listeners, so the class string is "public consumable" API
+ *
+ * @title Determination of the listing product aggregations
+ *
+ * @description This event allows intercepting the listing process, when the product aggregations should be determined for the current category page and the applied filter.
+ *
+ * @codeCoverageIgnore
+ *
+ * @extends Extension<?AggregationResultCollection>
+ */
+#[Package('inventory')]
+final class ResolveListingAggregationsExtension extends Extension
+{
+    public const NAME = 'listing-loader.resolve-listing-aggregations';
+
+    /**
+     * @internal shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(
+        /**
+         * @public
+         *
+         * @description The criteria which should be used to load the product aggregations. Is also containing the selected customer filter
+         */
+        public Criteria $criteria,
+
+        /**
+         * @public
+         *
+         * @description Allows you to access to the current customer/sales-channel context
+         */
+        public SalesChannelContext $context,
+
+        /**
+         * @public
+         *
+         * @description The result of the id search result, which contains the product ids that are listed in the current category with the applied filter
+         */
+        public IdSearchResult $idSearchResult,
+    ) {
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\Product\SalesChannel\Search\ResolvedCriteriaProductSearchRoute;
 use Shopware\Core\Content\Product\SalesChannel\Suggest\ProductSuggestRoute;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -39,7 +40,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class ProductListingLoader
 {
     public const ID_CACHE_KEY = 'product-listing-ids-';
-    public const AGGREGATION_CACHE_KEY = 'product-listing-aggregations-';
+    public const AGGREGATIONS_CACHE_KEY = 'product-listing-aggregations-';
 
     /**
      * @internal
@@ -302,18 +303,24 @@ class ProductListingLoader
             $item->expiresAfter(3600);
             $item->tag($cacheTags);
 
-            return [
-                'ids' => $ids,
-                'total' => $idSearchResult->getTotal(),
-            ];
+            // To reduce cache size and to prevent cache issues we clear context and criteria before caching
+            // They will be reassigned right after uncompressing the cached value
+            $idSearchResult->assign(['context' => Context::createDefaultContext(), 'criteria' => new Criteria()]);
+
+            return CacheValueCompressor::compress($idSearchResult);
         });
 
-        return IdSearchResult::fromIds($ids['ids'], $criteria, $context->getContext(), $ids['total']);
+        /** @var IdSearchResult */
+        $ids = CacheValueCompressor::uncompress($ids);
+
+        $ids->assign(['context' => $context->getContext(), 'criteria' => $criteria]);
+
+        return $ids;
     }
 
     private function resolveAggregations(Criteria $criteria, SalesChannelContext $context, IdSearchResult $idSearchResult): ?AggregationResultCollection
     {
-        $cacheKey = self::AGGREGATION_CACHE_KEY . $this->generator->getCriteriaHash($criteria) . $this->generator->getSalesChannelContextHash($context);
+        $cacheKey = self::AGGREGATIONS_CACHE_KEY . $this->generator->getCriteriaHash($criteria) . $this->generator->getSalesChannelContextHash($context);
 
         $aggregations = $this->cache->get($cacheKey, function (ItemInterface $item) use ($criteria, $context, $idSearchResult) {
             $aggregationResult = $this->productRepository->aggregate($criteria, $context);

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\Events\ProductListingPreviewCriteriaEvent;
 use Shopware\Core\Content\Product\Events\ProductListingResolvePreviewEvent;
 use Shopware\Core\Content\Product\Extension\LoadPreviewExtension;
+use Shopware\Core\Content\Product\Extension\ResolveListingAggregationsExtension;
 use Shopware\Core\Content\Product\Extension\ResolveListingExtension;
 use Shopware\Core\Content\Product\Extension\ResolveListingIdsExtension;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -15,6 +16,9 @@ use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFact
 use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\Product\SalesChannel\Search\ResolvedCriteriaProductSearchRoute;
 use Shopware\Core\Content\Product\SalesChannel\Suggest\ProductSuggestRoute;
+use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
+use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
@@ -27,11 +31,16 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[Package('inventory')]
 class ProductListingLoader
 {
+    public const ID_CACHE_KEY = 'product-listing-ids-';
+    public const AGGREGATION_CACHE_KEY = 'product-listing-aggregations-';
+
     /**
      * @internal
      *
@@ -43,7 +52,9 @@ class ProductListingLoader
         private readonly Connection $connection,
         private readonly EventDispatcherInterface $dispatcher,
         private readonly AbstractProductCloseoutFilterFactory $productCloseoutFilterFactory,
-        private readonly ExtensionDispatcher $extensions
+        private readonly ExtensionDispatcher $extensions,
+        private readonly CacheInterface $cache,
+        private readonly EntityCacheKeyGenerator $generator,
     ) {
     }
 
@@ -74,9 +85,7 @@ class ProductListingLoader
             function: $this->resolveIds(...)
         );
 
-        $aggregations = $this->productRepository->aggregate($clone, $context);
-
-        /** @var list<string> $ids */
+        /** @var list<string> */
         $ids = $idResult->getIds();
         // no products found, no need to continue
         if (empty($ids)) {
@@ -84,7 +93,7 @@ class ProductListingLoader
                 ProductDefinition::ENTITY_NAME,
                 0,
                 new ProductCollection(),
-                $aggregations,
+                null,
                 $criteria,
                 $context->getContext()
             );
@@ -94,6 +103,12 @@ class ProductListingLoader
 
             return $result;
         }
+
+        $aggregations = $this->extensions->publish(
+            name: ResolveListingAggregationsExtension::NAME,
+            extension: new ResolveListingAggregationsExtension($clone, $context, $idResult),
+            function: $this->resolveAggregations(...)
+        );
 
         $mapping = $this->resolvePreviews($ids, $clone, $context);
 
@@ -274,7 +289,50 @@ class ProductListingLoader
             );
         }
 
-        return $this->productRepository->searchIds($criteria, $context);
+        $cacheKey = self::ID_CACHE_KEY . $this->generator->getCriteriaHash($criteria) . $this->generator->getSalesChannelContextHash($context);
+
+        $ids = $this->cache->get($cacheKey, function (ItemInterface $item) use ($criteria, $context) {
+            $idSearchResult = $this->productRepository->searchIds($criteria, $context);
+
+            /** @var list<string> */
+            $ids = $idSearchResult->getIds();
+
+            $cacheTags = \array_map(fn (string $id): string => EntityCacheKeyGenerator::buildProductTag($id), $ids);
+
+            $item->expiresAfter(3600);
+            $item->tag($cacheTags);
+
+            return [
+                'ids' => $ids,
+                'total' => $idSearchResult->getTotal(),
+            ];
+        });
+
+        return IdSearchResult::fromIds($ids['ids'], $criteria, $context->getContext(), $ids['total']);
+    }
+
+    private function resolveAggregations(Criteria $criteria, SalesChannelContext $context, IdSearchResult $idSearchResult): ?AggregationResultCollection
+    {
+        $cacheKey = self::AGGREGATION_CACHE_KEY . $this->generator->getCriteriaHash($criteria) . $this->generator->getSalesChannelContextHash($context);
+
+        $aggregations = $this->cache->get($cacheKey, function (ItemInterface $item) use ($criteria, $context, $idSearchResult) {
+            $aggregationResult = $this->productRepository->aggregate($criteria, $context);
+
+            /** @var list<string> */
+            $ids = $idSearchResult->getIds();
+
+            $cacheTags = \array_map(fn (string $id): string => EntityCacheKeyGenerator::buildProductTag($id), $ids);
+
+            $item->expiresAfter(3600);
+            $item->tag($cacheTags);
+
+            return CacheValueCompressor::compress($aggregationResult);
+        });
+
+        /** @var ?AggregationResultCollection */
+        $aggregations = CacheValueCompressor::uncompress($aggregations);
+
+        return $aggregations;
     }
 
     /**

--- a/src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
@@ -40,7 +40,7 @@ class IdSearchResult extends Struct
     }
 
     /**
-     * @param array<string> $ids
+     * @param list<string>|list<array<string, string>> $ids
      */
     public static function fromIds(
         array $ids,

--- a/src/Core/Test/Stub/DataAbstractionLayer/StaticEntityRepository.php
+++ b/src/Core/Test/Stub/DataAbstractionLayer/StaticEntityRepository.php
@@ -109,6 +109,23 @@ class StaticEntityRepository extends EntityRepository
         throw new \RuntimeException('Invalid mock repository configuration');
     }
 
+    public function aggregate(Criteria $criteria, Context $context): AggregationResultCollection
+    {
+        $result = \array_shift($this->searches);
+        $callable = $result;
+
+        if (\is_callable($callable)) {
+            /** @var callable(Criteria, Context): ResultTypes $callable */
+            $result = $callable($criteria, $context);
+        }
+
+        if ($result instanceof AggregationResultCollection) {
+            return $result;
+        }
+
+        throw new \RuntimeException('Invalid mock repository configuration');
+    }
+
     public function searchIds(Criteria $criteria, Context $context): IdSearchResult
     {
         $result = \array_shift($this->searches);

--- a/tests/examples/ResolveListingAggregationsExample.php
+++ b/tests/examples/ResolveListingAggregationsExample.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Examples;
+
+use GuzzleHttp\Client;
+use Shopware\Core\Content\Product\Extension\ResolveListingAggregationsExtension;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * @title Example how you control the listing product aggregations
+ *
+ * @description This example shows how you can control the listing product aggregations. It allows you to resolve the listing aggregations by your own over an API call or an own storage
+ */
+#[AsEventListener(
+    event: 'listing-loader.resolve-listing-aggregations.pre',
+    method: '__invoke'
+)]
+readonly class ResolveListingAggregationsExample
+{
+    /**
+     * @param EntityRepository<ProductCollection> $repository
+     */
+    public function __construct(
+        // you can inject your own services
+        private Client $client,
+        private EntityRepository $repository
+    ) {
+    }
+
+    public function __invoke(ResolveListingAggregationsExtension $event): void
+    {
+        $criteria = $event->criteria;
+
+        // building a json aware array for the API call
+        $context = [
+            'salesChannelId' => $event->context->getSalesChannelId(),
+            'currencyId' => $event->context->getCurrency(),
+            'languageId' => $event->context->getLanguageId(),
+        ];
+
+        // do an api call against your own server or another storage, or whatever you want
+        $ids = $this->client->get('https://your-api.com/listing-ids', [
+            'query' => [
+                'criteria' => json_encode($criteria),
+                'context' => json_encode($context),
+            ],
+        ]);
+
+        $data = json_decode($ids->getBody()->getContents(), true);
+
+        // create the expected result
+        $criteria = new Criteria($data['ids']);
+
+        $event->result = $this->repository->aggregate($criteria, $event->context->getContext());
+
+        // stop the event propagation, so core function will not be executed
+        $event->stopPropagation();
+    }
+}

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderExtensionsTests.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderExtensionsTests.php
@@ -6,18 +6,21 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Extension\ResolveListingAggregationsExtension;
 use Shopware\Core\Content\Product\Extension\ResolveListingExtension;
 use Shopware\Core\Content\Product\Extension\ResolveListingIdsExtension;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Bucket\BucketResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Tests\Examples\ResolveListingAggregationsExample;
 use Shopware\Tests\Examples\ResolveListingExample;
 use Shopware\Tests\Examples\ResolveListingIdsExample;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -29,6 +32,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 #[CoversClass(ResolveListingExample::class)]
 #[CoversClass(ResolveListingExtension::class)]
 #[CoversClass(ResolveListingIdsExtension::class)]
+#[CoversClass(ResolveListingAggregationsExtension::class)]
 class ProductListingLoaderExtensionsTests extends TestCase
 {
     public function testResolveListingIdsExtensions(): void
@@ -60,6 +64,44 @@ class ProductListingLoaderExtensionsTests extends TestCase
         static::assertInstanceOf(IdSearchResult::class, $result);
 
         static::assertSame(['plugin-id'], $result->getIds());
+    }
+
+    public function testResolveListingAggregationsExtensions(): void
+    {
+        /** @phpstan-ignore shopware.mockingSimpleObjects (for test purpose) */
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('get')
+            ->willReturn(new Response(200, [], json_encode(['aggregations' => []], \JSON_THROW_ON_ERROR)));
+
+        /** @var StaticEntityRepository<ProductCollection> $productRepo */
+        $productRepo = new StaticEntityRepository([
+            new AggregationResultCollection([new BucketResult('test-bucket', [])]),
+        ]);
+
+        $example = new ResolveListingAggregationsExample($client, $productRepo);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(ResolveListingAggregationsExtension::NAME . '.pre', $example);
+
+        $extension = new ResolveListingAggregationsExtension(
+            new Criteria(),
+            $this->createMock(SalesChannelContext::class),
+            $this->createMock(IdSearchResult::class)
+        );
+
+        $result = (new ExtensionDispatcher($dispatcher))->publish(
+            name: ResolveListingAggregationsExtension::NAME,
+            extension: $extension,
+            function: static function () {
+                return new AggregationResultCollection([new BucketResult('test-bucket', [])]);
+            }
+        );
+
+        static::assertInstanceOf(AggregationResultCollection::class, $result);
+
+        static::assertInstanceOf(BucketResult::class, $result->first());
+        static::assertSame('test-bucket', $result->first()->getName());
     }
 
     public function testResolveListingExtension(): void

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderExtensionsTests.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderExtensionsTests.php
@@ -87,7 +87,7 @@ class ProductListingLoaderExtensionsTests extends TestCase
         $extension = new ResolveListingAggregationsExtension(
             new Criteria(),
             $this->createMock(SalesChannelContext::class),
-            $this->createMock(IdSearchResult::class)
+            new IdSearchResult(0, [], new Criteria(), Context::createDefaultContext())
         );
 
         $result = (new ExtensionDispatcher($dispatcher))->publish(


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently, besides the http cache, there is no caching in the loading process of products from a category
- This process of loading products for a category + its aggregations can be extremely performance-consuming with a larger number of products and a larger set of product options/properties, resulting in larger aggregations
- We can extremely reduce this load on the database by just caching the product ids & aggregations
- In addition, the page response time could be reduced by a noticeable amount
- **In our production environment, we were able to reduce the total database load from ~80% to ~15%, which corresponds to an ~82% relative improvement (a reduction of 65 % points) in overall shopware database load. `Which initially seemed unbelievable, but was visible in raw numbers after the change, achieved solely through this PR improvements`**

### 2. What does this change do, exactly?
* Added `Shopware\Core\Content\Product\Extension\ResolveListingAggregationsExtension` to allow overriding the product listing aggregations result
* Changed `Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader` to cache the ids and aggregations results per criteria & sales channel context hash to improve performance

### 3. Describe each step to reproduce the issue or behaviour.
- See `1. Why is this change necessary?`

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
