### PR TITLE
fix: Custom fields with the same name as FKs can be saved

### DIFF
--- a/changelog/_unreleased/2025-09-08-fix-custom-fields-with-fk-names.md
+++ b/changelog/_unreleased/2025-09-08-fix-custom-fields-with-fk-names.md
@@ -1,0 +1,6 @@
+---
+title: Fix custom fields with same names as foreign keys
+issue: #12029
+---
+# Core
+* Changed `\Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue::hasUnresolvedForeignKey()` to not check JsonUpdate command payload for foreign key references, as JSON data can not include FK constraints, thus fixing an issue that custom fields with the same name as a FK field could not be saved.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1315,12 +1315,6 @@ parameters:
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Exception\\ImpossibleWriteOrderException\:\:__construct\(\) has parameter \$remaining with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Exception/ImpossibleWriteOrderException.php
-
-		-
 			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Exception\\SearchRequestException\:\:__construct\(\) has parameter \$exceptions with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1589,12 +1583,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/CloneBehavior.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 3
-			path: src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
 
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\ParentAssociatio
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\UnmappedFieldException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\DefinitionNotFoundException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\EntityRepositoryNotFoundException;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\ImpossibleWriteOrderException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidAggregationQueryException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidFilterQueryException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidRangeFilterParamException;
@@ -19,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Exception\UnsupportedCommandTyp
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\DateHistogramAggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteTypeIntendException;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\ExpectedArrayException;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
@@ -124,6 +126,26 @@ class DataAbstractionLayerException extends HttpException
             'Unknown or bad CronInterval format "{{ cronIntervalString }}".',
             ['cronIntervalString' => $cronIntervalString],
         );
+    }
+
+    public static function writeTypeIntendError(
+        EntityDefinition $definition,
+        string $expectedClass,
+        string $actualClass
+    ): self {
+        return new WriteTypeIntendException(
+            $definition,
+            $expectedClass,
+            $actualClass
+        );
+    }
+
+    /**
+     * @param list<string> $remainingEntities
+     */
+    public static function impossibleWriteOrder(array $remainingEntities): self
+    {
+        return new ImpossibleWriteOrderException($remainingEntities);
     }
 
     public static function invalidDateIntervalFormat(

--- a/src/Core/Framework/DataAbstractionLayer/Exception/ImpossibleWriteOrderException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/ImpossibleWriteOrderException.php
@@ -3,15 +3,23 @@ declare(strict_types=1);
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Exception;
 
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
 
 #[Package('framework')]
-class ImpossibleWriteOrderException extends ShopwareHttpException
+class ImpossibleWriteOrderException extends DataAbstractionLayerException
 {
+    public const IMPOSSIBLE_WRITE_ORDER = 'FRAMEWORK__IMPOSSIBLE_WRITE_ORDER';
+
+    /**
+     * @param list<string> $remaining
+     */
     public function __construct(array $remaining)
     {
         parent::__construct(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::IMPOSSIBLE_WRITE_ORDER,
             'Can not resolve write order for provided data. Remaining write order classes: {{ classesString }}',
             ['classes' => $remaining, 'classesString' => implode(', ', $remaining)]
         );

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Write\Command;
 
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\ImpossibleWriteOrderException;
@@ -86,7 +87,7 @@ class WriteCommandQueue
             ++$counter;
 
             if ($counter === 50) {
-                throw new ImpossibleWriteOrderException(array_keys($commands));
+                throw DataAbstractionLayerException::impossibleWriteOrder(array_keys($commands));
             }
 
             foreach ($commands as $definition => $defCommands) {
@@ -137,7 +138,7 @@ class WriteCommandQueue
 
         foreach ($commands as $command) {
             if (!$command instanceof $class) {
-                throw new WriteTypeIntendException($definition, $class, $command::class);
+                throw DataAbstractionLayerException::writeTypeIntendError($definition, $class, $command::class);
             }
         }
     }
@@ -199,9 +200,7 @@ class WriteCommandQueue
             if ($key instanceof VersionField || $key instanceof ReferenceVersionField) {
                 continue;
             }
-            if (!$key instanceof StorageAware) {
-                throw new \RuntimeException();
-            }
+            \assert($key instanceof StorageAware);
 
             $mapped[] = (string) $key->getSerializer()->decode($key, $primaryKey[$key->getStorageName()]);
         }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
@@ -220,6 +220,11 @@ class WriteCommandQueue
             return false;
         }
 
+        // JSON update commands can not reference foreign keys (verified by DB constraints)
+        if ($command instanceof JsonUpdateCommand) {
+            return false;
+        }
+
         // get access to all foreign keys of the definition
         $fks = $foreignKeys[$entity];
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteTypeIntendException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteTypeIntendException.php
@@ -2,14 +2,16 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Write\Command;
 
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('framework')]
-class WriteTypeIntendException extends ShopwareHttpException
+class WriteTypeIntendException extends DataAbstractionLayerException
 {
+    public const WRITE_TYPE_INTEND_ERROR = 'FRAMEWORK__WRITE_TYPE_INTEND_ERROR';
+
     public function __construct(
         EntityDefinition $definition,
         string $expectedClass,
@@ -19,19 +21,12 @@ class WriteTypeIntendException extends ShopwareHttpException
             [UpdateCommand::class, InsertCommand::class] => 'Hint: Use POST method to create new entities.',
             default => '',
         };
+
         parent::__construct(
+            Response::HTTP_BAD_REQUEST,
+            self::WRITE_TYPE_INTEND_ERROR,
             'Expected command for "{{ definition }}" to be "{{ expectedClass }}". (Got: {{ actualClass }})' . $hint,
             ['definition' => $definition->getEntityName(), 'expectedClass' => $expectedClass, 'actualClass' => $actualClass]
         );
-    }
-
-    public function getErrorCode(): string
-    {
-        return 'FRAMEWORK__WRITE_TYPE_INTEND_ERROR';
-    }
-
-    public function getStatusCode(): int
-    {
-        return Response::HTTP_BAD_REQUEST;
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
@@ -22,11 +22,14 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\CustomFieldTestDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\CustomFieldTestTranslationDefinition;
+use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\CustomFieldCollection;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
+use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -40,6 +43,7 @@ class CustomFieldTest extends TestCase
         tearDown as protected tearDownDefinitions;
     }
     use KernelTestBehaviour;
+    use BasicTestDataBehaviour;
 
     private Connection $connection;
 
@@ -1116,6 +1120,33 @@ class CustomFieldTest extends TestCase
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
         $encoded = json_decode(json_encode($first, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame($dateTime->format(\DateTime::ATOM), $encoded['custom']['json']['date']);
+    }
+
+    public function testCustomFieldWithSameNameAsFKWorks(): void
+    {
+        $repo = $this->getContainer()->get('language.repository');
+        static::assertInstanceOf(EntityRepository::class, $repo);
+
+        $id = Uuid::randomHex();
+        $entity = [
+            'id' => $id,
+            'name' => 'test',
+            'localeId' => $this->getLocaleIdOfSystemLanguage(),
+            'translationCodeId' => $this->getLocaleIdOfSystemLanguage(),
+        ];
+        $repo->create([$entity], Context::createDefaultContext());
+
+        $repo->update([[
+            'id' => $id,
+            'customFields' => [
+                'locale_id' => 'test that this works'
+            ]
+        ]], Context::createDefaultContext());
+
+
+        $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
+        static::assertInstanceOf(LanguageEntity::class, $first);
+        static::assertSame('test that this works', $first->getCustomFields()['locale_id']);
     }
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
@@ -24,7 +24,6 @@ use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\Custo
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\CustomFieldTestTranslationDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
-use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\CustomFieldCollection;
@@ -38,12 +37,12 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class CustomFieldTest extends TestCase
 {
+    use BasicTestDataBehaviour;
     use CacheTestBehaviour;
     use DataAbstractionLayerFieldTestBehaviour {
         tearDown as protected tearDownDefinitions;
     }
     use KernelTestBehaviour;
-    use BasicTestDataBehaviour;
 
     private Connection $connection;
 
@@ -1139,14 +1138,13 @@ class CustomFieldTest extends TestCase
         $repo->update([[
             'id' => $id,
             'customFields' => [
-                'locale_id' => 'test that this works'
-            ]
+                'locale_id' => 'test that this works',
+            ],
         ]], Context::createDefaultContext());
-
 
         $first = $repo->search(new Criteria([$id]), Context::createDefaultContext())->first();
         static::assertInstanceOf(LanguageEntity::class, $first);
-        static::assertSame('test that this works', $first->getCustomFields()['locale_id']);
+        static::assertSame('test that this works', $first->getCustomFields()['locale_id'] ?? '');
     }
 
     /**


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/12029

data inside JSON updates was analysed if it contains fk references, however you can't reference a constraint from inside JSON
