### PR TITLE
fix: remove wrong usage of skipping assertion in integration test

### DIFF
--- a/tests/integration/Core/Checkout/Customer/Repository/CustomerRepositoryTest.php
+++ b/tests/integration/Core/Checkout/Customer/Repository/CustomerRepositoryTest.php
@@ -170,8 +170,6 @@ class CustomerRepositoryTest extends TestCase
 
     public function testDeleteCustomerWithTags(): void
     {
-        static::expectNotToPerformAssertions();
-
         $customerId = Uuid::randomHex();
         $salutation = $this->getValidSalutationId();
         $customer = [


### PR DESCRIPTION
### 1. Why is this change necessary?
This line was wrongly introduced with https://github.com/shopware/shopware/pull/12018/files#diff-f4251c59bf7b2be988265bcc77426f1c575c33525cf8384345fe1fa61e1ad902R173

While 2 weeks the same test got some assertions added before https://github.com/shopware/shopware/pull/12096/files#diff-f4251c59bf7b2be988265bcc77426f1c575c33525cf8384345fe1fa61e1ad902R206

This is also marked as 'risky' for phpunit (if we have assertion then we should not  state we do not expect assertion)

### 2. What does this change do, exactly?

Removes the extra line

### 3. Describe each step to reproduce the issue or behaviour.
Run `composer run phpunit -- --testsuite integration --filter testDeleteCustomerWithTags` 

No risky test


### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/11998

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
