### PR TITLE
fix(admin): prevent page reload during order creation confirmation dialog

### DIFF
--- a/changelog/_unreleased/2025-09-09-fix-order-creation-page-reload-during-confirmation-dialog.md
+++ b/changelog/_unreleased/2025-09-09-fix-order-creation-page-reload-during-confirmation-dialog.md
@@ -1,0 +1,6 @@
+---
+title: Fix order creation page reload during confirmation dialog when clicking save order button
+issue: #12252
+---
+# Administration
+* Changed `onSaveOrder` method in `module/sw-order/page/sw-order-create/index.ts` to prevent immediate navigation when confirmation dialog is shown by removing `this.isSaveSuccessful = true` from the save completion flow

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/index.ts
@@ -163,7 +163,6 @@ export default Shopware.Component.wrapComponentConfig({
 
                 await this.fetchPaymentMethodName();
 
-                this.isSaveSuccessful = true;
                 this.showRemindPaymentModal = true;
             } catch (error) {
                 this.showError(error);

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.spec.js
@@ -210,4 +210,18 @@ describe('src/module/sw-order/page/sw-order-create', () => {
 
         expect(Shopware.Store.get('context').api.languageId).toBe('2fbb5fe2e29a4d70aa5854ce7ce3e20b');
     });
+
+    it('should NOT set isSaveSuccessful immediately after save order, only after modal interaction', async () => {
+        await wrapper.find('.sw-button-process').trigger('click');
+        await flushPromises();
+
+        expect(wrapper.vm.showRemindPaymentModal).toBe(true);
+        expect(wrapper.vm.isSaveSuccessful).toBe(false);
+
+        const modal = wrapper.find('.sw-modal');
+        await findByText(modal, 'button', 'global.default.no').trigger('click');
+
+        expect(wrapper.vm.isSaveSuccessful).toBe(true);
+        expect(wrapper.vm.showRemindPaymentModal).toBe(false);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When creating orders with payment methods requiring confirmation, the confirmation dialog "Do you want to remind the customer to pay this order with 'Paid in advance'?" appears but immediately disappears as the page navigates away. Users cannot interact with the dialog, breaking the payment reminder workflow.

### 2. What does this change do, exactly?
Fixes the timing issue by removing this.isSaveSuccessful = true from the immediate save completion flow. Now the confirmation dialog stays visible until the user responds, then navigation occurs. The change preserves all existing functionality while making the dialog interactive.

Before: Save → Show modal while Saved success → Navigate (immediately)
After: Save → Show modal → User responds → Saved success → Navigate

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- relates #12252
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #12252 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist
