### PR TITLE
fix(admin): Correct line-height for sw-field labels

### DIFF
--- a/changelog/_unreleased/2025-09-08-adjust-line-height-of-sw-label-to-match-the-mt-label-line-height.md
+++ b/changelog/_unreleased/2025-09-08-adjust-line-height-of-sw-label-to-match-the-mt-label-line-height.md
@@ -1,0 +1,8 @@
+---
+title: Adjust line height of sw-label to match the mt-label line height
+author: Max
+author_email: max@swk-web-com
+author_github: @aragon999
+---
+# Administration
+* Changed `line-height` of `.sw-field__label` to `16px` to match the line height of of `mt-field` labels

--- a/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-base-field/sw-base-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-base-field/sw-base-field.scss
@@ -10,7 +10,7 @@
 
     .sw-field__label {
         display: flex;
-        line-height: var(--font-line-height-xs);
+        line-height: 16px;
         font-size: var(--font-size-xs);
         margin-bottom: var(--scale-size-8);
         color: var(--color-text-primary-default);


### PR DESCRIPTION
to match the line height of mt-field labels

### 1. Why is this change necessary?
In https://github.com/shopware/shopware/commit/ae7857ecdfbcd073d44389729a53354729598ba0#diff-36a7c3213f4ea873cffa094c38c6e63c48c0da15680303361fd6f7ae5b6f62f0R9-R13
The line-height of the labels of the `sw-field` components has been changed, to use a CSS variable, however this does not match the line-height of the `mt-field` labels. Hence when displaying this side by side, it looks broken:
<img width="882" height="498" alt="image" src="https://github.com/user-attachments/assets/981e2a3f-c8fa-4325-bc14-ee6e12239ac6" />

### 2. What does this change do, exactly?
Revert the change for the line-height of the labels (there is no CSS variable for the line-height of `1rem`). The select fields are probably replaced by the mt components as well, hence I am not sure if it is worth the effort to fix it in a different way.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
