### PR TITLE
fix: Add the correct tax code to zugferd XML for intra community deliveries

### DIFF
--- a/changelog/_unreleased/2025-09-09-fix-taxcode-intra-community-electronic-invoice.md
+++ b/changelog/_unreleased/2025-09-09-fix-taxcode-intra-community-electronic-invoice.md
@@ -1,0 +1,6 @@
+---
+title: Fix intra community electronic invoice
+issue: 12182
+---
+# Core
+* Added `intraCommunityDelivery` information to electronic zugferd invoices to use the correct tax code `K`.

--- a/src/Core/Checkout/DependencyInjection/document.xml
+++ b/src/Core/Checkout/DependencyInjection/document.xml
@@ -169,6 +169,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Checkout\Document\Service\DocumentConfigLoader"/>
             <argument type="service" id="Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface"/>
+            <argument type="service" id="validator"/>
 
             <tag name="document.renderer"/>
         </service>

--- a/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[Package('after-sales')]
@@ -36,6 +37,7 @@ class ZugferdRenderer extends AbstractDocumentRenderer
         protected EventDispatcherInterface $eventDispatcher,
         protected DocumentConfigLoader $documentConfigLoader,
         protected NumberRangeValueGeneratorInterface $numberRangeValueGenerator,
+        protected ValidatorInterface $validator,
     ) {
     }
 
@@ -105,6 +107,10 @@ class ZugferdRenderer extends AbstractDocumentRenderer
             'custom' => [
                 'invoiceNumber' => $number,
             ],
+            'intraCommunityDelivery' => $this->isAllowIntraCommunityDelivery(
+                $config->jsonSerialize(),
+                $order,
+            ) && $this->isValidVat($order, $this->validator),
         ]);
 
         // create version of order to ensure the document stays the same even if the order changes

--- a/src/Core/Checkout/Document/Zugferd/ZugferdBuilder.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdBuilder.php
@@ -57,7 +57,13 @@ class ZugferdBuilder
         }
 
         $taxStatus = $order->getTaxStatus() ?? $order->getPrice()->getTaxStatus();
-        $document = (new ZugferdDocument(ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_XRECHNUNG_3), $taxStatus === CartPrice::TAX_STATE_GROSS))
+
+        $isIntraCommunityDelivery = false;
+        if ($config->__isset('intraCommunityDelivery') && \is_bool($config->__get('intraCommunityDelivery'))) {
+            $isIntraCommunityDelivery = $config->__get('intraCommunityDelivery');
+        }
+
+        $document = (new ZugferdDocument(ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_XRECHNUNG_3), $taxStatus === CartPrice::TAX_STATE_GROSS, $isIntraCommunityDelivery))
             ->withBuyerInformation($customer, $billingAddress)
             ->withSellerInformation($config)
             ->withDelivery($order->getDeliveries() ?? new OrderDeliveryCollection())

--- a/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
@@ -66,6 +66,7 @@ class ZugferdDocument
     public function __construct(
         protected readonly ZugferdDocumentBuilder $zugferdBuilder,
         protected readonly bool $isGross = false,
+        protected readonly bool $isIntraCommunityDelivery = false,
     ) {
     }
 
@@ -383,6 +384,10 @@ class ZugferdDocument
 
     protected function getTaxCode(?CalculatedTax $tax): string
     {
+        if ($this->isIntraCommunityDelivery) {
+            return ZugferdDutyTaxFeeCategories::VAT_EXEMPT_FOR_EEA_INTRACOMMUNITY_SUPPLY_OF_GOODS_AND_SERVICES;
+        }
+
         return match ($tax?->getTaxRate() ?? 0.0) {
             0.0 => ZugferdDutyTaxFeeCategories::ZERO_RATED_GOODS,
             default => ZugferdDutyTaxFeeCategories::STANDARD_RATE,

--- a/tests/unit/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -41,7 +42,8 @@ class ZugferdRendererTest extends TestCase
             $this->createMock(ZugferdBuilder::class),
             $this->createMock(EventDispatcherInterface::class),
             new DocumentConfigLoader($this->createMock(EntityRepository::class), $this->createMock(EntityRepository::class)),
-            $this->createMock(NumberRangeValueGeneratorInterface::class)
+            $this->createMock(NumberRangeValueGeneratorInterface::class),
+            $this->createMock(ValidatorInterface::class),
         );
 
         static::assertSame('zugferd_invoice', $renderer->supports());
@@ -91,7 +93,8 @@ class ZugferdRendererTest extends TestCase
             $builder,
             $this->createMock(EventDispatcherInterface::class),
             new DocumentConfigLoader($this->createMock(EntityRepository::class), $this->createMock(EntityRepository::class)),
-            $this->createMock(NumberRangeValueGeneratorInterface::class)
+            $this->createMock(NumberRangeValueGeneratorInterface::class),
+            $this->createMock(ValidatorInterface::class),
         );
 
         $rendered = $renderer->render(

--- a/tests/unit/Core/Checkout/Document/Zugferd/ZugferdBuilderTest.php
+++ b/tests/unit/Core/Checkout/Document/Zugferd/ZugferdBuilderTest.php
@@ -126,6 +126,42 @@ class ZugferdBuilderTest extends TestCase
         }
     }
 
+    public function testBuildDocumentForIntraCommunityDelivery(): void
+    {
+        $order = $this->buildOrder();
+
+        $country = new CountryEntity();
+        $country->setId(Uuid::randomHex());
+        $country->setIso('UK');
+
+        $config = [
+            'documentNumber' => 'test-1000',
+            'companyCountryId' => $country->getId(),
+            'companyStreet' => 'Musterstreet 1',
+            'companyZipcode' => '12345',
+            'companyCity' => 'Mustercity',
+            'companyName' => 'Muster company SE',
+            'companyEmail' => 'test@example.de',
+            'companyPhone' => '0123456789',
+            'executiveDirector' => 'Max Mustermann',
+            'placeOfJurisdiction' => 'Muster',
+            'taxNumber' => '0123456789',
+            'vatId' => '012356789',
+            'paymentDueDate' => '+30 day',
+            'intraCommunityDelivery' => true,
+        ];
+
+        $documentConfig = DocumentConfigurationFactory::createConfiguration($config);
+        $documentConfig->setCompanyCountry($country);
+
+        $xmlContent = (new ZugferdBuilder(
+            $this->createMock(EventDispatcherInterface::class),
+            new AmountCalculator(new CashRounding(), new PercentageTaxRuleBuilder(), new TaxCalculator())
+        ))->buildDocument($order, $documentConfig, Context::createDefaultContext());
+
+        static::assertStringContainsString('CategoryCode>K', $xmlContent);
+    }
+
     private function buildOrder(): OrderEntity
     {
         $normalId = Uuid::randomHex();


### PR DESCRIPTION
### 1. Why is this change necessary?

For Intra Community Deliveries the Taxcode `K` must be used. See https://unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred5305.htm


### 2. What does this change do, exactly?

The changes use the same logic as in the `InvoiceRenderer` to determine if the order is a Intra Community Delivery and than uses the correct Taxcode in the XML File

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a order that qualifies for Intra Community Delivery
2. Create the Zugferd XML
3. See the Taxcode K in the fields `CategoryCode`

### 4. Please link to the relevant issues (if any).

- relates shopware/shopware/issues/12182

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
