### PR TITLE
fix: initialization of DiscountCampaignStruct, add additional properties

### DIFF
--- a/changelog/_unreleased/2025-09-10-fix-initialization-of-discount-campaign-struct-and-add-additional-properties.md
+++ b/changelog/_unreleased/2025-09-10-fix-initialization-of-discount-campaign-struct-and-add-additional-properties.md
@@ -1,0 +1,14 @@
+---
+title: Fix initialization of DiscountCampaignStruct and add additional properties 
+author: Kai Gossel
+author_email: k.gossel@shopware.com
+author_github: kaigossel
+---
+# Core
+* Changed `\Shopware\Core\Framework\Store\Struct\VariantStruct::fromArray` to initialize discount campaign objects by calling `\Shopware\Core\Framework\Store\Struct\DiscountCampaignStruct::fromArray`.
+* Changed `\Shopware\Core\Framework\Store\Struct\DiscountCampaignStruct::fromArray` to correctly initialize `\Shopware\Core\Framework\Store\Struct\DiscountCampaignStruct::$startDate` and `\Shopware\Core\Framework\Store\Struct\DiscountCampaignStruct::$endDate` as `DateTimeImmutable`.
+* Added additional `\Shopware\Core\Framework\Store\Struct\VariantStruct` properties `$duration`, `$netPricePerMonth` for future use
+* Added additional `\Shopware\Core\Framework\Store\Struct\DiscountCampaignStruct` property `$discountedPricePerMonth` for future use
+___
+# Administration
+* Changed TypeScript interfaces in `module/sw-extension/service/extension-store-action.service.ts` to match properties for `\Shopware\Core\Framework\Store\Struct\VariantStruct`, `\Shopware\Core\Framework\Store\Struct\DiscountCampaignStruct`

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/extension-store-action.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/extension-store-action.service.ts
@@ -8,6 +8,7 @@ import ApiService from 'src/core/service/api.service';
 type ExtensionVariantType = 'rent' | 'buy' | 'free';
 type ExtensionType = 'app' | 'plugin';
 type ExtensionSource = 'local' | 'store';
+type ExtensionRentDuration = 1 | 12;
 
 type ExtensionStoreActionHeaders = BasicHeaders & {
     'sw-language-id'?: string;
@@ -19,6 +20,7 @@ interface DiscountCampaign {
     endDate: string | null;
     discount: number;
     discountedPrice: number | null;
+    discountedPricePerMonth: number | null;
     discountAppliesForMonths: number | null;
 }
 
@@ -26,6 +28,8 @@ interface ExtensionVariant {
     id: number;
     type: ExtensionVariantType;
     netPrice: number;
+    netPricePerMonth: number;
+    duration: ExtensionRentDuration;
     trialPhaseIncluded: boolean;
     discountCampaign: DiscountCampaign | null;
 }

--- a/src/Core/Framework/Store/Struct/DiscountCampaignStruct.php
+++ b/src/Core/Framework/Store/Struct/DiscountCampaignStruct.php
@@ -20,6 +20,8 @@ class DiscountCampaignStruct extends StoreStruct
 
     protected float $discountedPrice;
 
+    protected float $discountedPricePerMonth;
+
     protected ?int $discountAppliesForMonths = null;
 
     /**
@@ -27,7 +29,16 @@ class DiscountCampaignStruct extends StoreStruct
      */
     public static function fromArray(array $data): StoreStruct
     {
-        return (new self())->assign($data);
+        $discountCampaign = (new self())->assign($data);
+
+        if (isset($data['startDate']) && \is_string($data['startDate'])) {
+            $discountCampaign->setStartDate(new \DateTimeImmutable($data['startDate']));
+        }
+        if (isset($data['endDate']) && \is_string($data['endDate'])) {
+            $discountCampaign->setEndDate(new \DateTimeImmutable($data['endDate']));
+        }
+
+        return $discountCampaign;
     }
 
     public function getName(): string
@@ -78,6 +89,16 @@ class DiscountCampaignStruct extends StoreStruct
     public function setDiscountedPrice(float $discountedPrice): void
     {
         $this->discountedPrice = $discountedPrice;
+    }
+
+    public function getDiscountedPricePerMonth(): float
+    {
+        return $this->discountedPricePerMonth;
+    }
+
+    public function setDiscountedPricePerMonth(float $discountedPricePerMonth): void
+    {
+        $this->discountedPricePerMonth = $discountedPricePerMonth;
     }
 
     public function getDiscountAppliesForMonths(): ?int

--- a/src/Core/Framework/Store/Struct/VariantStruct.php
+++ b/src/Core/Framework/Store/Struct/VariantStruct.php
@@ -13,6 +13,8 @@ class VariantStruct extends StoreStruct
     final public const TYPE_RENT = 'rent';
     final public const TYPE_BUY = 'buy';
     final public const TYPE_FREE = 'free';
+    final public const RENT_DURATION_MONTHLY = 1;
+    final public const RENT_DURATION_YEARLY = 12;
 
     protected int $id;
 
@@ -20,7 +22,11 @@ class VariantStruct extends StoreStruct
 
     protected float $netPrice;
 
+    protected float $netPricePerMonth;
+
     protected bool $trialPhaseIncluded = false;
+
+    protected int $duration;
 
     protected ?DiscountCampaignStruct $discountCampaign = null;
 
@@ -29,7 +35,13 @@ class VariantStruct extends StoreStruct
      */
     public static function fromArray(array $data): StoreStruct
     {
-        return (new self())->assign($data);
+        $variant = (new self())->assign($data);
+
+        if (isset($data['discountCampaign']) && \is_array($data['discountCampaign'])) {
+            $variant->setDiscountCampaign(DiscountCampaignStruct::fromArray($data['discountCampaign']));
+        }
+
+        return $variant;
     }
 
     public function getId(): int
@@ -45,6 +57,16 @@ class VariantStruct extends StoreStruct
     public function getNetPrice(): float
     {
         return $this->netPrice;
+    }
+
+    public function getNetPricePerMonth(): float
+    {
+        return $this->netPricePerMonth;
+    }
+
+    public function getDuration(): int
+    {
+        return $this->duration;
     }
 
     public function isTrialPhaseIncluded(): bool


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If initialization is not complete, discount campaign objects may be created in an undefined state. This can result in unpredictable behavior in the Extension Store functionality. For example, you may see missing information on running discount campaigns, even though they are available on store.shopware.com.

Furthermore, we would like to add more properties for future use in the Extension Store.

### 2. What does this change do, exactly?

- Fixes the initialization of extension variant discount campaign objects in `VariantStruct::fromArray` by calling `DiscountCampaignStruct::fromArray`.
- Fixes the initialization of `DiscountCampaignStruct::$startDate` and `DiscountCampaignStruct::$endDate` when a new object is created with `DiscountCampaignStruct::fromArray`
- Adds additional `VariantStruct` properties `$duration`, `$netPricePerMonth` for future use
- Adds additional `DiscountCampaignStruct` property `$discountedPricePerMonth` for future use
- Updates TypeScript interfaces to match properties for `VariantStruct`, `DiscountCampaignStruct`

### 3. Describe each step to reproduce the issue or behaviour.

1. Navigate to [store.shopware.com/en/sale](https://store.shopware.com/en/sale)
2. Pick an extension with an active discount campaign
3. Open the In-Admin Extension Store and search for the same extension
4. The discount information is missing

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
