### PR TITLE
fix: Do not rely on relative path of bleeding edge PHPStan config

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -1,5 +1,5 @@
 includes:
-    - ../../../../../vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - phar://phpstan.phar/conf/bleedingEdge.neon
     - extension.neon
     - rules.neon
 


### PR DESCRIPTION
### 1. Why is this change necessary?

In same environments the current used path is not correct, if Shopware is also part of the vendor directory in a project. (e.g. our SaaS template)

### 2. What does this change do, exactly?

Use the preferred way to include the bleeding edge PHPStan config

### 3. Describe each step to reproduce the issue or behaviour.

see https://github.com/shopware/saas/actions/runs/17608752745/job/50025557282?pr=233

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
