### PR TITLE
fix: cast XML config values for `Length` constraint to `int` to prevent type errors

### DIFF
--- a/changelog/_unreleased/2025-09-10-fix-type-cast-system-config-validation.md
+++ b/changelog/_unreleased/2025-09-10-fix-type-cast-system-config-validation.md
@@ -1,0 +1,10 @@
+---
+title: Fix type error when using named arguments in validation constraints
+author: Grzegorz Jan Rolka
+author_email: grzegorz.rolka@pickware.de
+author_github: @grzegorzrolka
+---
+
+# Core
+* Fixed a type error in `SystemConfigValidator` when creating `Length` constraint with named arguments. XML configuration values such as `<maxLength>10</maxLength>` were parsed as strings and passed directly to
+  `Symfony\Component\Validator\Constraints\Length::__construct()`, which now requires `int|null` for `min` and `max`.

--- a/changelog/_unreleased/2025-09-10-fix-type-cast-system-config-validation.md
+++ b/changelog/_unreleased/2025-09-10-fix-type-cast-system-config-validation.md
@@ -6,5 +6,5 @@ author_github: @grzegorzrolka
 ---
 
 # Core
-* Fixed a type error in `SystemConfigValidator` when creating `Length` constraint with named arguments. XML configuration values such as `<maxLength>10</maxLength>` were parsed as strings and passed directly to
+* Changed Shopware\Core\System\SystemConfig\Validation\SystemConfigValidator to fix unsupported argument type when creating `Length` constraint with named arguments.  XML configuration values such as `<maxLength>10</maxLength>` were parsed as strings and passed directly to `Symfony\Component\Validator\Constraints\Length::__construct()`, which now requires `int|null` for `min` and `max`.
   `Symfony\Component\Validator\Constraints\Length::__construct()`, which now requires `int|null` for `min` and `max`.

--- a/changelog/_unreleased/2025-09-10-fix-type-cast-system-config-validation.md
+++ b/changelog/_unreleased/2025-09-10-fix-type-cast-system-config-validation.md
@@ -7,4 +7,3 @@ author_github: @grzegorzrolka
 
 # Core
 * Changed Shopware\Core\System\SystemConfig\Validation\SystemConfigValidator to fix unsupported argument type when creating `Length` constraint with named arguments.  XML configuration values such as `<maxLength>10</maxLength>` were parsed as strings and passed directly to `Symfony\Component\Validator\Constraints\Length::__construct()`, which now requires `int|null` for `min` and `max`.
-  `Symfony\Component\Validator\Constraints\Length::__construct()`, which now requires `int|null` for `min` and `max`.

--- a/changelog/_unreleased/2025-09-10-fix-type-cast-system-config-validation.md
+++ b/changelog/_unreleased/2025-09-10-fix-type-cast-system-config-validation.md
@@ -1,5 +1,5 @@
 ---
-title: Fix type error when using named arguments in validation constraints
+title: Fix type error when using named arguments in the Length validation constraint
 author: Grzegorz Jan Rolka
 author_email: grzegorz.rolka@pickware.de
 author_github: @grzegorzrolka

--- a/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
+++ b/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
@@ -105,8 +105,8 @@ class SystemConfigValidator
     {
         /** @var array<string, callable(mixed): Constraint> $constraints */
         $constraints = [
-            'minLength' => fn (mixed $ruleValue) => new Assert\Length(min: (int) $ruleValue),
-            'maxLength' => fn (mixed $ruleValue) => new Assert\Length(max: (int) $ruleValue),
+            'minLength' => fn (mixed $ruleValue) => new Assert\Length(min: $ruleValue === null ? null : max(0, (int) $ruleValue)),
+            'maxLength' => fn (mixed $ruleValue) => new Assert\Length(max: $ruleValue === null ? null : max(1, (int) $ruleValue)),
             'min' => fn (mixed $ruleValue) => new Assert\Range(min: $ruleValue),
             'max' => fn (mixed $ruleValue) => new Assert\Range(max: $ruleValue),
             'dataType' => fn (mixed $ruleValue) => new Assert\Type($ruleValue),

--- a/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
+++ b/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
@@ -105,8 +105,8 @@ class SystemConfigValidator
     {
         /** @var array<string, callable(mixed): Constraint> $constraints */
         $constraints = [
-            'minLength' => fn (mixed $ruleValue) => new Assert\Length(min: $ruleValue),
-            'maxLength' => fn (mixed $ruleValue) => new Assert\Length(max: $ruleValue),
+            'minLength' => fn (mixed $ruleValue) => new Assert\Length(min: (int) $ruleValue),
+            'maxLength' => fn (mixed $ruleValue) => new Assert\Length(max: (int) $ruleValue),
             'min' => fn (mixed $ruleValue) => new Assert\Range(min: $ruleValue),
             'max' => fn (mixed $ruleValue) => new Assert\Range(max: $ruleValue),
             'dataType' => fn (mixed $ruleValue) => new Assert\Type($ruleValue),

--- a/tests/unit/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
+++ b/tests/unit/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
@@ -211,6 +211,22 @@ class SystemConfigValidatorTest extends TestCase
             ],
             'allowNulls' => true,
         ];
+
+        yield 'element config with string values for minLength and maxLength' => [
+            'elementConfig' => [
+                'required' => false,
+                'dataType' => 'string',
+                'minLength' => '5',
+                'maxLength' => '100',
+            ],
+            'expected' => [
+                new Assert\Length(min: 5),
+                new Assert\Length(max: 100),
+                new Assert\Type('string'),
+                new Assert\NotBlank(),
+            ],
+            'allowNulls' => false,
+        ];
     }
 
     public static function dataProviderTestValidateSuccess(): \Generator


### PR DESCRIPTION
### 1. Why is this change necessary?
Due to the changes introduced in https://github.com/shopware/shopware/commit/1ac67e2ead5fa6b92def097160bd858278b4f925, constructor calls for Symfony Validator constraints were replaced with named arguments. As a result, XML-based system config values such as `<minLength>` or `<maxLength>`, which are parsed as strings, are now passed directly into the `Length` constraint. Since the constructor requires integers for these arguments, this leads to a type error (“string given, int expected”), which in turn breaks validation for the affected system config fields.

### 2. What does this change do, exactly?
This change normalizes numeric XML values (`minLength`, `maxLength`) by explicitly casting them to `int` before constructing the corresponding Symfony constraints.

### 3. Describe each step to reproduce the issue or behaviour.
1. Define a system config field in XML with a `<maxLength>` or `<minLength>` value (e.g. `<maxLength>14</maxLength>`).
2. Load or save a value for this field so that validation is triggered.
3. The process fails with an error:
```php
Argument #3 ($max) must be of type ?int, string given
```
### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
