### PR TITLE
fix: Fix inherited switch value

### DIFF
--- a/changelog/_unreleased/2025-09-10-fix-inherited-switch-value.md
+++ b/changelog/_unreleased/2025-09-10-fix-inherited-switch-value.md
@@ -1,0 +1,13 @@
+---
+title: Fix inherited switch value
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Added `inherited-value` property to inherited switches in following product component templates:
+    - `sw-product-basic-form.html.twig`
+    - `sw-product-category-form.html.twig`
+    - `sw-product-deliverability-downloadable-form.html.twig`
+    - `sw-product-deliverability-form.html.twig`
+* Added computed property `showStockSetting` to `sw-product-deliverability-downloadable-form` component.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
@@ -110,6 +110,7 @@
                     :error="productMarkAsTopsellerError"
                     :is-inheritance-field="props.isInheritField"
                     :is-inherited="props.isInherited"
+                    :inherited-value="parentProduct.markAsTopseller"
                     :help-text="highlightHelpText"
                     :label="$tc('sw-product.settingsForm.labelMarkAsTopseller')"
                     :disabled="props.isInherited || !allowEdit"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
@@ -58,6 +58,7 @@
                     :error="productActiveError"
                     :is-inheritance-field="props.isInheritField"
                     :is-inherited="props.isInherited"
+                    :inherited-value="parentProduct.active"
                     :label="$tc('sw-product.settingsForm.labelActive')"
                     :disabled="props.isInherited || !allowEdit"
                     :model-value="props.currentValue"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-downloadable-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-downloadable-form/index.js
@@ -42,6 +42,14 @@ export default {
             return Shopware.Store.get('swProductDetail').showModeSetting;
         },
 
+        showStockSetting() {
+            if (this.product.isCloseout !== null || !this.parentProduct?.id) {
+                return this.product.isCloseout;
+            }
+
+            return this.parentProduct.isCloseout;
+        },
+
         ...mapPropertyErrors('product', [
             'stock',
             'deliveryTimeId',

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-downloadable-form/sw-product-deliverability-downloadable-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-downloadable-form/sw-product-deliverability-downloadable-form.html.twig
@@ -15,6 +15,7 @@
                 :error="productIsCloseoutError"
                 :is-inheritance-field="props.isInheritField"
                 :is-inherited="props.isInherited"
+                :inherited-value="parentProduct.isCloseout"
                 :label="$tc('sw-product.detailBase.manageStockLabel')"
                 :help-text="$tc('sw-product.detailBase.manageStockTooltip')"
                 :disabled="props.isInherited || disabled"
@@ -28,7 +29,7 @@
     </sw-inherit-wrapper>
 
     <sw-container
-        v-show="product.isCloseout"
+        v-show="showStockSetting"
         columns="1fr 1fr"
         gap="0px 30px"
     >

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-form/sw-product-deliverability-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-form/sw-product-deliverability-form.html.twig
@@ -39,6 +39,7 @@
                     :error="productIsCloseoutError"
                     :is-inheritance-field="props.isInheritField"
                     :is-inherited="props.isInherited"
+                    :inherited-value="parentProduct.isCloseout"
                     :label="$tc('sw-product.settingsForm.labelIsCloseout')"
                     :help-text="$tc('sw-product.settingsForm.isCloseoutHelpText')"
                     :disabled="props.isInherited || !allowEdit"
@@ -127,6 +128,7 @@
                 <mt-switch
                     :is-inheritance-field="props.isInheritField"
                     :is-inherited="props.isInherited"
+                    :inherited-value="parentProduct.shippingFree"
                     :error="productShippingFreeError"
                     :label="$tc('sw-product.settingsForm.labelShippingFree')"
                     :disabled="props.isInherited || !allowEdit"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Inherited switch values are not correctly shown on product variants.

### 2. What does this change do, exactly?
* Added `inherited-value` property to inherited switches in following product component templates:
    - `sw-product-basic-form.html.twig`
    - `sw-product-category-form.html.twig`
    - `sw-product-deliverability-downloadable-form.html.twig`
    - `sw-product-deliverability-form.html.twig`
* Added computed property `showStockSetting` to `sw-product-deliverability-downloadable-form` component.

### 3. Describe each step to reproduce the issue or behaviour.
Create a product and activate the "closeout" switch > create variants on this product and open a variant configuration

Expected behaviour: Closeout switch has the inherited state "active"
Actual behaviour: Closeout switch has the inherited state "inactive"

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
