### PR TITLE
chore: unmute triggerIfCalledFromOutside function from dbal

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,7 @@
             <function>trigger_deprecation</function>
             <method>Doctrine\Deprecations\Deprecation::trigger</method>
             <method>Doctrine\Deprecations\Deprecation::delegateTriggerToBackend</method>
+            <method>Doctrine\Deprecations\Deprecation::triggerIfCalledFromOutside</method>
         </deprecationTrigger>
         <include>
             <directory suffix=".php">src</directory>

--- a/src/Core/Framework/Adapter/Doctrine/Patch/AbstractAsset.php
+++ b/src/Core/Framework/Adapter/Doctrine/Patch/AbstractAsset.php
@@ -154,66 +154,26 @@ abstract class AbstractAsset
     }
 
     /**
-     * Gets the quoted representation of this asset but only if it was defined with one. Otherwise
-     * return the plain unquoted value as inserted.
+     * Returns the quoted representation of this asset's name. If the name is unquoted, it is normalized according to
+     * the platform's unquoted name normalization rules.
      *
-     * @deprecated Use {@see NamedObject::getObjectName()} or {@see OptionallyQualifiedName::getObjectName()} followed
-     * by {@see Name::toSQL()} instead.
+     * getReservedKeywordsList is not used here, because it will be removed without replacement in DBAL 5.0
+     *
+     * @see https://github.com/doctrine/dbal/pull/6589
      */
     public function getQuotedName(AbstractPlatform $platform): string
     {
-        Deprecation::triggerIfCalledFromOutside(
-            'doctrine/dbal',
-            'https://github.com/doctrine/dbal/pull/6674',
-            '%s is deprecated and will be removed in 5.0.',
-            __METHOD__,
-        );
+        $parts = array_map(static function (Identifier $identifier) use ($platform): string {
+            $value = $identifier->getValue();
 
-        $keywords = $platform->getReservedKeywordsList();
-        $folding = $platform->getUnquotedIdentifierFolding();
-        $parts = $normalizedParts = [];
+            // We do not normalize quoted identifiers, as the method is not available.
+            // if (! $identifier->isQuoted()) {
+            //    $value = $platform->normalizeUnquotedIdentifier($value);
+            // }
+            return $platform->quoteSingleIdentifier($value);
+        }, $this->identifiers);
 
-        foreach (explode('.', $this->getName()) as $identifier) {
-            $isQuoted = $this->_quoted || $keywords->isKeyword($identifier);
-
-            if (!$isQuoted) {
-                $parts[] = $identifier;
-
-                /** @phpstan-ignore argument.type */
-                $normalizedParts[] = $folding->foldUnquotedIdentifier($identifier);
-            } else {
-                $parts[] = $platform->quoteSingleIdentifier($identifier);
-                $normalizedParts[] = $identifier;
-            }
-        }
-
-        $name = implode('.', $parts);
-
-        if ($this->validateFuture) {
-            $futureParts = array_map(static function (Identifier $identifier) use ($folding): string {
-                $value = $identifier->getValue();
-
-                if (!$identifier->isQuoted()) {
-                    $value = $folding->foldUnquotedIdentifier($value);
-                }
-
-                return $value;
-            }, $this->identifiers);
-
-            if ($normalizedParts !== $futureParts) {
-                Deprecation::trigger(
-                    'doctrine/dbal',
-                    'https://github.com/doctrine/dbal/pull/6592',
-                    'Relying on implicitly quoted identifiers preserving their original case is deprecated. '
-                    . 'The current name %s will become %s in 5.0. '
-                    . 'Please quote the name if the case needs to be preserved.',
-                    $name,
-                    implode('.', array_map([$platform, 'quoteSingleIdentifier'], $futureParts)),
-                );
-            }
-        }
-
-        return $name;
+        return implode('.', $parts);
     }
 
     /**

--- a/src/Core/Framework/DataAbstractionLayer/MigrationQueryGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/MigrationQueryGenerator.php
@@ -4,6 +4,8 @@ namespace Shopware\Core\Framework\DataAbstractionLayer;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\ComparatorConfig;
 use Doctrine\DBAL\Schema\Table;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\SchemaBuilder;
 use Shopware\Core\Framework\Log\Package;
@@ -51,7 +53,13 @@ class MigrationQueryGenerator
 
         $this->dropIndexes($tableSchema);
 
-        return $this->getPlatform()->getAlterTableSQL($schemaManager->createComparator()->compareTables($originalTableSchema, $tableSchema));
+        // ReportModifiedIndexes is no longer supported in the Comparator as of doctrine/dbal 5.x
+        // but schemaManager->createComparator() does not allow us to pass a config
+        $config = new ComparatorConfig();
+        $config = $config->withReportModifiedIndexes(false);
+        $comparator = new Comparator($this->getPlatform(), $config);
+
+        return $this->getPlatform()->getAlterTableSQL($comparator->compareTables($originalTableSchema, $tableSchema));
     }
 
     /**
@@ -71,11 +79,16 @@ class MigrationQueryGenerator
         return $this->connection->getDatabasePlatform();
     }
 
+    /**
+     * Never try to drop primary key, they are listed in indexes until doctrine/dbal 5.x,
+     * $table->getPrimaryKeyConstraint() cannot be matched against index name,
+     * a primary key is by default named 'primary' in doctrine/dbal 4.x within index list.
+     */
     private function dropIndexes(Table $table): void
     {
         foreach ($table->getIndexes() as $index) {
-            /** @phpstan-ignore method.deprecated (if can be removed with DBAL 5.0 as primaries won't be inlcuded anymore) */
-            if ($index->isPrimary()) {
+            // Skip primary key, this is not an index that can be dropped, it won't be listed in doctrine/dbal 5.x
+            if ($index->getName() === 'primary') {
                 continue;
             }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/MigrationQueryGeneratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/MigrationQueryGeneratorTest.php
@@ -71,8 +71,8 @@ class MigrationQueryGeneratorTest extends TestCase
         $queries = $this->generator->generateQueries($entityDefinition);
 
         static::assertCount(2, $queries);
-        static::assertStringContainsString('ALTER TABLE test ADD priority INT NOT NULL, ADD test2_id VARCHAR(255) NOT NULL', $queries[0]);
-        static::assertStringContainsString('ALTER TABLE test ADD CONSTRAINT fk_column_id FOREIGN KEY (test2_id) REFERENCES test2 (id)', $queries[1]);
+        static::assertStringContainsString('ALTER TABLE `test` ADD `priority` INT NOT NULL, ADD `test2_id` VARCHAR(255) NOT NULL', $queries[0]);
+        static::assertStringContainsString('ALTER TABLE `test` ADD CONSTRAINT `fk_column_id` FOREIGN KEY (`test2_id`) REFERENCES `test2` (`id`)', $queries[1]);
     }
 
     public function testGenerateQueriesForNewTable(): void
@@ -86,8 +86,8 @@ class MigrationQueryGeneratorTest extends TestCase
         $queries = $this->generator->generateQueries($entityDefinition);
 
         static::assertCount(2, $queries);
-        static::assertStringContainsString('CREATE TABLE test (id VARCHAR(255) NOT NULL, name VARCHAR(255) NOT NULL, priority INT NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, test2_id VARCHAR(255) NOT NULL, PRIMARY KEY (`id`))', $queries[0]);
-        static::assertStringContainsString('ALTER TABLE test ADD CONSTRAINT fk_column_id FOREIGN KEY (test2_id) REFERENCES test2 (id)', $queries[1]);
+        static::assertStringContainsString('CREATE TABLE `test` (`id` VARCHAR(255) NOT NULL, `name` VARCHAR(255) NOT NULL, `priority` INT NOT NULL, `created_at` DATETIME NOT NULL, `updated_at` DATETIME NOT NULL, `test2_id` VARCHAR(255) NOT NULL, PRIMARY KEY (`id`))', $queries[0]);
+        static::assertStringContainsString('ALTER TABLE `test` ADD CONSTRAINT `fk_column_id` FOREIGN KEY (`test2_id`) REFERENCES `test2` (`id`)', $queries[1]);
     }
 
     private function getOriginalTable(): Table


### PR DESCRIPTION
### 1. Why is this change necessary?
This is needed to provide visibility in phpunit test reporting towards custom deprecations from dbal library in our codebase.

After dealing with deprecations in https://github.com/shopware/shopware/issues/11789, doctrine deprecation were dealt with  https://github.com/shopware/shopware/pull/11870

It appears there was another custom function used in dbal to consider: `triggerIfCalledFromOutside`
We need to evaluate the hidden deprecations from this, once reactivated in phpunit.xml.dist

### 2. What does this change do, exactly?
- Activate handler of phpunit for this method in phpunit.xml.dist
- Track and fix any deprecation found (triggered by the unit/integration/devops/migration tests)

In unit test suite, from the first commit :

```
1) /home/runner/work/shopware/shopware/vendor/doctrine/deprecations/src/Deprecation.php:173
Checking whether an index is primary is deprecated. Use PrimaryKeyConstraint instead. (Index.php:317 called by MigrationQueryGenerator.php:78, https://github.com/doctrine/dbal/pull/6867, package doctrine/dbal)

2) /home/runner/work/shopware/shopware/vendor/doctrine/deprecations/src/Deprecation.php:173
Doctrine\DBAL\Platforms\AbstractPlatform::getReservedKeywordsList is deprecated. (AbstractPlatform.php:2288 called by AbstractAsset.php:172, https://github.com/doctrine/dbal/pull/6607, package doctrine/dbal)
```

see https://github.com/shopware/shopware/actions/runs/17621234263/job/50067223182?pr=12440#step:7:225
```
2 tests triggered 2 deprecations
```

In integration, migration, devops test suites, from the first commit : 
The same deprecations can be found on multiple tests

see https://github.com/shopware/shopware/actions/runs/17621234284/job/50067241699#step:7:53
```
5 tests triggered 1 deprecation
```

see https://github.com/shopware/shopware/actions/runs/17621234284/job/50067241698#step:8:51
```
8 tests triggered 1 deprecation
```

see https://github.com/shopware/shopware/actions/runs/17621234284/job/50067241787#step:7:32
```
28 tests triggered 1 deprecation
```

see https://github.com/shopware/shopware/actions/runs/17621234284/job/50067241769#step:7:45
```
1 test triggered 1 deprecation
```

### 3. Describe each step to reproduce the issue or behaviour.
- Check on the pipeline from the first commit
- Locally run the tests (unit/integration) tailed to the files involved

### 4. Please link to the relevant issues (if any).
relates https://github.com/shopware/shopware/issues/11789

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
