### PR TITLE
fix: endless redirect loop when product SEO URL contains query parameters

### DIFF
--- a/changelog/_unreleased/2025-09-11-fix-canonical-redirect-for-seo-urls-with-query.md
+++ b/changelog/_unreleased/2025-09-11-fix-canonical-redirect-for-seo-urls-with-query.md
@@ -1,0 +1,31 @@
+---
+title: Fix redirect loop for SEO URLs with query parameters
+issue: 10833
+---
+# Core
+* Changed `Shopware\\Core\\Content\\Seo\\SeoResolver::resolve` to consider the request query string when matching stored `seo_path_info`, ensuring exact matches for SEO URLs that include query parameters and preventing redirect loops.
+* Deprecated `Shopware\\Core\\Content\\Seo\\AbstractSeoResolver::resolve()` without `$queryString`; an optional 4th parameter `$queryString` will be added in v6.8.
+* Changed `Shopware\\Core\\Content\\Seo\\EmptyPathInfoResolver::resolve` to forward the optional `$queryString` to the decorated resolver.
+___
+# Storefront
+* Changed `Shopware\\Storefront\\Framework\\Routing\\RequestTransformer::transform` to forward the request query string to the resolver so exact matching works end-to-end and to set the canonical link from the resolved `canonicalPathInfo` when present.
+___
+# Upgrade Information
+## Prepare for `$queryString` in SEO resolver
+If you extend or decorate `AbstractSeoResolver::resolve`, add an optional 4th parameter `?string $queryString = null` and pass it through to the decorated resolver. Existing calls continue to work; this ensures forward compatibility with v6.8.
+
+Before:
+
+```php
+public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
+```
+
+After:
+
+```php
+public function resolve(string $languageId, string $salesChannelId, string $pathInfo, ?string $queryString = null): array
+```
+___
+# Next Major Version Changes
+`AbstractSeoResolver::resolve` adds the optional `?string $queryString = null` 4th parameter in v6.8. Implementations must update their signatures accordingly.
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2578,12 +2578,6 @@ parameters:
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
 			count: 1
-			path: src/Storefront/Framework/Routing/RequestTransformer.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
 			path: src/Storefront/Framework/Seo/SeoUrlRoute/LandingPageSeoUrlRoute.php
 
 		-

--- a/src/Core/Content/Seo/AbstractSeoResolver.php
+++ b/src/Core/Content/Seo/AbstractSeoResolver.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Content\Seo;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @phpstan-type ResolvedSeoUrl = array{id?: string, pathInfo: string, isCanonical: bool|string, canonicalPathInfo?: string}
+ * @phpstan-type ResolvedSeoUrl = array{id?: string, pathInfo: string, isCanonical: bool|string, canonicalPathInfo?: string, seoPathInfo?: string}
  */
 #[Package('inventory')]
 abstract class AbstractSeoResolver
@@ -13,7 +13,9 @@ abstract class AbstractSeoResolver
     abstract public function getDecorated(): AbstractSeoResolver;
 
     /**
+     * @deprecated tag:v6.8.0 - reason:new-optional-parameter - parameter $queryString will be added
+     *
      * @return ResolvedSeoUrl
      */
-    abstract public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array;
+    abstract public function resolve(string $languageId, string $salesChannelId, string $pathInfo /* , string $queryString = null */): array;
 }

--- a/src/Core/Content/Seo/EmptyPathInfoResolver.php
+++ b/src/Core/Content/Seo/EmptyPathInfoResolver.php
@@ -23,15 +23,20 @@ class EmptyPathInfoResolver extends AbstractSeoResolver
     }
 
     /**
+     * @deprecated tag:v6.8.0 - reason:new-optional-parameter - parameter $queryString will be added
+     *
      * @return ResolvedSeoUrl
      */
-    public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
+    public function resolve(string $languageId, string $salesChannelId, string $pathInfo/* , ?string $queryString = null */): array
     {
+        $queryString = \func_num_args() === 4 ? func_get_arg(3) : null;
+
         $seoPathInfo = ltrim($pathInfo, '/');
         if ($seoPathInfo === '') {
             return ['pathInfo' => '/', 'isCanonical' => false];
         }
 
-        return $this->getDecorated()->resolve($languageId, $salesChannelId, $pathInfo);
+        /** @phpstan-ignore-next-line parameter $queryString will be added in v6.8 */
+        return $this->getDecorated()->resolve($languageId, $salesChannelId, $pathInfo, $queryString);
     }
 }

--- a/src/Core/Content/Seo/SeoResolver.php
+++ b/src/Core/Content/Seo/SeoResolver.php
@@ -27,32 +27,52 @@ class SeoResolver extends AbstractSeoResolver
     }
 
     /**
+     * @deprecated tag:v6.8.0 - reason:new-optional-parameter - parameter $queryString will be added
+     *
      * @return ResolvedSeoUrl
      */
-    public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
+    public function resolve(string $languageId, string $salesChannelId, string $pathInfo/* , ?string $queryString = null */): array
     {
+        $queryString = \func_num_args() === 4 ? func_get_arg(3) : null;
+
         $seoPathInfo = trim($pathInfo, '/');
 
         $query = (new QueryBuilder($this->connection))
             ->select('id', 'path_info pathInfo', 'is_canonical isCanonical', 'sales_channel_id salesChannelId')
             ->from('seo_url')
             ->where('language_id = :language_id')
-            ->andWhere('(sales_channel_id = :sales_channel_id OR sales_channel_id IS NULL)')
-            ->andWhere('(seo_path_info = :seoPath OR seo_path_info = :seoPathWithSlash)')
-            ->setParameter('language_id', Uuid::fromHexToBytes($languageId))
+            ->andWhere('(sales_channel_id = :sales_channel_id OR sales_channel_id IS NULL)');
+
+        $seoPathConditions = [
+            'seo_path_info = :seoPath',
+            'seo_path_info = :seoPathWithSlash',
+            'IF(LOCATE(\'?\', seo_path_info) > 0, LEFT(seo_path_info, LOCATE(\'?\', seo_path_info) - 1), seo_path_info) = :seoPath',
+            'IF(LOCATE(\'?\', seo_path_info) > 0, LEFT(seo_path_info, LOCATE(\'?\', seo_path_info) - 1), seo_path_info) = :seoPathWithSlash',
+        ];
+
+        $query->setParameter('language_id', Uuid::fromHexToBytes($languageId))
             ->setParameter('sales_channel_id', Uuid::fromHexToBytes($salesChannelId))
             ->setParameter('seoPath', $seoPathInfo)
             ->setParameter('seoPathWithSlash', $seoPathInfo . '/');
 
+        if ($queryString !== null) {
+            $seoPathConditions[] = 'seo_path_info = :seoPathWithQuery';
+            $seoPathConditions[] = 'seo_path_info = :seoPathWithSlashAndQuery';
+            $query->setParameter('seoPathWithQuery', $seoPathInfo . '?' . $queryString)
+                ->setParameter('seoPathWithSlashAndQuery', $seoPathInfo . '/?' . $queryString);
+        }
+
+        $query->andWhere('(' . implode(' OR ', $seoPathConditions) . ')');
+
         $query->setTitle('seo-url::resolve');
 
         $seoPaths = $query->executeQuery()->fetchAllAssociative();
-
         // sort seoPaths by filled salesChannelId and isCanonical, save file sort on SQL server
         usort($seoPaths, static function ($a, $b) {
             if ($a['isCanonical'] === null) {
                 return 1;
             }
+
             if ($b['isCanonical'] === null) {
                 return -1;
             }
@@ -60,6 +80,7 @@ class SeoResolver extends AbstractSeoResolver
             if ($a['salesChannelId'] === null) {
                 return 1;
             }
+
             if ($b['salesChannelId'] === null) {
                 return -1;
             }
@@ -67,7 +88,14 @@ class SeoResolver extends AbstractSeoResolver
             return 0;
         });
 
-        $seoPath = $seoPaths[0] ?? ['pathInfo' => $seoPathInfo, 'isCanonical' => false];
+        $seoPath = ['pathInfo' => $seoPathInfo, 'isCanonical' => false];
+
+        foreach ($seoPaths as $path) {
+            $seoPath = $path;
+            if ($path['isCanonical']) {
+                break;
+            }
+        }
 
         if (!$seoPath['isCanonical']) {
             $query = (new QueryBuilder($this->connection))

--- a/src/Core/Framework/Routing/RoutingException.php
+++ b/src/Core/Framework/Routing/RoutingException.php
@@ -20,6 +20,7 @@ class RoutingException extends HttpException
     public const ACCESS_DENIED_FOR_XML_HTTP_REQUEST = 'FRAMEWORK__ACCESS_DENIED_FOR_XML_HTTP_REQUEST';
     public const CURRENCY_NOT_FOUND = 'FRAMEWORK__ROUTING_CURRENCY_NOT_FOUND';
     public const MISSING_PRIVILEGE = 'FRAMEWORK__ROUTING_MISSING_PRIVILEGE';
+    public const INVALID_SALES_CHANNEL_MAPPING = 'FRAMEWORK__INVALID_SALES_CHANNEL_MAPPING';
 
     public static function invalidRequestParameter(string $name): self
     {
@@ -92,6 +93,16 @@ class RoutingException extends HttpException
             self::CURRENCY_NOT_FOUND,
             'Currency with id "{{ currencyId }}" not found.',
             ['currencyId' => $currencyId]
+        );
+    }
+
+    public static function invalidSalesChannelMapping(string $url): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::INVALID_SALES_CHANNEL_MAPPING,
+            'Unable to find a matching sales channel for the request: "{{ url }}". Please make sure the domain mapping is correct.',
+            ['url' => $url]
         );
     }
 

--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -5,9 +5,9 @@ namespace Shopware\Storefront\Framework\Routing;
 use Shopware\Core\Content\Seo\AbstractSeoResolver;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
+use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
-use Shopware\Storefront\Framework\Routing\Exception\SalesChannelMappingException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -107,7 +107,7 @@ class RequestTransformer implements RequestTransformerInterface
         if ($salesChannel === null) {
             // this class and therefore the "isSalesChannelRequired" method is currently not extendable
             // which can cause problems when adding custom paths
-            throw new SalesChannelMappingException($request->getUri());
+            throw RoutingException::invalidSalesChannelMapping($request->getUri());
         }
 
         $absoluteBaseUrl = $this->getSchemeAndHttpHost($request) . $request->getBaseUrl();
@@ -308,13 +308,21 @@ class RequestTransformer implements RequestTransformerInterface
         // without leading slash, detail would be stripped
         $baseUrl = rtrim($baseUrl, '/') . '/';
 
+        // Include query string in resolving so SEO URLs stored with query parameters
+        // (e.g., "awesome-product?test=123") are matched exactly when present.
+        $queryString = null;
+        if (!empty($request->getQueryString())) {
+            $queryString = $request->getQueryString();
+        }
+
         if ($this->equalsBaseUrl($seoPathInfo, $baseUrl)) {
             $seoPathInfo = '';
         } elseif ($this->containsBaseUrl($seoPathInfo, $baseUrl)) {
             $seoPathInfo = mb_substr($seoPathInfo, mb_strlen($baseUrl));
         }
 
-        $resolved = $this->resolver->resolve($languageId, $salesChannelId, $seoPathInfo);
+        /** @phpstan-ignore-next-line parameter $queryString will be added in v6.8 */
+        $resolved = $this->resolver->resolve($languageId, $salesChannelId, $seoPathInfo, $queryString);
 
         $resolved['pathInfo'] = '/' . ltrim($resolved['pathInfo'], '/');
 

--- a/tests/integration/Core/Content/Seo/SeoResolverTest.php
+++ b/tests/integration/Core/Content/Seo/SeoResolverTest.php
@@ -305,4 +305,65 @@ class SeoResolverTest extends TestCase
         $salesChannelResponse = $this->seoResolver->resolve(Defaults::LANGUAGE_SYSTEM, Uuid::randomHex(), 'awesome-product');
         static::assertSame('/default', $salesChannelResponse['pathInfo']);
     }
+
+    public function testResolveSeoPathWithCanonicalContainingQueryString(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/12345',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        // When the canonical entry includes a query string, resolving with the same query string
+        // should return the canonical path directly (no canonicalPathInfo set)
+        /** @phpstan-ignore-next-line parameter $queryString will be added in v6.8 */
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'Main-product/SWDEMO10001', 'test=123');
+
+        static::assertSame('/detail/12345', $resolved['pathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
+
+    public function testResolveWithoutQueryFallsBackWhenCanonicalContainsQueryString(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/12345',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+                'isCanonical' => true,
+            ],
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/12345',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+                'isCanonical' => false,
+            ],
+        ], $context);
+
+        // Without the query part, resolver should not find the exact canonical entry, but
+        // should return a non-canonical match with canonicalPathInfo populated.
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'Main-product/SWDEMO10001');
+
+        static::assertSame('/detail/12345', $resolved['pathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
 }

--- a/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -11,13 +11,13 @@ use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\Routing\RequestTransformer as CoreRequestTransformer;
+use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Framework\Routing\DomainLoader;
-use Shopware\Storefront\Framework\Routing\Exception\SalesChannelMappingException;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Shopware\Storefront\Test\Framework\Routing\Helper\ExpectedRequest;
 use Symfony\Component\HttpFoundation\Request;
@@ -244,9 +244,9 @@ class RequestTransformerTest extends TestCase
                     self::getInactiveSalesChannel($germanId, $gerDomainId, 'http://inactive.test'),
                 ],
                 [
-                    new ExpectedRequest('http://inactive.test', null, null, null, null, null, null, null, null, null, SalesChannelMappingException::class),
-                    new ExpectedRequest('http://inactive.test/', null, null, null, null, null, null, null, null, null, SalesChannelMappingException::class),
-                    new ExpectedRequest('http://inactive.test/foobar', null, null, null, null, null, null, null, null, null, SalesChannelMappingException::class),
+                    new ExpectedRequest('http://inactive.test', null, null, null, null, null, null, null, null, null, RoutingException::class),
+                    new ExpectedRequest('http://inactive.test/', null, null, null, null, null, null, null, null, null, RoutingException::class),
+                    new ExpectedRequest('http://inactive.test/foobar', null, null, null, null, null, null, null, null, null, RoutingException::class),
                 ],
             ],
             'punycode' => [
@@ -299,6 +299,44 @@ class RequestTransformerTest extends TestCase
         $resolved = $this->requestTransformer->transform($request);
 
         static::assertSame('http://base.test' . $resolvedUrl, $resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
+    }
+
+    public function testCanonicalSeoUrlWithQueryParameterDoesNotSetCanonicalLink(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $domainId = Uuid::randomHex();
+
+        $this->createSalesChannels([
+            self::getGermanSalesChannel($salesChannelId, $domainId, 'http://base.test'),
+        ]);
+
+        $con = static::getContainer()->get(Connection::class);
+        $con->insert(
+            'seo_url',
+            [
+                'id' => Uuid::randomBytes(),
+                'language_id' => Uuid::fromHexToBytes($this->deLanguageId),
+                'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                'foreign_key' => Uuid::randomBytes(),
+                'route_name' => 'frontend.detail.page',
+                'path_info' => '/detail/87a78cf58f114d5587ae23c140825694',
+                'seo_path_info' => 'Main-product/SWDEMO10001?test=123',
+                'is_canonical' => 1,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+
+        $request = Request::create('http://base.test/Main-product/SWDEMO10001?test=123');
+
+        $resolved = $this->requestTransformer->transform($request);
+
+        static::assertSame(
+            '/detail/87a78cf58f114d5587ae23c140825694',
+            $resolved->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI)
+        );
+
+        // Matching canonical SEO URL should not set a canonical link (no redirect loop)
+        static::assertNull($resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
     }
 
     /**

--- a/tests/unit/Core/Content/Seo/SeoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoResolverTest.php
@@ -125,6 +125,57 @@ class SeoResolverTest extends TestCase
         static::assertSame($expected, $resolvedSeoUrl['canonicalPathInfo']);
     }
 
+    public function testResolveWithQueryStringReturnsCanonical(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $expectedPathInfo = '/detail/12345';
+
+        $seoResolver = new SeoResolver($this->getMockConnection($salesChannelId, true, $expectedPathInfo));
+
+        $resolvedSeoUrl = $seoResolver->resolve(Uuid::randomHex(), $salesChannelId, 'Main-product/SWDEMO10001');
+
+        static::assertSame($expectedPathInfo, $resolvedSeoUrl['pathInfo']);
+        static::assertTrue((bool) $resolvedSeoUrl['isCanonical']);
+    }
+
+    public function testResolveWithoutQueryStringReturnsCanonical(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/default',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+            ],
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => null,
+                'pathInfo' => '/sales-channel',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolve(Uuid::randomHex(), $salesChannelId, 'Main-product/SWDEMO10001');
+
+        static::assertNotEmpty($resolved);
+
+        static::assertSame('/default', $resolved['pathInfo']);
+        static::assertArrayHasKey('seoPathInfo', $resolved);
+        static::assertSame('Main-product/SWDEMO10001?test=123', $resolved['seoPathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+    }
+
     private function getMockConnection(string $salesChannelId, bool $isCanonical, string $pathInfo): Connection&MockObject
     {
         $mock = $this->createMock(Connection::class);

--- a/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -8,8 +8,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\AbstractSeoResolver;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
+use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Storefront\Framework\Routing\AbstractDomainLoader;
-use Shopware\Storefront\Framework\Routing\Exception\SalesChannelMappingException;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -57,8 +57,62 @@ class RequestTransformerTest extends TestCase
 
         $originalRequest = Request::create('http://shopware.com/api');
 
-        static::expectException(SalesChannelMappingException::class);
+        static::expectException(RoutingException::class);
         $requestTransformer->transform($originalRequest);
+    }
+
+    public function testResolverReceivesQueryStringForExactMatching(): void
+    {
+        $decorated = $this->createMock(RequestTransformerInterface::class);
+        $decorated->method('transform')->willReturnCallback(fn ($request) => $request);
+
+        $languageId = bin2hex(random_bytes(16));
+        $salesChannelId = bin2hex(random_bytes(16));
+
+        $resolver = $this->createMock(AbstractSeoResolver::class);
+        $resolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with(
+                $languageId,
+                $salesChannelId,
+                'Main-product/SWDEMO10001',
+                'test=123'
+            )
+            ->willReturn([
+                'pathInfo' => '/detail/123',
+                'isCanonical' => true,
+            ]);
+
+        $domainLoader = $this->createMock(AbstractDomainLoader::class);
+        $domainLoader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn([
+                // keys are normalized with trailing slash in RequestTransformer
+                'http://shopware.com/' => [
+                    'url' => 'http://shopware.com',
+                    'id' => bin2hex(random_bytes(16)),
+                    'salesChannelId' => $salesChannelId,
+                    'typeId' => bin2hex(random_bytes(16)),
+                    'snippetSetId' => bin2hex(random_bytes(16)),
+                    'currencyId' => bin2hex(random_bytes(16)),
+                    'languageId' => $languageId,
+                    'themeId' => bin2hex(random_bytes(16)),
+                    'maintenance' => '0',
+                    'maintenanceIpWhitelist' => '',
+                    'locale' => 'en-GB',
+                    'themeName' => 'Storefront',
+                    'parentThemeName' => '',
+                ],
+            ]);
+
+        $requestTransformer = new RequestTransformer($decorated, $resolver, [], $domainLoader);
+
+        $originalRequest = Request::create('http://shopware.com/Main-product/SWDEMO10001?test=123');
+        $transformedRequest = $requestTransformer->transform($originalRequest);
+
+        static::assertSame('/detail/123', $transformedRequest->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI));
     }
 
     /**


### PR DESCRIPTION
### Actual behaviour

If a product is assigned a custom SEO URL in the admin that includes a query parameter (e.g. Main-product/SWDEMO10001?test=123), accessing this URL results in an endless redirect loop.
The query parameter is continuously appended, e.g.:
?test=123?test=123?test=123 etc.

### Expected behaviour

Custom SEO URLs with query parameters should either:

Load correctly without triggering a redirect loop, or

Be validated and disallowed if unsupported.

### How to reproduce

1. Go to Shopware Administration → Catalogues → Products.
2. Edit any product (e.g., Main Product).
3. Scroll to the SEO URLs section.
4. Add a custom SEO path like: Main-product/SWDEMO10001?test=123
5. Save and clear the cache.
6. Open the generated URL in the browser.
7. Observe the infinite redirect loop.
