### PR TITLE
chore: Fix document_base_config migration

### DIFF
--- a/src/Core/Migration/V6_7/Migration1754295570DocumentActivateReturnAddress.php
+++ b/src/Core/Migration/V6_7/Migration1754295570DocumentActivateReturnAddress.php
@@ -25,6 +25,7 @@ class Migration1754295570DocumentActivateReturnAddress extends MigrationStep
             if (!\array_key_exists('config', $arr) || !\is_string($arr['config'])) {
                 $arr['config'] = [];
                 $arr['config']['displayReturnAddress'] = true;
+                $arr['config'] = json_encode($arr['config']);
 
                 return $arr;
             }

--- a/src/Core/Migration/V6_7/Migration1754295570DocumentActivateReturnAddress.php
+++ b/src/Core/Migration/V6_7/Migration1754295570DocumentActivateReturnAddress.php
@@ -19,13 +19,23 @@ class Migration1754295570DocumentActivateReturnAddress extends MigrationStep
 
     public function update(Connection $connection): void
     {
+        $documentConfigData = $connection->executeQuery('SELECT `id`, `config` FROM `document_base_config`;')->fetchAllAssociative();
+
         $documentConfig = array_map(function ($arr): array {
+            if (!\array_key_exists('config', $arr) || !\is_string($arr['config'])) {
+                $arr['config'] = [];
+                $arr['config']['displayReturnAddress'] = true;
+
+                return $arr;
+            }
+
             $arr['config'] = json_decode($arr['config'], true, 512, \JSON_THROW_ON_ERROR);
             $arr['config']['displayReturnAddress'] = true;
             $arr['config'] = json_encode($arr['config']);
 
             return $arr;
-        }, $connection->executeQuery('SELECT id, config FROM document_base_config;')->fetchAllAssociative());
+        }, $documentConfigData);
+
         array_walk(
             $documentConfig,
             function (array $arr) use ($connection): void {

--- a/tests/migration/Core/V6_7/Migration1754295570DocumentActivateReturnAddressTest.php
+++ b/tests/migration/Core/V6_7/Migration1754295570DocumentActivateReturnAddressTest.php
@@ -25,6 +25,7 @@ class Migration1754295570DocumentActivateReturnAddressTest extends TestCase
     {
         $this->connection = KernelLifecycleManager::getConnection();
         $this->connection->update('document_base_config', ['config' => '{}']);
+        $this->connection->update('document_base_config', ['config' => null], ['name' => 'cancellation_invoice']);
     }
 
     public function testMigration(): void

--- a/tests/migration/Core/V6_7/Migration1754295570DocumentActivateReturnAddressTest.php
+++ b/tests/migration/Core/V6_7/Migration1754295570DocumentActivateReturnAddressTest.php
@@ -34,10 +34,12 @@ class Migration1754295570DocumentActivateReturnAddressTest extends TestCase
         $migration->update($this->connection);
 
         $documentConfig = $this->connection->executeQuery('SELECT config FROM document_base_config;')->fetchAllAssociative();
+
         array_walk(
             $documentConfig,
             function (array $arr): void {
                 $arr['config'] = json_decode($arr['config'], true, 512, \JSON_THROW_ON_ERROR);
+
                 static::assertTrue($arr['config']['displayReturnAddress']);
             }
         );


### PR DESCRIPTION
Migration fails if JSON config is null