### PR TITLE
test: use named argument for constraint in EntityNotExistsValidatorTest

### DIFF
--- a/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php
@@ -135,14 +135,12 @@ class EntityNotExistsValidatorTest extends TestCase
         $validator = $this->getValidator();
 
         $constraint = new All(
-            [
-                'constraints' => [
-                    new EntityNotExists(
-                        entity: LocaleDefinition::ENTITY_NAME,
-                        context: $context,
-                    ),
-                ],
-            ]
+            constraints: [
+                new EntityNotExists(
+                    entity: LocaleDefinition::ENTITY_NAME,
+                    context: $context,
+                ),
+            ],
         );
 
         $violations = $validator->validate([Uuid::randomHex(), Uuid::randomHex()], $constraint);


### PR DESCRIPTION
### 1. Why is this change necessary?
Following up https://github.com/shopware/shopware/pull/11873, it seems we have forgotten 1 test to fix

See Nightly https://github.com/shopware/shopware/actions/runs/17631345643/job/50099204964#step:7:181

```
1 test triggered 1 deprecation:

1) /home/runner/work/shopware/shopware/vendor/symfony/validator/Constraints/All.php:36
Since symfony/validator 7.3: Passing an array of options to configure the "Symfony\Component\Validator\Constraints\All" constraint is deprecated, use named arguments instead.

Triggered by:

* Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Validation\EntityNotExistsValidatorTest::testValidatorWorksWithCompositeConstraint
  /home/runner/work/shopware/shopware/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php:119

```


### 2. What does this change do, exactly?
Uses named argument for Symfony constraint All in `testValidatorWorksWithCompositeConstraint`


### 3. Describe each step to reproduce the issue or behaviour.
Run `composer run phpunit -- --testsuite integration --filter EntityNotExistsValidatorTest` => no deprecation

### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/11789


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
