### PR TITLE
fix: Elasticsearch indexing when a sales channel lacks the system default language

### DIFF
--- a/changelog/_unreleased/2025-09-11-fix-es-index-language-inheritance-issue.md
+++ b/changelog/_unreleased/2025-09-11-fix-es-index-language-inheritance-issue.md
@@ -1,0 +1,6 @@
+---
+title: Fix ES index language inheritance issue
+issue: 12433
+---
+# Core
+* Changed `\Shopware\Elasticsearch\Product\ElasticsearchProductDefinition::fetchProducts` to always fetch default translation of products to ensure fall language inheritance in Elasticsearch index

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -343,6 +343,11 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
     {
         $languages = \array_keys($this->salesChannelLanguageLoader->loadLanguages());
 
+        // always add the system language to have a fallback
+        if (!\in_array(Defaults::LANGUAGE_SYSTEM, $languages, true)) {
+            $languages[] = Defaults::LANGUAGE_SYSTEM;
+        }
+
         $baseSql = <<<'SQL'
 SELECT
     LOWER(HEX(p.id)) AS id,
@@ -638,7 +643,7 @@ SQL;
             if (!isset($salesChannelLanguages[$languageId])) {
                 continue;
             }
-            // If the has parent language, we add the parent language into the mapping
+            // If the language has parent language, we add the parent language into the mapping
             if (isset($language['parentId'])) {
                 $mapping[$language['parentId']] = Defaults::LANGUAGE_SYSTEM;
             }


### PR DESCRIPTION
Fix Elasticsearch indexing when a sales channel does not include the system default language. Allows index creation without requiring the default language in the channel's languages. Commit: 64b9c35e5fe.