### PR TITLE
fix: ThemeCreateCommandTest in shopware-private

### DIFF
--- a/tests/unit/Storefront/Theme/Command/ThemeCreateCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeCreateCommandTest.php
@@ -27,7 +27,7 @@ class ThemeCreateCommandTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->removeTheme(self::THEME_NAME);
+        $this->removeTheme();
     }
 
     public function testSuccessfulCreateCommand(): void
@@ -76,7 +76,7 @@ class ThemeCreateCommandTest extends TestCase
 
         $result = preg_replace('/\s+/', ' ', trim($commandTester->getDisplay(true)));
         static::assertIsString($result);
-        static::assertStringContainsString(self::THEME_NAME . ' already exists', $result);
+        static::assertStringContainsString('already exists', $result);
     }
 
     #[DataProvider('commandFailsWithWrongNameDataProvider')]
@@ -102,7 +102,7 @@ class ThemeCreateCommandTest extends TestCase
         ];
     }
 
-    private function removeTheme(string $pluginName): bool
+    private function removeTheme(): bool
     {
         $directory = $this->projectDir . '/custom/';
 


### PR DESCRIPTION
Test was broken in 6.6, see https://github.com/shopware/shopware-private/pull/32

This was fixed with the latest security release for trunk (and fixed with the merge back here: https://github.com/shopware/shopware/commit/e17ad9397cdef29632938a5b22568bb524860f94#diff-bde75b1e5cba51db68b3aa88c67179e8eead475cc4c446c452677475c37f3fe4) , but 6.6 it is still broken
