### PR TITLE
fix: deletion of active customer address

### DIFF
--- a/changelog/_unreleased/2025-09-11-fix-deletion-of-active-customer-address.md
+++ b/changelog/_unreleased/2025-09-11-fix-deletion-of-active-customer-address.md
@@ -1,0 +1,9 @@
+---
+title: Fix deletion of active customer address
+issue: #12434
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# API
+* Changed `Shopware\Core\Checkout\Customer\SalesChannel\DeleteAddressRoute` to allow for the deletion of active customer addresses.

--- a/src/Core/Checkout/Customer/CustomerEntity.php
+++ b/src/Core/Checkout/Customer/CustomerEntity.php
@@ -609,7 +609,10 @@ class CustomerEntity extends Entity implements \Stringable
         return $this->activeBillingAddress ?? $this->defaultBillingAddress;
     }
 
-    public function setActiveBillingAddress(?CustomerAddressEntity $activeBillingAddress): void
+    /**
+     * @deprecated tag:v6.8.0 - reason:parameter-type-change $activeBillingAddress will accept null values
+     */
+    public function setActiveBillingAddress(/* ? */ CustomerAddressEntity $activeBillingAddress): void
     {
         $this->activeBillingAddress = $activeBillingAddress;
     }
@@ -619,7 +622,10 @@ class CustomerEntity extends Entity implements \Stringable
         return $this->activeShippingAddress ?? $this->defaultShippingAddress;
     }
 
-    public function setActiveShippingAddress(?CustomerAddressEntity $activeShippingAddress): void
+    /**
+     * @deprecated tag:v6.8.0 - reason:parameter-type-change $activeShippingAddress will accept null values
+     */
+    public function setActiveShippingAddress(/* ? */ CustomerAddressEntity $activeShippingAddress): void
     {
         $this->activeShippingAddress = $activeShippingAddress;
     }

--- a/src/Core/Checkout/Customer/CustomerEntity.php
+++ b/src/Core/Checkout/Customer/CustomerEntity.php
@@ -609,7 +609,7 @@ class CustomerEntity extends Entity implements \Stringable
         return $this->activeBillingAddress ?? $this->defaultBillingAddress;
     }
 
-    public function setActiveBillingAddress(CustomerAddressEntity $activeBillingAddress): void
+    public function setActiveBillingAddress(?CustomerAddressEntity $activeBillingAddress): void
     {
         $this->activeBillingAddress = $activeBillingAddress;
     }
@@ -619,7 +619,7 @@ class CustomerEntity extends Entity implements \Stringable
         return $this->activeShippingAddress ?? $this->defaultShippingAddress;
     }
 
-    public function setActiveShippingAddress(CustomerAddressEntity $activeShippingAddress): void
+    public function setActiveShippingAddress(?CustomerAddressEntity $activeShippingAddress): void
     {
         $this->activeShippingAddress = $activeShippingAddress;
     }

--- a/src/Core/Checkout/Customer/CustomerException.php
+++ b/src/Core/Checkout/Customer/CustomerException.php
@@ -46,6 +46,9 @@ class CustomerException extends HttpException
     public const PRODUCT_IDS_PARAMETER_IS_MISSING = 'CHECKOUT__PRODUCT_IDS_PARAMETER_IS_MISSING';
     public const CUSTOMER_ADDRESS_NOT_FOUND = 'CHECKOUT__CUSTOMER_ADDRESS_NOT_FOUND';
     public const CUSTOMER_AUTH_BAD_CREDENTIALS = 'CHECKOUT__CUSTOMER_AUTH_BAD_CREDENTIALS';
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
     public const CUSTOMER_ADDRESS_IS_ACTIVE = 'CHECKOUT__CUSTOMER_ADDRESS_IS_ACTIVE';
     public const CUSTOMER_ADDRESS_IS_DEFAULT = 'CHECKOUT__CUSTOMER_ADDRESS_IS_DEFAULT';
     public const CUSTOMER_IS_ALREADY_CONFIRMED = 'CHECKOUT__CUSTOMER_IS_ALREADY_CONFIRMED';
@@ -179,8 +182,13 @@ class CustomerException extends HttpException
         return new BadCredentialsException();
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
     public static function cannotDeleteActiveAddress(string $id): ShopwareHttpException
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, __FUNCTION__, 'v6.8.0.0'));
+
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::CUSTOMER_ADDRESS_IS_ACTIVE,

--- a/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
@@ -54,11 +54,15 @@ class DeleteAddressRoute extends AbstractDeleteAddressRoute
         $this->addressRepository->delete([['id' => $addressId]], $context->getContext());
 
         if ($addressId === $customer->getActiveBillingAddress()?->getId()) {
-            $customer->setActiveBillingAddress($customer->getDefaultBillingAddress());
+            /** @deprecated tag:v6.8.0 - Use setter instead */
+            $customer->assign(['activeBillingAddress' => $customer->getDefaultBillingAddress()]);
+            // $customer->setActiveBillingAddress($customer->getDefaultBillingAddress());
         }
 
         if ($addressId === $customer->getActiveShippingAddress()?->getId()) {
-            $customer->setActiveShippingAddress($customer->getDefaultShippingAddress());
+            /** @deprecated tag:v6.8.0 - Use setter instead */
+            $customer->assign(['activeShippingAddress' => $customer->getDefaultShippingAddress()]);
+            // $customer->setActiveBillingAddress($customer->getDefaultBillingAddress());
         }
 
         return new NoContentResponse();

--- a/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
@@ -62,7 +62,7 @@ class DeleteAddressRoute extends AbstractDeleteAddressRoute
         if ($addressId === $customer->getActiveShippingAddress()?->getId()) {
             /** @deprecated tag:v6.8.0 - Use setter instead */
             $customer->assign(['activeShippingAddress' => $customer->getDefaultShippingAddress()]);
-            // $customer->setActiveBillingAddress($customer->getDefaultBillingAddress());
+            // $customer->setActiveShippingAddress($customer->getDefaultShippingAddress());
         }
 
         return new NoContentResponse();

--- a/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
@@ -51,17 +51,15 @@ class DeleteAddressRoute extends AbstractDeleteAddressRoute
             throw CustomerException::cannotDeleteDefaultAddress($addressId);
         }
 
-        $activeBillingAddress = $customer->getActiveBillingAddress();
-        $activeShippingAddress = $customer->getActiveShippingAddress();
+        $this->addressRepository->delete([['id' => $addressId]], $context->getContext());
 
-        if (
-            ($activeBillingAddress && $addressId === $activeBillingAddress->getId())
-            || ($activeShippingAddress && $addressId === $activeShippingAddress->getId())
-        ) {
-            throw CustomerException::cannotDeleteActiveAddress($addressId);
+        if ($addressId === $customer->getActiveBillingAddress()?->getId()) {
+            $customer->setActiveBillingAddress($customer->getDefaultBillingAddress());
         }
 
-        $this->addressRepository->delete([['id' => $addressId]], $context->getContext());
+        if ($addressId === $customer->getActiveShippingAddress()?->getId()) {
+            $customer->setActiveShippingAddress($customer->getDefaultShippingAddress());
+        }
 
         return new NoContentResponse();
     }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/DeprecatedMethodsThrowDeprecationRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/DeprecatedMethodsThrowDeprecationRule.php
@@ -48,6 +48,8 @@ class DeprecatedMethodsThrowDeprecationRule implements Rule
         'reason:becomes-final',
         // If the return type change, the functionality itself is not deprecated, therefore they do not trigger deprecations.
         'reason:return-type-change',
+        // If the parameter type change, the functionality itself is not deprecated, therefore they do not trigger deprecations.
+        'reason:parameter-type-change',
         // If a parameter becomes more flexible, this does not need action and trigger a deprecation warning.
         'reason:parameter-type-extension',
         // If there will be in the class hierarchy of a class we mark the whole class as deprecated, but the functionality itself is not deprecated, therefore they do not trigger deprecations.

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/DeleteAddressRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/DeleteAddressRouteTest.php
@@ -192,10 +192,7 @@ class DeleteAddressRouteTest extends TestCase
                 '/store-api/account/address/' . $addressId
             );
 
-        static::assertNotSame(204, $this->browser->getResponse()->getStatusCode());
-        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-
-        static::assertSame('CHECKOUT__CUSTOMER_ADDRESS_IS_ACTIVE', $response['errors'][0]['code']);
+        static::assertSame(204, $this->browser->getResponse()->getStatusCode());
     }
 
     public function testDeleteNewCreatedAddressGuest(): void

--- a/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
+++ b/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
@@ -108,6 +108,10 @@ class CustomerExceptionTest extends TestCase
         static::assertEmpty($exception->getParameters());
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testCannotDeleteActiveAddress(): void
     {
         $exception = CustomerException::cannotDeleteActiveAddress('id-1');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Since #6580 it's possible to have diverged default and active customer addresses. This was not handled before in the account and not thought of during the implementation of the address manager.

### 2. What does this change do, exactly?
As active addresses are runtime fields that are resolved correctly if saved IDs are unavailable, the `Active addresses can't be deleted` exception was artificial after all.
We can therefore safely remove this guard and allow active addresses to be deleted.

### 3. Describe each step to reproduce the issue or behaviour.
See #12434

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #12434

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
