### PR TITLE
fix: theme config boolean values

### DIFF
--- a/changelog/_unreleased/2025-09-11-fixed-boolean-fields-in-theme-config.md
+++ b/changelog/_unreleased/2025-09-11-fixed-boolean-fields-in-theme-config.md
@@ -1,0 +1,6 @@
+---
+title: Fix boolean fields in theme config
+issue: #11766
+---
+# Storefront
+* Changed `Shopware\Storefront\Theme\Validator\SCSSValidator` to not fall back to `null` on boolean fields with value `false`.

--- a/src/Storefront/Theme/Validator/SCSSValidator.php
+++ b/src/Storefront/Theme/Validator/SCSSValidator.php
@@ -23,7 +23,7 @@ class SCSSValidator
         if (!\array_key_exists('value', $data)
             || !isset($data['value'])
             || $data['value'] === ''
-            || $data['value'] === false) {
+            || ($data['value'] === false && !in_array($data['type'], ['checkbox', 'switch', 'boolean', 'bool']))) {
             return null;
         }
 

--- a/src/Storefront/Theme/Validator/SCSSValidator.php
+++ b/src/Storefront/Theme/Validator/SCSSValidator.php
@@ -23,7 +23,7 @@ class SCSSValidator
         if (!\array_key_exists('value', $data)
             || !isset($data['value'])
             || $data['value'] === ''
-            || ($data['value'] === false && !in_array($data['type'], ['checkbox', 'switch', 'boolean', 'bool'], true))) {
+            || ($data['value'] === false && !\in_array($data['type'], ['checkbox', 'switch', 'boolean', 'bool'], true))) {
             return null;
         }
 

--- a/src/Storefront/Theme/Validator/SCSSValidator.php
+++ b/src/Storefront/Theme/Validator/SCSSValidator.php
@@ -23,7 +23,7 @@ class SCSSValidator
         if (!\array_key_exists('value', $data)
             || !isset($data['value'])
             || $data['value'] === ''
-            || ($data['value'] === false && !in_array($data['type'], ['checkbox', 'switch', 'boolean', 'bool']))) {
+            || ($data['value'] === false && !in_array($data['type'], ['checkbox', 'switch', 'boolean', 'bool'], true))) {
             return null;
         }
 

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -211,7 +211,7 @@ class SCSSValidatorTest extends TestCase
         // Boolean values
         yield 'checkbox true' => [
             [
-                'type' => 'boolean',
+                'type' => 'checkbox',
                 'value' => true,
             ],
             true,
@@ -225,7 +225,7 @@ class SCSSValidatorTest extends TestCase
         ];
         yield 'checkbox false' => [
             [
-                'type' => 'boolean',
+                'type' => 'checkbox',
                 'value' => false,
             ],
             false,
@@ -633,7 +633,7 @@ class SCSSValidatorTest extends TestCase
         // Boolean values
         yield 'checkbox true' => [
             [
-                'type' => 'boolean',
+                'type' => 'checkbox',
                 'value' => true,
             ],
             true,
@@ -641,13 +641,13 @@ class SCSSValidatorTest extends TestCase
         yield 'switch true' => [
             [
                 'type' => 'switch',
-                'value' => false,
+                'value' => true,
             ],
-            false,
+            true,
         ];
         yield 'checkbox false' => [
             [
-                'type' => 'boolean',
+                'type' => 'checkbox',
                 'value' => false,
             ],
             false,

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -21,7 +21,7 @@ class SCSSValidatorTest extends TestCase
      * @param array<string, string> $data
      */
     #[DataProvider('sanitizeDataProvider')]
-    public function testValidateSanitize(array $data, ?string $expected): void
+    public function testValidateSanitize(array $data, string|bool|null $expected): void
     {
         $returned = SCSSValidator::validate(new ScssPhpCompiler(), $data, [], true);
 
@@ -32,7 +32,7 @@ class SCSSValidatorTest extends TestCase
      * @param array<string, string> $data
      */
     #[DataProvider('validateDataProvider')]
-    public function testValidateNoSanitize(array $data, ?string $expected, bool $throwsException = false): void
+    public function testValidateNoSanitize(array $data, string|bool|null $expected, bool $throwsException = false): void
     {
         if ($throwsException) {
             self::expectException(ThemeException::class);
@@ -47,7 +47,7 @@ class SCSSValidatorTest extends TestCase
      * @param array<string, string> $data
      */
     #[DataProvider('validateDataProviderRegex')]
-    public function testValidateNoSanitizeRegex(array $data, string $expected, bool $throwsException = false): void
+    public function testValidateNoSanitizeRegex(array $data, string|bool|null $expected, bool $throwsException = false): void
     {
         if ($throwsException) {
             self::expectException(ThemeException::class);
@@ -207,6 +207,35 @@ class SCSSValidatorTest extends TestCase
                 'value' => '',
             ],
             null,
+        ];
+        // Boolean values
+        yield 'checkbox true' => [
+            [
+                'type' => 'boolean',
+                'value' => true,
+            ],
+            true,
+        ];
+        yield 'switch true' => [
+            [
+                'type' => 'switch',
+                'value' => true,
+            ],
+            true,
+        ];
+        yield 'checkbox false' => [
+            [
+                'type' => 'boolean',
+                'value' => false,
+            ],
+            false,
+        ];
+        yield 'switch false' => [
+            [
+                'type' => 'switch',
+                'value' => false,
+            ],
+            false,
         ];
         // Zero values
         yield 'color with "0" value is sanitized' => [
@@ -600,6 +629,35 @@ class SCSSValidatorTest extends TestCase
                 'value' => 'rgba(4, 4, 4, 5)',
             ],
             '#040404',
+        ];
+        // Boolean values
+        yield 'checkbox true' => [
+            [
+                'type' => 'boolean',
+                'value' => true,
+            ],
+            true,
+        ];
+        yield 'switch true' => [
+            [
+                'type' => 'switch',
+                'value' => false,
+            ],
+            false,
+        ];
+        yield 'checkbox false' => [
+            [
+                'type' => 'boolean',
+                'value' => false,
+            ],
+            false,
+        ];
+        yield 'switch false' => [
+            [
+                'type' => 'switch',
+                'value' => false,
+            ],
+            false,
         ];
         // Empty values (are valid and will be set to null)
         yield 'color empty' => [


### PR DESCRIPTION
fixes #11766

### 1. Why is this change necessary?

Config fields with value `false` fallback to `null`. This should not be the case for boolean fields.

### 2. What does this change do, exactly?

Exclude boolean fields from falling back to `null` on falsy value in the SCSS Validator.

### 3. Describe each step to reproduce the issue or behaviour.

Create a theme config field of type `switch` or `checkbox` and try to save the theme config. The value should always be saved as a boolean value.
