### PR TITLE
fix: media search is partially broken

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.html.twig
@@ -6,6 +6,7 @@
         <sw-search-bar
             initial-search-type="media"
             :initial-search="term"
+            :type-search-always-in-container="false"
             @search="onSearch"
         />
     </template>


### PR DESCRIPTION
Fix: Admin media search partially broken with Elasticsearch

This change makes the search behavior in the media module stay the same with/without opensearch but this will also lead to the es-search not being utilized in the media module (trade-off), A proper fix needs a general solution that will be addressed here (WIP): https://github.com/shopware/shopware/issues/11252
