### PR TITLE
fix: skip codeQL job on private repos

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -234,6 +234,7 @@ jobs:
         run: ./local-php-security-checker
   code-ql:
     name: Analyze
+    if: ${{ github.repository == 'shopware/shopware' }}
     runs-on: ubuntu-24.04
 
     strategy:


### PR DESCRIPTION
The job is failing on shopware-private repo, because on private repos the security features are not available

was already skipped on trunk: https://github.com/shopware/shopware-private/blob/trunk/.github/workflows/integration.yml#L226
