### PR TITLE
chore: update releases.json with 6.7.1.0/6.7.2.0

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -88,5 +88,18 @@
     "release_date": "2025-06-17",
     "extended_eol": false,
     "security_eol": "2027-02-28"
+  },
+  
+  {
+    "version": "6.7.1.0",
+    "release_date": "2025-07-24",
+    "extended_eol": false,
+    "security_eol": "2027-02-28"
+  },
+  {
+    "version": "6.7.2.0",
+    "release_date": "2025-09-01",
+    "extended_eol": false,
+    "security_eol": "2027-02-28"
   }
 ]


### PR DESCRIPTION
### 1. Why is this change necessary?

6.7.1.0 and 6.7.2.0 were missing from the Shopware Release Calendar

### 2. What does this change do, exactly?

Update latest release dates

### 3. Describe each step to reproduce the issue or behaviour.

Please refer to https://developer.shopware.com/release-notes/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
