### PR TITLE
fix: kernel resetinterface

### DIFF
--- a/changelog/_unreleased/2025-09-12-fully-restore-symfony-resetinterface-lifecycle-in-kernel-handle.md
+++ b/changelog/_unreleased/2025-09-12-fully-restore-symfony-resetinterface-lifecycle-in-kernel-handle.md
@@ -1,0 +1,17 @@
+---
+title: Fully restore Symfony ResetInterface lifecycle in Kernel::handle
+author: Mateusz Flasiński
+author_email: mateuszflasinski@gmail.com
+author_github: mateuszfl
+---
+
+# Core
+* Changed: `Shopware\Core\Kernel::handle` now calls `parent::handle()` instead of a custom override, ensuring Symfony's internal request/reset lifecycle is preserved.
+* Added: new method `preInitializePlugins()` to safely prepare Shopware plugins before boot without interfering with Symfony's reset mechanism.
+
+___
+
+# Upgrade Information
+## Correct ResetInterface handling in long-running runtimes
+When running Shopware in long-running environments (FrankenPHP, RoadRunner, Swoole), services implementing Symfony's `ResetInterface` are now reliably reset between requests.  
+No configuration changes are required.

--- a/changelog/_unreleased/2025-09-12-fully-restore-symfony-resetinterface-lifecycle-in-kernel-handle.md
+++ b/changelog/_unreleased/2025-09-12-fully-restore-symfony-resetinterface-lifecycle-in-kernel-handle.md
@@ -6,12 +6,13 @@ author_github: mateuszfl
 ---
 
 # Core
-* Changed: `Shopware\Core\Kernel::handle` now calls `parent::handle()` instead of a custom override, ensuring Symfony's internal request/reset lifecycle is preserved.
-* Added: new method `preInitializePlugins()` to safely prepare Shopware plugins before boot without interfering with Symfony's reset mechanism.
+* Changed: `Shopware\Core\Kernel::handle` now tracks nested request handling and defers service resets; once the outermost request finishes, `boot()` triggers `services_resetter` to restore all `ResetInterface` services. This aligns the per-request reset lifecycle with Symfony in long‑running runtimes.
+* Added: internal properties `requestStackSize` and `resetServices`, a `__clone()` override to clear them, and clearing these flags again in `shutdown()` to avoid stale state across reboots.
 
 ___
 
 # Upgrade Information
 ## Correct ResetInterface handling in long-running runtimes
-When running Shopware in long-running environments (FrankenPHP, RoadRunner, Swoole), services implementing Symfony's `ResetInterface` are now reliably reset between requests.  
-No configuration changes are required.
+When running Shopware in long-running environments (FrankenPHP, RoadRunner, Swoole), services implementing Symfony's `ResetInterface` are now reliably reset after each completed request cycle. The kernel defers resets while nested requests are in progress and performs a single reset once the outermost request completes.  
+No configuration or code changes are required.
+

--- a/src/Core/Framework/Resources/config/packages/framework.yaml
+++ b/src/Core/Framework/Resources/config/packages/framework.yaml
@@ -24,7 +24,7 @@ framework:
     serializer: { enabled: true }
     secret: "%env(APP_SECRET)%"
     profiler:
-        enabled: false
+        with_constructor_extractor: false
     property_info:
         enabled: true
     validation:

--- a/src/Core/Framework/Resources/config/packages/framework.yaml
+++ b/src/Core/Framework/Resources/config/packages/framework.yaml
@@ -26,7 +26,7 @@ framework:
     profiler:
         enabled: false
     property_info:
-        with_constructor_extractor: true
+        enabled: true
     validation:
         enable_attributes: true
         email_validation_mode: html5

--- a/src/Core/Framework/Resources/config/packages/framework.yaml
+++ b/src/Core/Framework/Resources/config/packages/framework.yaml
@@ -24,9 +24,9 @@ framework:
     serializer: { enabled: true }
     secret: "%env(APP_SECRET)%"
     profiler:
-        with_constructor_extractor: false
+        enabled: false
     property_info:
-        enabled: true
+        with_constructor_extractor: true
     validation:
         enable_attributes: true
         email_validation_mode: html5

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -52,6 +52,9 @@ class Kernel extends HttpKernel
 
     private string $cacheRootDir;
 
+    private int $requestStackSize = 0;
+    private bool $resetServices = false;
+
     /**
      * @internal
      */
@@ -74,6 +77,13 @@ class Kernel extends HttpKernel
         $this->shopwareVersionRevision = $versionArray['revision'];
 
         $this->cacheRootDir = EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()) . '/var/cache';
+    }
+
+    public function __clone()
+    {
+        parent::__clone();
+        $this->requestStackSize = 0;
+        $this->resetServices = false;
     }
 
     public function registerBundles(): iterable
@@ -123,14 +133,50 @@ class Kernel extends HttpKernel
 
     public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
-        $this->preInitializePlugins();
+        $this->boot();
 
-        return parent::handle($request, $type, $catch);
+        ++$this->requestStackSize;
+        $this->resetServices = true;
+
+        try {
+            return $this->getHttpKernel()->handle($request, $type, $catch);
+        } finally {
+            --$this->requestStackSize;
+        }
     }
 
     public function boot(): void
     {
-        $this->preInitializePlugins();
+        if (false === $this->booted) {
+            if ($this->debug && !EnvironmentHelper::hasVariable('SHELL_VERBOSITY')) {
+                putenv('SHELL_VERBOSITY=1');
+                $_ENV['SHELL_VERBOSITY'] = 1;
+                $_SERVER['SHELL_VERBOSITY'] = 1;
+            }
+
+            try {
+                // initialize plugins before booting
+                $this->pluginLoader->initializePlugins($this->getProjectDir());
+            } catch (DBALException $e) {
+                if (\defined('\STDERR')) {
+                    fwrite(\STDERR, 'Warning: Failed to load plugins. Message: ' . $e->getMessage() . \PHP_EOL);
+                }
+            }
+        }
+
+        if (true === $this->booted) {
+            if (!$this->requestStackSize && $this->resetServices) {
+                if ($this->container->has('services_resetter')) {
+                    $this->container->get('services_resetter')->reset();
+                }
+                $this->resetServices = false;
+                if ($this->debug) {
+                    $this->startTime = microtime(true);
+                }
+            }
+
+            return;
+        }
 
         parent::boot();
     }
@@ -185,6 +231,9 @@ class Kernel extends HttpKernel
         if (!$this->rebooting) {
             self::$connection = null;
         }
+
+        $this->requestStackSize = 0;
+        $this->resetServices = false;
 
         parent::shutdown();
     }
@@ -381,32 +430,5 @@ PHP;
     {
         return \array_key_exists($bundle->getName(), $instantiatedBundleNames)
             || \array_key_exists($bundle->getName(), $this->bundles);
-    }
-
-    /**
-     * Initializes Shopware plugins and environment settings before Symfony's
-     * container/bundles are initialized. Safe to call multiple times.
-     */
-    private function preInitializePlugins(): void
-    {
-        if ($this->booted) {
-            return;
-        }
-
-        if ($this->debug && !EnvironmentHelper::hasVariable('SHELL_VERBOSITY')) {
-            putenv('SHELL_VERBOSITY=1');
-            $_ENV['SHELL_VERBOSITY'] = 1;
-            $_SERVER['SHELL_VERBOSITY'] = 1;
-        }
-
-        try {
-            // Initialize plugins before Symfony preBoot() runs so that bundles
-            // provided by plugins are registered during initializeBundles().
-            $this->pluginLoader->initializePlugins($this->getProjectDir());
-        } catch (DBALException $e) {
-            if (\defined('\STDERR')) {
-                fwrite(\STDERR, 'Warning: Failed to load plugins. Message: ' . $e->getMessage() . \PHP_EOL);
-            }
-        }
     }
 }

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -81,9 +81,9 @@ class Kernel extends HttpKernel
 
     public function __clone()
     {
-        parent::__clone();
         $this->requestStackSize = 0;
         $this->resetServices = false;
+        parent::__clone();
     }
 
     public function registerBundles(): iterable

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -123,29 +123,14 @@ class Kernel extends HttpKernel
 
     public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
-        $this->boot();
+        $this->preInitializePlugins();
 
-        return $this->getHttpKernel()->handle($request, $type, $catch);
+        return parent::handle($request, $type, $catch);
     }
 
     public function boot(): void
     {
-        if (!$this->booted) {
-            if ($this->debug && !EnvironmentHelper::hasVariable('SHELL_VERBOSITY')) {
-                putenv('SHELL_VERBOSITY=1');
-                $_ENV['SHELL_VERBOSITY'] = 1;
-                $_SERVER['SHELL_VERBOSITY'] = 1;
-            }
-
-            try {
-                // initialize plugins before booting
-                $this->pluginLoader->initializePlugins($this->getProjectDir());
-            } catch (DBALException $e) {
-                if (\defined('\STDERR')) {
-                    fwrite(\STDERR, 'Warning: Failed to load plugins. Message: ' . $e->getMessage() . \PHP_EOL);
-                }
-            }
-        }
+        $this->preInitializePlugins();
 
         parent::boot();
     }
@@ -396,5 +381,32 @@ PHP;
     {
         return \array_key_exists($bundle->getName(), $instantiatedBundleNames)
             || \array_key_exists($bundle->getName(), $this->bundles);
+    }
+
+    /**
+     * Initializes Shopware plugins and environment settings before Symfony's
+     * container/bundles are initialized. Safe to call multiple times.
+     */
+    private function preInitializePlugins(): void
+    {
+        if ($this->booted) {
+            return;
+        }
+
+        if ($this->debug && !EnvironmentHelper::hasVariable('SHELL_VERBOSITY')) {
+            putenv('SHELL_VERBOSITY=1');
+            $_ENV['SHELL_VERBOSITY'] = 1;
+            $_SERVER['SHELL_VERBOSITY'] = 1;
+        }
+
+        try {
+            // Initialize plugins before Symfony preBoot() runs so that bundles
+            // provided by plugins are registered during initializeBundles().
+            $this->pluginLoader->initializePlugins($this->getProjectDir());
+        } catch (DBALException $e) {
+            if (\defined('\STDERR')) {
+                fwrite(\STDERR, 'Warning: Failed to load plugins. Message: ' . $e->getMessage() . \PHP_EOL);
+            }
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware overrides `Kernel::handle()` and `Kernel::boot()`.  
This override bypasses Symfony’s internal logic in `Kernel::handle()` which manages two private fields:  

- `requestStackSize`  
- `resetServices`  

These fields control when `ResetInterface::reset()` is executed.  
Because Shopware calls `$this->boot()` and then delegates directly to `getHttpKernel()->handle()`, the counters are never updated, so Symfony never calls `services_resetter->reset()`.  

As a result, services implementing `ResetInterface` are **not reset between requests** in long-running runtimes (FrankenPHP, RoadRunner, Swoole).

---

### 2. What does this change do, exactly?

- Restores Symfony’s native lifecycle by delegating `Kernel::handle()` directly to `parent::handle()`.  
- Introduces `preInitializePlugins()` to load Shopware plugins before boot, without interfering with Symfony’s internal state.  
- Ensures that `requestStackSize` and `resetServices` are updated correctly, triggering `ResetInterface::reset()` between requests.

---

### 3. Describe each step to reproduce the issue or behaviour.

1. Run Shopware in a long-running runtime (e.g. FrankenPHP).  
2. Open the Administration panel in a browser.  
3. Twig’s `vite_entry_script_tags` uses `Pentatrion\ViteBundle\Service\EntrypointRenderer`.  
4. `EntrypointRenderer` caches already served JS files in a PHP array.  
5. Because `ResetInterface::reset()` is never called, refreshing the Administration multiple times results in missing JS assets (the renderer believes they were already served).  
6. After this change, Symfony’s `Kernel::handle()` updates `requestStackSize`/`resetServices`, and `services_resetter->reset()` clears the cache between requests — assets load correctly every time.

---

### 4. Relevant issues

_No public GitHub issue._  

---

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change  
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes  
- [ ] I have written or adjusted the documentation according to my changes  
- [x] This change has comments for package types, values, functions, and non-obvious lines of code  
- [x] I have read the contribution requirements and fulfilled them