### PR TITLE
fix: promotion discount entity property initialization error in shopping cart

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -74,6 +74,12 @@ return [
         preg_quote('CHANGED: Type of property Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#$url changed from string to string|null', '/'),
         preg_quote('CHANGED: Type of property Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#$mediaId changed from string to string|null', '/'),
 
+        // Fix for promotion discount entity property initialization error - necessary to prevent runtime errors
+        preg_quote('CHANGED: Type of property Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity#$sorterKey changed from string to string|null', '/'),
+        preg_quote('CHANGED: Type of property Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity#$applierKey changed from string to string|null', '/'),
+        preg_quote('CHANGED: The parameter $sorterKey of Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity#setSorterKey() changed from string to string|null', '/'),
+        preg_quote('CHANGED: The parameter $applierKey of Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity#setApplierKey() changed from string to string|null', '/'),
+
         // The media thumbnail size id changes have not been released
         preg_quote('CHANGED: Type of property Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#$mediaThumbnailSizeId changed from string to string|null', '/'),
         preg_quote('CHANGED: The return type of Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity#getMediaThumbnailSizeId() changed from string to the non-covariant string|null', '/'),

--- a/changelog/_unreleased/2025-09-15-fix-promotion-discount-entity-property-initialization-error.md
+++ b/changelog/_unreleased/2025-09-15-fix-promotion-discount-entity-property-initialization-error.md
@@ -1,0 +1,6 @@
+---
+title: Fix promotion discount entity property initialization error in shopping cart
+issue: #11962
+---
+# Core
+* Changed property declarations in `\Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity` to make `sorterKey` and `applierKey` nullable

--- a/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountEntity.php
+++ b/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountEntity.php
@@ -82,9 +82,9 @@ class PromotionDiscountEntity extends Entity
 
     protected ?PromotionDiscountPriceCollection $promotionDiscountPrices = null;
 
-    protected string $sorterKey;
+    protected ?string $sorterKey = null;
 
-    protected string $applierKey;
+    protected ?string $applierKey = null;
 
     protected string $usageKey;
 
@@ -228,22 +228,32 @@ class PromotionDiscountEntity extends Entity
         return str_replace($prefix, '', $this->scope);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return `?string` in the future
+     * @deprecated tag:v6.8.0 - reason:behavior-change - The fallback to empty string will be removed
+     */
     public function getSorterKey(): string
     {
-        return $this->sorterKey;
+        // @deprecated tag:v6.8.0 - The fallback to empty string will be removed
+        return $this->sorterKey ?? '';
     }
 
-    public function setSorterKey(string $sorterKey): void
+    public function setSorterKey(?string $sorterKey): void
     {
         $this->sorterKey = $sorterKey;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return `?string` in the future
+     * @deprecated tag:v6.8.0 - reason:behavior-change - The fallback to empty string will be removed
+     */
     public function getApplierKey(): string
     {
-        return $this->applierKey;
+        // @deprecated tag:v6.8.0 - The fallback to empty string will be removed
+        return $this->applierKey ?? '';
     }
 
-    public function setApplierKey(string $applierKey): void
+    public function setApplierKey(?string $applierKey): void
     {
         $this->applierKey = $applierKey;
     }

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionProcessorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionProcessorTest.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Promotion\Cart;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Checkout\Promotion\PromotionCollection;
+use Shopware\Core\Checkout\Promotion\PromotionDefinition;
+use Shopware\Core\Checkout\Promotion\PromotionEntity;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Integration\Traits\TestShortHands;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class PromotionProcessorTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use TestShortHands;
+
+    /**
+     * @var EntityRepository<PromotionCollection>
+     */
+    private EntityRepository $promotionRepository;
+
+    private IdsCollection $ids;
+
+    protected function setUp(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->promotionRepository = static::getContainer()->get(\sprintf('%s.repository', PromotionDefinition::ENTITY_NAME));
+    }
+
+    public function testPromotionDiscountWithUninitializedFilterKeys(): void
+    {
+        $taxId = static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT LOWER(HEX(id)) FROM tax LIMIT 1');
+
+        $product = (new ProductBuilder($this->ids, 'test-product'))
+            ->price(100)
+            ->stock(10)
+            ->visibility();
+
+        $productData = $product->build();
+        $productData['taxId'] = $taxId;
+
+        static::getContainer()->get('product.repository')
+            ->create([$productData], Context::createDefaultContext());
+
+        $context = $this->getContext();
+        $promotionId = $this->createPromotionWithAdvancedRulesButUninitializedKeys($context);
+        $cart = $this->addProductToCart($product->id, $context);
+
+        $criteria = new Criteria([$promotionId]);
+        $criteria->addAssociation('discounts');
+
+        $promotion = $this->promotionRepository->search($criteria, $context->getContext())->first();
+        static::assertInstanceOf(PromotionEntity::class, $promotion);
+
+        $discounts = $promotion->getDiscounts();
+        static::assertNotNull($discounts, 'Promotion should have discounts');
+        $discount = $discounts->first();
+        static::assertInstanceOf(PromotionDiscountEntity::class, $discount);
+
+        // @deprecated tag:v6.8.0 - Empty sorter and applier keys will no longer be supported.
+        static::assertSame('', $discount->getSorterKey());
+        static::assertSame('', $discount->getApplierKey());
+
+        $promotionItems = $cart->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE);
+        static::assertGreaterThan(0, $promotionItems->count(), 'Promotion should be applied to cart');
+        static::assertSame(95.0, $cart->getPrice()->getTotalPrice(), 'Cart total should be 95€ (100€ - 5€ discount)');
+
+        $errors = $cart->getErrors()->getElements();
+        static::assertCount(1, $errors, 'Cart should have exactly one error informational entry');
+        $promotionError = array_values($errors)[0];
+        static::assertInstanceOf(PromotionCartAddedInformationError::class, $promotionError);
+        static::assertStringContainsString('has been added', $promotionError->getMessage());
+    }
+
+    /**
+     * Creates a promotion with considerAdvancedRules=true but leaves filter keys uninitialized.
+     * This simulates the Admin UI scenario where "Apply to specific range" is enabled
+     * but the "Apply to" and "Sort by" dropdowns are left as "Select...".
+     */
+    private function createPromotionWithAdvancedRulesButUninitializedKeys(SalesChannelContext $context): string
+    {
+        $promotionId = Uuid::randomHex();
+        $validFrom = new \DateTime();
+        $validFrom->sub(new \DateInterval('PT1H'));
+        $validUntil = new \DateTime();
+        $validUntil->add(new \DateInterval('P1D'));
+        $promotionData = [
+            'id' => $promotionId,
+            'active' => true,
+            'exclusive' => false,
+            'priority' => 1,
+            'useCodes' => false,
+            'useIndividualCodes' => false,
+            'useSetGroups' => false,
+            'name' => 'Test Auto Promotion with Advanced Rules',
+            'preventCombination' => false,
+            'validFrom' => $validFrom,
+            'validUntil' => $validUntil,
+            'maxRedemptionsGlobal' => null,
+            'maxRedemptionsPerCustomer' => null,
+            'salesChannels' => [
+                [
+                    'salesChannelId' => $context->getSalesChannel()->getId(),
+                    'priority' => 1,
+                ],
+            ],
+            'discounts' => [
+                [
+                    'id' => Uuid::randomHex(),
+                    'scope' => PromotionDiscountEntity::SCOPE_CART,
+                    'type' => PromotionDiscountEntity::TYPE_ABSOLUTE,
+                    'value' => 5.0,
+                    'considerAdvancedRules' => true,
+                    'usageKey' => 'cart-usage',
+                    'promotionDiscountPrices' => [],
+                ],
+            ],
+        ];
+
+        $this->promotionRepository->create(
+            [$promotionData],
+            $context->getContext()
+        );
+
+        return $promotionId;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The changelog now explains that the `PromotionDiscountEntity` class had typed string properties without default values, which caused fatal PHP errors when promotion discounts with advanced rules were processed before the properties were initialized.

### 2. What does this change do, exactly?
- Makes the problematic properties nullable (?string)
- Maintains backward compatibility with original return types and null coalescing operators
- Adds deprecation notices for future v6.8.0 changes
- Preserves existing behavior while preventing the initialization error

### 3. Describe each step to reproduce the issue or behaviour.
Create a new promotion and set the discount for a specific range of products, the “Apply to” and “Sort by” fields are not pre-filled. In addition, values that have been entered can be deleted using the “X” button, which means that the configuration can be saved even without values.

If no value has been saved under “Apply to” or if an item quantity has been selected there and no value has been entered under “Sort by”, no more products can be added to the shopping cart.

### 4. Please link to the relevant issues (if any).
- relates #11962
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
