### PR TITLE
fix: remove Elasticsearch dependencies in Core namespace

### DIFF
--- a/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
+++ b/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
@@ -40,7 +40,6 @@ use Shopware\Core\System\SalesChannel\Event\SalesChannelContextSwitchEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
-use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -261,7 +260,7 @@ class SalesChannelProxyController extends AbstractController
         $salesChannelContext = $this->fetchSalesChannelContext($salesChannelId, $subrequest, $context);
 
         if ($path === self::SEARCH_ROUTE) {
-            $salesChannelContext->getContext()->addState(ElasticsearchEntitySearcher::EXPLAIN_MODE);
+            $salesChannelContext->getContext()->addState(Context::ELASTICSEARCH_EXPLAIN_MODE);
         }
 
         $subrequest->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);

--- a/src/Core/Framework/Context.php
+++ b/src/Core/Framework/Context.php
@@ -24,6 +24,8 @@ class Context extends Struct
 
     final public const SKIP_TRIGGER_FLOW = 'skipTriggerFlow';
 
+    final public const ELASTICSEARCH_EXPLAIN_MODE = 'explain-mode';
+
     protected string $scope = self::USER_SCOPE;
 
     protected bool $rulesLocked = false;

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -27,7 +27,6 @@ use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Execution\Hook;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
-use Shopware\Elasticsearch\Product\ElasticsearchProductException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -808,10 +807,10 @@ class DataAbstractionLayerException extends HttpException
     /**
      * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self
      */
-    public static function configNotFound(): self|ElasticsearchProductException
+    public static function configNotFound(): self|\Shopware\Elasticsearch\Product\ElasticsearchProductException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            throw ElasticsearchProductException::configNotFound();
+        if (!Feature::isActive('v6.8.0.0') && class_exists('\Shopware\Elasticsearch\Product\ElasticsearchProductException')) {
+            return \Shopware\Elasticsearch\Product\ElasticsearchProductException::configNotFound();
         }
 
         return new self(

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -5,13 +5,13 @@ namespace Shopware\Core\System\SalesChannel\Context;
 use Shopware\Core\Checkout\Cart\AbstractCartPersister;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -108,8 +108,8 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
 
             $context = $this->factory->create($token, $parameters->getSalesChannelId(), $session);
 
-            if ($parameters->getOriginalContext()?->hasState(ElasticsearchEntitySearcher::EXPLAIN_MODE)) {
-                $context->addState(ElasticsearchEntitySearcher::EXPLAIN_MODE);
+            if ($parameters->getOriginalContext()?->hasState(Context::ELASTICSEARCH_EXPLAIN_MODE)) {
+                $context->addState(Context::ELASTICSEARCH_EXPLAIN_MODE);
             }
 
             $this->eventDispatcher->dispatch(new SalesChannelContextCreatedEvent($context, $token, $session));

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
@@ -24,7 +24,10 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[Package('framework')]
 class ElasticsearchEntitySearcher implements EntitySearcherInterface
 {
-    final public const EXPLAIN_MODE = 'explain-mode';
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed, use \Shopware\Core\Framework\Context::ELASTICSEARCH_EXPLAIN_MODE instead.
+     */
+    final public const EXPLAIN_MODE = Context::ELASTICSEARCH_EXPLAIN_MODE;
     final public const MAX_LIMIT = 10000;
     final public const RESULT_STATE = 'loaded-by-elastic';
 
@@ -72,7 +75,7 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
                 'body' => $this->convertSearch($criteria, $definition, $context, $search),
             ];
 
-            if ($context->hasState(self::EXPLAIN_MODE)) {
+            if ($context->hasState(Context::ELASTICSEARCH_EXPLAIN_MODE)) {
                 $params['include_named_queries_score'] = true;
                 $params['track_scores'] = true;
             }
@@ -130,7 +133,7 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
      */
     private function convertSearch(Criteria $criteria, EntityDefinition $definition, Context $context, Search $search): array
     {
-        if ($context->hasState(self::EXPLAIN_MODE)) {
+        if ($context->hasState(Context::ELASTICSEARCH_EXPLAIN_MODE)) {
             $search->setExplain(true);
         }
 

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -24,7 +24,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\CustomFieldService;
-use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
 use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Product\SearchFieldConfig;
 
@@ -52,7 +51,7 @@ class TokenQueryBuilder
     public function build(string $entity, string $token, array $configs, Context $context): ?BuilderInterface
     {
         $languageIdChain = $context->getLanguageIdChain();
-        $explainMode = $context->hasState(ElasticsearchEntitySearcher::EXPLAIN_MODE);
+        $explainMode = $context->hasState(Context::ELASTICSEARCH_EXPLAIN_MODE);
 
         $tokenQueries = [];
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
@@ -13,7 +13,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
-use Shopware\Elasticsearch\Product\ElasticsearchProductException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -256,7 +255,11 @@ class DataAbstractionLayerExceptionTest extends TestCase
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testConfigNotFoundDeprecated(): void
     {
-        $e = ElasticsearchProductException::configNotFound();
+        if (!\class_exists('\Shopware\Elasticsearch\Product\ElasticsearchProductException')) {
+            static::markTestSkipped('\Shopware\Elasticsearch\Product\ElasticsearchProductException does not exist');
+        }
+
+        $e = DataAbstractionLayerException::configNotFound();
 
         static::assertSame('Configuration for product elasticsearch definition not found', $e->getMessage());
         static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());

--- a/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistryTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistryTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cleanup\CleanupCartTask;
+use Shopware\Core\Content\Sitemap\ScheduledTask\SitemapGenerateTask;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
@@ -16,7 +17,6 @@ use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
-use Shopware\Elasticsearch\Framework\Indexing\CreateAliasTask;
 use Shopware\Tests\Unit\Core\Framework\MessageQueue\ScheduledTask\Scheduler\TestScheduledTask;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
@@ -38,10 +38,10 @@ class TaskRegistryTest extends TestCase
 
     public function testNewTasksAreCreated(): void
     {
-        $tasks = [new TestScheduledTask(), new CreateAliasTask(), new CleanupCartTask()];
+        $tasks = [new TestScheduledTask(), new SitemapGenerateTask(), new CleanupCartTask()];
         $parameterBag = new ParameterBag([
             'shopware.test.active' => true,
-            'elasticsearch.enabled' => false,
+            'shopware.sitemap.scheduled_task.enabled' => false,
         ]);
 
         $registeredTask = new ScheduledTaskEntity();
@@ -74,10 +74,10 @@ class TaskRegistryTest extends TestCase
                 ],
                 [
                     [
-                        'name' => CreateAliasTask::getTaskName(),
-                        'scheduledTaskClass' => CreateAliasTask::class,
-                        'runInterval' => CreateAliasTask::getDefaultInterval(),
-                        'defaultRunInterval' => CreateAliasTask::getDefaultInterval(),
+                        'name' => SitemapGenerateTask::getTaskName(),
+                        'scheduledTaskClass' => SitemapGenerateTask::class,
+                        'runInterval' => SitemapGenerateTask::getDefaultInterval(),
+                        'defaultRunInterval' => SitemapGenerateTask::getDefaultInterval(),
                         'status' => ScheduledTaskDefinition::STATUS_SKIPPED,
                     ],
                 ],
@@ -117,12 +117,12 @@ class TaskRegistryTest extends TestCase
 
     public function testQueuedOrScheduledTasksShouldBecomeSkipped(): void
     {
-        $tasks = [new TestScheduledTask(), new CreateAliasTask()];
+        $tasks = [new TestScheduledTask(), new SitemapGenerateTask()];
 
         // passing these parameters so these task shouldRun return false
         $parameterBag = new ParameterBag([
             'shopware.test.active' => false,
-            'elasticsearch.enabled' => false,
+            'shopware.sitemap.scheduled_task.enabled' => false,
         ]);
 
         $registry = new TaskRegistry($tasks, $this->scheduleTaskRepository, $parameterBag);
@@ -139,12 +139,12 @@ class TaskRegistryTest extends TestCase
         $queuedTask->setScheduledTaskClass(TestScheduledTask::class);
 
         $scheduledTask->setId('scheduledTask');
-        $scheduledTask->setName(CreateAliasTask::getTaskName());
-        $scheduledTask->setRunInterval(CreateAliasTask::getDefaultInterval());
-        $scheduledTask->setDefaultRunInterval(CreateAliasTask::getDefaultInterval());
+        $scheduledTask->setName(SitemapGenerateTask::getTaskName());
+        $scheduledTask->setRunInterval(SitemapGenerateTask::getDefaultInterval());
+        $scheduledTask->setDefaultRunInterval(SitemapGenerateTask::getDefaultInterval());
         $scheduledTask->setStatus(ScheduledTaskDefinition::STATUS_SCHEDULED);
         $scheduledTask->setNextExecutionTime(new \DateTimeImmutable());
-        $scheduledTask->setScheduledTaskClass(CreateAliasTask::class);
+        $scheduledTask->setScheduledTaskClass(SitemapGenerateTask::class);
 
         $result = $this->createMock(EntitySearchResult::class);
         $result->method('getEntities')->willReturn(new ScheduledTaskCollection([$queuedTask, $scheduledTask]));
@@ -179,12 +179,12 @@ class TaskRegistryTest extends TestCase
 
     public function testQueuedOrSkippedTasksShouldBecomeScheduled(): void
     {
-        $tasks = [new TestScheduledTask(), new CreateAliasTask()];
+        $tasks = [new TestScheduledTask(), new SitemapGenerateTask()];
 
         // passing these parameters so these task shouldRun return true
         $parameterBag = new ParameterBag([
             'shopware.test.active' => true,
-            'elasticsearch.enabled' => true,
+            'shopware.sitemap.scheduled_task.enabled' => true,
         ]);
 
         $registry = new TaskRegistry($tasks, $this->scheduleTaskRepository, $parameterBag);
@@ -201,12 +201,12 @@ class TaskRegistryTest extends TestCase
         $queuedTask->setScheduledTaskClass(TestScheduledTask::class);
 
         $skippedTask->setId('skippedTask');
-        $skippedTask->setName(CreateAliasTask::getTaskName());
-        $skippedTask->setRunInterval(CreateAliasTask::getDefaultInterval());
-        $skippedTask->setDefaultRunInterval(CreateAliasTask::getDefaultInterval());
+        $skippedTask->setName(SitemapGenerateTask::getTaskName());
+        $skippedTask->setRunInterval(SitemapGenerateTask::getDefaultInterval());
+        $skippedTask->setDefaultRunInterval(SitemapGenerateTask::getDefaultInterval());
         $skippedTask->setStatus(ScheduledTaskDefinition::STATUS_SKIPPED);
         $skippedTask->setNextExecutionTime(new \DateTimeImmutable());
-        $skippedTask->setScheduledTaskClass(CreateAliasTask::class);
+        $skippedTask->setScheduledTaskClass(SitemapGenerateTask::class);
 
         $result = $this->createMock(EntitySearchResult::class);
         $result->method('getEntities')->willReturn(new ScheduledTaskCollection([$queuedTask, $skippedTask]));

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -25,7 +25,6 @@ use Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
-use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -251,12 +250,12 @@ class SalesChannelContextServiceTest extends TestCase
     {
         $token = 'test-token';
         $originalContext = new Context(new SystemSource());
-        $originalContext->addState(ElasticsearchEntitySearcher::EXPLAIN_MODE);
+        $originalContext->addState(Context::ELASTICSEARCH_EXPLAIN_MODE);
         $context = $this->createMock(SalesChannelContext::class);
         $context->method('withPermissions')->willReturn($this->createMock(RuleLoaderResult::class));
         $context->expects($this->once())
             ->method('addState')
-            ->with(ElasticsearchEntitySearcher::EXPLAIN_MODE);
+            ->with(Context::ELASTICSEARCH_EXPLAIN_MODE);
         $session = [
             'foo' => 'bar',
             'languageId' => Defaults::LANGUAGE_SYSTEM,

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcherTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcherTest.php
@@ -243,7 +243,7 @@ class ElasticsearchEntitySearcherTest extends TestCase
         );
 
         $context = Context::createDefaultContext();
-        $context->addState(ElasticsearchEntitySearcher::EXPLAIN_MODE);
+        $context->addState(Context::ELASTICSEARCH_EXPLAIN_MODE);
 
         $criteria->addState(Criteria::STATE_ELASTICSEARCH_AWARE);
 

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -31,7 +31,6 @@ use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Core\Test\Stub\Framework\Adapter\Storage\ArrayKeyValueStorage;
-use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
 use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Product\ProductSearchQueryBuilder;
 use Shopware\Elasticsearch\Product\SearchFieldConfig;
@@ -91,7 +90,7 @@ class TokenQueryBuilderTest extends TestCase
             'languageIdChain' => [Defaults::LANGUAGE_SYSTEM],
         ]);
 
-        $context->addState(ElasticsearchEntitySearcher::EXPLAIN_MODE);
+        $context->addState(Context::ELASTICSEARCH_EXPLAIN_MODE);
 
         $query = $this->tokenQueryBuilder->build('product', $term, $config, $context);
 


### PR DESCRIPTION
allow Core to operate without Elasticsearch package while preserving explain-mode behavior