### PR TITLE
fix: getAllCodes returns only string array

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/CartPromotionsDataDefinition.php
+++ b/src/Core/Checkout/Promotion/Cart/CartPromotionsDataDefinition.php
@@ -100,7 +100,7 @@ class CartPromotionsDataDefinition extends Struct
      */
     public function getAllCodes(): array
     {
-        return array_keys($this->codePromotions);
+        return array_map(\strval(...), array_keys($this->codePromotions));
     }
 
     public function getApiAlias(): string

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/CartPromotionsDataDefinitionTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/CartPromotionsDataDefinitionTest.php
@@ -158,4 +158,20 @@ class CartPromotionsDataDefinitionTest extends TestCase
 
         static::assertSame('100', $tuple->getCode());
     }
+
+    /**
+     * This test verifies that getAllCodes returns only a string array.
+     */
+    #[Group('promotions')]
+    public function testGetAllCodeReturnsStringArray(): void
+    {
+        $promotion1 = new PromotionEntity();
+        $promotion2 = new PromotionEntity();
+
+        $definition = new CartPromotionsDataDefinition();
+        $definition->addCodePromotions('100', [$promotion1]);
+        $definition->addCodePromotions('test', [$promotion2]);
+
+        static::assertContainsOnlyString($definition->getAllCodes());
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
getAllCodes code could return int array


### 4. Please link to the relevant issues (if any).
fixes #12506