### PR TITLE
fix: correct color for active column in product list

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
@@ -201,16 +201,9 @@
                     {% block sw_product_list_grid_columns_active_content %}
                     <template v-else>
                         <mt-icon
-                            v-if="item.active"
-                            name="regular-checkmark-xs"
+                            :name="item.active ? 'regular-checkmark-xs' : 'regular-times-s'"
+                            :color="item.active ? '#37d046' : '#de294c'"
                             size="16px"
-                            class="is--active"
-                        />
-                        <mt-icon
-                            v-else
-                            name="regular-times-s"
-                            size="16px"
-                            class="is--inactive"
                         />
                     </template>
                     {% endblock %}


### PR DESCRIPTION
Before 
<img width="1280" height="370" alt="Screenshot 2025-09-16 at 11 05 37 AM" src="https://github.com/user-attachments/assets/d795c715-0616-457b-950a-3c7ef2a25071" />

After

<img width="1347" height="567" alt="image" src="https://github.com/user-attachments/assets/cb1e5eed-3725-440b-8ca2-653735fa3074" />
