### PR TITLE
fix: only create install.lock on successful installation

### DIFF
--- a/changelog/_unreleased/2025-09-17-fix-install-lock-creation-on-failure.md
+++ b/changelog/_unreleased/2025-09-17-fix-install-lock-creation-on-failure.md
@@ -1,0 +1,8 @@
+---
+title: Fix install lock creation on failure
+author: Martin Bens
+author_email: m.bens@shopware.com
+author_github: @SpiGAndromeda
+---
+# Core
+* Changed `\Shopware\Core\Maintenance\System\Command\SystemInstallCommand` to only create `install.lock` when installation succeeds

--- a/src/Core/Maintenance/System/Command/SystemInstallCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemInstallCommand.php
@@ -174,7 +174,9 @@ class SystemInstallCommand extends Command
             copy($this->projectDir . '/public/.htaccess.dist', $this->projectDir . '/public/.htaccess');
         }
 
-        touch($this->projectDir . '/install.lock');
+        if ($result === self::SUCCESS) {
+            touch($this->projectDir . '/install.lock');
+        }
 
         return $result;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

The `system:install` command incorrectly creates an `install.lock` file even when installation fails. This prevents re-running the installer after a failed installation attempt, forcing users to manually delete the lock file.

### 2. What does this change do, exactly?

Modified `SystemInstallCommand::execute()` to only create `install.lock` when `runCommands()` returns `SUCCESS`.

### 3. Describe each step to reproduce the issue or behaviour.

**Before this fix:**
1. Run `bin/console system:install` with a condition that causes failure (e.g., database connection issue)
2. Command fails with non-zero exit code
3. Check project root. The `install.lock` exists despite failure
4. Cannot re-run installer without manually deleting lock file

**After this fix:**
1. Run `bin/console system:install` with failure condition  
2. Command fails with non-zero exit code
3. Check project root - no `install.lock` file created
4. Can immediately re-run installer after fixing the issue

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them