### PR TITLE
chore: Clarify integration documentation

### DIFF
--- a/changelog/_unreleased/2025-09-19-improve-integration-docs.md
+++ b/changelog/_unreleased/2025-09-19-improve-integration-docs.md
@@ -1,0 +1,8 @@
+---
+title: Clarify integration documentation
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Administration
+* Changed text in integration to clarify that the keys are not yet active when displayed.

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/snippet/de.json
@@ -30,7 +30,7 @@
       "labelFieldLabel": "Name",
       "idFieldLabel": "Zugangs-ID",
       "secretFieldLabel": "Sicherheitsschlüssel",
-      "secretHelpText": "Bitte notiere Dir jetzt den Sicherheitsschlüssel. Nachdem die Integration gespeichert wurde, wird der Schlüssel aus Sicherheitsgründen nicht wieder angezeigt.",
+      "secretHelpText": "Zugangs-ID und Sicherheitsschlüssel werden erst nach dem Speichern aktiv. Bitte notiere Dir jetzt den Sicherheitsschlüssel. Nachdem die Integration gespeichert wurde, wird der Schlüssel aus Sicherheitsgründen nicht wieder angezeigt.",
       "permissions": "Berechtigungen",
       "readAccessFieldLabel": "Lesen (Standard)",
       "writeAccessFieldLabel": "Schreiben (optional)",

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/snippet/en.json
@@ -30,7 +30,7 @@
       "labelFieldLabel": "Name",
       "idFieldLabel": "Access key ID",
       "secretFieldLabel": "Secret access key",
-      "secretHelpText": "Please note down the access key now. After saving the integration, the key will no longer be visible, due to safety concerns.",
+      "secretHelpText": "Access key ID and Secret access key are only activate after saving the integration. Please note down the access key now. After saving the integration, the key will no longer be visible, due to safety concerns.",
       "permissions": "Permissions",
       "readAccessFieldLabel": "Read (default)",
       "writeAccessFieldLabel": "Write (optional)",


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently it looks like this in the integration:

<img width="582" height="794" alt="image" src="https://github.com/user-attachments/assets/81b474a0-b4fa-4a28-8436-ced2917ab9cf" />

More often than not, admins tend to copy&paste these details to the 3rd party integration and are confused why they get an auth error, because the settings where not yet saved.

### 2. What does this change do, exactly?

It adds the text

* Zugangs-ID und Sicherheitsschlüssel werden erst nach dem Speichern aktiv.
* Access key ID and Secret access key are only activate after saving the integration. 

### 3. Describe each step to reproduce the issue or behaviour.

Just open the integration modal

### 5. Checklist

- [text only] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
