### PR TITLE
chore(administration): Add lint:scss and format to lint:all command

### DIFF
--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -24,7 +24,7 @@
     "preinstall": "node ./scripts/validate-package-json/index.mjs",
     "postinstall": "patch-package",
     "lint": "eslint --ext .js,.ts,.vue,.html.twig src test build.ts --cache",
-    "lint:all": "npm run lint:types && npm run lint",
+    "lint:all": "npm run lint:types && npm run lint && npm run lint:scss && npm run format",
     "lint:debugging": "eslint --ext .js,.ts,.vue,.html.twig",
     "lint:deprecations": "eslint --rule '\"sw-new-core-rules/private-feature-declarations\": \"error\"' $(git status -s | awk '/(js|ts|vue|html\\.twig)$/ {print $2}')",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
It just annoys me that `lint:all` doesn't run all the linter tasks that run in the CI pipeline. :sweat_smile: 

I hope you're with me about that.