### PR TITLE
fix: Add missing refreshTokenTtl context field to administration template

### DIFF
--- a/changelog/_unreleased/2025-09-23-add-missing-refresh-token-ttl-to-admin-template.md
+++ b/changelog/_unreleased/2025-09-23-add-missing-refresh-token-ttl-to-admin-template.md
@@ -1,0 +1,8 @@
+---
+title: Add missing refreshTokenTtl context field to administration template
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Added the missing `refreshTokenTtl` context field to the administration template `Resources/views/administration/index.html.twig`

--- a/src/Administration/Resources/views/administration/index.html.twig
+++ b/src/Administration/Resources/views/administration/index.html.twig
@@ -57,6 +57,7 @@
                     systemLanguageId: '{{ systemLanguageId }}',
                     apiVersion: {{ apiVersion }},
                     assetPath: '{{ asset('', 'asset') }}',
+                    refreshTokenTtl: {{ refreshTokenTtl }},
                     serviceRegistryUrl: '{{ serviceRegistryUrl }}',
                 },
                 appContext: {


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the config option `shopware.api.refresh_token_ttl` is injected into the administration template but never set there correctly
- This leaves the variable undefined and uses the fallback of 7 days in the login process in the login service

### 2. What does this change do, exactly?
* Added the missing `refreshTokenTtl` context field to the administration template `Resources/views/administration/index.html.twig`

### 3. Describe each step to reproduce the issue or behaviour.
- Change the `shopware.api.refresh_token_ttl` config option
- Open the administration
- Login to the administration with "remember me"
- Check the cookie lifetime (it will use the fallback of 7 days all the time, ignoring the config option)

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
