### PR TITLE
feat: custom exception for missing route

### DIFF
--- a/src/Core/Framework/Resources/config/packages/framework.yaml
+++ b/src/Core/Framework/Resources/config/packages/framework.yaml
@@ -229,3 +229,5 @@ framework:
             log_level: notice
         Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\ParentAssociationCanNotBeFetched:
             log_level: notice
+        Shopware\Storefront\Controller\Exception\StorefrontRouteNotFoundException:
+            log_level: notice

--- a/src/Storefront/Controller/Exception/StorefrontException.php
+++ b/src/Storefront/Controller/Exception/StorefrontException.php
@@ -133,4 +133,12 @@ class StorefrontException extends HttpException
             ['salesChannel' => $salesChannel->getTranslation('name')],
         );
     }
+
+    /**
+     * Throwing the custom exception allows to still catch {@see \Symfony\Component\Routing\Exception\RouteNotFoundException} as usual
+     */
+    public static function routeNotFound(string $route, ?\Throwable $previous = null): StorefrontRouteNotFoundException
+    {
+        return new StorefrontRouteNotFoundException($route, $previous);
+    }
 }

--- a/src/Storefront/Controller/Exception/StorefrontRouteNotFoundException.php
+++ b/src/Storefront/Controller/Exception/StorefrontRouteNotFoundException.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Controller\Exception;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
+#[Package('framework')]
+class StorefrontRouteNotFoundException extends RouteNotFoundException
+{
+    public function __construct(string $route, ?\Throwable $previous = null)
+    {
+        parent::__construct(
+            \sprintf('Route "%s" not found.', $route),
+            previous: $previous
+        );
+    }
+}

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
@@ -146,7 +147,11 @@ abstract class StorefrontController extends AbstractController
     {
         $router = $this->container->get('router');
 
-        $url = $this->generateUrl($routeName, $routeParameters, Router::PATH_INFO);
+        try {
+            $url = $this->generateUrl($routeName, $routeParameters, Router::PATH_INFO);
+        } catch (RouteNotFoundException $e) {
+            throw StorefrontException::routeNotFound($routeName, $e);
+        }
 
         // for the route matching the request method is set to "GET" because
         // this method is not ought to be used as a post passthrough
@@ -253,7 +258,11 @@ abstract class StorefrontController extends AbstractController
         $event = new StorefrontRedirectEvent($route, $parameters, $status);
         $this->container->get('event_dispatcher')->dispatch($event);
 
-        return parent::redirectToRoute($event->getRoute(), $event->getParameters(), $event->getStatus());
+        try {
+            return parent::redirectToRoute($event->getRoute(), $event->getParameters(), $event->getStatus());
+        } catch (RouteNotFoundException $e) {
+            throw StorefrontException::routeNotFound($route, $e);
+        }
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Without this change, attackers can manipulate the `redirectTo` field in the storefront by injecting invalid values, which leads to hundreds of `RouteNotFoundException` entries in the logs.

By introducing a custom exception that extends `RouteNotFoundException`, we can selectively ignore these expected cases and reduce noise in Datadog, resulting in cleaner and more meaningful log data.
