### PR TITLE
fix: do not throw errors on finalize-transaction calls with invalidated token

### DIFF
--- a/src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
+++ b/src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
@@ -81,10 +81,6 @@ class JWTFactoryV2 implements TokenFactoryInterfaceV2
             throw PaymentException::invalidToken($token);
         }
 
-        if (!$this->has($token)) {
-            throw PaymentException::tokenInvalidated($token);
-        }
-
         $errorUrl = $jwtToken->claims()->get('eul');
 
         /** @var \DateTimeImmutable $expires */
@@ -97,7 +93,8 @@ class JWTFactoryV2 implements TokenFactoryInterfaceV2
             $jwtToken->claims()->get('sub'),
             $jwtToken->claims()->get('ful'),
             $expires->getTimestamp(),
-            $errorUrl
+            $errorUrl,
+            !$this->has($token),
         );
     }
 

--- a/src/Core/Checkout/Payment/Cart/Token/TokenStruct.php
+++ b/src/Core/Checkout/Payment/Cart/Token/TokenStruct.php
@@ -12,6 +12,8 @@ class TokenStruct extends Struct
 
     protected int $expires;
 
+    protected bool $invalidated;
+
     public function __construct(
         protected ?string $id = null,
         protected ?string $token = null,
@@ -19,7 +21,8 @@ class TokenStruct extends Struct
         protected ?string $transactionId = null,
         protected ?string $finishUrl = null,
         ?int $expires = null,
-        protected ?string $errorUrl = null
+        protected ?string $errorUrl = null,
+        bool $invalidated = false,
     ) {
         $this->expires = $expires ?? 1800;
     }
@@ -82,5 +85,10 @@ class TokenStruct extends Struct
     public function getApiAlias(): string
     {
         return 'payment_token';
+    }
+
+    public function isInvalidated(): bool
+    {
+        return $this->invalidated;
     }
 }

--- a/src/Core/Checkout/Payment/Cart/Token/TokenStruct.php
+++ b/src/Core/Checkout/Payment/Cart/Token/TokenStruct.php
@@ -12,8 +12,6 @@ class TokenStruct extends Struct
 
     protected int $expires;
 
-    protected bool $invalidated;
-
     public function __construct(
         protected ?string $id = null,
         protected ?string $token = null,
@@ -22,7 +20,7 @@ class TokenStruct extends Struct
         protected ?string $finishUrl = null,
         ?int $expires = null,
         protected ?string $errorUrl = null,
-        bool $invalidated = false,
+        protected bool $invalidated = false,
     ) {
         $this->expires = $expires ?? 1800;
     }

--- a/src/Core/Checkout/Payment/PaymentProcessor.php
+++ b/src/Core/Checkout/Payment/PaymentProcessor.php
@@ -111,6 +111,22 @@ class PaymentProcessor
 
         try {
             $transactionStruct = $this->paymentTransactionStructFactory->build($token->getTransactionId(), $context->getContext());
+
+            if ($token->isInvalidated()) {
+                // Token was already handled - check current state of the transaction
+                $stateName = $transactionStruct->getOrderTransaction()->getStateMachineState()->getTechnicalName();
+                if ($stateName === OrderTransactionStates::STATE_AUTHORIZED || $stateName === OrderTransactionStates::STATE_PAID || $stateName === OrderTransactionStates::STATE_PARTIALLY_PAID) {
+                    return $token;
+                }
+
+                if ($stateName === OrderTransactionStates::STATE_FAILED || $stateName === OrderTransactionStates::STATE_CANCELLED) {
+                    $token->setException(new TokenInvalidatedException($token->getToken() ?? ''));
+                    return $token;
+                }
+
+                throw new TokenInvalidatedException($token->getToken() ?? '');
+            }
+
             $paymentHandler->finalize($request, $transactionStruct, $context->getContext());
         } catch (\Throwable $e) {
             if ($e instanceof PaymentException && $e->getErrorCode() === PaymentException::PAYMENT_CUSTOMER_CANCELED_EXTERNAL) {


### PR DESCRIPTION
1. Why is this change necessary?
Some PSP's will not work as SW intends, i.e. call the finalize payment endpoint when they are not supposed to, causing the user to see an error because of an invalidated token, while we can circumvent the issue in most cases. So instead of being strict, and throw an error in the face of the user, even while the payment has been handled correctly, be a little more loose and do an extra check to see if we can continue nicely.

2. What does this change do, exactly?
Instead of being strict and complaining that (aka throwing an error because) a token was already used and thus has been invalidated , check the state of the transaction. If it is already handled, meaning the transaction has been set to paid, just let the PaymentService return the token without actually finalizing the payment (as it was already finalized).

3. Describe each step to reproduce the issue or behaviour.
Call the finalize endpoint twice (which would normally be done by a PSP)

4. Please link to the relevant issues (if any).
See this issue that was also raised with the Adyen plugin: https://github.com/Adyen/adyen-shopware6/issues/510
Note that even though they may fix it on their side, doesn't mean SW cannot be more compliant.
https://github.com/shopware/shopware/pull/4952
https://github.com/shopware/shopware/issues/12593

5. Checklist
 I have rebased my changes to remove merge conflicts
 I have written tests and verified that they fail without my change
 I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md?rgh-link-date=2024-10-04T10%3A00%3A41Z) with all necessary information about my changes
 I have written or adjusted the documentation according to my changes
 This change has comments for package types, values, functions, and non-obvious lines of code
 I have read the contribution requirements and fulfil them.