### PR TITLE
fix: Change error output of app loader while running in CI env

### DIFF
--- a/changelog/_unreleased/2025-09-24-improve-error-output-of-app-loader.md
+++ b/changelog/_unreleased/2025-09-24-improve-error-output-of-app-loader.md
@@ -1,0 +1,10 @@
+---
+title: Improve error output of app loader in CI environment
+author: Michael Telgmann
+author_github: @mitelg
+---
+
+# Core
+
+* Added `\Shopware\Core\Framework\Util\IOStreamHelper` to centralize IO stream handling.
+* Changed error output of `\Shopware\Core\Framework\App\ActiveAppsLoader::loadApps` in CI environment to show a less urgent error message.

--- a/src/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoader.php
@@ -6,6 +6,7 @@ namespace Shopware\Core\Framework\Plugin\KernelPluginLoader;
 use Shopware\Core\Framework\Adapter\Composer\ComposerInfoProvider;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Util\PluginFinder;
+use Shopware\Core\Framework\Util\IOStreamHelper;
 
 /**
  * @phpstan-import-type PluginInfo from KernelPluginLoader
@@ -41,13 +42,13 @@ class ComposerPluginLoader extends KernelPluginLoader
             \assert(\is_array($composerJson));
             $pluginClass = $composerJson['extra']['shopware-plugin-class'] ?? '';
 
-            if (\defined('\STDERR') && ($pluginClass === '' || !\class_exists($pluginClass))) {
-                \fwrite(\STDERR, \sprintf('Skipped package %s due invalid "shopware-plugin-class" config', $composerPackage->name) . \PHP_EOL);
+            if ($pluginClass === '' || !\class_exists($pluginClass)) {
+                IOStreamHelper::writeError(\sprintf('Skipped package %s due invalid "shopware-plugin-class" config', $composerPackage->name));
 
                 continue;
             }
 
-            $nameParts = \explode('\\', (string) $pluginClass);
+            $nameParts = \explode('\\', $pluginClass);
 
             $this->pluginInfos[] = [
                 'name' => \end($nameParts),

--- a/src/Core/Framework/Util/IOStreamHelper.php
+++ b/src/Core/Framework/Util/IOStreamHelper.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Util;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+final class IOStreamHelper
+{
+    public static function writeError(string $message, ?\Throwable $error = null): void
+    {
+        $errorMessage = '';
+        if ($error !== null) {
+            $errorMessage = ' Error message: ' . $error->getMessage();
+        }
+
+        if (\defined('\STDERR')) {
+            fwrite(\STDERR, $message . $errorMessage . \PHP_EOL);
+        }
+    }
+}

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Util\Hasher;
+use Shopware\Core\Framework\Util\IOStreamHelper;
 use Shopware\Core\Framework\Util\VersionParser;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\ConfigCache;
@@ -141,9 +142,7 @@ class Kernel extends HttpKernel
                 // initialize plugins before booting
                 $this->pluginLoader->initializePlugins($this->getProjectDir());
             } catch (DBALException $e) {
-                if (\defined('\STDERR')) {
-                    fwrite(\STDERR, 'Warning: Failed to load plugins. Message: ' . $e->getMessage() . \PHP_EOL);
-                }
+                IOStreamHelper::writeError('Warning: Failed to load plugins', $e);
             }
         }
 

--- a/src/Storefront/Theme/Subscriber/ThemeCompilerEnrichScssVarSubscriber.php
+++ b/src/Storefront/Theme/Subscriber/ThemeCompilerEnrichScssVarSubscriber.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Theme\Subscriber;
 use Doctrine\DBAL\Exception as DBALException;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\IOStreamHelper;
 use Shopware\Core\System\SystemConfig\Service\ConfigurationService;
 use Shopware\Storefront\Theme\Event\ThemeCompilerEnrichScssVariablesEvent;
 use Shopware\Storefront\Theme\StorefrontPluginRegistry;
@@ -58,12 +59,8 @@ class ThemeCompilerEnrichScssVarSubscriber implements EventSubscriberInterface
                 );
             }
         } catch (DBALException $e) {
-            if (\defined('\STDERR') && !EnvironmentHelper::getVariable('TESTS_RUNNING')) {
-                fwrite(
-                    \STDERR,
-                    'Warning: Failed to load plugin css configuration. Ignoring plugin css customizations. Message: '
-                    . $e->getMessage() . \PHP_EOL
-                );
+            if (!EnvironmentHelper::getVariable('TESTS_RUNNING')) {
+                IOStreamHelper::writeError('Warning: Failed to load plugin css configuration. Ignoring plugin css customizations.', $e);
             }
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

While setting up Shopware in a CI environment, the error output could unsettle users. 

### 2. What does this change do, exactly?

If the `CI` env variable is set, the message is slightly different, less "thrilling" 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

Successor of #12402 
Closes https://github.com/shopware/shopware/pull/12402

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
