### PR TITLE
fix: Decreased camera clipping distance in 3D viewer.

### DIFF
--- a/changelog/_unreleased/2025-09-25-decreased-near-clipping-distance-of-camera-in-3d-viewer.md
+++ b/changelog/_unreleased/2025-09-25-decreased-near-clipping-distance-of-camera-in-3d-viewer.md
@@ -1,0 +1,9 @@
+---
+title: Decreased camera's near clipping distance in 3D viewer
+issue: #12655
+author: Felix Frank
+author_email: f.frank@shopware.com
+author_github: @ffrank913
+---
+# Storefront
+* Changed camera's near clipping distance in 3D viewer.

--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
-        "@shopware-ag/dive": "2.2.2",
+        "@shopware-ag/dive": "2.2.3",
         "@swc/core": "^1.10.14",
         "autoprefixer": "10.4.13",
         "bootstrap": "5.3.3",
@@ -3276,9 +3276,9 @@
       }
     },
     "node_modules/@shopware-ag/dive": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.2.tgz",
-      "integrity": "sha512-B3p0U5KMhRQknxXnp3IaN4JsOxDLynhuGg5BWppdOYx9N3rZgUq1rJU/JAyrCH3kFxqfER+dMd2mwrfm3H1qEw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.3.tgz",
+      "integrity": "sha512-6ZKarQe8GWpp4OASSN5pOATFMf/I0Xxvxvhmc/jVfRsFeSSa9i/Qxc2XSbw6leuMwZK53XMPtHQ7/5XaGcd8Gg==",
       "license": "MIT",
       "dependencies": {
         "@tweenjs/tween.js": "^23.1.1",
@@ -16424,9 +16424,9 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@shopware-ag/dive": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.2.tgz",
-      "integrity": "sha512-B3p0U5KMhRQknxXnp3IaN4JsOxDLynhuGg5BWppdOYx9N3rZgUq1rJU/JAyrCH3kFxqfER+dMd2mwrfm3H1qEw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.3.tgz",
+      "integrity": "sha512-6ZKarQe8GWpp4OASSN5pOATFMf/I0Xxvxvhmc/jVfRsFeSSa9i/Qxc2XSbw6leuMwZK53XMPtHQ7/5XaGcd8Gg==",
       "requires": {
         "@tweenjs/tween.js": "^23.1.1",
         "lodash": "^4.17.21",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@popperjs/core": "2.11.8",
-    "@shopware-ag/dive": "2.2.2",
+    "@shopware-ag/dive": "2.2.3",
     "@swc/core": "^1.10.14",
     "autoprefixer": "10.4.13",
     "bootstrap": "5.3.3",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The current settings for clipping of the camera in the 3D viewer are too high: small models are not shown because they are clipped away by the near plane.

### 2. What does this change do, exactly?
Decreases the near plane distance to show small models still very near to the camera.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
