### PR TITLE
fix: styling for blockquotes

### DIFF
--- a/changelog/_unreleased/2025-09-25-storefront-blockquote-styling.md
+++ b/changelog/_unreleased/2025-09-25-storefront-blockquote-styling.md
@@ -1,0 +1,6 @@
+---
+title: Add global styling for blockquotes
+issue: #11055
+---
+# Storefront
+* Added proper global styling for `<blockquote>` by moving the cms element styling from `scss/skin/shopware/component/_cms-element.scss` to a global definition in `scss/skin/shopware/base/_typography.scss`.

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/base/_typography.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/base/_typography.scss
@@ -58,3 +58,22 @@ ul,
 dl {
     margin-bottom: $paragraph-margin-bottom;
 }
+
+blockquote {
+    font-size: $font-size-lg;
+    font-style: italic;
+    line-height: 24px;
+    margin-top: 16px;
+    margin-left: 20px;
+    position: relative;
+
+    &::before {
+        content: '"';
+        font-size: 40px;
+        line-height: 16px;
+        color: $cms-element-text-quotes-color;
+        position: absolute;
+        top: 10px;
+        left: -24px;
+    }
+}

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_cms-element.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_cms-element.scss
@@ -11,24 +11,3 @@ Skin styling for cms elements
         margin-bottom: $spacer-lg;
     }
 }
-
-.cms-element-text {
-    blockquote {
-        font-size: $font-size-lg;
-        font-style: italic;
-        line-height: 24px;
-        margin-top: 16px;
-        margin-left: 20px;
-        position: relative;
-
-        &::before {
-            content: '"';
-            font-size: 40px;
-            line-height: 16px;
-            color: $cms-element-text-quotes-color;
-            position: absolute;
-            top: 10px;
-            left: -24px;
-        }
-    }
-}


### PR DESCRIPTION
Fixes: #11055 

### 1. Why is this change necessary?

The Storefront is missing a general styling for `<blockquote>` tags, although the text editor allows you to style text in that way.

### 2. What does this change do, exactly?

* Moved the restricted blockquote styling from the CMS text element to the global scope, so all blockquotes are styled correctly.

### 3. Describe each step to reproduce the issue or behaviour.

* Add a blockquote to a product description.
* Open the product detail page in the Storefront.
* Notice that the blockquote looks like a normal paragraph.

