### PR TITLE
refactor: deprecate SalesChannelContextSwitcher

### DIFF
--- a/src/Core/System/SalesChannel/SalesChannel/SalesChannelContextSwitcher.php
+++ b/src/Core/System/SalesChannel/SalesChannel/SalesChannelContextSwitcher.php
@@ -2,10 +2,14 @@
 
 namespace Shopware\Core\System\SalesChannel\SalesChannel;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @deprecated tag:v6.8.0 - will be removed as it is unused. Use AbstractContextSwitchRoute directly.
+ */
 #[Package('framework')]
 class SalesChannelContextSwitcher
 {
@@ -18,6 +22,11 @@ class SalesChannelContextSwitcher
 
     public function update(DataBag $data, SalesChannelContext $context): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(SalesChannelContextSwitcher::class, 'v6.8.0.0', AbstractContextSwitchRoute::class)
+        );
+
         $this->contextSwitchRoute->switchContext($data->toRequestDataBag(), $context);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
This class is completely unused and only calls the `ContextSwitchRoute`

### 2. What does this change do, exactly?
Deprecate it for 6.8.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
