### PR TITLE
chore: Added PHPStan rule to forbid update statements in executeQuery…

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoUpdatesInExecuteQueryRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoUpdatesInExecuteQueryRule.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @implements Rule<FuncCall>
+ */
+#[Package('framework')]
+class NoUpdatesInExecuteQueryRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!($node->name instanceof Identifier) ||
+            $node->name->toString() !== 'executeQuery'
+        ) {
+            return [];
+        }
+
+        $errors = [];
+
+        $varType = $scope->getType($node->var);
+        if (in_array(QueryBuilder::class, $varType->getObjectClassNames(), true)) {
+            $current = $node->var;
+            $hasWriteCall = false;
+
+            while ($current instanceof Node\Expr\MethodCall) {
+                if ($current->name instanceof Identifier) {
+                    $method = strtolower($current->name->toString());
+                    if (in_array($method, ['update','insert','delete'], true)) {
+                        $hasWriteCall = true;
+                        break;
+                    }
+                }
+                $current = $current->var;
+            }
+
+            if ($hasWriteCall) {
+                $errors[] = RuleErrorBuilder::message(
+                    'Calling executeQuery() on a Doctrine QueryBuilder that performs update/insert/delete is forbidden. Use executeStatement() instead.'
+                )->identifier('shopware.noExecuteQuery')->build();
+            }
+
+            return $errors;
+        }
+
+        if (!empty($node->args)) {
+            $firstArg = $node->args[0]->value;
+            if ($firstArg instanceof Node\Scalar\String_) {
+                $sql = strtoupper($firstArg->value);
+                if (preg_match('/\b(UPDATE|DELETE|INSERT|REPLACE|DROP|TRUNCATE)\b/', $sql)) {
+                    $errors[] = RuleErrorBuilder::message(
+                        'executeQuery() with raw SQL containing write operations (UPDATE/DELETE/INSERT/...) is forbidden. Use executeStatement() instead.'
+                    )->identifier('shopware.noExecuteQuery')->build();
+                }
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoUpdatesInExecuteQueryRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoUpdatesInExecuteQueryRule.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
 
 use Doctrine\DBAL\Query\QueryBuilder;
 use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
@@ -14,19 +14,20 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  *
- * @implements Rule<FuncCall>
+ * @implements Rule<MethodCall>
  */
 #[Package('framework')]
 class NoUpdatesInExecuteQueryRule implements Rule
 {
     public function getNodeType(): string
     {
-        return Node\Expr\MethodCall::class;
+        return MethodCall::class;
     }
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!($node->name instanceof Identifier)
+        if (!$node instanceof MethodCall
+            || !($node->name instanceof Identifier)
             || $node->name->toString() !== 'executeQuery'
         ) {
             return [];
@@ -39,7 +40,7 @@ class NoUpdatesInExecuteQueryRule implements Rule
             $current = $node->var;
             $hasWriteCall = false;
 
-            while ($current instanceof Node\Expr\MethodCall) {
+            while ($current instanceof MethodCall) {
                 if ($current->name instanceof Identifier) {
                     $method = strtolower($current->name->toString());
                     if (\in_array($method, ['update', 'insert', 'delete'], true)) {
@@ -60,13 +61,33 @@ class NoUpdatesInExecuteQueryRule implements Rule
         }
 
         if (!empty($node->args)) {
-            $firstArg = $node->args[0]->value;
-            if ($firstArg instanceof Node\Scalar\String_) {
-                $sql = strtoupper($firstArg->value);
+            $firstArg = $node->args[0];
+
+            if ($firstArg instanceof Node\Arg && $firstArg->value instanceof Node\Scalar\String_) {
+                $sql = strtoupper($firstArg->value->value);
                 if (preg_match('/\b(UPDATE|DELETE|INSERT|REPLACE|DROP|TRUNCATE)\b/', $sql)) {
                     $errors[] = RuleErrorBuilder::message(
                         'executeQuery() with raw SQL containing write operations (UPDATE/DELETE/INSERT/...) is forbidden. Use executeStatement() instead.'
                     )->identifier('shopware.noExecuteQuery')->build();
+                }
+            } elseif ($firstArg instanceof Node\Arg && $firstArg->value instanceof Node\Expr\Variable) {
+                $variableName = $firstArg->value->name;
+
+                $variableType = $scope->getType($firstArg->value);
+                if ($variableType->isString()->yes()) {
+                    $constantStrings = $variableType->getConstantStrings();
+                    foreach ($constantStrings as $constantString) {
+                        $sql = strtoupper($constantString->getValue());
+                        if (preg_match('/\b(UPDATE|DELETE|INSERT|REPLACE|DROP|TRUNCATE)\b/', $sql)) {
+                            $errors[] = RuleErrorBuilder::message(
+                                \sprintf(
+                                    'Passing a variable ($%s) containing SQL with write operations to executeQuery() is forbidden. Use executeStatement() instead.',
+                                    \is_string($variableName) ? $variableName : 'unknown'
+                                )
+                            )->identifier('shopware.noExecuteQueryVariable')->build();
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoUpdatesInExecuteQueryRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoUpdatesInExecuteQueryRule.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
 
@@ -26,8 +26,8 @@ class NoUpdatesInExecuteQueryRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!($node->name instanceof Identifier) ||
-            $node->name->toString() !== 'executeQuery'
+        if (!($node->name instanceof Identifier)
+            || $node->name->toString() !== 'executeQuery'
         ) {
             return [];
         }
@@ -35,14 +35,14 @@ class NoUpdatesInExecuteQueryRule implements Rule
         $errors = [];
 
         $varType = $scope->getType($node->var);
-        if (in_array(QueryBuilder::class, $varType->getObjectClassNames(), true)) {
+        if (\in_array(QueryBuilder::class, $varType->getObjectClassNames(), true)) {
             $current = $node->var;
             $hasWriteCall = false;
 
             while ($current instanceof Node\Expr\MethodCall) {
                 if ($current->name instanceof Identifier) {
                     $method = strtolower($current->name->toString());
-                    if (in_array($method, ['update','insert','delete'], true)) {
+                    if (\in_array($method, ['update', 'insert', 'delete'], true)) {
                         $hasWriteCall = true;
                         break;
                     }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
@@ -21,3 +21,4 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoManualSalesChannelContextCreationRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoDelayStampRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoAddCacheTagEventRule
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoUpdatesInExecuteQueryRule

--- a/src/Core/Framework/App/Lifecycle/Persister/WebhookPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/WebhookPersister.php
@@ -66,7 +66,7 @@ class WebhookPersister
      */
     private function deleteOldWebhooks(array $toBeRemoved): void
     {
-        $this->connection->executeQuery(
+        $this->connection->executeStatement(
             'DELETE FROM webhook WHERE id IN (:ids)',
             ['ids' => Uuid::fromHexToBytesList(array_keys($toBeRemoved))],
             ['ids' => ArrayParameterType::STRING],

--- a/src/Core/Framework/MessageQueue/Stats/MySQLStatsRepository.php
+++ b/src/Core/Framework/MessageQueue/Stats/MySQLStatsRepository.php
@@ -89,6 +89,6 @@ class MySQLStatsRepository extends AbstractStatsRepository
         $this->connection->createQueryBuilder()->delete('messenger_stats')
             ->where('created_at < :olderThan')
             ->setParameter('olderThan', $olderThan->format(Defaults::STORAGE_DATE_TIME_FORMAT))
-            ->executeQuery();
+            ->executeStatement();
     }
 }

--- a/src/Core/Installer/Database/BlueGreenDeploymentService.php
+++ b/src/Core/Installer/Database/BlueGreenDeploymentService.php
@@ -31,7 +31,7 @@ class BlueGreenDeploymentService
         } catch (Exception) {
             return false;
         } finally {
-            $connection->executeQuery('DROP TABLE IF EXISTS example');
+            $connection->executeStatement('DROP TABLE IF EXISTS example');
         }
 
         return true;

--- a/src/Core/Migration/V6_4/Migration1616076922AppPaymentMethod.php
+++ b/src/Core/Migration/V6_4/Migration1616076922AppPaymentMethod.php
@@ -76,7 +76,7 @@ class Migration1616076922AppPaymentMethod extends MigrationStep
         $defaultFolderId = Uuid::randomBytes();
         $configurationId = Uuid::randomBytes();
 
-        $connection->executeQuery(
+        $connection->executeStatement(
             'REPLACE INTO `media_default_folder` SET
                 id = :id,
                 entity = :entity,

--- a/src/Core/Migration/V6_5/Migration1688556247FixCoverMediaVersionID.php
+++ b/src/Core/Migration/V6_5/Migration1688556247FixCoverMediaVersionID.php
@@ -20,7 +20,7 @@ class Migration1688556247FixCoverMediaVersionID extends MigrationStep
     public function update(Connection $connection): void
     {
         do {
-            $stmt = $connection->executeQuery('UPDATE product SET product_media_version_id = 0x0fa91ce3e96a4bc2be4bd9ce752c3425 WHERE product_media_id IS NOT NULL AND product_media_version_id IS NULL LIMIT 100');
-        } while ($stmt->rowCount() > 0);
+            $stmt = $connection->executeStatement('UPDATE product SET product_media_version_id = 0x0fa91ce3e96a4bc2be4bd9ce752c3425 WHERE product_media_id IS NOT NULL AND product_media_version_id IS NULL LIMIT 100');
+        } while ($stmt > 0);
     }
 }

--- a/src/Core/Migration/V6_5/Migration1692279790AppShippingMethod.php
+++ b/src/Core/Migration/V6_5/Migration1692279790AppShippingMethod.php
@@ -71,7 +71,7 @@ SQL
         $defaultFolderId = Uuid::randomBytes();
         $configurationId = Uuid::randomBytes();
 
-        $connection->executeQuery(
+        $connection->executeStatement(
             'REPLACE INTO `media_default_folder` SET
                 id = :id,
                 entity = :entity,

--- a/src/Core/Migration/V6_5/Migration1697462064FixMediaPath.php
+++ b/src/Core/Migration/V6_5/Migration1697462064FixMediaPath.php
@@ -19,8 +19,8 @@ class Migration1697462064FixMediaPath extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        $connection->executeQuery('UPDATE media SET path = NULL WHERE file_name IS NULL OR file_name = \'\'');
-        $connection->executeQuery('UPDATE media_thumbnail, media SET media_thumbnail.path = NULL WHERE (media.file_name IS NULL OR file_name = \'\') AND media.id = media_thumbnail.media_id');
+        $connection->executeStatement('UPDATE media SET path = NULL WHERE file_name IS NULL OR file_name = \'\'');
+        $connection->executeStatement('UPDATE media_thumbnail, media SET media_thumbnail.path = NULL WHERE (media.file_name IS NULL OR file_name = \'\') AND media.id = media_thumbnail.media_id');
 
         $this->registerIndexer($connection, 'media.path.post_update');
     }

--- a/src/Core/Migration/V6_5/Migration1697532722FixADInMediaPath.php
+++ b/src/Core/Migration/V6_5/Migration1697532722FixADInMediaPath.php
@@ -20,7 +20,7 @@ class Migration1697532722FixADInMediaPath extends MigrationStep
     public function update(Connection $connection): void
     {
         // replace /ad/ with /g0/ in media.path and media_thumbnail.path
-        $connection->executeQuery('UPDATE media SET path = REPLACE(path, \'/ad/\', \'/g0/\') WHERE path LIKE \'%/ad/%\'');
-        $connection->executeQuery('UPDATE media_thumbnail SET path = REPLACE(path, \'/ad/\', \'/g0/\') WHERE path LIKE \'%/ad/%\'');
+        $connection->executeStatement('UPDATE media SET path = REPLACE(path, \'/ad/\', \'/g0/\') WHERE path LIKE \'%/ad/%\'');
+        $connection->executeStatement('UPDATE media_thumbnail SET path = REPLACE(path, \'/ad/\', \'/g0/\') WHERE path LIKE \'%/ad/%\'');
     }
 }

--- a/src/Core/Migration/V6_6/Migration1717601705AddIntraCommunityLabelDocumentConfigToStorno.php
+++ b/src/Core/Migration/V6_6/Migration1717601705AddIntraCommunityLabelDocumentConfigToStorno.php
@@ -39,7 +39,7 @@ class Migration1717601705AddIntraCommunityLabelDocumentConfigToStorno extends Mi
                 $config['displayAdditionalNoteDelivery'] = false;
             }
 
-            $transaction->executeQuery(
+            $transaction->executeStatement(
                 'UPDATE `document_base_config` SET `config` = :config WHERE `id` = :id;',
                 [
                     'id' => $stornoConfig['id'],

--- a/src/Core/Migration/V6_6/Migration1717601705AddIntraCommunityLabelDocumentConfigToStorno.php
+++ b/src/Core/Migration/V6_6/Migration1717601705AddIntraCommunityLabelDocumentConfigToStorno.php
@@ -21,7 +21,7 @@ class Migration1717601705AddIntraCommunityLabelDocumentConfigToStorno extends Mi
     {
         $connection->transactional(function (Connection $transaction): void {
             $stornoConfig = $transaction->executeQuery(
-                <<<SQL
+                <<<'SQL'
                     SELECT `document_base_config`.`id`, `document_base_config`.`config` FROM `document_base_config`
                     JOIN `document_type` ON `document_base_config`.`document_type_id` = `document_type`.`id`
                     WHERE `document_type`.`technical_name` = :technicalName;

--- a/src/Core/Migration/V6_6/Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNote.php
+++ b/src/Core/Migration/V6_6/Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNote.php
@@ -21,7 +21,7 @@ class Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNote extend
     {
         $connection->transactional(function (Connection $transaction): void {
             $invoiceConfig = $transaction->executeQuery(
-                <<<SQL
+                <<<'SQL'
                     SELECT `document_base_config`.`id`, `document_base_config`.`config` FROM `document_base_config`
                     JOIN `document_type` ON `document_base_config`.`document_type_id` = `document_type`.`id`
                     WHERE `document_type`.`technical_name` = :technicalName;

--- a/src/Core/Migration/V6_6/Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNote.php
+++ b/src/Core/Migration/V6_6/Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNote.php
@@ -39,7 +39,7 @@ class Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNote extend
                 $config['displayAdditionalNoteDelivery'] = false;
             }
 
-            $transaction->executeQuery(
+            $transaction->executeStatement(
                 'UPDATE `document_base_config` SET `config` = :config WHERE `id` = :id;',
                 [
                     'id' => $invoiceConfig['id'],

--- a/src/Core/Migration/V6_6/Migration1732608755MigrateNavigationSettingsForProductSlider.php
+++ b/src/Core/Migration/V6_6/Migration1732608755MigrateNavigationSettingsForProductSlider.php
@@ -37,7 +37,7 @@ class Migration1732608755MigrateNavigationSettingsForProductSlider extends Migra
 
     public function setDeactivatedNavigationArrows(Connection $connection): void
     {
-        $connection->executeQuery(
+        $connection->executeStatement(
             <<<'SQL'
                 UPDATE `cms_slot_translation`
                 LEFT JOIN `cms_slot` ON `cms_slot`.`id` = `cms_slot_translation`.`cms_slot_id`
@@ -57,7 +57,7 @@ class Migration1732608755MigrateNavigationSettingsForProductSlider extends Migra
 
     public function setActivatedNavigationArrows(Connection $connection): void
     {
-        $connection->executeQuery(
+        $connection->executeStatement(
             <<<'SQL'
                 UPDATE `cms_slot_translation`
                 LEFT JOIN `cms_slot` ON `cms_slot`.`id` = `cms_slot_translation`.`cms_slot_id`
@@ -75,7 +75,7 @@ class Migration1732608755MigrateNavigationSettingsForProductSlider extends Migra
 
     public function removeOldSliderConfig(Connection $connection): void
     {
-        $connection->executeQuery(
+        $connection->executeStatement(
             <<<'SQL'
                 UPDATE `cms_slot_translation`
                 LEFT JOIN `cms_slot` ON `cms_slot`.`id` = `cms_slot_translation`.`cms_slot_id`

--- a/src/Core/Migration/V6_6/Migration1736831335AddGenerateDocumentTypesForDocumentConfig.php
+++ b/src/Core/Migration/V6_6/Migration1736831335AddGenerateDocumentTypesForDocumentConfig.php
@@ -52,7 +52,7 @@ class Migration1736831335AddGenerateDocumentTypesForDocumentConfig extends Migra
                     $config['fileTypes'] = [HtmlRenderer::FILE_EXTENSION, PdfRenderer::FILE_EXTENSION];
                 }
 
-                $transaction->executeQuery(
+                $transaction->executeStatement(
                     'UPDATE `document_base_config` SET `config` = :config WHERE `id` = :id;',
                     [
                         'id' => $id,

--- a/src/Core/Migration/V6_6/Migration1736831335AddGenerateDocumentTypesForDocumentConfig.php
+++ b/src/Core/Migration/V6_6/Migration1736831335AddGenerateDocumentTypesForDocumentConfig.php
@@ -31,7 +31,7 @@ class Migration1736831335AddGenerateDocumentTypesForDocumentConfig extends Migra
     {
         $connection->transactional(function (Connection $transaction): void {
             $documentConfig = $transaction->executeQuery(
-                <<<SQL
+                <<<'SQL'
                     SELECT `document_base_config`.`id`, `document_base_config`.`config` FROM `document_base_config`
                     JOIN `document_type` ON `document_base_config`.`document_type_id` = `document_type`.`id`
                     WHERE `document_type`.`technical_name` IN (:technicalName);

--- a/src/Core/Migration/V6_7/Migration1740321707SetAutoplayTimeoutAndSpeedSettingsForProductSlider.php
+++ b/src/Core/Migration/V6_7/Migration1740321707SetAutoplayTimeoutAndSpeedSettingsForProductSlider.php
@@ -36,7 +36,7 @@ class Migration1740321707SetAutoplayTimeoutAndSpeedSettingsForProductSlider exte
 
     public function setAutoplayTimeout(Connection $connection): void
     {
-        $connection->executeQuery(
+        $connection->executeStatement(
             <<<'SQL'
                 UPDATE `cms_slot_translation`
                 LEFT JOIN `cms_slot` ON `cms_slot`.`id` = `cms_slot_translation`.`cms_slot_id`
@@ -53,7 +53,7 @@ class Migration1740321707SetAutoplayTimeoutAndSpeedSettingsForProductSlider exte
 
     public function setSpeed(Connection $connection): void
     {
-        $connection->executeQuery(
+        $connection->executeStatement(
             <<<'SQL'
                 UPDATE `cms_slot_translation`
                 LEFT JOIN `cms_slot` ON `cms_slot`.`id` = `cms_slot_translation`.`cms_slot_id`

--- a/tests/integration/Core/Framework/Sso/Helper/FakeUserInstaller.php
+++ b/tests/integration/Core/Framework/Sso/Helper/FakeUserInstaller.php
@@ -25,7 +25,7 @@ class FakeUserInstaller
 
         $sql = 'INSERT INTO `user` (`id`, `username`, `password`, `first_name`, `last_name`, `title`, `email`, `active`, `admin`, `avatar_id`, `locale_id`, `store_token`, `last_updated_password_at`, `time_zone`, `custom_fields`, `created_at`, `updated_at`) VALUES
                 (?, ?, \'$53CR3D9422W0RD\', ?, ?, \'Baz\', ?, 0, 1, NULL, ?, NULL, \'2024-01-01 08:00:00.000\', \'Europe/Berlin\', NULL, \'2024-01-01 08:00:00.000\', NULL);';
-        $this->connection->executeQuery($sql, [$id, $email, $email, $email, $email, $byteLocaleId]);
+        $this->connection->executeStatement($sql, [$id, $email, $email, $email, $email, $byteLocaleId]);
     }
 
     public function installTokenUser(string $userId, string $subject): void
@@ -35,6 +35,6 @@ class FakeUserInstaller
 
         $sql = 'INSERT INTO `oauth_user` (`id`, `user_id`, `user_sub`, `token`, `expiry`, `created_at`, `updated_at`) VALUES
                 (?, ?, ?, \'{"token": "invalid", "refreshToken": "invalid"}\', \'2024-01-01 08:00:00.000\', \'2024-01-01 08:00:00.000\', NULL);';
-        $this->connection->executeQuery($sql, [$id, $userId, $subject]);
+        $this->connection->executeStatement($sql, [$id, $userId, $subject]);
     }
 }

--- a/tests/integration/Core/System/UsageData/EntitySync/DispatchEntityMessageHandlerTest.php
+++ b/tests/integration/Core/System/UsageData/EntitySync/DispatchEntityMessageHandlerTest.php
@@ -286,7 +286,7 @@ class DispatchEntityMessageHandlerTest extends TestCase
         $qb->update('product')
             ->set('updated_at', ':updatedAt')
             ->setParameter('updatedAt', $currentTime->add(new DateInterval('P1D'))->format(Defaults::STORAGE_DATE_TIME_FORMAT))
-            ->executeQuery();
+            ->executeStatement();
 
         $dispatchEntityMessage = new DispatchEntityMessage(
             'product',

--- a/tests/unit/Core/Installer/Database/BlueGreenDeploymentServiceTest.php
+++ b/tests/unit/Core/Installer/Database/BlueGreenDeploymentServiceTest.php
@@ -26,7 +26,8 @@ class BlueGreenDeploymentServiceTest extends TestCase
         $this->setEnvVars([BlueGreenDeploymentService::ENV_NAME => '0']);
 
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->exactly(3))->method('executeQuery');
+        $connection->expects($this->exactly(2))->method('executeQuery');
+        $connection->expects($this->exactly(1))->method('executeStatement');
 
         $service = new BlueGreenDeploymentService();
         $session = new Session(new MockArraySessionStorage());
@@ -43,13 +44,14 @@ class BlueGreenDeploymentServiceTest extends TestCase
         $this->setEnvVars([BlueGreenDeploymentService::ENV_NAME => '1']);
 
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->exactly(3))
+        $connection->expects($this->exactly(2))
             ->method('executeQuery')
             ->willReturnOnConsecutiveCalls(
                 $this->createMock(Result::class),
                 static::throwException(TestExceptionFactory::createException('test')),
-                $this->createMock(Result::class)
             );
+
+        $connection->expects($this->exactly(1))->method('executeStatement');
 
         $service = new BlueGreenDeploymentService();
         $session = new Session(new MockArraySessionStorage());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This PR adds a PHPStan rule to check for write queries in executeQuery calls. 
These can lead to errors when MySQL read replicas are used.

