### PR TITLE
fix: Ensure cache events produce same hash

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -20,17 +20,17 @@ return [
         // Will be typed in Symfony 8 (maybe)
         preg_quote('Symfony\Component\Console\Command\Command#configure() changed from no type to void', '/'),
 
-        // Version related const values changed for 7.3 update
+        // Version-related const values changed for the 7.3 update
         preg_quote('Value of constant Symfony\Component\HttpKernel\Kernel', '/'),
 
-        // Can not be inspected through reflection https://github.com/Roave/BetterReflection/issues/1376
+        // Cannot be inspected through reflection https://github.com/Roave/BetterReflection/issues/1376
         'An enum expression .* is not supported in .*',
 
         // Incorrectly deprecated
         'The return type of Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentException.* changed from self',
         preg_quote('The return type of Shopware\Core\Content\Product\ProductException::productNotFound() changed from self|Shopware\Core\Content\Product\Exception\ProductNotFoundException to Shopware\Core\Content\Product\Exception\ProductNotFoundException', '/'),
 
-        // Expected to be appended when new event is added
+        // Expected to be appended when a new event is added
         preg_quote('Value of constant Shopware\Core\Framework\Webhook\Hookable', '/'),
 
         // Adding optional parameters to a constructor is not a BC
@@ -56,7 +56,7 @@ return [
         // Only new additions
         'Value of constant Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\OrderConverter::ADMIN_EDIT_ORDER_PERMISSIONS changed from array \((\n.*)*to array \((\n.*)*skipCartPersistence(.*\n.*)*skipPrimaryOrderIds(.*\n.*)*automaticPromotionDeletionNotices',
 
-        // No break as mixed is the top type and every other type is a subtype of mixed
+        // No break as mixed is the top type, and every other type is a subtype of mixed
         preg_quote('The parameter $value of Shopware\Storefront\Event\StorefrontRenderEvent#setParameter() changed from no type to mixed', '/'),
 
         // No break as the `{get,set}SeoLink()` changes have not been released
@@ -131,7 +131,12 @@ return [
         preg_quote('CHANGED: Parameter 1 of Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent#__construct() changed name from salesChannelContext to request', '/'),
 
         // Moved endpoint to Shopware\Core\Framework\Sso\Controller\SsoController to not have a hard dependency between admin and core packages
-        // It was never intended to be used outside of SaaS in it's initial release (still marked experimental / internal everywhere else, only this one method was forgotten)
+        // It was never intended to be used outside of SaaS in its initial release (still marked experimental / internal everywhere else, only this one method was forgotten)
         preg_quote('REMOVED: Method Shopware\Administration\Controller\AdministrationController#ssoAuth() was removed', '/'),
+
+        // The "parts" arrays of these events could contain values that are not correctly represented in the getter and add methods. Those are necessary fixes, otherwise type errors will occur.
+        preg_quote('CHANGED: The return type of Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheKeyEvent#get() changed from string', '/'),
+        preg_quote('CHANGED: The return type of Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheCookieEvent#get() changed from string|null', '/'),
+        preg_quote('CHANGED: The parameter $value of Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheCookieEvent#add() changed from string', '/'),
     ],
 ];

--- a/src/Core/Framework/Adapter/Cache/Event/HttpCacheCookieEvent.php
+++ b/src/Core/Framework/Adapter/Cache/Event/HttpCacheCookieEvent.php
@@ -16,7 +16,7 @@ class HttpCacheCookieEvent
     public const LOGGED_IN_STATE = 'logged-in';
 
     /**
-     * @param array<string|int, mixed> $parts
+     * @param array<string, string|array<string>|null> $parts
      */
     public function __construct(
         public readonly Request $request,
@@ -25,12 +25,18 @@ class HttpCacheCookieEvent
     ) {
     }
 
-    public function get(string $key): ?string
+    /**
+     * @return string|array<string>|null
+     */
+    public function get(string $key): string|array|null
     {
         return $this->parts[$key] ?? null;
     }
 
-    public function add(string $key, string $value): void
+    /**
+     * @param string|array<string> $value
+     */
+    public function add(string $key, string|array $value): void
     {
         $this->parts[$key] = $value;
     }
@@ -41,10 +47,13 @@ class HttpCacheCookieEvent
     }
 
     /**
-     * @return array<string|int, mixed>
+     * @return array<string, string|array<string>|null>
      */
     public function getParts(): array
     {
-        return $this->parts;
+        $parts = $this->parts;
+        ksort($parts);
+
+        return $parts;
     }
 }

--- a/src/Core/Framework/Adapter/Cache/Event/HttpCacheKeyEvent.php
+++ b/src/Core/Framework/Adapter/Cache/Event/HttpCacheKeyEvent.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 class HttpCacheKeyEvent
 {
     /**
-     * @param array<string, string> $parts - Contains a associative array of all parts which are
+     * @param array<string, string> $parts - Contains an associative array of all parts that are:
      *
      * @examples $parts = [
      *  'uri' => 'https://www.my-domain.com/shoes',
@@ -27,9 +27,9 @@ class HttpCacheKeyEvent
         return isset($this->parts[$key]);
     }
 
-    public function get(string $key): string
+    public function get(string $key): ?string
     {
-        return $this->parts[$key];
+        return $this->parts[$key] ?? null;
     }
 
     /**
@@ -37,7 +37,10 @@ class HttpCacheKeyEvent
      */
     public function getParts(): array
     {
-        return $this->parts;
+        $parts = $this->parts;
+        ksort($parts);
+
+        return $parts;
     }
 
     public function remove(string ...$key): self


### PR DESCRIPTION
### 1. Why is this change necessary?

If the order of the "parts" changed, but the values stay the same, the generated hash is different. 

### 2. What does this change do, exactly?

Sort the parts in the getter method to ensure that they produce the same hash

### 3. Describe each step to reproduce the issue or behaviour.

Have a look at the added tests

### 4. Please link to the relevant issues (if any).
- closes #12652 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
