### PR TITLE
fix: typo in select sales channel alert

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en.json
@@ -507,7 +507,7 @@
         "columnEmailAddress": "Email address",
         "titleSelectSalesChannel": "Select Sales Channel",
         "descriptionSelectSalesChannel": "The selected customer has access to multiple Sales Channels, please select the Sales Channel you wish to use for this order.",
-        "alertSelectSalesChannel": "Because the selected Sales channel channel determines the available products and options, changing it will remove the products and reset the options.",
+        "alertSelectSalesChannel": "Because the selected Sales Channel determines the available products and options, changing it will remove the products and reset the options.",
         "labelSalesChannel": "Use Sales Channel",
         "placeholderSalesChannel": "Select a Sales Channel...",
         "buttonSelectSalesChannel": "Select",


### PR DESCRIPTION
Noticed this typo while working through the User & Administration Essentials path in the Community Hub:

<img width="2722" height="1346" src="https://github.com/user-attachments/assets/13821b3a-ea17-4ded-90bb-6c51f9c499ed" />