### PR TITLE
fix: Properly calculate the padding of the admin modal

### DIFF
--- a/changelog/_unreleased/2025-09-27-properly-define-the-padding-of-the-admin-modal.md
+++ b/changelog/_unreleased/2025-09-27-properly-define-the-padding-of-the-admin-modal.md
@@ -1,0 +1,9 @@
+---
+title: Properly define the padding of the admin modal
+author: Max
+author_email: max@swk-web-com
+author_github: @aragon999
+---
+
+# Administration
+* Changed the calculation of the padding for the admin modal to work with CSS variables

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss
@@ -26,7 +26,7 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
     flex-direction: row;
     justify-content: center;
     align-items: center;
-    padding: 0 math.div($sw-modal-gap, 2);
+    padding: 0 calc($sw-modal-gap / 2);
 
     .sw-modal__dialog {
         @include drop-shadow-default;


### PR DESCRIPTION
### 1. Why is this change necessary?
The current definition produces the following warning when building the administration:
```
Warning: math.div() will only support number arguments in a future release.
Use list.slash() instead for a slash separator.

   ╷
29 │     padding: 0 math.div($sw-modal-gap, 2);
   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    src/app/component/base/sw-modal/sw-modal.scss 29:16  root stylesheet
```

Furthermore it produces invalid SCSS such that the padding of the `sw-modal` is not existent.

### 2. What does this change do, exactly?
Use the corresponding CSS calculation method.

### 3. Describe each step to reproduce the issue or behaviour.
Look at the CSS of an admin modal.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
