### PR TITLE
feat(product-analytics): Add default properties for events

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -8,6 +8,24 @@ jest.mock('@amplitude/analytics-browser', () => ({
 }));
 
 describe('src/app/post-init/amplitude.init.ts', () => {
+    beforeEach(() => {
+        global.repositoryFactoryMock.responses.addResponse({
+            method: 'Post',
+            url: '/search/language',
+            status: 200,
+            response: {
+                data: [
+                    {
+                        id: 'language-id',
+                        attributes: {
+                            name: 'English',
+                        },
+                    },
+                ],
+            },
+        });
+    });
+
     describe('initialization', () => {
         it('add enrichment plugin and calls initialization routine', async () => {
             const { init, add } = await import('@amplitude/analytics-browser');

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -8,18 +8,37 @@ import { TelemetryEvent, type EventTypes } from '../../core/telemetry/types';
 /**
  * @private
  */
-export default function (): Promise<void> {
+export default async function (): Promise<void> {
+    let defaultLanguageName = '';
+
+    try {
+        defaultLanguageName = await getDefaultLanguageName();
+    } catch {
+        defaultLanguageName = 'N/A';
+    }
+
     amplitude.add({
         name: 'DefaultShopwareProperties',
         execute: (amplitudeEvent) => {
+            const route = Shopware.Application.view?.router?.currentRoute
+                ? {
+                      sw_page_name: Shopware.Application.view.router.currentRoute.value.name,
+                      sw_page_path: Shopware.Application.view.router.currentRoute.value.path,
+                      sw_page_full_path: Shopware.Application.view.router.currentRoute.value.fullPath,
+                  }
+                : {};
+
             amplitudeEvent.event_properties = {
                 ...amplitudeEvent.event_properties,
                 sw_version: Shopware.Store.get('context').app.config.version,
-                sw_user_language: Shopware.Store.get('session').currentLocale,
-                sw_user_is_admin: Shopware.Store.get('session').currentUser?.admin === true,
-                sw_user_timezone: Shopware.Store.get('session').currentUser?.timeZone,
                 sw_shop_id: Shopware.Store.get('context').app.config.shopId,
-                sw_environment: Shopware.Store.get('context').app.environment,
+                sw_user_agent: window.navigator.userAgent,
+                sw_default_language: defaultLanguageName,
+                sw_default_currency: Shopware.Context.app.systemCurrencyISOCode,
+                sw_screen_width: window.screen.width,
+                sw_screen_height: window.screen.height,
+                sw_screen_orientation: window.screen.orientation.type.split('-')[0],
+                ...route,
             };
             return Promise.resolve(amplitudeEvent);
         },
@@ -80,8 +99,13 @@ export default function (): Promise<void> {
             });
         }
     });
+}
 
-    return Promise.resolve();
+async function getDefaultLanguageName(): Promise<string> {
+    const languageRepository = Shopware.Service('repositoryFactory').create('language');
+    const defaultLanguage = await languageRepository.get(Shopware.Context.api.systemLanguageId!);
+
+    return defaultLanguage!.name;
 }
 
 function isTelemetryEvent(telemetryEvent: Event): telemetryEvent is TelemetryEvent<EventTypes> {


### PR DESCRIPTION
Defines and adds properties that should be sent with every request to amplitude

Resolves  shopware/services-roadmap#149