### PR TITLE
fix: Remove wrong theme assocation from media definition

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -138,5 +138,10 @@ return [
         preg_quote('CHANGED: The return type of Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheKeyEvent#get() changed from string', '/'),
         preg_quote('CHANGED: The return type of Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheCookieEvent#get() changed from string|null', '/'),
         preg_quote('CHANGED: The parameter $value of Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheCookieEvent#add() changed from string', '/'),
+
+        // The property was wrongly added as it introduced a dependency on the Storefront package
+        preg_quote('REMOVED: Property Shopware\Core\Content\Media\MediaEntity#$themes was removed', '/'),
+        preg_quote('REMOVED: Method Shopware\Core\Content\Media\MediaEntity#getThemes() was removed', '/'),
+        preg_quote('REMOVED: Method Shopware\Core\Content\Media\MediaEntity#setThemes() was removed', '/'),
     ],
 ];

--- a/src/Core/Content/Media/MediaDefinition.php
+++ b/src/Core/Content/Media/MediaDefinition.php
@@ -54,7 +54,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\System\User\UserDefinition;
-use Shopware\Storefront\Theme\Aggregate\ThemeMediaDefinition;
 
 #[Package('discovery')]
 class MediaDefinition extends EntityDefinition
@@ -88,7 +87,7 @@ class MediaDefinition extends EntityDefinition
 
     protected function defineFields(): FieldCollection
     {
-        $fields = new FieldCollection([
+        return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
             new FkField('user_id', 'userId', UserDefinition::class),
             new FkField('media_folder_id', 'mediaFolderId', MediaFolderDefinition::class),
@@ -113,7 +112,6 @@ class MediaDefinition extends EntityDefinition
             (new ManyToManyAssociationField('tags', TagDefinition::class, MediaTagDefinition::class, 'media_id', 'tag_id'))->addFlags(new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
             (new OneToManyAssociationField('thumbnails', MediaThumbnailDefinition::class, 'media_id'))->addFlags(new ApiAware(), new CascadeDelete()),
             // reverse side of the associations, not available in store-api
-            (new ManyToManyAssociationField('themes', UserDefinition::class, ThemeMediaDefinition::class, 'media_id', 'theme_id'))->addFlags(new RestrictDelete()),
             new ManyToOneAssociationField('user', 'user_id', UserDefinition::class, 'id', false),
             (new OneToManyAssociationField('categories', CategoryDefinition::class, 'media_id', 'id'))->addFlags(new SetNullOnDelete()),
             (new OneToManyAssociationField('productManufacturers', ProductManufacturerDefinition::class, 'media_id', 'id'))->addFlags(new SetNullOnDelete()),
@@ -138,7 +136,5 @@ class MediaDefinition extends EntityDefinition
             (new OneToManyAssociationField('appShippingMethods', AppShippingMethodDefinition::class, 'original_media_id', 'id'))->addFlags(new SetNullOnDelete()),
             (new StringField('file_hash', 'fileHash'))->addFlags(new Computed()),
         ]);
-
-        return $fields;
     }
 }

--- a/src/Core/Content/Media/MediaEntity.php
+++ b/src/Core/Content/Media/MediaEntity.php
@@ -33,7 +33,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagCollection;
 use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserEntity;
-use Shopware\Storefront\Theme\ThemeCollection;
 
 /**
  * @phpstan-type MediaConfig array{'spatialObject': array{'arReady': bool, 'arPlacement': string}}
@@ -81,8 +80,6 @@ class MediaEntity extends Entity
     protected ?MediaTranslationCollection $translations = null;
 
     protected ?CategoryCollection $categories = null;
-
-    protected ?ThemeCollection $themes = null;
 
     protected ?ProductManufacturerCollection $productManufacturers = null;
 
@@ -289,16 +286,6 @@ class MediaEntity extends Entity
     public function setCategories(CategoryCollection $categories): void
     {
         $this->categories = $categories;
-    }
-
-    public function getThemes(): ?ThemeCollection
-    {
-        return $this->themes;
-    }
-
-    public function setThemes(ThemeCollection $themes): void
-    {
-        $this->themes = $themes;
     }
 
     public function getProductManufacturers(): ?ProductManufacturerCollection

--- a/src/Storefront/Theme/Extension/MediaExtension.php
+++ b/src/Storefront/Theme/Extension/MediaExtension.php
@@ -4,6 +4,7 @@ namespace Shopware\Storefront\Theme\Extension;
 
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityExtension;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
@@ -21,7 +22,7 @@ class MediaExtension extends EntityExtension
         );
 
         $collection->add(
-            new ManyToManyAssociationField('themeMedia', ThemeDefinition::class, ThemeMediaDefinition::class, 'media_id', 'theme_id')
+            (new ManyToManyAssociationField('themeMedia', ThemeDefinition::class, ThemeMediaDefinition::class, 'media_id', 'theme_id'))->addFlags(new RestrictDelete())
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

With https://github.com/shopware/shopware/pull/11491 a hard dependency of the Storefront bundle was introduced. This could break environments where this is not installed. 

### 2. What does this change do, exactly?

Remove the association field again. It was already added before with the `\Shopware\Storefront\Theme\Extension\MediaExtension`. 
The `RestrictDelete` was added there, so the intended behaviour of the PR mentioned above should still be there.

### 3. Describe each step to reproduce the issue or behaviour.

See linked issue

### 4. Please link to the relevant issues (if any).
- closes #12581 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
