### PR TITLE
feat(product-analytics): Add properties for page viewed and link visited events

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -45,7 +45,11 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             [
                 new TelemetryEvent('page_change', {
                     from: { name: 'sw.dashboard.index', path: '/sw/dashboard/index' },
-                    to: { name: 'sw.product.index', path: '/sw/product/index', fullPath: '/sw-product/index?order=asc&page=1&limit=50' },
+                    to: {
+                        name: 'sw.product.index',
+                        path: '/sw/product/index',
+                        fullPath: '/sw-product/index?order=asc&page=1&limit=50',
+                    },
                 }),
                 {
                     eventName: 'Page Viewed',
@@ -54,7 +58,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                         sw_route_from_href: '/sw/dashboard/index',
                         sw_route_to_name: 'sw.product.index',
                         sw_route_to_href: '/sw/product/index',
-                        sw_route_to_query: 'order=asc&page=1&limit=50'
+                        sw_route_to_query: 'order=asc&page=1&limit=50',
                     },
                 },
             ],
@@ -62,20 +66,12 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                 new TelemetryEvent('link_visited', {
                     href: 'https://example.com',
                     linkType: 'external',
-                    target: (() => {
-                        const fakeLink = document.createElement('a');
-                        fakeLink.textContent = 'Read more';
-
-                        return fakeLink;
-                    })(),
-                    originalEvent: new Event('click'),
                 }),
                 {
                     eventName: 'Link Visited',
                     properties: {
-                        sw_link_href: 'https://example.com',
-                        sw_link_type: 'external',
-                        sw_link_label: 'Read more',
+                        href: 'https://example.com',
+                        link_type: 'external',
                     },
                 },
             ],

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -45,15 +45,16 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             [
                 new TelemetryEvent('page_change', {
                     from: { name: 'sw.dashboard.index', path: '/sw/dashboard/index' },
-                    to: { name: 'sw.product.index', path: '/sw/product/index' },
+                    to: { name: 'sw.product.index', path: '/sw/product/index', fullPath: '/sw-product/index?order=asc&page=1&limit=50' },
                 }),
                 {
                     eventName: 'Page Viewed',
                     properties: {
-                        sw_route_from: 'sw.dashboard.index',
-                        href_route_from: '/sw/dashboard/index',
-                        sw_route_to: 'sw.product.index',
-                        href_route_to: '/sw/product/index',
+                        sw_route_from_name: 'sw.dashboard.index',
+                        sw_route_from_href: '/sw/dashboard/index',
+                        sw_route_to_name: 'sw.product.index',
+                        sw_route_to_href: '/sw/product/index',
+                        sw_route_to_query: 'order=asc&page=1&limit=50'
                     },
                 },
             ],
@@ -61,12 +62,20 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                 new TelemetryEvent('link_visited', {
                     href: 'https://example.com',
                     linkType: 'external',
+                    target: (() => {
+                        const fakeLink = document.createElement('a');
+                        fakeLink.textContent = 'Read more';
+
+                        return fakeLink;
+                    })(),
+                    originalEvent: new Event('click'),
                 }),
                 {
                     eventName: 'Link Visited',
                     properties: {
-                        href: 'https://example.com',
-                        link_type: 'external',
+                        sw_link_href: 'https://example.com',
+                        sw_link_type: 'external',
+                        sw_link_label: 'Read more',
                     },
                 },
             ],

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -58,9 +58,8 @@ export default function (): Promise<void> {
 
         if (isEventOfType('link_visited', telemetryEvent)) {
             amplitude.track('Link Visited', {
-                sw_link_href: telemetryEvent.detail.eventData.href,
-                sw_link_type: telemetryEvent.detail.eventData.linkType,
-                sw_link_label: telemetryEvent.detail.eventData.target.textContent,
+                href: telemetryEvent.detail.eventData.href,
+                link_type: telemetryEvent.detail.eventData.linkType,
             });
             return;
         }

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -47,18 +47,20 @@ export default function (): Promise<void> {
 
         if (isEventOfType('page_change', telemetryEvent)) {
             amplitude.track('Page Viewed', {
-                sw_route_from: telemetryEvent.detail.eventData.from.name,
-                href_route_from: telemetryEvent.detail.eventData.from.path,
-                sw_route_to: telemetryEvent.detail.eventData.to.name,
-                href_route_to: telemetryEvent.detail.eventData.to.path,
+                sw_route_from_name: telemetryEvent.detail.eventData.from.name,
+                sw_route_from_href: telemetryEvent.detail.eventData.from.path,
+                sw_route_to_name: telemetryEvent.detail.eventData.to.name,
+                sw_route_to_href: telemetryEvent.detail.eventData.to.path,
+                sw_route_to_query: telemetryEvent.detail.eventData.to.fullPath.split('?')[1],
             });
             return;
         }
 
         if (isEventOfType('link_visited', telemetryEvent)) {
             amplitude.track('Link Visited', {
-                href: telemetryEvent.detail.eventData.href,
-                link_type: telemetryEvent.detail.eventData.linkType,
+                sw_link_href: telemetryEvent.detail.eventData.href,
+                sw_link_type: telemetryEvent.detail.eventData.linkType,
+                sw_link_label: telemetryEvent.detail.eventData.target.textContent,
             });
             return;
         }

--- a/src/Administration/Resources/app/administration/src/core/telemetry/index.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/index.spec.js
@@ -195,8 +195,6 @@ describe('src/core/telemetry/index.js', () => {
                 eventData: {
                     href: '/test-page',
                     linkType: 'external',
-                    target: link,
-                    originalEvent: expect.anything(),
                 },
                 timestamp: new Date('2025-09-23'),
             });

--- a/src/Administration/Resources/app/administration/src/core/telemetry/index.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/index.spec.js
@@ -176,15 +176,15 @@ describe('src/core/telemetry/index.js', () => {
             telemetry.initialize();
             telemetry.addListener(listener);
 
-            const element = document.createElement('a');
-            element.setAttribute('id', 'tested-element');
-            element.setAttribute('href', '/test-page');
-            element.setAttribute('target', '_blank');
-            document.body.appendChild(element);
+            const link = document.createElement('a');
+            link.setAttribute('id', 'tested-element');
+            link.setAttribute('href', '/test-page');
+            link.setAttribute('target', '_blank');
+            document.body.appendChild(link);
 
             await flushPromises();
 
-            element.click();
+            link.click();
             expect(listener).toHaveBeenCalled();
 
             const telemetryEvent = listener.mock.calls[0][0];
@@ -195,6 +195,8 @@ describe('src/core/telemetry/index.js', () => {
                 eventData: {
                     href: '/test-page',
                     linkType: 'external',
+                    target: link,
+                    originalEvent: expect.anything(),
                 },
                 timestamp: new Date('2025-09-23'),
             });

--- a/src/Administration/Resources/app/administration/src/core/telemetry/index.ts
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/index.ts
@@ -112,11 +112,13 @@ export class Telemetry {
         if (el.nodeName === 'A') {
             el.addEventListener('click', (event) => {
                 const target = event.currentTarget ?? event.target;
-                if (!this.assertIsElement(target)) {
+                if (!this.isElement(target)) {
                     return;
                 }
 
                 this.dispatchEvent('link_visited', {
+                    target: target,
+                    originalEvent: event,
                     href: target.getAttribute('href') ?? '',
                     linkType: target.getAttribute('target') === '_blank' ? 'external' : 'internal',
                 });
@@ -129,12 +131,12 @@ export class Telemetry {
 
         el.addEventListener(eventName, (event) => {
             const target = event.currentTarget ?? event.target;
-            if (!this.assertIsElement(target)) {
+            if (!this.isElement(target)) {
                 return;
             }
 
             this.dispatchEvent('user_interaction', {
-                target: event.currentTarget ?? event.target,
+                target: target,
                 originalEvent: event,
             });
         });
@@ -148,7 +150,7 @@ export class Telemetry {
         this.#eventTarget.dispatchEvent(new TelemetryEvent<N>(eventType, eventData));
     }
 
-    private assertIsElement(target: EventTarget | null): target is Element {
+    private isElement(target: EventTarget | null): target is Element {
         return target !== null && target instanceof Element;
     }
 }

--- a/src/Administration/Resources/app/administration/src/core/telemetry/index.ts
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/index.ts
@@ -117,8 +117,6 @@ export class Telemetry {
                 }
 
                 this.dispatchEvent('link_visited', {
-                    target: target,
-                    originalEvent: event,
                     href: target.getAttribute('href') ?? '',
                     linkType: target.getAttribute('target') === '_blank' ? 'external' : 'internal',
                 });

--- a/src/Administration/Resources/app/administration/src/core/telemetry/types.ts
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/types.ts
@@ -7,7 +7,7 @@ type TrackableType = string | string[] | number | boolean;
 
 type AnalyticsEvents = {
     user_interaction: {
-        target: EventTarget | null;
+        target: Element;
         originalEvent: Event;
     };
     page_change: {
@@ -17,7 +17,7 @@ type AnalyticsEvents = {
     programmatic: {
         [key: string]: TrackableType;
     };
-    link_visited: {
+    link_visited: AnalyticsEvents["user_interaction"] & {
         href: string;
         linkType: 'internal' | 'external';
     };

--- a/src/Administration/Resources/app/administration/src/core/telemetry/types.ts
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/types.ts
@@ -17,7 +17,7 @@ type AnalyticsEvents = {
     programmatic: {
         [key: string]: TrackableType;
     };
-    link_visited: AnalyticsEvents["user_interaction"] & {
+    link_visited: {
         href: string;
         linkType: 'internal' | 'external';
     };


### PR DESCRIPTION
Renames and adds fields to `link_visited` and `page_change` events

Resolves shopware/services-roadmap#147

Edit: I reverted the changes to link events because I want to remove them in favour of `user_interactions`.