### PR TITLE
test: update installation e2e to include language downloads

### DIFF
--- a/tests/acceptance/tests/Install/Installation.spec.ts
+++ b/tests/acceptance/tests/Install/Installation.spec.ts
@@ -1,57 +1,106 @@
 import { test, expect } from '@fixtures/AcceptanceTest';
 
-test('Install a new Shopware instance.', { tag: '@Install' }, async ({ InstallPage }) => {
+test('Install a new Shopware instance.', { tag: '@Install' }, async ({ IdProvider, InstallPage }) => {
+
     const page = InstallPage;
 
-    await page.goto(process.env.APP_URL);
+    test.slow(); 
 
-    await page.getByRole('link', { name: 'Next' }).click();
-    await page.getByRole('button', { name: 'Next' }).click();
-    await page.getByText('I agree to the General Terms and Conditions of Business (GTC)').click();
-    await page.getByRole('button', { name: 'Next' }).click();
+    await test.step('Open welcome screen and set installation wizard language to English (US)', async () => {
+        await page.goto(process.env.APP_URL);
+        await expect(page.getByRole('heading', { name: 'Welcome to Shopware 6',  level: 1 } )).toBeVisible();
+        
+        const installerLanguageDropdown = page.getByLabel('Installation wizard language');
+        await installerLanguageDropdown.selectOption('English (US)');
+        await expect(installerLanguageDropdown).toContainText('English (US)');
+        
+        await page.getByRole('link', { name: 'Next' }).click();
+     });
 
-    await page.getByLabel('Server:').fill(process.env.ATS_DATABASE_HOST ?? 'database');
-    await page.getByLabel('User:').fill(process.env.ATS_DATABASE_USERNAME ?? 'root');
-    await page.getByLabel('Password:').fill(process.env.ATS_DATABASE_PASSWORD ?? 'app');
-
-    await page.getByText('New database:').click();
-    await page.locator('#databaseName_new').fill(process.env.ATS_DATABASE_NAME ?? 'install_test');
-
-    await page.getByRole('button', { name: 'Start installation' }).click();
-
-    test.slow();
-
-    await expect(page.locator('#import-finished:visible div').first())
-        .toHaveText('Shopware 6 has been installed!', { timeout: 120000 });
-    await page.getByRole('link', { name: 'Next' }).click();
-
-    await page.getByLabel('Shop name').fill('Basic install test');
-
-    await page.locator('#shop-configuration div').filter({ hasText: 'Almost done. You just need to make some few basic settings in your shop, Shopwar' }).click();
-
-    await page.getByLabel('Shop email address:').fill('mustermann@example.com');
-    await page.locator('label').filter({ hasText: 'Pound sterling (UK)' }).click();
-
-    await page.getByLabel('Admin email:').fill('admin@example.com');
-
-    await page.getByLabel('Admin first name:').fill('Admin');
-    await page.getByLabel('Admin last name:').fill('Admin');
-    await page.getByLabel('Admin login name:').fill('admin');
-    await page.getByLabel('Admin password:').fill('shopware');
-
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    await expect(page.getByText('Installation completed')).toBeVisible({
-        timeout: 30000,
+    await test.step('Check system requirements are met', async () => {
+        await expect(page.getByRole('heading', { name: 'System requirements', level: 2 })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Your system is ready for Shopware 6', level: 3 })).toBeVisible();
+        await page.getByRole('button', { name: 'Next' }).click();
+    });
+    
+    await test.step('Agree to the license terms and conditions', async () => {
+        await expect(page.getByRole('heading', { name: 'General Terms and Conditions of Business ("GTC")', level: 2 })).toBeVisible();
+        
+        const termsCheckbox = page.getByText('I agree to the General Terms and Conditions of Business (GTC)');
+        await termsCheckbox.click();
+        await expect(termsCheckbox).toBeChecked();
+        
+        await page.getByRole('button', { name: 'Next' }).click();
     });
 
-    // Click "Continue to shop" button
-    await page.getByRole('link', { name: 'Continue to shop' }).click();
+    await test.step('Database Configuration', async () => {
+        await expect(page.getByRole('heading', { name: 'Configure database', level: 2 })).toBeVisible();
+        await page.getByLabel('Server:').fill(process.env.ATS_DATABASE_HOST ?? 'database');
+        await page.getByLabel('User:').fill(process.env.ATS_DATABASE_USERNAME ?? 'root');
+        await page.getByLabel('Password:').fill(process.env.ATS_DATABASE_PASSWORD ?? 'app');
 
-    // test admin login
+        const newDatabaseCheckbox = page.getByText('New database:');
+        await newDatabaseCheckbox.click();
+        await expect(newDatabaseCheckbox).toBeChecked();
+        await page.locator('#databaseName_new').fill(process.env.ATS_DATABASE_NAME ?? 'install_test');
+    });
 
-    // Wait until the page is loaded
-    await expect(page.locator('css=.sw-admin-menu__header-logo').first()).toBeVisible({
-        timeout: 20000,
+    await test.step('Install Shopware 6', async () => {
+        const installComplete = page.waitForURL(`${process.env.APP_URL}installer/database-import`, { waitUntil: 'networkidle' });
+        await page.getByRole('button', { name: 'Start installation' }).click();
+        await expect(page.getByRole('heading', { name: 'Installation', level: 2 })).toBeVisible();
+        
+        const installed = await installComplete;
+        await expect(page.getByRole('heading', { name: 'Shopware 6 has been installed!', level: 3 })).toBeVisible();
+        await page.getByRole('link', { name: 'Next' }).click();
+    });
+
+    await test.step('Configure basic shop settings and create the first admin user', async () => {
+        await expect(page.getByRole('heading', { name: 'Configuration', level: 2 })).toBeVisible();
+
+        await page.getByLabel('Shop name').fill('Basic install test');
+        await page.getByLabel('Shop email address:').fill('mustermann@example.com');
+
+        //languages, currency, country are autoselected based on installation wizard language
+        await expect(page.getByLabel('Default system language:')).toContainText('English (United States of America)');
+        await expect(page.getByLabel('Default currency:')).toContainText('Dollar (US)');
+        await expect(page.getByLabel('Default country:')).toContainText('United States of America');
+        await expect(page.getByRole('checkbox', { name: 'English (US)' })).toBeChecked();
+        await expect(page.getByRole('checkbox', { name: 'English (US)' })).toBeDisabled();
+        await expect(page.getByRole('checkbox', { name: 'Dollar (US)' })).toBeChecked();
+
+        await page.getByLabel('Admin email:').fill('admin@example.com');
+        await page.getByLabel('Admin first name:').fill('Admin');
+        await page.getByLabel('Admin last name:').fill('Admin');
+        await page.getByLabel('Admin login name:').fill('admin');
+        await page.getByLabel('Admin password:').fill('shopware');
+
+        await page.getByRole('button', { name: 'Next' }).click();
+    });
+
+    await test.step('Download and install additional languages', async () => {
+        await expect(page.getByRole('heading', { name: 'Languages Download', level: 2 })).toBeVisible();
+    });
+ 
+    await test.step('Finish installation and open the admin dashboard', async () => {
+        await page.waitForURL(`${process.env.APP_URL}installer/finish?completed=1`, { waitUntil: 'commit' });
+        await expect(page.getByRole('heading', { name: 'Installation completed', level: 2 })).toBeVisible();
+        await page.getByRole('link', { name: 'Continue to shop' }).click();
+
+        await page.waitForURL(`${process.env.APP_URL}admin#/sw/dashboard/index`, { waitUntil: 'commit' });
+        await expect(page.getByRole('heading', { name: 'Introducing Shopware Services', level: 3 })).toBeVisible({ timeout: 20000 });
+    });
+
+    await test.step('Check that the system language is available', async () => {
+        await page.goto(`${process.env.APP_URL}admin#/sw/settings/language/index`, { waitUntil: 'commit'});
+        await expect(page.getByRole('heading', { name: 'Settings Languages', level: 2 })).toBeVisible();
+        await expect(page.getByText('Languages (3)')).toBeVisible();
+        await expect(page.getByRole('row', { name: 'English (US) Default' }).locator('#meteor-icon-kit__regular-checkmark-xs')).toBeVisible();
+    });
+
+    await test.step('Check that the system language snippets are available', async () => {
+        await page.goto(`${process.env.APP_URL}admin#/sw/settings/snippet/index`, { waitUntil: 'commit'});
+        await expect(page.getByRole('heading', { name: 'Settings Snippets', level: 2 })).toBeVisible();
+        await expect(page.getByRole('row', { name: 'BASE en-US' })).toBeVisible(); 
     });
 });

--- a/tests/acceptance/tests/Install/Installation.spec.ts
+++ b/tests/acceptance/tests/Install/Installation.spec.ts
@@ -1,106 +1,99 @@
 import { test, expect } from '@fixtures/AcceptanceTest';
 
-test('Install a new Shopware instance.', { tag: '@Install' }, async ({ IdProvider, InstallPage }) => {
-
-    const page = InstallPage;
-
+test('Install a new Shopware instance.', { tag: '@Install' }, async ({ ShopAdmin, SetupInstall }) => {
     test.slow(); 
 
     await test.step('Open welcome screen and set installation wizard language to English (US)', async () => {
-        await page.goto(process.env.APP_URL);
-        await expect(page.getByRole('heading', { name: 'Welcome to Shopware 6',  level: 1 } )).toBeVisible();
+        await ShopAdmin.goesTo(SetupInstall.url());
+        await ShopAdmin.expects(SetupInstall.welcomeHeading).toBeVisible();
         
-        const installerLanguageDropdown = page.getByLabel('Installation wizard language');
-        await installerLanguageDropdown.selectOption('English (US)');
-        await expect(installerLanguageDropdown).toContainText('English (US)');
+        await SetupInstall.languageDropdown.selectOption('English (US)');
+        await expect(SetupInstall.languageDropdown).toContainText('English (US)');
         
-        await page.getByRole('link', { name: 'Next' }).click();
-     });
+        await SetupInstall.welcomeNextLink.click();
+    });
 
     await test.step('Check system requirements are met', async () => {
-        await expect(page.getByRole('heading', { name: 'System requirements', level: 2 })).toBeVisible();
-        await expect(page.getByRole('heading', { name: 'Your system is ready for Shopware 6', level: 3 })).toBeVisible();
-        await page.getByRole('button', { name: 'Next' }).click();
+        await expect(SetupInstall.systemRequirementsHeading).toBeVisible();
+        await expect(SetupInstall.systemReadyHeading).toBeVisible();
+        await SetupInstall.systemNextButton.click();
     });
     
     await test.step('Agree to the license terms and conditions', async () => {
-        await expect(page.getByRole('heading', { name: 'General Terms and Conditions of Business ("GTC")', level: 2 })).toBeVisible();
+        await expect(SetupInstall.licenseHeading).toBeVisible();
         
-        const termsCheckbox = page.getByText('I agree to the General Terms and Conditions of Business (GTC)');
-        await termsCheckbox.click();
-        await expect(termsCheckbox).toBeChecked();
+        await SetupInstall.termsCheckbox.click();
+        await expect(SetupInstall.termsCheckbox).toBeChecked();
         
-        await page.getByRole('button', { name: 'Next' }).click();
+        await SetupInstall.licenseNextButton.click();
     });
 
     await test.step('Database Configuration', async () => {
-        await expect(page.getByRole('heading', { name: 'Configure database', level: 2 })).toBeVisible();
-        await page.getByLabel('Server:').fill(process.env.ATS_DATABASE_HOST ?? 'database');
-        await page.getByLabel('User:').fill(process.env.ATS_DATABASE_USERNAME ?? 'root');
-        await page.getByLabel('Password:').fill(process.env.ATS_DATABASE_PASSWORD ?? 'app');
+        await expect(SetupInstall.databaseHeading).toBeVisible();
+        await SetupInstall.serverField.fill(process.env.ATS_DATABASE_HOST ?? 'database');
+        await SetupInstall.userField.fill(process.env.ATS_DATABASE_USERNAME ?? 'root');
+        await SetupInstall.passwordField.fill(process.env.ATS_DATABASE_PASSWORD ?? 'app');
 
-        const newDatabaseCheckbox = page.getByText('New database:');
-        await newDatabaseCheckbox.click();
-        await expect(newDatabaseCheckbox).toBeChecked();
-        await page.locator('#databaseName_new').fill(process.env.ATS_DATABASE_NAME ?? 'install_test');
+        await SetupInstall.newDatabaseCheckbox.click();
+        await expect(SetupInstall.newDatabaseCheckbox).toBeChecked();
+        await SetupInstall.databaseNameField.fill(process.env.ATS_DATABASE_NAME ?? 'install_test');
     });
 
     await test.step('Install Shopware 6', async () => {
-        const installComplete = page.waitForURL(`${process.env.APP_URL}installer/database-import`, { waitUntil: 'networkidle' });
-        await page.getByRole('button', { name: 'Start installation' }).click();
-        await expect(page.getByRole('heading', { name: 'Installation', level: 2 })).toBeVisible();
+        await SetupInstall.startInstallationButton.click();
+        await expect(SetupInstall.installationHeading).toBeVisible();
         
-        const installed = await installComplete;
-        await expect(page.getByRole('heading', { name: 'Shopware 6 has been installed!', level: 3 })).toBeVisible();
-        await page.getByRole('link', { name: 'Next' }).click();
+        await SetupInstall.waitForInstallationComplete();
+        await expect(SetupInstall.installationCompleteHeading).toBeVisible();
+        await SetupInstall.installationNextLink.click();
     });
 
     await test.step('Configure basic shop settings and create the first admin user', async () => {
-        await expect(page.getByRole('heading', { name: 'Configuration', level: 2 })).toBeVisible();
+        await expect(SetupInstall.configurationHeading).toBeVisible();
 
-        await page.getByLabel('Shop name').fill('Basic install test');
-        await page.getByLabel('Shop email address:').fill('mustermann@example.com');
+        await SetupInstall.shopNameField.fill('Basic install test');
+        await SetupInstall.shopEmailField.fill('mustermann@example.com');
 
-        //languages, currency, country are autoselected based on installation wizard language
-        await expect(page.getByLabel('Default system language:')).toContainText('English (United States of America)');
-        await expect(page.getByLabel('Default currency:')).toContainText('Dollar (US)');
-        await expect(page.getByLabel('Default country:')).toContainText('United States of America');
-        await expect(page.getByRole('checkbox', { name: 'English (United States of America)' })).toBeChecked();
-        await expect(page.getByRole('checkbox', { name: 'English (United States of America)' })).toBeDisabled();
-        await expect(page.getByRole('checkbox', { name: 'Dollar (US)' })).toBeChecked();
+        // Languages, currency, country are autoselected based on installation wizard language
+        await expect(SetupInstall.defaultLanguageField).toContainText('English (United States of America)');
+        await expect(SetupInstall.defaultCurrencyField).toContainText('Dollar (US)');
+        await expect(SetupInstall.defaultCountryField).toContainText('United States of America');
+        await expect(SetupInstall.englishLanguageCheckbox).toBeChecked();
+        await expect(SetupInstall.englishLanguageCheckbox).toBeDisabled();
+        await expect(SetupInstall.dollarCurrencyCheckbox).toBeChecked();
 
-        await page.getByLabel('Admin email:').fill('admin@example.com');
-        await page.getByLabel('Admin first name:').fill('Admin');
-        await page.getByLabel('Admin last name:').fill('Admin');
-        await page.getByLabel('Admin login name:').fill('admin');
-        await page.getByLabel('Admin password:').fill('shopware');
+        await SetupInstall.adminEmailField.fill('admin@example.com');
+        await SetupInstall.adminFirstNameField.fill('Admin');
+        await SetupInstall.adminLastNameField.fill('Admin');
+        await SetupInstall.adminLoginField.fill('admin');
+        await SetupInstall.adminPasswordField.fill('shopware');
 
-        await page.getByRole('button', { name: 'Next' }).click();
+        await SetupInstall.configurationNextButton.click();
     });
 
     await test.step('Download and install additional languages', async () => {
-        await expect(page.getByRole('heading', { name: 'Languages Download', level: 2 })).toBeVisible();
+        await expect(SetupInstall.languagesDownloadHeading).toBeVisible();
     });
  
     await test.step('Finish installation and open the admin dashboard', async () => {
-        await page.waitForURL(`${process.env.APP_URL}installer/finish?completed=1`, { waitUntil: 'commit' });
-        await expect(page.getByRole('heading', { name: 'Installation completed', level: 2 })).toBeVisible();
-        await page.getByRole('link', { name: 'Continue to shop' }).click();
+        await SetupInstall.waitForFinishPage();
+        await expect(SetupInstall.installationCompletedHeading).toBeVisible();
+        await SetupInstall.continueToShopLink.click();
 
-        await page.waitForURL(`${process.env.APP_URL}admin#/sw/dashboard/index`, { waitUntil: 'commit' });
-        await expect(page.getByRole('heading', { name: 'Introducing Shopware Services', level: 3 })).toBeVisible({ timeout: 20000 });
+        await SetupInstall.waitForAdminDashboard();
+        await expect(SetupInstall.dashboardHeading).toBeVisible({ timeout: 20000 });
     });
 
     await test.step('Check that the system language is available', async () => {
-        await page.goto(`${process.env.APP_URL}admin#/sw/settings/language/index`, { waitUntil: 'commit'});
-        await expect(page.getByRole('heading', { name: 'Settings Languages', level: 2 })).toBeVisible();
-        await expect(page.getByText('Languages (3)')).toBeVisible();
-        await expect(page.getByRole('row', { name: 'English (US) Default' }).locator('#meteor-icon-kit__regular-checkmark-xs')).toBeVisible();
+        await SetupInstall.gotoAdminLanguages();
+        await expect(SetupInstall.settingsLanguagesHeading).toBeVisible();
+        await expect(SetupInstall.languagesCount).toBeVisible();
+        await expect(SetupInstall.englishDefaultRow).toBeVisible();
     });
 
     await test.step('Check that the system language snippets are available', async () => {
-        await page.goto(`${process.env.APP_URL}admin#/sw/settings/snippet/index`, { waitUntil: 'commit'});
-        await expect(page.getByRole('heading', { name: 'Settings Snippets', level: 2 })).toBeVisible();
-        await expect(page.getByRole('row', { name: 'BASE en-US' })).toBeVisible(); 
+        await SetupInstall.gotoAdminSnippets();
+        await expect(SetupInstall.settingsSnippetsHeading).toBeVisible();
+        await expect(SetupInstall.baseEnUsRow).toBeVisible(); 
     });
 });

--- a/tests/acceptance/tests/Install/Installation.spec.ts
+++ b/tests/acceptance/tests/Install/Installation.spec.ts
@@ -1,99 +1,106 @@
 import { test, expect } from '@fixtures/AcceptanceTest';
 
-test('Install a new Shopware instance.', { tag: '@Install' }, async ({ ShopAdmin, SetupInstall }) => {
+test('Install a new Shopware instance.', { tag: '@Install' }, async ({ IdProvider, InstallPage }) => {
+
+    const page = InstallPage;
+
     test.slow(); 
 
     await test.step('Open welcome screen and set installation wizard language to English (US)', async () => {
-        await ShopAdmin.goesTo(SetupInstall.url());
-        await ShopAdmin.expects(SetupInstall.welcomeHeading).toBeVisible();
+        await page.goto(process.env.APP_URL);
+        await expect(page.getByRole('heading', { name: 'Welcome to Shopware 6',  level: 1 } )).toBeVisible();
         
-        await SetupInstall.languageDropdown.selectOption('English (US)');
-        await expect(SetupInstall.languageDropdown).toContainText('English (US)');
+        const installerLanguageDropdown = page.getByLabel('Installation wizard language');
+        await installerLanguageDropdown.selectOption('English (US)');
+        await expect(installerLanguageDropdown).toContainText('English (US)');
         
-        await SetupInstall.welcomeNextLink.click();
-    });
+        await page.getByRole('link', { name: 'Next' }).click();
+     });
 
     await test.step('Check system requirements are met', async () => {
-        await expect(SetupInstall.systemRequirementsHeading).toBeVisible();
-        await expect(SetupInstall.systemReadyHeading).toBeVisible();
-        await SetupInstall.systemNextButton.click();
+        await expect(page.getByRole('heading', { name: 'System requirements', level: 2 })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Your system is ready for Shopware 6', level: 3 })).toBeVisible();
+        await page.getByRole('button', { name: 'Next' }).click();
     });
     
     await test.step('Agree to the license terms and conditions', async () => {
-        await expect(SetupInstall.licenseHeading).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'General Terms and Conditions of Business ("GTC")', level: 2 })).toBeVisible();
         
-        await SetupInstall.termsCheckbox.click();
-        await expect(SetupInstall.termsCheckbox).toBeChecked();
+        const termsCheckbox = page.getByText('I agree to the General Terms and Conditions of Business (GTC)');
+        await termsCheckbox.click();
+        await expect(termsCheckbox).toBeChecked();
         
-        await SetupInstall.licenseNextButton.click();
+        await page.getByRole('button', { name: 'Next' }).click();
     });
 
     await test.step('Database Configuration', async () => {
-        await expect(SetupInstall.databaseHeading).toBeVisible();
-        await SetupInstall.serverField.fill(process.env.ATS_DATABASE_HOST ?? 'database');
-        await SetupInstall.userField.fill(process.env.ATS_DATABASE_USERNAME ?? 'root');
-        await SetupInstall.passwordField.fill(process.env.ATS_DATABASE_PASSWORD ?? 'app');
+        await expect(page.getByRole('heading', { name: 'Configure database', level: 2 })).toBeVisible();
+        await page.getByLabel('Server:').fill(process.env.ATS_DATABASE_HOST ?? 'database');
+        await page.getByLabel('User:').fill(process.env.ATS_DATABASE_USERNAME ?? 'root');
+        await page.getByLabel('Password:').fill(process.env.ATS_DATABASE_PASSWORD ?? 'app');
 
-        await SetupInstall.newDatabaseCheckbox.click();
-        await expect(SetupInstall.newDatabaseCheckbox).toBeChecked();
-        await SetupInstall.databaseNameField.fill(process.env.ATS_DATABASE_NAME ?? 'install_test');
+        const newDatabaseCheckbox = page.getByText('New database:');
+        await newDatabaseCheckbox.click();
+        await expect(newDatabaseCheckbox).toBeChecked();
+        await page.locator('#databaseName_new').fill(process.env.ATS_DATABASE_NAME ?? 'install_test');
     });
 
     await test.step('Install Shopware 6', async () => {
-        await SetupInstall.startInstallationButton.click();
-        await expect(SetupInstall.installationHeading).toBeVisible();
+        const installComplete = page.waitForURL(`${process.env.APP_URL}installer/database-import`, { waitUntil: 'networkidle' });
+        await page.getByRole('button', { name: 'Start installation' }).click();
+        await expect(page.getByRole('heading', { name: 'Installation', level: 2 })).toBeVisible();
         
-        await SetupInstall.waitForInstallationComplete();
-        await expect(SetupInstall.installationCompleteHeading).toBeVisible();
-        await SetupInstall.installationNextLink.click();
+        const installed = await installComplete;
+        await expect(page.getByRole('heading', { name: 'Shopware 6 has been installed!', level: 3 })).toBeVisible();
+        await page.getByRole('link', { name: 'Next' }).click();
     });
 
     await test.step('Configure basic shop settings and create the first admin user', async () => {
-        await expect(SetupInstall.configurationHeading).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Configuration', level: 2 })).toBeVisible();
 
-        await SetupInstall.shopNameField.fill('Basic install test');
-        await SetupInstall.shopEmailField.fill('mustermann@example.com');
+        await page.getByLabel('Shop name').fill('Basic install test');
+        await page.getByLabel('Shop email address:').fill('mustermann@example.com');
 
-        // Languages, currency, country are autoselected based on installation wizard language
-        await expect(SetupInstall.defaultLanguageField).toContainText('English (United States of America)');
-        await expect(SetupInstall.defaultCurrencyField).toContainText('Dollar (US)');
-        await expect(SetupInstall.defaultCountryField).toContainText('United States of America');
-        await expect(SetupInstall.englishLanguageCheckbox).toBeChecked();
-        await expect(SetupInstall.englishLanguageCheckbox).toBeDisabled();
-        await expect(SetupInstall.dollarCurrencyCheckbox).toBeChecked();
+        //languages, currency, country are autoselected based on installation wizard language
+        await expect(page.getByLabel('Default system language:')).toContainText('English (United States of America)');
+        await expect(page.getByLabel('Default currency:')).toContainText('Dollar (US)');
+        await expect(page.getByLabel('Default country:')).toContainText('United States of America');
+        await expect(page.getByRole('checkbox', { name: 'English (United States of America)' })).toBeChecked();
+        await expect(page.getByRole('checkbox', { name: 'English (United States of America)' })).toBeDisabled();
+        await expect(page.getByRole('checkbox', { name: 'Dollar (US)' })).toBeChecked();
 
-        await SetupInstall.adminEmailField.fill('admin@example.com');
-        await SetupInstall.adminFirstNameField.fill('Admin');
-        await SetupInstall.adminLastNameField.fill('Admin');
-        await SetupInstall.adminLoginField.fill('admin');
-        await SetupInstall.adminPasswordField.fill('shopware');
+        await page.getByLabel('Admin email:').fill('admin@example.com');
+        await page.getByLabel('Admin first name:').fill('Admin');
+        await page.getByLabel('Admin last name:').fill('Admin');
+        await page.getByLabel('Admin login name:').fill('admin');
+        await page.getByLabel('Admin password:').fill('shopware');
 
-        await SetupInstall.configurationNextButton.click();
+        await page.getByRole('button', { name: 'Next' }).click();
     });
 
     await test.step('Download and install additional languages', async () => {
-        await expect(SetupInstall.languagesDownloadHeading).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Languages Download', level: 2 })).toBeVisible();
     });
  
     await test.step('Finish installation and open the admin dashboard', async () => {
-        await SetupInstall.waitForFinishPage();
-        await expect(SetupInstall.installationCompletedHeading).toBeVisible();
-        await SetupInstall.continueToShopLink.click();
+        await page.waitForURL(`${process.env.APP_URL}installer/finish?completed=1`, { waitUntil: 'commit' });
+        await expect(page.getByRole('heading', { name: 'Installation completed', level: 2 })).toBeVisible();
+        await page.getByRole('link', { name: 'Continue to shop' }).click();
 
-        await SetupInstall.waitForAdminDashboard();
-        await expect(SetupInstall.dashboardHeading).toBeVisible({ timeout: 20000 });
+        await page.waitForURL(`${process.env.APP_URL}admin#/sw/dashboard/index`, { waitUntil: 'commit' });
+        await expect(page.getByRole('heading', { name: 'Introducing Shopware Services', level: 3 })).toBeVisible({ timeout: 20000 });
     });
 
     await test.step('Check that the system language is available', async () => {
-        await SetupInstall.gotoAdminLanguages();
-        await expect(SetupInstall.settingsLanguagesHeading).toBeVisible();
-        await expect(SetupInstall.languagesCount).toBeVisible();
-        await expect(SetupInstall.englishDefaultRow).toBeVisible();
+        await page.goto(`${process.env.APP_URL}admin#/sw/settings/language/index`, { waitUntil: 'commit'});
+        await expect(page.getByRole('heading', { name: 'Settings Languages', level: 2 })).toBeVisible();
+        await expect(page.getByText('Languages (3)')).toBeVisible();
+        await expect(page.getByRole('row', { name: 'English (US) Default' }).locator('#meteor-icon-kit__regular-checkmark-xs')).toBeVisible();
     });
 
     await test.step('Check that the system language snippets are available', async () => {
-        await SetupInstall.gotoAdminSnippets();
-        await expect(SetupInstall.settingsSnippetsHeading).toBeVisible();
-        await expect(SetupInstall.baseEnUsRow).toBeVisible(); 
+        await page.goto(`${process.env.APP_URL}admin#/sw/settings/snippet/index`, { waitUntil: 'commit'});
+        await expect(page.getByRole('heading', { name: 'Settings Snippets', level: 2 })).toBeVisible();
+        await expect(page.getByRole('row', { name: 'BASE en-US' })).toBeVisible(); 
     });
 });

--- a/tests/acceptance/tests/Install/Installation.spec.ts
+++ b/tests/acceptance/tests/Install/Installation.spec.ts
@@ -65,8 +65,8 @@ test('Install a new Shopware instance.', { tag: '@Install' }, async ({ IdProvide
         await expect(page.getByLabel('Default system language:')).toContainText('English (United States of America)');
         await expect(page.getByLabel('Default currency:')).toContainText('Dollar (US)');
         await expect(page.getByLabel('Default country:')).toContainText('United States of America');
-        await expect(page.getByRole('checkbox', { name: 'English (US)' })).toBeChecked();
-        await expect(page.getByRole('checkbox', { name: 'English (US)' })).toBeDisabled();
+        await expect(page.getByRole('checkbox', { name: 'English (United States of America)' })).toBeChecked();
+        await expect(page.getByRole('checkbox', { name: 'English (United States of America)' })).toBeDisabled();
         await expect(page.getByRole('checkbox', { name: 'Dollar (US)' })).toBeChecked();
 
         await page.getByLabel('Admin email:').fill('admin@example.com');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Per Epic https://github.com/shopware/shopware/issues/8366 languages are now a part of the core platform, meaning customers can now include their desired languages as part of the installation

### 2. What does this change do, exactly?

Updates the Installation.spec.ts to include the changes to the Web Installer, as well as cleans it up a bit for readability and so it more closely follows our general patterns.

### 3. Describe each step to reproduce the issue or behaviour.

To test - in a working instance:
[Setup](https://github.com/shopware/shopware/issues/8366) Playwright 
delete `install.lock` file 
run `npx playwright test Installation`

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
