### PR TITLE
ci: skip milestone labels in backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -160,7 +160,7 @@ jobs:
               .map(label => label.name.replace('backport-', ''));
 
             const filteredLabels = labels
-              .filter(label => !label.name.startsWith('backport-'))
+              .filter(label => !label.name.startsWith('backport-') && !label.name.startsWith('milestone/'))
               .map(label => label.name);
 
             core.setOutput('target-branches', JSON.stringify(targetBranches));
@@ -211,6 +211,6 @@ jobs:
           reviewers: >- # Add the original assignees, as well as the reviewers of the original PR
             ${{ github.event.pull_request.assignees && format('{0},', join(github.event.pull_request.assignees.*.login, ',')) || '' }}
             ${{ github.event.pull_request.requested_reviewers && join(github.event.pull_request.requested_reviewers.*.login, ',') || '' }}
-          labels: >- # Inherit original labels, except backport ones
+          labels: >- # Inherit original labels, except backport and milestone ones
             ${{ needs.parse-labels.outputs.labels && join(fromJSON(needs.parse-labels.outputs.labels), ',') || '' }}
           dry-run: ${{ github.event.act && true || false }}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when a backport is created, it copies the `milestone/` labels. This sets the wrong milestone on the backport.
e.g. If I want to backport a change to `6.7.3.x` it shouldn't get the `6.7.4.0` milestone.

### 2. What does this change do, exactly?
Ignore the `milestone/` labels in the backport creation.

### 3. Describe each step to reproduce the issue or behaviour.
Backport a change from trunk, which automatically gets the `milestone/6.7.4.0` label.