### PR TITLE
refactor: Allow to inherit cms page slot configs

### DIFF
--- a/changelog/_unreleased/2025-10-01-allow-to-inherit-cms-slot-configs-from-the-shopping-experiences.md
+++ b/changelog/_unreleased/2025-10-01-allow-to-inherit-cms-slot-configs-from-the-shopping-experiences.md
@@ -1,0 +1,8 @@
+---
+title: Allow to inherit CMS slot configs from the shopping experiences
+author: Max
+author_email: max@swk-web-com
+author_github: @aragon999
+---
+# Administration
+* Added the possibility to inherit CMS slot configs from the shopping experiences for products, categories and landing pages

--- a/src/Administration/Resources/app/administration/src/app/init/cms.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/cms.init.ts
@@ -21,6 +21,7 @@ export default function initializeCms(): void {
             appData: {
                 baseUrl: extension.baseUrl,
             },
+            defaultConfig: {},
         });
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -618,7 +618,8 @@ export default {
         async onSave() {
             this.isSaveSuccessful = false;
 
-            // Explicitly set the slot config to null, as the DAL would convert it to an empty array, instead of an empty object
+            // Explicitly set the slot config to null, as the DAL would convert it to an empty array,
+            // instead of an empty object
             if (this.category.slotConfig && Object.keys(this.category.slotConfig).length === 0) {
                 this.category.slotConfig = null;
             }
@@ -695,7 +696,8 @@ export default {
         onSaveLandingPage() {
             this.isSaveSuccessful = false;
 
-            // Explicitly set the slot config to null, as the DAL would convert it to an empty array, instead of an empty object
+            // Explicitly set the slot config to null, as the DAL would convert it to an empty array,
+            // instead of an empty object
             if (this.landingPage.slotConfig && Object.keys(this.landingPage.slotConfig).length === 0) {
                 this.landingPage.slotConfig = null;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -4,7 +4,6 @@ import './sw-category-detail.scss';
 
 const { Context, Mixin } = Shopware;
 const { Criteria, ChangesetGenerator, EntityCollection } = Shopware.Data;
-const { cloneDeep, merge } = Shopware.Utils.object;
 const type = Shopware.Utils.types;
 
 /**
@@ -133,7 +132,7 @@ export default {
                 return this.landingPage.cmsPageId ?? null;
             }
 
-            return this.category ? this.category.cmsPageId : null;
+            return this.category?.cmsPageId;
         },
 
         customFieldSetRepository() {
@@ -396,10 +395,8 @@ export default {
             const criteria = new Criteria(1, 1);
             criteria.setIds([cmsPageId]);
             criteria.addAssociation('previewMedia');
-            criteria.addAssociation('sections');
-            criteria.getAssociation('sections').addSorting(Criteria.sort('position'));
 
-            criteria.addAssociation('sections.blocks');
+            criteria.getAssociation('sections').addSorting(Criteria.sort('position'));
             criteria.getAssociation('sections.blocks').addSorting(Criteria.sort('position', 'ASC')).addAssociation('slots');
 
             return this.cmsPageRepository.search(criteria).then((response) => {
@@ -407,21 +404,6 @@ export default {
 
                 if (cmsPageId !== this.cmsPageId) {
                     return null;
-                }
-
-                if (this.category.slotConfig !== null) {
-                    cmsPage.sections.forEach((section) => {
-                        section.blocks.forEach((block) => {
-                            block.slots.forEach((slot) => {
-                                if (this.category.slotConfig[slot.id]) {
-                                    if (slot.config === null) {
-                                        slot.config = {};
-                                    }
-                                    merge(slot.config, cloneDeep(this.category.slotConfig[slot.id]));
-                                }
-                            });
-                        });
-                    });
                 }
 
                 this.updateCmsPageDataMapping();
@@ -446,10 +428,7 @@ export default {
             const criteria = new Criteria(1, 1);
             criteria.setIds([cmsPageId]);
             criteria.addAssociation('previewMedia');
-            criteria.addAssociation('sections');
             criteria.getAssociation('sections').addSorting(Criteria.sort('position'));
-
-            criteria.addAssociation('sections.blocks');
             criteria
                 .getAssociation('sections.blocks')
                 .addSorting(Criteria.sort('position', 'ASC'))
@@ -460,21 +439,6 @@ export default {
                 const cmsPage = response.get(cmsPageId);
                 if (cmsPageId !== this.cmsPageId) {
                     return null;
-                }
-
-                if (this.landingPage.slotConfig !== null) {
-                    cmsPage.sections.forEach((section) => {
-                        section.blocks.forEach((block) => {
-                            block.slots.forEach((slot) => {
-                                if (this.landingPage.slotConfig[slot.id]) {
-                                    if (slot.config === null) {
-                                        slot.config = {};
-                                    }
-                                    merge(slot.config, cloneDeep(this.landingPage.slotConfig[slot.id]));
-                                }
-                            });
-                        });
-                    });
                 }
 
                 this.updateCmsPageDataMappingForLandingPage();
@@ -654,10 +618,9 @@ export default {
         async onSave() {
             this.isSaveSuccessful = false;
 
-            const pageOverrides = this.getCmsPageOverrides();
-
-            if (type.isPlainObject(pageOverrides)) {
-                this.category.slotConfig = cloneDeep(pageOverrides);
+            // Explicitly set the slot config to null, as the DAL would convert it to an empty array, instead of an empty object
+            if (this.category.slotConfig && Object.keys(this.category.slotConfig).length === 0) {
+                this.category.slotConfig = null;
             }
 
             if (!this.entryPointOverwriteConfirmed) {
@@ -732,10 +695,9 @@ export default {
         onSaveLandingPage() {
             this.isSaveSuccessful = false;
 
-            const pageOverrides = this.getCmsPageOverrides();
-
-            if (type.isPlainObject(pageOverrides)) {
-                this.landingPage.slotConfig = cloneDeep(pageOverrides);
+            // Explicitly set the slot config to null, as the DAL would convert it to an empty array, instead of an empty object
+            if (this.landingPage.slotConfig && Object.keys(this.landingPage.slotConfig).length === 0) {
+                this.landingPage.slotConfig = null;
             }
 
             if (this.landingPageId !== 'create') {
@@ -794,6 +756,9 @@ export default {
             });
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Unused and will be removed
+         */
         getCmsPageOverrides() {
             if (this.cmsPage === null) {
                 return null;
@@ -825,6 +790,9 @@ export default {
             return slotOverrides;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Unused and will be removed
+         */
         deleteSpecifcKeys(sections) {
             if (!sections) {
                 return;

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-cms/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-cms/index.js
@@ -25,5 +25,15 @@ export default {
         cmsPage() {
             return Shopware.Store.get('cmsPage').currentPage;
         },
+
+        cmsElementConfig() {
+            const category = this.category;
+
+            if (!category.slotConfig) {
+                category.slotConfig = {};
+            }
+
+            return category.slotConfig;
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-cms/sw-category-detail-cms.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-cms/sw-category-detail-cms.html.twig
@@ -12,6 +12,7 @@
     <sw-cms-page-form
         v-if="cmsPage && acl.can('category.editor')"
         :page="cmsPage"
+        :entity-config="cmsElementConfig"
     />
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-cms/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-cms/index.js
@@ -23,5 +23,15 @@ export default {
         cmsPage() {
             return Shopware.Store.get('cmsPage').currentPage;
         },
+
+        cmsElementConfig() {
+            const landingPage = this.landingPage;
+
+            if (!landingPage.slotConfig) {
+                landingPage.slotConfig = {};
+            }
+
+            return landingPage.slotConfig;
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-cms/sw-landing-page-detail-cms.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-cms/sw-landing-page-detail-cms.html.twig
@@ -14,6 +14,7 @@
     <sw-cms-page-form
         v-if="cmsPage"
         :page="cmsPage"
+        :entity-config="cmsElementConfig"
     />
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
@@ -100,13 +100,11 @@ export default Shopware.Component.wrapComponentConfig({
                 return false;
             }
 
-            for (const element of block.slots) {
-                if (this.entityConfig.hasOwnProperty(element.id)) {
-                    return false;
-                }
-            }
+            const hasOwnConfig = block.slots.some((element) => {
+                return Object.prototype.hasOwnProperty.call(this.entityConfig, element.id);
+            });
 
-            return true;
+            return !hasOwnConfig;
         },
 
         restoreBlockInheritance(block: Entity<'cms_block'>) {
@@ -114,27 +112,22 @@ export default Shopware.Component.wrapComponentConfig({
                 return;
             }
 
-            let hasChanges = false;
-            for (const element of block.slots) {
+            const hasChanges = block.slots.some((element) => {
                 const elementChanges = getObjectDiff(this.entityConfig[element.id], element.config);
-
-                if (Object.keys(elementChanges).length) {
-                    hasChanges = true;
-                    break;
-                }
-            }
+                return Object.keys(elementChanges).length > 0;
+            });
 
             if (!hasChanges) {
-                for (const element of block.slots) {
+                block.slots.forEach((element) => {
                     delete this.entityConfig[element.id];
-                }
+                });
 
                 return;
             }
 
-            for (const element of block.slots) {
+            block.slots.forEach((element) => {
                 this.restoreBlockInheritanceIds.push(element.id);
-            }
+            });
         },
 
         removeBlockInheritance(block: Entity<'cms_block'>) {
@@ -142,9 +135,9 @@ export default Shopware.Component.wrapComponentConfig({
                 return;
             }
 
-            for (const element of block.slots) {
+            block.slots.forEach((element) => {
                 this.entityConfig[element.id] = cloneDeep(element.config) || {};
-            }
+            });
         },
 
         slotConfig(slot: Entity<'cms_slot'>) {
@@ -161,21 +154,21 @@ export default Shopware.Component.wrapComponentConfig({
 
             const defaultConfig = this.cmsElements[slot.type]?.defaultConfig;
             if (defaultConfig instanceof Object && slotElement.config) {
-                for (const configKey in defaultConfig) {
-                    if (!slotElement.config.hasOwnProperty(configKey)) {
+                Object.keys(defaultConfig).forEach((configKey) => {
+                    if (!Object.prototype.hasOwnProperty.call(slotElement.config, configKey)) {
                         // @ts-expect-error
                         slotElement.config[configKey] = defaultConfig[configKey];
                     }
-                }
+                });
             }
 
             return slotElement;
         },
 
         onConfirmRestoreBlockInheritance() {
-            for (const elementId of this.restoreBlockInheritanceIds) {
+            this.restoreBlockInheritanceIds.forEach((elementId) => {
                 delete this.entityConfig[elementId];
-            }
+            });
 
             this.restoreBlockInheritanceIds = [];
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
@@ -32,7 +32,7 @@ export default Shopware.Component.wrapComponentConfig({
     data: () => {
         return {
             restoreBlockInheritanceIds: [] as string[],
-        }
+        };
     },
 
     computed: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
@@ -113,7 +113,9 @@ export default Shopware.Component.wrapComponentConfig({
             }
 
             const hasChanges = block.slots.some((element) => {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 const elementChanges = getObjectDiff(this.entityConfig[element.id], element.config);
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 return Object.keys(elementChanges).length > 0;
             });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
@@ -1,5 +1,6 @@
 import template from './sw-cms-page-form.html.twig';
 import './sw-cms-page-form.scss';
+const { cloneDeep, getObjectDiff } = Shopware.Utils.object;
 
 /**
  * @private
@@ -15,11 +16,22 @@ export default Shopware.Component.wrapComponentConfig({
             type: Object as PropType<Entity<'cms_page'>>,
             required: true,
         },
+        entityConfig: {
+            type: Object,
+            required: false,
+            default: null,
+        },
         elementUpdate: {
             type: Function,
             required: false,
             default: () => {},
         },
+    },
+
+    data: () => {
+        return {
+            restoreBlockInheritanceIds: [] as string[],
+        }
     },
 
     computed: {
@@ -80,6 +92,95 @@ export default Shopware.Component.wrapComponentConfig({
             }
 
             return '';
+        },
+
+        isInherited(block: Entity<'cms_block'>) {
+            if (this.entityConfig === null || !block.slots) {
+                return false;
+            }
+
+            for (const element of block.slots) {
+                if (this.entityConfig.hasOwnProperty(element.id)) {
+                    return false;
+                }
+            }
+
+            return true;
+        },
+
+        restoreBlockInheritance(block: Entity<'cms_block'>) {
+            if (!block.slots) {
+                return;
+            }
+
+            let hasChanges = false;
+            for (const element of block.slots) {
+                const elementChanges = getObjectDiff(this.entityConfig[element.id], element.config);
+
+                if (Object.keys(elementChanges).length) {
+                    hasChanges = true;
+                    break;
+                }
+            }
+
+            if (!hasChanges) {
+                for (const element of block.slots) {
+                    delete this.entityConfig[element.id];
+                }
+
+                return;
+            }
+
+            for (const element of block.slots) {
+                this.restoreBlockInheritanceIds.push(element.id);
+            }
+        },
+
+        removeBlockInheritance(block: Entity<'cms_block'>) {
+            if (!block.slots) {
+                return;
+            }
+
+            for (const element of block.slots) {
+                this.entityConfig[element.id] = cloneDeep(element.config) || {};
+            }
+        },
+
+        slotConfig(slot: Entity<'cms_slot'>) {
+            // Fallback to old behavior if no entityConfig is set, and directly mutate the reference
+            if (this.entityConfig === null) {
+                return slot;
+            }
+
+            const slotElement = cloneDeep(slot);
+
+            if (this.entityConfig[slot.id]) {
+                slotElement['config'] = this.entityConfig[slot.id];
+            }
+
+            const defaultConfig = this.cmsElements[slot.type]?.defaultConfig;
+            if (defaultConfig instanceof Object && slotElement.config) {
+                for (const configKey in defaultConfig) {
+                    if (!slotElement.config.hasOwnProperty(configKey)) {
+                        // @ts-ignore
+                        slotElement.config[configKey] = defaultConfig[configKey];
+                    }
+                }
+            }
+
+            return slotElement;
+        },
+
+        onConfirmRestoreBlockInheritance() {
+            for (const elementId of this.restoreBlockInheritanceIds) {
+                delete this.entityConfig[elementId];
+            }
+
+            this.restoreBlockInheritanceIds = [];
+        },
+
+        onCancelRestoreBlockInheritance() {
+            this.restoreBlockInheritanceIds = [];
         },
 
         displaySectionType(block: Entity<'cms_block'>) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
@@ -1,5 +1,6 @@
 import template from './sw-cms-page-form.html.twig';
 import './sw-cms-page-form.scss';
+
 const { cloneDeep, getObjectDiff } = Shopware.Utils.object;
 
 /**
@@ -155,14 +156,14 @@ export default Shopware.Component.wrapComponentConfig({
             const slotElement = cloneDeep(slot);
 
             if (this.entityConfig[slot.id]) {
-                slotElement['config'] = this.entityConfig[slot.id];
+                slotElement.config = this.entityConfig[slot.id];
             }
 
             const defaultConfig = this.cmsElements[slot.type]?.defaultConfig;
             if (defaultConfig instanceof Object && slotElement.config) {
                 for (const configKey in defaultConfig) {
                     if (!slotElement.config.hasOwnProperty(configKey)) {
-                        // @ts-ignore
+                        // @ts-expect-error
                         slotElement.config[configKey] = defaultConfig[configKey];
                     }
                 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
@@ -138,7 +138,7 @@
                     {% block sw_cms_page_form_card_content %}
                     <div
                         v-for="(element, blockIndex) in block.slots"
-                        :blockIndex="blockIndex"
+                        :key="blockIndex"
                         class="sw-cms-page-form__element-config"
                         :disabled="isInherited(block)"
                     >

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
@@ -108,6 +108,22 @@
                     class="sw-cms-page-form__block-card"
                     :title="$tc(getBlockTitle(block))"
                 >
+                    <template #title>
+                        <div class="mt-card__title">
+                            <sw-inheritance-switch
+                                v-if="entityConfig !== null"
+                                :is-inherited="isInherited(block)"
+                                class="sw-inherit-wrapper__inheritance-icon"
+                                @inheritance-restore="restoreBlockInheritance(block)"
+                                @inheritance-remove="removeBlockInheritance(block)"
+                            />
+
+                            {{ $tc(getBlockTitle(block)) }}
+
+                            <sw-ai-copilot-badge v-if="aiBadge" />
+                        </div>
+                    </template>
+
                     <template #headerRight>
                         <div class="sw-cms-page-form__block-device-actions">
                             <mt-icon :name="getDeviceActive('mobile', section, block)" />
@@ -116,15 +132,16 @@
 
                             <mt-icon :name="getDeviceActive('desktop', section, block)" />
                         </div>
+
                     </template>
 
                     {% block sw_cms_page_form_card_content %}
                     <div
                         v-for="(element, blockIndex) in block.slots"
-                        :key="blockIndex"
+                        :blockIndex="blockIndex"
                         class="sw-cms-page-form__element-config"
+                        :disabled="isInherited(block)"
                     >
-
                         <template v-if="displayNotification(section, block)">
                             <mt-banner variant="info">
                                 {{ $tc('sw-cms.blocks.blockDisableState') }}
@@ -134,7 +151,7 @@
                         {% block sw_cms_page_form_element_config %}
                         <component
                             :is="cmsElements[element.type].configComponent"
-                            :element="element"
+                            :element="slotConfig(element)"
                             :element-data="cmsElements[element.type]"
                             @element-update="elementUpdate"
                         />
@@ -148,5 +165,14 @@
         {% endblock %}
     </template>
     {% endblock %}
+
+    <sw-confirm-modal
+        v-if="restoreBlockInheritanceIds.length"
+        type="yesno"
+        :text="$tc('sw-cms.general.restoreBlockInheritanceWarning')"
+        @confirm="onConfirmRestoreBlockInheritance"
+        @close="onCancelRestoreBlockInheritance"
+        @cancel="onCancelRestoreBlockInheritance"
+    />
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
@@ -37,6 +37,19 @@
         margin-bottom: 22px;
         border-bottom: 1px solid $color-gray-300;
 
+        &[disabled="true"]:after {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: unset;
+            background: var(--color-gray-300);
+            opacity: 0.4;
+            z-index: 5;
+        }
+
         &:last-child {
             margin-bottom: 0;
             border-bottom: 0 none;
@@ -49,10 +62,15 @@
     }
 
     .mt-card .mt-card__title {
+        display: flex;
         width: auto;
         position: static;
         text-align: left;
         font-size: 22px;
+
+        .sw-inherit-wrapper__inheritance-icon {
+            margin: -1px 8px 0 0;
+        }
     }
 
     .sw-cms-page-form__block-card {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
@@ -37,7 +37,7 @@
         margin-bottom: 22px;
         border-bottom: 1px solid $color-gray-300;
 
-        &[disabled="true"]:after {
+        &[disabled="true"]::after {
             content: "";
             position: absolute;
             top: 0;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.spec.js
@@ -68,6 +68,7 @@ async function createWrapper() {
                             'elementData',
                         ],
                     },
+                    'sw-inheritance-switch': true,
                     'sw-extension-component-section': true,
                 },
                 provide: {
@@ -142,5 +143,93 @@ describe('module/sw-cms/component/sw-cms-page-form', () => {
 
         expect(formDeviceActions.exists()).toBeTruthy();
         expect(blockFormDeviceActions.exists()).toBeTruthy();
+    });
+
+    it('disables element config when block is inherited and shows inheritance switch', async () => {
+        const wrapper = await mount(
+            await wrapTestComponent('sw-cms-page-form', { sync: true }),
+            {
+                props: {
+                    page: defaultPage,
+                    entityConfig: {},
+                },
+                global: {
+                    stubs: {
+                        'sw-cms-el-config-text': {
+                            template: '<div class="sw-cms-el-config-text">Config element</div>',
+                            props: ['element', 'elementData'],
+                        },
+                        'sw-inheritance-switch': true,
+                        'sw-extension-component-section': true,
+                    },
+                    provide: {
+                        cmsService: {
+                            getCmsBlockRegistry: () => ({}),
+                            getCmsElementRegistry: () => ({
+                                text: { configComponent: 'sw-cms-el-config-text' },
+                            }),
+                        },
+                    },
+                },
+            },
+        );
+
+        const elementConfig = wrapper.find('.sw-cms-page-form__element-config');
+        expect(elementConfig.exists()).toBeTruthy();
+        // inherited => disabled overlay is applied
+        expect(elementConfig.attributes('disabled')).toBe('true');
+
+        const inheritanceSwitch = wrapper.find('sw-inheritance-switch-stub');
+        expect(inheritanceSwitch.exists()).toBeTruthy();
+    });
+
+    it('applies entity-config overrides to slot element passed to config component', async () => {
+        const pageWithIds = {
+            sections: [{
+                blocks: [{
+                    name: 'BLOCK NAME',
+                    slots: [{ id: 'slot1', type: 'text', config: { content: { value: 'original' } } }],
+                }],
+            }],
+        };
+
+        const wrapper = await mount(
+            await wrapTestComponent('sw-cms-page-form', { sync: true }),
+            {
+                props: {
+                    page: pageWithIds,
+                    entityConfig: {
+                        slot1: { content: { value: 'overridden', source: 'static' } },
+                    },
+                },
+                global: {
+                    stubs: {
+                        'sw-cms-el-config-text': {
+                            template: '<div class="sw-cms-el-config-text">Config element</div>',
+                            props: ['element', 'elementData'],
+                        },
+                        'sw-inheritance-switch': true,
+                        'sw-extension-component-section': true,
+                    },
+                    provide: {
+                        cmsService: {
+                            getCmsBlockRegistry: () => ({}),
+                            getCmsElementRegistry: () => ({
+                                text: { configComponent: 'sw-cms-el-config-text' },
+                            }),
+                        },
+                    },
+                },
+            },
+        );
+
+        const configEl = wrapper.getComponent('.sw-cms-el-config-text');
+        const passedElement = configEl.props('element');
+
+        expect(passedElement).toEqual({
+            id: 'slot1',
+            type: 'text',
+            config: { content: { value: 'overridden', source: 'static' } },
+        });
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.spec.js
@@ -70,6 +70,7 @@ async function createWrapper() {
                     },
                     'sw-inheritance-switch': true,
                     'sw-extension-component-section': true,
+                    'mt-card': true,
                 },
                 provide: {
                     cmsService: {
@@ -161,6 +162,7 @@ describe('module/sw-cms/component/sw-cms-page-form', () => {
                         },
                         'sw-inheritance-switch': true,
                         'sw-extension-component-section': true,
+                        'mt-card': true,
                     },
                     provide: {
                         cmsService: {
@@ -210,6 +212,7 @@ describe('module/sw-cms/component/sw-cms-page-form', () => {
                         },
                         'sw-inheritance-switch': true,
                         'sw-extension-component-section': true,
+                        'mt-card': true,
                     },
                     provide: {
                         cmsService: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.spec.js
@@ -147,34 +147,34 @@ describe('module/sw-cms/component/sw-cms-page-form', () => {
     });
 
     it('disables element config when block is inherited and shows inheritance switch', async () => {
-        const wrapper = await mount(
-            await wrapTestComponent('sw-cms-page-form', { sync: true }),
-            {
-                props: {
-                    page: defaultPage,
-                    entityConfig: {},
-                },
-                global: {
-                    stubs: {
-                        'sw-cms-el-config-text': {
-                            template: '<div class="sw-cms-el-config-text">Config element</div>',
-                            props: ['element', 'elementData'],
-                        },
-                        'sw-inheritance-switch': true,
-                        'sw-extension-component-section': true,
-                        'mt-card': true,
+        const wrapper = await mount(await wrapTestComponent('sw-cms-page-form', { sync: true }), {
+            props: {
+                page: defaultPage,
+                entityConfig: {},
+            },
+            global: {
+                stubs: {
+                    'sw-cms-el-config-text': {
+                        template: '<div class="sw-cms-el-config-text">Config element</div>',
+                        props: [
+                            'element',
+                            'elementData',
+                        ],
                     },
-                    provide: {
-                        cmsService: {
-                            getCmsBlockRegistry: () => ({}),
-                            getCmsElementRegistry: () => ({
-                                text: { configComponent: 'sw-cms-el-config-text' },
-                            }),
-                        },
+                    'sw-inheritance-switch': true,
+                    'sw-extension-component-section': true,
+                    'mt-card': true,
+                },
+                provide: {
+                    cmsService: {
+                        getCmsBlockRegistry: () => ({}),
+                        getCmsElementRegistry: () => ({
+                            text: { configComponent: 'sw-cms-el-config-text' },
+                        }),
                     },
                 },
             },
-        );
+        });
 
         const elementConfig = wrapper.find('.sw-cms-page-form__element-config');
         expect(elementConfig.exists()).toBeTruthy();
@@ -187,44 +187,48 @@ describe('module/sw-cms/component/sw-cms-page-form', () => {
 
     it('applies entity-config overrides to slot element passed to config component', async () => {
         const pageWithIds = {
-            sections: [{
-                blocks: [{
-                    name: 'BLOCK NAME',
-                    slots: [{ id: 'slot1', type: 'text', config: { content: { value: 'original' } } }],
-                }],
-            }],
+            sections: [
+                {
+                    blocks: [
+                        {
+                            name: 'BLOCK NAME',
+                            slots: [{ id: 'slot1', type: 'text', config: { content: { value: 'original' } } }],
+                        },
+                    ],
+                },
+            ],
         };
 
-        const wrapper = await mount(
-            await wrapTestComponent('sw-cms-page-form', { sync: true }),
-            {
-                props: {
-                    page: pageWithIds,
-                    entityConfig: {
-                        slot1: { content: { value: 'overridden', source: 'static' } },
-                    },
+        const wrapper = await mount(await wrapTestComponent('sw-cms-page-form', { sync: true }), {
+            props: {
+                page: pageWithIds,
+                entityConfig: {
+                    slot1: { content: { value: 'overridden', source: 'static' } },
                 },
-                global: {
-                    stubs: {
-                        'sw-cms-el-config-text': {
-                            template: '<div class="sw-cms-el-config-text">Config element</div>',
-                            props: ['element', 'elementData'],
-                        },
-                        'sw-inheritance-switch': true,
-                        'sw-extension-component-section': true,
-                        'mt-card': true,
+            },
+            global: {
+                stubs: {
+                    'sw-cms-el-config-text': {
+                        template: '<div class="sw-cms-el-config-text">Config element</div>',
+                        props: [
+                            'element',
+                            'elementData',
+                        ],
                     },
-                    provide: {
-                        cmsService: {
-                            getCmsBlockRegistry: () => ({}),
-                            getCmsElementRegistry: () => ({
-                                text: { configComponent: 'sw-cms-el-config-text' },
-                            }),
-                        },
+                    'sw-inheritance-switch': true,
+                    'sw-extension-component-section': true,
+                    'mt-card': true,
+                },
+                provide: {
+                    cmsService: {
+                        getCmsBlockRegistry: () => ({}),
+                        getCmsElementRegistry: () => ({
+                            text: { configComponent: 'sw-cms-el-config-text' },
+                        }),
                     },
                 },
             },
-        );
+        });
 
         const configEl = wrapper.getComponent('.sw-cms-el-config-text');
         const passedElement = configEl.props('element');

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
@@ -85,6 +85,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
                 value: null,
             },
             overrideFromCategory: 'bar',
+            overrideFromProp: 'foo',
         };
 
         const wrapper = await createWrapper(defaultElement, 'sw.category.detail');

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -135,11 +135,12 @@ export default Mixin.register(
                 )
 
                 this.element.config = this.element.config || {};
-                for (const configKey in fallbackConfig) {
-                    if (!this.element.config.hasOwnProperty(configKey) && fallbackConfig.hasOwnProperty(configKey)) {
+                Object.keys(fallbackConfig).forEach((configKey) => {
+                    if (!Object.prototype.hasOwnProperty.call(this.element.config, configKey)
+                        && Object.prototype.hasOwnProperty.call(fallbackConfig, configKey)) {
                         this.element.config[configKey] = fallbackConfig[configKey];
                     }
-                }
+                });
             },
 
             initElementData(elementName: string) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -119,9 +119,27 @@ export default Mixin.register(
 
         methods: {
             initElementConfig(elementName: string) {
-                const defaultConfig = this.defaultConfig || this.cmsElements[elementName]?.defaultConfig || {};
+                let fallbackCategoryConfig = {};
+                if (this.category?.translations) {
+                    // @ts-expect-error
+                    // eslint-disable-next-line max-len
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
+                    fallbackCategoryConfig = this.getDefaultTranslations(this.category)?.slotConfig?.[this.element.id];
+                }
 
-                this.element.config = merge(cloneDeep(defaultConfig), cloneDeep(this.configOverride));
+                const fallbackConfig = merge(
+                    {},
+                    this.defaultConfig || this.cmsElements[elementName]?.defaultConfig || {},
+                    fallbackCategoryConfig,
+                    this.element?.translated?.config || {},
+                )
+
+                this.element.config = this.element.config || {};
+                for (const configKey in fallbackConfig) {
+                    if (!this.element.config.hasOwnProperty(configKey) && fallbackConfig.hasOwnProperty(configKey)) {
+                        this.element.config[configKey] = fallbackConfig[configKey];
+                    }
+                }
             },
 
             initElementData(elementName: string) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -132,12 +132,14 @@ export default Mixin.register(
                     this.defaultConfig || this.cmsElements[elementName]?.defaultConfig || {},
                     fallbackCategoryConfig,
                     this.element?.translated?.config || {},
-                )
+                );
 
                 this.element.config = this.element.config || {};
                 Object.keys(fallbackConfig).forEach((configKey) => {
-                    if (!Object.prototype.hasOwnProperty.call(this.element.config, configKey)
-                        && Object.prototype.hasOwnProperty.call(fallbackConfig, configKey)) {
+                    if (
+                        !Object.prototype.hasOwnProperty.call(this.element.config, configKey) &&
+                        Object.prototype.hasOwnProperty.call(fallbackConfig, configKey)
+                    ) {
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                         this.element.config[configKey] = fallbackConfig[configKey];
                     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -138,6 +138,7 @@ export default Mixin.register(
                 Object.keys(fallbackConfig).forEach((configKey) => {
                     if (!Object.prototype.hasOwnProperty.call(this.element.config, configKey)
                         && Object.prototype.hasOwnProperty.call(fallbackConfig, configKey)) {
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                         this.element.config[configKey] = fallbackConfig[configKey];
                     }
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
@@ -49,7 +49,7 @@ type CmsElementConfig = {
         collectionMap: { [key: string]: EntityCollection<EntityName> },
     ) => void;
     allowedPageTypes?: string[];
-    defaultConfig?: {[index: string]: object};
+    defaultConfig?: { [index: string]: object };
     disabledConfigInfoTextKey?: string;
     defaultData?: unknown;
     hidden?: boolean;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
@@ -49,7 +49,7 @@ type CmsElementConfig = {
         collectionMap: { [key: string]: EntityCollection<EntityName> },
     ) => void;
     allowedPageTypes?: string[];
-    defaultConfig?: unknown;
+    defaultConfig?: {[index: string]: object};
     disabledConfigInfoTextKey?: string;
     defaultData?: unknown;
     hidden?: boolean;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
@@ -6,6 +6,7 @@
       "moduleTitle": "Erlebniswelten",
       "greeting": "Layouts",
       "createNewLayout": "Neues Layout anlegen",
+      "restoreBlockInheritanceWarning": "Dies setzt alle, individuell konfigurierten Einstellungen in dem Block auf die Werte aus dem Layout zurück, auch wenn die Vererbung wieder aufgehoben wird. Um das Rückgängig zu machen, kann die Seite neu geladen werden oder die Bearbeitung abgebrochen werden. Dabei werden jedoch auch alle anderen nicht gespeicherten Änderungen Rückgängig gemacht.",
       "deleteDisabledToolTip": "Das Layout ist noch mindestens einer Kategorie zugewiesen.",
       "deleteDisabledProductToolTip": "Das Layout ist noch mindestens einem Produkt zugewiesen.",
       "deleteDisabledLandingPageToolTip": "Das Layout ist noch mindestens einer Landingpage zugewiesen.",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
@@ -6,6 +6,7 @@
       "moduleTitle": "Shopping Experiences",
       "greeting": "Layouts",
       "createNewLayout": "Create new layout",
+      "restoreBlockInheritanceWarning": "This resets all individual configured settings of this block to the values from the layout, even if the inheritance is removed again. This can be reverted by reloading the page or canceling the current action. However, then also all other unsaved changes will be reverted.",
       "deleteDisabledToolTip": "The layout you want to delete is still assigned to at least one category.",
       "deleteDisabledProductToolTip": "The layout you want to delete is still assigned to at least one product.",
       "deleteDisabledLandingPageToolTip": "The layout you want to delete is still assigned to at least one landing page.",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -975,10 +975,9 @@ export default {
 
             this.isSaveSuccessful = false;
 
-            const pageOverrides = this.getCmsPageOverrides();
-
-            if (type.isPlainObject(pageOverrides)) {
-                this.product.slotConfig = cloneDeep(pageOverrides);
+            // Explicitly set the slot config to null, as the DAL would convert it to an empty array, instead of an empty object
+            if (this.product.slotConfig && Object.keys(this.product.slotConfig).length === 0) {
+                this.product.slotConfig = null;
             }
 
             if (!this.entityValidationService.validate(this.product, this.customValidate, this.ignoreFieldsValidation)) {
@@ -1260,6 +1259,9 @@ export default {
             return true;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Unused and will be removed
+         */
         getCmsPageOverrides() {
             if (this.currentPage === null) {
                 return null;
@@ -1292,6 +1294,9 @@ export default {
             return slotOverrides;
         },
 
+        /**
+         * @deprecated tag:v6.8.0 - Unused and will be removed
+         */
         deleteSpecifcKeys(sections) {
             if (!sections) {
                 return;

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -975,7 +975,8 @@ export default {
 
             this.isSaveSuccessful = false;
 
-            // Explicitly set the slot config to null, as the DAL would convert it to an empty array, instead of an empty object
+            // Explicitly set the slot config to null, as the DAL would convert it to an empty array,
+            // instead of an empty object
             if (this.product.slotConfig && Object.keys(this.product.slotConfig).length === 0) {
                 this.product.slotConfig = null;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/index.js
@@ -7,7 +7,7 @@ import './sw-product-detail-layout.scss';
 
 const { Context, Utils } = Shopware;
 const { Criteria } = Shopware.Data;
-const { cloneDeep, merge, get } = Utils.object;
+const { get } = Utils.object;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
@@ -178,8 +178,9 @@ export default {
         },
 
         /**
-         * @deprecated tag:v6.8.0 - Will be removed, as the listener is not needed anymore, will also not be called anymore, i.e. removed from the template
+         * @deprecated tag:v6.8.0 - Will be removed, as the listener is not needed anymore,
+         * will also not be called anymore, i.e. should be removed from the twig template
          */
-        elementUpdate(element) {},
+        elementUpdate() {},
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/index.js
@@ -51,10 +51,8 @@ export default {
         cmsPageCriteria() {
             const criteria = new Criteria(1, 25);
             criteria.addAssociation('previewMedia');
-            criteria.addAssociation('sections');
             criteria.getAssociation('sections').addSorting(Criteria.sort('position'));
 
-            criteria.addAssociation('sections.blocks');
             criteria.getAssociation('sections.blocks').addSorting(Criteria.sort('position', 'ASC')).addAssociation('slots');
 
             return criteria;
@@ -70,6 +68,16 @@ export default {
 
         cmsPageState() {
             return Shopware.Store.get('cmsPage');
+        },
+
+        cmsElementConfig() {
+            const product = this.product;
+
+            if (!product.slotConfig) {
+                product.slotConfig = {};
+            }
+
+            return product.slotConfig;
         },
     },
 
@@ -153,21 +161,6 @@ export default {
             this.isConfigLoading = true;
 
             this.cmsPageRepository.get(this.cmsPageId, Context.api, this.cmsPageCriteria).then((cmsPage) => {
-                if (this.product.slotConfig && cmsPage) {
-                    cmsPage.sections.forEach((section) => {
-                        section.blocks.forEach((block) => {
-                            block.slots.forEach((slot) => {
-                                if (!this.product.slotConfig[slot.id]) {
-                                    return;
-                                }
-
-                                slot.config = slot.config || {};
-                                merge(slot.config, cloneDeep(this.product.slotConfig[slot.id]));
-                            });
-                        });
-                    });
-                }
-
                 this.cmsPageState.setCurrentPage(cmsPage);
                 this.updateCmsPageDataMapping();
                 this.isConfigLoading = false;
@@ -184,11 +177,9 @@ export default {
             this.onSelectLayout(null);
         },
 
-        elementUpdate(element) {
-            const slotContent = this.product.slotConfig[element.id]?.content;
-            if (slotContent && slotContent.value) {
-                slotContent.value = element.config.content.value;
-            }
-        },
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed, as the listener is not needed anymore, will also not be called anymore, i.e. removed from the template
+         */
+        elementUpdate(element) {},
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.html.twig
@@ -44,6 +44,7 @@
             v-if="showCmsForm"
             :page="currentPage"
             :element-update="elementUpdate"
+            :entity-config="cmsElementConfig"
         />
 
         <mt-card

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.spec.js
@@ -203,7 +203,7 @@ describe('src/module/sw-product/view/sw-product-detail-layout', () => {
         expect(wrapper.vm.product.cmsPageId).toBeNull();
     });
 
-    it('should be able to overwrite product config to selected layout config', async () => {
+    it('passes entity-config to cms form and does not mutate CMS page slot config', async () => {
         Shopware.Store.get('swProductDetail').product = {
             id: '1',
             cmsPageId: 'cmsPageId',
@@ -217,15 +217,22 @@ describe('src/module/sw-product/view/sw-product-detail-layout', () => {
             },
         };
 
-        const wrapper = await createWrapper();
+        const wrapper = await createWrapper(['product.editor']);
         await wrapper.vm.handleGetCmsPage();
 
+        // CMS page slot config remains unchanged (no merge into page data)
         expect(wrapper.vm.currentPage.sections[0].blocks[0].slots[0].config).toEqual({
             content: {
-                value: 'Hello World',
-                source: 'static',
+                value: 'product.name',
+                source: 'mapped',
             },
         });
+
+        // sw-cms-page-form receives the entity-config prop with product.slotConfig
+        const cmsForm = wrapper.find('sw-cms-page-form-stub');
+        expect(cmsForm.exists()).toBeTruthy();
+        // Vue Test Utils exposes props on stubs as attributes; ensure attribute is present
+        expect(cmsForm.attributes()).toHaveProperty('entity-config');
     });
 
     it('onOpenLayoutModal: should be able to open layout assignment', async () => {
@@ -272,7 +279,7 @@ describe('src/module/sw-product/view/sw-product-detail-layout', () => {
         expect(infoNoConfig.exists()).toBeTruthy();
     });
 
-    it('should update new content of slotConfig in product', async () => {
+    it('elementUpdate is deprecated: calling it does not mutate product.slotConfig', async () => {
         const wrapper = await createWrapper();
 
         Store.get('swProductDetail').product = {
@@ -296,7 +303,7 @@ describe('src/module/sw-product/view/sw-product-detail-layout', () => {
 
         wrapper.vm.elementUpdate(element);
 
-        expect(wrapper.vm.product.slotConfig[element.id].content.value).toBe(element.config.content.value);
+        expect(wrapper.vm.product.slotConfig[element.id].content.value).toBe('InitialValue');
     });
 
     it('should call handleGetCmsPage when languageId changes', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when someones edits a category or product, the layout information is persisted into the `slot_config` of each of the related entities, as a JSON blob. And there is no way to use the original configuration from the Shopping experience. 

This has the consequence, that even if there are no real changes, or one wants to revert this and use the changes from the Shopping experience again, there is no way. 
Making it not possible to change a lot of things on layouts at once.

Furthermore there is no indication if an element has been changed, or where the configuration is coming from.

There have been several attempts in the past to solve this, however none succeeded, hence this new attempt:
- First attempt: https://github.com/shopware/shopware/pull/1024
- Second attempt: https://github.com/shopware/shopware/pull/3369
- Current attempt: https://github.com/shopware/shopware/pull/12688 (which allows for even more fine grained control, however modifications for each config components are needed as far as I can tell, this PR should also make it easier to implement this in the future and may serve as ground work)

Furthermore this PR cleans up a lot of the not needed work around logic which has been added over the time to determine if something should be stored.

### 2. What does this change do, exactly?
Add an inheritance switch to each block, making it possible to restore the inheritance from the Shopping experience and allow to restore the inheritance from the Shopping experience:
<img width="1226" height="792" alt="image" src="https://github.com/user-attachments/assets/e9e18f8c-7e73-4e36-b104-6d195f0d814a" />
<img width="1221" height="766" alt="image" src="https://github.com/user-attachments/assets/57845f16-e5c3-4791-b39b-0f0c546ed24a" />
<img width="850" height="666" alt="image" src="https://github.com/user-attachments/assets/8585dddf-6dda-4823-a9fc-6c76b903772c" />

### 3. Describe each step to reproduce the issue or behaviour.
See 1.

### 4. Please link to the relevant issues (if any).
There are probably a lot of them.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
