### PR TITLE
feat: Add config to always accept the TOS on order confirmation

### DIFF
--- a/changelog/_unreleased/2025-10-02-add-possibility-to-disable-tos-checkbox-on-order-confirmation.md
+++ b/changelog/_unreleased/2025-10-02-add-possibility-to-disable-tos-checkbox-on-order-confirmation.md
@@ -1,0 +1,8 @@
+---
+title: Add possibility to disable TOS checkbox on order confirmation
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Added config `core.cart.showTosCheckbox` to enable/disable TOS checkbox on order confirmation

--- a/src/Core/Migration/V6_7/Migration1759390536CartConfigShowTosCheckbox.php
+++ b/src/Core/Migration/V6_7/Migration1759390536CartConfigShowTosCheckbox.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1759390536CartConfigShowTosCheckbox extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1759390536;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->insertConfig($connection, 'core.cart.showTosCheckbox');
+    }
+
+    private function insertConfig(Connection $connection, string $key): void
+    {
+        $config = $connection->fetchAllAssociativeIndexed(
+            'SELECT `configuration_value` FROM `system_config` WHERE `configuration_key` = ? and `sales_channel_id` is null',
+            [$key]
+        );
+
+        if (!empty($config)) {
+            return;
+        }
+
+        $connection->insert('system_config', [
+            'id' => Uuid::randomBytes(),
+            'configuration_key' => $key,
+            'configuration_value' => json_encode(['_value' => true]),
+            'sales_channel_id' => null,
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+}

--- a/src/Core/System/Resources/config/cart.xml
+++ b/src/Core/System/Resources/config/cart.xml
@@ -55,6 +55,12 @@
         <title lang="de-DE">Bestellabschluss</title>
 
         <input-field type="bool">
+            <name>showTosCheckbox</name>
+            <label>Show required tos checkbox</label>
+            <label lang="de-DE">Erforderliche AGB Checkbox anzeigen</label>
+        </input-field>
+
+        <input-field type="bool">
             <name>showCustomerComment</name>
             <label>Show comment field on checkout confirm page</label>
             <label lang="de-DE">Kommentarfeld auf der Bestellabschlussseite anzeigen</label>

--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -497,7 +497,7 @@
     "confirmTermsText": "Ich habe die <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"AGB\">AGB</a> gelesen und bin mit ihnen einverstanden.",
     "confirmTermsTextModal": "Ich habe die %tosModalTagOpen%AGB%tosModalTagClose% gelesen und bin mit ihnen einverstanden.",
     "confirmTermsTextPage": "Ich habe die <a href=\"%url%\">AGB</a> gelesen und bin mit ihnen einverstanden.",
-    "autoConfirmTermsText": "Mit Ihrer Bestellung akzeptieren Sie unsere %tosModalTagOpen%AGB%tosModalTagClose%.",
+    "autoConfirmTermsText": "Mit Ihrer Bestellung akzeptieren Sie unsere %tosModalTagOpen%AGB%tosModalTagClose% und die %revocationModalTagOpen%Widerrufsbelehrung%revocationModalTagClose%.",
     "confirmTermsReminderText": "Sie haben bereits die <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"AGB\">AGB</a> akzeptiert.",
     "confirmTermsReminderTextModal": "Sie haben bereits die %tosModalTagOpen%AGB%tosModalTagClose% akzeptiert.",
     "confirmRevocationTerms": "Ja, ich möchte sofort Zugang zu dem digitalen Inhalt und weiß, dass mein Widerrufsrecht mit dem Zugang erlischt.",

--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -497,6 +497,7 @@
     "confirmTermsText": "Ich habe die <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"AGB\">AGB</a> gelesen und bin mit ihnen einverstanden.",
     "confirmTermsTextModal": "Ich habe die %tosModalTagOpen%AGB%tosModalTagClose% gelesen und bin mit ihnen einverstanden.",
     "confirmTermsTextPage": "Ich habe die <a href=\"%url%\">AGB</a> gelesen und bin mit ihnen einverstanden.",
+    "autoConfirmTermsText": "Mit Ihrer Bestellung akzeptieren Sie unsere %tosModalTagOpen%AGB%tosModalTagClose%.",
     "confirmTermsReminderText": "Sie haben bereits die <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"AGB\">AGB</a> akzeptiert.",
     "confirmTermsReminderTextModal": "Sie haben bereits die %tosModalTagOpen%AGB%tosModalTagClose% akzeptiert.",
     "confirmRevocationTerms": "Ja, ich möchte sofort Zugang zu dem digitalen Inhalt und weiß, dass mein Widerrufsrecht mit dem Zugang erlischt.",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -497,6 +497,7 @@
     "confirmTermsText": "I have read and accepted the <a class=\"checkout-confirm-terms-modal\" data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\">general terms and conditions</a>.",
     "confirmTermsTextModal": "I have read and accepted the %tosModalTagOpen%general terms and conditions%tosModalTagClose%.",
     "confirmTermsTextPage": "I have read and accepted the <a href=\"%url%\">general terms and conditions</a>.",
+    "autoConfirmTermsText": "By placing your order you accept our %tosModalTagOpen%Terms and Conditions%tosModalTagClose%.",
     "confirmTermsReminderText": "You have already accepted the <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"general terms and conditions\">general terms and conditions</a>.",
     "confirmTermsReminderTextModal": "You have already accepted the %tosModalTagOpen%general terms and conditions%tosModalTagClose%.",
     "confirmRevocationTerms": "I want immediate access to the digital content and I acknowledge that thereby I waive my right to cancel.",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -497,7 +497,7 @@
     "confirmTermsText": "I have read and accepted the <a class=\"checkout-confirm-terms-modal\" data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\">general terms and conditions</a>.",
     "confirmTermsTextModal": "I have read and accepted the %tosModalTagOpen%general terms and conditions%tosModalTagClose%.",
     "confirmTermsTextPage": "I have read and accepted the <a href=\"%url%\">general terms and conditions</a>.",
-    "autoConfirmTermsText": "By placing your order you accept our %tosModalTagOpen%Terms and Conditions%tosModalTagClose%.",
+    "autoConfirmTermsText": "By placing your order you accept our %tosModalTagOpen%Terms and Conditions%tosModalTagClose% and %revocationModalTagOpen%cancellation policy%revocationModalTagClose%.",
     "confirmTermsReminderText": "You have already accepted the <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"general terms and conditions\">general terms and conditions</a>.",
     "confirmTermsReminderTextModal": "You have already accepted the %tosModalTagOpen%general terms and conditions%tosModalTagClose%.",
     "confirmRevocationTerms": "I want immediate access to the digital content and I acknowledge that thereby I waive my right to cancel.",

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -58,28 +58,44 @@
                         {% endblock %}
 
                         {% block page_checkout_confirm_tos_control %}
-                            <div class="form-check">
-                                {% block page_checkout_confirm_tos_control_checkbox %}
-                                    <input type="checkbox"
-                                           class="checkout-confirm-tos-checkbox form-check-input{% if formViolations.getViolations('/tos') is not empty %} is-invalid{% endif %}"
-                                           required="required"
-                                           id="tos"
-                                           form="confirmOrderForm"
-                                           name="tos">
-                                {% endblock %}
+                            {% set tosModalTagOpen = '<button type="button" class="checkout-confirm-terms-modal btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path('frontend.cms.page', { id: config('core.basicInformation.tosPage') }) ~ '">' %}
+                            {% set tosModalTagClose = '</button>' %}
 
-                                {% block page_checkout_confirm_tos_control_label %}
-                                    {% set tosSnippetKey = 'checkout.confirmTermsTextModal' %}
-                                    {% set cmsPath = 'frontend.cms.page' %}
-                                    <label for="tos"
-                                           class="checkout-confirm-tos-label custom-control-label">
-                                        {{ tosSnippetKey|trans({
-                                            '%tosModalTagOpen%': '<button type="button" class="checkout-confirm-terms-modal btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.tosPage') }) ~ '">',
-                                            '%tosModalTagClose%': '</button>'
-                                        })|raw }}
-                                    </label>
+                            {% if config('core.cart.showTosCheckbox') %}
+                                <div class="form-check">
+                                    {% block page_checkout_confirm_tos_control_checkbox %}
+                                        <input type="checkbox"
+                                            class="checkout-confirm-tos-checkbox form-check-input{% if formViolations.getViolations('/tos') is not empty %} is-invalid{% endif %}"
+                                            required="required"
+                                            id="tos"
+                                            form="confirmOrderForm"
+                                            name="tos">
+                                    {% endblock %}
+
+                                    {% block page_checkout_confirm_tos_control_label %}
+                                        <label for="tos"
+                                            class="checkout-confirm-tos-label custom-control-label">
+                                            {{ 'checkout.confirmTermsTextModal'|trans({
+                                                '%tosModalTagOpen%': tosModalTagOpen,
+                                                '%tosModalTagClose%': tosModalTagClose,
+                                            })|raw }}
+                                        </label>
+                                    {% endblock %}
+                                </div>
+                            {% else %}
+                                {% block page_checkout_confirm_tos_auto_confirmed %}
+                                    <input type="hidden" name="tos" value="1" form="confirmOrderForm">
+
+                                    {% block page_checkout_confirm_tos_auto_confirmed_text %}
+                                        <div class="checkout-confirm-tos-information mb-2">
+                                            {{ 'checkout.autoConfirmTermsText'|trans({
+                                                '%tosModalTagOpen%': tosModalTagOpen,
+                                                '%tosModalTagClose%': tosModalTagClose,
+                                            })|raw }}
+                                        </div>
+                                    {% endblock %}
                                 {% endblock %}
-                            </div>
+                            {% endif %}
                         {% endblock %}
 
                         {% block page_checkout_confirm_revocation_control %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -35,33 +35,33 @@
         {% endblock %}
 
         {% block page_checkout_confirm_tos %}
-            <div class="confirm-tos">
-                <div class="card checkout-card">
-                    <div class="card-body">
+            {% if config('core.cart.showTosCheckbox') %}
+                <div class="confirm-tos">
+                    <div class="card checkout-card">
+                        <div class="card-body">
 
-                        {% block page_checkout_confirm_tos_header %}
-                            <div class="card-title">
-                                {{ 'checkout.confirmTermsHeader'|trans|sw_sanitize }}
-                            </div>
-                        {% endblock %}
+                            {% block page_checkout_confirm_tos_header %}
+                                <div class="card-title">
+                                    {{ 'checkout.confirmTermsHeader'|trans|sw_sanitize }}
+                                </div>
+                            {% endblock %}
 
-                        {% block page_checkout_confirm_revocation_notice %}
-                            {% set cmsPath = 'frontend.cms.page' %}
-                            <p class="revocation-notice">
-                                {% set revocationSnippetKey = 'checkout.confirmRevocationNoticeModal' %}
+                            {% block page_checkout_confirm_revocation_notice %}
+                                {% set cmsPath = 'frontend.cms.page' %}
+                                <p class="revocation-notice">
+                                    {% set revocationSnippetKey = 'checkout.confirmRevocationNoticeModal' %}
 
-                                {{ revocationSnippetKey|trans({
-                                    '%revocationModalTagOpen%': '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.revocationPage') }) ~ '">',
-                                    '%revocationModalTagClose%': '</button>'
-                                })|raw }}
-                            </p>
-                        {% endblock %}
+                                    {{ revocationSnippetKey|trans({
+                                        '%revocationModalTagOpen%': '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.revocationPage') }) ~ '">',
+                                        '%revocationModalTagClose%': '</button>'
+                                    })|raw }}
+                                </p>
+                            {% endblock %}
 
-                        {% block page_checkout_confirm_tos_control %}
-                            {% set tosModalTagOpen = '<button type="button" class="checkout-confirm-terms-modal btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path('frontend.cms.page', { id: config('core.basicInformation.tosPage') }) ~ '">' %}
-                            {% set tosModalTagClose = '</button>' %}
+                            {% block page_checkout_confirm_tos_control %}
+                                {% set tosModalTagOpen = '<button type="button" class="checkout-confirm-terms-modal btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path('frontend.cms.page', { id: config('core.basicInformation.tosPage') }) ~ '">' %}
+                                {% set tosModalTagClose = '</button>' %}
 
-                            {% if config('core.cart.showTosCheckbox') %}
                                 <div class="form-check">
                                     {% block page_checkout_confirm_tos_control_checkbox %}
                                         <input type="checkbox"
@@ -82,46 +82,33 @@
                                         </label>
                                     {% endblock %}
                                 </div>
-                            {% else %}
-                                {% block page_checkout_confirm_tos_auto_confirmed %}
-                                    <input type="hidden" name="tos" value="1" form="confirmOrderForm">
+                            {% endblock %}
 
-                                    {% block page_checkout_confirm_tos_auto_confirmed_text %}
-                                        <div class="checkout-confirm-tos-information mb-2">
-                                            {{ 'checkout.autoConfirmTermsText'|trans({
-                                                '%tosModalTagOpen%': tosModalTagOpen,
-                                                '%tosModalTagClose%': tosModalTagClose,
-                                            })|raw }}
-                                        </div>
-                                    {% endblock %}
-                                {% endblock %}
-                            {% endif %}
-                        {% endblock %}
+                            {% block page_checkout_confirm_revocation_control %}
+                                {% if page.showRevocation() %}
+                                    <div class="form-check">
+                                        {% block page_checkout_confirm_revocation_control_checkbox %}
+                                            <input type="checkbox"
+                                                   class="checkout-confirm-revocation-checkbox form-check-input{% if formViolations.getViolations('/revocation') is not empty %} is-invalid{% endif %}"
+                                                   required="required"
+                                                   id="revocation"
+                                                   form="confirmOrderForm"
+                                                   name="revocation">
+                                        {% endblock %}
 
-                        {% block page_checkout_confirm_revocation_control %}
-                            {% if page.showRevocation() %}
-                                <div class="form-check">
-                                    {% block page_checkout_confirm_revocation_control_checkbox %}
-                                        <input type="checkbox"
-                                               class="checkout-confirm-revocation-checkbox form-check-input{% if formViolations.getViolations('/revocation') is not empty %} is-invalid{% endif %}"
-                                               required="required"
-                                               id="revocation"
-                                               form="confirmOrderForm"
-                                               name="revocation">
-                                    {% endblock %}
-
-                                    {% block page_checkout_confirm_revocation_control_label %}
-                                        <label for="revocation"
-                                               class="checkout-confirm-revocation-label custom-control-label">
-                                            {{ 'checkout.confirmRevocationTerms'|trans() }}
-                                        </label>
-                                    {% endblock %}
-                                </div>
-                            {% endif %}
-                        {% endblock %}
+                                        {% block page_checkout_confirm_revocation_control_label %}
+                                            <label for="revocation"
+                                                   class="checkout-confirm-revocation-label custom-control-label">
+                                                {{ 'checkout.confirmRevocationTerms'|trans() }}
+                                            </label>
+                                        {% endblock %}
+                                    </div>
+                                {% endif %}
+                            {% endblock %}
+                        </div>
                     </div>
                 </div>
-            </div>
+            {% endif %}
         {% endblock %}
 
         {% block page_checkout_confirm_address %}
@@ -236,6 +223,29 @@
 {% set confirmOrderFormAction = path('frontend.checkout.finish.order') %}
 
 {% block page_checkout_aside_actions %}
+    {% block page_checkout_confirm_tos_auto_confirmed %}
+        {% if not config('core.cart.showTosCheckbox') %}
+            <input type="hidden" name="tos" value="1" form="confirmOrderForm">
+
+            {% set tosModalTagOpen = '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path('frontend.cms.page', { id: config('core.basicInformation.tosPage') }) ~ '">' %}
+            {% set tosModalTagClose = '</button>' %}
+
+            {% set revocationModalTagOpen = '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path('frontend.cms.page', { id: config('core.basicInformation.revocationPage') }) ~ '">' %}
+            {% set revocationModalTagClose = '</button>' %}
+
+            {% block page_checkout_confirm_tos_auto_confirmed_text %}
+                <div class="checkout-confirm-tos-information my-3 fs-6">
+                    {{ 'checkout.autoConfirmTermsText'|trans({
+                        '%tosModalTagOpen%': tosModalTagOpen,
+                        '%tosModalTagClose%': tosModalTagClose,
+                        '%revocationModalTagOpen%': revocationModalTagOpen,
+                        '%revocationModalTagClose%': revocationModalTagClose,
+                    })|raw }}
+                </div>
+            {% endblock %}
+        {% endif %}
+    {% endblock %}
+
     <div class="checkout-aside-action">
         <form id="confirmOrderForm"
               action="{{ confirmOrderFormAction }}"

--- a/tests/migration/Core/V6_7/Migration1759390536CartConfigShowTosCheckboxTest.php
+++ b/tests/migration/Core/V6_7/Migration1759390536CartConfigShowTosCheckboxTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1759390536CartConfigShowTosCheckbox;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1759390536CartConfigShowTosCheckbox::class)]
+class Migration1759390536CartConfigShowTosCheckboxTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testMigration(): void
+    {
+        $key = 'core.cart.showTosCheckbox';
+
+        $connection = self::getContainer()->get(Connection::class);
+
+        $connection->delete('system_config', ['configuration_key' => $key]);
+
+        $migration = new Migration1759390536CartConfigShowTosCheckbox();
+        $migration->update($connection);
+        $migration->update($connection);
+
+        $newConfiguration = $this->getConditionValues($key);
+        $id = array_key_first($newConfiguration);
+
+        static::assertCount(1, $newConfiguration);
+        static::assertSame(['_value' => true], $newConfiguration[$id]);
+
+        $connection->update(
+            'system_config',
+            ['configuration_value' => '{"_value": false}'],
+            ['id' => Uuid::fromHexToBytes((string) $id)]
+        );
+
+        $migration->update($connection);
+
+        $newConfiguration = $this->getConditionValues($key);
+        $id = array_key_first($newConfiguration);
+
+        static::assertCount(1, $newConfiguration);
+        static::assertSame(['_value' => false], $newConfiguration[$id]);
+    }
+
+    /**
+     * @return array<string, array{'_value': bool}>
+     */
+    private function getConditionValues(string $key): array
+    {
+        return array_map(
+            static fn (string $json) => json_decode($json, true),
+            static::getContainer()->get(Connection::class)->fetchAllKeyValue(
+                'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = :key',
+                ['key' => $key],
+            )
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
See the related details here (German): https://feedback.shopware.com/forums/942607-shopware-6-product-feedback-ideas/suggestions/50063418-checkbox-f%C3%BCr-agb-entfernen-weil-rechtlich-unn%C3%B6tig
And here (also German): https://www.heise.de/hintergrund/Warum-im-Netz-Checkboxen-fuer-AGB-und-Datenschutz-meist-ueberfluessig-sind-10449542.html

### 2. What does this change do, exactly?
Add a configuration to show the checkbox for the TOS or always accept them.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
