### PR TITLE
fix: Support User-agent and other directives in robots.txt

### DIFF
--- a/changelog/release-6-7-1-0/2025-10-02-support-user-agent-in-robots-txt.md
+++ b/changelog/release-6-7-1-0/2025-10-02-support-user-agent-in-robots-txt.md
@@ -1,0 +1,28 @@
+---
+title: Support User-agent and other directives in robots.txt configuration
+issue: 12787
+author: Claude
+author_email: noreply@anthropic.com
+author_github: @anthropics
+---
+# Storefront
+* Added support for all robots.txt directives (User-agent, Crawl-delay, etc.) in `Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct`
+___
+# Upgrade Information
+
+## robots.txt Configuration Now Supports All Directives
+
+Previously, the configurable robots.txt feature only parsed `Allow` and `Disallow` directives, ignoring other valid directives like `User-agent` and `Crawl-delay`.
+
+Now you can use all standard robots.txt directives in your configuration:
+
+```
+User-agent: Googlebot
+Disallow: /private/
+
+User-agent: Bingbot
+Crawl-delay: 10
+Allow: /
+```
+
+Path-based directives (`Allow` and `Disallow`) continue to work with the domain base path as before, while other directives are rendered as-is without path modification.

--- a/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
@@ -52,7 +52,7 @@ class DomainRuleStruct extends Struct
                 $path = $this->basePath . '/' . ltrim($value, '/');
                 $this->rules[] = ['type' => ucfirst($ruleType), 'path' => '/' . ltrim($path, '/')];
             } else {
-                // Handle other directives (User-agent, Crawl-delay, etc.) without base path modification
+                // Handle other directives (User-agent, Crawl-delay, etc.) without base path modification, use the value as it is
                 $this->rules[] = ['type' => ucfirst($ruleType), 'path' => $value];
             }
         }

--- a/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
@@ -39,12 +39,22 @@ class DomainRuleStruct extends Struct
             $rule = explode(':', $rule, 2);
 
             $ruleType = mb_strtolower($rule[0] ?? '');
-            if (!\in_array($ruleType, ['allow', 'disallow'], true)) {
+
+            // Skip empty or invalid rules
+            if ($ruleType === '' || !isset($rule[1])) {
                 continue;
             }
 
-            $path = $this->basePath . '/' . ltrim(trim($rule[1] ?? ''), '/');
-            $this->rules[] = ['type' => ucfirst($ruleType), 'path' => '/' . ltrim($path, '/')];
+            $value = trim($rule[1] ?? '');
+
+            // Handle path-based directives (Allow/Disallow) with base path
+            if (\in_array($ruleType, ['allow', 'disallow'], true)) {
+                $path = $this->basePath . '/' . ltrim($value, '/');
+                $this->rules[] = ['type' => ucfirst($ruleType), 'path' => '/' . ltrim($path, '/')];
+            } else {
+                // Handle other directives (User-agent, Crawl-delay, etc.) without base path modification
+                $this->rules[] = ['type' => ucfirst($ruleType), 'path' => $value];
+            }
         }
     }
 }

--- a/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
@@ -45,7 +45,7 @@ class DomainRuleStruct extends Struct
                 continue;
             }
 
-            $value = trim($rule[1] ?? '');
+            $value = trim($rule[1]);
 
             // Handle path-based directives (Allow/Disallow) with base path
             if (\in_array($ruleType, ['allow', 'disallow'], true)) {

--- a/tests/unit/Storefront/Page/Robots/Struct/DomainRuleStructTest.php
+++ b/tests/unit/Storefront/Page/Robots/Struct/DomainRuleStructTest.php
@@ -107,6 +107,38 @@ class DomainRuleStructTest extends TestCase
                     ['type' => 'Allow', 'path' => '/en/widgets/menu/'],
                 ],
             ],
+            'user-agent directive' => [
+                'User-agent: Googlebot',
+                '',
+                [
+                    ['type' => 'User-agent', 'path' => 'Googlebot'],
+                ],
+            ],
+            'user-agent with disallow rules' => [
+                "User-agent: Googlebot\nDisallow: /private/",
+                '/en',
+                [
+                    ['type' => 'User-agent', 'path' => 'Googlebot'],
+                    ['type' => 'Disallow', 'path' => '/en/private/'],
+                ],
+            ],
+            'crawl-delay directive' => [
+                'Crawl-delay: 10',
+                '',
+                [
+                    ['type' => 'Crawl-delay', 'path' => '10'],
+                ],
+            ],
+            'multiple user-agents with rules' => [
+                "User-agent: Googlebot\nDisallow: /private/\nUser-agent: Bingbot\nAllow: /",
+                '',
+                [
+                    ['type' => 'User-agent', 'path' => 'Googlebot'],
+                    ['type' => 'Disallow', 'path' => '/private/'],
+                    ['type' => 'User-agent', 'path' => 'Bingbot'],
+                    ['type' => 'Allow', 'path' => '/'],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #12787
- Updates robots.txt parser to accept all standard directives (User-agent, Crawl-delay, etc.)
- Maintains backward compatibility for Allow/Disallow directives with base path handling

## Changes
- Modified `DomainRuleStruct::parseRules()` to distinguish between path-based directives (Allow/Disallow) and other directives
- Added test cases for User-agent, Crawl-delay, and mixed directive scenarios
- Added changelog entry documenting the new functionality

## Test plan
- [x] Unit tests pass (14 tests in DomainRuleStructTest)
- [x] Integration tests pass (RobotsControllerTest)
- [x] New test cases cover User-agent and Crawl-delay directives
- [ ] Manual testing: Configure robots.txt with User-agent directives in admin panel and verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)