### PR TITLE
fix: Google storage factory deprecations

### DIFF
--- a/changelog/_unreleased/2025-10-02-change-googlestoragefactory-authentication-to-use-the-serviceaccountcredentials-loader.md
+++ b/changelog/_unreleased/2025-10-02-change-googlestoragefactory-authentication-to-use-the-serviceaccountcredentials-loader.md
@@ -1,0 +1,8 @@
+---
+title: Change GoogleStorageFactory authentication to use the `ServiceAccountCredentials` loader
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed the autentication using a `keyFile` or `keyFilePath` to utilize the `ServiceAccountCredentials` loader for better security 

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/GoogleStorageFactory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/GoogleStorageFactory.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Adapter\Filesystem\Adapter;
 
+use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Cloud\Storage\StorageClient;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\GoogleCloudStorage\GoogleCloudStorageAdapter;
@@ -21,10 +22,27 @@ class GoogleStorageFactory implements AdapterFactoryInterface
 
         $options = $this->resolveStorageConfig($config);
         $storageConfig = ['projectId' => $options['projectId']];
-        if (isset($config['keyFile'])) {
-            $storageConfig['keyFile'] = $options['keyFile'];
-        } else {
-            $storageConfig['keyFilePath'] = $options['keyFilePath'];
+
+        if (isset($options['keyFile']) && \is_array($options['keyFile'])) {
+            $storageConfig['credentialsFetcher'] = new ServiceAccountCredentials(
+                scope: [StorageClient::FULL_CONTROL_SCOPE],
+                jsonKey: $options['keyFile'],
+            );
+        } elseif (isset($options['keyFilePath']) && \is_string($options['keyFilePath']) && $options['keyFilePath'] !== '') {
+            $json = @file_get_contents($options['keyFilePath']);
+            if ($json !== false) {
+                try {
+                    $serviceAccount = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+                    if (\is_array($serviceAccount)) {
+                        $storageConfig['credentialsFetcher'] = new ServiceAccountCredentials(
+                            scope: [StorageClient::FULL_CONTROL_SCOPE],
+                            jsonKey: $serviceAccount,
+                        );
+                    }
+                } catch (\JsonException) {
+                    // Ignore invalid JSON and fall back to ADC
+                }
+            }
         }
 
         // @phpstan-ignore method.deprecated

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/fixtures/keyfile.json
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/fixtures/keyfile.json
@@ -1,8 +1,4 @@
 {
-    "name":"projects/123456789/serviceAccounts/TEST@shopware.iam.gserviceaccount.com/keys/534534534534534",
-    "privateKeyType": "TYPE_GOOGLE_CREDENTIALS_FILE",
-    "privateKeyData":"MHGZZJ . . .",
-    "validBeforeTime": "2028-05-08T21:00:00Z",
-    "validAfterTime": "2016-01-25T18:38:09.000Z",
-    "keyAlgorithm": "KEY_ALG_RSA_2048"
+    "client_email": "foo@bar.de",
+    "private_key": "MHGZZJ . . ."
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
https://github.com/shopware/shopware/actions/runs/18187014763/job/51773360038#step:5:43

### 2. What does this change do, exactly?
Use the dedicated `ServiceAccountCredentials` class to fetch the key.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
