### PR TITLE
fix: package annotation affiliate tracking

### DIFF
--- a/src/Storefront/Framework/AffiliateTracking/AffiliateTrackingListener.php
+++ b/src/Storefront/Framework/AffiliateTracking/AffiliateTrackingListener.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 class AffiliateTrackingListener implements EventSubscriberInterface
 {
     final public const AFFILIATE_CODE_KEY = OrderService::AFFILIATE_CODE_KEY;


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the AffiliateTrackingListener is annotated with framework team, however the entities that use tracking codes (order, customer, cart) and all classes that move that code around (OrderService, RegisterRoute, CartTransformer) fall in your area, only the listener that reads the code from the query param to the session is in framework

### 2. What does this change do, exactly?
It makes sense that we fully own the tracking code implementation

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
