### PR TITLE
fix: proper display of the administrator switch in the user create

### DIFF
--- a/changelog/_unreleased/2025-10-04-fix-proper-display-of-the-administrator-switch-in-the-user-create.md
+++ b/changelog/_unreleased/2025-10-04-fix-proper-display-of-the-administrator-switch-in-the-user-create.md
@@ -1,0 +1,9 @@
+---
+title: Fix proper display of the administrator switch in the user create
+author: Wanne Van Camp
+author_email: info@campit.be
+author_github: @wannevancamp
+---
+
+# Administration
+* Added proper display of the administrator switch in the user create in `src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig`

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
@@ -183,6 +183,7 @@
                             class="sw-settings-user-detail__grid-is-admin"
                             :label="$tc('sw-users-permissions.users.user-detail.labelAdministrator')"
                             :disabled="isCurrentUser || !acl.can('users_and_permissions.editor') || undefined"
+                            bordered
                         />
                         {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Inspired by https://github.com/shopware/shopware/pull/12831 :)

<img width="972" height="518" alt="Image 2025-10-04 22-31-56" src="https://github.com/user-attachments/assets/f273f821-95d8-4908-931a-49dff95190c0" />


### 2. What does this change do, exactly?
<img width="972" height="521" alt="Image 2025-10-04 22-39-51" src="https://github.com/user-attachments/assets/d32284ff-319b-4999-b2d8-6fa645a141c1" />


### 3. Describe each step to reproduce the issue or behaviour.
👀

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
