### PR TITLE
refactor: replace the latest sw-switch-field component with a bool input

### DIFF
--- a/changelog/_unreleased/2025-10-04-replace-latest-sw-switch-field-component-with-bool-input.md
+++ b/changelog/_unreleased/2025-10-04-replace-latest-sw-switch-field-component-with-bool-input.md
@@ -1,0 +1,9 @@
+---
+title: Replace latest sw-switch-field component with bool input
+author: Wanne Van Camp
+author_email: info@campit.be
+author_github: @wannevancamp
+---
+
+# Administration
+* Changed sw-switch-field component from `<component name="sw-switch-field">` to `<input-field type="bool">` in `src/Core/System/Resources/config/basicInformation.xml`

--- a/src/Core/System/Resources/config/basicInformation.xml
+++ b/src/Core/System/Resources/config/basicInformation.xml
@@ -160,50 +160,45 @@
         <title>Security and Privacy</title>
         <title lang="de-DE">Sicherheit und Datenschutz</title>
 
-        <component name="sw-switch-field">
+        <input-field type="bool">
             <name>useDefaultCookieConsent</name>
-            <bordered>bordered</bordered>
             <label>Use default cookie notification</label>
             <label lang="de-DE">Standard-Cookie-Hinweis verwenden</label>
             <helpText>You should deactivate the default cookie notification only if you are using an alternative third-party solution.</helpText>
             <helpText lang="de-DE">Du solltest den Standard-Cookie-Hinweis hier nur deaktivieren, wenn Du eine alternative Drittanbieterlösung verwendest.</helpText>
-        </component>
+        </input-field>
 
-        <component name="sw-switch-field">
+        <input-field type="bool">
             <name>acceptAllCookies</name>
-            <bordered>bordered</bordered>
             <label>Show "Accept all cookies" button</label>
             <label lang="de-DE">"Alle Cookies akzeptieren"-Button anzeigen</label>
             <helpText>Shows a button which allows users to accept all cookies in the storefront</helpText>
             <helpText lang="de-DE">Zeigt einen Button an, der es Nutzern erlaubt alle Cookies in der Storefront zu akzeptieren</helpText>
-        </component>
+        </input-field>
 
-        <component name="sw-switch-field">
+        <input-field type="bool">
             <name>firstNameFieldRequired</name>
-            <bordered>bordered</bordered>
             <label>First name in contact forms required</label>
             <label lang="de-DE">Vorname in Kontaktformularen als Pflichtfeld behandeln</label>
             <helpText>If active, the field "first name" has to be filled in, in order to submit a contact form.</helpText>
             <helpText lang="de-DE">Wenn aktiv, muss das Feld "Vorname" ausgefüllt werden, um ein Kontaktformular absenden zu können.</helpText>
-        </component>
+        </input-field>
 
-        <component name="sw-switch-field">
+        <input-field type="bool">
             <name>lastNameFieldRequired</name>
-            <bordered>bordered</bordered>
             <label>Last name in contact forms required</label>
             <label lang="de-DE">Nachname in Kontaktformularen als Pflichtfeld behandeln</label>
             <helpText>If active, the field "last name" has to be filled in, in order to submit a contact form.</helpText>
             <helpText lang="de-DE">Wenn aktiv, muss das Feld "Nachname" ausgefüllt werden, um ein Kontaktformular absenden zu können.</helpText>
-        </component>
+        </input-field>
 
-        <component name="sw-switch-field">
+        <input-field type="bool">
             <name>phoneNumberFieldRequired</name>
-            <bordered>bordered</bordered>
             <label>Phone number in contact forms required</label>
             <label lang="de-DE">Telefonummer in Kontaktformularen als Pflichtfeld behandeln</label>
             <helpText>If active, the field "phone number" has to be filled in, in order to submit a contact form.</helpText>
             <helpText lang="de-DE">Wenn aktiv, muss das Feld "Telefonnummer" ausgefüllt werden, um ein Kontaktformular absenden zu können.</helpText>
-        </component>
+        </input-field>
     </card>
 
     <card>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, the UX of `<component name="sw-switch-field">` differs from `<input-field type="bool">`. To ensure consistency in the admin interface, the remaining sw-switch-field components should be replaced with bool inputs. This will make the design consistent.
<img width="971" height="188" alt="Image 2025-10-04 22-53-01" src="https://github.com/user-attachments/assets/482050db-ea6c-48f1-a6b5-f198ccc495c8" />


### 2. What does this change do, exactly?
Replace the latest 5 components with a bool input.
<img width="971" height="198" alt="Image 2025-10-04 22-53-36" src="https://github.com/user-attachments/assets/001a141c-af79-446e-bd64-c121db7102bf" />

### 3. Describe each step to reproduce the issue or behaviour.
Navigate to `/admin#/sw/settings/basic/information/index` and check the UX

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
