### PR TITLE
feat: add new twig blocks for product box

### DIFF
--- a/changelog/_unreleased/2025-10-05-add-blocks-to-reduce-code-you-need-to-copy.md
+++ b/changelog/_unreleased/2025-10-05-add-blocks-to-reduce-code-you-need-to-copy.md
@@ -1,0 +1,8 @@
+---
+title: Add more Twig blocks to product box to reduce amount of code to be copied over 
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added blocks `component_product_box_action_buttons` to `storefront/component/product/card/action.html.twig` and `component_product_box_cheapest_price`, `component_product_box_price_label`, `component_product_box_from_price`, `component_product_box_main_price` and `component_product_box_regulation_price` to `storefront/component/product/card/price-unit.html.twig`

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -5,76 +5,78 @@
         {% set displayFrom = product.calculatedPrices.count > 1 %}
         {% set displayBuyButton = isAvailable and not displayFrom and product.childCount <= 0 %}
 
-        {% if displayBuyButton and config('core.listing.allowBuyInListing') %}
-            {% block component_product_box_action_buy %}
-                {# @var product \Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity #}
-                <form action="{{ path('frontend.checkout.line-item.add') }}"
-                      method="post"
-                      class="buy-widget"
-                      data-add-to-cart="true">
-                    {% block component_product_box_action_form %}
-                        {% block component_product_box_action_buy_redirect_input %}
-                            {# fallback redirect back to detail page is deactivated via js #}
-                            <input type="hidden"
-                                   name="redirectTo"
-                                   value="frontend.detail.page">
+        {% block component_product_box_action_buttons %}
+            {% if displayBuyButton and config('core.listing.allowBuyInListing') %}
+                {% block component_product_box_action_buy %}
+                    {# @var product \Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity #}
+                    <form action="{{ path('frontend.checkout.line-item.add') }}"
+                          method="post"
+                          class="buy-widget"
+                          data-add-to-cart="true">
+                        {% block component_product_box_action_form %}
+                            {% block component_product_box_action_buy_redirect_input %}
+                                {# fallback redirect back to detail page is deactivated via js #}
+                                <input type="hidden"
+                                       name="redirectTo"
+                                       value="frontend.detail.page">
 
-                            <input type="hidden"
-                                   name="redirectParameters"
-                                   data-redirect-parameters="true"
-                                   value="{{ {productId: id}|json_encode }}">
-                        {% endblock %}
+                                <input type="hidden"
+                                       name="redirectParameters"
+                                       data-redirect-parameters="true"
+                                       value="{{ {productId: id}|json_encode }}">
+                            {% endblock %}
 
-                        {% block component_product_box_action_buy_info %}
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][id]"
-                                   value="{{ id }}">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][referencedId]"
-                                   value="{{ id }}">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][type]"
-                                   value="product">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][stackable]"
-                                   value="1">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][removable]"
-                                   value="1">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][quantity]"
-                                   value="{{ product.minPurchase }}">
-                        {% endblock %}
+                            {% block component_product_box_action_buy_info %}
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][id]"
+                                       value="{{ id }}">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][referencedId]"
+                                       value="{{ id }}">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][type]"
+                                       value="product">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][stackable]"
+                                       value="1">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][removable]"
+                                       value="1">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][quantity]"
+                                       value="{{ product.minPurchase }}">
+                            {% endblock %}
 
-                        {% block component_product_box_action_buy_meta %}
-                            <input type="hidden"
-                                   name="product-name"
-                                   value="{{ product.translated.name }}">
-                        {% endblock %}
+                            {% block component_product_box_action_buy_meta %}
+                                <input type="hidden"
+                                       name="product-name"
+                                       value="{{ product.translated.name }}">
+                            {% endblock %}
 
-                        {% block component_product_box_action_buy_button %}
-                            <div class="d-grid">
-                                <button class="btn btn-buy">
-                                    {% block page_product_detail_product_buy_button_label %}
-                                        {{ 'listing.boxAddProduct'|trans|sw_sanitize }}
-                                    {% endblock %}
-                                </button>
-                            </div>
+                            {% block component_product_box_action_buy_button %}
+                                <div class="d-grid">
+                                    <button class="btn btn-buy">
+                                        {% block page_product_detail_product_buy_button_label %}
+                                            {{ 'listing.boxAddProduct'|trans|sw_sanitize }}
+                                        {% endblock %}
+                                    </button>
+                                </div>
+                            {% endblock %}
                         {% endblock %}
-                    {% endblock %}
-                </form>
-            {% endblock %}
-        {% else %}
-            {% block component_product_box_action_detail %}
-                <div class="d-grid">
-                    <a href="{{ seoUrl('frontend.detail.page', {productId: id}) }}"
-                       class="btn btn-light btn-detail">
-                        {% block component_product_box_action_detail_label %}
-                            {{ 'listing.boxProductDetails'|trans|sw_sanitize }}
-                        {% endblock %}
-                    </a>
-                </div>
-            {% endblock %}
-        {% endif %}
+                    </form>
+                {% endblock %}
+            {% else %}
+                {% block component_product_box_action_detail %}
+                    <div class="d-grid">
+                        <a href="{{ seoUrl('frontend.detail.page', {productId: id}) }}"
+                           class="btn btn-light btn-detail">
+                            {% block component_product_box_action_detail_label %}
+                                {{ 'listing.boxProductDetails'|trans|sw_sanitize }}
+                            {% endblock %}
+                        </a>
+                    </div>
+                {% endblock %}
+            {% endif %}
+        {% endblock %}
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
@@ -55,70 +55,80 @@
                     Cheapest price display for variants. Used when the product is a single variant that is directly buy-able from the listing.
                     Example: "Variants from $120.00"
                 #}
-                <div class="product-cheapest-price{% if isListPrice and isRegulationPrice and not displayFrom and not displayFromVariants %} with-list-price{% endif %}{% if isRegulationPrice and not displayFrom and displayFromVariants %} with-regulation-price{% endif %}{% if displayFrom and isRegulationPrice %} with-from-price{% endif %}">
-                    {% if cheapest.unitPrice != real.unitPrice and cheapest.variantId != product.id %}
-                        {{ 'listing.cheapestPriceLabel'|trans|sw_sanitize }}<span class="product-cheapest-price-price"> {{ cheapest.unitPrice|currency }}</span>
-                    {% endif %}
-                </div>
+                {% block component_product_box_cheapest_price %}
+                    <div class="product-cheapest-price{% if isListPrice and isRegulationPrice and not displayFrom and not displayFromVariants %} with-list-price{% endif %}{% if isRegulationPrice and not displayFrom and displayFromVariants %} with-regulation-price{% endif %}{% if displayFrom and isRegulationPrice %} with-from-price{% endif %}">
+                        {% if cheapest.unitPrice != real.unitPrice and cheapest.variantId != product.id %}
+                            {{ 'listing.cheapestPriceLabel'|trans|sw_sanitize }}<span class="product-cheapest-price-price"> {{ cheapest.unitPrice|currency }}</span>
+                        {% endif %}
+                    </div>
+                {% endblock %}
 
                 {#
                     Price label for screen readers.
                     Example with regular price: "Regular price:"
                     Example with list price: "Sale price:"
                 #}
-                <span class="visually-hidden product-price-label">
-                    {% if isListPrice and not displayFrom and not displayFromVariants %}
-                        {{ 'listing.listPriceLabel'|trans|sw_sanitize }}
-                    {% else %}
-                        {{ 'listing.regularPriceLabel'|trans|sw_sanitize }}
-                    {% endif %}
-                </span>
+                {% block component_product_box_price_label %}
+                    <span class="visually-hidden product-price-label">
+                        {% if isListPrice and not displayFrom and not displayFromVariants %}
+                            {{ 'listing.listPriceLabel'|trans|sw_sanitize }}
+                        {% else %}
+                            {{ 'listing.regularPriceLabel'|trans|sw_sanitize }}
+                        {% endif %}
+                    </span>
+                {% endblock %}
 
                 {#
                     "From" price display. Used for advanced pricing tables or variants when the storefront presentation is set to "main variant".
                     The product is not directly buy-able from the listing.
                     Example: "From $120.00"
                 #}
-                {% if displayFrom or (displayParent and hasDifferentPrice and hasRange and totalVariants|length > 1) %}
-                    {{ 'listing.listingTextFrom'|trans|sw_sanitize }}
-                {% endif %}
+                {% block component_product_box_from_price %}
+                    {% if displayFrom or (displayParent and hasDifferentPrice and hasRange and totalVariants|length > 1) %}
+                        {{ 'listing.listingTextFrom'|trans|sw_sanitize }}
+                    {% endif %}
+                {% endblock %}
 
                 {#
                     Main price display. Always used, can also include list prices.
                     Example: $150.00"
                     Example with list price: €400.00 <s>€500.00</s> (20% saved)"
                 #}
-                <span class="product-price{% if isListPrice and not displayFrom and not displayFromVariants %} with-list-price{% endif %}">
-                    {{ price.unitPrice|currency }}
+                {% block component_product_box_main_price %}
+                    <span class="product-price{% if isListPrice and not displayFrom and not displayFromVariants %} with-list-price{% endif %}">
+                        {{ price.unitPrice|currency }}
 
-                    {% if isListPrice and not displayFrom and not displayFromVariants %}
-                        {% set afterListPriceSnippetExists = 'listing.afterListPrice'|trans|length > 0 %}
-                        {% set beforeListPriceSnippetExists = 'listing.beforeListPrice'|trans|length > 0 %}
-                        {% set hideStrikeTrough = beforeListPriceSnippetExists or afterListPriceSnippetExists %}
+                        {% if isListPrice and not displayFrom and not displayFromVariants %}
+                            {% set afterListPriceSnippetExists = 'listing.afterListPrice'|trans|length > 0 %}
+                            {% set beforeListPriceSnippetExists = 'listing.beforeListPrice'|trans|length > 0 %}
+                            {% set hideStrikeTrough = beforeListPriceSnippetExists or afterListPriceSnippetExists %}
 
-                        <span class="list-price{% if hideStrikeTrough %} list-price-no-line-through{% endif %}">
-                            {% if beforeListPriceSnippetExists %}{{ 'listing.beforeListPrice'|trans|trim|sw_sanitize }}{% endif %}
+                            <span class="list-price{% if hideStrikeTrough %} list-price-no-line-through{% endif %}">
+                                {% if beforeListPriceSnippetExists %}{{ 'listing.beforeListPrice'|trans|trim|sw_sanitize }}{% endif %}
 
-                            <span class="visually-hidden list-price-label">{{ 'listing.regularPriceLabel'|trans|sw_sanitize }}</span>
+                                <span class="visually-hidden list-price-label">{{ 'listing.regularPriceLabel'|trans|sw_sanitize }}</span>
 
-                            <span class="list-price-price">{{ price.listPrice.price|currency }}</span>
+                                <span class="list-price-price">{{ price.listPrice.price|currency }}</span>
 
-                            {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans|trim|sw_sanitize }}{% endif %}
+                                {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans|trim|sw_sanitize }}{% endif %}
 
-                            <span class="list-price-percentage">{{ 'detail.listPricePercentage'|trans({'%price%': price.listPrice.percentage })|sw_sanitize }}</span>
-                        </span>
-                    {% endif %}
-                </span>
+                                <span class="list-price-percentage">{{ 'detail.listPricePercentage'|trans({'%price%': price.listPrice.percentage })|sw_sanitize }}</span>
+                            </span>
+                        {% endif %}
+                    </span>
+                {% endblock %}
 
                 {#
                     Display for previous price
                     Example: "previously €300.00"
                 #}
-                {% if isRegulationPrice %}
-                    <span class="product-price with-regulation-price">
-                        {% if isListPrice %}<br aria-hidden="true">{% endif %}<span class="regulation-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}</span>
-                    </span>
-                {% endif %}
+                {% block component_product_box_regulation_price %}
+                    {% if isRegulationPrice %}
+                        <span class="product-price with-regulation-price">
+                            {% if isListPrice %}<br aria-hidden="true">{% endif %}<span class="regulation-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}</span>
+                        </span>
+                    {% endif %}
+                {% endblock %}
             </div>
         {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

I had different bundles, that needed to overwrite different parts of the product pricing without affecting the other bundle. But the prices in a product box need to be overwritten completely so it was difficult to align the changes without the blocks.

### 2. What does this change do, exactly?

Add some twig blocks related to product boxes

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
