### PR TITLE
fix: Allow long update messages to be stored for the administration

### DIFF
--- a/changelog/_unreleased/2023-10-19-ensure-update-texts-longer-than-storage-can-be-displayed.md
+++ b/changelog/_unreleased/2023-10-19-ensure-update-texts-longer-than-storage-can-be-displayed.md
@@ -1,0 +1,8 @@
+---
+title: Ensure update information
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed `\Shopware\Core\Framework\Update\Subscriber\UpdateSubscriber` to split up the notification text based on the storage size so everything of a message can be shown

--- a/src/Core/Framework/Update/Subscriber/UpdateSubscriber.php
+++ b/src/Core/Framework/Update/Subscriber/UpdateSubscriber.php
@@ -51,18 +51,21 @@ class UpdateSubscriber implements EventSubscriberInterface
             $integrationId = $source->getIntegrationId();
             $createdByUserId = $source->getUserId();
         }
+        $wrappedMessage = \wordwrap($event->getPostUpdateMessage(), 255, "\v", true);
 
-        $this->notificationService->createNotification(
-            [
-                'id' => Uuid::randomHex(),
-                'status' => 'warning',
-                'message' => $event->getPostUpdateMessage(),
-                'adminOnly' => true,
-                'requiredPrivileges' => [],
-                'createdByIntegrationId' => $integrationId,
-                'createdByUserId' => $createdByUserId,
-            ],
-            $event->getContext()
-        );
+        foreach (\array_map(fn (string $message): string => trim($message, ' '), \array_reverse(\explode("\v", $wrappedMessage))) as $partialMessage) {
+            $this->notificationService->createNotification(
+                [
+                    'id' => Uuid::randomHex(),
+                    'status' => 'warning',
+                    'message' => $partialMessage,
+                    'adminOnly' => true,
+                    'requiredPrivileges' => [],
+                    'createdByIntegrationId' => $integrationId,
+                    'createdByUserId' => $createdByUserId,
+                ],
+                $event->getContext()
+            );
+        }
     }
 }

--- a/tests/unit/Core/Framework/Update/Subscriber/UpdateSubscriberTest.php
+++ b/tests/unit/Core/Framework/Update/Subscriber/UpdateSubscriberTest.php
@@ -49,6 +49,24 @@ class UpdateSubscriberTest extends TestCase
         $updateSubscriber->updateFinishedDone($event);
     }
 
+    public function testUpdateSuccessfulWithMuchInformation(): void
+    {
+        $context = Context::createDefaultContext(new AdminApiSource('userId123', 'integrationId321'));
+        $version = '6.0.1_test';
+
+        $notificationServiceMock = $this->createMock(NotificationService::class);
+        $notificationServiceMock
+            ->expects($this->atLeast(2))
+            ->method('createNotification');
+
+        $event = new UpdatePostFinishEvent($context, $version, $version);
+        $event->appendPostUpdateMessage('something to inform' . bin2hex(\random_bytes(200)));
+
+        $updateSubscriber = new UpdateSubscriber($notificationServiceMock);
+
+        $updateSubscriber->updateFinishedDone($event);
+    }
+
     public function testUpdateWithoutMessageGetsSkipped(): void
     {
         $context = Context::createDefaultContext();


### PR DESCRIPTION
### 1. Why is this change necessary?

When you add more info to the update messages, they will be cut off in the administration as the text won't be split up matching the storage size.

### 2. What does this change do, exactly?

Adding a word-wrap around the size of the storage, so every word will make it in a readable manner into the notifications.

### 3. Describe each step to reproduce the issue or behaviour.

1. Subscribe to `UpdatePostFinishEvent` and add more useful information
2. Update a shop
3. Do not see the newly added information as it is too much

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
