### PR TITLE
feat: Change auto form submission to use requestSubmit

### DIFF
--- a/changelog/_unreleased/2025-10-05-form-auto-submit-with-validation.md
+++ b/changelog/_unreleased/2025-10-05-form-auto-submit-with-validation.md
@@ -1,0 +1,9 @@
+---
+title: Add option for FormAutoSubmit to trigger form validation
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added opt-out option `useRequestSubmit` to `FormAutoSubmit` storefront plugin to trigger the form submit using `requestSubmit` to trigger client side validation first
+* Changed `FormAutoSubmit` to trigger client-side validation first to reduce requests

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
@@ -42,6 +42,13 @@ export default class FormAutoSubmitPlugin extends Plugin {
          * @type {string}
          */
         focusHandlerKey: 'form-auto-submit',
+
+        /**
+         * When active, the form submission is more humanly triggered with validation and submit event
+         * @link https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit#usage_notes
+         * @type {boolean}
+         */
+        useRequestSubmit: true,
     };
 
     init() {
@@ -149,7 +156,12 @@ export default class FormAutoSubmitPlugin extends Plugin {
     _submitNativeForm() {
         this.$emitter.publish('beforeChange');
 
-        this._form.submit();
+        if (this.options.useRequestSubmit) {
+            this._form.requestSubmit();
+        } else {
+            this._form.submit();
+        }
+
         PageLoadingIndicatorUtil.create();
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When using the auto submit plugin to build dynamic and reactive it will not care right now about whatever frontend validation you've already set in place. To reduce the amount of requests, that are triggered by the javascript, to spam the frontend servers with requests, that would be denied anyway as the given data is obviously invalid, we can block them before hand.

### 2. What does this change do, exactly?

Use https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit#usage_notes instead of https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
