### PR TITLE
chore(administration): ignore new axios audit issue due to no ability to upgrade

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/runNpmAudit.ts
+++ b/src/Administration/Resources/app/administration/scripts/runNpmAudit.ts
@@ -5,6 +5,7 @@ import { execSync } from "child_process";
 const ignored = [
   1103617, // axios - we cannot upgrade to 1.x due to breaking changes
   1107599, // axios - we cannot upgrade to 1.x due to breaking changes
+  1108262, // axios - we cannot upgrade to 1.x due to breaking changes
 ];
 let auditRaw = "";
 


### PR DESCRIPTION
We need to ignore axios vulnerabilities temporarily, as the administration has currently no ability to upgrade its version.