### PR TITLE
fix: api encode issue with partial entity

### DIFF
--- a/src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
+++ b/src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
@@ -85,10 +85,12 @@ class JsonEntityEncoder
             $decoded['translated']['customFields'] = new \stdClass();
         }
 
-        unset($decoded['extensions']['foreignKeys']);
+        if (isset($decoded['extensions'])) {
+            unset($decoded['extensions']['foreignKeys']);
 
-        if ($decoded['extensions'] === []) {
-            unset($decoded['extensions']);
+            if ($decoded['extensions'] === []) {
+                unset($decoded['extensions']);
+            }
         }
 
         return $this->removeNotAllowedFields($decoded, $definition, $baseUrl);

--- a/tests/integration/Core/Framework/Api/Serializer/JsonEntityEncoderTest.php
+++ b/tests/integration/Core/Framework/Api/Serializer/JsonEntityEncoderTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\Api\Serializer\AssertValuesTrait;
@@ -274,5 +275,19 @@ class JsonEntityEncoderTest extends TestCase
 
         // extensions should be completely removed
         static::assertArrayNotHasKey('extensions', $actual);
+    }
+
+    public function testExtensionsRemovalPartialEntity(): void
+    {
+        $encoder = static::getContainer()->get(JsonEntityEncoder::class);
+
+        $definition = new CustomFieldTestDefinition();
+        $definition->compile(static::getContainer()->get(DefinitionInstanceRegistry::class));
+
+        $struct2 = new PartialEntity();
+        $struct2->set('id', 'test-id-2');
+        $actual = $encoder->encode(new Criteria(), $definition, $struct2, SerializationFixture::API_BASE_URL);
+
+        static::assertSame(['translated' => [], 'id' => 'test-id-2', 'apiAlias' => 'partial'], $actual);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

accessing missing "extensions" key throws a deprecation and this lets the api request fail.


### 2. What does this change do, exactly?

check if the array key exists before accessing


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
