### PR TITLE
ci: fix milestone version detection

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -34,22 +34,24 @@ jobs:
                 const nextPatch = process.env.NEXT_PATCH.substring(1);
 
                 const versionRegex = new RegExp(/^([0-9]+).([0-9]+).([0-9]+).([0-9]+|x)$/, "mg");
+                const versionBaseRef = versionRegex.exec(context.payload.pull_request.base.ref);
 
                 // Use next minor if target is trunk or is an issue
                 if (context.payload.pull_request.base.ref == "trunk") {
                   return nextMinor;
-                } else if (versionRegex.test(context.payload.pull_request.base.ref)) {
+                } else if (versionBaseRef !== null) {
+                    const refVersion = `${versionBaseRef.slice(1, versionBaseRef.length - 1).join(".")}.0`
                     try {
                         await github.rest.repos.getReleaseByTag({
                             owner: "shopware",
                             repo: "shopware",
-                            tag: `v${context.payload.pull_request.base.ref}`
+                            tag: `v${refVersion}`
                         });
                         // Use next patch if target is a version branch and the minor is released
                         return nextPatch;
                     } catch(err) {
                         // Use next minor if target is a version branch and the minor is not released
-                        return `${context.payload.pull_request.base.ref}`;
+                        return `${refVersion}`;
                     }
                 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
As we decided to use `6.$MAJOR.$MINOR.x` instead of `6.$MAJOR.$MINOR.0` as branch name, the current logic produces wrong milestones.

### 2. What does this change do, exactly?
We now extract the `6.$MAJOR.$MINOR` part of the branch name and append a `.0`.

### 3. Describe each step to reproduce the issue or behaviour.
(After merge and backport) Create a PR which targets a version branch and check the `milestone/` label.