### PR TITLE
fix: Improve handling of legacy cookie values

### DIFF
--- a/src/Core/Content/Cookie/Service/CookieProvider.php
+++ b/src/Core/Content/Cookie/Service/CookieProvider.php
@@ -193,31 +193,35 @@ class CookieProvider
             if ($snippetName === null) {
                 throw CookieException::invalidLegacyCookieGroupProvided($legacyCookieGroup);
             }
+            $snippetName = (string) $snippetName;
 
-            $cookieGroup = $cookieGroupCollection->get($legacyCookieGroup['snippet_name']);
+            $cookieGroup = $cookieGroupCollection->get($snippetName);
             if ($cookieGroup === null) {
-                $cookieGroup = new CookieGroup($legacyCookieGroup['snippet_name']);
+                $cookieGroup = new CookieGroup($snippetName);
                 $cookieGroupCollection->add($cookieGroup);
             }
 
             if (\array_key_exists('snippet_description', $legacyCookieGroup)) {
-                $cookieGroup->description = $legacyCookieGroup['snippet_description'];
+                $description = (string) $legacyCookieGroup['snippet_description'];
+                $cookieGroup->description = $description !== '' ? $description : null;
             }
 
             if (\array_key_exists('cookie', $legacyCookieGroup)) {
-                $cookieGroup->setCookie($legacyCookieGroup['cookie']);
+                $cookie = (string) $legacyCookieGroup['cookie'];
+                $cookieGroup->setCookie($cookie !== '' ? $cookie : null);
             }
 
             if (\array_key_exists('value', $legacyCookieGroup)) {
-                $cookieGroup->value = $legacyCookieGroup['value'];
+                $value = (string) $legacyCookieGroup['value'];
+                $cookieGroup->value = $value !== '' ? $value : null;
             }
 
-            if (\array_key_exists('expiration', $legacyCookieGroup)) {
+            if (isset($legacyCookieGroup['expiration'])) {
                 $cookieGroup->expiration = (int) $legacyCookieGroup['expiration'];
             }
 
-            if (\array_key_exists('isRequired', $legacyCookieGroup)) {
-                $cookieGroup->isRequired = $legacyCookieGroup['isRequired'];
+            if (isset($legacyCookieGroup['isRequired'])) {
+                $cookieGroup->isRequired = (bool) $legacyCookieGroup['isRequired'];
             }
 
             if (\array_key_exists('entries', $legacyCookieGroup)) {
@@ -232,25 +236,28 @@ class CookieProvider
                     if ($cookie === null) {
                         throw CookieException::invalidLegacyCookieEntryProvided($entry);
                     }
-                    $cookieEntry = new CookieEntry($entry['cookie']);
+                    $cookieEntry = new CookieEntry((string) $cookie);
 
                     if (\array_key_exists('snippet_name', $entry)) {
-                        $cookieEntry->name = $entry['snippet_name'];
+                        $name = (string) $entry['snippet_name'];
+                        $cookieEntry->name = $name !== '' ? $name : null;
                     }
 
                     if (\array_key_exists('snippet_description', $entry)) {
-                        $cookieEntry->description = $entry['snippet_description'];
+                        $description = (string) $entry['snippet_description'];
+                        $cookieEntry->description = $description !== '' ? $description : null;
                     }
 
                     if (\array_key_exists('value', $entry)) {
-                        $cookieEntry->value = $entry['value'];
+                        $value = (string) $entry['value'];
+                        $cookieEntry->value = $value !== '' ? $value : null;
                     }
 
-                    if (\array_key_exists('expiration', $entry)) {
+                    if (isset($entry['expiration'])) {
                         $cookieEntry->expiration = (int) $entry['expiration'];
                     }
 
-                    if (\array_key_exists('hidden', $entry)) {
+                    if (isset($entry['hidden'])) {
                         $cookieEntry->hidden = (bool) $entry['hidden'];
                     }
 

--- a/tests/unit/Core/Content/Cookie/Service/CookieProviderTest.php
+++ b/tests/unit/Core/Content/Cookie/Service/CookieProviderTest.php
@@ -166,10 +166,22 @@ class CookieProviderTest extends TestCase
         $testGroup2 = $cookieGroups->get('test-group-2');
         static::assertInstanceOf(CookieGroup::class, $testGroup2);
         static::assertNotNull($testGroup2->getEntries());
-        static::assertCount(1, $testGroup2->getEntries());
-        $testGroup2Entry = $testGroup2->getEntries()->get('test-cookie-2');
-        static::assertNotNull($testGroup2Entry);
-        static::assertSame('test-description', $testGroup2Entry->description);
+
+        static::assertCount(3, $testGroup2->getEntries());
+
+        $testGroup2Entry1 = $testGroup2->getEntries()->get('test-cookie-2');
+        static::assertNotNull($testGroup2Entry1);
+        static::assertSame('test-description', $testGroup2Entry1->description);
+
+        $testGroup2Entry2 = $testGroup2->getEntries()->get('test-cookie-3');
+        static::assertNotNull($testGroup2Entry2);
+        static::assertSame('0', $testGroup2Entry2->value);
+        static::assertNull($testGroup2Entry2->name);
+        static::assertNull($testGroup2Entry2->description);
+
+        $testGroup2Entry3 = $testGroup2->getEntries()->get('test-cookie-4');
+        static::assertNotNull($testGroup2Entry3);
+        static::assertSame('1', $testGroup2Entry3->value);
     }
 
     #[DisabledFeatures(['v6.8.0.0'])]
@@ -249,15 +261,30 @@ class LegacyCookieProviderForTesting extends LegacyCookieProvider
             'expiration' => '10',
         ];
         $cookieGroups[] = [
+            'snippet_name' => 'test-group-will-be-ignored',
+            'cookie' => null,
+        ];
+        $cookieGroups[] = [
             'snippet_name' => 'test-group-2',
             'entries' => [
                 [
                     'cookie' => 'test-cookie-2',
                     'snippet_description' => 'test-description',
                 ],
+                [
+                    'cookie' => 'test-cookie-3',
+                    'value' => 0,
+                    'snippet_name' => null,
+                    'snippet_description' => '',
+                ],
+                [
+                    'cookie' => 'test-cookie-4',
+                    'value' => true,
+                ],
             ],
         ];
 
+        /** @phpstan-ignore return.type (Intentionally test not allowed values for legacy reasons) */
         return $cookieGroups;
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Cookies provided via the legacy way, might use values, that do not have the correct type. 

### 2. What does this change do, exactly?

Cast incoming values to necessary types to prevent type errors

### 3. Describe each step to reproduce the issue or behaviour.

See tests.

### 4. Please link to the relevant issues (if any).

- closes #12884 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
