### PR TITLE
fix: include `/Test/` directories in classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -497,7 +497,6 @@
       "Shopware\\": "src/"
     },
     "exclude-from-classmap": [
-      "src/**/Test/",
       "tests/"
     ]
   },

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -12,9 +12,6 @@
         "files": [
             "Framework/Adapter/Doctrine/Patch/AbstractAsset.php"
         ],
-        "exclude-from-classmap": [
-            "*/Test/"
-        ],
         "psr-4": {
             "Shopware\\Core\\": ""
         }

--- a/src/Elasticsearch/composer.json
+++ b/src/Elasticsearch/composer.json
@@ -6,10 +6,7 @@
     "autoload": {
         "psr-4": {
             "Shopware\\Elasticsearch\\": ""
-        },
-        "exclude-from-classmap": [
-            "/Test/"
-        ]
+        }
     },
     "config": {
         "sort-packages": true

--- a/src/Storefront/composer.json
+++ b/src/Storefront/composer.json
@@ -6,10 +6,7 @@
     "autoload": {
         "psr-4": {
             "Shopware\\Storefront\\": ""
-        },
-        "exclude-from-classmap": [
-            "*/Test/"
-        ]
+        }
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Several places depend on these classes, which leads to errors when authoritative classmaps are used.

related discussion: #12882

resolves #12623
resolves #12727
closes #12882