### PR TITLE
fix: update event binding for multi-select switch and add related tests

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.html.twig
@@ -8,7 +8,7 @@
     class="sw-custom-field-detail__switch"
     :disabled="multiSelectSwitchDisabled || undefined"
     :label="$tc('sw-settings-custom-field.customField.detail.labelMultiSelect')"
-    @update:value="onChangeMultiSelectSwitch"
+    @update:modelValue="onChangeMultiSelectSwitch"
 />
 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.spec.js
@@ -178,4 +178,28 @@ describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-sel
 
         expect(wrapper.vm.currentCustomField.config.componentName).toBe('sw-single-select');
     });
+
+    it('should toggle multi-switch on switch', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        // Initially should be sw-single-select
+        expect(wrapper.vm.currentCustomField.config.componentName).toBe('sw-single-select');
+        expect(wrapper.vm.multiSelectSwitch).toBe(false);
+
+        // Find the switch and trigger checkbox input event to change to true
+        const mtSwitch = wrapper.find('.sw-custom-field-detail__switch input');
+        await mtSwitch.setValue(true);
+        await flushPromises();
+
+        // Should now be sw-multi-select
+        expect(wrapper.vm.currentCustomField.config.componentName).toBe('sw-multi-select');
+
+        // Toggle back to false
+        await mtSwitch.setValue(false);
+        await flushPromises();
+
+        // Should be back to sw-single-select
+        expect(wrapper.vm.currentCustomField.config.componentName).toBe('sw-single-select');
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Fixes https://github.com/shopware/shopware/issues/12855

### 2. What does this change do, exactly?

This pull request updates the event binding for the multi-select switch in the custom field type select component and adds a new test to verify the switch's behavior.

Component event binding update:

* Changed the event binding in `sw-custom-field-type-select.html.twig` from `@update:value` to `@update:modelValue` for the multi-select switch to ensure correct event handling.

Test coverage improvements:

* Added a new test in `sw-custom-field-type-select.spec.js` to verify that toggling the multi-select switch updates the component configuration between `sw-single-select` and `sw-multi-select` as expected.

### 3. Describe each step to reproduce the issue or behaviour.

See issue

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
Closes #12855

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
