### PR TITLE
feat(product-analytics): Add appUrl to analytics events

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/composables/use-context.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-context.spec.ts
@@ -22,6 +22,7 @@ describe('use-context', () => {
                     versionRevision: null,
                     inAppPurchases: {},
                     shopId: null,
+                    appUrl: null,
                 },
                 environment: null,
                 fallbackLocale: null,

--- a/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
@@ -40,6 +40,7 @@ export interface ContextState {
             versionRevision: null | string;
             inAppPurchases: Record<string, string[]>;
             shopId: null | string;
+            appUrl: null | string;
         };
         environment: null | 'development' | 'production' | 'testing';
         fallbackLocale: null | string;
@@ -86,6 +87,7 @@ const state: ContextState = reactive({
             versionRevision: null,
             inAppPurchases: {},
             shopId: null,
+            appUrl: null,
         },
         environment: null,
         fallbackLocale: null,

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -32,6 +32,8 @@ export default async function (): Promise<void> {
                 ...amplitudeEvent.event_properties,
                 sw_version: Shopware.Store.get('context').app.config.version,
                 sw_shop_id: Shopware.Store.get('context').app.config.shopId,
+                sw_app_url: Shopware.Store.get('context').app.config.appUrl,
+                sw_browser_url: window.location.origin,
                 sw_user_agent: window.navigator.userAgent,
                 sw_default_language: defaultLanguageName,
                 sw_default_currency: Shopware.Context.app.systemCurrencyISOCode,

--- a/src/Administration/Resources/app/administration/src/app/store/context.store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/context.store.spec.ts
@@ -20,24 +20,24 @@ describe('context.store', () => {
     });
 
     it('has initial state', () => {
-        expect(store.app).toEqual(
-            expect.objectContaining({
-                config: {
-                    adminWorker: null,
-                    bundles: null,
-                    version: null,
-                    versionRevision: null,
-                    inAppPurchases: {},
-                    shopId: null,
-                },
-                environment: null,
-                fallbackLocale: null,
-                features: null,
-                firstRunWizard: null,
-                systemCurrencyId: null,
-                systemCurrencyISOCode: null,
-            }),
-        );
+        expect(store.app).toEqual({
+            config: {
+                adminWorker: null,
+                bundles: null,
+                version: null,
+                versionRevision: null,
+                inAppPurchases: {},
+                shopId: null,
+                appUrl: null,
+            },
+            environment: null,
+            fallbackLocale: null,
+            features: null,
+            firstRunWizard: null,
+            systemCurrencyId: null,
+            systemCurrencyISOCode: null,
+            windowId: null,
+        });
 
         expect(store.api).toEqual(
             expect.objectContaining({

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Api\Controller;
 use Doctrine\DBAL\Connection;
 use Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator;
 use Shopware\Core\Content\Flow\Api\FlowActionCollector;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\EntitySchemaGenerator;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi3Generator;
@@ -177,6 +178,7 @@ class InfoController extends AbstractController
         return new JsonResponse([
             'version' => $this->getShopwareVersion(),
             'shopId' => $this->getShopId(),
+            'appUrl' => (string) EnvironmentHelper::getVariable('APP_URL'),
             'versionRevision' => $this->params->get('kernel.shopware_version_revision'),
             'adminWorker' => [
                 'enableAdminWorker' => $this->params->get('shopware.admin_worker.enable_admin_worker'),

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -34,6 +34,7 @@ use Shopware\Core\Framework\MessageQueue\Stats\StatsService;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Store\InAppPurchase;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Kernel;
 use Shopware\Core\Maintenance\System\Service\AppUrlVerifier;
@@ -58,6 +59,8 @@ class InfoControllerTest extends TestCase
 
     use AppSystemTestBehaviour;
 
+    use EnvTestBehaviour;
+
     private Connection $connection;
 
     protected function setUp(): void
@@ -67,11 +70,16 @@ class InfoControllerTest extends TestCase
 
     public function testGetConfig(): void
     {
+        $this->setEnvVars([
+            'APP_URL' => 'https://test-app.url',
+        ]);
+
         $shopId = static::getContainer()->get(ShopIdProvider::class)->getShopId();
 
         $expected = [
             'version' => '6.7.9999999.9999999-dev',
             'shopId' => $shopId,
+            'appUrl' => 'https://test-app.url',
             'versionRevision' => str_repeat('0', 32),
             'adminWorker' => [
                 'enableAdminWorker' => true,

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -26,6 +26,7 @@ use Shopware\Core\Framework\MessageQueue\Stats\StatsService;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Store\InAppPurchase;
 use Shopware\Core\Framework\Test\Store\StaticInAppPurchaseFactory;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Maintenance\System\Service\AppUrlVerifier;
 use Shopware\Core\Test\Stub\Symfony\StubKernel;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
@@ -42,6 +43,8 @@ use Symfony\Component\Routing\RouterInterface;
 #[CoversClass(InfoController::class)]
 class InfoControllerTest extends TestCase
 {
+    use EnvTestBehaviour;
+
     private InfoController $infoController;
 
     private ParameterBagInterface&MockObject $parameterBagMock;
@@ -62,6 +65,10 @@ class InfoControllerTest extends TestCase
 
     public function testConfig(): void
     {
+        $this->setEnvVars([
+            'APP_URL' => 'https://app.url',
+        ]);
+
         $this->createInstance();
 
         $this->shopIdProvider->expects($this->once())->method('getShopId')->willReturn('shop-id');
@@ -79,6 +86,8 @@ class InfoControllerTest extends TestCase
         static::assertArrayHasKey('adminWorker', $data);
         static::assertArrayHasKey('shopId', $data);
         static::assertSame('shop-id', $data['shopId']);
+        static::assertArrayHasKey('appUrl', $data);
+        static::assertSame('https://app.url', $data['appUrl']);
 
         $workerConfig = $data['adminWorker'];
         static::assertArrayHasKey('enableAdminWorker', $workerConfig);


### PR DESCRIPTION
Adds the `appUrl` and the Admin's `origin` to tracked analytic events.

Resolves shopware/services-roadmap#144