### PR TITLE
fix: Use agnostic language layer functionality when loading snippets

### DIFF
--- a/src/Core/System/Snippet/SnippetPatterns.php
+++ b/src/Core/System/Snippet/SnippetPatterns.php
@@ -29,6 +29,8 @@ final class SnippetPatterns
 
     public const ADMIN_SNIPPET_FILE_PATTERN = '/^' . self::LOCALE_PATTERN . '\.json$/';
 
+    public const COMPLETE_LOCALE_PATTERN = '/^' . self::LOCALE_PATTERN . '$/';
+
     private function __construct()
     {
     }

--- a/src/Core/System/Snippet/SnippetService.php
+++ b/src/Core/System/Snippet/SnippetService.php
@@ -306,14 +306,14 @@ class SnippetService
     }
 
     /**
-     *  Collects snippet files for each given locale (ISO code).
+     *  Collects snippet files for each given locale.
      *
-     *  For each locale (e.g., "en-GB"), the method first tries to load files
+     *  For each locale (e.g., "es-AR"), the method first tries to load files
      *  that match the exact locale. If that locale contains a region separator ("-"),
-     *  it will also load files for the base language (e.g., "en").
+     *  it will also load files for the base language (e.g., "es").
      *
-     *  The base-language snippet files are prepended, ensuring region-specific
-     *  snippets (e.g., "en-GB") override more general ones ("en").
+     *  The base language snippet files are prepended, ensuring country-specific
+     *  snippets (e.g. "es-AR") override more general ones ("es").
      *
      * @param array<string, string> $isoList
      *
@@ -323,23 +323,24 @@ class SnippetService
     {
         $result = [];
         foreach ($isoList as $iso) {
-            // Load all snippet files that match the exact locale (e.g., "en-GB")
+            // Load all snippet files that match the exact locale (e.g., "es-AR")
             $files = $this->snippetFileCollection->getSnippetFilesByIso($iso);
+            preg_match(
+                SnippetPatterns::COMPLETE_LOCALE_PATTERN,
+                $iso,
+                $matchedPattern,
+                \PREG_UNMATCHED_AS_NULL
+            );
 
-            // If the locale has a region (e.g., "de-AT"), try to load its base language ("de")
-            if (\str_contains($iso, '-')) {
-                [$baseIso] = \explode('-', $iso, 2);
-
-                if ($baseIso !== $iso) {
-                    // Load snippet files for the base language
-                    $fallbackFiles = $this->snippetFileCollection->getSnippetFilesByIso($baseIso);
-
-                    // Prepend fallback files so region-specific ones override them
-                    $files = [...$fallbackFiles, ...$files];
-                }
+            // If the locale has a region (e.g., "es-AR"), try to load its base language ("es")
+            if (!empty($matchedPattern['region']) && strtolower($matchedPattern['region']) !== $iso) {
+                \assert(!empty($matchedPattern['language']));
+                \assert(!empty($matchedPattern['region']));
+                $fallbackFiles = $this->snippetFileCollection->getSnippetFilesByIso($matchedPattern['language']);
+                // Prepend fallback files so region-specific ones override them
+                $files = [...$fallbackFiles, ...$files];
             }
 
-            // Store all resolved snippet files for the current locale
             $result[$iso] = $files;
         }
 

--- a/src/Core/System/Snippet/SnippetService.php
+++ b/src/Core/System/Snippet/SnippetService.php
@@ -306,6 +306,15 @@ class SnippetService
     }
 
     /**
+     *  Collects snippet files for each given locale (ISO code).
+     *
+     *  For each locale (e.g., "en-GB"), the method first tries to load files
+     *  that match the exact locale. If that locale contains a region separator ("-"),
+     *  it will also load files for the base language (e.g., "en").
+     *
+     *  The base-language snippet files are prepended, ensuring region-specific
+     *  snippets (e.g., "en-GB") override more general ones ("en").
+     *
      * @param array<string, string> $isoList
      *
      * @return array<string, list<AbstractSnippetFile>>
@@ -314,12 +323,24 @@ class SnippetService
     {
         $result = [];
         foreach ($isoList as $iso) {
-            $mappedIso = match ($iso) {
-                'de-DE' => 'de',
-                'en-GB' => 'en',
-                default => $iso,
-            };
-            $result[$iso] = $this->snippetFileCollection->getSnippetFilesByIso($mappedIso);
+            // Load all snippet files that match the exact locale (e.g., "en-GB")
+            $files = $this->snippetFileCollection->getSnippetFilesByIso($iso);
+
+            // If the locale has a region (e.g., "de-AT"), try to load its base language ("de")
+            if (\str_contains($iso, '-')) {
+                [$baseIso] = \explode('-', $iso, 2);
+
+                if ($baseIso !== $iso) {
+                    // Load snippet files for the base language
+                    $fallbackFiles = $this->snippetFileCollection->getSnippetFilesByIso($baseIso);
+
+                    // Prepend fallback files so region-specific ones override them
+                    $files = [...$fallbackFiles, ...$files];
+                }
+            }
+
+            // Store all resolved snippet files for the current locale
+            $result[$iso] = $files;
         }
 
         return $result;

--- a/tests/unit/Core/System/Snippet/Mock/_fixtures/agnostic.es.json
+++ b/tests/unit/Core/System/Snippet/Mock/_fixtures/agnostic.es.json
@@ -1,0 +1,4 @@
+{
+  "title": "Agnostic ES",
+  "baseOnly": "Agnostic ES"
+}

--- a/tests/unit/Core/System/Snippet/Mock/_fixtures/base.es.json
+++ b/tests/unit/Core/System/Snippet/Mock/_fixtures/base.es.json
@@ -1,4 +1,0 @@
-{
-  "title": "Base ES",
-  "baseOnly": "Base ES"
-}

--- a/tests/unit/Core/System/Snippet/Mock/_fixtures/base.es.json
+++ b/tests/unit/Core/System/Snippet/Mock/_fixtures/base.es.json
@@ -1,0 +1,4 @@
+{
+  "title": "Base ES",
+  "baseOnly": "Base ES"
+}

--- a/tests/unit/Core/System/Snippet/Mock/_fixtures/country.es-AR.json
+++ b/tests/unit/Core/System/Snippet/Mock/_fixtures/country.es-AR.json
@@ -1,0 +1,3 @@
+{
+  "title": "Country es-AR"
+}

--- a/tests/unit/Core/System/Snippet/Mock/_fixtures/country.fr-CA.json
+++ b/tests/unit/Core/System/Snippet/Mock/_fixtures/country.fr-CA.json
@@ -1,0 +1,3 @@
+{
+  "title": "Country fr-CA"
+}

--- a/tests/unit/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetServiceTest.php
@@ -9,7 +9,6 @@ use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -313,8 +312,6 @@ class SnippetServiceTest extends TestCase
 
     /**
      * @param array<string,string> $expectedSnippets
-     *
-     * @throws Exception
      */
     #[DataProvider('getListDataProvider')]
     public function testGetList(string $iso, array $expectedSnippets): void
@@ -436,8 +433,6 @@ class SnippetServiceTest extends TestCase
      *
      * @param StaticEntityRepository<SnippetCollection>|null $snippetRepository
      * @param StaticEntityRepository<SnippetSetCollection>|null $snippetSetRepository
-     *
-     * @throws Exception
      */
     private function createSnippetService(
         ?EventDispatcherInterface $eventDispatcher = null,
@@ -448,14 +443,21 @@ class SnippetServiceTest extends TestCase
         ?SnippetFilterFactory $snippetFilterFactory = null,
         ?ExtensionDispatcher $extensionDispatcher = null
     ): SnippetService {
-        // Use provided or fall back to sensible defaults and mocks.
-        $snippetRepository = $snippetRepository ?? $this->createMock(EntityRepository::class);
-        $snippetSetRepository = $snippetSetRepository ?? $this->createMock(EntityRepository::class);
+        if ($snippetRepository === null) {
+            $snippetRepository = new StaticEntityRepository([]);
+        }
+
+        if ($snippetSetRepository === null) {
+            $snippetSetRepository = new StaticEntityRepository([]);
+        }
+
         $snippetFileCollection = $snippetFileCollection ?? $this->snippetCollection;
         $connection = $connection ?? $this->connection;
         $snippetFilterFactory = $snippetFilterFactory ?? $this->createMock(SnippetFilterFactory::class);
         $extensionDispatcher = $extensionDispatcher ?? new ExtensionDispatcher(new EventDispatcher());
 
+        /** @var EntityRepository<SnippetCollection> $snippetRepository */
+        /** @var EntityRepository<SnippetSetCollection> $snippetSetRepository */
         return new SnippetService(
             $connection,
             $snippetFileCollection,

--- a/tests/unit/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetServiceTest.php
@@ -9,9 +9,11 @@ use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
@@ -19,6 +21,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Locale\LocaleCollection;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetCollection;
+use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetEntity;
 use Shopware\Core\System\Snippet\DataTransfer\Language\Language as LanguageDto;
 use Shopware\Core\System\Snippet\DataTransfer\Language\LanguageCollection as LanguageDtoCollection;
 use Shopware\Core\System\Snippet\DataTransfer\PluginMapping\PluginMappingCollection;
@@ -27,6 +30,7 @@ use Shopware\Core\System\Snippet\Files\RemoteSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\Filter\SnippetFilterFactory;
 use Shopware\Core\System\Snippet\Service\TranslationLoader;
+use Shopware\Core\System\Snippet\SnippetCollection;
 use Shopware\Core\System\Snippet\SnippetException;
 use Shopware\Core\System\Snippet\SnippetService;
 use Shopware\Core\System\Snippet\Struct\TranslationConfig;
@@ -307,6 +311,118 @@ class SnippetServiceTest extends TestCase
         ];
     }
 
+    /**
+     * @param array<string,string> $expectedSnippets
+     *
+     * @throws Exception
+     */
+    #[DataProvider('getListDataProvider')]
+    public function testGetList(string $iso, array $expectedSnippets): void
+    {
+        $availableFixtures = [
+            'base.es',
+            'country.es-AR',
+            'country.fr-CA',
+            'base.zh',
+            'country.zh-Hans-CN',
+        ];
+
+        $baseIso = \explode('-', $iso, 2)[0];
+
+        $baseFileName = 'base.' . $baseIso;
+        $countryFileName = 'country.' . $iso;
+
+        $snippetCollection = new SnippetFileCollection();
+        // only add files that exist in fixtures list
+        if (\in_array($baseFileName, $availableFixtures, true)) {
+            $snippetCollection->add(new MockSnippetFile($baseFileName, $baseIso));
+        }
+
+        if (\in_array($countryFileName, $availableFixtures, true)) {
+            $snippetCollection->add(new MockSnippetFile($countryFileName, $iso));
+        }
+
+        // Create snippet set entity representing available snippet set
+        $snippetSet = new SnippetSetEntity();
+        $setId = Uuid::randomHex();
+        $snippetSet->setId($setId);
+        $snippetSet->setIso($iso);
+        $snippetSet->setName('test');
+        $snippetSet->setBaseFile($countryFileName . '.json');
+
+        $snippetSetCollection = new SnippetSetCollection();
+        $snippetSetCollection->add($snippetSet);
+
+        /** @var StaticEntityRepository<SnippetSetCollection> $snippetSetRepository */
+        $snippetSetRepository = new StaticEntityRepository([
+            static function ($criteria, $context) use ($snippetSetCollection) {
+                return $snippetSetCollection;
+            },
+        ]);
+        /** @var StaticEntityRepository<SnippetCollection> $snippetRepository */
+        $snippetRepository = new StaticEntityRepository([
+            static function ($criteria, $context) {
+                return new SnippetCollection();
+            },
+        ]);
+
+        $service = $this->createSnippetService(
+            snippetRepository: $snippetRepository,
+            snippetSetRepository: $snippetSetRepository,
+            snippetFileCollection: $snippetCollection,
+            connection: $this->connection,
+        );
+
+        $context = Context::createDefaultContext();
+        $result = $service->getList(1, 10, $context, [], []);
+
+        // Assert the total count matches the number of expected translation keys
+        static::assertSame(\count($expectedSnippets), $result['total']);
+
+        // Assert each expected translation key is present and has the correct value
+        foreach ($expectedSnippets as $translationKey => $value) {
+            static::assertArrayHasKey($translationKey, $result['data']);
+            static::assertSame($value, $result['data'][$translationKey][0]['value']);
+        }
+    }
+
+    /**
+     * Data provider for getList tests.
+     */
+    public static function getListDataProvider(): \Generator
+    {
+        yield 'base locale es without country' => [
+            'iso' => 'es',
+            'expectedSnippets' => [
+                'title' => 'Base ES',
+                'baseOnly' => 'Base ES',
+            ],
+        ];
+
+        yield 'es-AR iso falls back to es' => [
+            'iso' => 'es-AR',
+            'expectedSnippets' => [
+                'title' => 'Country es-AR',
+                'baseOnly' => 'Base ES',
+            ],
+        ];
+
+        yield 'country exists without base' => [
+            'iso' => 'fr-CA',
+            'expectedSnippets' => [
+                'title' => 'Country fr-CA',
+            ],
+        ];
+
+        yield 'country es-EM does not exist - only base es exists' => [
+            'iso' => 'es-EM',
+            'expectedSnippets' => [
+                'title' => 'Base ES',
+                'baseOnly' => 'Base ES',
+            ],
+        ];
+    }
+
     private function addThemes(): void
     {
         $this->snippetCollection->add(new MockSnippetFile('storefront.de', 'de', '{}', true, 'Storefront'));
@@ -315,16 +431,38 @@ class SnippetServiceTest extends TestCase
         $this->snippetCollection->add(new MockSnippetFile('swagtheme.en', 'en', '{}', true, 'SwagTheme'));
     }
 
+    /**
+     * All parameters are optional. When provided they override defaults.
+     *
+     * @param StaticEntityRepository<SnippetCollection>|null $snippetRepository
+     * @param StaticEntityRepository<SnippetSetCollection>|null $snippetSetRepository
+     *
+     * @throws Exception
+     */
     private function createSnippetService(
         ?EventDispatcherInterface $eventDispatcher = null,
+        ?EntityRepository $snippetRepository = null,
+        ?EntityRepository $snippetSetRepository = null,
+        ?SnippetFileCollection $snippetFileCollection = null,
+        ?Connection $connection = null,
+        ?SnippetFilterFactory $snippetFilterFactory = null,
+        ?ExtensionDispatcher $extensionDispatcher = null
     ): SnippetService {
+        // Use provided or fall back to sensible defaults and mocks.
+        $snippetRepository = $snippetRepository ?? $this->createMock(EntityRepository::class);
+        $snippetSetRepository = $snippetSetRepository ?? $this->createMock(EntityRepository::class);
+        $snippetFileCollection = $snippetFileCollection ?? $this->snippetCollection;
+        $connection = $connection ?? $this->connection;
+        $snippetFilterFactory = $snippetFilterFactory ?? $this->createMock(SnippetFilterFactory::class);
+        $extensionDispatcher = $extensionDispatcher ?? new ExtensionDispatcher(new EventDispatcher());
+
         return new SnippetService(
-            $this->connection,
-            $this->snippetCollection,
-            $this->createMock(EntityRepository::class),
-            $this->createMock(EntityRepository::class),
-            $this->createMock(SnippetFilterFactory::class),
-            new ExtensionDispatcher(new EventDispatcher()),
+            $connection,
+            $snippetFileCollection,
+            $snippetRepository,
+            $snippetSetRepository,
+            $snippetFilterFactory,
+            $extensionDispatcher,
             $eventDispatcher ?? new EventDispatcher(),
             $this->flysystem,
             $this->filesystem,

--- a/tests/unit/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetServiceTest.php
@@ -320,16 +320,16 @@ class SnippetServiceTest extends TestCase
     public function testGetList(string $iso, array $expectedSnippets): void
     {
         $availableFixtures = [
-            'base.es',
+            'agnostic.es',
             'country.es-AR',
             'country.fr-CA',
-            'base.zh',
+            'agnostic.zh',
             'country.zh-Hans-CN',
         ];
 
         $baseIso = \explode('-', $iso, 2)[0];
 
-        $baseFileName = 'base.' . $baseIso;
+        $baseFileName = 'agnostic.' . $baseIso;
         $countryFileName = 'country.' . $iso;
 
         $snippetCollection = new SnippetFileCollection();
@@ -391,11 +391,11 @@ class SnippetServiceTest extends TestCase
      */
     public static function getListDataProvider(): \Generator
     {
-        yield 'base locale es without country' => [
+        yield 'agnostic locale es without country' => [
             'iso' => 'es',
             'expectedSnippets' => [
-                'title' => 'Base ES',
-                'baseOnly' => 'Base ES',
+                'title' => 'Agnostic ES',
+                'baseOnly' => 'Agnostic ES',
             ],
         ];
 
@@ -403,7 +403,7 @@ class SnippetServiceTest extends TestCase
             'iso' => 'es-AR',
             'expectedSnippets' => [
                 'title' => 'Country es-AR',
-                'baseOnly' => 'Base ES',
+                'baseOnly' => 'Agnostic ES',
             ],
         ];
 
@@ -417,8 +417,8 @@ class SnippetServiceTest extends TestCase
         yield 'country es-EM does not exist - only base es exists' => [
             'iso' => 'es-EM',
             'expectedSnippets' => [
-                'title' => 'Base ES',
-                'baseOnly' => 'Base ES',
+                'title' => 'Agnostic ES',
+                'baseOnly' => 'Agnostic ES',
             ],
         ];
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

closes #12732

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
