### PR TITLE
refactor(discount): Only consider filterable price definitions

### DIFF
--- a/changelog/_unreleased/2025-10-08-only-consider-filterable-discount-packages.md
+++ b/changelog/_unreleased/2025-10-08-only-consider-filterable-discount-packages.md
@@ -1,0 +1,13 @@
+---
+title: Only consider filterable discount packages
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+
+# Core
+* Changed the `Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\SetGroupScopeFilter` to only filter for price definitions when they implement the `Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface` instead of explicitly checking for the `getFilter` method
+
+___
+# Upgrade Information
+When you want to have a price definition which supports filtering when building discount packages, it was previously considered when the `getFilter()` method is implemented, for Shopware 6.8.0.0 the price definition needs to implement the `Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface`

--- a/changelog/_unreleased/2025-10-08-only-consider-filterable-discount-packages.md
+++ b/changelog/_unreleased/2025-10-08-only-consider-filterable-discount-packages.md
@@ -9,5 +9,7 @@ author_github: @aragon999
 * Changed the `Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\SetGroupScopeFilter` to only filter for price definitions when they implement the `Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface` instead of explicitly checking for the `getFilter` method
 
 ___
-# Upgrade Information
-When you want to have a price definition which supports filtering when building discount packages, it was previously considered when the `getFilter()` method is implemented, for Shopware 6.8.0.0 the price definition needs to implement the `Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface`
+# Next Major Version Changes
+## Filterable price definitions now require an explicit interface
+Previously, a price definition was treated as filterable when it implemented a `getFilter()` method. From now on, price definitions must explicitly implement the
+`Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface`, which defines the required `getFilter()` method.

--- a/changelog/_unreleased/2025-10-08-only-consider-filterable-discount-packages.md
+++ b/changelog/_unreleased/2025-10-08-only-consider-filterable-discount-packages.md
@@ -12,7 +12,7 @@ ___
 # Upgrade Information
 ## Add the correct interface to filterable price definitions
 If a price definition should be filterable, explicitly implement the `Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface`, which defines the required `getFilter()` method.
-
+___
 # Next Major Version Changes
 ## Filterable price definitions now require an explicit interface
 Previously, a price definition was treated as filterable when it implemented a `getFilter()` method. From now on, price definitions must explicitly implement the

--- a/changelog/_unreleased/2025-10-08-only-consider-filterable-discount-packages.md
+++ b/changelog/_unreleased/2025-10-08-only-consider-filterable-discount-packages.md
@@ -9,6 +9,10 @@ author_github: @aragon999
 * Changed the `Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\SetGroupScopeFilter` to only filter for price definitions when they implement the `Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface` instead of explicitly checking for the `getFilter` method
 
 ___
+# Upgrade Information
+## Add the correct interface to filterable price definitions
+If a price definition should be filterable, explicitly implement the `Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface`, which defines the required `getFilter()` method.
+
 # Next Major Version Changes
 ## Filterable price definitions now require an explicit interface
 Previously, a price definition was treated as filterable when it implemented a `getFilter()` method. From now on, price definitions must explicitly implement the

--- a/src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageRules.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageRules.php
@@ -6,11 +6,13 @@ use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemQuantity;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemQuantityCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemFlatCollection;
+use Shopware\Core\Checkout\Cart\Price\Struct\FilterableInterface;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceDefinitionInterface;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountLineItem;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackage;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackageCollection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Rule\Rule;
@@ -41,30 +43,33 @@ class AdvancedPackageRules extends SetGroupScopeFilter
 
     private function isRulesFilterValid(LineItem $item, PriceDefinitionInterface $priceDefinition, SalesChannelContext $context): bool
     {
-        // if the price definition doesnt allow filters,
-        // then return valid for the item
-        if (!method_exists($priceDefinition, 'getFilter')) {
-            return true;
+        if (Feature::isActive('v6.8.0.0')) {
+            if (!$priceDefinition instanceof FilterableInterface) {
+                return true;
+            }
+
+            $filter = $priceDefinition->getFilter();
+            if ($filter === null) {
+                return true;
+            }
+        } else {
+            // if the price definition doesnt allow filters,
+            // then return valid for the item
+            if (!method_exists($priceDefinition, 'getFilter')) {
+                return true;
+            }
+
+            /** @var Rule|null $filter */
+            $filter = $priceDefinition->getFilter();
+
+            // if the definition exists, but is empty
+            // this means we have no restrictions and thus its valid
+            if (!$filter instanceof Rule) {
+                return true;
+            }
         }
 
-        /** @var Rule|null $filter */
-        $filter = $priceDefinition->getFilter();
-
-        // if the definition exists, but is empty
-        // this means we have no restrictions and thus its valid
-        if (!$filter instanceof Rule) {
-            return true;
-        }
-
-        // if our price definition has a filter rule
-        // then extract it, and check if it matches
-        $scope = new LineItemScope($item, $context);
-
-        if ($filter->match($scope)) {
-            return true;
-        }
-
-        return false;
+        return $filter->match(new LineItemScope($item, $context));
     }
 
     /**


### PR DESCRIPTION
which implement the correct interface in discount packages

### 1. Why is this change necessary?
For more consistency, in most other places this check is already used, for example: https://github.com/shopware/shopware/blob/trunk/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/CartScopeDiscountPackager.php#L38

### 2. What does this change do, exactly?
Use the proper interface to check if the price definition is filterable.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
