### PR TITLE
feat(product-analytics): Use EventBus for event propagation

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -131,14 +131,9 @@ describe('src/app/post-init/amplitude.init.ts', () => {
         ])('handles event', async (telemetryEvent, trackedData) => {
             const { track } = await import('@amplitude/analytics-browser');
 
-            let amplitudeListener;
-            jest.spyOn(Shopware.Telemetry, 'addListener').mockImplementationOnce((callback) => {
-                amplitudeListener = callback;
-            });
-
             await initAmplitude();
 
-            amplitudeListener(telemetryEvent);
+            Shopware.Utils.EventBus.emit('telemetry', telemetryEvent);
 
             expect(track).toHaveBeenCalled();
             expect(track).toHaveBeenCalledWith(trackedData.eventName, trackedData.properties);

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -3,7 +3,7 @@
  */
 import * as amplitude from '@amplitude/analytics-browser';
 import { string } from 'src/core/service/util.service';
-import { TelemetryEvent, type EventTypes, type TrackableType } from '../../core/telemetry/types';
+import type { TelemetryEvent, EventTypes, TrackableType } from '../../core/telemetry/types';
 
 /**
  * @private
@@ -60,55 +60,54 @@ export default async function (): Promise<void> {
         // serverUrl: use proxy server url here, e.g. usage-data.shopware.io/product-analytics,
     });
 
-    Shopware.Telemetry.addListener((telemetryEvent) => {
-        if (!isTelemetryEvent(telemetryEvent)) {
-            return;
+    // eslint-disable-next-line listeners/no-missing-remove-event-listener
+    Shopware.Utils.EventBus.on('telemetry', pushTelemetryEventToAmplitude);
+}
+
+function pushTelemetryEventToAmplitude(telemetryEvent: TelemetryEvent<EventTypes>) {
+    if (isEventOfType('page_change', telemetryEvent)) {
+        amplitude.track('Page Viewed', {
+            sw_route_from_name: telemetryEvent.eventData.from.name,
+            sw_route_from_href: telemetryEvent.eventData.from.path,
+            sw_route_to_name: telemetryEvent.eventData.to.name,
+            sw_route_to_href: telemetryEvent.eventData.to.path,
+            sw_route_to_query: telemetryEvent.eventData.to.fullPath.split('?')[1],
+        });
+        return;
+    }
+
+    if (isEventOfType('user_interaction', telemetryEvent)) {
+        const { target, originalEvent } = telemetryEvent.eventData;
+
+        const eventProperties: Record<string, TrackableType> = {};
+
+        const capitalizedTagName = string.capitalizeString(target.tagName);
+        const capitalizedEventName = string.capitalizeString(originalEvent.type);
+
+        let eventName = `${capitalizedTagName} ${capitalizedEventName}`;
+
+        if (target.tagName === 'A') {
+            eventName = 'Link Visited';
+
+            eventProperties.sw_link_href = target.getAttribute('href') ?? '';
+            eventProperties.sw_link_type = target.getAttribute('target') === '_blank' ? 'external' : 'internal';
         }
 
-        if (isEventOfType('page_change', telemetryEvent)) {
-            amplitude.track('Page Viewed', {
-                sw_route_from_name: telemetryEvent.detail.eventData.from.name,
-                sw_route_from_href: telemetryEvent.detail.eventData.from.path,
-                sw_route_to_name: telemetryEvent.detail.eventData.to.name,
-                sw_route_to_href: telemetryEvent.detail.eventData.to.path,
-                sw_route_to_query: telemetryEvent.detail.eventData.to.fullPath.split('?')[1],
-            });
-            return;
-        }
-
-        if (isEventOfType('user_interaction', telemetryEvent)) {
-            const { target, originalEvent } = telemetryEvent.detail.eventData;
-
-            const eventProperties: Record<string, TrackableType> = {};
-
-            const capitalizedTagName = string.capitalizeString(target.tagName);
-            const capitalizedEventName = string.capitalizeString(originalEvent.type);
-
-            let eventName = `${capitalizedTagName} ${capitalizedEventName}`;
-
-            if (target.tagName === 'A') {
-                eventName = 'Link Visited';
-
-                eventProperties.sw_link_href = target.getAttribute('href') ?? '';
-                eventProperties.sw_link_type = target.getAttribute('target') === '_blank' ? 'external' : 'internal';
+        target.getAttributeNames().forEach((attributeName) => {
+            if (attributeName.startsWith('data-analytics-')) {
+                const propertyName = string.snakeCase(attributeName.replace('data-analytics-', 'sw_element_'));
+                eventProperties[propertyName] = target.getAttribute(attributeName);
             }
+        });
 
-            target.getAttributeNames().forEach((attributeName) => {
-                if (attributeName.startsWith('data-analytics-')) {
-                    const propertyName = string.snakeCase(attributeName.replace('data-analytics-', 'sw_element_'));
-                    eventProperties[propertyName] = target.getAttribute(attributeName);
-                }
-            });
-
-            if (originalEvent instanceof MouseEvent) {
-                eventProperties.sw_pointer_x = originalEvent.clientX;
-                eventProperties.sw_pointer_y = originalEvent.clientY;
-                eventProperties.sw_pointer_button = originalEvent.buttons;
-            }
-
-            amplitude.track(eventName, eventProperties);
+        if (originalEvent instanceof MouseEvent) {
+            eventProperties.sw_pointer_x = originalEvent.clientX;
+            eventProperties.sw_pointer_y = originalEvent.clientY;
+            eventProperties.sw_pointer_button = originalEvent.buttons;
         }
-    });
+
+        amplitude.track(eventName, eventProperties);
+    }
 }
 
 async function getDefaultLanguageName(): Promise<string> {
@@ -118,13 +117,9 @@ async function getDefaultLanguageName(): Promise<string> {
     return defaultLanguage!.name;
 }
 
-function isTelemetryEvent(telemetryEvent: Event): telemetryEvent is TelemetryEvent<EventTypes> {
-    return telemetryEvent instanceof TelemetryEvent;
-}
-
 function isEventOfType<N extends EventTypes>(
     eventType: N,
     telemetryEvent: TelemetryEvent<EventTypes>,
 ): telemetryEvent is TelemetryEvent<N> {
-    return telemetryEvent.detail.eventType === eventType;
+    return telemetryEvent.eventType === eventType;
 }

--- a/src/Administration/Resources/app/administration/src/core/service/utils/eventBus.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/eventBus.utils.ts
@@ -3,6 +3,7 @@
  */
 
 import mitt from 'mitt';
+import type { TelemetryEvent, EventTypes as TelemetryEventTypes } from '../../telemetry/types';
 
 /**
  * The pattern for event names = component name in kebab case followed by the event
@@ -14,6 +15,7 @@ interface Events extends Record<string | symbol, unknown> {
     'sw-sales-channel-detail-base-sales-channel-change': undefined;
     'sw-sales-channel-list-add-new-channel': undefined;
     'sw-media-library-item-updated': undefined;
+    telemetry: TelemetryEvent<TelemetryEventTypes>;
 }
 
 const emitter = mitt<Events>();

--- a/src/Administration/Resources/app/administration/src/core/telemetry/types.ts
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/types.ts
@@ -27,21 +27,15 @@ type AnalyticsEvents = {
 
 type EventTypes = keyof AnalyticsEvents;
 type EventPayload<N extends EventTypes> = AnalyticsEvents[N];
-type EventData<N extends EventTypes> = {
-    eventType: N;
-    eventData: EventPayload<N>;
-    timestamp: Date;
-};
 
-class TelemetryEvent<N extends EventTypes> extends CustomEvent<EventData<N>> {
-    constructor(eventType: N, eventData: AnalyticsEvents[N]) {
-        super('telemetry', {
-            detail: {
-                eventType,
-                eventData,
-                timestamp: new Date(),
-            },
-        });
+class TelemetryEvent<N extends EventTypes> {
+    public readonly timestamp: Date;
+
+    constructor(
+        public readonly eventType: N,
+        public readonly eventData: AnalyticsEvents[N],
+    ) {
+        this.timestamp = new Date();
     }
 }
 


### PR DESCRIPTION
Use `Shopware.Utils.EventBus`  for event propagation instead of an own `EventTarget`