### PR TITLE
fix: Clearance sale (stock handling) is ignored as soon as a product is in the cart 

### DIFF
--- a/changelog/_unreleased/2025-10-09-clearance-sale-stock-handling-is-ignored-as-soon-as-a-product-is-in-the-cart.md
+++ b/changelog/_unreleased/2025-10-09-clearance-sale-stock-handling-is-ignored-as-soon-as-a-product-is-in-the-cart.md
@@ -1,0 +1,6 @@
+---
+title: Clearance sale (stock handling) is ignored as soon as a product is in the cart
+issue: 12805
+---
+# Core
+* Changed `alter` method in `Shopware\Core\Content\Product\Stock\StockStorage` to update updated_ted at field when stock is changed, to make sure the cart is recalculated when stock changes.

--- a/src/Core/Content/Product/Stock/StockStorage.php
+++ b/src/Core/Content/Product/Stock/StockStorage.php
@@ -52,7 +52,7 @@ class StockStorage extends AbstractStockStorage
 
         $sql = <<<'SQL'
             UPDATE product
-            SET stock = stock + :quantity, sales = sales - :quantity, available_stock = stock
+            SET stock = stock + :quantity, sales = sales - :quantity, available_stock = stock, updated_at = NOW()
             WHERE id = :id AND version_id = :version
         SQL;
 
@@ -109,7 +109,8 @@ class StockStorage extends AbstractStockStorage
                 COALESCE(product.is_closeout, parent.is_closeout, 0) * product.stock
                 >=
                 COALESCE(product.is_closeout, parent.is_closeout, 0) * IFNULL(product.min_purchase, parent.min_purchase)
-            ), 0)
+            ), 0),
+                product.updated_at = NOW()
             WHERE product.id IN (:ids)
             AND product.version_id = :version
         ';


### PR DESCRIPTION
This pull request improves the handling of product stock updates during clearance sales by ensuring that the `updated_at` timestamp is refreshed whenever stock changes, which helps trigger cart recalculations as needed. It also adds a new test to verify this behavior specifically for clearance sale products.

**Stock update logic improvements:**

* Modified the `alter` method in `Shopware\Core\Content\Product\Stock\StockStorage` so that the `updated_at` field is set to the current time whenever stock is changed. This ensures the cart will be recalculated when stock changes. [[1]](diffhunk://#diff-bdc6dec57de05aeca2e66f7c0ca3339ef254ce2744e4f87bf74d33c3da7c3a32L55-R55) [[2]](diffhunk://#diff-fdfd4b70a475c265e7dd8384642e66e134da5741058b3a6612994e22c2eedc04R1-R6)
