### PR TITLE
fix: Invalid spelling of modelValue / model-value

### DIFF
--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-colorpicker.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-colorpicker.check.js
@@ -42,11 +42,11 @@ const handleMtColorpicker = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -54,7 +54,7 @@ const handleMtColorpicker = (context, node) => {
     if (vModelValue) {
         context.report({
             node: vModelValue,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
@@ -66,11 +66,11 @@ const handleMtColorpicker = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -78,11 +78,11 @@ const handleMtColorpicker = (context, node) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key.argument, 'update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key.argument, 'update:model-value');
             }
         });
     }
@@ -126,7 +126,7 @@ const mtColorpickerValidTests = [
 
 const mtColorpickerInvalidTests = [
     {
-        name: '"mt-colorpicker" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-colorpicker" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -134,14 +134,14 @@ const mtColorpickerInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-colorpicker modelValue="Hello World" />
+                <mt-colorpicker model-value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-colorpicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-colorpicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-colorpicker" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-colorpicker" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -149,11 +149,11 @@ const mtColorpickerInvalidTests = [
                 <mt-colorpicker value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-colorpicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-colorpicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-colorpicker" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-colorpicker" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -161,14 +161,14 @@ const mtColorpickerInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-colorpicker :modelValue="myValue" />
+                <mt-colorpicker :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-colorpicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-colorpicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-colorpicker" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-colorpicker" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -176,7 +176,7 @@ const mtColorpickerInvalidTests = [
                 <mt-colorpicker :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-colorpicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-colorpicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -191,7 +191,7 @@ const mtColorpickerInvalidTests = [
                 <mt-colorpicker v-model="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-colorpicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-colorpicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -203,11 +203,11 @@ const mtColorpickerInvalidTests = [
                 <mt-colorpicker v-model:value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-colorpicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-colorpicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-colorpicker" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-colorpicker" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -215,14 +215,14 @@ const mtColorpickerInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-colorpicker @update:modelValue="updateValue" />
+                <mt-colorpicker @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-colorpicker] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-colorpicker] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-colorpicker" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-colorpicker" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -230,7 +230,7 @@ const mtColorpickerInvalidTests = [
                 <mt-colorpicker @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-colorpicker] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-colorpicker] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-datepicker.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-datepicker.check.js
@@ -42,11 +42,11 @@ const handleMtDatepicker = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -54,11 +54,11 @@ const handleMtDatepicker = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -78,11 +78,11 @@ const handleMtDatepicker = (context, node) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key.argument, 'update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key.argument, 'update:model-value');
             }
         });
     }
@@ -134,7 +134,7 @@ const mtDatepickerValidTests = [
 
 const mtDatepickerInvalidTests = [
     {
-        name: '"mt-datepicker" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-datepicker" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -142,14 +142,14 @@ const mtDatepickerInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-datepicker modelValue="yes" />
+                <mt-datepicker model-value="yes" />
             </template>`,
         errors: [{
-            message: '[mt-datepicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-datepicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-datepicker" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-datepicker" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -157,11 +157,11 @@ const mtDatepickerInvalidTests = [
                 <mt-datepicker value="yes" />
             </template>`,
         errors: [{
-            message: '[mt-datepicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-datepicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-datepicker" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-datepicker" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -169,14 +169,14 @@ const mtDatepickerInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-datepicker :modelValue="myValue" />
+                <mt-datepicker :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-datepicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-datepicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-datepicker" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-datepicker" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -184,7 +184,7 @@ const mtDatepickerInvalidTests = [
                 <mt-datepicker :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-datepicker] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-datepicker] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -215,7 +215,7 @@ const mtDatepickerInvalidTests = [
         }]
     },
     {
-        name: '"mt-datepicker" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-datepicker" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -223,14 +223,14 @@ const mtDatepickerInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-datepicker @update:modelValue="updateValue" />
+                <mt-datepicker @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-datepicker] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-datepicker] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-datepicker" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-datepicker" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -238,7 +238,7 @@ const mtDatepickerInvalidTests = [
                 <mt-datepicker @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-datepicker] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-datepicker] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-email-field.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-email-field.check.js
@@ -17,7 +17,7 @@ const mtEmailFieldValidTests = [
 
 const mtEmailFieldInvalidTests = [
     {
-        name: '"mt-email-field" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-email-field" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -25,14 +25,14 @@ const mtEmailFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-email-field modelValue="Hello World" />
+                <mt-email-field model-value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-email-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-email-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-email-field" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-email-field" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -40,11 +40,11 @@ const mtEmailFieldInvalidTests = [
                 <mt-email-field value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-email-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-email-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-email-field" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-email-field" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -52,14 +52,14 @@ const mtEmailFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-email-field :modelValue="myValue" />
+                <mt-email-field :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-email-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-email-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-email-field" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-email-field" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -67,7 +67,7 @@ const mtEmailFieldInvalidTests = [
                 <mt-email-field :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-email-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-email-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -82,7 +82,7 @@ const mtEmailFieldInvalidTests = [
                 <mt-email-field v-model="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-email-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-email-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -94,7 +94,7 @@ const mtEmailFieldInvalidTests = [
                 <mt-email-field v-model:value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-email-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-email-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -233,7 +233,7 @@ const mtEmailFieldInvalidTests = [
         }]
     },
     {
-        name: '"mt-email-field" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-email-field" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -241,14 +241,14 @@ const mtEmailFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-email-field @update:modelValue="updateValue" />
+                <mt-email-field @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-email-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-email-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-email-field" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-email-field" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -256,7 +256,7 @@ const mtEmailFieldInvalidTests = [
                 <mt-email-field @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-email-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-email-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-number-field.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-number-field.check.js
@@ -43,11 +43,11 @@ const handleMtNumberField = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -55,7 +55,7 @@ const handleMtNumberField = (context, node) => {
     if (vModelValue) {
         context.report({
             node: vModelValue,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
@@ -67,11 +67,11 @@ const handleMtNumberField = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -104,17 +104,17 @@ const handleMtNumberField = (context, node) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key.argument, 'update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key.argument, 'update:model-value');
             }
         });
     }
 }
 
-// - prop "value" was replaced with "modelValue"
+// - prop "value" was replaced with "model-value"
 // - slot "label" was removed and should be replaced with "label" prop
 // - event "update:value" was replaced with "change"
 
@@ -131,7 +131,7 @@ const mtNumberFieldValidTests = [
 
 const mtNumberFieldInvalidTests = [
     {
-        name: '"mt-number-field" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-number-field" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -139,14 +139,14 @@ const mtNumberFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-number-field modelValue="5" />
+                <mt-number-field model-value="5" />
             </template>`,
         errors: [{
-            message: '[mt-number-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-number-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-number-field" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-number-field" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -154,11 +154,11 @@ const mtNumberFieldInvalidTests = [
                 <mt-number-field value="5" />
             </template>`,
         errors: [{
-            message: '[mt-number-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-number-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-number-field" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-number-field" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -166,14 +166,14 @@ const mtNumberFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-number-field :modelValue="myValue" />
+                <mt-number-field :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-number-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-number-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-number-field" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-number-field" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -181,7 +181,7 @@ const mtNumberFieldInvalidTests = [
                 <mt-number-field :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-number-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-number-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -196,7 +196,7 @@ const mtNumberFieldInvalidTests = [
                 <mt-number-field v-model="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-number-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-number-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -208,7 +208,7 @@ const mtNumberFieldInvalidTests = [
                 <mt-number-field v-model:value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-number-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-number-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -286,7 +286,7 @@ const mtNumberFieldInvalidTests = [
         }]
     },
     {
-        name: '"mt-number-field" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-number-field" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -294,14 +294,14 @@ const mtNumberFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-number-field @update:modelValue="updateValue" />
+                <mt-number-field @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-number-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-number-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-number-field" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-number-field" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -309,7 +309,7 @@ const mtNumberFieldInvalidTests = [
                 <mt-number-field @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-number-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-number-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
 ];

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-password-field.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-password-field.check.js
@@ -80,11 +80,11 @@ const handleMtPasswordField = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -92,7 +92,7 @@ const handleMtPasswordField = (context, node) => {
     if (vModelValue) {
         context.report({
             node: vModelValue,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
@@ -104,11 +104,11 @@ const handleMtPasswordField = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -152,11 +152,11 @@ const handleMtPasswordField = (context, node) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key.argument, 'update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key.argument, 'update:model-value');
             }
         });
     }
@@ -237,7 +237,7 @@ const mtPasswordFieldValidTests = [
 
 const mtPasswordFieldInvalidTests = [
     {
-        name: '"mt-password-field" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-password-field" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -245,14 +245,14 @@ const mtPasswordFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-password-field modelValue="Hello World" />
+                <mt-password-field model-value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-password-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-password-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-password-field" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-password-field" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -260,11 +260,11 @@ const mtPasswordFieldInvalidTests = [
                 <mt-password-field value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-password-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-password-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-password-field" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-password-field" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -272,14 +272,14 @@ const mtPasswordFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-password-field :modelValue="myValue" />
+                <mt-password-field :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-password-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-password-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-password-field" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-password-field" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -287,7 +287,7 @@ const mtPasswordFieldInvalidTests = [
                 <mt-password-field :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-password-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-password-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -302,7 +302,7 @@ const mtPasswordFieldInvalidTests = [
                 <mt-password-field v-model="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-password-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-password-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -314,7 +314,7 @@ const mtPasswordFieldInvalidTests = [
                 <mt-password-field v-model:value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-password-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-password-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -399,7 +399,7 @@ const mtPasswordFieldInvalidTests = [
         }]
     },
     {
-        name: '"mt-password-field" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-password-field" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -407,14 +407,14 @@ const mtPasswordFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-password-field @update:modelValue="updateValue" />
+                <mt-password-field @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-password-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-password-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-password-field" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-password-field" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -422,7 +422,7 @@ const mtPasswordFieldInvalidTests = [
                 <mt-password-field @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-password-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-password-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-progress-bar.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-progress-bar.check.js
@@ -31,11 +31,11 @@ const handleMtProgressBar = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -43,7 +43,7 @@ const handleMtProgressBar = (context, node) => {
     if (vModelValue) {
         context.report({
             node: vModelValue,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
@@ -55,11 +55,11 @@ const handleMtProgressBar = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -67,11 +67,11 @@ const handleMtProgressBar = (context, node) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key.argument, 'update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key.argument, 'update:model-value');
             }
         });
     }
@@ -90,7 +90,7 @@ const mtProgressBarValidTests = [
 
 const mtProgressBarInvalidTests = [
     {
-        name: '"mt-progress-bar" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-progress-bar" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -98,14 +98,14 @@ const mtProgressBarInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-progress-bar modelValue="Hello World" />
+                <mt-progress-bar model-value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-progress-bar] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-progress-bar] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-progress-bar" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-progress-bar" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -113,11 +113,11 @@ const mtProgressBarInvalidTests = [
                 <mt-progress-bar value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-progress-bar] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-progress-bar] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-progress-bar" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-progress-bar" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -125,14 +125,14 @@ const mtProgressBarInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-progress-bar :modelValue="myValue" />
+                <mt-progress-bar :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-progress-bar] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-progress-bar] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-progress-bar" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-progress-bar" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -140,7 +140,7 @@ const mtProgressBarInvalidTests = [
                 <mt-progress-bar :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-progress-bar] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-progress-bar] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -155,7 +155,7 @@ const mtProgressBarInvalidTests = [
                 <mt-progress-bar v-model="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-progress-bar] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-progress-bar] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -167,11 +167,11 @@ const mtProgressBarInvalidTests = [
                 <mt-progress-bar v-model:value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-progress-bar] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-progress-bar] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-progress-bar" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-progress-bar" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -179,14 +179,14 @@ const mtProgressBarInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-progress-bar @update:modelValue="updateValue" />
+                <mt-progress-bar @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-progress-bar] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-progress-bar] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-progress-bar" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-progress-bar" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -194,7 +194,7 @@ const mtProgressBarInvalidTests = [
                 <mt-progress-bar @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-progress-bar] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-progress-bar] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
 ];

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-select.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-select.check.js
@@ -94,11 +94,11 @@ const handleMtSelect = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -106,11 +106,11 @@ const handleMtSelect = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -190,11 +190,11 @@ const handleMtSelect = (context, node) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key, '@update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key, '@update:model-value');
             }
         });
     }
@@ -202,11 +202,11 @@ const handleMtSelect = (context, node) => {
     if (updateValueEventLongSyntax) {
         context.report({
             node: updateValueEventLongSyntax,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEventLongSyntax.key, 'v-on:update:modelValue');
+                yield fixer.replaceText(updateValueEventLongSyntax.key, 'v-on:update:model-value');
             }
         });
     }
@@ -264,7 +264,7 @@ const mtSelectValidTests = [
 
 const mtSelectInvalidTests = [
     {
-        name: '"mt-select" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-select" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -272,14 +272,14 @@ const mtSelectInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-select modelValue="optionA" />
+                <mt-select model-value="optionA" />
             </template>`,
         errors: [{
-            message: '[mt-select] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-select] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-select" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-select" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -287,11 +287,11 @@ const mtSelectInvalidTests = [
                 <mt-select value="optionA" />
             </template>`,
         errors: [{
-            message: '[mt-select] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-select] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-select" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-select" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -299,14 +299,14 @@ const mtSelectInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-select :modelValue="myValue" />
+                <mt-select :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-select] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-select] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-select" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-select" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -314,7 +314,7 @@ const mtSelectInvalidTests = [
                 <mt-select :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-select] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-select] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -546,7 +546,7 @@ const mtSelectInvalidTests = [
         }]
     },
     {
-        name: '"mt-select" event "update:value" was renamed to "update:modelValue"',
+        name: '"mt-select" event "update:value" was renamed to "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -554,14 +554,14 @@ const mtSelectInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-select @update:modelValue="onUpdateValue" />
+                <mt-select @update:model-value="onUpdateValue" />
             </template>`,
         errors: [{
-            message: '[mt-select] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-select] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }]
     },
     {
-        name: '"mt-select" event "update:value" was renamed to "update:modelValue" [disableFix]',
+        name: '"mt-select" event "update:value" was renamed to "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -569,11 +569,11 @@ const mtSelectInvalidTests = [
                 <mt-select @update:value="onUpdateValue" />
             </template>`,
         errors: [{
-            message: '[mt-select] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-select] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }]
     },
     {
-        name: '"mt-select" event "update:value" was renamed to "update:modelValue" [long syntax]',
+        name: '"mt-select" event "update:value" was renamed to "update:mode-value" [long syntax]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -581,14 +581,14 @@ const mtSelectInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-select v-on:update:modelValue="onUpdateValue" />
+                <mt-select v-on:update:model-value="onUpdateValue" />
             </template>`,
         errors: [{
-            message: '[mt-select] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-select] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }]
     },
     {
-        name: '"mt-select" event "update:value" was renamed to "update:modelValue" [long syntax, disableFix]',
+        name: '"mt-select" event "update:value" was renamed to "update:mode-value" [long syntax, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -596,7 +596,7 @@ const mtSelectInvalidTests = [
                 <mt-select v-on:update:value="onUpdateValue" />
             </template>`,
         errors: [{
-            message: '[mt-select] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-select] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }]
     },
 ]

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-switch.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-switch.check.js
@@ -196,11 +196,11 @@ const handleMtSwitch = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtSwitchComponentName}] The "value" prop is removed. Use "modelValue" instead.`,
+            message: `[${mtSwitchComponentName}] The "value" prop is removed. Use "model-value" instead.`,
             *fix(fixer) {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -224,11 +224,11 @@ const handleMtSwitch = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtSwitchComponentName}] The "value" prop is removed. Use "modelValue" instead.`,
+            message: `[${mtSwitchComponentName}] The "value" prop is removed. Use "model-value" instead.`,
             *fix(fixer) {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -602,7 +602,7 @@ const mtSwitchInvalidChecks = [
         }],
     },
     {
-        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "modelValue".',
+        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "model-value".',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -610,14 +610,14 @@ const mtSwitchInvalidChecks = [
             </template>`,
         output: `
             <template>
-                <mt-switch modelValue="true" />
+                <mt-switch model-value="true" />
             </template>`,
         errors: [{
-            message: '[mt-switch] The "value" prop is removed. Use "modelValue" instead.',
+            message: '[mt-switch] The "value" prop is removed. Use "model-value" instead.',
         }],
     },
     {
-        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "modelValue". [disabledFix]',
+        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "model-value". [disabledFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -625,11 +625,11 @@ const mtSwitchInvalidChecks = [
                 <mt-switch value="true" />
             </template>`,
         errors: [{
-            message: '[mt-switch] The "value" prop is removed. Use "modelValue" instead.',
+            message: '[mt-switch] The "value" prop is removed. Use "model-value" instead.',
         }],
     },
     {
-        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "modelValue". [expression]',
+        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "model-value". [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -637,14 +637,14 @@ const mtSwitchInvalidChecks = [
             </template>`,
         output: `
             <template>
-                <mt-switch :modelValue="myValue" />
+                <mt-switch :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-switch] The "value" prop is removed. Use "modelValue" instead.',
+            message: '[mt-switch] The "value" prop is removed. Use "model-value" instead.',
         }],
     },
     {
-        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "modelValue". [expression, disabledFix]',
+        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "model-value". [expression, disabledFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -652,11 +652,11 @@ const mtSwitchInvalidChecks = [
                 <mt-switch :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-switch] The "value" prop is removed. Use "modelValue" instead.',
+            message: '[mt-switch] The "value" prop is removed. Use "model-value" instead.',
         }],
     },
     {
-        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "modelValue". [withoutBinding]',
+        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "model-value". [withoutBinding]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -664,14 +664,14 @@ const mtSwitchInvalidChecks = [
             </template>`,
         output: `
             <template>
-                <mt-switch modelValue />
+                <mt-switch model-value />
             </template>`,
         errors: [{
-            message: '[mt-switch] The "value" prop is removed. Use "modelValue" instead.',
+            message: '[mt-switch] The "value" prop is removed. Use "model-value" instead.',
         }],
     },
     {
-        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "modelValue". [withoutBinding, disabledFix]',
+        name: '"mt-switch" wrong "value" prop usage. Should be replaced with "model-value". [withoutBinding, disabledFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -679,7 +679,7 @@ const mtSwitchInvalidChecks = [
                 <mt-switch value />
             </template>`,
         errors: [{
-            message: '[mt-switch] The "value" prop is removed. Use "modelValue" instead.',
+            message: '[mt-switch] The "value" prop is removed. Use "model-value" instead.',
         }],
     },
     {

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-text-field.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-text-field.check.js
@@ -92,11 +92,11 @@ const handleMtTextField = (context, node, emailMode = false) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -104,7 +104,7 @@ const handleMtTextField = (context, node, emailMode = false) => {
     if (vModelValue) {
         context.report({
             node: vModelValue,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
@@ -116,11 +116,11 @@ const handleMtTextField = (context, node, emailMode = false) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -188,11 +188,11 @@ const handleMtTextField = (context, node, emailMode = false) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key.argument, 'update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key.argument, 'update:model-value');
             }
         });
     }
@@ -248,7 +248,7 @@ const mtTextFieldValidTests = [
 
 const mtTextFieldInvalidTests = [
     {
-        name: '"mt-text-field" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-text-field" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -256,14 +256,14 @@ const mtTextFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-text-field modelValue="Hello World" />
+                <mt-text-field model-value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-text-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-text-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-text-field" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-text-field" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -271,11 +271,11 @@ const mtTextFieldInvalidTests = [
                 <mt-text-field value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-text-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-text-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-text-field" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-text-field" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -283,14 +283,14 @@ const mtTextFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-text-field :modelValue="myValue" />
+                <mt-text-field :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-text-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-text-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-text-field" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-text-field" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -298,7 +298,7 @@ const mtTextFieldInvalidTests = [
                 <mt-text-field :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-text-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-text-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -313,7 +313,7 @@ const mtTextFieldInvalidTests = [
                 <mt-text-field v-model="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-text-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-text-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -325,7 +325,7 @@ const mtTextFieldInvalidTests = [
                 <mt-text-field v-model:value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-text-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-text-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -464,7 +464,7 @@ const mtTextFieldInvalidTests = [
         }]
     },
     {
-        name: '"mt-text-field" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-text-field" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -472,14 +472,14 @@ const mtTextFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-text-field @update:modelValue="updateValue" />
+                <mt-text-field @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-text-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-text-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-text-field" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-text-field" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -487,7 +487,7 @@ const mtTextFieldInvalidTests = [
                 <mt-text-field @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-text-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-text-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-textarea.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-textarea.check.js
@@ -42,11 +42,11 @@ const handleMtTextarea = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -54,11 +54,11 @@ const handleMtTextarea = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -78,11 +78,11 @@ const handleMtTextarea = (context, node) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key.argument, 'update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key.argument, 'update:model-value');
             }
         });
     }
@@ -126,7 +126,7 @@ const mtTextareaValidTests = [
 
 const mtTextareaInvalidTests = [
     {
-        name: '"mt-textarea" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-textarea" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -134,14 +134,14 @@ const mtTextareaInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-textarea modelValue="yes" />
+                <mt-textarea model-value="yes" />
             </template>`,
         errors: [{
-            message: '[mt-textarea] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-textarea] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-textarea" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-textarea" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -149,11 +149,11 @@ const mtTextareaInvalidTests = [
                 <mt-textarea value="yes" />
             </template>`,
         errors: [{
-            message: '[mt-textarea] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-textarea] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-textarea" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-textarea" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -161,14 +161,14 @@ const mtTextareaInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-textarea :modelValue="myValue" />
+                <mt-textarea :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-textarea] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-textarea] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-textarea" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-textarea" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -176,7 +176,7 @@ const mtTextareaInvalidTests = [
                 <mt-textarea :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-textarea] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-textarea] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -207,7 +207,7 @@ const mtTextareaInvalidTests = [
         }]
     },
     {
-        name: '"mt-textarea" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-textarea" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -215,14 +215,14 @@ const mtTextareaInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-textarea @update:modelValue="updateValue" />
+                <mt-textarea @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-textarea] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-textarea] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-textarea" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-textarea" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -230,7 +230,7 @@ const mtTextareaInvalidTests = [
                 <mt-textarea @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-textarea] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-textarea] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {

--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-url-field.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-url-field.check.js
@@ -52,11 +52,11 @@ const handleMtUrlField = (context, node) => {
     if (valueAttribute) {
         context.report({
             node: valueAttribute,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttribute.key, 'modelValue');
+                yield fixer.replaceText(valueAttribute.key, 'model-value');
             }
         });
     }
@@ -64,7 +64,7 @@ const handleMtUrlField = (context, node) => {
     if (vModelValue) {
         context.report({
             node: vModelValue,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
@@ -76,11 +76,11 @@ const handleMtUrlField = (context, node) => {
     if (valueAttributeExpression) {
         context.report({
             node: valueAttributeExpression,
-            message: `[${mtComponentName}] The "value" prop is deprecated. Use "modelValue" instead.`,
+            message: `[${mtComponentName}] The "value" prop is deprecated. Use "model-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(valueAttributeExpression.key.argument, 'modelValue');
+                yield fixer.replaceText(valueAttributeExpression.key.argument, 'model-value');
             }
         });
     }
@@ -88,11 +88,11 @@ const handleMtUrlField = (context, node) => {
     if (updateValueEvent) {
         context.report({
             node: updateValueEvent,
-            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:modelValue" instead.`,
+            message: `[${mtComponentName}] The "update:value" event is deprecated. Use "update:mode-value" instead.`,
             *fix(fixer)  {
                 if (context.options.includes('disableFix')) return;
 
-                yield fixer.replaceText(updateValueEvent.key.argument, 'update:modelValue');
+                yield fixer.replaceText(updateValueEvent.key.argument, 'update:model-value');
             }
         });
     }
@@ -161,7 +161,7 @@ const mtUrlFieldValidTests = [
 
 const mtUrlFieldInvalidTests = [
     {
-        name: '"mt-url-field" wrong "value" prop usage should be replaced with "modelValue"',
+        name: '"mt-url-field" wrong "value" prop usage should be replaced with "model-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -169,14 +169,14 @@ const mtUrlFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-url-field modelValue="Hello World" />
+                <mt-url-field model-value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-url-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-url-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-url-field" wrong "value" prop usage should be replaced with "modelValue" [disableFix]',
+        name: '"mt-url-field" wrong "value" prop usage should be replaced with "model-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -184,11 +184,11 @@ const mtUrlFieldInvalidTests = [
                 <mt-url-field value="Hello World" />
             </template>`,
         errors: [{
-            message: '[mt-url-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-url-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-url-field" wrong "value" prop usage should be replaced with "modelValue" [expression]',
+        name: '"mt-url-field" wrong "value" prop usage should be replaced with "model-value" [expression]',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -196,14 +196,14 @@ const mtUrlFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-url-field :modelValue="myValue" />
+                <mt-url-field :model-value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-url-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-url-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
-        name: '"mt-url-field" wrong "value" prop usage should be replaced with "modelValue" [expression, disableFix]',
+        name: '"mt-url-field" wrong "value" prop usage should be replaced with "model-value" [expression, disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -211,7 +211,7 @@ const mtUrlFieldInvalidTests = [
                 <mt-url-field :value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-url-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-url-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -226,7 +226,7 @@ const mtUrlFieldInvalidTests = [
                 <mt-url-field v-model="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-url-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-url-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -238,7 +238,7 @@ const mtUrlFieldInvalidTests = [
                 <mt-url-field v-model:value="myValue" />
             </template>`,
         errors: [{
-            message: '[mt-url-field] The "value" prop is deprecated. Use "modelValue" instead.',
+            message: '[mt-url-field] The "value" prop is deprecated. Use "model-value" instead.',
         }]
     },
     {
@@ -323,7 +323,7 @@ const mtUrlFieldInvalidTests = [
         }]
     },
     {
-        name: '"mt-url-field" wrong "update:value" event usage should be replaced with "update:modelValue"',
+        name: '"mt-url-field" wrong "update:value" event usage should be replaced with "update:mode-value"',
         filename: 'test.html.twig',
         code: `
             <template>
@@ -331,14 +331,14 @@ const mtUrlFieldInvalidTests = [
             </template>`,
         output: `
             <template>
-                <mt-url-field @update:modelValue="updateValue" />
+                <mt-url-field @update:model-value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-url-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-url-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {
-        name: '"mt-url-field" wrong "update:value" event usage should be replaced with "update:modelValue" [disableFix]',
+        name: '"mt-url-field" wrong "update:value" event usage should be replaced with "update:mode-value" [disableFix]',
         filename: 'test.html.twig',
         options: ['disableFix'],
         code: `
@@ -346,7 +346,7 @@ const mtUrlFieldInvalidTests = [
                 <mt-url-field @update:value="updateValue" />
             </template>`,
         errors: [{
-            message: '[mt-url-field] The "update:value" event is deprecated. Use "update:modelValue" instead.',
+            message: '[mt-url-field] The "update:value" event is deprecated. Use "update:mode-value" instead.',
         }],
     },
     {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.html.twig
@@ -8,7 +8,7 @@
     class="sw-custom-field-detail__switch"
     :disabled="multiSelectSwitchDisabled || undefined"
     :label="$tc('sw-settings-custom-field.customField.detail.labelMultiSelect')"
-    @update:modelValue="onChangeMultiSelectSwitch"
+    @update:model-value="onChangeMultiSelectSwitch"
 />
 {% endblock %}
 

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -387,7 +387,7 @@
                                                                                     :disabled="isInherited || !acl.can('theme.editor') || themeConfig[fieldName].editable === false"
                                                                                     :model-value="cssValue(currentValue)"
                                                                                     :error="themeConfigErrors[fieldName]"
-                                                                                    @update:modelValue="updateCurrentValue"
+                                                                                    @update:model-value="updateCurrentValue"
                                                                                 />
                                                                             </template>
                                                                         </sw-inherit-wrapper>


### PR DESCRIPTION
### 1. Why is this change necessary?
- Right now there are a few places where `model-value` is written as `modelValue` which is invalid for the lint command
- e.g. see https://github.com/shopware/shopware/pull/12909/files#diff-b2ee2983dba7de09ee08d7e63bd1e50a3bfdb94675c7ca3a8bb27b66f7fe4980

### 2. What does this change do, exactly?
- Replace `modelValue` with `model-value` in templates

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/pull/12909/files#diff-b2ee2983dba7de09ee08d7e63bd1e50a3bfdb94675c7ca3a8bb27b66f7fe4980

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
