### PR TITLE
chore(ci): add include and exclude options to update snapshots

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -23,6 +23,14 @@ on:
 
   workflow_call:
     inputs:
+      include:
+        description: 'File name or glob pattern to include (e.g. Visual/Storefront)'
+        type: string
+        default: ''
+      exclude:
+        description: 'File name or glob pattern to exclude (e.g. Visual/Administration)'
+        type: string
+        default: ''
       update-snapshots:
         description: 'Update snapshots?'
         type: boolean
@@ -31,10 +39,6 @@ on:
         description: 'Report to currents?'
         type: boolean
         default: false
-      filter:
-        description: 'Use this field to provide a filter that will be passed to playwrights `--grep` input.'
-        type: string
-        default: ''
 
 jobs:
   visual-tests:
@@ -52,7 +56,8 @@ jobs:
           workers: 1
           extra-options: >-
             ${{ inputs.update-snapshots && ' --update-snapshots' || '' }}
-            ${{ inputs.filter && format(' --grep="{0}"', inputs.filter) || '' }}
+            ${{ inputs.include && format(' --test-match="**/{0}/**/*.spec.ts"', inputs.include) || '' }}
+            ${{ inputs.exclude && format(' --test-ignore="**/{0}/**/*.spec.ts"', inputs.exclude) || '' }}
           use-currents: ${{ inputs.currents && 'true' || '' }}
           currents-project-id: ${{ secrets.CURRENTS_PROJECT_ID_VISUAL }}
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}


### PR DESCRIPTION
This PR updates the **Playwright visual test workflow** to make snapshot updates more flexible and easier to control.

Previously, the workflow relied on a single `filter` input that passed values to Playwright’s `--grep` flag.

This approach worked for tagged tests but was limited when we needed to run or exclude specific **test files or folders**.

---

### 🧩 What’s Changed

- Replaced the `filter` input with two new inputs:
    - `include`: File name or glob pattern to include (e.g. `Visual/storefront` or `tests/Visual/**/*.spec.ts`)
    - `exclude`: File name or glob pattern to exclude (e.g. `Visual/experimental` or `tests/**/deprecated/*.spec.ts`)
- Updated the workflow logic to use Playwright’s:
    - `-test-match` for `include`
    - `-test-ignore` for `exclude`
- `-grep` is no longer required for snapshot updates.

---

### ⚙️ How It Works

- Leaving both inputs empty runs **all tests** (default behavior).
- Setting `include` limits the run to matching files/folders.
- Setting `exclude` skips matching files/folders.
- You can combine both for more control (e.g., include `Visual` but exclude `Visual/experimental`).

---

### ✅ Example Scenarios


Goal | Input | Result
-- | -- | --
Run all tests | (empty) | All tests run
Update only storefront snapshots | include: Visual/storefront | Only that folder runs & updates
Exclude experimental tests | exclude: Visual/experimental | All tests except that folder
Include + Exclude | include: Visual, exclude: Visual/experimental | Visual tests run except experimental ones

