### PR TITLE
fix: Fix preview seo url template function

### DIFF
--- a/changelog/_unreleased/2025-10-09-fix-issue-with-loading-seo-url-preview.md
+++ b/changelog/_unreleased/2025-10-09-fix-issue-with-loading-seo-url-preview.md
@@ -1,0 +1,6 @@
+---
+title: Fix issue with loading seo url preview
+issue: 12292
+---
+# Core
+* Changed `preview` method in `Shopware\Core\Content\Seo\Api\SeoActionController` to apply route filters when loading SEO URL preview.


### PR DESCRIPTION
This pull request fixes an issue with loading SEO URL previews by ensuring that route-specific filters are properly applied when generating previews. The main change is to the `preview` method in `Shopware\Core\Content\Seo\Api\SeoActionController`, improving the accuracy of SEO URL previews based on route criteria and sales channel context. Additionally, new integration tests have been added to verify these improvements.

**Core Logic Improvements**
* Updated the `preview` method in `SeoActionController` to call `prepareCriteria` on the SEO URL route, ensuring route-specific filters are applied when loading SEO URL previews. This change guarantees that only relevant entities are considered for preview generation. [[1]](diffhunk://#diff-f11af3c829092d28b75748b8a77d78c26a1cab16d6122d556f73894f110b1d7fL289-R294) [[2]](diffhunk://#diff-f11af3c829092d28b75748b8a77d78c26a1cab16d6122d556f73894f110b1d7fR304-R315) [[3]](diffhunk://#diff-fb6dd9b6c4edb5295c3bd8f0ba8e32d6d5403506f46ab0b7dffb5c2cb87745f0R1-R9)
