### PR TITLE
fix: skip-optional-construct-parameters.patch

### DIFF
--- a/vendor-bin/roave-backward-compatibility-check/patches/skip-optional-construct-parameters.patch
+++ b/vendor-bin/roave-backward-compatibility-check/patches/skip-optional-construct-parameters.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ ../src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
-@@ -30,6 +30,12 @@
+@@ -30,6 +30,14 @@
              array_map(static fn (ReflectionParameter $param) => $param->getName(), $fromMethod->getParameters()),
          );
  
@@ -11,7 +11,7 @@
 +                return $param !== null && !$param->isOptional();
 +            });
 +        }
-
++
          return Changes::fromList(
              ...array_map(
                  static fn (string $paramName): Change => Change::added(


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/pull/12941#issuecomment-3385609628

### 2. What does this change do, exactly?
- Fix skip-optional-construct-parameters.patch patch-rows

### 3. Describe each step to reproduce the issue or behaviour.
- See https://github.com/shopware/shopware/pull/12941#issuecomment-3385609628

### 4. Please link to the relevant issues (if any).
- See https://github.com/shopware/shopware/pull/12941#issuecomment-3385609628

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
