### PR TITLE
chore(ci): add support for non-blocking codeownership

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -1,0 +1,16 @@
+# Use this file for more fine-grained control over code ownership, if the default CODEOWNERS file is not sufficient.
+# See the docs for more information: https://github.com/marketplace/actions/codeowners-plus#codeowners-file-spec
+
+? src/Administration/Resources/app/administration/src/module/sw-category @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-cms @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-landing-page @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-media @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-sales-channel @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-settings-country @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-settings-customer-group @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-settings-language @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-settings-sitemap @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/module/sw-settings-snippet @shopware/product-cc-discovery
+? src/Administration/Resources/app/administration/src/app/component/media @shopware/product-cc-discovery
+? src/Storefront/Resources/views/storefront/element/cms-element-* @shopware/product-cc-discovery

--- a/.github/workflows/codeowner.yml
+++ b/.github/workflows/codeowner.yml
@@ -1,0 +1,32 @@
+name: 'Code Owners'
+
+concurrency:
+  group: codeowners-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  codeowners:
+    name: 'Run Codeowners Plus'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Code Repository'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 'Codeowners Plus'
+        uses: multimediallc/codeowners-plus@v1.5.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          pr: '${{ github.event.pull_request.number }}'
+          verbose: true
+          quiet: ${{ github.event.pull_request.draft }}


### PR DESCRIPTION
We want to provide a way to keep track of changes in certain areas without blocking pull requests.
This PR introduces a new GH action ("Codeowners Plus"), which introduce a new `.codeowners` file supporting [more options](https://github.com/marketplace/actions/codeowners-plus#codeowners-file-spec) out-of-the-box in addition to the base `CODEOWNERS` file.