### PR TITLE
fix: Promotion setgroup can't be deleted (#12842) & Poor TAG readabil…

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
@@ -116,8 +116,8 @@
 
         .sw-label,
         .sw-label--dismissable:hover {
-            background-color: var(--color-interaction-secondary-disabled);
-            color: var(--color-text-primary-disabled);
+            background-color: var(--color-background-tertiary-default);
+            color: var(--color-text-primary-default);
             border-color: var(--color-border-primary-default);
 
             .sw-label__dismiss {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-cart-condition-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-cart-condition-form/index.js
@@ -113,34 +113,18 @@ export default {
         },
     },
 
-    watch: {
-        promotion() {
-            this.loadSetGroups();
-        },
-    },
-
     created() {
         this.createdComponent();
     },
 
     methods: {
         createdComponent() {
-            if (this.promotion) {
-                this.loadSetGroups();
-            }
-
             this.promotionSyncService.loadPackagers().then((keys) => {
                 this.packagerKeys = keys;
             });
 
             this.promotionSyncService.loadSorters().then((keys) => {
                 this.sorterKeys = keys;
-            });
-        },
-
-        loadSetGroups() {
-            this.promotionGroupRepository.search(this.setGroupCriteria).then((groups) => {
-                this.promotion.setgroups = groups;
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-detail/index.js
@@ -81,7 +81,8 @@ export default {
                 .addAssociation('personaRules')
                 .addAssociation('orderRules')
                 .addAssociation('cartRules')
-                .addAssociation('salesChannels');
+                .addAssociation('salesChannels')
+                .addAssociation('setgroups.setGroupRules');
 
             criteria.getAssociation('discounts').addSorting(Criteria.sort('createdAt', 'ASC'));
 


### PR DESCRIPTION
### 1. Why is this change necessary?

- Update background color and color for the tags to make it more readability
- Fix the bug that cannot updating product set groups in promotion

### 2. What does this change do, exactly?

- Update styles for the tags
- Update select component in **sw-promotion-v2-cart-condition-form** to not load the set of groups - The parent component now becomes the single source of truth for the entire promotion entity, including its nested setgroups and setGroupRules.

### 3. Describe each step to reproduce the issue or behaviour.

- Create tags or assign existing tags to a customer, then goes into customer page or customer details to see the tag
- Go to [promotion page](http://localhost:5173/#/sw/promotion/v2/index?limit=25&page=1&sortBy=createdAt&sortDirection=DESC&naturalSorting=false), create a promotion or edit an existing promotion then update product rules in rule based conditions section 
 

### 4. Please link to the relevant issues (if any).

- closes #12842 - closes the issue #12842 when the PR is merged
- closes #12741 - closes the issue #12741 when the PR is merged

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
