### PR TITLE
fix: Encoding of Context Gateway Endpoint

### DIFF
--- a/src/Core/Framework/App/Payload/AppPayloadServiceHelper.php
+++ b/src/Core/Framework/App/Payload/AppPayloadServiceHelper.php
@@ -57,26 +57,12 @@ class AppPayloadServiceHelper
 
         foreach ($array as $propertyName => $property) {
             if ($property instanceof SalesChannelContext) {
-                $salesChannelContext = $property->jsonSerialize();
-
-                foreach ($salesChannelContext as $subPropertyName => $subProperty) {
-                    if (!$subProperty instanceof Entity) {
-                        continue;
-                    }
-
-                    $salesChannelContext[$subPropertyName] = $this->encodeEntity($subProperty);
-                }
-
-                $array[$propertyName] = $salesChannelContext;
+                $array[$propertyName] = $this->encodeSalesChannelContext($property);
+            } elseif ($property instanceof Entity) {
+                $array[$propertyName] = $this->encodeEntity($property);
             } elseif ($property instanceof RequestDataBag) {
                 $array[$propertyName] = $property->all();
             }
-
-            if (!$property instanceof Entity) {
-                continue;
-            }
-
-            $array[$propertyName] = $this->encodeEntity($property);
         }
 
         return $array;
@@ -129,5 +115,21 @@ class AppPayloadServiceHelper
             $entity,
             '/api'
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function encodeSalesChannelContext(SalesChannelContext $salesChannelContext): array
+    {
+        $array = $salesChannelContext->jsonSerialize();
+
+        foreach ($array as $propertyName => $property) {
+            if ($property instanceof Entity) {
+                $array[$propertyName] = $this->encodeEntity($property);
+            }
+        }
+
+        return $array;
     }
 }

--- a/src/Core/Framework/App/Payload/AppPayloadServiceHelper.php
+++ b/src/Core/Framework/App/Payload/AppPayloadServiceHelper.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\InAppPurchase;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 /**
@@ -67,6 +68,8 @@ class AppPayloadServiceHelper
                 }
 
                 $array[$propertyName] = $salesChannelContext;
+            } elseif ($property instanceof RequestDataBag) {
+                $array[$propertyName] = $property->all();
             }
 
             if (!$property instanceof Entity) {


### PR DESCRIPTION
### 1. Why is this change necessary?
In the current implementation the custom payload does not get passed to the app server as stated here:
https://developer.shopware.com/docs/guides/plugins/apps/gateways/context/context-gateway.html#context-gateway-endpoint

This is because the `data` property of `Shopware\Core\Framework\Gateway\Context\Command\Struct\ContextGatewayPayloadStruct` is of the type `Shopware\Core\Framework\Log\Package\RequestDataBag` and this does not automatically get translated into an array when `json_encode` is applied.

### 2. What does this change do, exactly?
Handling `RequestDataBag` separately during encoding.


### 3. Describe each step to reproduce the issue or behaviour.
Try to pass data to an app server as described here: https://developer.shopware.com/docs/guides/plugins/apps/gateways/context/context-gateway.html#context-gateway-endpoint

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
