### PR TITLE
fix: product exports may get stuck permanently

### DIFF
--- a/src/Core/Content/DependencyInjection/product_export.xml
+++ b/src/Core/Content/DependencyInjection/product_export.xml
@@ -6,6 +6,9 @@
     <parameters>
         <parameter key="product_export.directory">export</parameter>
         <parameter key="product_export.read_buffer_size">100</parameter>
+        <!-- Stale detection tuning: unlock stuck exports when older than max(min_seconds, factor * interval) -->
+        <parameter key="product_export.stale_min_seconds">300</parameter>
+        <parameter key="product_export.stale_interval_factor">2.0</parameter>
     </parameters>
     <services>
         <service id="Shopware\Core\Content\ProductExport\ProductExportDefinition">
@@ -60,10 +63,10 @@
         <service id="Shopware\Core\Content\ProductExport\ScheduledTask\ProductExportGenerateTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
-            <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory"/>
-            <argument type="service" id="sales_channel.repository"/>
-            <argument type="service" id="product_export.repository"/>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="messenger.default_bus"/>
+            <argument type="string">%product_export.stale_min_seconds%</argument>
+            <argument type="string">%product_export.stale_interval_factor%</argument>
             <tag name="messenger.message_handler"/>
         </service>
 

--- a/src/Core/Content/ProductExport/EventListener/ProductExportEventListener.php
+++ b/src/Core/Content/ProductExport/EventListener/ProductExportEventListener.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\ProductExport\EventListener;
 
 use League\Flysystem\FilesystemOperator;
 use Shopware\Core\Content\ProductExport\ProductExportCollection;
+use Shopware\Core\Content\ProductExport\ProductExportDefinition;
 use Shopware\Core\Content\ProductExport\Service\ProductExportFileHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
@@ -52,6 +53,8 @@ class ProductExportEventListener implements EventSubscriberInterface
                     [
                         'id' => $primaryKey,
                         'generatedAt' => null,
+                        // Reset stuck runs when a user/admin edits the export
+                        'isRunning' => false,
                     ],
                 ],
                 $event->getContext()
@@ -71,8 +74,9 @@ class ProductExportEventListener implements EventSubscriberInterface
 
     private function productExportWritten(EntityWriteResult $writeResult): bool
     {
-        return $writeResult->getEntityName() === 'product_export'
+        return $writeResult->getEntityName() === ProductExportDefinition::ENTITY_NAME
             && $writeResult->getOperation() !== EntityWriteResult::OPERATION_DELETE
-            && !\array_key_exists('generatedAt', $writeResult->getPayload());
+            && !\array_key_exists('generatedAt', $writeResult->getPayload())
+            && !\array_key_exists('isRunning', $writeResult->getPayload());
     }
 }

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -2,21 +2,15 @@
 
 namespace Shopware\Core\Content\ProductExport\ScheduledTask;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Content\ProductExport\ProductExportCollection;
-use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
-use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -31,16 +25,14 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
      * @internal
      *
      * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
-     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
-     * @param EntityRepository<ProductExportCollection> $productExportRepository
      */
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
-        private readonly AbstractSalesChannelContextFactory $salesChannelContextFactory,
-        private readonly EntityRepository $salesChannelRepository,
-        private readonly EntityRepository $productExportRepository,
-        private readonly MessageBusInterface $messageBus
+        private readonly Connection $connection,
+        private readonly MessageBusInterface $messageBus,
+        private readonly int $staleMinSeconds = 300,
+        private readonly float $staleIntervalFactor = 2.0
     ) {
         parent::__construct($scheduledTaskRepository, $logger);
     }
@@ -50,7 +42,7 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
         foreach ($this->fetchSalesChannelIds() as $salesChannelId) {
             $productExports = $this->fetchProductExports($salesChannelId);
 
-            if ($productExports->count() === 0) {
+            if ($productExports === []) {
                 continue;
             }
 
@@ -62,7 +54,7 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
                 }
 
                 $this->messageBus->dispatch(
-                    new ProductExportPartialGeneration($productExport->getId(), $salesChannelId)
+                    new ProductExportPartialGeneration($productExport['id'], $salesChannelId)
                 );
             }
         }
@@ -73,55 +65,117 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
      */
     private function fetchSalesChannelIds(): array
     {
-        $criteria = new Criteria();
-        $criteria
-            ->addFilter(new EqualsFilter('typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT))
-            ->addFilter(new EqualsFilter('active', true));
+        $salesChannelIds = $this->connection->fetchFirstColumn(
+            <<<'SQL'
+                SELECT `id`
+                FROM `sales_channel`
+                WHERE `type_id` = :typeId
+                  AND `active` = 1
+            SQL,
+            ['typeId' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_STOREFRONT)],
+            ['typeId' => ParameterType::BINARY]
+        );
 
-        return $this->salesChannelRepository
-            ->searchIds($criteria, Context::createCLIContext())
-            ->getIds();
+        /** @var list<string> $salesChannelIds */
+        return array_values(array_map(
+            static fn (string $id): string => Uuid::fromBytesToHex($id),
+            array_filter($salesChannelIds, static fn ($id): bool => \is_string($id))
+        ));
     }
 
-    private function fetchProductExports(string $salesChannelId): ProductExportCollection
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetchProductExports(string $salesChannelId): array
     {
-        $salesChannelContext = $this->salesChannelContextFactory->create(Uuid::randomHex(), $salesChannelId);
+        $productExports = [];
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT
+                    LOWER(HEX(pe.id)) AS id,
+                    pe.generated_at,
+                    pe.interval,
+                    pe.is_running,
+                    pe.updated_at,
+                    pe.created_at
+                FROM product_export pe
+                INNER JOIN sales_channel sc
+                    ON sc.id = pe.sales_channel_id
+                INNER JOIN sales_channel_domain scd
+                    ON scd.id = pe.sales_channel_domain_id
+                WHERE pe.generate_by_cronjob = 1
+                  AND sc.active = 1
+                  AND (
+                        pe.storefront_sales_channel_id = :salesChannelId
+                        OR scd.sales_channel_id = :salesChannelId
+                  )
+            SQL,
+            ['salesChannelId' => Uuid::fromHexToBytes($salesChannelId)],
+            ['salesChannelId' => ParameterType::BINARY]
+        );
 
-        $criteria = new Criteria();
-        $criteria
-            ->addAssociation('salesChannel')
-            ->addFilter(
-                new MultiFilter(
-                    'AND',
-                    [
-                        new EqualsFilter('generateByCronjob', true),
-                        new EqualsFilter('salesChannel.active', true),
-                    ]
-                )
-            )
-            ->addFilter(
-                new MultiFilter(
-                    'OR',
-                    [
-                        new EqualsFilter('storefrontSalesChannelId', $salesChannelId),
-                        new EqualsFilter('salesChannelDomain.salesChannel.id', $salesChannelId),
-                    ]
-                )
-            );
+        foreach ($rows as $row) {
+            if (!\is_string($row['id'])) {
+                continue;
+            }
 
-        return $this->productExportRepository->search($criteria, $salesChannelContext->getContext())->getEntities();
-    }
-
-    private function shouldBeRun(ProductExportEntity $productExport, \DateTimeImmutable $now): bool
-    {
-        if ($productExport->getIsRunning()) {
-            return false;
+            $productExports[] = $row;
         }
 
-        if ($productExport->getGeneratedAt() === null) {
+        return $productExports;
+    }
+
+    /**
+     * @param array<string, mixed> $productExport
+     */
+    private function shouldBeRun(array &$productExport, \DateTimeImmutable $now): bool
+    {
+        if ($productExport['is_running']) {
+            // If a previous run was aborted unexpectedly, the flag may be stuck.
+            // Consider the run stale if the entity hasn't been updated for a
+            // reasonable duration based on the configured interval.
+            if ($this->isStale($productExport, $now)) {
+                // Reset the running flag to allow scheduling to continue
+                $this->connection->update(
+                    'product_export',
+                    ['is_running' => 0],
+                    ['id' => Uuid::fromHexToBytes($productExport['id'])],
+                    ['id' => ParameterType::BINARY]
+                );
+                $productExport['is_running'] = 1;
+            // Fall through to the time-based checks
+            } else {
+                return false;
+            }
+        }
+
+        if ($productExport['generated_at'] === null) {
             return true;
         }
 
-        return $now->getTimestamp() - $productExport->getGeneratedAt()->getTimestamp() >= $productExport->getInterval();
+        $generatedAt = new \DateTimeImmutable($productExport['generated_at']);
+
+        return $now->getTimestamp() - $generatedAt->getTimestamp() >= $productExport['interval'];
+    }
+
+    /**
+     * @param array<string, mixed> $productExport
+     */
+    private function isStale(array $productExport, \DateTimeImmutable $now): bool
+    {
+        // Determine the last activity timestamp: updatedAt when available, otherwise createdAt
+        $lastActivity = $productExport['updated_at'] ?? $productExport['created_at'];
+        if ($lastActivity === null) {
+            return false;
+        }
+
+        $lastActivity = new \DateTimeImmutable($lastActivity);
+
+        // Threshold: max(configured min seconds, configured factor * interval)
+        $interval = max(1, $productExport['interval']);
+        $threshold = max($this->staleMinSeconds, (int) \ceil($this->staleIntervalFactor * $interval));
+
+        return ($now->getTimestamp() - $lastActivity->getTimestamp()) >= $threshold;
     }
 }

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -65,9 +65,9 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
      */
     private function fetchSalesChannelIds(): array
     {
-        $salesChannelIds = $this->connection->fetchFirstColumn(
+        return $this->connection->fetchFirstColumn(
             <<<'SQL'
-                SELECT `id`
+                SELECT LOWER(HEX(id))
                 FROM `sales_channel`
                 WHERE `type_id` = :typeId
                   AND `active` = 1
@@ -75,12 +75,6 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
             ['typeId' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_STOREFRONT)],
             ['typeId' => ParameterType::BINARY]
         );
-
-        /** @var list<string> $salesChannelIds */
-        return array_values(array_map(
-            static fn (string $id): string => Uuid::fromBytesToHex($id),
-            array_filter($salesChannelIds, static fn ($id): bool => \is_string($id))
-        ));
     }
 
     /**
@@ -93,22 +87,22 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
                 SELECT
-                    LOWER(HEX(pe.id)) AS id,
-                    pe.generated_at,
-                    pe.interval,
-                    pe.is_running,
-                    pe.updated_at,
-                    pe.created_at
-                FROM product_export pe
-                INNER JOIN sales_channel sc
-                    ON sc.id = pe.sales_channel_id
-                INNER JOIN sales_channel_domain scd
-                    ON scd.id = pe.sales_channel_domain_id
-                WHERE pe.generate_by_cronjob = 1
-                  AND sc.active = 1
+                    LOWER(HEX(product_export.id)) AS id,
+                    product_export.generated_at,
+                    product_export.interval,
+                    product_export.is_running,
+                    product_export.updated_at,
+                    product_export.created_at
+                FROM product_export
+                INNER JOIN sales_channel
+                    ON sales_channel.id = product_export.sales_channel_id
+                INNER JOIN sales_channel_domain
+                    ON sales_channel_domain.id = product_export.sales_channel_domain_id
+                WHERE product_export.generate_by_cronjob = 1
+                  AND sales_channel.active = 1
                   AND (
-                        pe.storefront_sales_channel_id = :salesChannelId
-                        OR scd.sales_channel_id = :salesChannelId
+                        product_export.storefront_sales_channel_id = :salesChannelId
+                        OR sales_channel_domain.sales_channel_id = :salesChannelId
                   )
             SQL,
             ['salesChannelId' => Uuid::fromHexToBytes($salesChannelId)],
@@ -129,7 +123,7 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
     /**
      * @param array<string, mixed> $productExport
      */
-    private function shouldBeRun(array &$productExport, \DateTimeImmutable $now): bool
+    private function shouldBeRun(array $productExport, \DateTimeImmutable $now): bool
     {
         if ($productExport['is_running']) {
             // If a previous run was aborted unexpectedly, the flag may be stuck.
@@ -143,11 +137,11 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
                     ['id' => Uuid::fromHexToBytes($productExport['id'])],
                     ['id' => ParameterType::BINARY]
                 );
-                $productExport['is_running'] = 1;
-            // Fall through to the time-based checks
-            } else {
-                return false;
+
+                return true;
             }
+
+            return false;
         }
 
         if ($productExport['generated_at'] === null) {

--- a/tests/integration/Core/Content/ProductExport/EventListener/ProductExportEventListenerTest.php
+++ b/tests/integration/Core/Content/ProductExport/EventListener/ProductExportEventListenerTest.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\ProductExport\EventListener;
+
+use Doctrine\DBAL\Connection;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
+use Shopware\Core\Content\ProductExport\ProductExportEntity;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+
+/**
+ * @internal
+ */
+#[Group('slow')]
+class ProductExportEventListenerTest extends TestCase
+{
+    use AdminFunctionalTestBehaviour;
+
+    /**
+     * @var EntityRepository<ProductExportCollection>
+     */
+    private EntityRepository $productExportRepository;
+
+    private Context $context;
+
+    private FilesystemOperator $fileSystem;
+
+    protected function setUp(): void
+    {
+        $this->productExportRepository = static::getContainer()->get('product_export.repository');
+        $this->context = Context::createDefaultContext();
+        $this->fileSystem = static::getContainer()->get('shopware.filesystem.private');
+        $this->ensureProductStream();
+    }
+
+    public function testEditResetsIsRunningAndDeletesFile(): void
+    {
+        $exportId = $this->createTestEntity('EventListenerTest.csv');
+
+        // Create an existing export file
+        $filePath = \sprintf('%s/%s', static::getContainer()->getParameter('product_export.directory'), 'EventListenerTest.csv');
+        $this->fileSystem->write($filePath, 'dummy');
+        static::assertTrue($this->fileSystem->fileExists($filePath));
+
+        // Mark as running to simulate stuck state
+        $this->productExportRepository->update([[
+            'id' => $exportId,
+            'isRunning' => true,
+        ]], $this->context);
+
+        // Update an unrelated property to trigger the listener
+        $this->productExportRepository->update([[
+            'id' => $exportId,
+            'interval' => 999,
+        ]], $this->context);
+
+        // Assert file deleted and flags reset
+        static::assertFalse($this->fileSystem->fileExists($filePath));
+
+        $entity = $this->productExportRepository->search(new Criteria([$exportId]), $this->context)->getEntities()->first();
+        static::assertNotNull($entity);
+        static::assertFalse($entity->getIsRunning());
+        static::assertNull($entity->getGeneratedAt());
+    }
+
+    private function ensureProductStream(): void
+    {
+        /** @var Connection $connection */
+        $connection = static::getContainer()->get(Connection::class);
+        $exists = (bool) $connection->fetchOne('SELECT COUNT(*) FROM product_stream WHERE id = UNHEX(?)', ['137b079935714281ba80b40f83f8d7eb']);
+        if ($exists) {
+            return;
+        }
+
+        $connection->executeStatement('
+            INSERT INTO `product_stream` (`id`, `api_filter`, `invalid`, `created_at`, `updated_at`)
+            VALUES
+                (UNHEX(\'137B079935714281BA80B40F83F8D7EB\'), \'[]\', 0, \'2019-08-16 08:43:57.488\', NULL);
+        ');
+    }
+
+    private function getSalesChannelId(): string
+    {
+        /** @var EntityRepository<SalesChannelCollection> $repository */
+        $repository = static::getContainer()->get('sales_channel.repository');
+
+        $id = $repository->search(new Criteria(), $this->context)->getEntities()->first()?->getId();
+        static::assertIsString($id);
+
+        return $id;
+    }
+
+    private function getSalesChannelDomain(): SalesChannelDomainEntity
+    {
+        /** @var EntityRepository<SalesChannelDomainCollection> $repository */
+        $repository = static::getContainer()->get('sales_channel_domain.repository');
+
+        $criteria = new Criteria();
+        $criteria->addAssociation('salesChannel');
+
+        $domainEntity = $repository->search($criteria, $this->context)->getEntities()->first();
+        static::assertNotNull($domainEntity);
+
+        return $domainEntity;
+    }
+
+    private function createTestEntity(string $filename): string
+    {
+        $id = Uuid::randomHex();
+        $this->productExportRepository->upsert([
+            [
+                'id' => $id,
+                'fileName' => $filename,
+                'accessKey' => Uuid::randomHex(),
+                'encoding' => ProductExportEntity::ENCODING_UTF8,
+                'fileFormat' => ProductExportEntity::FILE_FORMAT_CSV,
+                'interval' => 10,
+                'headerTemplate' => 'name,url',
+                'bodyTemplate' => '{{ product.name }}',
+                'productStreamId' => '137b079935714281ba80b40f83f8d7eb',
+                'storefrontSalesChannelId' => $this->getSalesChannelDomain()->getSalesChannelId(),
+                'salesChannelId' => $this->getSalesChannelId(),
+                'salesChannelDomainId' => $this->getSalesChannelDomain()->getId(),
+                'generatedAt' => null,
+                'generateByCronjob' => true,
+                'currencyId' => Defaults::CURRENCY,
+            ],
+        ], $this->context);
+
+        return $id;
+    }
+}

--- a/tests/integration/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/tests/integration/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -22,7 +22,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
-use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
@@ -84,6 +83,43 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         static::assertSame($previousGeneratedAt->format(Defaults::STORAGE_DATE_TIME_FORMAT), $newExport->getGeneratedAt()?->format(Defaults::STORAGE_DATE_TIME_FORMAT));
     }
 
+    public function testStaleRunningExportIsUnlockedAndGenerated(): void
+    {
+        $this->createProductStream();
+
+        $exportId = $this->createTestEntity(null, 10, 'StaleTestexport.csv', true);
+
+        // Simulate a stuck run: set is_running=1 and updated_at in the past
+        /** @var Connection $connection */
+        $connection = static::getContainer()->get(Connection::class);
+        $connection->executeStatement(
+            'UPDATE `product_export` SET `is_running` = 1, `updated_at` = :updatedAt WHERE `id` = :id',
+            [
+                'updatedAt' => (new \DateTimeImmutable('-1 hour'))->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                'id' => Uuid::fromHexToBytes($exportId),
+            ]
+        );
+
+        $this->clearQueue();
+        $this->getTaskHandler()->run();
+
+        // Consume all queued messages
+        $client = $this->getBrowser();
+        $client->request('POST', '/api/_action/message-queue/consume', ['receiver' => 'async']);
+
+        static::assertSame(200, $client->getResponse()->getStatusCode());
+
+        // File should be generated
+        $filePath = \sprintf('%s/%s', static::getContainer()->getParameter('product_export.directory'), 'StaleTestexport.csv');
+        static::assertTrue($this->fileSystem->fileExists($filePath));
+
+        // And the export entity should be unlocked and have a generatedAt timestamp
+        $newExport = $this->productExportRepository->search(new Criteria([$exportId]), $this->context)->getEntities()->first();
+        static::assertNotNull($newExport);
+        static::assertFalse($newExport->getIsRunning());
+        static::assertInstanceOf(\DateTimeInterface::class, $newExport->getGeneratedAt());
+    }
+
     protected function createSecondStorefrontSalesChannel(): void
     {
         /** @var EntityRepository<SalesChannelCollection> $salesChannelRepository */
@@ -123,9 +159,7 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         return new ProductExportGenerateTaskHandler(
             static::getContainer()->get('scheduled_task.repository'),
             $this->createMock(LoggerInterface::class),
-            static::getContainer()->get(SalesChannelContextFactory::class),
-            static::getContainer()->get('sales_channel.repository'),
-            static::getContainer()->get('product_export.repository'),
+            static::getContainer()->get(Connection::class),
             static::getContainer()->get('messenger.default_bus')
         );
     }

--- a/tests/unit/Core/Content/ProductExport/EventListener/ProductExportEventListenerTest.php
+++ b/tests/unit/Core/Content/ProductExport/EventListener/ProductExportEventListenerTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ProductExport\EventListener;
+
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ProductExport\EventListener\ProductExportEventListener;
+use Shopware\Core\Content\ProductExport\ProductExportCollection;
+use Shopware\Core\Content\ProductExport\ProductExportEntity;
+use Shopware\Core\Content\ProductExport\Service\ProductExportFileHandlerInterface;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProductExportEventListener::class)]
+class ProductExportEventListenerTest extends TestCase
+{
+    public function testAfterWriteResetsFlagsAndDeletesFileOnEdit(): void
+    {
+        $id = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $entity = new ProductExportEntity();
+        $entity->setId($id);
+        $entity->setUniqueIdentifier($id);
+        $entity->setFileName('UnitTest.csv');
+
+        $productExportRepository = $this->createMock(EntityRepository::class);
+        $productExportRepository
+            ->expects($this->once())
+            ->method('update')
+            ->with(static::callback(function (array $payload) use ($id): bool {
+                $first = $payload[0] ?? [];
+
+                return ($first['id'] ?? null) === $id
+                    && \array_key_exists('generatedAt', $first)
+                    && $first['generatedAt'] === null
+                    && \array_key_exists('isRunning', $first)
+                    && $first['isRunning'] === false;
+            }), $context);
+
+        $productExportRepository
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'product_export',
+                1,
+                new ProductExportCollection([$entity]),
+                null,
+                new Criteria([$id]),
+                $context
+            ));
+
+        $fileHandler = $this->createMock(ProductExportFileHandlerInterface::class);
+        $fileHandler
+            ->expects($this->once())
+            ->method('getFilePath')
+            ->with(static::isInstanceOf(ProductExportEntity::class))
+            ->willReturn('/export/UnitTest.csv');
+
+        $fs = $this->createMock(FilesystemOperator::class);
+        $fs->expects($this->once())->method('fileExists')->with('/export/UnitTest.csv')->willReturn(true);
+        $fs->expects($this->once())->method('delete')->with('/export/UnitTest.csv');
+
+        $listener = new ProductExportEventListener($productExportRepository, $fileHandler, $fs);
+
+        $writeResult = new EntityWriteResult(['id' => $id], ['interval' => 300], 'product_export', EntityWriteResult::OPERATION_UPDATE);
+        $event = new EntityWrittenEvent('product_export', [$writeResult], $context);
+
+        $listener->afterWrite($event);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('skipPayloadProvider')]
+    public function testAfterWriteSkipsWhenPayloadContainsManagedFields(array $payload): void
+    {
+        $context = Context::createDefaultContext();
+
+        $productExportRepository = $this->createMock(EntityRepository::class);
+        $productExportRepository->expects($this->never())->method('update');
+        $productExportRepository->expects($this->never())->method('search');
+
+        $fileHandler = $this->createMock(ProductExportFileHandlerInterface::class);
+        $fileHandler->expects($this->never())->method('getFilePath');
+
+        $fs = $this->createMock(FilesystemOperator::class);
+        $fs->expects($this->never())->method('fileExists');
+        $fs->expects($this->never())->method('delete');
+
+        $listener = new ProductExportEventListener($productExportRepository, $fileHandler, $fs);
+
+        $writeResult = new EntityWriteResult(['id' => Uuid::randomHex()], $payload, 'product_export', EntityWriteResult::OPERATION_UPDATE);
+        $event = new EntityWrittenEvent('product_export', [$writeResult], $context);
+
+        $listener->afterWrite($event);
+    }
+
+    public static function skipPayloadProvider(): \Generator
+    {
+        yield 'explicit generatedAt update' => [[
+            'generatedAt' => new \DateTime(),
+        ]];
+
+        yield 'explicit isRunning update' => [[
+            'isRunning' => true,
+        ]];
+    }
+}

--- a/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -2,22 +2,15 @@
 
 namespace Shopware\Tests\Unit\Core\Content\ProductExport\ScheduledTask;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Content\ProductExport\ProductExportCollection;
-use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ScheduledTask\ProductExportGenerateTaskHandler;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
-use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
-use Shopware\Core\System\SalesChannel\SalesChannelCollection;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\MessageBus\CollectingMessageBus;
 
 /**
@@ -26,21 +19,39 @@ use Shopware\Core\Test\Stub\MessageBus\CollectingMessageBus;
 #[CoversClass(ProductExportGenerateTaskHandler::class)]
 class ProductExportGenerateTaskHandlerTest extends TestCase
 {
+    /**
+     * @param array{id: string, generated_at: ?string, interval: int, is_running: bool, updated_at: ?string, created_at: ?string} $productExportRow
+     */
     #[DataProvider('shouldBeRunDataProvider')]
-    public function testShouldBeRun(ProductExportEntity $productExportEntity, bool $expectedResult): void
+    public function testShouldBeRun(array $productExportRow, bool $expectedResult, bool $expectsReset): void
     {
-        $salesChannelRepositoryMock = $this->getSalesChannelRepositoryMock();
-        $salesChannelContextFactoryMock = $this->getSalesChannelContextFactoryMock();
-        $productExportRepositoryMock = $this->getProductExportRepositoryMock($productExportEntity);
+        $connection = $this->createMock(Connection::class);
+        $salesChannelId = '8fdd4e21be6b4ad59656fb856d0375e7';
+
+        $connection->method('fetchFirstColumn')
+            ->willReturn([Uuid::fromHexToBytes($salesChannelId)]);
+
+        $connection->method('fetchAllAssociative')
+            ->willReturn([$productExportRow]);
+
+        $updateExpectation = $connection->expects($expectsReset ? $this->once() : $this->never())
+            ->method('update');
+
+        if ($expectsReset) {
+            $updateExpectation->with(
+                'product_export',
+                ['is_running' => 0],
+                ['id' => Uuid::fromHexToBytes($productExportRow['id'])],
+                ['id' => ParameterType::BINARY]
+            );
+        }
 
         $messageBusMock = new CollectingMessageBus();
 
         $productExportGenerateTaskHandler = new ProductExportGenerateTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
-            $salesChannelContextFactoryMock,
-            $salesChannelRepositoryMock,
-            $productExportRepositoryMock,
+            $connection,
             $messageBusMock
         );
 
@@ -56,88 +67,55 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
     public static function shouldBeRunDataProvider(): \Generator
     {
         yield 'next generation not reached' => [
-            // Should not run because: next generation time not reached (time + intervall > now)
-            self::prepareProductExportEntity(false, false, 45),
+            // Should not run because: next generation time not reached (time + interval > now)
+            self::productExportRow(false, '3022-07-18 10:59:30', 45),
+            false,
             false,
         ];
         yield 'already running' => [
             // Should not run because: is running is true (another export is being generated atm.)
-            self::prepareProductExportEntity(true, false, 10),
+            self::productExportRow(true, ' ', 10),
+            false,
+            false,
+        ];
+        yield 'already running but recent' => [
+            // Should not run because: isRunning is true and last activity is recent (below stale threshold)
+            self::productExportRow(true, ' ', 10, '-10 seconds'),
+            false,
             false,
         ];
         yield 'not generated before' => [
             // Should run because: has not been generated before
-            self::prepareProductExportEntity(false, null, 0),
+            self::productExportRow(false, null, 0),
             true,
+            false,
         ];
         yield 'generation is due' => [
             // Should run because: next run is due (last generated + intervall < now)
-            self::prepareProductExportEntity(false, true, 10),
+            self::productExportRow(false, '1022-07-18 10:59:30', 10),
+            true,
+            false,
+        ];
+        yield 'already running but stale' => [
+            // Should run because: isRunning is true but last activity is stale
+            self::productExportRow(true, null, 10, '-1 hour'),
+            true,
             true,
         ];
     }
 
-    private static function getGeneratedAtTimestamp(?bool $generatedAtBeforeInterval): ?\DateTime
-    {
-        if ($generatedAtBeforeInterval === true) {
-            return new \DateTime('1022-07-18 10:59:30');
-        }
-        if ($generatedAtBeforeInterval === false) {
-            return new \DateTime('3022-07-18 10:59:30');
-        }
-
-        return null;
-    }
-
-    private static function prepareProductExportEntity(bool $isRunning, ?bool $generatedAtBeforeInterval, int $interval): ProductExportEntity
-    {
-        $productExportEntity = new ProductExportEntity();
-        $productExportEntity->setIsRunning($isRunning);
-        $productExportEntity->setGeneratedAt(self::getGeneratedAtTimestamp($generatedAtBeforeInterval));
-        $productExportEntity->setInterval($interval);
-        $productExportEntity->setUniqueIdentifier('TestExportEntity');
-        $productExportEntity->setId('afdd4e21be6b4ad59656fb856d0375e5');
-
-        return $productExportEntity;
-    }
-
     /**
-     * @return EntityRepository<ProductExportCollection>&MockObject
+     * @return array{id: string, generated_at: ?string, interval: int, is_running: bool, updated_at: ?string, created_at: ?string}
      */
-    private function getProductExportRepositoryMock(ProductExportEntity $productExportEntity): EntityRepository&MockObject
+    private static function productExportRow(bool $isRunning, ?string $generatedAt, int $interval, ?string $updatedAt = null, ?string $createdAt = null): array
     {
-        $productEntitySearchResult = new EntitySearchResult(
-            'product',
-            1,
-            new ProductExportCollection([$productExportEntity]),
-            null,
-            new Criteria(),
-            Context::createDefaultContext()
-        );
-
-        $productExportRepositoryMock = $this->createMock(EntityRepository::class);
-        $productExportRepositoryMock->method('search')->willReturn($productEntitySearchResult);
-
-        return $productExportRepositoryMock;
-    }
-
-    /**
-     * @return StaticEntityRepository<SalesChannelCollection>
-     */
-    private function getSalesChannelRepositoryMock(): StaticEntityRepository
-    {
-        /** @var StaticEntityRepository<SalesChannelCollection> */
-        return new StaticEntityRepository([['8fdd4e21be6b4ad59656fb856d0375e7']]);
-    }
-
-    private function getSalesChannelContextFactoryMock(): SalesChannelContextFactory
-    {
-        $salesChannelContextMock = $this->createMock(SalesChannelContext::class);
-        $salesChannelContextMock->method('getContext')->willReturn(Context::createDefaultContext());
-
-        $salesChannelContextFactoryMock = $this->createMock(SalesChannelContextFactory::class);
-        $salesChannelContextFactoryMock->method('create')->willReturn($salesChannelContextMock);
-
-        return $salesChannelContextFactoryMock;
+        return [
+            'id' => 'afdd4e21be6b4ad59656fb856d0375e5',
+            'generated_at' => $generatedAt,
+            'interval' => $interval,
+            'is_running' => $isRunning,
+            'updated_at' => $updatedAt,
+            'created_at' => $createdAt,
+        ];
     }
 }

--- a/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -26,10 +26,9 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
     public function testShouldBeRun(array $productExportRow, bool $expectedResult, bool $expectsReset): void
     {
         $connection = $this->createMock(Connection::class);
-        $salesChannelId = '8fdd4e21be6b4ad59656fb856d0375e7';
 
         $connection->method('fetchFirstColumn')
-            ->willReturn([Uuid::fromHexToBytes($salesChannelId)]);
+            ->willReturn([Uuid::randomHex()]);
 
         $connection->method('fetchAllAssociative')
             ->willReturn([$productExportRow]);


### PR DESCRIPTION
### Actual behaviour

When a product export is aborted unexpectedly (i.e. on a server restart or killing of a PHP process) and it remains in the state 'is_running' = 1, it will never run again unless it is recreated or the entry for 'is_running' is manually set to 0 in the database.

### Expected behaviour

Whenever a product export takes longer than expected or the scheduled task has ended long ago, the 'is_running' value should be reset in some manner. Editing the product export should do the same, especially when changing scheduler settings.

### How to reproduce

- Create a product export and set the scheduler to 5 minutes
- Check that the output file is generated and contains the correct data
- Go to the DB table 'product_export' and set 'is_running' to 1 to simulate an aborted run
- Change some product properties and observe that the export data will not be updated after 5 minutes
- Change the scheduler settings (or anything for that matter) on the export settings page, the export data will be updated once, but the flag 'is_running' = 1 will remain and no further automatic exports will happen