### PR TITLE
feat: compatibility with OpenSearch 3.x

### DIFF
--- a/changelog/_unreleased/2025-10-13-compatibility-with-opensearch-3-x.md
+++ b/changelog/_unreleased/2025-10-13-compatibility-with-opensearch-3-x.md
@@ -1,0 +1,40 @@
+---
+title: compatibility with OpenSearch 3.x
+issue: shopware/shopware#12979
+---
+# Core
+* Changed `\Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder::customFields` to omit custom fields's `properties` when its empty to comply with OpenSearch 3.x
+___
+# Upgrade Information
+
+## Opensearch 3.x compatibility
+
+OpenSearch 3.x introduced a breaking change that disallows defining index mapping fields with empty array `properties`. For e.g: 
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "customFields": {
+        "type": "object",
+        "properties": []
+      }
+    }
+  }
+}
+```
+
+So instead of defining a index mapping with empty `properties`, we should omit `properties` entirely or define it with empty object `{}`:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "customFields": {
+        "type": "object",
+        "properties": {} // or can be omitted entirely
+      }
+    }
+  }
+}
+```

--- a/src/Core/System/Language/LanguageLoaderInterface.php
+++ b/src/Core/System/Language/LanguageLoaderInterface.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\System\Language;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @phpstan-type LanguageData array<string, array{id: string, code: string, parentId: string, parentCode?: ?string}>
+ * @phpstan-type LanguageData array<string, array{id: string, code: string, parentId?: ?string, parentCode?: ?string}>
  */
 #[Package('fundamentals@discovery')]
 interface LanguageLoaderInterface

--- a/src/Elasticsearch/ElasticsearchException.php
+++ b/src/Elasticsearch/ElasticsearchException.php
@@ -153,13 +153,16 @@ class ElasticsearchException extends HttpException
         );
     }
 
+    /**
+     * @param array<mixed> $config
+     */
     public static function indexCreationFailed(string $index, array $config, \Throwable $exception): self
     {
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::INDEX_CREATION_ERROR,
             'Creating index {{ index }} failed with payload {{ payload }}. Reason: {{ reason }}',
-            ['index' => $index, 'reason' => $exception->getMessage(), 'payload' => json_encode($config, JSON_THROW_ON_ERROR)]
+            ['index' => $index, 'reason' => $exception->getMessage(), 'payload' => json_encode($config, \JSON_THROW_ON_ERROR)]
         );
     }
 

--- a/src/Elasticsearch/ElasticsearchException.php
+++ b/src/Elasticsearch/ElasticsearchException.php
@@ -13,6 +13,7 @@ class ElasticsearchException extends HttpException
     public const DEFINITION_NOT_FOUND = 'ELASTICSEARCH__DEFINITION_NOT_FOUND';
     public const UNSUPPORTED_DEFINITION = 'ELASTICSEARCH__UNSUPPORTED_DEFINITION';
     public const INDEXING_ERROR = 'ELASTICSEARCH__INDEXING_ERROR';
+    public const INDEX_CREATION_ERROR = 'ELASTICSEARCH__INDEX_CREATION_ERROR';
     public const NESTED_AGGREGATION_MISSING = 'ELASTICSEARCH__NESTED_FILTER_AGGREGATION_MISSING';
     public const UNSUPPORTED_AGGREGATION = 'ELASTICSEARCH__UNSUPPORTED_AGGREGATION';
     public const UNSUPPORTED_FILTER = 'ELASTICSEARCH__UNSUPPORTED_FILTER';
@@ -149,6 +150,16 @@ class ElasticsearchException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::EMPTY_INDEXING_REQUEST,
             'Empty indexing request provided'
+        );
+    }
+
+    public static function indexCreationFailed(string $index, array $config, \Throwable $exception): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::INDEX_CREATION_ERROR,
+            'Creating index {{ index }} failed with payload {{ payload }}. Reason: {{ reason }}',
+            ['index' => $index, 'reason' => $exception->getMessage(), 'payload' => json_encode($config, JSON_THROW_ON_ERROR)]
         );
     }
 

--- a/src/Elasticsearch/Framework/ElasticsearchFieldBuilder.php
+++ b/src/Elasticsearch/Framework/ElasticsearchFieldBuilder.php
@@ -121,6 +121,10 @@ class ElasticsearchFieldBuilder
             $mapping['properties'][$name] = $esType;
         }
 
+        if ($mapping['properties'] === []) {
+            unset($mapping['properties']);
+        }
+
         return $mapping;
     }
 }

--- a/src/Elasticsearch/Framework/Indexing/IndexCreator.php
+++ b/src/Elasticsearch/Framework/Indexing/IndexCreator.php
@@ -6,7 +6,9 @@ use OpenSearch\Client;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\AbstractElasticsearchDefinition;
+use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexConfigEvent;
 use Shopware\Elasticsearch\Framework\Indexing\Event\ElasticsearchIndexCreatedEvent;
 
@@ -27,7 +29,8 @@ class IndexCreator
         private readonly Client $client,
         array $config,
         private readonly IndexMappingProvider $mappingProvider,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ElasticsearchHelper $helper
     ) {
         if (isset($config['settings']['index'])) {
             if (\array_key_exists('number_of_shards', $config['settings']['index']) && $config['settings']['index']['number_of_shards'] === null) {
@@ -60,10 +63,15 @@ class IndexCreator
         $event = new ElasticsearchIndexConfigEvent($index, $body, $definition, $context);
         $this->eventDispatcher->dispatch($event);
 
-        $this->client->indices()->create([
-            'index' => $index,
-            'body' => $event->getConfig(),
-        ]);
+        try {
+            $this->client->indices()->create([
+                'index' => $index,
+                'body' => $event->getConfig(),
+            ]);
+        } catch (\Exception $exception) {
+            $exception = ElasticsearchException::indexCreationFailed($index, $event->getConfig(), $exception);
+            $this->helper->logAndThrowException($exception);
+        }
 
         $this->createAliasIfNotExisting($index, $alias);
 

--- a/src/Elasticsearch/Framework/Indexing/IndexCreator.php
+++ b/src/Elasticsearch/Framework/Indexing/IndexCreator.php
@@ -68,7 +68,7 @@ class IndexCreator
                 'index' => $index,
                 'body' => $event->getConfig(),
             ]);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             $exception = ElasticsearchException::indexCreationFailed($index, $event->getConfig(), $exception);
             $this->helper->logAndThrowException($exception);
         }

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -54,7 +54,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
     public function getMapping(Context $context): array
     {
         $languageFields = $this->fieldBuilder->translated(self::getTextFieldConfig());
-        $salesChannelByLanguage = $this->languageLoader->loadLanguages();
+        $salesChannelByLanguage = $this->salesChannelLanguageLoader->loadLanguages();
         $allSalesChannels = array_values(array_unique(array_merge(...array_values($salesChannelByLanguage))));
 
         $visibilities = [];

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -84,6 +84,7 @@
             <argument>%elasticsearch.index.config%</argument>
             <argument type="service" id="Shopware\Elasticsearch\Framework\Indexing\IndexMappingProvider"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchHelper"/>
         </service>
 
         <service id="Shopware\Elasticsearch\Framework\Indexing\IndexMappingProvider">

--- a/tests/unit/Elasticsearch/ElasticsearchExceptionTest.php
+++ b/tests/unit/Elasticsearch/ElasticsearchExceptionTest.php
@@ -56,6 +56,17 @@ class ElasticsearchExceptionTest extends TestCase
         static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
     }
 
+    public function testIndexCreationFailed(): void
+    {
+        $exception = ElasticsearchException::indexCreationFailed('foo', ['settings' => ['index' => ['number_of_shards' => 1]]], new \RuntimeException('boom'));
+
+        static::assertSame(ElasticsearchException::INDEX_CREATION_ERROR, $exception->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertStringContainsString('boom', $exception->getMessage());
+        static::assertSame('foo', $exception->getParameters()['index']);
+        static::assertArrayHasKey('payload', $exception->getParameters());
+    }
+
     public function testNestedAggregationMissingInFilterAggregation(): void
     {
         $exception = ElasticsearchException::nestedAggregationMissingInFilterAggregation('foo');

--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -308,12 +308,10 @@ class ElasticsearchProductDefinitionTest extends TestCase
                         'lang_en' => [
                             'type' => 'object',
                             'dynamic' => true,
-                            'properties' => [],
                         ],
                         'lang_de' => [
                             'type' => 'object',
                             'dynamic' => true,
-                            'properties' => [],
                         ],
                     ],
                 ],
@@ -330,6 +328,9 @@ class ElasticsearchProductDefinitionTest extends TestCase
                             'type' => 'long',
                         ],
                     ],
+                ],
+                'visibility_' . TestDefaults::SALES_CHANNEL => [
+                    'type' => 'integer',
                 ],
             ],
             'dynamic_templates' => [


### PR DESCRIPTION
From opensearch 3.x empty properties `properties: []` is not allowed during indexing which cause an error 