### PR TITLE
fix: sidebar width persistence

### DIFF
--- a/changelog/_unreleased/2025-10-13-fix-sidebar-width-persistence.md
+++ b/changelog/_unreleased/2025-10-13-fix-sidebar-width-persistence.md
@@ -1,0 +1,5 @@
+---
+title: Fix sidebar width persistence issue when collapsed through button
+---
+# Administration
+* Changed `collapseSidebar` method in `Shopware/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts` to save the new width to local storage.

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
@@ -49,6 +49,7 @@ export default Shopware.Component.wrapComponentConfig({
 
         const collapseSidebar = () => {
             sidebarSetWidth.value = MIN_SIDEBAR_WIDTH;
+            localStorage.setItem('sw-sidebar-width', MIN_SIDEBAR_WIDTH.toString());
         };
 
         const handleSidebarResize = (event: MouseEvent) => {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -1,7 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { ui } from '@shopware-ag/meteor-admin-sdk';
 import initializeSidebar from 'src/app/init/sidebar.init';
-import { mock } from 'node:test';
 
 describe('src/app/component/structure/sw-sidebar-renderer', () => {
     let mockLocalStorage;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -163,7 +163,6 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$nextTick();
             await wrapper.vm.$nextTick();
 
-
             expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('480px');
             expect(mockLocalStorage.setItem).toHaveBeenCalledWith('sw-sidebar-width', '480');
         });

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { ui } from '@shopware-ag/meteor-admin-sdk';
 import initializeSidebar from 'src/app/init/sidebar.init';
+import { mock } from 'node:test';
 
 describe('src/app/component/structure/sw-sidebar-renderer', () => {
     let mockLocalStorage;
@@ -142,6 +143,30 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
 
             expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('480px');
             expect(mockLocalStorage.getItem).toHaveBeenCalledWith('sw-sidebar-width');
+        });
+
+        it('should reset the width when sidebar was collapsed through the button', async () => {
+            mockLocalStorage.getItem.mockReturnValue('600');
+
+            const wrapper = await createWrapper();
+
+            await ui.sidebar.add({
+                title: 'Test sidebar',
+                locationId: 'test-sidebar',
+                resizable: true,
+            });
+            Shopware.Store.get('sidebar').sidebars[0].active = true;
+            await wrapper.vm.$nextTick();
+
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('600px');
+
+            await wrapper.find('.sw-sidebar-renderer__button-collapse').trigger('click');
+            await wrapper.vm.$nextTick();
+            await wrapper.vm.$nextTick();
+
+
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('480px');
+            expect(mockLocalStorage.setItem).toHaveBeenCalledWith('sw-sidebar-width', '480');
         });
 
         it('should not render handle when resizing is not allowed', async () => {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When sidebar is collapse through the button, it does not persist new width to the local stirage.

### 2. What does this change do, exactly?
It does persist the new width after sidebar collapsed to the minimum width.

### 3. Describe each step to reproduce the issue or behaviour.
Drag sidebar to some extent, use collapse button to minify the sidebar then refresh the page and open the sidebar.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
