### PR TITLE
fix: cache cookie handling to prevent cache poisioning

### DIFF
--- a/changelog/_unreleased/2025-10-14-fix-cache-cookie-handling.md
+++ b/changelog/_unreleased/2025-10-14-fix-cache-cookie-handling.md
@@ -1,0 +1,9 @@
+---
+title: Fix Cache Cookie Handling to prevent cache poisoning
+issue: #12756
+---
+
+# Core
+* Changed `\Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator::generate()` to accept an optional Response object, when the cache key is generated to store the response in the cache. 
+  When the response is set, the cache cookies are first checked on the response object, as those might differ from the request cookies, and the request cookies can be manipulated by the client. This prevents cache poisoning when the request cookies are not sent correctly.
+* Changed `\Shopware\Core\Framework\Adapter\Cache\Http\CacheStateValidator::isValid()` to also check the response cookies first for the same reason. 

--- a/src/Core/Framework/Adapter/Cache/Http/CacheStore.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheStore.php
@@ -119,7 +119,7 @@ class CacheStore implements StoreInterface
 
     public function write(Request $request, Response $response): string
     {
-        $key = $this->cacheKeyGenerator->generate($request);
+        $key = $this->cacheKeyGenerator->generate($request, $response);
 
         // maintenance mode active and current ip is whitelisted > disable caching
         if ($this->maintenanceResolver->isMaintenanceRequest($request)) {

--- a/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
+++ b/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
@@ -127,7 +127,7 @@ class HttpCacheKeyGenerator
     /**
      * get Cookie value, if exists use response cookie value instead of request cookie value as request cookies can be overwritten by the client
      */
-    private function getCookieValue(Request $request, ?Response $response, string $cookieName): mixed
+    private function getCookieValue(Request $request, ?Response $response, string $cookieName): ?string
     {
         if ($response) {
             $cookie = Cookie::create($cookieName);
@@ -146,7 +146,7 @@ class HttpCacheKeyGenerator
         }
 
         if ($request->cookies->has($cookieName)) {
-            return $request->cookies->get($cookieName);
+            return (string) $request->cookies->get($cookieName);
         }
 
         return null;

--- a/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
+++ b/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
@@ -6,7 +6,10 @@ use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheKeyEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\SalesChannelRequest;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -51,7 +54,7 @@ class HttpCacheKeyGenerator
      *
      * @return string A key for the given request
      */
-    public function generate(Request $request): string
+    public function generate(Request $request, ?Response $response = null): string
     {
         $event = new HttpCacheKeyEvent($request);
 
@@ -59,7 +62,7 @@ class HttpCacheKeyGenerator
 
         $event->add('hash', $this->cacheHash);
 
-        $this->addCookies($request, $event);
+        $this->addCookies($request, $response, $event);
 
         $this->dispatcher->dispatch($event);
 
@@ -91,23 +94,23 @@ class HttpCacheKeyGenerator
         );
     }
 
-    private function addCookies(Request $request, HttpCacheKeyEvent $event): void
+    private function addCookies(Request $request, ?Response $response, HttpCacheKeyEvent $event): void
     {
         // this will be changed within v6.6 lane that we only use the context cache cookie and developers can change the cookie instead
         // with this change, the reverse proxies are much easier to configure
-        if ($request->cookies->has(self::CONTEXT_CACHE_COOKIE)) {
+        if ($cacheCookie = $this->getCookieValue($request, $response, self::CONTEXT_CACHE_COOKIE)) {
             $event->add(
                 self::CONTEXT_CACHE_COOKIE,
-                $request->cookies->get(self::CONTEXT_CACHE_COOKIE, '')
+                $cacheCookie
             );
 
             return;
         }
 
-        if ($request->cookies->has(self::CURRENCY_COOKIE)) {
+        if ($currencyCookie = $this->getCookieValue($request, $response, self::CURRENCY_COOKIE)) {
             $event->add(
                 self::CURRENCY_COOKIE,
-                $request->cookies->get(self::CURRENCY_COOKIE, '')
+                $currencyCookie
             );
 
             return;
@@ -119,5 +122,33 @@ class HttpCacheKeyGenerator
                 $request->attributes->get(SalesChannelRequest::ATTRIBUTE_DOMAIN_CURRENCY_ID)
             );
         }
+    }
+
+    /**
+     * get Cookie value, if exists use response cookie value instead of request cookie value as request cookies can be overwritten by the client
+     */
+    private function getCookieValue(Request $request, ?Response $response, string $cookieName): mixed
+    {
+        if ($response) {
+            $cookie = Cookie::create($cookieName);
+
+            $responseCookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
+
+            $responseCookie = $responseCookies[$cookie->getDomain()][$cookie->getPath()][$cookieName] ?? null;
+
+            if ($responseCookie) {
+                // if the response contains the cookie, we use it instead of the request cookie
+                // as the request cookie can be overwritten by the client
+                // however the response cookie is only set if it differs from the request cookie,
+                // so we need to fall back to the request cookie when the response cookie is not set
+                return $responseCookie->getValue();
+            }
+        }
+
+        if ($request->cookies->has($cookieName)) {
+            return $request->cookies->get($cookieName);
+        }
+
+        return null;
     }
 }

--- a/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
+++ b/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
@@ -94,7 +94,6 @@ class HttpCacheIntegrationTest extends TestCase
         static::assertIsString($appUrl);
 
         $request = $this->createRequest($appUrl);
-        $request->cookies->set(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, 'a');
 
         $response = $kernel->handle($request);
         $this->assertCacheHeader('GET /: miss, store', $response);


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/12756


Storage of responses in the cache was based on state cookies on the request, however the request cookies can be manipulated. For that reason we already add the correct cookie values to the response, however they were not considered when determining **if** (CacheStateValidator) and **where (cache key)** (CacheKeyGenerator) to cache the response

this might lead to wrongly stored chached pages / cache poisioning (e.g. cache of logged in customer is stored as cache entry for not logged in customer)