### PR TITLE
fix: Allow more options for RGB and HSL color functions.

### DIFF
--- a/changelog/_unreleased/2025-10-14-improve-scss-color-validation.md
+++ b/changelog/_unreleased/2025-10-14-improve-scss-color-validation.md
@@ -1,0 +1,19 @@
+---
+title: Improve SCSS color validation
+issue: #12947
+---
+# Storefront
+* Changed `Shopware\Storefront\Theme\Validator\SCSSValidator` to allow more options for `rgb()` and `hsl()` color functions.
+    * RGB and RGBA with hex colors and SCSS variables:*
+        * `rgb($primary / 0.5)`
+        * `rgb(#fff / 0.5)`
+        * `rgba($primary, 0.5)`
+        * `rgba(#fff, 0.5)`
+    * RGB and RGBA in combination with SCSS functions:
+        * `rgb(red($primary), green($primary), blue($primary))`
+        * `rgba(red($primary), green($primary), blue($primary), 0.5)`
+        * `rgba(red($primary), green($primary), blue($primary), alpha($primary))`
+    * HSL and HSLA in combination with SCSS functions:
+        * `hsl(hue($primary), saturation($primary), 94%)`
+        * `hsl(180deg saturation($primary) lightness($primary)`
+        * `hsla(hue($primary), saturation($primary), lightness($primary), alpha($primary))`

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -519,12 +519,112 @@ class SCSSValidatorTest extends TestCase
             ],
             'rgb(255 0 0 / 0.5)',
         ];
+        yield 'color correct rgb modern with variable' => [
+            [
+                'type' => 'color',
+                'value' => 'rgb($myColor / 0.5)',
+            ],
+            'rgb($myColor / 0.5)',
+        ];
+        yield 'color correct rgb modern with hex color' => [
+            [
+                'type' => 'color',
+                'value' => 'rgb(#fff / 0.5)',
+            ],
+            'rgb(#fff / 0.5)',
+        ];
         yield 'color correct rgba' => [
             [
                 'type' => 'color',
                 'value' => 'rgba(255, 0, 0, 0.5)',
             ],
             'rgba(255, 0, 0, 0.5)',
+        ];
+        yield 'color correct rgba with variable' => [
+            [
+                'type' => 'color',
+                'value' => 'rgba($myColor, 0.5)',
+            ],
+            'rgba($myColor, 0.5)',
+        ];
+        yield 'color correct rgba with hex color' => [
+            [
+                'type' => 'color',
+                'value' => 'rgba(#fff, 0.5)',
+            ],
+            'rgba(#fff, 0.5)',
+        ];
+        // HSL/HSLA with SCSS functions
+        yield 'color correct hsl with SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'hsl(hue($sw-border-color), saturation($sw-border-color), 94%)',
+            ],
+            'hsl(hue($sw-border-color), saturation($sw-border-color), 94%)',
+        ];
+        yield 'color correct hsl with partial SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'hsl(hue($primary), 100%, 50%)',
+            ],
+            'hsl(hue($primary), 100%, 50%)',
+        ];
+        yield 'color correct hsl modern with SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'hsl(180deg saturation($primary) lightness($primary))',
+            ],
+            'hsl(180deg saturation($primary) lightness($primary))',
+        ];
+        yield 'color correct hsla with SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'hsla(hue($color), saturation($color), 50%, 0.8)',
+            ],
+            'hsla(hue($color), saturation($color), 50%, 0.8)',
+        ];
+        yield 'color correct hsla with alpha function' => [
+            [
+                'type' => 'color',
+                'value' => 'hsla(hue($color), saturation($color), lightness($color), alpha($color))',
+            ],
+            'hsla(hue($color), saturation($color), lightness($color), alpha($color))',
+        ];
+        // RGB/RGBA with SCSS functions
+        yield 'color correct rgb with SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'rgb(red($primary), green($primary), blue($primary))',
+            ],
+            'rgb(red($primary), green($primary), blue($primary))',
+        ];
+        yield 'color correct rgb with partial SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'rgb(red($color), 128, blue($color))',
+            ],
+            'rgb(red($color), 128, blue($color))',
+        ];
+        yield 'color correct rgb modern with SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'rgb(red($color) 128 blue($color))',
+            ],
+            'rgb(red($color) 128 blue($color))',
+        ];
+        yield 'color correct rgba with SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'rgba(red($primary), green($primary), blue($primary), 0.5)',
+            ],
+            'rgba(red($primary), green($primary), blue($primary), 0.5)',
+        ];
+        yield 'color correct rgba with all SCSS functions' => [
+            [
+                'type' => 'color',
+                'value' => 'rgba(red($color), green($color), blue($color), alpha($color))',
+            ],
+            'rgba(red($color), green($color), blue($color), alpha($color))',
         ];
         // Boolean values
         yield 'checkbox true' => [


### PR DESCRIPTION
Fixes: #12947 

### 1. Why is this change necessary?

The new SCSS validation does not support some combinations for RGB and HSL color functions.

### 2. What does this change do, exactly?

Add support for the following formats:

**RGB and RGBA with hex colors and SCSS variables:**
* `rgb($primary / 0.5)`
* `rgb(#fff / 0.5)`
* `rgba($primary, 0.5)`
* `rgba(#fff, 0.5)`

**RGB and RGBA in combination with SCSS functions:**
* `rgb(red($primary), green($primary), blue($primary))`
* `rgba(red($primary), green($primary), blue($primary), 0.5)`
* `rgba(red($primary), green($primary), blue($primary), alpha($primary))`

**HSL and HSLA in combination with SCSS functions:**
* `hsl(hue($primary), saturation($primary), 94%)`
* `hsl(180deg saturation($primary) lightness($primary)`
* `hsla(hue($primary), saturation($primary), lightness($primary), alpha($primary))`


### 3. Describe each step to reproduce the issue or behaviour.

* Open the theme manager and edit the default theme.
* Add some of the color values mentioned above.
* Validate that the configuration can be saved and the theme can be compiled correctly.
