### PR TITLE
fix: flaky testRespondToAccessTokenRequest in ShopwareGrantTypeTest

### DIFF
--- a/tests/integration/Core/Framework/Sso/ShopwareGrantTypeTest.php
+++ b/tests/integration/Core/Framework/Sso/ShopwareGrantTypeTest.php
@@ -94,7 +94,8 @@ class ShopwareGrantTypeTest extends TestCase
         static::assertArrayHasKey('access_token', $responseBodyData);
         static::assertArrayHasKey('refresh_token', $responseBodyData);
         static::assertSame('Bearer', $responseBodyData['token_type']);
-        static::assertSame(3600, $responseBodyData['expires_in']);
+        // Assert that expires_in is between 3590 and 3600 to account for minor delays in processing
+        static::assertTrue($responseBodyData['expires_in'] <= 3600 && $responseBodyData['expires_in'] > 3595);
         static::assertIsString($responseBodyData['access_token']);
         static::assertIsString($responseBodyData['refresh_token']);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/actions/runs/18495592004/job/52698954061
- Allow a small variance in "expires_in", as this is calculated at the time the response is send to the client. It may deviate from exactly 3600 if there is a delay for some reason

### 2. What does this change do, exactly?
- Allow a small variance in "expires_in", as this is calculated at the time the response is send to the client. It may deviate from exactly 3600 if there is a delay for some reason

### 3. Describe each step to reproduce the issue or behaviour.
- See `1. Why is this change necessary?`

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
