### PR TITLE
fix: List/price percentage ratio dynamic product groups not working

### DIFF
--- a/changelog/_unreleased/2025-10-14-fix-dynamic-product-group-percentage-accessor.md
+++ b/changelog/_unreleased/2025-10-14-fix-dynamic-product-group-percentage-accessor.md
@@ -4,8 +4,8 @@ issue: 12996
 ---
 # Core
 * Changed `Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceAccessorBuilder::buildAccessor` to ignore zero-valued entries so dynamic product group conditions based on percentage ratios evaluate correctly again.
-* Added the `symfony/polyfill-php85` dependency and moved affected internals to `array_last()` so pointer handling stays consistent across supported PHP versions.
+* Added the `symfony/polyfill-php85` dependency to make it possible to use PHP 8.5 features.
 ___
 # Upgrade Information
-## array_last helper availability
-All installations now ship with `symfony/polyfill-php85`, which exposes the native `array_last()` helper on PHP 8.2 and 8.3. Plugin developers can drop custom implementations and rely on the global `array_last()` function for consistent pointer handling across Shopware and their extensions.
+## Added PHP 8.5 polyfill
+The new dependency `symfony/polyfill-php85` was added, to make it possible to already use PHP 8.5 features, like `array_first` and `array_last

--- a/changelog/_unreleased/2025-10-14-fix-dynamic-product-group-percentage-accessor.md
+++ b/changelog/_unreleased/2025-10-14-fix-dynamic-product-group-percentage-accessor.md
@@ -1,0 +1,11 @@
+---
+title: Fix percentage ratio dynamic product groups
+issue: 12996
+---
+# Core
+* Changed `Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceAccessorBuilder::buildAccessor` to ignore zero-valued entries so dynamic product group conditions based on percentage ratios evaluate correctly again.
+* Added the `symfony/polyfill-php85` dependency and moved affected internals to `array_last()` so pointer handling stays consistent across supported PHP versions.
+___
+# Upgrade Information
+## array_last helper availability
+All installations now ship with `symfony/polyfill-php85`, which exposes the native `array_last()` helper on PHP 8.2 and 8.3. Plugin developers can drop custom implementations and rely on the global `array_last()` function for consistent pointer handling across Shopware and their extensions.

--- a/changelog/_unreleased/2025-10-14-fix-dynamic-product-group-percentage-accessor.md
+++ b/changelog/_unreleased/2025-10-14-fix-dynamic-product-group-percentage-accessor.md
@@ -8,4 +8,4 @@ issue: 12996
 ___
 # Upgrade Information
 ## Added PHP 8.5 polyfill
-The new dependency `symfony/polyfill-php85` was added, to make it possible to already use PHP 8.5 features, like `array_first` and `array_last
+The new dependency `symfony/polyfill-php85` was added, to make it possible to already use PHP 8.5 features, like `array_first` and `array_last`

--- a/composer.json
+++ b/composer.json
@@ -152,6 +152,7 @@
         "symfony/options-resolver": "~7.3.0",
         "symfony/polyfill-php83": ">=1.31.0",
         "symfony/polyfill-php84": ">=1.31.0",
+        "symfony/polyfill-php85": ">=1.33.0",
         "symfony/process": "~7.3.0",
         "symfony/property-access": "~7.3.0",
         "symfony/property-info": "~7.3.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1035,12 +1035,6 @@ parameters:
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
 			count: 6
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
 

--- a/src/Core/Content/Flow/Api/FlowActionCollector.php
+++ b/src/Core/Content/Flow/Api/FlowActionCollector.php
@@ -76,7 +76,7 @@ class FlowActionCollector
         $requirementsName = [];
         foreach ($service->requirements() as $requirement) {
             $className = explode('\\', $requirement);
-            $requirementsName[] = lcfirst(end($className));
+            $requirementsName[] = lcfirst(array_last($className));
         }
 
         $delayable = false;

--- a/src/Core/Content/Seo/SeoUrlGenerator.php
+++ b/src/Core/Content/Seo/SeoUrlGenerator.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -206,11 +207,11 @@ class SeoUrlGenerator
         foreach ($variables as $variable) {
             $fields = EntityDefinitionQueryHelper::getFieldsOfAccessor($definition, $variable, true);
 
-            $lastField = end($fields);
+            $lastField = array_last($fields);
 
             $runtime = new Runtime();
 
-            if ($lastField && $lastField->getFlag(Runtime::class)) {
+            if ($lastField instanceof Field && $lastField->getFlag(Runtime::class)) {
                 $associations = array_merge($associations, $runtime->getDepends());
             }
 

--- a/src/Core/Framework/Api/Controller/CacheController.php
+++ b/src/Core/Framework/Api/Controller/CacheController.php
@@ -103,7 +103,7 @@ class CacheController extends AbstractController
         $name = $adapter::class;
         \assert(\is_string($name));
         $parts = explode('\\', $name);
-        $name = str_replace('Adapter', '', end($parts));
+        $name = str_replace('Adapter', '', array_last($parts));
 
         return $name;
     }

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -67,6 +67,7 @@ class DataAbstractionLayerException extends HttpException
     public const ATTRIBUTE_NOT_FOUND = 'FRAMEWORK__ATTRIBUTE_NOT_FOUND';
     public const EXPECTED_ARRAY_WITH_TYPE = 'FRAMEWORK__EXPECTED_ARRAY_WITH_TYPE';
     public const EXPECTED_FIELD_VALUE_TYPE_WITH_VALUE = 'FRAMEWORK__EXPECTED_FIELD_VALUE_TYPE_WITH_VALUE';
+    public const REPOSITORY_ITERATOR_EXPECTED_STRING_LAST_ID = 'FRAMEWORK__REPOSITORY_ITERATOR_EXPECTED_STRING_LAST_ID';
     public const INVALID_AGGREGATION_NAME = 'FRAMEWORK__INVALID_AGGREGATION_NAME';
     public const MISSING_FIELD_VALUE = 'FRAMEWORK__MISSING_FIELD_VALUE';
     public const NOT_CUSTOM_FIELDS_SUPPORT = 'FRAMEWORK__NOT_CUSTOM_FIELDS_SUPPORT';
@@ -188,6 +189,15 @@ class DataAbstractionLayerException extends HttpException
             self::INVALID_CRITERIA_IDS,
             'Invalid ids provided in criteria. {{ reason }}. Ids: {{ ids }}.',
             ['ids' => print_r($ids, true), 'reason' => $reason]
+        );
+    }
+
+    public static function repositoryIteratorExpectedStringLastId(): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REPOSITORY_ITERATOR_EXPECTED_STRING_LAST_ID,
+            'Expected string as last element of ids array.'
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common;
 
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -87,9 +88,9 @@ class RepositoryIterator
             return $values;
         }
 
-        $last = end($values);
+        $last = array_last($values);
         if (!\is_string($last)) {
-            throw new \RuntimeException('Expected string as last element of ids array');
+            throw DataAbstractionLayerException::repositoryIteratorExpectedStringLastId();
         }
 
         $increment = $ids->getDataFieldOfId($last, 'autoIncrement') ?? 0;

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilder.php
@@ -41,24 +41,24 @@ class PriceFieldAccessorBuilder implements FieldAccessorBuilderInterface
         $parts = explode('.', $accessor);
 
         // is tax state explicitly requested? => overwrite selector
-        if (\in_array(end($parts), ['net', 'gross'], true)) {
-            $jsonAccessor = end($parts);
+        if (\in_array(array_last($parts), ['net', 'gross'], true)) {
+            $jsonAccessor = array_last($parts);
             array_pop($parts);
         }
 
         // filter / search / sort for list prices? => extend selector
-        if (end($parts) === 'listPrice') {
+        if (array_last($parts) === 'listPrice') {
             $jsonAccessor = 'listPrice.' . $jsonAccessor;
             array_pop($parts);
         }
 
-        if (end($parts) === 'percentage') {
+        if (array_last($parts) === 'percentage') {
             $jsonAccessor = 'percentage.' . $jsonAccessor;
             array_pop($parts);
         }
 
         // is specific currency id provided? => overwrite currency id and currency factor
-        $lastPart = (string) end($parts);
+        $lastPart = (string) array_last($parts);
         if (Uuid::isValid($lastPart)) {
             $currencyId = $lastPart;
             $currencyFactor = \sprintf(

--- a/src/Core/Framework/DataAbstractionLayer/Entity.php
+++ b/src/Core/Framework/DataAbstractionLayer/Entity.php
@@ -223,7 +223,7 @@ class Entity extends Struct
 
         $class = static::class;
         $class = explode('\\', $class);
-        $class = end($class);
+        $class = array_last($class);
 
         $entityName = preg_replace(
             '/_entity$/',

--- a/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
@@ -163,7 +163,7 @@ class CategoryGenerator implements DemodataGeneratorInterface
                 $commaSeparatedCategories = implode(', ', \array_slice($categories, 0, -1));
                 $categories = [
                     $commaSeparatedCategories,
-                    end($categories),
+                    array_last($categories),
                 ];
             }
             ++$max;

--- a/src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
+++ b/src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
@@ -281,7 +281,7 @@ EOD;
     private function determineAddColumnSql(ForeignKeyConstraint $fk, array $keyStructure, string $foreignKeyColumnName, string $default): string
     {
         \assert(\is_string($keyStructure['TABLE_NAME']));
-        $columnName = end($keyStructure['COLUMN_NAME']);
+        $columnName = array_last($keyStructure['COLUMN_NAME']);
         \assert(\is_string($columnName));
 
         $isNullable = $fk->getOnDeleteAction()->value === 'SET NULL';

--- a/src/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoader.php
@@ -51,7 +51,7 @@ class ComposerPluginLoader extends KernelPluginLoader
             $nameParts = \explode('\\', $pluginClass);
 
             $this->pluginInfos[] = [
-                'name' => \end($nameParts),
+                'name' => array_last($nameParts),
                 'baseClass' => $pluginClass,
                 'active' => true,
                 'path' => $composerPackage->path,

--- a/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
@@ -64,7 +64,7 @@ trait SalesChannelApiTestBehaviour
             throw new \LogicException('The sales channel id can only be requested after calling `createSalesChannelApiClient`.');
         }
 
-        return end($this->salesChannelIds);
+        return array_last($this->salesChannelIds);
     }
 
     /**

--- a/src/Core/System/Snippet/SnippetFixer.php
+++ b/src/Core/System/Snippet/SnippetFixer.php
@@ -100,7 +100,7 @@ class SnippetFixer
         $keyParts = explode('.', $key);
 
         $currentJson = &$json;
-        $lastKey = end($keyParts);
+        $lastKey = array_last($keyParts);
         reset($keyParts);
         foreach ($keyParts as $keyPart) {
             if ($keyPart === $lastKey) {
@@ -125,7 +125,7 @@ class SnippetFixer
         $keyParts = explode('.', $key);
 
         $currentJson = &$json;
-        $lastKey = end($keyParts);
+        $lastKey = array_last($keyParts);
         reset($keyParts);
         foreach ($keyParts as $keyPart) {
             if ($keyPart === $lastKey) {

--- a/src/Core/Test/PHPUnit/Extension/DatabaseDiff/DbState.php
+++ b/src/Core/Test/PHPUnit/Extension/DatabaseDiff/DbState.php
@@ -31,7 +31,7 @@ class DbState
 
         $stateResult = [];
         foreach ($tables as $nested) {
-            $tableName = (string) end($nested);
+            $tableName = (string) array_last($nested);
 
             $count = $this->connection->fetchOne('SELECT COUNT(*) FROM `' . $tableName . '`');
 

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -230,7 +230,7 @@ class TestBootstrapper
         }
 
         $parts = explode('\\', (string) $baseClass);
-        $pluginName = end($parts);
+        $pluginName = array_last($parts);
 
         $this->addActivePlugins($pluginName);
 

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -125,6 +125,7 @@
         "symfony/options-resolver": "~7.3.0",
         "symfony/polyfill-php83": ">=1.31.0",
         "symfony/polyfill-php84": ">=1.31.0",
+        "symfony/polyfill-php85": ">=1.33.0",
         "symfony/process": "~7.3.0",
         "symfony/property-access": "~7.3.0",
         "symfony/property-info": "~7.3.0",

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilderTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilderTest.php
@@ -53,7 +53,7 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
+        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100), 0)', $sql);
     }
 
     public function testWithPercentageAccessorWithRule(): void
@@ -67,7 +67,7 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
+        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100), 0)', $sql);
     }
 
     public function testRuleLimit(): void
@@ -82,6 +82,6 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
+        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100), 0)', $sql);
     }
 }


### PR DESCRIPTION
### Shopware Version

6.7.1.2

### Affected Area / Extension

We have created a dynamic product group with a "Price/Percentage Strike" rule of 0.

*_Expected Behavior:_*

The dynamic product group rule "Price/Percentage Strike" should display the same product list in both the storefront and the admin

*_Actual Behavior:_*

The dynamic product group rule "Price/Percentage Strike" is not working correctly in both admin and storefront (the issue only occurs when the value is 0)

*_How to reproduce:_*

1. Create a dynamic product group and apply a "Price/Percentage Strike" rule of 0
2. Assign the created dynamic product group to a category
3. Check the list displayed in the storefront