### PR TITLE
fix(PHPStan): Add missing Storefront route prefix, fix typo and clean up configuration files

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/StorefrontRouteUsageRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/StorefrontRouteUsageRule.php
@@ -19,7 +19,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('framework')]
-class StorefrontRouteUsageRUle implements Rule
+class StorefrontRouteUsageRule implements Rule
 {
     /**
      * @var list<string>
@@ -57,17 +57,24 @@ class StorefrontRouteUsageRUle implements Rule
         }
 
         $value = $node->value;
-        /** @phpstan-ignore shopware.storefrontRouteUsage (As the PHPStan rule checks itself, this needs to be ignored) */
-        if (str_starts_with($value, 'frontend.')) {
-            $message = \sprintf('Using a route name starting with "frontend." is not allowed in the "%s" namespace (found: "%s").', $namespace, $value);
+        /** @phpstan-ignore shopware.storefrontRouteUsage, shopware.storefrontRouteUsage (As the PHPStan rule checks itself, this needs to be ignored) */
+        foreach (['frontend.', 'widgets.'] as $notAllowedStorefrontRoutesPrefix) {
+            if (str_starts_with($value, $notAllowedStorefrontRoutesPrefix)) {
+                $message = \sprintf(
+                    'Using a route name starting with "%s" is not allowed in the "%s" namespace (found: "%s").',
+                    $notAllowedStorefrontRoutesPrefix,
+                    $namespace,
+                    $value
+                );
 
-            return [
-                RuleErrorBuilder::message($message)
-                    ->line($node->getStartLine())
-                    ->identifier('shopware.storefrontRouteUsage')
-                    ->tip('Routes starting with "frontend." are provided by the Storefront package, which is not always installed.')
-                    ->build(),
-            ];
+                return [
+                    RuleErrorBuilder::message($message)
+                        ->line($node->getStartLine())
+                        ->identifier('shopware.storefrontRouteUsage')
+                        ->tip(\sprintf('Routes starting with "%s" are provided by the Storefront package, which is not always installed.', $notAllowedStorefrontRoutesPrefix))
+                        ->build(),
+                ];
+            }
         }
 
         return [];

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/StorefrontRouteUsageRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/StorefrontRouteUsageRule.php
@@ -23,6 +23,13 @@ class StorefrontRouteUsageRule implements Rule
 {
     /**
      * @var list<string>
+     *
+     * @phpstan-ignore shopware.storefrontRouteUsage, shopware.storefrontRouteUsage (As the PHPStan rule checks itself, this needs to be ignored)
+     */
+    private const NOT_ALLOWED_STOREFRONT_ROUTE_PREFIXES = ['frontend.', 'widgets.'];
+
+    /**
+     * @var list<string>
      */
     private array $allowedStorefrontRouteNamespaces;
 
@@ -57,8 +64,7 @@ class StorefrontRouteUsageRule implements Rule
         }
 
         $value = $node->value;
-        /** @phpstan-ignore shopware.storefrontRouteUsage, shopware.storefrontRouteUsage (As the PHPStan rule checks itself, this needs to be ignored) */
-        foreach (['frontend.', 'widgets.'] as $notAllowedStorefrontRoutesPrefix) {
+        foreach (self::NOT_ALLOWED_STOREFRONT_ROUTE_PREFIXES as $notAllowedStorefrontRoutesPrefix) {
             if (str_starts_with($value, $notAllowedStorefrontRoutesPrefix)) {
                 $message = \sprintf(
                     'Using a route name starting with "%s" is not allowed in the "%s" namespace (found: "%s").',

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -35,24 +35,28 @@ parameters:
         no_mixed_caller: true
         null_over_false: true
 
+    shopware:
+        allowedNonDomainExceptions:
+            - Shopware\Core\Framework\Plugin\Exception\DecorationPatternException
+            - Shopware\Core\Framework\Validation\Exception\ConstraintViolationException
+            - Shopware\Core\Framework\Api\Controller\Exception\PermissionDeniedException
+            - Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException
+            - Twig\Error\LoaderError
+            - Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+            - Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException
+            - Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException
+            - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+            - Symfony\Component\HttpFoundation\Exception\BadRequestException
+
+        allowedStorefrontRouteNamespaces:
+            - Shopware\Storefront
+
 services:
-    - # register the class, so we can decorate it, but don't tag it as a rule, so only our decorator is used by PHPStan
-        class: Symplify\PHPStanRules\Rules\NoReturnSetterMethodRule
+    -   factory: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Configuration(%shopware%)
+    -   class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AclValidPermissionsHelper
 
-rules:
-    # rules from https://github.com/symplify/phpstan-rules
-    # domain
-    - Symplify\PHPStanRules\Rules\Enum\RequireUniqueEnumConstantRule
-    - Symplify\PHPStanRules\Rules\PreventParentMethodVisibilityOverrideRule
-
-    # explicit naming
-    - Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule
-
-    - Symplify\PHPStanRules\Rules\Complexity\ForbiddenArrayMethodCallRule
-
-    # naming rules
-    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Symplify\NoReturnSetterMethodWithFluentSettersRule
-    - Symplify\PHPStanRules\Rules\UppercaseConstantRule
-
-    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\PublicServiceDecoratorRule
-
+parametersSchema:
+    shopware: structure([
+        allowedNonDomainExceptions: list(string),
+        allowedStorefrontRouteNamespaces: list(string),
+])

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
@@ -18,7 +18,7 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\ShopwareNamespaceStyleRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AttributeFinalRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NameConstantEntityDefinition
-    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\StorefrontRouteUsageRUle
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\StorefrontRouteUsageRule
 
 services:
     -

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/extension.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/extension.neon
@@ -3,29 +3,3 @@ services:
         class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Type\CollectionHasSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.methodTypeSpecifyingExtension
-
-    -   factory: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Configuration(%shopware%)
-
-    -   class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AclValidPermissionsHelper
-
-parameters:
-    shopware:
-        allowedNonDomainExceptions:
-            - Shopware\Core\Framework\Plugin\Exception\DecorationPatternException
-            - Shopware\Core\Framework\Validation\Exception\ConstraintViolationException
-            - Shopware\Core\Framework\Api\Controller\Exception\PermissionDeniedException
-            - Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException
-            - Twig\Error\LoaderError
-            - Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-            - Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException
-            - Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException
-            - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-            - Symfony\Component\HttpFoundation\Exception\BadRequestException
-        allowedStorefrontRouteNamespaces:
-            - Shopware\Storefront
-
-parametersSchema:
-    shopware: structure([
-        allowedNonDomainExceptions: list(string),
-        allowedStorefrontRouteNamespaces: list(string),
-    ])

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
@@ -21,8 +21,26 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoDelayStampRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoAddCacheTagEventRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoUpdatesInExecuteQueryRule
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\PublicServiceDecoratorRule
+
+    # rules from https://github.com/symplify/phpstan-rules
+    # domain
+    - Symplify\PHPStanRules\Rules\Enum\RequireUniqueEnumConstantRule
+    - Symplify\PHPStanRules\Rules\PreventParentMethodVisibilityOverrideRule
+
+    # explicit naming
+    - Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule
+
+    - Symplify\PHPStanRules\Rules\Complexity\ForbiddenArrayMethodCallRule
+
+    # naming rules
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Symplify\NoReturnSetterMethodWithFluentSettersRule
+    - Symplify\PHPStanRules\Rules\UppercaseConstantRule
 
 services:
+    - # register the class, so we can decorate it, but don't tag it as a rule, so only our decorator is used by PHPStan
+        class: Symplify\PHPStanRules\Rules\NoReturnSetterMethodRule
+
     -
         class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NotExtendFlowEventAwareRule
         tags:


### PR DESCRIPTION
### 1. Why is this change necessary?

- Add missing Storefront route prefix
- fixed typo
- cleanup and re-order configuration files

