### PR TITLE
fix: Oauth grant open api specs

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/OAuthScopes.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/OAuthScopes.json
@@ -65,7 +65,7 @@
                                 "type": "string",
                                 "enum": ["administration"]
                             },
-                            "scopes": {
+                            "scope": {
                                 "$ref": "#/components/schemas/OAuthScopes"
                             },
                             "username": {
@@ -79,7 +79,7 @@
                         },
                         "required": [
                             "client_id",
-                            "scopes",
+                            "scope",
                             "username",
                             "password"
                         ]
@@ -97,7 +97,7 @@
                                 "type": "string",
                                 "enum": ["administration"]
                             },
-                            "scopes": {
+                            "scope": {
                                 "$ref": "#/components/schemas/OAuthScopes"
                             },
                             "refresh_token": {
@@ -105,7 +105,7 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["client_id", "scopes", "refresh_token"]
+                        "required": ["client_id", "scope", "refresh_token"]
                     }
                 ]
             }


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/12428

Since 6.7.0.0 and the oauth server update the `scopes`prop is not supported anymore you need to provide it as `scope`, see https://github.com/shopware/shopware/blob/trunk/UPGRADE-6.7.md#non-spec-compliant-apioauthtoken-requests-are-not-supported-anymore 
