### PR TITLE
fix: Paypal errors showing on category page (#12701)

### DIFF
--- a/changelog/release-6-7-3-0/2025-10-15-storefront-fixed-showing-paypal-errors-on-category-page.md
+++ b/changelog/release-6-7-3-0/2025-10-15-storefront-fixed-showing-paypal-errors-on-category-page.md
@@ -1,0 +1,7 @@
+---
+title: Fixed Paypal errors showing on category pages
+issue: 12701
+author: Nam Dinh
+---
+# Storefront
+* Indicated the suitable flash messages in `storefront/resources/views/storefront/base.html.twig` and `storefront/resources/views/storefront/page/checkout/_page.html.twig` to make sure that the paypal errors only showing in checkout page, not showing on other pages.

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -55,7 +55,9 @@
                 {% block base_flashbags %}
                     <div class="flashbags container">
                         {% for type, messages in app.flashes %}
-                            {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
+                            {% if type != 'paypal-error' %}
+                                {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
+                            {% endif %}
                         {% endfor %}
                     </div>
                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
@@ -16,7 +16,11 @@
                             {% block base_flashbags_checkout %}
                                 <div class="flashbags">
                                     {% for type, messages in app.flashes %}
-                                        {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
+                                        {% set alertType = type == 'paypal-error' ? 'danger' : type %}
+                                        {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+                                            type: alertType,
+                                            list: messages
+                                        } %}
                                     {% endfor %}
                                 </div>
                             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

- Only showing Paypal error messages in checkout page, not showing in category or other pages

### 2. What does this change do, exactly?

- Indicated the suitable flash messages in `storefront/resources/views/storefront/base.html.twig` and `storefront/resources/views/storefront/page/checkout/_page.html.twig` to make sure that the paypal errors only showing in checkout page, not showing on other pages.


### 3. Describe each step to reproduce the issue or behaviour.

- Make some steps on Storefront during Paypal checkout modal opened and in progress then close it or do something to interrupt that progress

### 4. Please link to the relevant issues (if any).

- closes #12701   - closes the issue #12701 when the PR is merged

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-15-storefront-fixed-showing-paypal-errors-on-category-page) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
