### PR TITLE
refactor: Use lists where we know that it is a list

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,18 +13,6 @@ parameters:
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:buildHierarchyTree\(\) has parameter \$flowSequences with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
-
-		-
-			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:buildHierarchyTree\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
-
-		-
 			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:createNestedAction\(\) has parameter \$currentSequence with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Core/Checkout/Cart/Order/LineItemDownloadLoader.php
+++ b/src/Core/Checkout/Cart/Order/LineItemDownloadLoader.php
@@ -26,7 +26,7 @@ class LineItemDownloadLoader
     /**
      * @param mixed[][] $lineItems
      *
-     * @return array<int, array<int, array{position: int, mediaId: string, accessGranted: bool}>>
+     * @return array<int, list<array{position: int, mediaId: string, accessGranted: bool}>>
      */
     public function load(array $lineItems, Context $context): array
     {
@@ -57,7 +57,7 @@ class LineItemDownloadLoader
     /**
      * @param array<string, int> $lineItemKeys
      *
-     * @return array<int, array<int, array{position: int, mediaId: string, accessGranted: bool}>>
+     * @return array<int, list<array{position: int, mediaId: string, accessGranted: bool}>>
      */
     private function getLineItemDownloadPayload(array $lineItemKeys, Context $context): array
     {

--- a/src/Core/Checkout/Cart/Order/Transformer/DeliveryTransformer.php
+++ b/src/Core/Checkout/Cart/Order/Transformer/DeliveryTransformer.php
@@ -22,7 +22,7 @@ class DeliveryTransformer
      * @param array<string, array<string, mixed>> $lineItems
      * @param array<int|string, array<string, string|array<mixed>>> $addresses
      *
-     * @return array<int, DeliveryArray>
+     * @return list<DeliveryArray>
      */
     public static function transformCollection(
         DeliveryCollection $deliveries,

--- a/src/Core/Checkout/Cart/Order/Transformer/TransactionTransformer.php
+++ b/src/Core/Checkout/Cart/Order/Transformer/TransactionTransformer.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 class TransactionTransformer
 {
     /**
-     * @return array<int, array<string, string|CalculatedPrice|array<array-key, mixed>|null>>
+     * @return list<array<string, string|CalculatedPrice|array<array-key, mixed>|null>>
      */
     public static function transformCollection(
         TransactionCollection $transactions,

--- a/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
@@ -30,7 +30,7 @@ abstract class AbstractDocumentRenderer
     /**
      * @param array<int, string> $ids
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<array<string, mixed>>
      */
     protected function getOrdersLanguageId(array $ids, string $versionId, Connection $connection): array
     {

--- a/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
+++ b/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
@@ -256,7 +256,7 @@ class CategoryBreadcrumbBuilder
     /**
      * @param array<string> $categoryIds
      *
-     * @return array<int, array<string, string|mixed>>
+     * @return list<array<string, string|mixed>>
      */
     private function loadSeoUrls(array $categoryIds, Context $context, SalesChannelEntity $salesChannel): array
     {
@@ -283,7 +283,7 @@ class CategoryBreadcrumbBuilder
     }
 
     /**
-     * @param array<int, array<string, string|mixed>> $seoUrls
+     * @param list<array<string, string|mixed>> $seoUrls
      */
     private function convertCategoriesToBreadcrumbUrls(CategoryCollection $categories, array $seoUrls): BreadcrumbCollection
     {

--- a/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
+++ b/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
@@ -69,7 +69,7 @@ class CmsVersionMergeSubscriber implements EventSubscriberInterface
      * @param array<int, array<string, mixed>> $slots
      * @param array<string, array<string, bool>> $deletedBlocks
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<array<string, mixed>>
      */
     private function filterSlots(array $slots, array $deletedBlocks): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeAction.php
@@ -35,7 +35,7 @@ class AddCustomerAffiliateAndCampaignCodeAction extends FlowAction implements De
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/AddCustomerTagAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/AddCustomerTagAction.php
@@ -31,7 +31,7 @@ class AddCustomerTagAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeAction.php
@@ -35,7 +35,7 @@ class AddOrderAffiliateAndCampaignCodeAction extends FlowAction implements Delay
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/AddOrderTagAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/AddOrderTagAction.php
@@ -31,7 +31,7 @@ class AddOrderTagAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupAction.php
@@ -31,7 +31,7 @@ class ChangeCustomerGroupAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusAction.php
@@ -31,7 +31,7 @@ class ChangeCustomerStatusAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/GenerateDocumentAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/GenerateDocumentAction.php
@@ -34,7 +34,7 @@ class GenerateDocumentAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/GrantDownloadAccessAction.php
@@ -31,7 +31,7 @@ class GrantDownloadAccessAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagAction.php
@@ -32,7 +32,7 @@ class RemoveCustomerTagAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/RemoveOrderTagAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/RemoveOrderTagAction.php
@@ -32,7 +32,7 @@ class RemoveOrderTagAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/SetCustomerCustomFieldAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SetCustomerCustomFieldAction.php
@@ -37,7 +37,7 @@ class SetCustomerCustomFieldAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/SetCustomerGroupCustomFieldAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SetCustomerGroupCustomFieldAction.php
@@ -37,7 +37,7 @@ class SetCustomerGroupCustomFieldAction extends FlowAction implements DelayableA
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/SetOrderCustomFieldAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SetOrderCustomFieldAction.php
@@ -37,7 +37,7 @@ class SetOrderCustomFieldAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/SetOrderStateAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SetOrderStateAction.php
@@ -48,7 +48,7 @@ class SetOrderStateAction extends FlowAction implements DelayableAction, Transac
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/Action/StopFlowAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/StopFlowAction.php
@@ -18,7 +18,7 @@ class StopFlowAction extends FlowAction implements DelayableAction
     }
 
     /**
-     * @return array<int, string|null>
+     * @return list<string|null>
      */
     public function requirements(): array
     {

--- a/src/Core/Content/Flow/Dispatching/FlowBuilder.php
+++ b/src/Core/Content/Flow/Dispatching/FlowBuilder.php
@@ -33,10 +33,14 @@ class FlowBuilder
         return new Flow($id, $sequences, $flat);
     }
 
+    /**
+     * @param array<int, array<string, mixed>> $flowSequences
+     *
+     * @return list<array<string, mixed>>
+     */
     private function buildHierarchyTree(array $flowSequences, ?string $parentId = null): array
     {
         $children = [];
-
         foreach ($flowSequences as $key => $flowSequence) {
             if ($flowSequence['parent_id'] !== $parentId) {
                 continue;
@@ -48,7 +52,6 @@ class FlowBuilder
         }
 
         $items = [];
-
         foreach ($children as $child) {
             $child['children'] = $this->buildHierarchyTree($flowSequences, $child['sequence_id']);
             $items[] = $child;

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -269,7 +269,7 @@ class Translator extends AbstractTranslator
     }
 
     /**
-     * @return array<int, MessageCatalogueInterface>
+     * @return list<MessageCatalogueInterface>
      */
     public function getCatalogues(): array
     {

--- a/src/Core/Framework/Api/Controller/CustomSnippetFormatController.php
+++ b/src/Core/Framework/Api/Controller/CustomSnippetFormatController.php
@@ -53,7 +53,7 @@ class CustomSnippetFormatController
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     private function getCoreSnippets(): array
     {
@@ -63,7 +63,7 @@ class CustomSnippetFormatController
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     private function getPluginSnippets(): array
     {
@@ -83,7 +83,7 @@ class CustomSnippetFormatController
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     private function getSnippetsFromDir(string $directory): array
     {

--- a/src/Core/Framework/App/Command/ValidateAppCommand.php
+++ b/src/Core/Framework/App/Command/ValidateAppCommand.php
@@ -72,7 +72,7 @@ class ValidateAppCommand extends Command
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     private function validate(string $appDir): array
     {

--- a/src/Core/Framework/App/Manifest/XmlParserUtils.php
+++ b/src/Core/Framework/App/Manifest/XmlParserUtils.php
@@ -49,7 +49,7 @@ class XmlParserUtils
     }
 
     /**
-     * @return array<int, string|null>
+     * @return list<string|null>
      */
     public static function parseChildrenAsList(\DOMElement $element, ?callable $transformer = null): array
     {

--- a/src/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregation.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregation.php
@@ -16,7 +16,7 @@ use Shopware\Core\Framework\Log\Package;
 final class RangeAggregation extends Aggregation
 {
     /**
-     * @var array<int, array<string, float|string|null>>
+     * @var list<array<string, float|string|null>>
      */
     protected array $ranges;
 
@@ -39,7 +39,7 @@ final class RangeAggregation extends Aggregation
     }
 
     /**
-     * @return array<int, array<string, float|string|null>>
+     * @return list<array<string, float|string|null>>
      */
     public function getRanges(): array
     {

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
@@ -163,7 +163,7 @@ class WriteCommandQueue
     }
 
     /**
-     * @return array<int, mixed>
+     * @return list<mixed>
      */
     private static function decodeCommandPrimary(DefinitionInstanceRegistry $registry, WriteCommand $command): array
     {

--- a/src/Core/Framework/Rule/RuleConstraints.php
+++ b/src/Core/Framework/Rule/RuleConstraints.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints\Type;
 class RuleConstraints
 {
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function float(): array
     {
@@ -23,7 +23,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function int(): array
     {
@@ -31,7 +31,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function string(): array
     {
@@ -39,7 +39,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function stringArray(): array
     {
@@ -47,7 +47,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function bool(bool $notNull = false): array
     {
@@ -63,7 +63,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function uuids(): array
     {
@@ -71,7 +71,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function date(): array
     {
@@ -79,7 +79,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function datetime(): array
     {
@@ -89,7 +89,7 @@ class RuleConstraints
     /**
      * @param array<int, string> $choices
      *
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function choice(array $choices): array
     {
@@ -97,7 +97,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function numericOperators(bool $emptyAllowed = true): array
     {
@@ -121,7 +121,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function stringOperators(bool $emptyAllowed = true): array
     {
@@ -141,7 +141,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function uuidOperators(bool $emptyAllowed = true): array
     {
@@ -161,7 +161,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function dateOperators(bool $emptyAllowed = true): array
     {
@@ -185,7 +185,7 @@ class RuleConstraints
     }
 
     /**
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     public static function datetimeOperators(bool $emptyAllowed = true): array
     {

--- a/src/Core/Framework/Webhook/BusinessEventEncoder.php
+++ b/src/Core/Framework/Webhook/BusinessEventEncoder.php
@@ -163,7 +163,7 @@ class BusinessEventEncoder
      * @param array<string, mixed> $dataType
      * @param array<string, mixed> $property
      *
-     * @return array<int, mixed>
+     * @return list<mixed>
      */
     private function encodeArray(array $dataType, array $property): array
     {

--- a/src/Core/Installer/Controller/ShopConfigurationController.php
+++ b/src/Core/Installer/Controller/ShopConfigurationController.php
@@ -167,7 +167,7 @@ class ShopConfigurationController extends InstallerController
     }
 
     /**
-     * @return array<int, array{iso3: string, default: bool}>
+     * @return list<array{iso3: string, default: bool}>
      */
     private function getCountryIsos(Connection $connection, string $currentLocale): array
     {

--- a/src/Core/Maintenance/System/Service/ShopConfigurator.php
+++ b/src/Core/Maintenance/System/Service/ShopConfigurator.php
@@ -286,7 +286,7 @@ class ShopConfigurator
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return list<array<string, mixed>>
      */
     private function getLocaleTranslations(string $localeId): array
     {

--- a/src/Core/Migration/V6_3/Migration1584002637NewImportExport.php
+++ b/src/Core/Migration/V6_3/Migration1584002637NewImportExport.php
@@ -123,7 +123,7 @@ class Migration1584002637NewImportExport extends MigrationStep
     }
 
     /**
-     * @return array<int, array{id: string, width: int, height: int}>
+     * @return list<array{id: string, width: int, height: int}>
      */
     private function getThumbnailSizes(Connection $connection): array
     {

--- a/src/Core/Service/Subscriber/WebhookManagerSubscriber.php
+++ b/src/Core/Service/Subscriber/WebhookManagerSubscriber.php
@@ -44,7 +44,7 @@ class WebhookManagerSubscriber implements EventSubscriberInterface
      * @param list<T> $array
      * @param callable(T): int $callback
      *
-     * @return array<int, list<T>>
+     * @return list<list<T>>
      */
     private function partitionArray(array $array, callable $callback): array
     {

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -171,7 +171,7 @@ readonly class SnippetValidator implements SnippetValidatorInterface
     /**
      * @param array<string, mixed> $dataSet
      *
-     * @return array<int, array<string, mixed>>
+     * @return list<array<string, mixed>>
      */
     private function getRecursiveArrayKeys(array $dataSet, string $keyString = ''): array
     {
@@ -196,7 +196,7 @@ readonly class SnippetValidator implements SnippetValidatorInterface
 
     /**
      * @param array<string, array<string, array<string, mixed>>> $snippetFileMappings
-     * @param array<int, string> $availableISOs
+     * @param list<string> $availableISOs
      */
     private function findMissingSnippets(array $snippetFileMappings, array $availableISOs): MissingSnippetCollection
     {

--- a/src/Core/System/SystemConfig/Util/ConfigReader.php
+++ b/src/Core/System/SystemConfig/Util/ConfigReader.php
@@ -51,7 +51,7 @@ class ConfigReader extends XmlReader
     }
 
     /**
-     * @return array<array{title: array<string, string|null>, name: string|null, elements: array<int, array<string, mixed>>, flag?: string|null}>
+     * @return array<array{title: array<string, string|null>, name: string|null, elements: list<array<string, mixed>>, flag?: string|null}>
      */
     private function getCardDefinitions(\DOMDocument $xml): array
     {
@@ -86,20 +86,18 @@ class ConfigReader extends XmlReader
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return list<array<string, mixed>>
      */
     private function getElements(\DOMElement $xml): array
     {
         $elements = [];
-        $count = 0;
         foreach (static::getAllChildren($xml) as $element) {
             $nodeName = $element->nodeName;
             if (\in_array($nodeName, ['title', 'name', 'flag'], true)) {
                 continue;
             }
 
-            $elements[$count] = $this->elementToArray($element);
-            ++$count;
+            $elements[] = $this->elementToArray($element);
         }
 
         return $elements;

--- a/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
+++ b/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
@@ -99,7 +99,7 @@ class SystemConfigValidator
     /**
      * @param array<string, mixed> $elementConfig
      *
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     private function buildConstraintsWithConfigs(array $elementConfig, bool $allowNulls): array
     {

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -449,7 +449,7 @@ class CriteriaParser
     }
 
     /**
-     * @return array<int, array<string, string|float>>
+     * @return list<array<string, string|float>>
      */
     private function getCheapestPriceAccessors(Context $context, bool $percentage = false): array
     {

--- a/src/Elasticsearch/Framework/ElasticsearchFieldMapper.php
+++ b/src/Elasticsearch/Framework/ElasticsearchFieldMapper.php
@@ -82,7 +82,7 @@ class ElasticsearchFieldMapper
      * @param array<int, array{id: string, languageId?: string}> $items An array of items with language information.
      * @param list<string> $translatedFields An array of fields to be translated.
      *
-     * @return array<int, array<string, array<string, string>>> An array of items with nested arrays containing translated values.
+     * @return list<array<string, array<string, string>>> An array of items with nested arrays containing translated values.
      *
      * @example
      *

--- a/src/Elasticsearch/Framework/ElasticsearchRangeAggregation.php
+++ b/src/Elasticsearch/Framework/ElasticsearchRangeAggregation.php
@@ -15,22 +15,16 @@ class ElasticsearchRangeAggregation extends AbstractAggregation
     use BucketingTrait;
 
     /**
-     * @var array<int, array<string, float>>
-     */
-    private array $ranges = [];
-
-    /**
      * @param array<int, array<string, float>> $ranges
      */
     public function __construct(
         string $name,
         string $field,
-        array $ranges
+        private array $ranges,
     ) {
         parent::__construct($name);
 
         $this->setField($field);
-        $this->setRanges($ranges);
     }
 
     /**

--- a/src/Storefront/Controller/FormController.php
+++ b/src/Storefront/Controller/FormController.php
@@ -96,7 +96,7 @@ class FormController extends StorefrontController
     }
 
     /**
-     * @return array<int, array<string|int, mixed>>
+     * @return list<array<string|int, mixed>>
      */
     private function handleSubscribe(Request $request, RequestDataBag $data, SalesChannelContext $context): array
     {
@@ -143,7 +143,7 @@ class FormController extends StorefrontController
     }
 
     /**
-     * @return array<int, array<string|int, mixed>>
+     * @return list<array<string|int, mixed>>
      */
     private function handleUnsubscribe(RequestDataBag $data, SalesChannelContext $context): array
     {

--- a/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+++ b/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
@@ -203,7 +203,7 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     private function getScssEntryFileInDir(string $path, string $basePath): array
     {

--- a/src/Storefront/Theme/ThemeScripts.php
+++ b/src/Storefront/Theme/ThemeScripts.php
@@ -47,10 +47,9 @@ readonly class ThemeScripts
 
         $runtimeConfig = $this->themeRuntimeConfigService->getResolvedRuntimeConfig($themeId);
 
-        if ($runtimeConfig === null) {
+        if ($runtimeConfig?->scriptFiles === null) {
             return [];
         }
-        \assert($runtimeConfig->scriptFiles !== null);
 
         return $runtimeConfig->scriptFiles;
     }

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -102,7 +102,7 @@ class ThemeService implements ResetInterface
     /**
      * Compiles all dependend saleschannel/Theme combinations
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public function compileThemeById(
         string $themeId,

--- a/src/Storefront/Theme/Validator/SCSSValidator.php
+++ b/src/Storefront/Theme/Validator/SCSSValidator.php
@@ -190,7 +190,7 @@ class SCSSValidator
     }
 
     /**
-     * @return array<int, string>
+     * @return list<string>
      */
     private static function extractSCSSvars(string $value): array
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
While lying in bed with a cold and getting bored, I decided to tackle a lightweight problem, and replace all occurrences, where we know that we return a `list`, instead of an `array<int, ...>`. I do not replace any public parameters to not break anything else, just to be able to use the proper information downstream. 

### 2. What does this change do, exactly?
Replace `array<int, ...>` by `list<...>` where we know it does not affect anything else but makes the type stricter.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
