### PR TITLE
feat: bump acceptance test suite version to 11.35.0

### DIFF
--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@currents/playwright": "1.16.0",
-        "@shopware-ag/acceptance-test-suite": "11.34.1",
+        "@shopware-ag/acceptance-test-suite": "11.35.0",
         "@shopware/api-client": "1.3.0",
         "lighthouse": "12.8.2",
         "playwright-lighthouse": "4.0.0"
@@ -1135,10 +1135,9 @@
       }
     },
     "node_modules/@shopware-ag/acceptance-test-suite": {
-      "version": "11.34.1",
-      "resolved": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@503",
-      "integrity": "sha512-YPBP6EzdP5is3MJyCLl/ScmJaiO96no66dY3iwEPjrWOHPBDpcqLGp6ywlZe6/XpWz8k4qvdDBLQ09hQkfU8cQ==",
-      "license": "MIT",
+      "version": "11.35.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-11.35.0.tgz",
+      "integrity": "sha512-AViNb6TrAvVskUCqneyFiyVtCrAr6ncz98lOAlZDeY5vanYtRcsGgW37RYZkXk0KwQR0/NBklKtUqKqypaeBQw==",
       "dependencies": {
         "@axe-core/playwright": "^4.10.2",
         "@eslint/js": "^9.35.0",

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "1.16.0",
-    "@shopware-ag/acceptance-test-suite": "11.34.1",
+    "@shopware-ag/acceptance-test-suite": "11.35.0",
     "@shopware/api-client": "1.3.0",
     "lighthouse": "12.8.2",
     "playwright-lighthouse": "4.0.0"


### PR DESCRIPTION
### 1. Why is this change necessary?
Bump the current acceptance test suite version to the newest one.

### 2. What does this change do, exactly?
Bump the current acceptance test suite version to the newest one.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
