### PR TITLE
fix: Hide `shopware.yaml` danger warning on `config-schema.json` change

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -107,7 +107,7 @@ return (new Config())
     ->useRule(function (Context $context): void {
         $files = $context->platform->pullRequest->getFiles();
 
-        if ($files->matches('*/shopware.yaml')->count() > 0) {
+        if ($files->matches('*/shopware.yaml')->count() > 0 && $files->matches('*/config-schema.json')->count() === 0) {
             $context->warning('You updated the shopware.yaml, please consider to update the config-schema.json');
         }
     })


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/pull/13007#issuecomment-3409532313

### 2. What does this change do, exactly?
- Hide `shopware.yaml` danger warning, if there is already a change in the `config-schema.json` file

### 3. Describe each step to reproduce the issue or behaviour.
- Update `shopware.yaml` & `config-schema.json` files

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
