### PR TITLE
fix: flaky DeleteExpiredFilesServiceTest

### DIFF
--- a/src/Core/Content/ImportExport/Service/DeleteExpiredFilesService.php
+++ b/src/Core/Content/ImportExport/Service/DeleteExpiredFilesService.php
@@ -26,10 +26,9 @@ class DeleteExpiredFilesService
     public function countFiles(Context $context): int
     {
         $criteria = $this->buildCriteria();
-        $criteria->setLimit(1);
         $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);
 
-        return $this->fileRepository->search($criteria, $context)->getTotal();
+        return $this->fileRepository->searchIds($criteria, $context)->getTotal();
     }
 
     public function deleteFiles(Context $context): void

--- a/tests/integration/Core/Content/ImportExport/Service/DeleteExpiredFilesServiceTest.php
+++ b/tests/integration/Core/Content/ImportExport/Service/DeleteExpiredFilesServiceTest.php
@@ -72,17 +72,17 @@ class DeleteExpiredFilesServiceTest extends TestCase
         static::assertSame(3, $count);
     }
 
-    public function testCountFilesWithExactlyThirtyDaysOldFiles(): void
+    public function testCountFilesWithNearlyThirtyDaysOldFiles(): void
     {
-        // Create files exactly 30 days old - should not be expired
+        // Create files nearly 30 days old
         $this->createTestFiles([
-            ['expireDate' => new \DateTimeImmutable('-30 days')],
+            ['expireDate' => new \DateTimeImmutable('-29 days -23 hours -59 minutes -55 seconds')], // Should not expire (buffer of 5 seconds for test execution time)
+            ['expireDate' => new \DateTimeImmutable('-30 days -1 second')], // Should expire
         ]);
 
         $count = $this->deleteExpiredFilesService->countFiles($this->context);
 
-        // Should not count files that are exactly 30 days old (LT filter)
-        static::assertSame(0, $count);
+        static::assertSame(1, $count);
     }
 
     public function testDeleteFilesWithNoExpiredFiles(): void
@@ -141,7 +141,6 @@ class DeleteExpiredFilesServiceTest extends TestCase
             ['expireDate' => new \DateTimeImmutable('+1 day')],
             ['expireDate' => new \DateTimeImmutable('-1 day')],
             ['expireDate' => new \DateTimeImmutable('-29 days')],
-            ['expireDate' => new \DateTimeImmutable('-30 days')], // Exactly 30 days - not expired
         ]);
 
         // Verify count before deletion

--- a/tests/integration/Core/Framework/Sso/ShopwareGrantTypeTest.php
+++ b/tests/integration/Core/Framework/Sso/ShopwareGrantTypeTest.php
@@ -94,7 +94,7 @@ class ShopwareGrantTypeTest extends TestCase
         static::assertArrayHasKey('access_token', $responseBodyData);
         static::assertArrayHasKey('refresh_token', $responseBodyData);
         static::assertSame('Bearer', $responseBodyData['token_type']);
-        // Assert that expires_in is between 3590 and 3600 to account for minor delays in processing
+        // Assert that expires_in is between 3595 and 3600 to account for minor delays in processing
         static::assertTrue($responseBodyData['expires_in'] <= 3600 && $responseBodyData['expires_in'] > 3595);
         static::assertIsString($responseBodyData['access_token']);
         static::assertIsString($responseBodyData['refresh_token']);


### PR DESCRIPTION
### 1. Why is this change necessary?
- See https://github.com/shopware/shopware/actions/runs/18553920406/job/52886791539?pr=13038
- If there is a small delay in the test it will no longer correctly match the 30 days, the test is flaky
- We can also change the DeleteExpiredFilesService to not load all entities, but only check the total from the ids (improved performance)
- Also fixed a typo in my last flaky fix: https://github.com/shopware/shopware/pull/13008/files#diff-53559b73619dc386c91e764f61e3ff3de19d2c6f9e7fcf509579d9ed06ebfcb5R97

### 2. What does this change do, exactly?
- Added a buffer of 5 seconds to the test

### 3. Describe each step to reproduce the issue or behaviour.
- Run the DeleteExpiredFilesServiceTest several times

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
