### PR TITLE
fix: increase tolerance for data types in AnnotatePackageProcessor

### DIFF
--- a/src/Core/Framework/Log/Monolog/AnnotatePackageProcessor.php
+++ b/src/Core/Framework/Log/Monolog/AnnotatePackageProcessor.php
@@ -33,7 +33,7 @@ class AnnotatePackageProcessor implements ProcessorInterface
             return $record;
         }
 
-        $packages = $this->packageService->getPackageTrace($exception ?? $record);
+        $packages = $this->packageService->getPackageTrace($exception);
 
         if ($packages !== []) {
             $record->extra[Package::PACKAGE_TRACE_ATTRIBUTE_KEY] = $packages;

--- a/src/Core/Framework/Log/PackageService.php
+++ b/src/Core/Framework/Log/PackageService.php
@@ -21,7 +21,7 @@ class PackageService
     /**
      * @return array<string, string|null>
      */
-    public function getPackageTrace(object $subject): array
+    public function getPackageTrace(mixed $subject = null): array
     {
         $packages = [];
 

--- a/tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
+++ b/tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
@@ -283,6 +283,36 @@ class AnnotatePackageProcessorTest extends TestCase
 
         static::assertEquals($expected, $handler($record));
     }
+
+    public function testAnnotateCommandWithBogusLogData(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $requestStack = $this->createMock(RequestStack::class);
+        $packageService = new PackageService($requestStack, $container);
+        $handler = new AnnotatePackageProcessor($packageService);
+
+        $context = [
+            // In the case, someone reassigned $exception = $exception->getMessage() or similar before passing it into context
+            'exception' => 'This is not an exception',
+        ];
+        $record = new LogRecord(
+            new \DateTimeImmutable(),
+            'business events',
+            Level::Error,
+            'Some message',
+            $context
+        );
+
+        $expected = new LogRecord(
+            $record->datetime,
+            $record->channel,
+            $record->level,
+            $record->message,
+            $context
+        );
+
+        static::assertEquals($expected, $handler($record));
+    }
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Sometimes a log records' `$context['exception']` may contain an exception message (or whatever else), instead of a `\Throwable` instance, hence this error is thrown down the line:
```
Uncaught TypeError: Shopware\Core\Framework\Log\PackageService::getPackageTrace(): Argument #1 ($subject) must be of type object, string given, called in /var/www/html/vendor/shopware/platform/src/Core/Framework/Log/Monolog/AnnotatePackageProcessor.php
```

### 2. What does this change do, exactly?

For one, `getPackageTrace` never relied on its input being an `object` type, so its now changed to `mixed`.
Also, the `$record` was passed on beforehand as a fallback (I presume), but this was never actually used, so I've removed this as well.

### 3. Describe each step to reproduce the issue or behaviour.

See the testcase added.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
