### PR TITLE
fix: make product detail review form radio keyboard accessible

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/page/product-detail/_review.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/product-detail/_review.scss
@@ -46,12 +46,16 @@
 
 // review form
 .product-detail-review-form-radio {
-    display: none;
+    @include visually-hidden();
 }
 
 .product-detail-review-form-rating-input {
     display: flex;
-    align-items: center;
+
+    .product-detail-review-form-rating-text {
+        margin-left: $spacer-sm;
+        margin-bottom: 0;
+    }
 }
 
 .product-review-point svg {
@@ -66,8 +70,6 @@
 
 .point-rating {
     display: block;
-    top: 0;
-    left: 0;
 
     &.point-blank {
         .icon {
@@ -80,13 +82,12 @@
     position: absolute;
 }
 
-.product-detail-review-form-rating-text {
-    margin-left: $spacer-sm;
-    margin-bottom: 0;
-}
-
 .product-detail-review-form-star {
     margin-right: 10px;
+
+    &:has(.product-detail-review-form-radio:focus-visible) {
+        box-shadow: $input-btn-focus-box-shadow;
+    }
 }
 
 .product-detail-review-login .login-card .card-body {


### PR DESCRIPTION
resolves #12929

The review rating radios were not focusable because they used `display: none`. I updated the radios to be visually hidden using `visually-hidden()` instead, making them focusable. Additionally, I added a `box-shadow` to the star label when its child radio is focused, so keyboard users have a visual indicator. The other changes are just to improve the vertical alignment between the stars and the rating text.

I'm not sure if this is considered a breaking change, or how to deal with it if it is.

https://github.com/user-attachments/assets/cafe3aa9-7d95-49f6-ab77-a6a6e49ca976