### PR TITLE
fix(ADR): Revert changes and supersede ADR instead

### DIFF
--- a/adr/2023-05-16-symfony-dependency-management.md
+++ b/adr/2023-05-16-symfony-dependency-management.md
@@ -7,9 +7,9 @@ tags: [php, symfony, dependency]
 
 ## Context
 
-Recent versions of Symfony have introduced various new features for dependency management that simplify service configuration and improve the developer experience.
+The process of configuring dependencies has been upgraded with various new features in recent versions of Symfony.
 
-These features are now available in Shopware and include:
+We would like to utilise new features such as:
 
 * [Autowiring](https://symfony.com/doc/current/service_container.html)
 * [PHP configuration](https://symfony.com/doc/current/service_container/import.html)
@@ -17,21 +17,29 @@ These features are now available in Shopware and include:
 
 ## Decision
 
-Shopware now supports the following modern Symfony dependency management features:
+1. Autowiring will be enabled
+2. Support will be added to load service configuration from PHP files (as well as XML for backwards compatibility)
+3. Where services need a particular non default service, for example a different implementation, or scalar values, we can use attributes.
 
-1. **Autowiring**: Services can be automatically resolved by Symfony using type hints, reducing the need for explicit service definitions.
-2. **PHP-based service configuration**: Service configuration can be loaded from PHP files in addition to XML and YAML.
-3. **Autowire attribute**: Services requiring non-default implementations or scalar values can use the `Autowire` attribute for configuration.
+Note: Attributes should only be used in framework glue code, for example, in Controllers and commands. We do not want to couple our domain code too close to Symfony.
 
-**Note**: Attributes should only be used in framework glue code, such as Controllers and Commands.
-Domain code should remain decoupled from Symfony-specific implementations.
+With autowiring enabled, we can greatly reduce the amount of configuration in the XML files since most of the configuration is unnecessary. Most dependency graphs can be automatically resolved by Symfony using type hints.
+There are no runtime performance implications because the container with its definitions is compiled.
 
-With autowiring enabled, dependency graphs can be automatically resolved by Symfony using type hints, significantly reducing configuration overhead.
+Advantages:
 
-## Benefits for plugin development
+* Less code to maintain.
+* Better autocompletion with PHP.
+* More modern approach
 
-Plugin developers can now leverage these features to:
+## Backwards Compatibility / Migration Strategy
 
-* Reduce boilerplate configuration code
-* Benefit from better IDE autocompletion with PHP-based configuration
-* Use a more modern, streamlined approach
+To migrate our current XML dependency configurations, we can follow the below steps:
+
+Step 1: Add support for loading service definitions from PHP files as well as XML files.
+
+Step 2: Enable autowiring. Symfony should prefer the registered configuration before trying to autowire. In other words, Symfony will only autowire classes without configured definitions.
+
+Step 3: Delete definitions which are not required because they can be autoloaded.
+
+Step 4: Migrate any existing definitions to the PHP configurations or Attributes.

--- a/adr/_superseded/2023-05-16-symfony-dependency-management.md
+++ b/adr/_superseded/2023-05-16-symfony-dependency-management.md
@@ -5,6 +5,8 @@ area: core
 tags: [php, symfony, dependency]
 ---
 
+## Superseded as this was intended more like advice for plugin developers to use new Symfony features
+
 ## Context
 
 The process of configuring dependencies has been upgraded with various new features in recent versions of Symfony.


### PR DESCRIPTION
### 1. Why is this change necessary?

@JoshuaBehrens brought that up, by correctly noting, that we should not change past decision, but rather supersede them, if they are no longer up-to-date. 

### 2. What does this change do, exactly?

Revert the wording of the ADR to its original state and move the ADR to the `_superseded` section
The docs will be adjusted to advise plugins developers to use those features