### PR TITLE
feat: Add possibility to set fetchpriority high in images

### DIFF
--- a/changelog/_unreleased/2025-10-17-add-possibility-to-set-fetchpriority-high-on-cms-image-elements.md
+++ b/changelog/_unreleased/2025-10-17-add-possibility-to-set-fetchpriority-high-on-cms-image-elements.md
@@ -1,0 +1,8 @@
+---
+title: Add possibility to set `fetchpriority="high"` on cms image elements
+author: Max
+author_email: max@swk-web-com
+author_github: @aragon999
+---
+# Storefront
+* Added a configuration option to set `fetchpriority="high"` on cms image elements

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/config.spec.js
@@ -32,6 +32,7 @@ async function createWrapper() {
                     'sw-media-modal-v2': true,
                     'sw-context-button': true,
                     'sw-context-menu-item': true,
+                    'sw-container': await wrapTestComponent('sw-container'),
                 },
             },
             props: {
@@ -74,6 +75,10 @@ async function createWrapper() {
                             value: null,
                         },
                         isDecorative: {
+                            source: 'static',
+                            value: false,
+                        },
+                        fetchPriorityHigh: {
                             source: 'static',
                             value: false,
                         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -101,7 +101,7 @@
 
         <mt-switch
             v-model="element.config.fetchPriorityHigh.value"
-            :label="$tc('sw-cms.elements.image.config.label.fetchPriorityHigh')"
+            :label="$t('sw-cms.elements.image.config.label.fetchPriorityHigh')"
             :help-text="$t('sw-cms.elements.image.config.helpText.fetchPriorityHigh')"
             bordered
         />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -86,6 +86,27 @@
     />
     {% endblock %}
 
+    <sw-container
+        columns="1fr 1fr"
+        gap="0px 30px"
+    >
+        <mt-switch
+            class="sw-cms-el-config-image__is-decorative"
+            :model-value="element.config.isDecorative.value"
+            :label="$tc('sw-cms.elements.image.config.label.isDecorative')"
+            :help-text="$tc('sw-cms.elements.image.config.helpText.isDecorative')"
+            bordered
+            @update:model-value="onChangeIsDecorative"
+        />
+
+        <mt-switch
+            v-model="element.config.fetchPriorityHigh.value"
+            :label="$tc('sw-cms.elements.image.config.label.fetchPriorityHigh')"
+            :help-text="$tc('sw-cms.elements.image.config.helpText.fetchPriorityHigh')"
+            bordered
+        />
+    </sw-container>
+
     {% block sw_cms_element_image_config_link %}
     <div class="sw-cms-el-config-image__link">
         <sw-dynamic-url-field
@@ -106,13 +127,6 @@
         />
     </div>
     {% endblock %}
-
-    <mt-switch
-        class="sw-cms-el-config-image__is-decorative"
-        :model-value="element.config.isDecorative.value"
-        :label="$tc('sw-cms.elements.image.config.label.isDecorative')"
-        @update:model-value="onChangeIsDecorative"
-    />
 
     {% block sw_cms_element_image_config_media_modal %}
     <sw-media-modal-v2

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -102,7 +102,7 @@
         <mt-switch
             v-model="element.config.fetchPriorityHigh.value"
             :label="$tc('sw-cms.elements.image.config.label.fetchPriorityHigh')"
-            :help-text="$tc('sw-cms.elements.image.config.helpText.fetchPriorityHigh')"
+            :help-text="$t('sw-cms.elements.image.config.helpText.fetchPriorityHigh')"
             bordered
         />
     </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -93,8 +93,8 @@
         <mt-switch
             class="sw-cms-el-config-image__is-decorative"
             :model-value="element.config.isDecorative.value"
-            :label="$tc('sw-cms.elements.image.config.label.isDecorative')"
-            :help-text="$tc('sw-cms.elements.image.config.helpText.isDecorative')"
+            :label="$t('sw-cms.elements.image.config.label.isDecorative')"
+            :help-text="$t('sw-cms.elements.image.config.helpText.isDecorative')"
             bordered
             @update:model-value="onChangeIsDecorative"
         />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/index.ts
@@ -65,5 +65,9 @@ Shopware.Service('cmsService').registerCmsElement({
             source: 'static',
             value: false,
         },
+        fetchPriorityHigh: {
+            source: 'static',
+            value: false,
+        },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/manufacturer-logo/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/manufacturer-logo/config/config.spec.js
@@ -47,6 +47,10 @@ const defaultProps = {
                 source: 'static',
                 value: false,
             },
+            fetchPriorityHigh: {
+                source: 'static',
+                value: false,
+            },
         },
         data: {
             media: '',
@@ -84,6 +88,7 @@ async function createWrapper() {
                     'sw-context-button': true,
                     'sw-context-menu-item': true,
                     'mt-switch': true,
+                    'sw-container': true,
                 },
                 provide: {
                     repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
@@ -259,8 +259,8 @@
             "fetchPriorityHigh": "Hohe Ladepriorität"
           },
           "helpText": {
-            "fetchPriorityHigh": "Setze diese Option, wenn das Bild das erste Bild auf der Seite ist. Diesem Bild wird dann das Attribut \"fetchpriority=high\" hinzugefügt, was dem Browser mitteilt, dass das Bild mit höherer Priorität geladen werden soll, was den LCP (Largest Contentful Paint) verbessern kann.",
-            "isDecorative": "Wenn diese Option eingeschaltet wird, werden die Bildinformationen nicht von Screenreadern vorgelesen, das heißt der \"alt\"-Tag und \"title\"-Tag bleiben leer."
+            "fetchPriorityHigh": "Setze diese Option, wenn das Bild das erste Bild auf der Seite ist. Diesem Bild wird dann das Attribut \"fetchpriority=high\" hinzugefügt, was dem Browser mitteilt, dass das Bild mit höherer Priorität geladen werden soll, was den Largest Contentful Paint (LCP) verbessern kann.",
+            "isDecorative": "Wenn diese Option eingeschaltet ist, werden die Bildinformationen nicht von Screenreadern vorgelesen, das heißt der \"alt\"-Tag und \"title\"-Tag bleiben leer."
           },
           "placeholder": {
             "enterMinHeight": "Minimale Höhe eingeben ...",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
@@ -255,7 +255,12 @@
             "useFetchPriorityOnFirstItem": "Erstes Bild priorisiert laden",
             "useFetchPriorityOnFirstItemHelpText": "Wenn diese Option eingeschaltet wird, wird das erste Bild mit einer höheren Priorität geladen. Dies kann die Geschwindigkeit des Aufbaus der Seite im Browser verbessern.",
             "linkNewTab": "Link in neuem Tab öffnen",
-            "linkTo": "Linkziel"
+            "linkTo": "Linkziel",
+            "fetchPriorityHigh": "Hohe Ladepriorität"
+          },
+          "helpText": {
+            "fetchPriorityHigh": "Setze diese Option, wenn das Bild das erste Bild auf der Seite ist. Diesem Bild wird dann das Attribut \"fetchpriority=high\" hinzugefügt, was dem Browser mitteilt, dass das Bild mit höherer Priorität geladen werden soll, was den LCP (Largest Contentful Paint) verbessern kann.",
+            "isDecorative": "Wenn diese Option eingeschaltet wird, werden die Bildinformationen nicht von Screenreadern vorgelesen, das heißt der \"alt\"-Tag und \"title\"-Tag bleiben leer."
           },
           "placeholder": {
             "enterMinHeight": "Minimale Höhe eingeben ...",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
@@ -259,7 +259,7 @@
             "fetchPriorityHigh": "Hohe Ladepriorität"
           },
           "helpText": {
-            "fetchPriorityHigh": "Setze diese Option, wenn das Bild das erste Bild auf der Seite ist. Diesem Bild wird dann das Attribut \"fetchpriority=high\" hinzugefügt, was dem Browser mitteilt, dass das Bild mit höherer Priorität geladen werden soll, was den Largest Contentful Paint (LCP) verbessern kann.",
+            "fetchPriorityHigh": "Setze diese Option, wenn das Bild das erste Bild auf der Seite ist. Diesem Bild wird dann das Attribut 'fetchpriority=\"high\"' hinzugefügt, was dem Browser mitteilt, dass das Bild mit höherer Priorität geladen werden soll, was den Largest Contentful Paint (LCP) verbessern kann.",
             "isDecorative": "Wenn diese Option eingeschaltet ist, werden die Bildinformationen nicht von Screenreadern vorgelesen, das heißt der \"alt\"-Tag und \"title\"-Tag bleiben leer."
           },
           "placeholder": {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
@@ -255,7 +255,12 @@
             "useFetchPriorityOnFirstItem": "Load first image with higher priority",
             "useFetchPriorityOnFirstItemHelpText": "When this option is enabled, the first image is loaded with a higher priority. This can improve the speed at which the page is rendered in the browser.",
             "linkNewTab": "Open link in new tab",
-            "linkTo": "Link target"
+            "linkTo": "Link target",
+            "fetchPriorityHigh": "Fetch priority high"
+          },
+          "helpText": {
+            "fetchPriorityHigh": "Activate this option if the image is the first image on the page. This image will then be assigned the attribute \"fetchpriority=high\". This tells the browser that this image should be loaded with higher priority, which can improve the LCP (Largest Contentful Paint).",
+            "isDecorative": "When this option is enabled, the image information will not be read out by screen readers. This means that the \"alt\" and \"title\" tags will remain empty."
           },
           "placeholder": {
             "enterMinHeight": "Enter a minimum height...",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
@@ -259,7 +259,7 @@
             "fetchPriorityHigh": "Fetch priority high"
           },
           "helpText": {
-            "fetchPriorityHigh": "Activate this option if the image is the first image on the page. This image will then be assigned the attribute \"fetchpriority=high\". This tells the browser that this image should be loaded with higher priority, which can improve the LCP (Largest Contentful Paint).",
+            "fetchPriorityHigh": "Activate this option if the image is the first one on the page. The image will then be assigned the attribute 'fetchpriority=\"high\"', telling the browser to load it with higher priority. This can help improve the Largest Contentful Paint (LCP).",
             "isDecorative": "When this option is enabled, the image information will not be read out by screen readers. This means that the \"alt\" and \"title\" tags will remain empty."
           },
           "placeholder": {

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig
@@ -18,11 +18,16 @@
                                         'class': 'cms-image',
                                         'alt': element.translated.config.isDecorative.value ? '' : (element.data.media.translated.alt ?: ''),
                                         'title': element.translated.config.isDecorative.value ? '' : (element.data.media.translated.title ?: ''),
-                                        'loading': 'lazy'
                                     } %}
 
                                     {% if isCover or element.translated.config.displayMode.value == 'contain' %}
                                         {% set attributes = attributes|merge({ 'data-object-fit': element.translated.config.displayMode.value }) %}
+                                    {% endif %}
+
+                                    {% if element.translated.config.fetchPriorityHigh is defined and element.translated.config.fetchPriorityHigh.value %}
+                                        {% set attributes = attributes|merge({ 'fetchpriority': 'high' }) %}
+                                    {% else %}
+                                        {% set attributes = attributes|merge({ 'loading': 'lazy' }) %}
                                     {% endif %}
 
                                     {% sw_thumbnails 'cms-image-thumbnails' with {


### PR DESCRIPTION
### 1. Why is this change necessary?
At the moment there is no way to add the attribute `fetchpriority="high"` to an image, loaded by the CMS image element.

As it always depends on the content this should not be done automatically, but rather configurable.

### 2. What does this change do, exactly?
This PR adds an setting to add this attribute to the image. In this case we also do not use the `loading="lazy"` option.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
fixes: https://github.com/shopware/shopware/issues/11194

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
