### PR TITLE
fix: verify what phpstan is doing with its cache result

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -421,7 +421,7 @@
     "phpstan": [
       "Composer\\Config::disableProcessTimeout",
       "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
-      "phpstan analyze --memory-limit=2G -v"
+      "phpstan analyze --memory-limit=2G -vv"
     ],
     "phpstan-errors-by-area": [
       "php src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php phpstan-baseline.neon"


### PR DESCRIPTION
### 1. Why is this change necessary?
The PHP check job with PHPStan is getting slower. We want to verify if the configured result cache is consumed.

### 2. What does this change do, exactly?
Adds another level of logging with `-vv` option instead of `-v`
The command defined in composer is in used within https://github.com/shopware/shopware/blob/fd1b2065900e76773be97037739c28a54ca49b02/.github/workflows/php.yml#L85


### 3. Describe each step to reproduce the issue or behaviour.

We shall see more logs such as

[
<img width="537" height="209" alt="Screenshot 2025-10-20 at 09 49 11" src="https://github.com/user-attachments/assets/70de0d09-bc97-4ea7-bd23-08db2e485b17" />
](url)

Indicating what is going on with the result cache.

see phpstan job https://github.com/shopware/shopware/actions/runs/18645818897/job/53152770694?pr=13076

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
