### PR TITLE
feat: Add sitemap entity query events for products, landing pages and categories

### DIFF
--- a/changelog/_unreleased/2025-10-20-add-events-when-fetching-entities-for-the-sitemap.md
+++ b/changelog/_unreleased/2025-10-20-add-events-when-fetching-entities-for-the-sitemap.md
@@ -1,0 +1,8 @@
+---
+title: Add events when fetching entities for the sitemap
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added events `sitemap.query.product`, `sitemap.query.landing_page` and `sitemap.query.category` to allow modifying the query when fetching entities for the sitemap

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -68,6 +68,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory"/>
             <argument type="service" id="router"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="event_dispatcher"/>
 
             <tag name="shopware.sitemap_url_provider"/>
         </service>
@@ -76,6 +77,7 @@
             <argument type="service" id="Shopware\Core\Content\Sitemap\Service\ConfigHandler"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="router"/>
+            <argument type="service" id="event_dispatcher"/>
 
             <tag name="shopware.sitemap_url_provider"/>
         </service>

--- a/src/Core/Content/Sitemap/Event/SitemapQueryEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapQueryEvent.php
@@ -3,19 +3,21 @@
 namespace Shopware\Core\Content\Sitemap\Event;
 
 use Doctrine\DBAL\Query\QueryBuilder;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\GenericEvent;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('discovery')]
-final class SitemapQueryEvent extends Event implements GenericEvent
+final class SitemapQueryEvent extends Event implements GenericEvent, ShopwareSalesChannelEvent
 {
     public function __construct(
-        private readonly QueryBuilder $query,
-        private readonly SalesChannelContext $context,
-        private readonly int $limit,
-        private readonly ?int $offset,
+        public readonly QueryBuilder $query,
+        public readonly int $limit,
+        public readonly ?int $offset,
+        private readonly SalesChannelContext $salesChannelContext,
         private readonly string $name,
     ) {
     }
@@ -25,23 +27,13 @@ final class SitemapQueryEvent extends Event implements GenericEvent
         return $this->name;
     }
 
-    public function getQuery(): QueryBuilder
+    public function getSalesChannelContext(): SalesChannelContext
     {
-        return $this->query;
+        return $this->salesChannelContext;
     }
 
-    public function getContext(): SalesChannelContext
+    public function getContext(): Context
     {
-        return $this->context;
-    }
-
-    public function getLimit(): int
-    {
-        return $this->limit;
-    }
-
-    public function getOffset(): ?int
-    {
-        return $this->offset;
+        return $this->salesChannelContext->getContext();
     }
 }

--- a/src/Core/Content/Sitemap/Event/SitemapQueryEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapQueryEvent.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Sitemap\Event;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Shopware\Core\Framework\Event\GenericEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('discovery')]
+final class SitemapQueryEvent extends Event implements GenericEvent
+{
+    public function __construct(
+        private readonly QueryBuilder $query,
+        private readonly SalesChannelContext $context,
+        private readonly int $limit,
+        private readonly ?int $offset,
+        private readonly string $name,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getQuery(): QueryBuilder
+    {
+        return $this->query;
+    }
+
+    public function getContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getOffset(): ?int
+    {
+        return $this->offset;
+    }
+}

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -161,7 +161,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         $query->setParameter('folderType', CategoryDefinition::TYPE_FOLDER);
 
         $this->eventDispatcher->dispatch(
-            new SitemapQueryEvent($query, $context, $limit, $offset, self::QUERY_EVENT_NAME)
+            new SitemapQueryEvent($query, $limit, $offset, $context, self::QUERY_EVENT_NAME)
         );
 
         /** @var list<array{id: string, created_at: string, updated_at: string}> $result */

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Event\SalesChannelCategoryIdsFetchedEvent;
+use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
@@ -24,6 +25,8 @@ use Symfony\Component\Routing\RouterInterface;
 class CategoryUrlProvider extends AbstractUrlProvider
 {
     final public const CHANGE_FREQ = 'daily';
+
+    final public const QUERY_EVENT_NAME = 'sitemap.query.category';
 
     /**
      * @internal
@@ -156,6 +159,10 @@ class CategoryUrlProvider extends AbstractUrlProvider
         $query->setParameter('versionId', Uuid::fromHexToBytes(Defaults::LIVE_VERSION));
         $query->setParameter('linkType', CategoryDefinition::TYPE_LINK);
         $query->setParameter('folderType', CategoryDefinition::TYPE_FOLDER);
+
+        $this->eventDispatcher->dispatch(
+            new SitemapQueryEvent($query, $context, $limit, $offset, self::QUERY_EVENT_NAME)
+        );
 
         /** @var list<array{id: string, created_at: string, updated_at: string}> $result */
         $result = $query->executeQuery()->fetchAllAssociative();

--- a/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Sitemap\Provider;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
@@ -14,6 +15,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 #[Package('discovery')]
@@ -21,13 +23,16 @@ class LandingPageUrlProvider extends AbstractUrlProvider
 {
     final public const CHANGE_FREQ = 'daily';
 
+    final public const QUERY_EVENT_NAME = 'sitemap.query.landing_page';
+
     /**
      * @internal
      */
     public function __construct(
         private readonly ConfigHandler $configHandler,
         private readonly Connection $connection,
-        private readonly RouterInterface $router
+        private readonly RouterInterface $router,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -120,6 +125,10 @@ class LandingPageUrlProvider extends AbstractUrlProvider
 
         $query->setParameter('versionId', Uuid::fromHexToBytes(Defaults::LIVE_VERSION));
         $query->setParameter('salesChannelId', Uuid::fromHexToBytes($context->getSalesChannelId()));
+
+        $this->eventDispatcher->dispatch(
+            new SitemapQueryEvent($query, $context, $limit, $offset, self::QUERY_EVENT_NAME)
+        );
 
         /** @var list<array{id: string, created_at: string, updated_at: string}> $result */
         $result = $query->executeQuery()->fetchAllAssociative();

--- a/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
@@ -127,7 +127,7 @@ class LandingPageUrlProvider extends AbstractUrlProvider
         $query->setParameter('salesChannelId', Uuid::fromHexToBytes($context->getSalesChannelId()));
 
         $this->eventDispatcher->dispatch(
-            new SitemapQueryEvent($query, $context, $limit, $offset, self::QUERY_EVENT_NAME)
+            new SitemapQueryEvent($query, $limit, $offset, $context, self::QUERY_EVENT_NAME)
         );
 
         /** @var list<array{id: string, created_at: string, updated_at: string}> $result */

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -163,7 +163,7 @@ class ProductUrlProvider extends AbstractUrlProvider
         $query->setParameter('salesChannelId', Uuid::fromHexToBytes($context->getSalesChannelId()));
 
         $this->eventDispatcher->dispatch(
-            new SitemapQueryEvent($query, $context, $limit, $offset, self::QUERY_EVENT_NAME)
+            new SitemapQueryEvent($query, $limit, $offset, $context, self::QUERY_EVENT_NAME)
         );
 
         /** @var list<array{id: string, created_at: string, updated_at: string}> $result */

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
@@ -18,12 +19,15 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 #[Package('discovery')]
 class ProductUrlProvider extends AbstractUrlProvider
 {
     final public const CHANGE_FREQ = 'hourly';
+
+    final public const QUERY_EVENT_NAME = 'sitemap.query.product';
 
     private const CONFIG_EXCLUDE_LINKED_PRODUCTS = 'core.sitemap.excludeLinkedProducts';
 
@@ -38,7 +42,8 @@ class ProductUrlProvider extends AbstractUrlProvider
         private readonly ProductDefinition $definition,
         private readonly IteratorFactory $iteratorFactory,
         private readonly RouterInterface $router,
-        private readonly SystemConfigService $systemConfigService
+        private readonly SystemConfigService $systemConfigService,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -156,6 +161,10 @@ class ProductUrlProvider extends AbstractUrlProvider
 
         $query->setParameter('versionId', Uuid::fromHexToBytes(Defaults::LIVE_VERSION));
         $query->setParameter('salesChannelId', Uuid::fromHexToBytes($context->getSalesChannelId()));
+
+        $this->eventDispatcher->dispatch(
+            new SitemapQueryEvent($query, $context, $limit, $offset, self::QUERY_EVENT_NAME)
+        );
 
         /** @var list<array{id: string, created_at: string, updated_at: string}> $result */
         $result = $query->executeQuery()->fetchAllAssociative();

--- a/tests/integration/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
@@ -55,11 +55,7 @@ class LandingPageUrlProviderTest extends TestCase
             'test-landing-pages-sitemap',
         );
 
-        $this->landingPageUrlProvider = new LandingPageUrlProvider(
-            static::getContainer()->get(ConfigHandler::class),
-            static::getContainer()->get(Connection::class),
-            static::getContainer()->get(RouterInterface::class),
-        );
+        $this->landingPageUrlProvider = static::getContainer()->get(LandingPageUrlProvider::class);
     }
 
     public function testLandingPageUrlIsCorrect(): void
@@ -127,6 +123,7 @@ class LandingPageUrlProviderTest extends TestCase
             $configHandler,
             static::getContainer()->get(Connection::class),
             static::getContainer()->get(RouterInterface::class),
+            static::getContainer()->get('event_dispatcher'),
         );
 
         $urlResult = $landingPageUrlProvider->getUrls($this->salesChannelContext, 20);

--- a/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
@@ -239,14 +239,7 @@ class ProductUrlProviderTest extends TestCase
 
     private function getProductUrlProvider(): ProductUrlProvider
     {
-        return new ProductUrlProvider(
-            static::getContainer()->get(ConfigHandler::class),
-            static::getContainer()->get(Connection::class),
-            static::getContainer()->get(ProductDefinition::class),
-            static::getContainer()->get(IteratorFactory::class),
-            static::getContainer()->get(RouterInterface::class),
-            static::getContainer()->get(SystemConfigService::class)
-        );
+        return static::getContainer()->get(ProductUrlProvider::class);
     }
 
     /**

--- a/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
@@ -2,17 +2,13 @@
 
 namespace Shopware\Tests\Integration\Core\Content\Sitemap\Provider;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductCollection;
-use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Sitemap\Provider\ProductUrlProvider;
-use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
@@ -24,7 +20,6 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\Tax\TaxEntity;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @internal

--- a/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -100,9 +100,11 @@ class CategoryUrlProviderTest extends TestCase
             $context
         );
         $this->dispatcher
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('dispatch')
-            ->willReturn($event);
+            ->willReturnArgument(0)
+            ->willReturn($event)
+        ;
 
         $provider = $this->getCategoryUrlProvider();
         $urlResult = $provider->getUrls($context, 100, 50);
@@ -192,9 +194,11 @@ class CategoryUrlProviderTest extends TestCase
             [$categoryResult1['id']]
         );
         $this->dispatcher
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('dispatch')
-            ->willReturn($event);
+            ->willReturnArgument(0)
+            ->willReturn($event)
+        ;
 
         $provider = $this->getCategoryUrlProvider();
         $urlResult = $provider->getUrls($context, 100, 50);
@@ -229,9 +233,11 @@ class CategoryUrlProviderTest extends TestCase
         $categoryIds = \array_column([$categoryResult1, $categoryResult2], 'id');
         $event = $this->createSalesChannelCategoryIdsFetchedEvent($categoryIds, $context, $categoryIds);
         $this->dispatcher
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('dispatch')
-            ->willReturn($event);
+            ->willReturnArgument(0)
+            ->willReturn($event)
+        ;
 
         $provider = $this->getCategoryUrlProvider();
         $urlResult = $provider->getUrls($context, 100, 50);


### PR DESCRIPTION
### 1. Why is this change necessary?
I need to change the products which are shown in the sitemap, at the moment it is only possible by decorating the `ProductUrlProvider`, however this could be much more efficient, when I could "modify" the query directly.

### 2. What does this change do, exactly?
Add an event to modify the query builder when fetching products, landing pages and categories.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
