### PR TITLE
refactor: Change to correct native return type of `CmsPageLoadedEvent`

### DIFF
--- a/changelog/_unreleased/2025-10-20-replace-result-type-with-native-cmspagecollection-type-in-the-cmspageloadedevent.md
+++ b/changelog/_unreleased/2025-10-20-replace-result-type-with-native-cmspagecollection-type-in-the-cmspageloadedevent.md
@@ -1,0 +1,16 @@
+---
+title: Replace `$result` type with native `CmsPageCollection` type in the `CmsPageLoadedEvent`
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed the native type of the `$result` parameter in the `Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent` from `Shopware\Core\Framework\DataAbstractionLayer\EntityCollection` to `Shopware\Core\Content\Cms\CmsPageCollection`
+* Changed the native return type of the method `Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent::getResult` from `Shopware\Core\Framework\DataAbstractionLayer\EntityCollection` to `Shopware\Core\Content\Cms\CmsPageCollection`
+___
+# Next Major Version Changes
+## `CmsPageLoadedEvent::$result` now requires `CmsPageCollection` type
+
+The `$result` property of `Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent` now enforces the `Shopware\Core\Content\Cms\CmsPageCollection` type instead of the generic `Shopware\Core\Framework\DataAbstractionLayer\EntityCollection`.
+
+The event constructor now requires `CmsPageCollection` explicitly, and `CmsPageLoadedEvent::getResult()` return type has changed from `EntityCollection` to `CmsPageCollection`.

--- a/changelog/_unreleased/2025-10-20-replace-result-type-with-native-cmspagecollection-type-in-the-cmspageloadedevent.md
+++ b/changelog/_unreleased/2025-10-20-replace-result-type-with-native-cmspagecollection-type-in-the-cmspageloadedevent.md
@@ -5,8 +5,8 @@ author_email: max@swk-web.com
 author_github: @aragon999
 ---
 # Core
-* Changed the native type of the `$result` parameter in the `Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent` from `Shopware\Core\Framework\DataAbstractionLayer\EntityCollection` to `Shopware\Core\Content\Cms\CmsPageCollection`
-* Changed the native return type of the method `Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent::getResult` from `Shopware\Core\Framework\DataAbstractionLayer\EntityCollection` to `Shopware\Core\Content\Cms\CmsPageCollection`
+* Deprecated the `$result` parameter type in `Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent` constructor. Will change from `Shopware\Core\Framework\DataAbstractionLayer\EntityCollection` to `Shopware\Core\Content\Cms\CmsPageCollection` in v6.8.0
+* Deprecated the return type of `Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent::getResult()`. Will change from `EntityCollection` to `CmsPageCollection` in v6.8.0
 ___
 # Next Major Version Changes
 ## `CmsPageLoadedEvent::$result` now requires `CmsPageCollection` type

--- a/src/Core/Content/Cms/Events/CmsPageLoadedEvent.php
+++ b/src/Core/Content/Cms/Events/CmsPageLoadedEvent.php
@@ -14,19 +14,18 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 class CmsPageLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {
-    protected Request $request;
-
     protected CmsPageCollection $result;
 
-    protected SalesChannelContext $salesChannelContext;
-
     /**
+     * @deprecated tag:v6.8.0 - reason:parameter-type-change - $result type will be changed from `EntityCollection` to `CmsPageCollection`
+     *
      * @param CmsPageCollection $result
      */
     public function __construct(
-        Request $request,
+        protected Request $request,
+        /* protected CmsPageCollection $result, */
         EntityCollection $result,
-        SalesChannelContext $salesChannelContext
+        protected SalesChannelContext $salesChannelContext,
     ) {
         $this->request = $request;
         $this->result = $result;
@@ -39,9 +38,11 @@ class CmsPageLoadedEvent extends NestedEvent implements ShopwareSalesChannelEven
     }
 
     /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - return type will be changed from `EntityCollection` to `CmsPageCollection`
+     *
      * @return CmsPageCollection
      */
-    public function getResult(): EntityCollection
+    public function getResult(): EntityCollection /* CmsPageCollection */
     {
         return $this->result;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Look at the code, it is quite confusing and error prone.

### 2. What does this change do, exactly?
Implement a proper deprecations to replace the return type and constructor parameter type of the `$result`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
