### PR TITLE
feat: enable Meteor text editor with feature flag in administration

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-detail-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-detail-menu/index.js
@@ -10,6 +10,7 @@ export default {
     inject: [
         'acl',
         'repositoryFactory',
+        'feature',
     ],
 
     props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-detail-menu/sw-category-detail-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-detail-menu/sw-category-detail-menu.html.twig
@@ -50,8 +50,21 @@
 
     {% block sw_category_detail_menu_description %}
     <sw-text-editor
+        v-if="!feature.isActive('METEOR_TEXT_EDITOR')"
         :key="category.id + 'description'"
         v-model:value="category.description"
+        class="sw-category-detail-base__description"
+        type="textarea"
+        :disabled="!acl.can('category.editor')"
+        sanitize-input
+        sanitize-field-name="category_translation.description"
+        :label="$tc('sw-category.base.menu.descriptionLabel')"
+        :placeholder="$tc('sw-category.base.menu.descriptionPlaceholder')"
+    />
+    <mt-text-editor
+        v-else
+        :key="category.id + 'description' + feature.isActive('METEOR_TEXT_EDITOR')"
+        v-model="category.description"
         class="sw-category-detail-base__description"
         type="textarea"
         :disabled="!acl.can('category.editor')"

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-detail-menu/sw-category-detail-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-detail-menu/sw-category-detail-menu.html.twig
@@ -63,7 +63,7 @@
     />
     <mt-text-editor
         v-else
-        :key="category.id + 'description' + feature.isActive('METEOR_TEXT_EDITOR')"
+        :key="category.id + 'description-meteor'"
         v-model="category.description"
         class="sw-category-detail-base__description"
         type="textarea"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/index.js
@@ -14,6 +14,8 @@ export default {
 
     emits: ['element-update'],
 
+    inject: ['feature'],
+
     mixins: [
         Mixin.getByName('cms-element'),
     ],

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.html.twig
@@ -7,7 +7,7 @@
     ></div>
 
     <sw-text-editor
-        v-else
+        v-else-if="!feature.isActive('METEOR_TEXT_EDITOR')"
         v-model:value="element.config.content.value"
         :disabled="disabled"
         :vertical-align="element.config.verticalAlign.value"
@@ -18,6 +18,13 @@
         enable-transparent-background
         @blur="onBlur"
         @update:value="onInput"
+    />
+    <mt-text-editor
+        v-else
+        :model-value="element.config.content.value"
+        :custom-buttons="customTextEditorButtons"
+        is-inline-edit
+        @update:model-value="onInput"
     />
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/index.js
@@ -13,6 +13,8 @@ export default {
 
     emits: ['element-update'],
 
+    inject: ['feature'],
+
     mixins: [
         Mixin.getByName('cms-element'),
     ],

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
@@ -44,6 +44,7 @@
                         :disabled="isInherited"
                     >
                         <sw-text-editor
+                            v-if="!feature.isActive('METEOR_TEXT_EDITOR')"
                             :key="isInherited"
                             :value="element.config.content.value"
                             :disabled="isInherited"
@@ -52,6 +53,14 @@
                             enable-transparent-background
                             @update:value="onInput"
                             @blur="onBlur"
+                        />
+
+                        <mt-text-editor
+                            v-else
+                            :key="isInherited"
+                            :model-value="element.config.content.value"
+                            :custom-buttons="customTextEditorButtons"
+                            @update:model-value="onInput"
                         />
 
                         <template #preview="{ demoValue }">

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
@@ -57,7 +57,8 @@
 
                         <mt-text-editor
                             v-else
-                            :key="isInherited"
+                            :key="isInherited + '-meteor'"
+                            :disabled="isInherited"
                             :model-value="element.config.content.value"
                             :custom-buttons="customTextEditorButtons"
                             @update:model-value="onInput"

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/index.js
@@ -20,6 +20,7 @@ export default {
         'repositoryFactory',
         'acl',
         'mediaDefaultFolderService',
+        'feature',
     ],
 
     mixins: [

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/sw-manufacturer-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/sw-manufacturer-detail.html.twig
@@ -139,7 +139,18 @@
 
                     {% block sw_manufacturer_detail_base_info_field_description %}
                     <sw-text-editor
+                        v-if="!feature.isActive('METEOR_TEXT_EDITOR')"
                         v-model:value="manufacturer.description"
+                        :label="$tc('sw-manufacturer.detail.labelDescription')"
+                        :placeholder="placeholder(manufacturer, 'description', $tc('sw-manufacturer.detail.placeholderDescription'))"
+                        name="description"
+                        sanitize-input
+                        sanitize-field-name="product_manufacturer_translation.description"
+                        :disabled="!acl.can('product_manufacturer.editor') || undefined"
+                    />
+                    <mt-text-editor
+                        v-else
+                        v-model="manufacturer.description"
                         :label="$tc('sw-manufacturer.detail.labelDescription')"
                         :placeholder="placeholder(manufacturer, 'description', $tc('sw-manufacturer.detail.placeholderDescription'))"
                         name="description"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/index.js
@@ -13,7 +13,10 @@ const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 export default {
     template,
 
-    inject: ['repositoryFactory', 'feature'],
+    inject: [
+        'repositoryFactory',
+        'feature',
+    ],
 
     mixins: [
         Mixin.getByName('placeholder'),

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/index.js
@@ -13,7 +13,7 @@ const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 export default {
     template,
 
-    inject: ['repositoryFactory'],
+    inject: ['repositoryFactory', 'feature'],
 
     mixins: [
         Mixin.getByName('placeholder'),

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
@@ -82,6 +82,7 @@
     >
         <template #content="{ currentValue, updateCurrentValue, isInherited }">
             <sw-text-editor
+                v-if="!feature.isActive('METEOR_TEXT_EDITOR')"
                 :key="isInherited"
                 :placeholder="placeholder(product, 'description', $tc('sw-product.basicForm.placeholderDescriptionLong'))"
                 :error="productDescriptionError"
@@ -90,6 +91,17 @@
                 sanitize-input
                 sanitize-field-name="product_translation.description"
                 @update:value="updateCurrentValue"
+            />
+            <mt-text-editor
+                v-else
+                :key="isInherited && feature.isActive('METEOR_TEXT_EDITOR')"
+                :placeholder="placeholder(product, 'description', $tc('sw-product.basicForm.placeholderDescriptionLong'))"
+                :error="productDescriptionError"
+                :disabled="isInherited || !allowEdit"
+                :model-value="currentValue"
+                sanitize-input
+                sanitize-field-name="product_translation.description"
+                @update:model-value="updateCurrentValue"
             />
         </template>
     </sw-inherit-wrapper>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
@@ -94,7 +94,7 @@
             />
             <mt-text-editor
                 v-else
-                :key="isInherited && feature.isActive('METEOR_TEXT_EDITOR')"
+                :key="'meteor-' + isInherited"
                 :placeholder="placeholder(product, 'description', $tc('sw-product.basicForm.placeholderDescriptionLong'))"
                 :error="productDescriptionError"
                 :disabled="isInherited || !allowEdit"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
@@ -18,6 +18,7 @@ export default {
         'repositoryFactory',
         'acl',
         'customFieldDataProviderService',
+        'feature',
     ],
 
     mixins: [

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.html.twig
@@ -147,7 +147,17 @@
 
                     {% block sw_settings_customer_group_detail_content_registration_card_introduction %}
                     <sw-text-editor
+                        v-if="!feature.isActive('METEOR_TEXT_EDITOR')"
                         v-model:value="customerGroup.registrationIntroduction"
+                        :label="$tc('sw-settings-customer-group.registration.introduction')"
+                        :placeholder="placeholder(customerGroup, 'registrationIntroduction', $tc('sw-settings-customer-group.registration.placeholderIntroduction'))"
+                        :disabled="!acl.can('customer_groups.editor') || undefined"
+                        sanitize-input
+                        sanitize-field-name="customer_group_translation.registrationIntroduction"
+                    />
+                    <mt-text-editor
+                        v-else
+                        v-model="customerGroup.registrationIntroduction"
                         :label="$tc('sw-settings-customer-group.registration.introduction')"
                         :placeholder="placeholder(customerGroup, 'registrationIntroduction', $tc('sw-settings-customer-group.registration.placeholderIntroduction'))"
                         :disabled="!acl.can('customer_groups.editor') || undefined"

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -61,3 +61,9 @@ shopware:
         major: true
         toggleable: true
         description: "This allows repeated calls to the /payment/finalize-transaction endpoint with the same token without throwing a 'token expired' exception."
+
+      - name: METEOR_TEXT_EDITOR
+        default: false
+        major: false
+        toggleable: true
+        description: "Enables the Meteor text editor in the administration."


### PR DESCRIPTION
This pull request introduces the new Meteor text editor (`mt-text-editor`) as an alternative to the existing `sw-text-editor` across several administration modules. The integration is controlled by a new feature flag, `METEOR_TEXT_EDITOR`, allowing for easy toggling between the two editors. The changes ensure that when the feature is active, the Meteor editor is used; otherwise, the legacy editor remains in place.

Closes https://github.com/shopware/shopware/issues/13097