### PR TITLE
fix(link-category): Enable offcanvas behaviour for category links

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
@@ -423,7 +423,7 @@ export default class CookieConfiguration extends Plugin {
      *
      * @param {function|null} callback
      */
-    openOffCanvas(callback) {
+    openOffCanvas(callback = null) {
         const { offCanvasPosition } = this.options;
         const url = window.router['frontend.cookie.offcanvas'];
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js
@@ -99,7 +99,6 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @private
      */
     _getLinkEventHandler(event, link) {
-
         // Initial navigation
         if (!link) {
             const initialContentElement = document.querySelector(this.options.initialContentSelector);

--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -96,6 +96,9 @@ export default class NavbarPlugin extends Plugin {
      * Navigates to the link href on click
      * We can not use event.pageType to check if the event was triggered by mouse (always undefined in firefox).
      * So we check the event type and the pageX position (pageX is always 0 on touch devices and keyboard).
+     *
+     * Since top level links lose the ability to be a link when a dropdown is attached, we enforce redirection here manually.
+     *
      * @param topLevelLink
      * @param event
      * @private
@@ -106,7 +109,10 @@ export default class NavbarPlugin extends Plugin {
                 window.open(topLevelLink.href, '_blank', 'noopener, noreferrer');
                 return;
             }
-            window.location.href = topLevelLink.href;
+
+            if (topLevelLink.parentNode.classList.contains('dropdown')) {
+                window.location.href = topLevelLink.href;
+            }
         }
     }
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
@@ -97,7 +97,13 @@ describe('NavbarPlugin', () => {
         window.location = new URL('https://www.example.com');
 
         const mockEventClick = { type: 'click', pageX: 99 };
-        const mockLink = { href: 'https://example.com/abc', target: '_self' };
+        const mockLink = {
+            href: 'https://example.com/abc',
+            target: '_self',
+            parentNode: {
+                classList: { contains: jest.fn().mockReturnValue(true) },
+            },
+        };
 
         navbarPlugin._navigateToLinkOnClick(mockLink, mockEventClick);
 
@@ -130,7 +136,7 @@ describe('NavbarPlugin', () => {
         const mockDropdown = {
             show: jest.fn(),
             hide: jest.fn(),
-            _menu: {classList: {contains: jest.fn().mockReturnValue(false)}}
+            _menu: { classList: { contains: jest.fn().mockReturnValue(false) } },
         };
         window.bootstrap = {
             Dropdown: {

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/item-link.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/item-link.html.twig
@@ -10,22 +10,25 @@
 {% block layout_navigation_offcanvas_navigation_category_item_link %}
     <li class="navigation-offcanvas-list-item">
         {% block layout_navigation_offcanvas_navigation_categories_list_category_item_link %}
-            <a class="navigation-offcanvas-link nav-item nav-link{% if isActive %} active{% endif %}{% if hasChildren %} js-navigation-offcanvas-link{% endif %}"
-               href="{{ url }}"
+            <a
+                class="navigation-offcanvas-link nav-item nav-link{% if isActive %} active{% endif %}{% if hasChildren %} js-navigation-offcanvas-link{% endif %}"
+                href="{{ url }}"
+                title="{{ name }}"
+                itemprop="url"
                 {% if hasChildren %}
                     data-href="{{ path('frontend.menu.offcanvas', {navigationId: item.category.id}) }}"
                 {% endif %}
-               itemprop="url"
-                {% if item.category.shouldOpenInNewTab %}target="_blank"{% endif %}
-               title="{{ name }}">
+                {% if item.category.shouldOpenInNewTab %}
+                    target="_blank"
+                {% endif %}
+            >
                 {% block layout_navigation_offcanvas_navigation_categories_list_category_item_link_text %}
                     <span itemprop="name">{{ name }}</span>
                     {% if hasChildren %}
                         {% block layout_navigation_offcanvas_navigation_categories_list_category_item_link_icon %}
-                            <span
-                                class="navigation-offcanvas-link-icon js-navigation-offcanvas-loading-icon">
-                            {% sw_icon 'arrow-medium-right' style { pack:'solid', size: 'sm' } %}
-                        </span>
+                            <span class="navigation-offcanvas-link-icon js-navigation-offcanvas-loading-icon">
+                                {% sw_icon 'arrow-medium-right' style { pack:'solid', size: 'sm' } %}
+                            </span>
                         {% endblock %}
                     {% endif %}
                 {% endblock %}


### PR DESCRIPTION
fixes #12612

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Offcanvas links currently open their offcanvas functionalty and then redirect to the page as well

### 2. What does this change do, exactly?
Remove the JS re-direct to maintain typical link behaviour

### 3. Describe each step to reproduce the issue or behaviour.
- Create a category
- Change type type link / external link
- Uncheck "protocol" and use `/cookie/offcanvas`
- Click this link in the storefront

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
