### PR TITLE
fix: adjust z-index for color picker popover in modal windows

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker-deprecated/sw-colorpicker.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker-deprecated/sw-colorpicker.scss
@@ -343,4 +343,8 @@
         }
     }
 }
+
+.sw-popover__wrapper:has(.sw-colorpicker__colorpicker) {
+    z-index: 1000;
+}
 /* stylelint-enable */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Closes https://github.com/shopware/shopware/issues/13088

### 2. What does this change do, exactly?

Fixes the z-index issue for the colorpicker
