### PR TITLE
fix: added cleaned directory name to lock key in CacheClearer

### DIFF
--- a/changelog/_unreleased/2025-10-21-fix-cacheclearer-global-locking.md
+++ b/changelog/_unreleased/2025-10-21-fix-cacheclearer-global-locking.md
@@ -1,0 +1,9 @@
+---
+title: Fix CacheClearer global locking
+issue: https://github.com/shopware/shopware/pull/13079
+author: Andrii Havryliuk
+author_email: a.havryliuk@shopware.com
+author_github: @Andrii Havryliuk
+---
+# Core
+* Changed `\Shopware\Core\Framework\Adapter\Cache\CacheClearer::clearContainerCache` to use current cache directory in the lock key, decreased lock timeout to 5 seconds.

--- a/changelog/_unreleased/2025-10-21-fix-cacheclearer-global-locking.md
+++ b/changelog/_unreleased/2025-10-21-fix-cacheclearer-global-locking.md
@@ -6,4 +6,4 @@ author_email: a.havryliuk@shopware.com
 author_github: @Andrii Havryliuk
 ---
 # Core
-* Changed `\Shopware\Core\Framework\Adapter\Cache\CacheClearer::clearContainerCache` to use current cache directory in the lock key, decreased lock timeout to 5 seconds.
+* Changed `\Shopware\Core\Framework\Adapter\Cache\CacheClearer::clearContainerCache` to use current cache directory in the lock key, decreased lock timeout to 5 seconds, improved exception processing.

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Cache\Message\CleanupOldCacheFolders;
 use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -21,7 +22,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 #[Package('framework')]
 class CacheClearer
 {
-    private const LOCK_TTL = 30;
+    private const LOCK_TTL = 5;
     private const LOCK_KEY_CONTAINER = 'container-cache-directories';
 
     /**
@@ -86,7 +87,8 @@ class CacheClearer
             return;
         }
 
-        $finder = (new Finder())->in($this->cacheDir)->name('*Container*')->depth(0);
+        $searchDir = $this->cacheDir;
+        $finder = (new Finder())->in($searchDir)->name('*Container*')->depth(0);
         $containerCaches = [];
 
         foreach ($finder->getIterator() as $containerPaths) {
@@ -95,7 +97,7 @@ class CacheClearer
 
         $this->lock(function () use ($containerCaches): void {
             $this->filesystem->remove($containerCaches);
-        }, self::LOCK_KEY_CONTAINER, self::LOCK_TTL);
+        }, $this->lockKeyForDir($searchDir), self::LOCK_TTL);
     }
 
     public function scheduleCacheFolderCleanup(): void
@@ -137,10 +139,11 @@ class CacheClearer
             return;
         }
 
+        $searchDir = \dirname($this->cacheDir) . '/';
         $finder = (new Finder())
             ->directories()
             ->name($this->environment . '*')
-            ->in(\dirname($this->cacheDir) . '/');
+            ->in($searchDir);
 
         if (!$finder->hasResults()) {
             return;
@@ -155,7 +158,7 @@ class CacheClearer
         if ($remove !== []) {
             $this->lock(function () use ($remove): void {
                 $this->filesystem->remove($remove);
-            }, self::LOCK_KEY_CONTAINER, self::LOCK_TTL);
+            }, $this->lockKeyForDir($searchDir), self::LOCK_TTL);
         }
     }
 
@@ -184,6 +187,11 @@ class CacheClearer
 
             $lock->release();
         }
+    }
+
+    private function lockKeyForDir(string $dir): string
+    {
+        return \sprintf('%s:%s', self::LOCK_KEY_CONTAINER, Hasher::hash($dir));
     }
 
     private function cleanupUrlGeneratorCacheFiles(): void

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -183,9 +183,11 @@ class CacheClearer
 
         // The execution is blocked until the key is found or the time to live is reached.
         if ($lock->acquire(true)) {
-            $closure();
-
-            $lock->release();
+            try {
+                $closure();
+            } finally {
+                $lock->release();
+            }
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`CacheClearer` uses global constant for the lock key name. That does not allow to run it in parallel for different directories. Also it uses very long timeout of 30 seconds which may lead to longer blocking of workers.

### 2. What does this change do, exactly?

The change adds cleaned directory name to the lock key and decreases lock timeout to 5 seconds.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/issues/12823

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
