### PR TITLE
fix: admin plugins with bundle suffix

### DIFF
--- a/changelog/_unreleased/2025-10-22-fix-vite-bundling-for-symfony-bundles.md
+++ b/changelog/_unreleased/2025-10-22-fix-vite-bundling-for-symfony-bundles.md
@@ -1,9 +1,9 @@
 ---
-title: Fix vite bundling for symfony bundles
+title: Fix vite bundling for Symfony bundles
 issue: #12165
 ---
 # Administration
-* Changed `loadExtensions()` in the `utils` Vite plugin to remove `bundle` suffix from the extension name folder, in line of what symfony assets are doing, thus fixing an issue that lazy loading of components from plugins with `Bundle`-Suffix did not work.
+* Changed `loadExtensions()` in the `utils` Vite plugin to remove `bundle` suffix from the extension name folder, in line of what Symfony assets are doing, thus fixing an issue that lazy loading of components from plugins or bundles with `Bundle`-Suffix did not work.
 ___
 # Core
 * Changed `\Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator::getContent()` to not remove `Bundle` suffix anymore on the fly, as the suffix is now already removed by vite itself and the generated entrypoints file already uses the correct path.

--- a/changelog/_unreleased/2025-10-22-fix-vite-bundling-for-symfony-bundles.md
+++ b/changelog/_unreleased/2025-10-22-fix-vite-bundling-for-symfony-bundles.md
@@ -1,0 +1,9 @@
+---
+title: Fix vite bundling for symfony bundles
+issue: #12165
+---
+# Administration
+* Changed `loadExtensions()` in the `utils` Vite plugin to remove `bundle` suffix from the extension name folder, in line of what symfony assets are doing, thus fixing an issue that lazy loading of components from plugins with `Bundle`-Suffix did not work.
+___
+# Core
+* Changed `\Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator::getContent()` to not remove `Bundle` suffix anymore on the fly, as the suffix is now already removed by vite itself and the generated entrypoints file already uses the correct path.

--- a/src/Administration/Framework/Twig/ViteFileAccessorDecorator.php
+++ b/src/Administration/Framework/Twig/ViteFileAccessorDecorator.php
@@ -121,10 +121,6 @@ class ViteFileAccessorDecorator extends FileAccessor
 
                 // Prepend the asset path to the every entry point
                 foreach ($entrypoint as $index => $entry) {
-                    // There is an edge case where symfony removes the "bundle" suffix from the bundle name
-                    // @see \Shopware\Core\Framework\Plugin\Util\AssetService::getTargetDirectory
-                    $entry = str_replace('bundle/administration', '/administration', $entry);
-
                     $content['entryPoints'][$technicalBundleName][$key][$index] = \sprintf('%s%s', $this->assetPath, $entry);
                 }
             }

--- a/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
@@ -197,7 +197,10 @@ export function loadExtensions(): ExtensionDefinition[] {
                     technicalName: technicalName,
                     // There is an edge case where symfony removes the "bundle" suffix from the bundle name
                     // @see \Shopware\Core\Framework\Plugin\Util\AssetService::getTargetDirectory
-                    technicalFolderName: name.toLowerCase().replace(/bundle$/, '').replace(/(-)/g, ''),
+                    technicalFolderName: name
+                        .toLowerCase()
+                        .replace(/bundle$/, '')
+                        .replace(/(-)/g, ''),
                     basePath: path.resolve(process.env.PROJECT_ROOT as string, definition.basePath),
                     path: path.resolve(
                         process.env.PROJECT_ROOT as string,

--- a/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
@@ -195,7 +195,9 @@ export function loadExtensions(): ExtensionDefinition[] {
                     isPlugin: true,
                     isApp: false,
                     technicalName: technicalName,
-                    technicalFolderName: name.replace(/(-)/g, '').toLowerCase(),
+                    // There is an edge case where symfony removes the "bundle" suffix from the bundle name
+                    // @see \Shopware\Core\Framework\Plugin\Util\AssetService::getTargetDirectory
+                    technicalFolderName: name.toLowerCase().replace(/bundle$/, '').replace(/(-)/g, ''),
                     basePath: path.resolve(process.env.PROJECT_ROOT as string, definition.basePath),
                     path: path.resolve(
                         process.env.PROJECT_ROOT as string,

--- a/tests/integration/Core/Framework/Api/Controller/Fixtures/InfoController/Resources/public/administration/.vite/entrypoints.json
+++ b/tests/integration/Core/Framework/Api/Controller/Fixtures/InfoController/Resources/public/administration/.vite/entrypoints.json
@@ -1,12 +1,12 @@
 {
-  "base": "/bundles/some-functionality-bundle/administration/",
+  "base": "/bundles/some-functionality/administration/",
   "entryPoints": {
     "some-functionality-bundle": {
       "css": [
       ],
       "dynamic": [],
       "js": [
-        "/bundles/somefunctionalitybundle/administration/js/some-functionality-bundle.js"
+        "/bundles/somefunctionality/administration/js/some-functionality-bundle.js"
       ],
       "legacy": false,
       "preload": []

--- a/tests/unit/Administration/Framework/Twig/Fixtures/TestBundle/Resources/public/administration/.vite/entrypoints.json
+++ b/tests/unit/Administration/Framework/Twig/Fixtures/TestBundle/Resources/public/administration/.vite/entrypoints.json
@@ -1,11 +1,11 @@
 {
-    "base": "/bundles/testbundle/administration/",
+    "base": "/bundles/test/administration/",
     "entryPoints": {
         "test-bundle": {
             "css": [],
             "dynamic": [],
             "js": [
-                "/bundles/testbundle/administration/assets/app.js"
+                "/bundles/test/administration/assets/app.js"
             ],
             "legacy": false,
             "preload": []


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/12165

### 1. Why is this change necessary?
When you have a plugin or a bundle with the `Bundle` suffix in the name, there are issues lazily loading components from those plugins, because symfony removes the bundle suffix in the name, however vite did not, thus wrong paths where generated.

### 2. What does this change do, exactly?
Remove the `bundle` suffix from the technical folder name for plugins, so vite uses the same folder name as symfonys asset system.

### 3. Describe each step to reproduce the issue or behaviour.
create a bundle or plugin with the `bundle` suffix and create an admin module that imports an component. See reproducer in the original ticket

### 4. Please link to the relevant issues (if any).
current issue: https://github.com/shopware/shopware/issues/12165

there is an older similiar issue: https://github.com/shopware/shopware/issues/8271 -> however in that fix we applied a workaround in the `ViteFileAccessorDecorator` to rewrite the paths in the entrypoints generated by vite, which fixed the problem that the whole module did not load, however as the base entrypoints that vite internally used where still wrong vite did generate the wrong import paths when trying to import components from those modules.
