### PR TITLE
chore: add flow execution asynchronous ADR

### DIFF
--- a/adr/2025-10-22-change-flow-execution-to-be-asynchronous.md
+++ b/adr/2025-10-22-change-flow-execution-to-be-asynchronous.md
@@ -1,0 +1,113 @@
+---
+title: Change flow execution to be asynchronous
+date: 2025-10-22
+area: Framework and CRM & After Sales
+tags: [flow, flow-action, experimental]
+---
+
+## Context
+
+The Flow Builder is a central automation feature in Shopware. Today, flows are executed inside the business process, inside an HTTP request.
+A “business process” refers to the synchronous domain transaction triggered by a user action such as a checkout (order creation, payment handling, stock update).
+This synchronous design introduces two key problems:
+
+- Failures in flow execution can directly interrupt the main business logic. For example, out of memory errors or long-running tasks like email sending may cause the checkout HTTP request itself to fail
+- Even when successful, flows add latency to critical user-facing actions. Business processes become slower as they wait for non-essential side effects to complete.
+
+## Decision
+
+Flow execution will be moved asynchronously into the message queue.
+During the business process, dedicated transport dispatches flows for background handling.
+This transport remains configurable: in special cases, it can be set to synchronous processing to restore the current behavior,
+but the default will be async.
+
+The change will be introduced behind the feature flag `FLOW_EXECUTION_AFTER_BUSINESS_PROCESS`.
+For Shopware 6.7 it remains opt-in; from Shopware 6.8 onward it becomes the default.
+
+## Consequences
+
+The main effect is isolation:
+business processes finish quickly and cannot be blocked by flow logic.
+Performance improves, and failures inside flows no longer jeopardize order placement or similar operations.
+
+However, execution is no longer immediate.
+The outcome of a flow, such as order status changes or sending a confirmation email, depends on queue throughput and consumer availability.
+Under load, this may mean noticeable delay. Extensions that assumed in-request execution need to be adapted.
+All flow actions must therefore be strictly independent of request context and only rely on the specific event data provided to them,
+which should already be the case for all default flow actions.
+
+The following table highlights the trade-off:
+
+| Aspect                | Synchronous (old)                | Asynchronous (new)                |
+| --------------------- | -------------------------------- | --------------------------------- |
+| Request latency       | Higher, includes flow runtime    | Lower, flow runs outside request  |
+| Failure impact        | Can break checkout or order flow | Contained in async queue handling |
+| Timing guarantees     | Immediate within request         | Eventual, depends on queue speed  |
+| Extension assumptions | May rely on sync state           | Must tolerate delayed execution   |
+
+Additionally, see these visualizations of the execution:
+
+```text
+CURRENT (synchronous)
+
+User -> [Checkout Request]  
+           |  
+           v  
+   [Business Process]  
+           |  
+           v  
+ [Flow Execution (inline)]  
+           |  
+           v  
+ [Response returned]   <-- response AFTER flows
+
+(flows run inside the request and can block/fail it)
+```
+
+```text
+PROPOSED (asynchronous)
+
+User -> [Checkout Request]
+           |
+           v
+   [Business Process]
+           |
+           v
+     [Enqueue to MQ] --------> [Consumer executes later in a different process]
+           |
+           v
+ [Response returned immediately]   <-- response BEFORE flows
+
+(flows run after the response; isolated in the queue)
+```
+
+### Technical insights
+
+A lot of preparation to enable this change is already done. 
+We have the concept of `StoreableFlow` and it's already used by the Delayed flows commercial feature.
+
+The flow storer mechanism extracts and serializes only the minimal, replayable bits of a flow’s execution context.
+When the flow is triggered, we enqueue that compact StorableFlow.
+Message consumers later restore the context and run the flow.
+This is what makes delayed / async flows practical and safe.
+
+More details on this can be found in our documentation: https://developer.shopware.com/docs/concepts/framework/flow-concept.html#storer-concept
+
+## Alternatives Considered
+
+Partial async: 
+Only some flow actions run asynchronously.
+This creates complexity: ordering cannot be guaranteed, and failures in sync actions can still break business processes.
+
+Post-process in request:
+Running flows after business logic but still inside the request (see [2025-01-31-move-flow-execution-after-business-process.md](https://github.com/shopware/shopware/blob/trunk/adr/_superseded/2025-01-31-move-flow-execution-after-business-process.md)).
+It isolates them from transactions but still adds overhead and failure risk.
+
+## Rollout & Migration
+
+During 6.7, projects can enable the `FLOW_EXECUTION_AFTER_BUSINESS_PROCESS` feature flag to test async execution and validate extensions.
+Please report issues you encounter with the new execution model during this time.
+
+In 6.8, the implementation will be enabled by default and the feature flag removed.
+Operators requiring strict sync execution can switch the flow transport back to synchronous via configuration,
+but are encouraged to adapt their environment to the new model.

--- a/adr/_superseded/2025-01-31-move-flow-execution-after-business-process.md
+++ b/adr/_superseded/2025-01-31-move-flow-execution-after-business-process.md
@@ -5,6 +5,8 @@ area: Core
 tags: [flow, flow-action, experimental]
 ---
 
+## Superseded because we found a different better suited solution, see [2025-10-01-change-flow-execution-to-be-asynchronous.md](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-01-change-flow-execution-to-be-asynchronous.md)
+
 ## Context
 
 Currently, flows are executed during the business process. A business


### PR DESCRIPTION
First draft of the ADR. Please comment and share feedback while it is being finalized.

Implementation PR: TBA

### Experiment

Plugin used, that adds different "crash" flow actions: 
[SwagCrashFlow.zip](https://github.com/user-attachments/files/23239418/SwagCrashFlow.zip)

Use the order placed flow trigger and one of the "crash" actions, then place a order in the storefront.

#### PHP Error (`APP_ENV=dev`)

if the flow action triggers an PHP error (`Throwable`, stronger than normal `Exception`'s but still `try` / `catch` able).
In this case a division by zero.

Order placed / persisted to DB?: yes
Shopping cart is empty?: yes
Checkout request: goes through without issues
Shopware log (`var/log/*.log`): contains the following row:
```txt
[2025-10-30T13:10:27.609046+00:00] app.ERROR: Could not execute flow with error message: Flow name: MyFlow Flow id: 019a30cc743175f9977acc3f157c3789 Division by zero Error Code: 0  {"exception":"[object] (DivisionByZeroError(code: 0): Division by zero at /Users/M.Janz/Repos/shopware/custom/plugins/SwagCrashFlow/src/Core/Content/Flow/Dispatching/Action/CrashByErrorAction.php:32)"} []
```

#### PHP Error (`APP_ENV=prod`)

same as above.

#### Out-of-memory PHP termination (`APP_ENV=dev`)

flow action that tries to allocate more memory than allowed by `php.ini`.

Order placed / persisted to DB?: yes
Shopping cart is empty?: no 🔴 
Checkout request: fails with the following error page  🔴 :
<img width="1795" height="1302" alt="Screenshot 2025-10-30 at 14-24-39 Error Allowed memory size of 2147483648 bytes exhausted (tried to allocate 4294967328 bytes) (500 Internal Server Error)" src="https://github.com/user-attachments/assets/3201054c-dde0-41e1-8965-b4169f3890f1" />

Shopware log (`var/log/*.log`): 
```txt
[2025-10-30T13:23:10.675873+00:00] request.CRITICAL: Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\OutOfMemoryError: "Error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 4294967328 bytes)" at CrashByOOMAction.php line 35 {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\OutOfMemoryError(code: 0): Error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 4294967328 bytes) at /Users/M.Janz/Repos/shopware/custom/plugins/SwagCrashFlow/src/Core/Content/Flow/Dispatching/Action/CrashByOOMAction.php:35)"} []
```

#### Out-of-memory PHP termination (`APP_ENV=prod`)

Order placed / persisted to DB?: yes
Shopping cart is empty?: no  🔴 
Checkout request: fails with 500 response and error message displayed in storefront listing  🔴 
<img width="1795" height="1500" alt="image" src="https://github.com/user-attachments/assets/527d2580-1514-458d-8cea-cb84bde546aa" />
Shopware log (`var/log/*.log`): same `CRITICAL` entry as above

#### Stack overflow PHP termination (`APP_ENV=dev`)

flow action that tries to does recursive calls until it reaches a stack overflow.

Order placed / persisted to DB?: yes
Shopping cart is empty?: no 🔴 
Checkout request: fails with the following error page  🔴 :
<img width="1810" height="1302" alt="image" src="https://github.com/user-attachments/assets/6eee6ea9-b30c-4e74-bdd3-698acc8cdd21" />

Shopware log (`var/log/*.log`): contains no related / error entry at all
Sidenote: after this request I'm unable to visit the storefront again (even in different browser tab) while the administration still works fine. I have to use a new private window or restart my browser (Firefox developer edition). After restarting my browser I have to log in again in the storefront, after that my cart is still filled.


#### Stack overflow PHP termination (`APP_ENV=prod`)

Order placed / persisted to DB?: yes
Shopping cart is empty?: no 🔴 
Checkout request: fails with the following error page  🔴 :
<img width="2560" height="1302" alt="image" src="https://github.com/user-attachments/assets/402cf641-4af4-405c-b15b-abfe1d743dd4" />
Shopware log (`var/log/*.log`): contains no related / error entry at all
Sidenote: same as above.

#### Timeout (`APP_ENV=dev`)

Flow action that sleeps for 180 seconds.

Order placed / persisted to DB?: yes
Shopping cart is empty?: yes
Checkout request: goes through normally, but takes 3 minutes to complete and until response is visible 🔴.
Shopware log (`var/log/*.log`): contains no related entries

#### Timeout (`APP_ENV=prod`)

exactly the same as above. Wondering if this might only be my local apache + php setup. I have `default_socket_timeout = 30` for my PHP 8.3 configuration.
Update: just doubled checked with another environment, it also only takes very long for the response but has no other consequences.

### Testing with the existing feature flag

`FLOW_EXECUTION_AFTER_BUSINESS_PROCESS=1`. All test are perfomed with `APP_ENV=prod` now. Every crash flow action had the same outcome:

Order placed / persisted to DB?: yes
Shopping cart is empty?: yes
Checkout request: finishes fast with successful response
Shopware log (`var/log/*.log`): still contains the expected error message

With the exception of the "Stack overflow PHP termination" and "Timeout" cases, there was no log entry at all, which is consistent to no feature flag.

### TLDR

The current arguments in the ADR are already solved by the existing feature flag. Still to be investigated is the topic of DB transactions and rollbacks.

### Update on DB transactions

They don't seem to be an issue for the current implementation. For details see my comment here:
https://github.com/shopware/shopware/pull/13128#discussion_r2690530398