### PR TITLE
fix: Remove PHP version pinning from bc-checker

### DIFF
--- a/vendor-bin/roave-backward-compatibility-check/composer.json
+++ b/vendor-bin/roave-backward-compatibility-check/composer.json
@@ -13,9 +13,6 @@
             "cweagans/composer-patches": true,
             "bamarni/composer-bin-plugin": true,
             "phpstan/extension-installer": true
-        },
-        "platform": {
-            "php": "8.3.9"
         }
     },
     "require": {


### PR DESCRIPTION
### 1. Why is this change necessary?

Due to the PHP version pin, a non PHP 8.2 compatible version was installed. 

Backport of #13099 / #13100

### 2. What does this change do, exactly?

Remove the pin, so PHP 8.2 is considered & plugin pipelines work again
