### PR TITLE
fix: webhook event cleanup for queued logs

### DIFF
--- a/changelog/_unreleased/2025-10-23-fix-webhook-cleanup-for-queued-messages.md
+++ b/changelog/_unreleased/2025-10-23-fix-webhook-cleanup-for-queued-messages.md
@@ -1,0 +1,5 @@
+---
+title: Fix webhook cleanup for queued webhook event logs
+---
+# Core
+* Changed `\Shopware\Core\Framework\Webhook\Service\WebhookCleanup::removeOldLogs()` to also delete webhook event logs in `queued` state after double the configured log retention time, assuming that the queue message is lost and the webhook won't be executed anymore. This prevents the webhook event log table from growing indefinitely.

--- a/changelog/_unreleased/2025-10-23-fix-webhook-cleanup-for-queued-messages.md
+++ b/changelog/_unreleased/2025-10-23-fix-webhook-cleanup-for-queued-messages.md
@@ -3,3 +3,4 @@ title: Fix webhook cleanup for queued webhook event logs
 ---
 # Core
 * Changed `\Shopware\Core\Framework\Webhook\Service\WebhookCleanup::removeOldLogs()` to also delete webhook event logs in `queued` state after double the configured log retention time, assuming that the queue message is lost and the webhook won't be executed anymore. This prevents the webhook event log table from growing indefinitely.
+* Changed `\Shopware\Core\Framework\Webhook\Handler\WebhookEventMessageHandler` to not fail the webhook delivery when the webhook log is already deleted.

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookCleanupTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookCleanupTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Webhook\Service;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
+use Shopware\Core\Framework\Webhook\Service\WebhookCleanup;
+use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
+use Symfony\Component\Clock\MockClock;
+
+/**
+ * @internal
+ */
+#[CoversClass(WebhookCleanup::class)]
+class WebhookCleanupTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private Connection $connection;
+
+    public function testRemoveOldLogs(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+        $systemConfigService = new StaticSystemConfigService([
+            'core.webhook.entryLifetimeSeconds' => 3600, // 1 hour
+        ]);
+        $mockedDate = new \DateTimeImmutable('2 January 2023 13:00');
+        $cleanup = new WebhookCleanup($systemConfigService, $this->connection, new MockClock($mockedDate));
+
+        $this->connection->executeStatement('DELETE FROM webhook_event_log');
+
+        $beforeLifetime = $mockedDate->modify('- 59 min')->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+        $afterLifetime = $mockedDate->modify('- 61 min')->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+        $afterDoubleLifetime = $mockedDate->modify('- 121 min')->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+        // Insert entries
+        $this->insertLog('success_recent', $beforeLifetime, WebhookEventLogDefinition::STATUS_SUCCESS);
+        $this->insertLog('running_old', $afterLifetime, WebhookEventLogDefinition::STATUS_RUNNING);
+        $this->insertLog('success_old', $afterLifetime, WebhookEventLogDefinition::STATUS_SUCCESS);
+        $this->insertLog('failed_very_old', $afterDoubleLifetime, WebhookEventLogDefinition::STATUS_FAILED);
+        $this->insertLog('queued_old', $afterLifetime, WebhookEventLogDefinition::STATUS_QUEUED);
+        $this->insertLog('queued_very_old', $afterDoubleLifetime, WebhookEventLogDefinition::STATUS_QUEUED);
+
+        $cleanup->removeOldLogs();
+
+        $remaining = $this->connection->fetchAllKeyValue('SELECT event_name, delivery_status FROM webhook_event_log');
+
+        static::assertCount(3, $remaining);
+        // To new to be cleaned up
+        static::assertArrayHasKey('success_recent', $remaining);
+        // To new to be cleaned up, queued entries are only cleaned up after double lifetime
+        static::assertArrayHasKey('queued_old', $remaining);
+        // Running is never cleaned up
+        static::assertArrayHasKey('running_old', $remaining);
+    }
+
+    private function insertLog(string $name, string $createdAt, string $status): void
+    {
+        $this->connection->insert('webhook_event_log', [
+            'id' => Uuid::randomBytes(),
+            'created_at' => $createdAt,
+            'delivery_status' => $status,
+            'event_name' => $name,
+            'webhook_name' => $name,
+            'url' => 'http://localhost',
+            'request_content' => '{}',
+            'response_content' => '{}',
+            'response_status_code' => 200,
+        ]);
+    }
+}

--- a/tests/unit/Core/Framework/Webhook/Service/WebhookCleanupTest.php
+++ b/tests/unit/Core/Framework/Webhook/Service/WebhookCleanupTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Unit\Core\Framework\Webhook\Service;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
 use Shopware\Core\Framework\Webhook\Service\WebhookCleanup;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Clock\MockClock;
@@ -41,17 +40,8 @@ class WebhookCleanupTest extends TestCase
             ->willReturn(86400);
 
         $conn = $this->createMock(Connection::class);
-        $conn->expects($this->once())
-            ->method('executeStatement')
-            ->with(
-                'DELETE FROM `webhook_event_log` WHERE `created_at` < :before AND (`delivery_status` = :success OR `delivery_status` = :failed) LIMIT :limit',
-                [
-                    'before' => '2023-01-01 13:04:00.000',
-                    'success' => WebhookEventLogDefinition::STATUS_SUCCESS,
-                    'failed' => WebhookEventLogDefinition::STATUS_FAILED,
-                    'limit' => 500,
-                ]
-            );
+        $conn->expects($this->exactly(2))
+            ->method('executeStatement');
 
         $cleaner = new WebhookCleanup($config, $conn, new MockClock(new \DateTimeImmutable('2 January 2023 13:04')));
         $cleaner->removeOldLogs();
@@ -66,18 +56,9 @@ class WebhookCleanupTest extends TestCase
             ->willReturn(86400);
 
         $conn = $this->createMock(Connection::class);
-        $conn->expects($this->exactly(2))
+        $conn->expects($this->exactly(3))
             ->method('executeStatement')
-            ->with(
-                'DELETE FROM `webhook_event_log` WHERE `created_at` < :before AND (`delivery_status` = :success OR `delivery_status` = :failed) LIMIT :limit',
-                [
-                    'before' => '2023-01-01 13:04:00.000',
-                    'success' => WebhookEventLogDefinition::STATUS_SUCCESS,
-                    'failed' => WebhookEventLogDefinition::STATUS_FAILED,
-                    'limit' => 500,
-                ]
-            )
-            ->willReturnOnConsecutiveCalls(500, 302);
+            ->willReturnOnConsecutiveCalls(500, 302, 300);
 
         $cleaner = new WebhookCleanup($config, $conn, new MockClock(new \DateTimeImmutable('2 January 2023 13:04')));
         $cleaner->removeOldLogs();


### PR DESCRIPTION
The webhook event log table was only cleaned up for success and failed logs.

However there might be cases where logs are stuck in `queued` state, e.g. queue messages dropped, worker dying, ...
We have shops in our own saas where they have more than a million of stuck webhook logs in the DB.

Now we also delete `queued` webhook event logs after double the lifetime of failed or sucess logs, assuming that the message got lost and the webhook won't be executed again.

The default lifetime is 14 days, meaning for queued state we delete after 28 days in the default, after that time it is unlikely that the queue message will arrive and at the same time the webhook information is so old that it is irrelevant.