### PR TITLE
fix: respect errorRoute parameter in captcha failure handler

### DIFF
--- a/changelog/_unreleased/2025-10-23-fix-captcha-error-route-parameter.md
+++ b/changelog/_unreleased/2025-10-23-fix-captcha-error-route-parameter.md
@@ -1,0 +1,9 @@
+---
+title: Fix captcha validation to respect errorRoute parameter
+issue: 12859
+author: Björn Meyer
+author_email: b.meyer@shopware.com
+author_github: @BrocksiNet
+---
+# Storefront
+* Changed `ErrorController::onCaptchaFailure` to respect the `errorRoute` parameter when forwarding after captcha validation failure, instead of always using the current route

--- a/src/Storefront/Controller/ErrorController.php
+++ b/src/Storefront/Controller/ErrorController.php
@@ -89,7 +89,10 @@ class ErrorController extends StorefrontController
     ): Response {
         $formViolations = new ConstraintViolationException($violations, []);
         if (!$request->isXmlHttpRequest()) {
-            return $this->forwardToRoute($request->get('_route'), ['formViolations' => $formViolations]);
+            $route = (string) ($request->request->get('errorRoute')
+                ?? $request->get('_route', 'frontend.home.page'));
+
+            return $this->forwardToRoute($route, ['formViolations' => $formViolations]);
         }
 
         $response = [];

--- a/src/Storefront/Controller/ErrorController.php
+++ b/src/Storefront/Controller/ErrorController.php
@@ -89,8 +89,8 @@ class ErrorController extends StorefrontController
     ): Response {
         $formViolations = new ConstraintViolationException($violations, []);
         if (!$request->isXmlHttpRequest()) {
-            $errorRoute = $request->request->get('errorRoute');
-            $route = !empty($errorRoute) ? (string) $errorRoute : (string) $request->get('_route', 'frontend.home.page');
+            $errorRoute = (string) $request->request->get('errorRoute');
+            $route = $errorRoute !== '' ? $errorRoute : (($fallback = (string) $request->get('_route')) !== '' ? $fallback : 'frontend.home.page');
 
             return $this->forwardToRoute($route, ['formViolations' => $formViolations]);
         }

--- a/src/Storefront/Controller/ErrorController.php
+++ b/src/Storefront/Controller/ErrorController.php
@@ -89,8 +89,8 @@ class ErrorController extends StorefrontController
     ): Response {
         $formViolations = new ConstraintViolationException($violations, []);
         if (!$request->isXmlHttpRequest()) {
-            $route = (string) ($request->request->get('errorRoute')
-                ?? $request->get('_route', 'frontend.home.page'));
+            $errorRoute = $request->request->get('errorRoute');
+            $route = !empty($errorRoute) ? (string) $errorRoute : (string) $request->get('_route', 'frontend.home.page');
 
             return $this->forwardToRoute($route, ['formViolations' => $formViolations]);
         }

--- a/tests/unit/Storefront/Controller/ErrorControllerTest.php
+++ b/tests/unit/Storefront/Controller/ErrorControllerTest.php
@@ -174,8 +174,8 @@ class ErrorControllerTest extends TestCase
 
         $this->controller->onCaptchaFailure($violations, $request);
 
-        // Empty string is cast to string and used as-is
-        static::assertSame('', $this->controller->forwardToRoute);
+        // Empty string should fall back to the _route attribute
+        static::assertSame('frontend.account.login.page', $this->controller->forwardToRoute);
     }
 }
 

--- a/tests/unit/Storefront/Controller/ErrorControllerTest.php
+++ b/tests/unit/Storefront/Controller/ErrorControllerTest.php
@@ -1,0 +1,196 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Storefront\Controller\ErrorController;
+use Shopware\Storefront\Framework\Twig\ErrorTemplateResolver;
+use Shopware\Storefront\Page\Navigation\Error\ErrorPageLoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(ErrorController::class)]
+class ErrorControllerTest extends TestCase
+{
+    private ErrorControllerTestClass $controller;
+
+    private ErrorTemplateResolver $errorTemplateResolver;
+
+    private SystemConfigService $systemConfigService;
+
+    private ErrorPageLoaderInterface $errorPageLoader;
+
+    protected function setUp(): void
+    {
+        $this->errorTemplateResolver = $this->createMock(ErrorTemplateResolver::class);
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+        $this->errorPageLoader = $this->createMock(ErrorPageLoaderInterface::class);
+
+        $this->controller = new ErrorControllerTestClass(
+            $this->errorTemplateResolver,
+            $this->systemConfigService,
+            $this->errorPageLoader,
+        );
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->set('request_stack', new RequestStack());
+        $this->controller->setContainer($containerBuilder);
+    }
+
+    public function testOnCaptchaFailureWithErrorRouteParameter(): void
+    {
+        $violation = new ConstraintViolation(
+            'Captcha is invalid',
+            null,
+            [],
+            null,
+            'captcha',
+            null,
+            null,
+            'captcha-invalid'
+        );
+        $violations = new ConstraintViolationList([$violation]);
+
+        $request = new Request();
+        $request->request->set('errorRoute', 'frontend.contact.page');
+        $request->attributes->set('_route', 'frontend.account.login.page');
+
+        $this->controller->onCaptchaFailure($violations, $request);
+
+        static::assertSame('frontend.contact.page', $this->controller->forwardToRoute);
+        static::assertArrayHasKey('formViolations', $this->controller->forwardToRouteAttributes);
+        static::assertInstanceOf(
+            ConstraintViolationException::class,
+            $this->controller->forwardToRouteAttributes['formViolations']
+        );
+    }
+
+    public function testOnCaptchaFailureWithRouteAttributeFallback(): void
+    {
+        $violation = new ConstraintViolation(
+            'Captcha is invalid',
+            null,
+            [],
+            null,
+            'captcha',
+            null,
+            null,
+            'captcha-invalid'
+        );
+        $violations = new ConstraintViolationList([$violation]);
+
+        $request = new Request();
+        $request->attributes->set('_route', 'frontend.account.register.page');
+
+        $this->controller->onCaptchaFailure($violations, $request);
+
+        static::assertSame('frontend.account.register.page', $this->controller->forwardToRoute);
+        static::assertArrayHasKey('formViolations', $this->controller->forwardToRouteAttributes);
+    }
+
+    public function testOnCaptchaFailureWithDefaultFallback(): void
+    {
+        $violation = new ConstraintViolation(
+            'Captcha is invalid',
+            null,
+            [],
+            null,
+            'captcha',
+            null,
+            null,
+            'captcha-invalid'
+        );
+        $violations = new ConstraintViolationList([$violation]);
+
+        $request = new Request();
+
+        $this->controller->onCaptchaFailure($violations, $request);
+
+        static::assertSame('frontend.home.page', $this->controller->forwardToRoute);
+        static::assertArrayHasKey('formViolations', $this->controller->forwardToRouteAttributes);
+    }
+
+    public function testOnCaptchaFailureWithXmlHttpRequest(): void
+    {
+        $violation = new ConstraintViolation(
+            'Captcha is invalid',
+            null,
+            [],
+            null,
+            'captcha',
+            null,
+            null,
+            'captcha-invalid'
+        );
+        $violations = new ConstraintViolationList([$violation]);
+
+        $request = new Request();
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $response = $this->controller->onCaptchaFailure($violations, $request);
+
+        static::assertInstanceOf(JsonResponse::class, $response);
+
+        $responseContent = $response->getContent();
+        static::assertNotFalse($responseContent);
+        $content = json_decode($responseContent, true);
+        static::assertIsArray($content);
+        static::assertCount(1, $content);
+        static::assertArrayHasKey('type', $content[0]);
+        static::assertSame('danger', $content[0]['type']);
+        static::assertArrayHasKey('error', $content[0]);
+        static::assertSame('invalid_captcha', $content[0]['error']);
+        static::assertArrayHasKey('alert', $content[0]);
+    }
+
+    public function testOnCaptchaFailureWithErrorRouteAsEmptyString(): void
+    {
+        $violation = new ConstraintViolation(
+            'Captcha is invalid',
+            null,
+            [],
+            null,
+            'captcha',
+            null,
+            null,
+            'captcha-invalid'
+        );
+        $violations = new ConstraintViolationList([$violation]);
+
+        $request = new Request();
+        $request->request->set('errorRoute', '');
+        $request->attributes->set('_route', 'frontend.account.login.page');
+
+        $this->controller->onCaptchaFailure($violations, $request);
+
+        // Empty string is cast to string and used as-is
+        static::assertSame('', $this->controller->forwardToRoute);
+    }
+}
+
+/**
+ * @internal
+ */
+class ErrorControllerTestClass extends ErrorController implements ResetInterface
+{
+    use StorefrontControllerMockTrait;
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    protected function renderView(string $view, array $parameters = []): string
+    {
+        return '<div>' . $view . '</div>';
+    }
+}

--- a/tests/unit/Storefront/Controller/ErrorControllerTest.php
+++ b/tests/unit/Storefront/Controller/ErrorControllerTest.php
@@ -31,6 +31,8 @@ class ErrorControllerTest extends TestCase
 
     private ErrorPageLoaderInterface $errorPageLoader;
 
+    private ConstraintViolationList $violations;
+
     protected function setUp(): void
     {
         $this->errorTemplateResolver = $this->createMock(ErrorTemplateResolver::class);
@@ -46,10 +48,7 @@ class ErrorControllerTest extends TestCase
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->set('request_stack', new RequestStack());
         $this->controller->setContainer($containerBuilder);
-    }
 
-    public function testOnCaptchaFailureWithErrorRouteParameter(): void
-    {
         $violation = new ConstraintViolation(
             'Captcha is invalid',
             null,
@@ -60,13 +59,16 @@ class ErrorControllerTest extends TestCase
             null,
             'captcha-invalid'
         );
-        $violations = new ConstraintViolationList([$violation]);
+        $this->violations = new ConstraintViolationList([$violation]);
+    }
 
+    public function testOnCaptchaFailureWithErrorRouteParameter(): void
+    {
         $request = new Request();
         $request->request->set('errorRoute', 'frontend.contact.page');
         $request->attributes->set('_route', 'frontend.account.login.page');
 
-        $this->controller->onCaptchaFailure($violations, $request);
+        $this->controller->onCaptchaFailure($this->violations, $request);
 
         static::assertSame('frontend.contact.page', $this->controller->forwardToRoute);
         static::assertArrayHasKey('formViolations', $this->controller->forwardToRouteAttributes);
@@ -78,22 +80,10 @@ class ErrorControllerTest extends TestCase
 
     public function testOnCaptchaFailureWithRouteAttributeFallback(): void
     {
-        $violation = new ConstraintViolation(
-            'Captcha is invalid',
-            null,
-            [],
-            null,
-            'captcha',
-            null,
-            null,
-            'captcha-invalid'
-        );
-        $violations = new ConstraintViolationList([$violation]);
-
         $request = new Request();
         $request->attributes->set('_route', 'frontend.account.register.page');
 
-        $this->controller->onCaptchaFailure($violations, $request);
+        $this->controller->onCaptchaFailure($this->violations, $request);
 
         static::assertSame('frontend.account.register.page', $this->controller->forwardToRoute);
         static::assertArrayHasKey('formViolations', $this->controller->forwardToRouteAttributes);
@@ -101,21 +91,9 @@ class ErrorControllerTest extends TestCase
 
     public function testOnCaptchaFailureWithDefaultFallback(): void
     {
-        $violation = new ConstraintViolation(
-            'Captcha is invalid',
-            null,
-            [],
-            null,
-            'captcha',
-            null,
-            null,
-            'captcha-invalid'
-        );
-        $violations = new ConstraintViolationList([$violation]);
-
         $request = new Request();
 
-        $this->controller->onCaptchaFailure($violations, $request);
+        $this->controller->onCaptchaFailure($this->violations, $request);
 
         static::assertSame('frontend.home.page', $this->controller->forwardToRoute);
         static::assertArrayHasKey('formViolations', $this->controller->forwardToRouteAttributes);
@@ -123,22 +101,10 @@ class ErrorControllerTest extends TestCase
 
     public function testOnCaptchaFailureWithXmlHttpRequest(): void
     {
-        $violation = new ConstraintViolation(
-            'Captcha is invalid',
-            null,
-            [],
-            null,
-            'captcha',
-            null,
-            null,
-            'captcha-invalid'
-        );
-        $violations = new ConstraintViolationList([$violation]);
-
         $request = new Request();
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
-        $response = $this->controller->onCaptchaFailure($violations, $request);
+        $response = $this->controller->onCaptchaFailure($this->violations, $request);
 
         static::assertInstanceOf(JsonResponse::class, $response);
 
@@ -156,23 +122,11 @@ class ErrorControllerTest extends TestCase
 
     public function testOnCaptchaFailureWithErrorRouteAsEmptyString(): void
     {
-        $violation = new ConstraintViolation(
-            'Captcha is invalid',
-            null,
-            [],
-            null,
-            'captcha',
-            null,
-            null,
-            'captcha-invalid'
-        );
-        $violations = new ConstraintViolationList([$violation]);
-
         $request = new Request();
         $request->request->set('errorRoute', '');
         $request->attributes->set('_route', 'frontend.account.login.page');
 
-        $this->controller->onCaptchaFailure($violations, $request);
+        $this->controller->onCaptchaFailure($this->violations, $request);
 
         // Empty string should fall back to the _route attribute
         static::assertSame('frontend.account.login.page', $this->controller->forwardToRoute);


### PR DESCRIPTION
### 1. Why is this change necessary?

The captcha validation error handling in `ErrorController::onCaptchaFailure` was ignoring the `errorRoute` parameter, causing users to always be redirected to the current route (typically `account/register`) even when attempting guest checkout. This resulted in guest checkout users losing their checkout context and being redirected to the wrong page when captcha validation failed.

### 2. What does this change do, exactly?

- Updates `ErrorController::onCaptchaFailure` to respect the `errorRoute` parameter when forwarding after captcha validation failure
- Instead of always using the current route, the controller now forwards to the route specified in the `errorRoute` parameter
- Adds unit test coverage in `ErrorControllerTest` to verify the `errorRoute` parameter is properly handled during captcha failures
- Preserves existing behavior when no `errorRoute` parameter is provided (defaults to current route)

### 3. Describe each step to reproduce the issue or behaviour.

1. Navigate to guest checkout (`/checkout/register`) 
2. Fill out the guest checkout form
3. Fail the captcha validation (e.g., by not completing it or entering incorrect data)
4. Observe that user is redirected to `/account/register` instead of staying on `/checkout/register`
5. Checkout context and form data preferences are lost

After the fix:
1. Follow steps 1-3 above
2. User is now correctly redirected back to `/checkout/register`
3. Checkout context and preferences are preserved

### 4. Please link to the relevant issues (if any).

- closes #12859

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them