### PR TITLE
fix: Use the `ComposerPluginLoader` when enabled in the `bin/{console/shopware}` command

### DIFF
--- a/bin/shopware
+++ b/bin/shopware
@@ -1,7 +1,9 @@
 #!/usr/bin/env php
 <?php
 
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
+use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Kernel;
@@ -39,15 +41,19 @@ return static function (array &$context) {
         $context['INSTALL'] = true;
     }
 
-    if (trim($context['DATABASE_URL'] ?? '') !== '' && !isset($context['INSTALL'])) {
-        $pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());
+    if (!isset($context['INSTALL'])) {
+        if (EnvironmentHelper::getVariable('COMPOSER_PLUGIN_LOADER', false)) {
+            $pluginLoader = new ComposerPluginLoader($classLoader, null);
+        } elseif (trim($context['DATABASE_URL'] ?? '') !== '') {
+            $pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());
+        }
     }
 
     $kernel = KernelFactory::create(
         $env,
-         $debug,
+        $debug,
         $classLoader,
-        $pluginLoader
+        $pluginLoader,
     );
 
     $application = new Application($kernel);

--- a/bin/shopware
+++ b/bin/shopware
@@ -1,7 +1,6 @@
 #!/usr/bin/env php
 <?php
 
-use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
@@ -42,7 +41,8 @@ return static function (array &$context) {
     }
 
     if (!isset($context['INSTALL'])) {
-        if (EnvironmentHelper::getVariable('COMPOSER_PLUGIN_LOADER', false)) {
+        $useComposerPluginLoader = (bool) ($context['COMPOSER_PLUGIN_LOADER'] ?? false);
+        if ($useComposerPluginLoader) {
             $pluginLoader = new ComposerPluginLoader($classLoader, null);
         } elseif (trim($context['DATABASE_URL'] ?? '') !== '') {
             $pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());

--- a/changelog/_unreleased/2025-10-23-respect-the-composer_plugin_loader-environment-variable-in-the-bin-shopware-cli-command.md
+++ b/changelog/_unreleased/2025-10-23-respect-the-composer_plugin_loader-environment-variable-in-the-bin-shopware-cli-command.md
@@ -1,0 +1,8 @@
+---
+title: Respect the `COMPOSER_PLUGIN_LOADER` environment variable in the `bin/shopware` cli command
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed the `bin/shopware` cli "binary" to respect the environment variable `COMPOSER_PLUGIN_LOADER` and use the `Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader` when enabled


### PR DESCRIPTION
### 1. Why is this change necessary?
While working on https://github.com/shopware/shopware/pull/12378 I noticed that the `bin/shopware` command does not respect the environment variable `COMPOSER_PLUGIN_LOADER`, as the `index.php` file does: https://github.com/shopware/shopware/blob/bc636cedaf2e72e066baabfdc65d3a665902e715/public/index.php#L55-L57

### 2. What does this change do, exactly?
Change the PHP script to respect this environment setting.

This also needs to be adjusted in the https://github.com/shopware/recipes repository, which I can do after this change has been merged.

### 3. Describe each step to reproduce the issue or behaviour.
Use `COMPOSER_PLUGIN_LOADER=1 php bin/console ...`

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
