### PR TITLE
fix: display only last date for search index

### DIFF
--- a/changelog/_unreleased/2025-10-24-only-display-last-search-index-date.md
+++ b/changelog/_unreleased/2025-10-24-only-display-last-search-index-date.md
@@ -1,0 +1,5 @@
+---
+title: Only display last search index date
+---
+# Administration
+* Changed `sw-settings-search-search-index` component to only display the last search index date instead of also the first one, as the first date is misleading and suggesting that the search index is iut of date even if it isn't.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/index.js
@@ -54,7 +54,6 @@ export default {
 
         productSearchKeywordsCriteria() {
             const criteria = new Criteria(1, 1);
-            criteria.addAggregation(Criteria.min('firstDate', 'createdAt'));
             criteria.addAggregation(Criteria.max('lastDate', 'createdAt'));
             return criteria;
         },
@@ -89,7 +88,6 @@ export default {
                     }
 
                     this.latestIndex = {
-                        firstDate: result.aggregations.firstDate.min,
                         lastDate: result.aggregations.lastDate.max,
                     };
                 })

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.html.twig
@@ -43,9 +43,6 @@
     <span class="sw-settings-search__search-index-latest-build">
         <template v-if="latestIndex">
             {{ $tc('sw-settings-search.generalTab.textLastedBuild') }} <sw-time-ago
-                :date="latestIndex.firstDate"
-                :date-time-format="{ month: '2-digit', day: '2-digit' }"
-            /> &dash; <sw-time-ago
                 :date="latestIndex.lastDate"
                 :date-time-format="{ month: '2-digit', day: '2-digit' }"
             />


### PR DESCRIPTION
The display of the oldest indexed search keyword was misleading, as it looked like the search index was quite old, but it is expected that when a product does not get changed the keywords won't be updated. But this lead customers to manually refresh the index when it was not necessary