### PR TITLE
chore: Do not reassign promoted property variables

### DIFF
--- a/src/Core/Content/Cms/Events/CmsPageLoadedEvent.php
+++ b/src/Core/Content/Cms/Events/CmsPageLoadedEvent.php
@@ -27,9 +27,7 @@ class CmsPageLoadedEvent extends NestedEvent implements ShopwareSalesChannelEven
         EntityCollection $result,
         protected SalesChannelContext $salesChannelContext,
     ) {
-        $this->request = $request;
         $this->result = $result;
-        $this->salesChannelContext = $salesChannelContext;
     }
 
     public function getRequest(): Request


### PR DESCRIPTION
### 1. Why is this change necessary?
I missed to remove the assignment for the promoted properties, in the original PR: https://github.com/shopware/shopware/pull/13091 :see_no_evil: 

### 2. What does this change do, exactly?
Remove not needed code.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
