### PR TITLE
fix(theme): ensure theme config directory is created

### DIFF
--- a/changelog/_unreleased/2025-01-24-fix-theme-config-directory-creation.md
+++ b/changelog/_unreleased/2025-01-24-fix-theme-config-directory-creation.md
@@ -1,0 +1,10 @@
+---
+title: Fix theme config directory creation for storefront watcher
+issue: 13051
+author: Björn Meyer
+author_email: b.meyer@shopware.com
+author_github: @BrocksiNet
+---
+# Storefront
+* Added directory existence check in `StaticFileConfigDumper::dumpConfig()` to ensure `theme-config` directory is created before writing theme configuration files
+

--- a/src/Storefront/Theme/ConfigLoader/StaticFileConfigDumper.php
+++ b/src/Storefront/Theme/ConfigLoader/StaticFileConfigDumper.php
@@ -49,6 +49,12 @@ class StaticFileConfigDumper implements EventSubscriberInterface
     public function dumpConfig(Context $context): void
     {
         $salesChannelToTheme = $this->availableThemeProvider->load($context, false);
+
+        $themeConfigDir = \dirname(StaticFileAvailableThemeProvider::THEME_INDEX);
+        if (!$this->privateFilesystem->directoryExists($themeConfigDir)) {
+            $this->privateFilesystem->createDirectory($themeConfigDir);
+        }
+
         $this->privateFilesystem->write(StaticFileAvailableThemeProvider::THEME_INDEX, \json_encode($salesChannelToTheme, \JSON_THROW_ON_ERROR));
 
         foreach ($salesChannelToTheme as $themeId) {


### PR DESCRIPTION
### 1. Why is this change necessary?

In Shopware 6.7.3, the storefront watcher fails because the `files/theme-config/` directory is not automatically created when running `bin/console theme:dump` or `theme:compile`. This prevents the `index.json` file from being written, causing the webpack watcher to fail with a file not found error.

This issue appears to be related to changes in the League/Flysystem library behavior between version 3.10.3 (used in 6.6.7) and 3.13.0 (used in 6.7.3), where implicit directory creation is no longer guaranteed.

### 2. What does this change do, exactly?

This PR adds a directory existence check in `StaticFileConfigDumper::dumpConfig()` before attempting to write theme configuration files. If the directory doesn't exist, it's created automatically.

**Changes:**
- Added `directoryExists()` check and `createDirectory()` call in `StaticFileConfigDumper::dumpConfig()`
- Used `dirname(StaticFileAvailableThemeProvider::THEME_INDEX)` to derive the directory path from the existing constant, avoiding magic strings
- Added unit test `testDumpConfigCreatesDirectoryIfNotExists()` to verify the directory creation logic
- Created changelog entry documenting the fix

This follows the same pattern already used in `AssetService` and `TranslationLoader` classes.

### 3. Describe each step to reproduce the issue or behaviour.

**Before the fix:**
1. Install a fresh Shopware 6.7.3 instance
2. Delete the `files/theme-config/` directory if it exists
3. Run `bin/console theme:dump`
4. Observe that the command fails or the directory is not created
5. Try to run the storefront watcher with `composer run watch:storefront`
6. Webpack fails with: `Cannot find file: files/theme-config/index.json`

**After the fix:**
1. Delete the `files/theme-config/` directory
2. Run `bin/console theme:dump`
3. The directory is automatically created
4. The `index.json` file is written successfully
5. The storefront watcher works correctly

### 4. Please link to the relevant issues (if any).

- closes #13051

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them