### PR TITLE
fix: Special Characters "/" in Search Not Working Even When Added as …

### DIFF
--- a/changelog/_unreleased/2025-10-26-special-characters-in-search-not-working-even-when-added-as-preserved-characters-in-config-file.md
+++ b/changelog/_unreleased/2025-10-26-special-characters-in-search-not-working-even-when-added-as-preserved-characters-in-config-file.md
@@ -1,0 +1,6 @@
+---
+title: Slash and backslash are now working correctly in search if configured as preserved characters
+issue: 13179
+---
+# Core
+* Changed `tokenize` method in `Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer` to properly handle special characters `/` and `\`, when they are specified as preserved characters in the configuration file.

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
@@ -33,7 +33,6 @@ class Tokenizer implements TokenizerInterface
         }
 
         $string = mb_strtolower(html_entity_decode($string), 'UTF-8');
-        $string = trim(str_replace(['/', '\\'], ' ', $string));
         $string = str_replace('<', ' <', $string);
         $string = strip_tags($string);
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Term/TokenizerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Term/TokenizerTest.php
@@ -47,7 +47,7 @@ class TokenizerTest extends TestCase
                 ['österreicher', 'essen'],
             ],
             'text with special chars' => [
-                '!Example"§$%``=)(/&%%$§""!',
+                '!Example"§$%``=)(/\&%%$§""!',
                 ['example'],
             ],
             'text with allowed chars' => [
@@ -68,6 +68,11 @@ class TokenizerTest extends TestCase
                 'Synergistic Copper DM.10000 Face@Master',
                 ['synergistic', 'copper', 'dm.10000', 'face@master'],
                 ['.', '@'],
+            ],
+            'text with allowed chars "/"' => [
+                '0000/0440',
+                ['0000/0440'],
+                ['/'],
             ],
         ];
     }


### PR DESCRIPTION
This pull request addresses an issue where special characters such as `/` and ` were not correctly handled in search tokenization, even when specified as preserved characters in the configuration file. The main change is an update to the `tokenize` method to ensure these characters are properly preserved, along with new unit tests to verify the fix.

Core functionality improvements:

* Updated the `tokenize` method in `Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer` to correctly handle special characters like `/` and `This pull request addresses an issue where special characters such as `/` and ` were not correctly handled in search tokenization, even when specified as preserved characters in the configuration file. The main change is an update to the `tokenize` method to ensure these characters are properly preserved, along with new unit tests to verify the fix.

Core functionality improvements:

 when they are listed as preserved characters in the config file. [[1]](diffhunk://#diff-3c170598ae59507e4cb67513522eee26a2f1d5671b2ecd473b4aa1f24a9191b0R1-R6) [[2]](diffhunk://#diff-a3cdab2d5909472e49840bf324a75c079a72901809eb63c1d94ff1063a353283L36)
