### PR TITLE
fix: Remove unnecessary PHPStan Symfony command feature

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2356,12 +2356,6 @@ parameters:
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
 			count: 1
-			path: src/Storefront/Theme/Command/ThemeCreateCommand.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
 			path: src/Storefront/Theme/ConfigLoader/StaticFileAvailableThemeProvider.php
 
 		-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
     symfony:
         constantHassers: false
         containerXmlPath: 'var/cache/static_phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml'
-        consoleApplicationLoader: src/Core/DevOps/StaticAnalyze/console-application.php
 
     excludePaths:
         # vendor patches over autoload files

--- a/src/Administration/Command/DeleteAdminFilesAfterBuildCommand.php
+++ b/src/Administration/Command/DeleteAdminFilesAfterBuildCommand.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
@@ -29,6 +30,7 @@ class DeleteAdminFilesAfterBuildCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $helper = $this->getHelper('question');
+        \assert($helper instanceof QuestionHelper);
 
         $question = new ConfirmationQuestion('This will delete all files unnecessary to build the administration. Do you want to continue? (y/n)');
 

--- a/src/Core/DevOps/StaticAnalyze/console-application.php
+++ b/src/Core/DevOps/StaticAnalyze/console-application.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
+trigger_deprecation('shopware/core', '', \sprintf('The "%s" file is deprecated and will be removed in v6.8.0.0 as the feature is no longer used in PHPStan', __FILE__));
+
 $classLoader = require __DIR__ . '/phpstan-bootstrap.php';
 
 $pluginLoader = new StaticKernelPluginLoader($classLoader);

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -9,6 +9,7 @@ use Shopware\Core\System\Snippet\SnippetValidator;
 use Shopware\Core\System\Snippet\Struct\InvalidPluralizationCollection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -89,6 +90,7 @@ class ValidateSnippetsCommand extends Command
         }
 
         $questionHelper = $this->getHelper('question');
+        \assert($questionHelper instanceof QuestionHelper);
 
         foreach ($missingSnippetsCollection->getIterator() as $missingSnippetStruct) {
             $question = \sprintf(

--- a/src/Storefront/Theme/Command/ThemeChangeCommand.php
+++ b/src/Storefront/Theme/Command/ThemeChangeCommand.php
@@ -15,6 +15,7 @@ use Shopware\Storefront\Theme\ThemeCollection;
 use Shopware\Storefront\Theme\ThemeService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -65,6 +66,7 @@ class ThemeChangeCommand extends Command
 
         $this->io = new SymfonyStyle($input, $output);
         $helper = $this->getHelper('question');
+        \assert($helper instanceof QuestionHelper);
 
         if ($input->getOption('sales-channel') && $input->getOption('all')) {
             $this->io->error('You can use either --sales-channel or --all, not both at the same time.');

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -3,6 +3,7 @@
 namespace Shopware\Storefront\Theme\Command;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Theme\Exception\ThemeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -133,7 +134,7 @@ class ThemeCreateCommand extends Command
     private function createDirectory(string $pathName): void
     {
         if (!mkdir($pathName, 0755, true) && !is_dir($pathName)) {
-            throw new \RuntimeException(\sprintf('Unable to create directory "%s". Please check permissions', $pathName));
+            throw ThemeException::themeCreationFailure(\sprintf('Unable to create directory "%s". Please check permissions', $pathName));
         }
     }
 

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Theme\Command;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -42,7 +43,9 @@ class ThemeCreateCommand extends Command
 
         if (!$themeName) {
             $question = new Question('Please enter a theme name: ');
-            $themeName = $this->getHelper('question')->ask($input, $output, $question);
+            $questionHelper = $this->getHelper('question');
+            \assert($questionHelper instanceof QuestionHelper);
+            $themeName = $questionHelper->ask($input, $output, $question);
         }
 
         if (!ctype_upper((string) $themeName[0])) {

--- a/src/Storefront/Theme/Command/ThemeDumpCommand.php
+++ b/src/Storefront/Theme/Command/ThemeDumpCommand.php
@@ -17,6 +17,7 @@ use Shopware\Storefront\Theme\ThemeFileResolver;
 use Shopware\Storefront\Theme\ThemeFilesystemResolver;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -79,6 +80,8 @@ class ThemeDumpCommand extends Command
 
             if ($input->isInteractive() && \count($choices) > 1) {
                 $helper = $this->getHelper('question');
+                \assert($helper instanceof QuestionHelper);
+
                 $this->io->note($this->getThemeAssignmentInfos());
                 $question = new ChoiceQuestion('Please select a theme:', $choices);
                 $themeName = $helper->ask($input, $output, $question);
@@ -211,6 +214,7 @@ class ThemeDumpCommand extends Command
 
         if (\count($domainUrls) > 1) {
             $helper = $this->getHelper('question');
+            \assert($helper instanceof QuestionHelper);
 
             $question = new ChoiceQuestion('Please select a domain url:', $domainUrls);
             $domainUrl = $helper->ask($input, $output, $question);

--- a/src/Storefront/Theme/Exception/ThemeException.php
+++ b/src/Storefront/Theme/Exception/ThemeException.php
@@ -23,6 +23,7 @@ class ThemeException extends HttpException
     public const ERROR_LOADING_RUNTIME_CONFIG = 'THEME__ERROR_LOADING_RUNTIME_CONFIG';
     public const ERROR_LOADING_FROM_PLUGIN_REGISTRY = 'THEME__ERROR_LOADING_THEME_FROM_PLUGIN_REGISTRY';
     public const THEME_ASSIGNMENT = 'THEME__THEME_ASSIGNMENT';
+    public const THEME_CREATION_FAILURE = 'THEME__THEME_CREATION_FAILURE';
 
     /**
      * @deprecated tag:v6.8.0 - will be removed, as the exception is no longer needed, use RestrictDeleteViolationException instead
@@ -158,6 +159,15 @@ class ThemeException extends HttpException
             self::ERROR_LOADING_FROM_PLUGIN_REGISTRY,
             'Error loading theme with technical name "{{ technicalName }}" from plugin registry',
             ['technicalName' => $technicalName]
+        );
+    }
+
+    public static function themeCreationFailure(string $message): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::THEME_CREATION_FAILURE,
+            $message,
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Increase performance by removing to boot up a kernel again. The feature no longer brings real value, as Symfony also improved their types in the mean time. 

### 2. What does this change do, exactly?

- Remove the PHPStan Symfony extension feature for the commands.