### PR TITLE
fix: Improve PHPStan bootstrapping

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,11 +10,14 @@ parameters:
         - tests
 
     bootstrapFiles:
-        - src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
-    # run `php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php` to create the container
+        - src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php # run `php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php` to create the container
     symfony:
         constantHassers: false
         containerXmlPath: 'var/cache/static_phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml'
+    scanDirectories:
+        - var/cache/static_phpstan_dev/Symfony/Config
+    scanFiles:
+        - vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php
 
     excludePaths:
         # vendor patches over autoload files

--- a/src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
+++ b/src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
@@ -34,6 +34,12 @@ if (!\defined('TEST_PROJECT_DIR')) {
 }
 
 $_ENV['PROJECT_ROOT'] = $_SERVER['PROJECT_ROOT'] = TEST_PROJECT_DIR;
+
+if (is_file(TEST_PROJECT_DIR . '/var/cache/static_phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml')) {
+    // If the container debug file already exists, the kernel does not need to be booted again
+    return;
+}
+
 $classLoader = require TEST_PROJECT_DIR . '/vendor/autoload.php';
 
 if (class_exists(Dotenv::class) && (\is_file(TEST_PROJECT_DIR . '/.env.local.php') || \is_file(TEST_PROJECT_DIR . '/.env') || \is_file(TEST_PROJECT_DIR . '/.env.dist'))) {
@@ -52,5 +58,3 @@ $kernel = KernelFactory::create(
 );
 
 $kernel->boot();
-
-return $classLoader;

--- a/src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
+++ b/src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Symfony\Component\Dotenv\Dotenv;
 
 if (!\defined('TEST_PROJECT_DIR')) {
-    \define('TEST_PROJECT_DIR', (function (): string {
+    \define('TEST_PROJECT_DIR', (static function (): string {
         if (isset($_SERVER['PROJECT_ROOT']) && \is_dir($_SERVER['PROJECT_ROOT'])) {
             return $_SERVER['PROJECT_ROOT'];
         }
@@ -34,13 +34,12 @@ if (!\defined('TEST_PROJECT_DIR')) {
 }
 
 $_ENV['PROJECT_ROOT'] = $_SERVER['PROJECT_ROOT'] = TEST_PROJECT_DIR;
+$classLoader = require TEST_PROJECT_DIR . '/vendor/autoload.php';
 
 if (is_file(TEST_PROJECT_DIR . '/var/cache/static_phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml')) {
     // If the container debug file already exists, the kernel does not need to be booted again
-    return;
+    return $classLoader;
 }
-
-$classLoader = require TEST_PROJECT_DIR . '/vendor/autoload.php';
 
 if (class_exists(Dotenv::class) && (\is_file(TEST_PROJECT_DIR . '/.env.local.php') || \is_file(TEST_PROJECT_DIR . '/.env') || \is_file(TEST_PROJECT_DIR . '/.env.dist'))) {
     (new Dotenv())->usePutenv()->bootEnv(TEST_PROJECT_DIR . '/.env');
@@ -58,3 +57,5 @@ $kernel = KernelFactory::create(
 );
 
 $kernel->boot();
+
+return $classLoader;


### PR DESCRIPTION
### 1. Why is this change necessary?

Skip unnecessary boots of the kernel

### 2. What does this change do, exactly?

Check if the needed XML file already exists. If so, skip the booting.
We still need to execute the boostrap file first and also having it in the config, due to the Symfony extension we are using: https://github.com/phpstan/phpstan-symfony/issues/299