### PR TITLE
fix: Cheapest price of variant product applies across sales channels

### DIFF
--- a/changelog/_unreleased/2025-10-27-cheapest-price-of-variant-product-applies-across-sales-channels.md
+++ b/changelog/_unreleased/2025-10-27-cheapest-price-of-variant-product-applies-across-sales-channels.md
@@ -1,0 +1,6 @@
+---
+title: Cheapest price of variant product applies across sales channels
+issue: 8577
+---
+# Core
+* Changed `Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPriceUpdater` to add the sales_channel_ids for each rule in cheapest_price_container, so we can correctly solve the available variant.

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainer.php
@@ -61,14 +61,8 @@ class CheapestPriceContainer extends Struct
                 }
 
                 // Check sales channel availability
-                if ($currentSalesChannelId) {
-                    $isAvailable = $price === $this->default
-                        ? $this->isVariantAvailableInSalesChannel(['default' => $this->default], $currentSalesChannelId)
-                        : $this->isVariantAvailableInSalesChannel($group, $currentSalesChannelId);
-
-                    if (!$isAvailable) {
-                        continue;
-                    }
+                if ($currentSalesChannelId && !$this->isVariantPriceAvailableInSalesChannel($price, $currentSalesChannelId)) {
+                    continue;
                 }
 
                 // overwrite the variantId in case the default price was added
@@ -293,25 +287,17 @@ class CheapestPriceContainer extends Struct
     }
 
     /**
-     * @param array<string, array<mixed>> $group
+     * @param array<mixed> $price
      */
-    private function isVariantAvailableInSalesChannel(array $group, string $salesChannelId): bool
+    private function isVariantPriceAvailableInSalesChannel(array $price, string $salesChannelId): bool
     {
-        foreach ($group as $priceData) {
-            if ($priceData === null) {
-                continue;
-            }
-
-            $salesChannelIds = $priceData['sales_channel_ids'] ?? [];
-
-            // If no sales channel IDs are stored, assume it's available everywhere
-            if (empty($salesChannelIds)) {
-                return true;
-            }
-
-            return \in_array($salesChannelId, $salesChannelIds, true);
+        // If no sales channel IDs are stored, assume it's available everywhere
+        if (!\array_key_exists('sales_channel_ids', $price)) {
+            return true;
         }
 
-        return false;
+        $salesChannelIds = $price['sales_channel_ids'] ?? [];
+
+        return \in_array($salesChannelId, $salesChannelIds, true);
     }
 }

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainer.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice;
 
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
@@ -48,12 +49,26 @@ class CheapestPriceContainer extends Struct
 
         $prices = [];
         $defaultWasAdded = false;
+        $source = $context->getSource();
+        $currentSalesChannelId = $source instanceof SalesChannelApiSource ? $source->getSalesChannelId() : null;
+
         foreach ($this->value as $variantId => $group) {
             foreach ($ruleIds as $ruleId) {
                 $price = $this->filterByRuleId($group, $ruleId, $defaultWasAdded);
 
                 if ($price === null) {
                     continue;
+                }
+
+                // Check sales channel availability
+                if ($currentSalesChannelId) {
+                    $isAvailable = $price === $this->default
+                        ? $this->isVariantAvailableInSalesChannel(['default' => $this->default], $currentSalesChannelId)
+                        : $this->isVariantAvailableInSalesChannel($group, $currentSalesChannelId);
+
+                    if (!$isAvailable) {
+                        continue;
+                    }
                 }
 
                 // overwrite the variantId in case the default price was added
@@ -275,5 +290,28 @@ class CheapestPriceContainer extends Struct
         }
 
         return $this->getCurrencyPrice($collection, Defaults::CURRENCY, false);
+    }
+
+    /**
+     * @param array<string, array<mixed>> $group
+     */
+    private function isVariantAvailableInSalesChannel(array $group, string $salesChannelId): bool
+    {
+        foreach ($group as $priceData) {
+            if ($priceData === null) {
+                continue;
+            }
+
+            $salesChannelIds = $priceData['sales_channel_ids'] ?? [];
+
+            // If no sales channel IDs are stored, assume it's available everywhere
+            if (empty($salesChannelIds)) {
+                return true;
+            }
+
+            return \in_array($salesChannelId, $salesChannelIds, true);
+        }
+
+        return false;
     }
 }

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -8,6 +8,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceContainer;
 use Shopware\Core\Content\Product\Events\ProductIndexerEvent;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;
@@ -186,63 +187,26 @@ class CheapestPriceUpdater
             'IFNULL(product.reference_unit, parent.reference_unit) as reference_unit',
             'IFNULL(product.min_purchase, parent.min_purchase) as min_purchase',
             'price.price',
-            'GROUP_CONCAT(DISTINCT LOWER(HEX(visibilities.sales_channel_id))) as sales_channel_ids',
         );
 
         $query->from('product', 'product');
         $query->innerJoin('product', 'product_price', 'price', 'price.product_id = product.prices AND product.version_id = price.product_version_id');
         $query->leftJoin('product', 'product', 'parent', 'parent.id = product.parent_id');
-        $query->leftJoin('product', 'product_visibility', 'visibilities', 'visibilities.product_id = product.id AND visibilities.product_version_id = product.version_id');
 
         $query->andWhere('product.id IN (:ids) OR product.parent_id IN (:ids)');
         $query->andWhere('product.version_id = :version');
         $query->andWhere('IFNULL(product.active, parent.active) = 1');
         $query->andWhere('(product.child_count = 0 OR product.parent_id IS NOT NULL)');
 
-        $query->groupBy(
-            'product.id',
-            'price.rule_id',
-            'product.parent_id',
-            'product.unit_id',
-            'parent.unit_id',
-            'product.purchase_unit',
-            'parent.purchase_unit',
-            'product.reference_unit',
-            'parent.reference_unit',
-            'product.min_purchase',
-            'parent.min_purchase',
-            'price.price'
-        );
-
         $this->quantitySelector->add($query);
 
-        $ids = Uuid::fromHexToBytesList($ids);
+        $idsBytes = Uuid::fromHexToBytesList($ids);
+        $versionBytes = Uuid::fromHexToBytes($context->getVersionId());
 
-        $query->setParameter('ids', $ids, ArrayParameterType::BINARY);
-        $query->setParameter('version', Uuid::fromHexToBytes($context->getVersionId()));
+        $query->setParameter('ids', $idsBytes, ArrayParameterType::BINARY);
+        $query->setParameter('version', $versionBytes);
 
         $data = $query->executeQuery()->fetchAllAssociative();
-
-        $grouped = [];
-        foreach ($data as $row) {
-            $row['price'] = json_decode((string) $row['price'], true, 512, \JSON_THROW_ON_ERROR);
-            $grouped[(string) $row['parent_id']][(string) $row['variant_id']][(string) $row['rule_id']] = $row;
-        }
-
-        // Process sales channel IDs for all grouped data
-        foreach ($grouped as $parentId => $variants) {
-            foreach ($variants as $variantId => $rules) {
-                foreach ($rules as $ruleId => $priceData) {
-                    if (isset($priceData['sales_channel_ids'])) {
-                        $salesChannelIds = [];
-                        if (!empty($priceData['sales_channel_ids'])) {
-                            $salesChannelIds = explode(',', $priceData['sales_channel_ids']);
-                        }
-                        $grouped[$parentId][$variantId][$ruleId]['sales_channel_ids'] = $salesChannelIds;
-                    }
-                }
-            }
-        }
 
         $query = $this->connection->createQueryBuilder();
         $query->select(
@@ -256,35 +220,34 @@ class CheapestPriceUpdater
             'IFNULL(product.purchase_unit, parent.purchase_unit) as purchase_unit',
             'IFNULL(product.reference_unit, parent.reference_unit) as reference_unit',
             'product.child_count as child_count',
-            'GROUP_CONCAT(DISTINCT LOWER(HEX(visibilities.sales_channel_id))) as sales_channel_ids',
         );
 
         $query->from('product', 'product');
         $query->leftJoin('product', 'product', 'parent', 'product.parent_id = parent.id');
-        $query->leftJoin('product', 'product_visibility', 'visibilities', 'visibilities.product_id = product.id AND visibilities.product_version_id = product.version_id');
         $query->andWhere('product.id IN (:ids) OR product.parent_id IN (:ids)');
         $query->andWhere('product.version_id = :version');
         $query->andWhere('IFNULL(product.active, parent.active) = 1 OR product.child_count > 0'); // always load parent products
-
-        $query->groupBy(
-            'product.id',
-            'product.parent_id',
-            'product.unit_id',
-            'parent.unit_id',
-            'product.purchase_unit',
-            'parent.purchase_unit',
-            'product.reference_unit',
-            'parent.reference_unit',
-            'product.min_purchase',
-            'parent.min_purchase',
-            'product.price',
-            'product.child_count'
-        );
-
-        $query->setParameter('ids', $ids, ArrayParameterType::BINARY);
-        $query->setParameter('version', Uuid::fromHexToBytes($context->getVersionId()));
+        $query->setParameter('ids', $idsBytes, ArrayParameterType::BINARY);
+        $query->setParameter('version', $versionBytes);
 
         $defaults = $query->executeQuery()->fetchAllAssociative();
+
+        // Collect all unique product IDs from both queries
+        $productIds = [];
+        $rows = [...$data, ...$defaults];
+        foreach ($rows as $row) {
+            $productIds[$row['variant_id']] = true;
+        }
+
+        // Fetch visibility once for all products
+        $visibilityMap = $this->fetchVisibilityMap(array_keys($productIds), $context);
+
+        $grouped = [];
+        foreach ($data as $row) {
+            $row['price'] = json_decode((string) $row['price'], true, 512, \JSON_THROW_ON_ERROR);
+            $row['sales_channel_ids'] = $visibilityMap[$row['variant_id']] ?? $visibilityMap[$row['parent_id']] ?? [];
+            $grouped[(string) $row['parent_id']][(string) $row['variant_id']][(string) $row['rule_id']] = $row;
+        }
 
         foreach ($defaults as $row) {
             if ($row['price'] === null) {
@@ -295,6 +258,8 @@ class CheapestPriceUpdater
 
             $row['price'] = json_decode((string) $row['price'], true, 512, \JSON_THROW_ON_ERROR);
             $row['price'] = $this->normalizePrices($row['price']);
+            $row['sales_channel_ids'] = $visibilityMap[$row['variant_id']] ?? $visibilityMap[$row['parent_id']] ?? [];
+
             if ($row['child_count'] > 0) {
                 $grouped[(string) $row['parent_id']]['default'] = $row;
 
@@ -304,29 +269,35 @@ class CheapestPriceUpdater
             $grouped[(string) $row['parent_id']][(string) $row['variant_id']]['default'] = $row;
         }
 
-        // Process sales channel IDs for default prices
-        foreach ($defaults as $row) {
-            if ($row['price'] === null) {
-                continue;
-            }
+        return $grouped;
+    }
 
-            $salesChannelIds = [];
-            if (!empty($row['sales_channel_ids'])) {
-                $salesChannelIds = explode(',', $row['sales_channel_ids']);
-            }
-
-            if ($row['child_count'] > 0) {
-                if (isset($grouped[(string) $row['parent_id']]['default'])) {
-                    $grouped[(string) $row['parent_id']]['default']['sales_channel_ids'] = $salesChannelIds;
-                }
-            } else {
-                if (isset($grouped[(string) $row['parent_id']][(string) $row['variant_id']]['default'])) {
-                    $grouped[(string) $row['parent_id']][(string) $row['variant_id']]['default']['sales_channel_ids'] = $salesChannelIds;
-                }
-            }
+    /**
+     * @param array<string> $productIds
+     *
+     * @return array<string, array<string>> Map of product_id => [sales_channel_ids]
+     */
+    private function fetchVisibilityMap(array $productIds, Context $context): array
+    {
+        if (empty($productIds)) {
+            return [];
         }
 
-        return $grouped;
+        $results = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(HEX(product_id)) as product_id, LOWER(HEX(sales_channel_id)) as sales_channel_id
+             FROM product_visibility
+             WHERE product_id IN (:ids)
+             AND product_version_id = :version',
+            [
+                'ids' => Uuid::fromHexToBytesList($productIds),
+                'version' => Uuid::fromHexToBytes($context->getVersionId()),
+            ],
+            [
+                'ids' => ArrayParameterType::BINARY,
+            ]
+        );
+
+        return FetchModeHelper::group($results, static fn ($row): string => (string) $row['sales_channel_id']);
     }
 
     /**

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -186,16 +186,33 @@ class CheapestPriceUpdater
             'IFNULL(product.reference_unit, parent.reference_unit) as reference_unit',
             'IFNULL(product.min_purchase, parent.min_purchase) as min_purchase',
             'price.price',
+            'GROUP_CONCAT(DISTINCT LOWER(HEX(visibilities.sales_channel_id))) as sales_channel_ids',
         );
 
         $query->from('product', 'product');
         $query->innerJoin('product', 'product_price', 'price', 'price.product_id = product.prices AND product.version_id = price.product_version_id');
         $query->leftJoin('product', 'product', 'parent', 'parent.id = product.parent_id');
+        $query->leftJoin('product', 'product_visibility', 'visibilities', 'visibilities.product_id = product.id AND visibilities.product_version_id = product.version_id');
 
         $query->andWhere('product.id IN (:ids) OR product.parent_id IN (:ids)');
         $query->andWhere('product.version_id = :version');
         $query->andWhere('IFNULL(product.active, parent.active) = 1');
         $query->andWhere('(product.child_count = 0 OR product.parent_id IS NOT NULL)');
+
+        $query->groupBy(
+            'product.id',
+            'price.rule_id',
+            'product.parent_id',
+            'product.unit_id',
+            'parent.unit_id',
+            'product.purchase_unit',
+            'parent.purchase_unit',
+            'product.reference_unit',
+            'parent.reference_unit',
+            'product.min_purchase',
+            'parent.min_purchase',
+            'price.price'
+        );
 
         $this->quantitySelector->add($query);
 
@@ -212,6 +229,21 @@ class CheapestPriceUpdater
             $grouped[(string) $row['parent_id']][(string) $row['variant_id']][(string) $row['rule_id']] = $row;
         }
 
+        // Process sales channel IDs for all grouped data
+        foreach ($grouped as $parentId => $variants) {
+            foreach ($variants as $variantId => $rules) {
+                foreach ($rules as $ruleId => $priceData) {
+                    if (isset($priceData['sales_channel_ids'])) {
+                        $salesChannelIds = [];
+                        if (!empty($priceData['sales_channel_ids'])) {
+                            $salesChannelIds = explode(',', $priceData['sales_channel_ids']);
+                        }
+                        $grouped[$parentId][$variantId][$ruleId]['sales_channel_ids'] = $salesChannelIds;
+                    }
+                }
+            }
+        }
+
         $query = $this->connection->createQueryBuilder();
         $query->select(
             'LOWER(HEX(IFNULL(product.parent_id, product.id))) as parent_id',
@@ -224,13 +256,30 @@ class CheapestPriceUpdater
             'IFNULL(product.purchase_unit, parent.purchase_unit) as purchase_unit',
             'IFNULL(product.reference_unit, parent.reference_unit) as reference_unit',
             'product.child_count as child_count',
+            'GROUP_CONCAT(DISTINCT LOWER(HEX(visibilities.sales_channel_id))) as sales_channel_ids',
         );
 
         $query->from('product', 'product');
         $query->leftJoin('product', 'product', 'parent', 'product.parent_id = parent.id');
+        $query->leftJoin('product', 'product_visibility', 'visibilities', 'visibilities.product_id = product.id AND visibilities.product_version_id = product.version_id');
         $query->andWhere('product.id IN (:ids) OR product.parent_id IN (:ids)');
         $query->andWhere('product.version_id = :version');
         $query->andWhere('IFNULL(product.active, parent.active) = 1 OR product.child_count > 0'); // always load parent products
+
+        $query->groupBy(
+            'product.id',
+            'product.parent_id',
+            'product.unit_id',
+            'parent.unit_id',
+            'product.purchase_unit',
+            'parent.purchase_unit',
+            'product.reference_unit',
+            'parent.reference_unit',
+            'product.min_purchase',
+            'parent.min_purchase',
+            'product.price',
+            'product.child_count'
+        );
 
         $query->setParameter('ids', $ids, ArrayParameterType::BINARY);
         $query->setParameter('version', Uuid::fromHexToBytes($context->getVersionId()));
@@ -253,6 +302,28 @@ class CheapestPriceUpdater
             }
 
             $grouped[(string) $row['parent_id']][(string) $row['variant_id']]['default'] = $row;
+        }
+
+        // Process sales channel IDs for default prices
+        foreach ($defaults as $row) {
+            if ($row['price'] === null) {
+                continue;
+            }
+
+            $salesChannelIds = [];
+            if (!empty($row['sales_channel_ids'])) {
+                $salesChannelIds = explode(',', $row['sales_channel_ids']);
+            }
+
+            if ($row['child_count'] > 0) {
+                if (isset($grouped[(string) $row['parent_id']]['default'])) {
+                    $grouped[(string) $row['parent_id']]['default']['sales_channel_ids'] = $salesChannelIds;
+                }
+            } else {
+                if (isset($grouped[(string) $row['parent_id']][(string) $row['variant_id']]['default'])) {
+                    $grouped[(string) $row['parent_id']][(string) $row['variant_id']]['default']['sales_channel_ids'] = $salesChannelIds;
+                }
+            }
         }
 
         return $grouped;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceUpdaterTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Product\DataAbstractionLayer\CheapestPrice;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceContainer;
+use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPriceQuantitySelector;
+use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPriceUpdater;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+class CheapestPriceUpdaterTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testCheapestPriceFilteredBySalesChannelId(): void
+    {
+        $ids = new IdsCollection();
+
+        $salesChannelId1 = TestDefaults::SALES_CHANNEL;
+
+        $context = Context::createDefaultContext();
+
+        $productBuilder = (new ProductBuilder($ids, 'testSalesChannelFilter_p1'))
+            ->price(100.0)
+            ->variant((new ProductBuilder($ids, 'testSalesChannelFilter_v1'))
+                ->price(80.0)
+                ->visibility($salesChannelId1)
+                ->build())
+            ->variant((new ProductBuilder($ids, 'testSalesChannelFilter_v2'))
+                ->price(90.0)
+                ->visibility()
+                ->build());
+
+        $productData = $productBuilder->build();
+        $this->getContainer()->get('product.repository')->create([$productData], $context);
+
+        $parentId = $productData['id'];
+        $variantId1 = $productData['children'][0]['id'];
+
+        $connection = $this->getContainer()->get(Connection::class);
+        $quantitySelector = new CheapestPriceQuantitySelector();
+        $eventDispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $updater = new CheapestPriceUpdater($connection, $quantitySelector, $eventDispatcher);
+        $updater->update([$parentId], $context);
+
+        $cheapestPriceRaw = $connection->fetchOne(
+            'SELECT cheapest_price FROM product WHERE id = UNHEX(:id) AND version_id = UNHEX(:version)',
+            [
+                'id' => str_replace('-', '', $parentId),
+                'version' => str_replace('-', '', $context->getVersionId()),
+            ]
+        );
+
+        static::assertNotEmpty($cheapestPriceRaw, 'Cheapest price should be stored');
+
+        $cheapestPrice = unserialize($cheapestPriceRaw);
+        static::assertInstanceOf(CheapestPriceContainer::class, $cheapestPrice);
+
+        $context = new Context(
+            new SalesChannelApiSource($salesChannelId1)
+        );
+
+        $resolvedPrice = $cheapestPrice->resolve($context);
+        static::assertNotNull($resolvedPrice);
+        static::assertSame($variantId1, $resolvedPrice->getVariantId());
+
+        $price = $resolvedPrice->getPrice()->first();
+        static::assertNotNull($price);
+        static::assertSame(80.0, $price->getGross());
+    }
+}

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainerSalesChannelTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainerSalesChannelTest.php
@@ -36,10 +36,11 @@ class CheapestPriceContainerSalesChannelTest extends TestCase
 
         $container = new CheapestPriceContainer([]);
         $reflection = new \ReflectionClass($container);
-        $method = $reflection->getMethod('isVariantAvailableInSalesChannel');
+        $method = $reflection->getMethod('isVariantPriceAvailableInSalesChannel');
         $method->setAccessible(true);
 
-        $result = $method->invoke($container, $group, $salesChannelId);
+        $price = $group['default'];
+        $result = $method->invoke($container, $price, $salesChannelId);
 
         static::assertTrue($result);
     }
@@ -64,15 +65,16 @@ class CheapestPriceContainerSalesChannelTest extends TestCase
 
         $container = new CheapestPriceContainer([]);
         $reflection = new \ReflectionClass($container);
-        $method = $reflection->getMethod('isVariantAvailableInSalesChannel');
+        $method = $reflection->getMethod('isVariantPriceAvailableInSalesChannel');
         $method->setAccessible(true);
 
-        $result = $method->invoke($container, $group, $salesChannelId);
+        $price = $group['default'];
+        $result = $method->invoke($container, $price, $salesChannelId);
 
         static::assertFalse($result);
     }
 
-    public function testIsVariantAvailableInSalesChannelWithEmptyIds(): void
+    public function testIsVariantAvailableInSalesChannelWithoutIds(): void
     {
         $salesChannelId = Uuid::randomHex();
         $group = [
@@ -80,7 +82,6 @@ class CheapestPriceContainerSalesChannelTest extends TestCase
                 'price' => [
                     ['currencyId' => Defaults::CURRENCY, 'gross' => 100.0, 'net' => 84.03, 'linked' => true],
                 ],
-                'sales_channel_ids' => [],
                 'is_ranged' => false,
                 'rule_id' => 'default',
                 'parent_id' => 'parent1',
@@ -91,10 +92,11 @@ class CheapestPriceContainerSalesChannelTest extends TestCase
 
         $container = new CheapestPriceContainer([]);
         $reflection = new \ReflectionClass($container);
-        $method = $reflection->getMethod('isVariantAvailableInSalesChannel');
+        $method = $reflection->getMethod('isVariantPriceAvailableInSalesChannel');
         $method->setAccessible(true);
 
-        $result = $method->invoke($container, $group, $salesChannelId);
+        $price = $group['default'];
+        $result = $method->invoke($container, $price, $salesChannelId);
 
         static::assertTrue($result);
     }

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainerSalesChannelTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainerSalesChannelTest.php
@@ -1,0 +1,195 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\DataAbstractionLayer\CheapestPrice;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceContainer;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[CoversClass(CheapestPriceContainer::class)]
+class CheapestPriceContainerSalesChannelTest extends TestCase
+{
+    public function testIsVariantAvailableInSalesChannelWithMatchingId(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $group = [
+            'default' => [
+                'price' => [
+                    ['currencyId' => Defaults::CURRENCY, 'gross' => 100.0, 'net' => 84.03, 'linked' => true],
+                ],
+                'sales_channel_ids' => [$salesChannelId],
+                'is_ranged' => false,
+                'rule_id' => 'default',
+                'parent_id' => 'parent1',
+                'purchase_unit' => 1.0,
+                'reference_unit' => 1.0,
+            ],
+        ];
+
+        $container = new CheapestPriceContainer([]);
+        $reflection = new \ReflectionClass($container);
+        $method = $reflection->getMethod('isVariantAvailableInSalesChannel');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($container, $group, $salesChannelId);
+
+        static::assertTrue($result);
+    }
+
+    public function testIsVariantAvailableInSalesChannelWithNonMatchingId(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $otherSalesChannelId = Uuid::randomHex();
+        $group = [
+            'default' => [
+                'price' => [
+                    ['currencyId' => Defaults::CURRENCY, 'gross' => 100.0, 'net' => 84.03, 'linked' => true],
+                ],
+                'sales_channel_ids' => [$otherSalesChannelId],
+                'is_ranged' => false,
+                'rule_id' => 'default',
+                'parent_id' => 'parent1',
+                'purchase_unit' => 1.0,
+                'reference_unit' => 1.0,
+            ],
+        ];
+
+        $container = new CheapestPriceContainer([]);
+        $reflection = new \ReflectionClass($container);
+        $method = $reflection->getMethod('isVariantAvailableInSalesChannel');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($container, $group, $salesChannelId);
+
+        static::assertFalse($result);
+    }
+
+    public function testIsVariantAvailableInSalesChannelWithEmptyIds(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $group = [
+            'default' => [
+                'price' => [
+                    ['currencyId' => Defaults::CURRENCY, 'gross' => 100.0, 'net' => 84.03, 'linked' => true],
+                ],
+                'sales_channel_ids' => [],
+                'is_ranged' => false,
+                'rule_id' => 'default',
+                'parent_id' => 'parent1',
+                'purchase_unit' => 1.0,
+                'reference_unit' => 1.0,
+            ],
+        ];
+
+        $container = new CheapestPriceContainer([]);
+        $reflection = new \ReflectionClass($container);
+        $method = $reflection->getMethod('isVariantAvailableInSalesChannel');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($container, $group, $salesChannelId);
+
+        static::assertTrue($result);
+    }
+
+    public function testResolveWithSalesChannelFiltering(): void
+    {
+        $currentSalesChannelId = Uuid::randomHex();
+        $otherSalesChannelId = Uuid::randomHex();
+
+        $testData = [
+            'variant1' => [
+                'default' => [
+                    'price' => [
+                        ['currencyId' => Defaults::CURRENCY, 'gross' => 50.0, 'net' => 42.02, 'linked' => true],
+                    ],
+                    'sales_channel_ids' => [$otherSalesChannelId],
+                    'is_ranged' => false,
+                    'rule_id' => 'default',
+                    'parent_id' => 'parent1',
+                    'purchase_unit' => 1.0,
+                    'reference_unit' => 1.0,
+                ],
+            ],
+            'variant2' => [
+                'default' => [
+                    'price' => [
+                        ['currencyId' => Defaults::CURRENCY, 'gross' => 100.0, 'net' => 84.03, 'linked' => true],
+                    ],
+                    'sales_channel_ids' => [$currentSalesChannelId],
+                    'is_ranged' => false,
+                    'rule_id' => 'default',
+                    'parent_id' => 'parent1',
+                    'purchase_unit' => 1.0,
+                    'reference_unit' => 1.0,
+                ],
+            ],
+        ];
+
+        $context = new Context(
+            new SalesChannelApiSource($currentSalesChannelId),
+            [],
+            Defaults::CURRENCY,
+            [Defaults::LANGUAGE_SYSTEM],
+            Defaults::LIVE_VERSION,
+            1.0,
+            true,
+            CartPrice::TAX_STATE_GROSS
+        );
+
+        $container = new CheapestPriceContainer($testData);
+        $cheapestPrice = $container->resolve($context);
+
+        static::assertNotNull($cheapestPrice);
+        static::assertSame('variant2', $cheapestPrice->getVariantId());
+
+        $firstPrice = $cheapestPrice->getPrice()->first();
+        static::assertNotNull($firstPrice);
+        static::assertSame(100.0, $firstPrice->getGross());
+    }
+
+    public function testResolveWithNoMatchingSalesChannel(): void
+    {
+        $currentSalesChannelId = Uuid::randomHex();
+        $otherSalesChannelId = Uuid::randomHex();
+
+        $testData = [
+            'variant1' => [
+                'default' => [
+                    'price' => [
+                        ['currencyId' => Defaults::CURRENCY, 'gross' => 50.0, 'net' => 42.02, 'linked' => true],
+                    ],
+                    'sales_channel_ids' => [$otherSalesChannelId],
+                    'is_ranged' => false,
+                    'rule_id' => 'default',
+                    'parent_id' => 'parent1',
+                    'purchase_unit' => 1.0,
+                    'reference_unit' => 1.0,
+                ],
+            ],
+        ];
+
+        $context = new Context(
+            new SalesChannelApiSource($currentSalesChannelId),
+            [],
+            Defaults::CURRENCY,
+            [Defaults::LANGUAGE_SYSTEM],
+            Defaults::LIVE_VERSION,
+            1.0,
+            true,
+            CartPrice::TAX_STATE_GROSS
+        );
+
+        $container = new CheapestPriceContainer($testData);
+        $cheapestPrice = $container->resolve($context);
+
+        static::assertNull($cheapestPrice);
+    }
+}

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdaterTest.php
@@ -77,4 +77,105 @@ class CheapestPriceUpdaterTest extends TestCase
 
         $updater->update($parentIds, $context);
     }
+
+    public function testFetchPricesWithSalesChannelData(): void
+    {
+        $parentId = Uuid::randomHex();
+        $variantId = Uuid::randomHex();
+        $salesChannelId1 = Uuid::randomHex();
+        $salesChannelId2 = Uuid::randomHex();
+
+        $mockedData = [
+            [
+                'parent_id' => $parentId,
+                'variant_id' => $variantId,
+                'rule_id' => 'default',
+                'is_ranged' => 0,
+                'price' => '{"cb7d2554b0ce847cd82f3ac9bd1c0dfca": {"net": 16.806722689076, "gross": 20.0, "linked": true}}',
+                'min_purchase' => 1,
+                'unit_id' => null,
+                'purchase_unit' => null,
+                'reference_unit' => null,
+                'child_count' => null,
+                'sales_channel_ids' => $salesChannelId1 . ',' . $salesChannelId2,
+            ],
+        ];
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAllAssociative')->willReturn($mockedData);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+
+        $updater = new CheapestPriceUpdater(
+            $connection,
+            $this->createMock(AbstractCheapestPriceQuantitySelector::class),
+            $this->createMock(EventDispatcherInterface::class)
+        );
+
+        $reflection = new \ReflectionClass($updater);
+        $method = $reflection->getMethod('fetchPrices');
+        $method->setAccessible(true);
+
+        $prices = $method->invoke($updater, [$parentId], Context::createDefaultContext());
+
+        static::assertArrayHasKey($parentId, $prices);
+        static::assertArrayHasKey($variantId, $prices[$parentId]);
+        static::assertArrayHasKey('default', $prices[$parentId][$variantId]);
+
+        $salesChannelIds = $prices[$parentId][$variantId]['default']['sales_channel_ids'];
+        static::assertEquals([$salesChannelId1, $salesChannelId2], $salesChannelIds);
+    }
+
+    public function testFetchPricesWithEmptySalesChannelData(): void
+    {
+        $parentId = Uuid::randomHex();
+        $variantId = Uuid::randomHex();
+
+        $mockedData = [
+            [
+                'parent_id' => $parentId,
+                'variant_id' => $variantId,
+                'rule_id' => 'default',
+                'is_ranged' => 0,
+                'price' => '{"cb7d2554b0ce847cd82f3ac9bd1c0dfca": {"net": 16.806722689076, "gross": 20.0, "linked": true}}',
+                'min_purchase' => 1,
+                'unit_id' => null,
+                'purchase_unit' => null,
+                'reference_unit' => null,
+                'child_count' => null,
+                'sales_channel_ids' => '',
+            ],
+        ];
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAllAssociative')->willReturn($mockedData);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+
+        $quantitySelector = $this->createMock(AbstractCheapestPriceQuantitySelector::class);
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $updater = new CheapestPriceUpdater($connection, $quantitySelector, $dispatcher);
+
+        $reflection = new \ReflectionClass($updater);
+        $method = $reflection->getMethod('fetchPrices');
+        $method->setAccessible(true);
+
+        $prices = $method->invoke($updater, [$parentId], Context::createDefaultContext());
+
+        static::assertArrayHasKey($parentId, $prices);
+        static::assertArrayHasKey($variantId, $prices[$parentId]);
+        static::assertArrayHasKey('default', $prices[$parentId][$variantId]);
+
+        $salesChannelIds = $prices[$parentId][$variantId]['default']['sales_channel_ids'];
+        static::assertEquals([], $salesChannelIds);
+    }
 }

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdaterTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Shopware\Core\Content\Product\DataAbstractionLayer\AbstractCheapestPriceQuantitySelector;
@@ -20,51 +21,48 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[CoversClass(CheapestPriceUpdater::class)]
 class CheapestPriceUpdaterTest extends TestCase
 {
+    private Connection&MockObject $connection;
+
+    private QueryBuilder&MockObject $queryBuilder;
+
+    private AbstractCheapestPriceQuantitySelector&MockObject $quantitySelector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->queryBuilder->method('setParameter')->willReturnSelf();
+        $this->queryBuilder->method('select')->willReturnSelf();
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('innerJoin')->willReturnSelf();
+        $this->queryBuilder->method('leftJoin')->willReturnSelf();
+        $this->queryBuilder->method('andWhere')->willReturnSelf();
+
+        $this->quantitySelector = $this->createMock(AbstractCheapestPriceQuantitySelector::class);
+        $this->quantitySelector->method('add')->willReturnSelf();
+
+        $this->connection = $this->createMock(Connection::class);
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+    }
+
     public function testDispatchesProductIndexerEvent(): void
     {
         $parentId = Uuid::randomHex();
         $variantId = Uuid::randomHex();
 
         $mockedData = [
-            [
-                'parent_id' => $parentId,
-                'variant_id' => $variantId,
-                'rule_id' => null,
-                'is_ranged' => 0,
-                'price' => '{}',
-                'min_purchase' => 1,
-                'unit_id' => null,
-                'purchase_unit' => null,
-                'reference_unit' => null,
-                'child_count' => null,
-            ],
-            [
-                'parent_id' => $parentId,
-                'variant_id' => $parentId,
-                'rule_id' => null,
-                'is_ranged' => 0,
-                'price' => '{"cb7d2554b0ce847cd82f3ac9bd1c0dfca": {"net": 16.806722689076, "gross": 20.0, "linked": true, "listPrice": {"net": 84.033613445378, "gross": 100, "linked": true, "listPrice": null, "currencyId": "b7d2554b0ce847cd82f3ac9bd1c0dfca", "extensions": [], "percentage": null, "regulationPrice": null}, "currencyId": "b7d2554b0ce847cd82f3ac9bd1c0dfca", "percentage": {"net": 80.0, "gross": 80.0}, "regulationPrice": null}}',
-                'min_purchase' => 1,
-                'unit_id' => null,
-                'purchase_unit' => null,
-                'reference_unit' => null,
-                'child_count' => null,
-            ],
+            $this->createPriceRow($parentId, $variantId),
+            $this->createPriceRow(
+                $parentId,
+                $parentId,
+                null,
+                '{"cb7d2554b0ce847cd82f3ac9bd1c0dfca":{"net":16.806722689076,"gross":20,"linked":true,"listPrice":{"net":84.033613445378,"gross":100,"linked":true,"listPrice":null,"currencyId":"b7d2554b0ce847cd82f3ac9bd1c0dfca","extensions":[],"percentage":null,"regulationPrice":null},"currencyId":"b7d2554b0ce847cd82f3ac9bd1c0dfca","percentage":{"net":80,"gross":80},"regulationPrice":null}}'
+            ),
         ];
 
-        $result = $this->createMock(Result::class);
-        $result->method('fetchAllAssociative')->willReturn($mockedData);
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('executeQuery')->willReturn($result);
-
-        $connection = $this->createMock(Connection::class);
-        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
-
-        $quantitySelector = $this->createMock(AbstractCheapestPriceQuantitySelector::class);
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
-
-        $updater = new CheapestPriceUpdater($connection, $quantitySelector, $dispatcher);
+        $updater = $this->createMockedUpdater($mockedData, [], [], $dispatcher);
 
         $parentIds = [Uuid::randomHex()];
         $context = Context::createDefaultContext();
@@ -86,48 +84,24 @@ class CheapestPriceUpdaterTest extends TestCase
         $salesChannelId2 = Uuid::randomHex();
 
         $mockedData = [
+            $this->createPriceRow($parentId, $variantId, 'default', '{"cb7d2554b0ce847cd82f3ac9bd1c0dfca":{"net":16.806722689076,"gross":20,"linked":true}}'),
+        ];
+
+        $mockedVisibility = [
             [
-                'parent_id' => $parentId,
-                'variant_id' => $variantId,
-                'rule_id' => 'default',
-                'is_ranged' => 0,
-                'price' => '{"cb7d2554b0ce847cd82f3ac9bd1c0dfca": {"net": 16.806722689076, "gross": 20.0, "linked": true}}',
-                'min_purchase' => 1,
-                'unit_id' => null,
-                'purchase_unit' => null,
-                'reference_unit' => null,
-                'child_count' => null,
-                'sales_channel_ids' => $salesChannelId1 . ',' . $salesChannelId2,
+                'product_id' => $variantId,
+                'sales_channel_id' => $salesChannelId1,
+            ],
+            [
+                'product_id' => $variantId,
+                'sales_channel_id' => $salesChannelId2,
             ],
         ];
 
-        $result = $this->createMock(Result::class);
-        $result->method('fetchAllAssociative')->willReturn($mockedData);
+        $updater = $this->createMockedUpdater($mockedData, [], $mockedVisibility);
+        $prices = $this->invokeFetchPrices($updater, [$parentId], Context::createDefaultContext());
 
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('executeQuery')->willReturn($result);
-
-        $connection = $this->createMock(Connection::class);
-        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
-
-        $updater = new CheapestPriceUpdater(
-            $connection,
-            $this->createMock(AbstractCheapestPriceQuantitySelector::class),
-            $this->createMock(EventDispatcherInterface::class)
-        );
-
-        $reflection = new \ReflectionClass($updater);
-        $method = $reflection->getMethod('fetchPrices');
-        $method->setAccessible(true);
-
-        $prices = $method->invoke($updater, [$parentId], Context::createDefaultContext());
-
-        static::assertArrayHasKey($parentId, $prices);
-        static::assertArrayHasKey($variantId, $prices[$parentId]);
-        static::assertArrayHasKey('default', $prices[$parentId][$variantId]);
-
-        $salesChannelIds = $prices[$parentId][$variantId]['default']['sales_channel_ids'];
-        static::assertEquals([$salesChannelId1, $salesChannelId2], $salesChannelIds);
+        $this->assertSalesChannelIds($prices, $parentId, $variantId, [$salesChannelId1, $salesChannelId2]);
     }
 
     public function testFetchPricesWithEmptySalesChannelData(): void
@@ -136,46 +110,91 @@ class CheapestPriceUpdaterTest extends TestCase
         $variantId = Uuid::randomHex();
 
         $mockedData = [
-            [
-                'parent_id' => $parentId,
-                'variant_id' => $variantId,
-                'rule_id' => 'default',
-                'is_ranged' => 0,
-                'price' => '{"cb7d2554b0ce847cd82f3ac9bd1c0dfca": {"net": 16.806722689076, "gross": 20.0, "linked": true}}',
-                'min_purchase' => 1,
-                'unit_id' => null,
-                'purchase_unit' => null,
-                'reference_unit' => null,
-                'child_count' => null,
-                'sales_channel_ids' => '',
-            ],
+            $this->createPriceRow($parentId, $variantId, 'default', '{"cb7d2554b0ce847cd82f3ac9bd1c0dfca":{"net":16.806722689076,"gross":20,"linked":true}}'),
         ];
 
-        $result = $this->createMock(Result::class);
-        $result->method('fetchAllAssociative')->willReturn($mockedData);
+        $updater = $this->createMockedUpdater($mockedData, [], []);
+        $prices = $this->invokeFetchPrices($updater, [$parentId], Context::createDefaultContext());
 
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('executeQuery')->willReturn($result);
+        $this->assertSalesChannelIds($prices, $parentId, $variantId, []);
+    }
 
-        $connection = $this->createMock(Connection::class);
-        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+    /**
+     * @param array<int, array<string, mixed>> $dataResults
+     * @param array<int, array<string, mixed>> $defaultsResults
+     * @param array<int, array<string, mixed>> $visibilityResults
+     */
+    private function createMockedUpdater(array $dataResults, array $defaultsResults, array $visibilityResults, ?EventDispatcherInterface $dispatcher = null): CheapestPriceUpdater
+    {
+        $result1 = $this->createMock(Result::class);
+        $result1->method('fetchAllAssociative')->willReturn($dataResults);
 
-        $quantitySelector = $this->createMock(AbstractCheapestPriceQuantitySelector::class);
-        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $result2 = $this->createMock(Result::class);
+        $result2->method('fetchAllAssociative')->willReturn($defaultsResults);
 
-        $updater = new CheapestPriceUpdater($connection, $quantitySelector, $dispatcher);
+        $this->queryBuilder->method('executeQuery')->willReturnOnConsecutiveCalls($result1, $result2);
 
+        $this->connection->method('fetchAllAssociative')
+            ->willReturn($visibilityResults);
+
+        return new CheapestPriceUpdater(
+            $this->connection,
+            $this->quantitySelector,
+            $dispatcher ?? $this->createMock(EventDispatcherInterface::class)
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createPriceRow(string $parentId, string $variantId, ?string $ruleId = null, ?string $priceJson = null): array
+    {
+        return [
+            'parent_id' => $parentId,
+            'variant_id' => $variantId,
+            'rule_id' => $ruleId,
+            'is_ranged' => 0,
+            'price' => $priceJson ?? '{}',
+            'min_purchase' => 1,
+            'unit_id' => null,
+            'purchase_unit' => null,
+            'reference_unit' => null,
+            'child_count' => null,
+        ];
+    }
+
+    /**
+     * @param array<string> $parentIds
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private function invokeFetchPrices(CheapestPriceUpdater $updater, array $parentIds, Context $context): array
+    {
         $reflection = new \ReflectionClass($updater);
         $method = $reflection->getMethod('fetchPrices');
         $method->setAccessible(true);
 
-        $prices = $method->invoke($updater, [$parentId], Context::createDefaultContext());
+        return $method->invoke($updater, $parentIds, $context);
+    }
 
+    /**
+     * @param array<string, array<string, array<string, mixed>>> $prices
+     * @param array<string> $expectedSalesChannelIds
+     */
+    private function assertSalesChannelIds(array $prices, string $parentId, string $variantId, array $expectedSalesChannelIds): void
+    {
         static::assertArrayHasKey($parentId, $prices);
-        static::assertArrayHasKey($variantId, $prices[$parentId]);
-        static::assertArrayHasKey('default', $prices[$parentId][$variantId]);
+        static::assertArrayHasKey($variantId, $prices[$parentId], 'Variant should exist in prices');
 
-        $salesChannelIds = $prices[$parentId][$variantId]['default']['sales_channel_ids'];
-        static::assertEquals([], $salesChannelIds);
+        $variantPrices = $prices[$parentId][$variantId];
+        foreach ($variantPrices as $ruleData) {
+            if (\is_array($ruleData) && isset($ruleData['sales_channel_ids'])) {
+                static::assertEquals($expectedSalesChannelIds, $ruleData['sales_channel_ids']);
+
+                return;
+            }
+        }
+
+        static::fail('Should have variant entry with sales_channel_ids');
     }
 }


### PR DESCRIPTION
This pull request enhances how the cheapest price for variant products is determined across different sales channels. The main improvement ensures that price calculations and availability checks for product variants now consider the sales channels where each variant is visible, resulting in more accurate pricing and product selection for customers in multi-channel setups. The changes introduce new logic for extracting and processing sales channel IDs, update SQL queries to collect sales channel data, and add comprehensive unit tests for these new behaviors.

**Cheapest price calculation and sales channel handling:**

* Updated `CheapestPriceContainer::resolve` to filter out product variants not available in the current sales channel, ensuring only relevant variants are considered for cheapest price selection.
* Added helper methods `extractSalesChannelId` and `isVariantAvailableInSalesChannel` to `CheapestPriceContainer`, enabling robust extraction and checking of sales channel IDs from context and variant data.

**Cheapest price updater and data processing:**

* Modified SQL queries in `CheapestPriceUpdater::fetchPrices` to join with the `product_visibility` table and aggregate sales channel IDs for each price, grouping results accordingly. [[1]](diffhunk://#diff-d1fa21da4ce6ba5d7ca0e598e286b86d386985d37777ad11cd890d9a635af929R189-R216) [[2]](diffhunk://#diff-d1fa21da4ce6ba5d7ca0e598e286b86d386985d37777ad11cd890d9a635af929R259-R283)
* Post-processed fetched price data to parse and assign sales channel IDs to each variant/rule combination, ensuring downstream logic can access this information. [[1]](diffhunk://#diff-d1fa21da4ce6ba5d7ca0e598e286b86d386985d37777ad11cd890d9a635af929R232-R246) [[2]](diffhunk://#diff-d1fa21da4ce6ba5d7ca0e598e286b86d386985d37777ad11cd890d9a635af929R307-R328)
