### PR TITLE
fix: Apply default indentation for composer.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,11 +16,11 @@ insert_final_newline = true
 [*.json]
 indent_size = 2
 
-[config-schema.json]
+[composer.json]
 indent_size = 4
 
-[*.md]
-trim_trailing_whitespace = false
+[config-schema.json]
+indent_size = 4
 
 [*.nix]
 indent_size = 2

--- a/composer.json
+++ b/composer.json
@@ -1,514 +1,514 @@
 {
-  "name": "shopware/platform",
-  "description": "The Shopware e-commerce core",
-  "type": "library",
-  "keywords": [
-    "framework",
-    "shopware"
-  ],
-  "homepage": "https://www.shopware.com",
-  "license": "MIT",
-  "replace": {
-    "shopware/core": "self.version",
-    "shopware/storefront": "self.version",
-    "shopware/administration": "self.version",
-    "shopware/elasticsearch": "self.version",
-    "symfony/polyfill-ctype": "*",
-    "symfony/polyfill-iconv": "*",
-    "symfony/polyfill-mbstring": "*",
-    "symfony/polyfill-intl-grapheme": "*",
-    "symfony/polyfill-intl-idn": "*",
-    "symfony/polyfill-intl-normalizer": "*",
-    "symfony/polyfill-php72": "*",
-    "symfony/polyfill-php73": "*",
-    "symfony/polyfill-php74": "*",
-    "symfony/polyfill-php80": "*",
-    "symfony/polyfill-php81": "*",
-    "symfony/polyfill-php82": "*",
-    "paragonie/random_compat": ">=2"
-  },
-  "support": {
-    "issues": "https://github.com/shopware/shopware/issues",
-    "forum": "https://forum.shopware.com",
-    "wiki": "https://developer.shopware.com",
-    "docs": "https://developer.shopware.com",
-    "chat": "https://chat.shopware.com/"
-  },
-  "extra": {
-    "bamarni-bin": {
-      "bin-links": false,
-      "forward-command": false
+    "name": "shopware/platform",
+    "description": "The Shopware e-commerce core",
+    "type": "library",
+    "keywords": [
+        "framework",
+        "shopware"
+    ],
+    "homepage": "https://www.shopware.com",
+    "license": "MIT",
+    "replace": {
+        "shopware/core": "self.version",
+        "shopware/storefront": "self.version",
+        "shopware/administration": "self.version",
+        "shopware/elasticsearch": "self.version",
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-mbstring": "*",
+        "symfony/polyfill-intl-grapheme": "*",
+        "symfony/polyfill-intl-idn": "*",
+        "symfony/polyfill-intl-normalizer": "*",
+        "symfony/polyfill-php72": "*",
+        "symfony/polyfill-php73": "*",
+        "symfony/polyfill-php74": "*",
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php82": "*",
+        "paragonie/random_compat": ">=2"
     },
-    "branch-alias": {
-      "dev-master": "6.7.x-dev",
-      "dev-trunk": "6.7.x-dev"
+    "support": {
+        "issues": "https://github.com/shopware/shopware/issues",
+        "forum": "https://forum.shopware.com",
+        "wiki": "https://developer.shopware.com",
+        "docs": "https://developer.shopware.com",
+        "chat": "https://chat.shopware.com/"
     },
-    "phpstan/extension-installer": {
-      "ignore": [
-        "composer/pcre"
-      ]
+    "extra": {
+        "bamarni-bin": {
+            "bin-links": false,
+            "forward-command": false
+        },
+        "branch-alias": {
+            "dev-master": "6.7.x-dev",
+            "dev-trunk": "6.7.x-dev"
+        },
+        "phpstan/extension-installer": {
+            "ignore": [
+                "composer/pcre"
+            ]
+        }
+    },
+    "config": {
+        "audit": {
+            "abandoned": "report"
+        },
+        "sort-packages": true,
+        "process-timeout": 7200,
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true,
+            "composer/package-versions-deprecated": true,
+            "cweagans/composer-patches": true,
+            "php-http/discovery": false,
+            "phpstan/extension-installer": true,
+            "symfony/runtime": true
+        }
+    },
+    "require": {
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+        "ext-curl": "*",
+        "ext-dom": "*",
+        "ext-fileinfo": "*",
+        "ext-gd": "*",
+        "ext-intl": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-openssl": "*",
+        "ext-pdo": "*",
+        "ext-pdo_mysql": "*",
+        "ext-session": "*",
+        "ext-simplexml": "*",
+        "ext-sodium": "*",
+        "ext-xml": "*",
+        "ext-zip": "*",
+        "ext-zlib": "*",
+        "composer-runtime-api": "^2.1",
+        "async-aws/core": "^1.22",
+        "cocur/slugify": "^4.3.0",
+        "composer/composer": "^2.8.5",
+        "composer/semver": "^3.4.0",
+        "doctrine/dbal": "^4.3.1",
+        "doctrine/inflector": "^2.0",
+        "dompdf/dompdf": "3.1.0",
+        "dragonmantank/cron-expression": "^3.3",
+        "ezyang/htmlpurifier": "^4.16",
+        "guzzlehttp/guzzle": "^7.5.0",
+        "guzzlehttp/psr7": "^2.4",
+        "horstoeko/zugferd": "^1.0.104",
+        "lcobucci/clock": "^3.1.0",
+        "lcobucci/jwt": "^5.5",
+        "league/flysystem": "^3.13.0",
+        "league/flysystem-local": "^3.29.0",
+        "league/flysystem-memory": "^3.10.3",
+        "league/mime-type-detection": "^1.13.0",
+        "league/oauth2-server": "^9.1",
+        "meyfa/php-svg": "^0.16.1",
+        "monolog/monolog": "^3.3.1",
+        "nyholm/psr7": "^1.5",
+        "opensearch-project/opensearch-php": "^2.3.1",
+        "pentatrion/vite-bundle": "^8.1",
+        "phpseclib/phpseclib": "^3.0",
+        "psr/cache": "^3.0.0",
+        "psr/event-dispatcher": "^1.0.0",
+        "psr/http-factory": "^1.0.1",
+        "psr/http-message": "^1.1 || ^2.0",
+        "psr/log": "^3.0.0",
+        "psr/simple-cache": "^3.0.0",
+        "ramsey/uuid": "^4.7",
+        "scssphp/scssphp": "v1.12.0",
+        "setasign/fpdi": "^2.3.7",
+        "setasign/tfpdf": "^1.33",
+        "shopware/conflicts": "0.6.0",
+        "shyim/opensearch-php-dsl": "^1.0.5",
+        "squirrelphp/twig-php-syntax": "^1.13.0",
+        "symfony/asset": "~7.3.0",
+        "symfony/cache": "~7.3.0",
+        "symfony/cache-contracts": "~3.6.0",
+        "symfony/clock": "~7.3.0",
+        "symfony/config": "~7.3.0",
+        "symfony/console": "~7.3.0",
+        "symfony/debug-bundle": "~7.3.0",
+        "symfony/dependency-injection": "~7.3.0",
+        "symfony/deprecation-contracts": "~3.6.0",
+        "symfony/doctrine-messenger": "~7.3.0",
+        "symfony/dotenv": "~7.3.0",
+        "symfony/error-handler": "~7.3.0",
+        "symfony/event-dispatcher": "~7.3.0",
+        "symfony/event-dispatcher-contracts": "~3.6.0",
+        "symfony/filesystem": "~7.3.0",
+        "symfony/finder": "~7.3.0",
+        "symfony/framework-bundle": "~7.3.0",
+        "symfony/http-client": "~7.3.0",
+        "symfony/http-client-contracts": "~3.6.0",
+        "symfony/http-foundation": "~7.3.0",
+        "symfony/http-kernel": "~7.3.0",
+        "symfony/intl": "~7.3.0",
+        "symfony/lock": "~7.3.0",
+        "symfony/mailer": "~7.3.0",
+        "symfony/messenger": "~7.3.0",
+        "symfony/mime": "~7.3.0",
+        "symfony/monolog-bridge": "~7.3.0",
+        "symfony/monolog-bundle": "~3.10.0",
+        "symfony/options-resolver": "~7.3.0",
+        "symfony/polyfill-php83": ">=1.31.0",
+        "symfony/polyfill-php84": ">=1.31.0",
+        "symfony/process": "~7.3.0",
+        "symfony/property-access": "~7.3.0",
+        "symfony/property-info": "~7.3.0",
+        "symfony/proxy-manager-bridge": "~6.4.8",
+        "symfony/psr-http-message-bridge": "~7.3.0",
+        "symfony/rate-limiter": "~7.3.0",
+        "symfony/routing": "~7.3.0",
+        "symfony/runtime": "~7.3.0",
+        "symfony/scheduler": "~7.3.0",
+        "symfony/security-core": "~7.3.0",
+        "symfony/serializer": "~7.3.0",
+        "symfony/service-contracts": "~3.6.0",
+        "symfony/stopwatch": "~7.3.0",
+        "symfony/string": "~7.3.0",
+        "symfony/translation": "~7.3.0",
+        "symfony/translation-contracts": "~3.6.0",
+        "symfony/twig-bridge": "~7.3.0",
+        "symfony/twig-bundle": "~7.3.0",
+        "symfony/validator": "~7.3.0",
+        "symfony/var-exporter": "~7.3.0",
+        "symfony/yaml": "~7.3.0",
+        "twig/intl-extra": "^3.10.0",
+        "twig/string-extra": "^3.10.0",
+        "twig/twig": "^3.21.1",
+        "zircote/swagger-php": "^4.9.2"
+    },
+    "require-dev": {
+        "ext-tokenizer": "*",
+        "ext-xmlwriter": "*",
+        "bamarni/composer-bin-plugin": "^1.8.2",
+        "dominikb/composer-license-checker": "^2.5",
+        "ergebnis/phpunit-slow-test-detector": "^2.4",
+        "friendsofphp/php-cs-fixer": "3.82.1",
+        "jdorn/sql-formatter": "^1.2.17",
+        "league/construct-finder": "^1.1",
+        "league/flysystem-async-aws-s3": "^3.29.0",
+        "league/flysystem-google-cloud-storage": "^3.10.3",
+        "nikic/php-parser": "^5.4.0",
+        "opis/json-schema": "^2.3.0",
+        "phpat/phpat": "0.12.0",
+        "phpbench/phpbench": "^1.2.15",
+        "phpdocumentor/reflection-docblock": "^5.3.0",
+        "phpdocumentor/type-resolver": "^1.7.1",
+        "phpstan/extension-installer": "^1.4.3",
+        "phpstan/phpdoc-parser": "^2.0.0",
+        "phpstan/phpstan": "2.1.18",
+        "phpstan/phpstan-deprecation-rules": "2.0.3",
+        "phpstan/phpstan-phpunit": "2.0.6",
+        "phpstan/phpstan-strict-rules": "2.0.4",
+        "phpstan/phpstan-symfony": "2.0.6",
+        "phpunit/phpunit": "^11.5.19",
+        "predis/predis": "^2.2",
+        "rector/type-perfect": "2.1.0",
+        "shopware/dev-tools": "^1.3",
+        "smalot/pdfparser": "^2.2.2",
+        "symfony/browser-kit": "~7.3.0",
+        "symfony/css-selector": "~7.3.0",
+        "symfony/dom-crawler": "~7.3.0",
+        "symfony/expression-language": "~7.3.0",
+        "symfony/phpunit-bridge": "~7.3.0",
+        "symfony/var-dumper": "~7.3.0",
+        "symfony/web-profiler-bundle": "~7.3.0",
+        "symplify/phpstan-rules": "14.6.11"
+    },
+    "suggest": {
+        "shopware/dev-tools": "For development tools, profiler, faker, etc",
+        "league/flysystem-async-aws-s3": "Required to use the Flysystem S3 driver (^3.10.3)",
+        "league/flysystem-google-cloud-storage": "Required to use the Flysystem Google cloud driver (^3.10.3)"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "custom/plugins/*",
+            "options": {
+                "symlink": true
+            }
+        },
+        {
+            "type": "path",
+            "url": "custom/static-plugins/*",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
+    "scripts-descriptions": {
+        "admin:code-mods": "Run admin code mods",
+        "admin:create:test": "Create a admin test blueprint",
+        "admin:generate-data-set-list": "Generate the list of all data sets. Used to track breaking changes.",
+        "admin:generate-entity-schema-types": "Generate the Typescript definition for the entity schema",
+        "admin:generate-position-identifier-list": "Generate the list of all position identifiers. Used to track breaking changes.",
+        "admin:unit": "Launches the jest unit test-suite for the Admin",
+        "admin:unit:watch": "Launches the interactive jest unit test-suite watcher for the Admin",
+        "bc-check": "Checks for backwards compatibility breaks in the current branch",
+        "build:js": "Builds Administration & Storefront",
+        "build:js:admin": "Builds the Administration",
+        "build:js:component-library": "Builds the component library",
+        "build:js:storefront": "Builds the Storefront's JavaScript",
+        "check:license": "Check thrid-party dependency licenses",
+        "ecs": "Checks all files regarding the PHP-CS-Fixer",
+        "ecs-fix": "Checks all files regarding the PHP-CS-Fixer and fixes them if possible",
+        "eslint": "Codestyle checks all (Administration/Storefront) JS/TS files",
+        "eslint:admin": "Codestyle checks Administration JS/TS files",
+        "eslint:admin:fix": "Codestyle checks Administration JS/TS files and fixes them if possible",
+        "eslint:storefront": "Codestyle checks all Storefront JS/TS files",
+        "eslint:storefront:fix": "Codestyle checks all Storefront JS/TS files and fixes them if possible",
+        "format:admin": "Dry run Prettier for the Administration",
+        "format:admin:fix": "Format the Administration with Prettier",
+        "framework:schema:dump": " ",
+        "hook:pre-commit": " ",
+        "hook:pre-commit:install": " ",
+        "hook:pre-push": " ",
+        "hook:pre-push:install": " ",
+        "init:db": " ",
+        "init:js": " ",
+        "init:testdb": "Initializes the test database",
+        "lint": "Shorthand for the composer commands 'stylelint', 'eslint', 'ecs', 'lint:changelog' and 'lint:snippets'",
+        "lint:changelog": "Validates changelogs",
+        "lint:snippets": "Validates existence of snippets in all core-supported languages",
+        "ludtwig:storefront": "Codestyle checks for all Storefront twig files using ludtwig",
+        "ludtwig:storefront:fix": "Auto-fixes all fixable twig codestyle in Storefront",
+        "make:coverage": "Generate test coverage files for current branch",
+        "npm:admin": " ",
+        "npm:admin:bin": " ",
+        "npm:admin:check-license": "Check thrid-party dependency licenses for administration",
+        "npm:component-library": " ",
+        "npm:component-library:bin": " ",
+        "npm:storefront": " ",
+        "npm:storefront:bin": " ",
+        "npm:storefront:check-license": "Check thrid-party dependency licenses for storefront",
+        "phpbench": " ",
+        "phpstan": "Launches the PHP static analysis tool",
+        "phpstan-errors-by-area": "Shows the ignored errors defined in the phpstan-baseline.neon by area",
+        "phpunit": "Launches the PHP unit test-suite",
+        "post-install-cmd": " ",
+        "post-update-cmd": " ",
+        "reset": "Resets this Shopware instance, without composer and npm install. (Faster reset if no dependencies changed)",
+        "setup": "Resets and re-installs this Shopware instance",
+        "static-analyze": "Launches the PHP Stan static analysis tool",
+        "storefront:unit": "Launches the jest unit test-suite for the Storefront",
+        "storefront:unit:watch": "Launches the interactive jest unit test-suite watcher for the Storefront",
+        "stylelint": "Codestyle checks all SCSS files of Administration and Storefront",
+        "stylelint:admin": "Code Style checks for all Admin SCSS files",
+        "stylelint:admin:fix": "Code Style checks for all Admin SCSS files and fixes them if possible",
+        "stylelint:storefront": "Code Style checks for all Storefront SCSS files",
+        "stylelint:storefront:fix": "Code Style checks for all Storefront SCSS files and fixes them if possible",
+        "translation:lint-filenames": "Validates snippet filesnames",
+        "translation:lint-filenames:fix": "Validates snippet filesnames and migrates them if necessary",
+        "translation:install": "Downloads and installs translations from the translations GitHub repository",
+        "translation:lint": "Validates existence of snippets in all core-supported languages",
+        "translation:update": "Updates all installed translations from the translations GitHub repository",
+        "watch:admin": "Enables hot module reloading for the Admin",
+        "watch:storefront": "Enables hot module reloading for the Storefront"
+    },
+    "scripts": {
+        "admin:code-mods": "@npm:admin run code-mods --",
+        "admin:create:test": "@npm:admin run create-test",
+        "admin:generate-data-set-list": [
+            "@npm:admin run generate-data-set-list"
+        ],
+        "admin:generate-entity-schema-types": [
+            "@framework:schema:dump",
+            "@npm:admin run convert-entity-schema"
+        ],
+        "admin:generate-position-identifier-list": [
+            "@npm:admin run generate-position-identifier-list"
+        ],
+        "admin:unit": [
+            "Composer\\Config::disableProcessTimeout",
+            "@framework:schema:dump",
+            "@npm:admin run unit-setup",
+            "@npm:admin run unit"
+        ],
+        "admin:unit:watch": [
+            "Composer\\Config::disableProcessTimeout",
+            "@framework:schema:dump",
+            "@npm:admin run unit-setup",
+            "@npm:admin run unit-watch"
+        ],
+        "bc-check": [
+            "@php vendor-bin/roave-backward-compatibility-check/bin/verify-version.php",
+            "roave-backward-compatibility-check --install-development-dependencies --from=$(git tag -l --sort -version:refname | grep \"^v$(sed -n 's/.*\"dev-trunk\": \"\\([0-9]*\\.[0-9]*\\).*\"/\\1/p' composer.json).\" | head -n 1)"
+        ],
+        "build:js": [
+            "@build:js:admin",
+            "@build:js:storefront"
+        ],
+        "build:js:admin": [
+            "@php bin/console bundle:dump",
+            "@php bin/console feature:dump",
+            "@admin:generate-entity-schema-types",
+            "@npm:admin run build",
+            "@php bin/console assets:install"
+        ],
+        "build:js:component-library": [
+            "@npm:component-library run generate"
+        ],
+        "build:js:storefront": [
+            "@php bin/console bundle:dump",
+            "@php bin/console feature:dump",
+            "@npm:storefront run production",
+            "cd src/Storefront/Resources/app/storefront && node copy-to-vendor.js",
+            "@php bin/console theme:compile --sync || true",
+            "@php bin/console assets:install"
+        ],
+        "check:license": "bash -c \"vendor/bin/composer-license-checker check -a $(sed -z 's/\\n/ -a /g' .allowed-licenses)\"",
+        "ecs": "php-cs-fixer fix --dry-run --diff",
+        "ecs-fix": "php-cs-fixer fix",
+        "eslint": [
+            "@eslint:admin",
+            "@eslint:storefront"
+        ],
+        "eslint:admin": "@npm:admin run lint:all",
+        "eslint:admin:fix": "@npm:admin run lint:fix",
+        "eslint:storefront": "@npm:storefront run lint:js",
+        "eslint:storefront:fix": "@npm:storefront run lint:js:fix",
+        "format:admin": "@npm:admin run format",
+        "format:admin:fix": "@npm:admin run format:fix",
+        "framework:schema:dump": "@php bin/console -e prod framework:schema -s 'entity-schema' src/Administration/Resources/app/administration/test/_mocks_/entity-schema.json",
+        "hook:pre-commit": [
+            "bin/pre-commit"
+        ],
+        "hook:pre-commit:install": [
+            "ln -sf $PWD/bin/pre-commit .git/hooks/pre-commit"
+        ],
+        "hook:pre-push": [
+            "bin/pre-commit"
+        ],
+        "hook:pre-push:install": [
+            "ln -sf $PWD/bin/pre-push .git/hooks/pre-push"
+        ],
+        "init:db": [
+            "@php bin/console system:install --drop-database --basic-setup --force --no-assign-theme"
+        ],
+        "init:js": [
+            "@npm:admin clean-install --no-audit --prefer-offline",
+            "@npm:storefront clean-install --no-audit --prefer-offline",
+            "export PROJECT_ROOT=\"$PWD\"; \"$PROJECT_ROOT\"/bin/install-extension-npm"
+        ],
+        "init:testdb": [
+            "@putenv FORCE_INSTALL=true",
+            "vendor/bin/phpunit --group=none --testsuite migration,unit,integration,devops"
+        ],
+        "lint": [
+            "@stylelint",
+            "@eslint",
+            "@ecs",
+            "@lint:changelog",
+            "@lint:snippets"
+        ],
+        "lint:changelog": "@php bin/shopware changelog:check",
+        "lint:snippets": "@translation:validate",
+        "ludtwig:storefront": "cd ./src/Storefront/Resources/views; ludtwig .",
+        "ludtwig:storefront:fix": "@ludtwig:storefront --fix",
+        "make:coverage": [
+            "@php bin/console make:coverage $(git diff --name-only origin/trunk -- \"*.php\" | grep -vE 'Test\\.php$' | sed 's/.*/\"&\"/' | tr '\\n' ' ')"
+        ],
+        "npm:admin": "@npm:admin:bin npm",
+        "npm:admin:bin": "export PROJECT_ROOT=\"$PWD\"; cd src/Administration/Resources/app/administration; export PATH=\"$PWD/node_modules/.bin/:$PATH\"; \"$PROJECT_ROOT\"/bin/exec-with-env ",
+        "npm:admin:check-license": "export ALLOWED_LICENSES=\"$(sed -z 's/\\n/;/g' .allowed-licenses)\"; cd src/Administration/Resources/app/administration; bash -c \"node_modules/.bin/license-checker-rseidelsohn --onlyAllow \\\"$ALLOWED_LICENSES\\\" --excludePrivatePackages\"",
+        "npm:component-library": "@npm:component-library:bin npm",
+        "npm:component-library:bin": "export PROJECT_ROOT=\"$PWD\"; cd src/Administration/Resources/app/administration/build/nuxt-component-library; export PATH=\"$PWD/node_modules/.bin/:$PATH\"; \"$PROJECT_ROOT\"/bin/exec-with-env ",
+        "npm:storefront": "@npm:storefront:bin npm",
+        "npm:storefront:bin": "export PROJECT_ROOT=\"$PWD\"; cd src/Storefront/Resources/app/storefront; export PATH=\"$PWD/node_modules/.bin/:$PATH\"; \"$PROJECT_ROOT\"/bin/exec-with-env ",
+        "npm:storefront:check-license": "export ALLOWED_LICENSES=\"$(sed -z 's/\\n/;/g' .allowed-licenses)\"; cd src/Storefront/Resources/app/storefront; bash -c \"node_modules/.bin/license-checker-rseidelsohn --onlyAllow \\\"$ALLOWED_LICENSES\\\" --excludePrivatePackages\"",
+        "phpbench": "phpbench run --report=compressed",
+        "phpstan": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
+            "phpstan analyze --memory-limit=2G -vv"
+        ],
+        "phpstan-errors-by-area": [
+            "php src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php phpstan-baseline.neon"
+        ],
+        "phpunit": [
+            "phpunit"
+        ],
+        "post-install-cmd": [
+            "@composer bin all install --ansi",
+            "ln -sf ./../../vendor-bin/roave-backward-compatibility-check/vendor/bin/roave-backward-compatibility-check vendor/bin/roave-backward-compatibility-check"
+        ],
+        "post-update-cmd": [
+            "@composer bin all update --ansi",
+            "ln -sf ./../../vendor-bin/roave-backward-compatibility-check/vendor/bin/roave-backward-compatibility-check vendor/bin/roave-backward-compatibility-check"
+        ],
+        "reset": [
+            "@init:db",
+            "@build:js",
+            "@php bin/console theme:change --sync --all Storefront",
+            "@php bin/console assets:install"
+        ],
+        "setup": [
+            "@composer install -o",
+            "mkdir -p custom/plugins || true",
+            "@init:db",
+            "@init:js",
+            "@build:js",
+            "@php bin/console theme:change --sync --all Storefront",
+            "@php bin/console assets:install"
+        ],
+        "static-analyze": [
+            "@phpstan src/"
+        ],
+        "storefront:unit": [
+            "@npm:storefront run unit"
+        ],
+        "storefront:unit:watch": [
+            "Composer\\Config::disableProcessTimeout",
+            "@npm:storefront run unit-watch"
+        ],
+        "stylelint": [
+            "@stylelint:admin src/**/*.scss",
+            "@stylelint:storefront src/**/*.scss"
+        ],
+        "stylelint:admin": "@npm:admin run lint:scss",
+        "stylelint:admin:fix": "@npm:admin run lint:scss-fix",
+        "stylelint:storefront": "@npm:storefront run lint:scss",
+        "stylelint:storefront:fix": "@npm:storefront run lint:scss-fix",
+        "translation:lint-filenames": "php bin/shopware translation:lint-filenames",
+        "translation:lint-filenames:fix": "php bin/shopware translation:lint-filenames --fix",
+        "translation:install": "php bin/shopware translation:install",
+        "translation:lint": "@php bin/shopware translation:validate",
+        "translation:update": "php bin/shopware translation:update",
+        "watch:admin": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php bin/console feature:dump",
+            "@php bin/console bundle:dump",
+            "@admin:generate-entity-schema-types",
+            "@npm:admin run dev"
+        ],
+        "watch:storefront": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php bin/console bundle:dump",
+            "@php bin/console feature:dump",
+            "@php bin/console theme:dump",
+            "@npm:storefront run hot-proxy"
+        ]
+    },
+    "autoload": {
+        "files": [
+            "src/Core/Framework/Adapter/Doctrine/Patch/AbstractAsset.php"
+        ],
+        "psr-4": {
+            "Shopware\\": "src/"
+        },
+        "exclude-from-classmap": [
+            "tests/"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Shopware\\Tests\\Examples\\": "tests/examples/",
+            "Shopware\\Tests\\Unit\\": "tests/unit/",
+            "Shopware\\Tests\\Integration\\": "tests/integration/",
+            "Shopware\\Tests\\Bench\\": "tests/performance/bench/",
+            "Shopware\\Tests\\Migration\\": "tests/migration/",
+            "Shopware\\Tests\\DevOps\\": "tests/devops/"
+        }
     }
-  },
-  "config": {
-    "audit": {
-      "abandoned": "report"
-    },
-    "sort-packages": true,
-    "process-timeout": 7200,
-    "allow-plugins": {
-      "bamarni/composer-bin-plugin": true,
-      "composer/package-versions-deprecated": true,
-      "cweagans/composer-patches": true,
-      "php-http/discovery": false,
-      "phpstan/extension-installer": true,
-      "symfony/runtime": true
-    }
-  },
-  "require": {
-    "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-    "ext-curl": "*",
-    "ext-dom": "*",
-    "ext-fileinfo": "*",
-    "ext-gd": "*",
-    "ext-intl": "*",
-    "ext-json": "*",
-    "ext-mbstring": "*",
-    "ext-openssl": "*",
-    "ext-pdo": "*",
-    "ext-pdo_mysql": "*",
-    "ext-session": "*",
-    "ext-simplexml": "*",
-    "ext-sodium": "*",
-    "ext-xml": "*",
-    "ext-zip": "*",
-    "ext-zlib": "*",
-    "composer-runtime-api": "^2.1",
-    "async-aws/core": "^1.22",
-    "cocur/slugify": "^4.3.0",
-    "composer/composer": "^2.8.5",
-    "composer/semver": "^3.4.0",
-    "doctrine/dbal": "^4.3.1",
-    "doctrine/inflector": "^2.0",
-    "dompdf/dompdf": "3.1.0",
-    "dragonmantank/cron-expression": "^3.3",
-    "ezyang/htmlpurifier": "^4.16",
-    "guzzlehttp/guzzle": "^7.5.0",
-    "guzzlehttp/psr7": "^2.4",
-    "horstoeko/zugferd": "^1.0.104",
-    "lcobucci/clock": "^3.1.0",
-    "lcobucci/jwt": "^5.5",
-    "league/flysystem": "^3.13.0",
-    "league/flysystem-local": "^3.29.0",
-    "league/flysystem-memory": "^3.10.3",
-    "league/mime-type-detection": "^1.13.0",
-    "league/oauth2-server": "^9.1",
-    "meyfa/php-svg": "^0.16.1",
-    "monolog/monolog": "^3.3.1",
-    "nyholm/psr7": "^1.5",
-    "opensearch-project/opensearch-php": "^2.3.1",
-    "pentatrion/vite-bundle": "^8.1",
-    "phpseclib/phpseclib": "^3.0",
-    "psr/cache": "^3.0.0",
-    "psr/event-dispatcher": "^1.0.0",
-    "psr/http-factory": "^1.0.1",
-    "psr/http-message": "^1.1 || ^2.0",
-    "psr/log": "^3.0.0",
-    "psr/simple-cache": "^3.0.0",
-    "ramsey/uuid": "^4.7",
-    "scssphp/scssphp": "v1.12.0",
-    "setasign/fpdi": "^2.3.7",
-    "setasign/tfpdf": "^1.33",
-    "shopware/conflicts": "0.6.0",
-    "shyim/opensearch-php-dsl": "^1.0.5",
-    "squirrelphp/twig-php-syntax": "^1.13.0",
-    "symfony/asset": "~7.3.0",
-    "symfony/cache": "~7.3.0",
-    "symfony/cache-contracts": "~3.6.0",
-    "symfony/clock": "~7.3.0",
-    "symfony/config": "~7.3.0",
-    "symfony/console": "~7.3.0",
-    "symfony/debug-bundle": "~7.3.0",
-    "symfony/dependency-injection": "~7.3.0",
-    "symfony/deprecation-contracts": "~3.6.0",
-    "symfony/doctrine-messenger": "~7.3.0",
-    "symfony/dotenv": "~7.3.0",
-    "symfony/error-handler": "~7.3.0",
-    "symfony/event-dispatcher": "~7.3.0",
-    "symfony/event-dispatcher-contracts": "~3.6.0",
-    "symfony/filesystem": "~7.3.0",
-    "symfony/finder": "~7.3.0",
-    "symfony/framework-bundle": "~7.3.0",
-    "symfony/http-client": "~7.3.0",
-    "symfony/http-client-contracts": "~3.6.0",
-    "symfony/http-foundation": "~7.3.0",
-    "symfony/http-kernel": "~7.3.0",
-    "symfony/intl": "~7.3.0",
-    "symfony/lock": "~7.3.0",
-    "symfony/mailer": "~7.3.0",
-    "symfony/messenger": "~7.3.0",
-    "symfony/mime": "~7.3.0",
-    "symfony/monolog-bridge": "~7.3.0",
-    "symfony/monolog-bundle": "~3.10.0",
-    "symfony/options-resolver": "~7.3.0",
-    "symfony/polyfill-php83": ">=1.31.0",
-    "symfony/polyfill-php84": ">=1.31.0",
-    "symfony/process": "~7.3.0",
-    "symfony/property-access": "~7.3.0",
-    "symfony/property-info": "~7.3.0",
-    "symfony/proxy-manager-bridge": "~6.4.8",
-    "symfony/psr-http-message-bridge": "~7.3.0",
-    "symfony/rate-limiter": "~7.3.0",
-    "symfony/routing": "~7.3.0",
-    "symfony/runtime": "~7.3.0",
-    "symfony/scheduler": "~7.3.0",
-    "symfony/security-core": "~7.3.0",
-    "symfony/serializer": "~7.3.0",
-    "symfony/service-contracts": "~3.6.0",
-    "symfony/stopwatch": "~7.3.0",
-    "symfony/string": "~7.3.0",
-    "symfony/translation": "~7.3.0",
-    "symfony/translation-contracts": "~3.6.0",
-    "symfony/twig-bridge": "~7.3.0",
-    "symfony/twig-bundle": "~7.3.0",
-    "symfony/validator": "~7.3.0",
-    "symfony/var-exporter": "~7.3.0",
-    "symfony/yaml": "~7.3.0",
-    "twig/intl-extra": "^3.10.0",
-    "twig/string-extra": "^3.10.0",
-    "twig/twig": "^3.21.1",
-    "zircote/swagger-php": "^4.9.2"
-  },
-  "require-dev": {
-    "ext-tokenizer": "*",
-    "ext-xmlwriter": "*",
-    "bamarni/composer-bin-plugin": "^1.8.2",
-    "dominikb/composer-license-checker": "^2.5",
-    "ergebnis/phpunit-slow-test-detector": "^2.4",
-    "friendsofphp/php-cs-fixer": "3.82.1",
-    "jdorn/sql-formatter": "^1.2.17",
-    "league/construct-finder": "^1.1",
-    "league/flysystem-async-aws-s3": "^3.29.0",
-    "league/flysystem-google-cloud-storage": "^3.10.3",
-    "nikic/php-parser": "^5.4.0",
-    "opis/json-schema": "^2.3.0",
-    "phpat/phpat": "0.12.0",
-    "phpbench/phpbench": "^1.2.15",
-    "phpdocumentor/reflection-docblock": "^5.3.0",
-    "phpdocumentor/type-resolver": "^1.7.1",
-    "phpstan/extension-installer": "^1.4.3",
-    "phpstan/phpdoc-parser": "^2.0.0",
-    "phpstan/phpstan": "2.1.18",
-    "phpstan/phpstan-deprecation-rules": "2.0.3",
-    "phpstan/phpstan-phpunit": "2.0.6",
-    "phpstan/phpstan-strict-rules": "2.0.4",
-    "phpstan/phpstan-symfony": "2.0.6",
-    "phpunit/phpunit": "^11.5.19",
-    "predis/predis": "^2.2",
-    "rector/type-perfect": "2.1.0",
-    "shopware/dev-tools": "^1.3",
-    "smalot/pdfparser": "^2.2.2",
-    "symfony/browser-kit": "~7.3.0",
-    "symfony/css-selector": "~7.3.0",
-    "symfony/dom-crawler": "~7.3.0",
-    "symfony/expression-language": "~7.3.0",
-    "symfony/phpunit-bridge": "~7.3.0",
-    "symfony/var-dumper": "~7.3.0",
-    "symfony/web-profiler-bundle": "~7.3.0",
-    "symplify/phpstan-rules": "14.6.11"
-  },
-  "suggest": {
-    "shopware/dev-tools": "For development tools, profiler, faker, etc",
-    "league/flysystem-async-aws-s3": "Required to use the Flysystem S3 driver (^3.10.3)",
-    "league/flysystem-google-cloud-storage": "Required to use the Flysystem Google cloud driver (^3.10.3)"
-  },
-  "repositories": [
-    {
-      "type": "path",
-      "url": "custom/plugins/*",
-      "options": {
-        "symlink": true
-      }
-    },
-    {
-      "type": "path",
-      "url": "custom/static-plugins/*",
-      "options": {
-        "symlink": true
-      }
-    }
-  ],
-  "scripts-descriptions": {
-    "admin:code-mods": "Run admin code mods",
-    "admin:create:test": "Create a admin test blueprint",
-    "admin:generate-data-set-list": "Generate the list of all data sets. Used to track breaking changes.",
-    "admin:generate-entity-schema-types": "Generate the Typescript definition for the entity schema",
-    "admin:generate-position-identifier-list": "Generate the list of all position identifiers. Used to track breaking changes.",
-    "admin:unit": "Launches the jest unit test-suite for the Admin",
-    "admin:unit:watch": "Launches the interactive jest unit test-suite watcher for the Admin",
-    "bc-check": "Checks for backwards compatibility breaks in the current branch",
-    "build:js": "Builds Administration & Storefront",
-    "build:js:admin": "Builds the Administration",
-    "build:js:component-library": "Builds the component library",
-    "build:js:storefront": "Builds the Storefront's JavaScript",
-    "check:license": "Check thrid-party dependency licenses",
-    "ecs": "Checks all files regarding the PHP-CS-Fixer",
-    "ecs-fix": "Checks all files regarding the PHP-CS-Fixer and fixes them if possible",
-    "eslint": "Codestyle checks all (Administration/Storefront) JS/TS files",
-    "eslint:admin": "Codestyle checks Administration JS/TS files",
-    "eslint:admin:fix": "Codestyle checks Administration JS/TS files and fixes them if possible",
-    "eslint:storefront": "Codestyle checks all Storefront JS/TS files",
-    "eslint:storefront:fix": "Codestyle checks all Storefront JS/TS files and fixes them if possible",
-    "format:admin": "Dry run Prettier for the Administration",
-    "format:admin:fix": "Format the Administration with Prettier",
-    "framework:schema:dump": " ",
-    "hook:pre-commit": " ",
-    "hook:pre-commit:install": " ",
-    "hook:pre-push": " ",
-    "hook:pre-push:install": " ",
-    "init:db": " ",
-    "init:js": " ",
-    "init:testdb": "Initializes the test database",
-    "lint": "Shorthand for the composer commands 'stylelint', 'eslint', 'ecs', 'lint:changelog' and 'lint:snippets'",
-    "lint:changelog": "Validates changelogs",
-    "lint:snippets": "Validates existence of snippets in all core-supported languages",
-    "ludtwig:storefront": "Codestyle checks for all Storefront twig files using ludtwig",
-    "ludtwig:storefront:fix": "Auto-fixes all fixable twig codestyle in Storefront",
-    "make:coverage": "Generate test coverage files for current branch",
-    "npm:admin": " ",
-    "npm:admin:bin": " ",
-    "npm:admin:check-license": "Check thrid-party dependency licenses for administration",
-    "npm:component-library": " ",
-    "npm:component-library:bin": " ",
-    "npm:storefront": " ",
-    "npm:storefront:bin": " ",
-    "npm:storefront:check-license": "Check thrid-party dependency licenses for storefront",
-    "phpbench": " ",
-    "phpstan": "Launches the PHP static analysis tool",
-    "phpstan-errors-by-area": "Shows the ignored errors defined in the phpstan-baseline.neon by area",
-    "phpunit": "Launches the PHP unit test-suite",
-    "post-install-cmd": " ",
-    "post-update-cmd": " ",
-    "reset": "Resets this Shopware instance, without composer and npm install. (Faster reset if no dependencies changed)",
-    "setup": "Resets and re-installs this Shopware instance",
-    "static-analyze": "Launches the PHP Stan static analysis tool",
-    "storefront:unit": "Launches the jest unit test-suite for the Storefront",
-    "storefront:unit:watch": "Launches the interactive jest unit test-suite watcher for the Storefront",
-    "stylelint": "Codestyle checks all SCSS files of Administration and Storefront",
-    "stylelint:admin": "Code Style checks for all Admin SCSS files",
-    "stylelint:admin:fix": "Code Style checks for all Admin SCSS files and fixes them if possible",
-    "stylelint:storefront": "Code Style checks for all Storefront SCSS files",
-    "stylelint:storefront:fix": "Code Style checks for all Storefront SCSS files and fixes them if possible",
-    "translation:lint-filenames": "Validates snippet filesnames",
-    "translation:lint-filenames:fix": "Validates snippet filesnames and migrates them if necessary",
-    "translation:install": "Downloads and installs translations from the translations GitHub repository",
-    "translation:lint": "Validates existence of snippets in all core-supported languages",
-    "translation:update": "Updates all installed translations from the translations GitHub repository",
-    "watch:admin": "Enables hot module reloading for the Admin",
-    "watch:storefront": "Enables hot module reloading for the Storefront"
-  },
-  "scripts": {
-    "admin:code-mods": "@npm:admin run code-mods --",
-    "admin:create:test": "@npm:admin run create-test",
-    "admin:generate-data-set-list": [
-      "@npm:admin run generate-data-set-list"
-    ],
-    "admin:generate-entity-schema-types": [
-      "@framework:schema:dump",
-      "@npm:admin run convert-entity-schema"
-    ],
-    "admin:generate-position-identifier-list": [
-      "@npm:admin run generate-position-identifier-list"
-    ],
-    "admin:unit": [
-      "Composer\\Config::disableProcessTimeout",
-      "@framework:schema:dump",
-      "@npm:admin run unit-setup",
-      "@npm:admin run unit"
-    ],
-    "admin:unit:watch": [
-      "Composer\\Config::disableProcessTimeout",
-      "@framework:schema:dump",
-      "@npm:admin run unit-setup",
-      "@npm:admin run unit-watch"
-    ],
-    "bc-check": [
-      "@php vendor-bin/roave-backward-compatibility-check/bin/verify-version.php",
-      "roave-backward-compatibility-check --install-development-dependencies --from=$(git tag -l --sort -version:refname | grep \"^v$(sed -n 's/.*\"dev-trunk\": \"\\([0-9]*\\.[0-9]*\\).*\"/\\1/p' composer.json).\" | head -n 1)"
-    ],
-    "build:js": [
-      "@build:js:admin",
-      "@build:js:storefront"
-    ],
-    "build:js:admin": [
-      "@php bin/console bundle:dump",
-      "@php bin/console feature:dump",
-      "@admin:generate-entity-schema-types",
-      "@npm:admin run build",
-      "@php bin/console assets:install"
-    ],
-    "build:js:component-library": [
-      "@npm:component-library run generate"
-    ],
-    "build:js:storefront": [
-      "@php bin/console bundle:dump",
-      "@php bin/console feature:dump",
-      "@npm:storefront run production",
-      "cd src/Storefront/Resources/app/storefront && node copy-to-vendor.js",
-      "@php bin/console theme:compile --sync || true",
-      "@php bin/console assets:install"
-    ],
-    "check:license": "bash -c \"vendor/bin/composer-license-checker check -a $(sed -z 's/\\n/ -a /g' .allowed-licenses)\"",
-    "ecs": "php-cs-fixer fix --dry-run --diff",
-    "ecs-fix": "php-cs-fixer fix",
-    "eslint": [
-      "@eslint:admin",
-      "@eslint:storefront"
-    ],
-    "eslint:admin": "@npm:admin run lint:all",
-    "eslint:admin:fix": "@npm:admin run lint:fix",
-    "eslint:storefront": "@npm:storefront run lint:js",
-    "eslint:storefront:fix": "@npm:storefront run lint:js:fix",
-    "format:admin": "@npm:admin run format",
-    "format:admin:fix": "@npm:admin run format:fix",
-    "framework:schema:dump": "@php bin/console -e prod framework:schema -s 'entity-schema' src/Administration/Resources/app/administration/test/_mocks_/entity-schema.json",
-    "hook:pre-commit": [
-      "bin/pre-commit"
-    ],
-    "hook:pre-commit:install": [
-      "ln -sf $PWD/bin/pre-commit .git/hooks/pre-commit"
-    ],
-    "hook:pre-push": [
-      "bin/pre-commit"
-    ],
-    "hook:pre-push:install": [
-      "ln -sf $PWD/bin/pre-push .git/hooks/pre-push"
-    ],
-    "init:db": [
-      "@php bin/console system:install --drop-database --basic-setup --force --no-assign-theme"
-    ],
-    "init:js": [
-      "@npm:admin clean-install --no-audit --prefer-offline",
-      "@npm:storefront clean-install --no-audit --prefer-offline",
-      "export PROJECT_ROOT=\"$PWD\"; \"$PROJECT_ROOT\"/bin/install-extension-npm"
-    ],
-    "init:testdb": [
-      "@putenv FORCE_INSTALL=true",
-      "vendor/bin/phpunit --group=none --testsuite migration,unit,integration,devops"
-    ],
-    "lint": [
-      "@stylelint",
-      "@eslint",
-      "@ecs",
-      "@lint:changelog",
-      "@lint:snippets"
-    ],
-    "lint:changelog": "@php bin/shopware changelog:check",
-    "lint:snippets": "@translation:validate",
-    "ludtwig:storefront": "cd ./src/Storefront/Resources/views; ludtwig .",
-    "ludtwig:storefront:fix": "@ludtwig:storefront --fix",
-    "make:coverage": [
-      "@php bin/console make:coverage $(git diff --name-only origin/trunk -- \"*.php\" | grep -vE 'Test\\.php$' | sed 's/.*/\"&\"/' | tr '\\n' ' ')"
-    ],
-    "npm:admin": "@npm:admin:bin npm",
-    "npm:admin:bin": "export PROJECT_ROOT=\"$PWD\"; cd src/Administration/Resources/app/administration; export PATH=\"$PWD/node_modules/.bin/:$PATH\"; \"$PROJECT_ROOT\"/bin/exec-with-env ",
-    "npm:admin:check-license": "export ALLOWED_LICENSES=\"$(sed -z 's/\\n/;/g' .allowed-licenses)\"; cd src/Administration/Resources/app/administration; bash -c \"node_modules/.bin/license-checker-rseidelsohn --onlyAllow \\\"$ALLOWED_LICENSES\\\" --excludePrivatePackages\"",
-    "npm:component-library": "@npm:component-library:bin npm",
-    "npm:component-library:bin": "export PROJECT_ROOT=\"$PWD\"; cd src/Administration/Resources/app/administration/build/nuxt-component-library; export PATH=\"$PWD/node_modules/.bin/:$PATH\"; \"$PROJECT_ROOT\"/bin/exec-with-env ",
-    "npm:storefront": "@npm:storefront:bin npm",
-    "npm:storefront:bin": "export PROJECT_ROOT=\"$PWD\"; cd src/Storefront/Resources/app/storefront; export PATH=\"$PWD/node_modules/.bin/:$PATH\"; \"$PROJECT_ROOT\"/bin/exec-with-env ",
-    "npm:storefront:check-license": "export ALLOWED_LICENSES=\"$(sed -z 's/\\n/;/g' .allowed-licenses)\"; cd src/Storefront/Resources/app/storefront; bash -c \"node_modules/.bin/license-checker-rseidelsohn --onlyAllow \\\"$ALLOWED_LICENSES\\\" --excludePrivatePackages\"",
-    "phpbench": "phpbench run --report=compressed",
-    "phpstan": [
-      "Composer\\Config::disableProcessTimeout",
-      "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
-      "phpstan analyze --memory-limit=2G -vv"
-    ],
-    "phpstan-errors-by-area": [
-      "php src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php phpstan-baseline.neon"
-    ],
-    "phpunit": [
-      "phpunit"
-    ],
-    "post-install-cmd": [
-      "@composer bin all install --ansi",
-      "ln -sf ./../../vendor-bin/roave-backward-compatibility-check/vendor/bin/roave-backward-compatibility-check vendor/bin/roave-backward-compatibility-check"
-    ],
-    "post-update-cmd": [
-      "@composer bin all update --ansi",
-      "ln -sf ./../../vendor-bin/roave-backward-compatibility-check/vendor/bin/roave-backward-compatibility-check vendor/bin/roave-backward-compatibility-check"
-    ],
-    "reset": [
-      "@init:db",
-      "@build:js",
-      "@php bin/console theme:change --sync --all Storefront",
-      "@php bin/console assets:install"
-    ],
-    "setup": [
-      "@composer install -o",
-      "mkdir -p custom/plugins || true",
-      "@init:db",
-      "@init:js",
-      "@build:js",
-      "@php bin/console theme:change --sync --all Storefront",
-      "@php bin/console assets:install"
-    ],
-    "static-analyze": [
-      "@phpstan src/"
-    ],
-    "storefront:unit": [
-      "@npm:storefront run unit"
-    ],
-    "storefront:unit:watch": [
-      "Composer\\Config::disableProcessTimeout",
-      "@npm:storefront run unit-watch"
-    ],
-    "stylelint": [
-      "@stylelint:admin src/**/*.scss",
-      "@stylelint:storefront src/**/*.scss"
-    ],
-    "stylelint:admin": "@npm:admin run lint:scss",
-    "stylelint:admin:fix": "@npm:admin run lint:scss-fix",
-    "stylelint:storefront": "@npm:storefront run lint:scss",
-    "stylelint:storefront:fix": "@npm:storefront run lint:scss-fix",
-    "translation:lint-filenames": "php bin/shopware translation:lint-filenames",
-    "translation:lint-filenames:fix": "php bin/shopware translation:lint-filenames --fix",
-    "translation:install": "php bin/shopware translation:install",
-    "translation:lint": "@php bin/shopware translation:validate",
-    "translation:update": "php bin/shopware translation:update",
-    "watch:admin": [
-      "Composer\\Config::disableProcessTimeout",
-      "@php bin/console feature:dump",
-      "@php bin/console bundle:dump",
-      "@admin:generate-entity-schema-types",
-      "@npm:admin run dev"
-    ],
-    "watch:storefront": [
-      "Composer\\Config::disableProcessTimeout",
-      "@php bin/console bundle:dump",
-      "@php bin/console feature:dump",
-      "@php bin/console theme:dump",
-      "@npm:storefront run hot-proxy"
-    ]
-  },
-  "autoload": {
-    "files": [
-      "src/Core/Framework/Adapter/Doctrine/Patch/AbstractAsset.php"
-    ],
-    "psr-4": {
-      "Shopware\\": "src/"
-    },
-    "exclude-from-classmap": [
-      "tests/"
-    ]
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Shopware\\Tests\\Examples\\": "tests/examples/",
-      "Shopware\\Tests\\Unit\\": "tests/unit/",
-      "Shopware\\Tests\\Integration\\": "tests/integration/",
-      "Shopware\\Tests\\Bench\\": "tests/performance/bench/",
-      "Shopware\\Tests\\Migration\\": "tests/migration/",
-      "Shopware\\Tests\\DevOps\\": "tests/devops/"
-    }
-  }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Composer itself uses four spaces as indentation for the `composer.json` files, while changing or generating them. We have a rule which uses two spaces for JSON files in general. Which is okay, but working with rufus is currently very annoying, as the whole file gets changed, while setting rufus up.

### 2. What does this change do, exactly?

Change the `.editorconfig` file and adding an exception for `composer.json` files to have four spaces as indentation.