### PR TITLE
fix: invalid wording in sw-order-general-info component

### DIFF
--- a/changelog/_unreleased/2025-10-29-fix-invalid-wording-in-sw-order-general-info.md
+++ b/changelog/_unreleased/2025-10-29-fix-invalid-wording-in-sw-order-general-info.md
@@ -1,0 +1,8 @@
+---
+title: Fix invalid wording in sw-order-general-info component
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: gecolay
+---
+# Administration
+* Changed `Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig` to no longer use `on` before the relative order time (e.g. "5 minutes ago" instead of "on 5 minutes ago").

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
@@ -29,7 +29,6 @@
         <div class="sw-order-general-info__summary-sub">
             {% block sw_order_detail_base_general_info_summary_sub_description %}
             <div class="sw-order-general-info__summary-sub-description">
-                {{ $tc('sw-order.generalTab.info.summary.on') }}
                 <sw-time-ago
                     :date="order.orderDateTime"
                     :date-time-format="{ month: '2-digit', day: '2-digit' }"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de.json
@@ -390,7 +390,6 @@
       "info": {
         "summary": {
           "and": "und",
-          "on": "am",
           "by": "durch",
           "lastChanged": "Zuletzt geändert",
           "with": "mit"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en.json
@@ -390,7 +390,6 @@
       "info": {
         "summary": {
           "and": "and",
-          "on": "on",
           "by": "by",
           "lastChanged": "Last changed",
           "with": "with"


### PR DESCRIPTION
### 1. Why is this change necessary?
- Right now the wording is no longer correct in the sw-order-general-info if the order was recently created
- With this PR we change the wording to e.g. "5 minutes ago" instead of "on 5 minutes ago"

### 2. What does this change do, exactly?
* Changed `Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig` to no longer use `on` before the relative order time (e.g. "5 minutes ago" instead of "on 5 minutes ago").

### 3. Describe each step to reproduce the issue or behaviour.
- Open an order in the administration that was recently created

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
