### PR TITLE
fix: Adapt product comparison templates

### DIFF
--- a/src/Administration/Resources/app/administration/build/vite-plugins/twigjs-plugin/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/twigjs-plugin/index.ts
@@ -28,16 +28,28 @@ export default function twigPlugin(): Plugin {
             // Trim the content and remove HTML comments
             fileContent = fileContent
                 .replace(/<!--[\s\S]*?-->/gm, '') // Remove HTML comments first
-                .trim()
-                .replace(/\s+/g, ' '); // Normalize whitespace
+                .trim();
+
+            const isProductExportTemplate = id.includes('product-export-templates/');
+            if (!isProductExportTemplate) {
+                fileContent = fileContent.replace(/\s+/g, ' '); // Normalize whitespace
+            }
 
             // Escape characters that might break the string
             fileContent = fileContent
                 .replace(/\\/g, '\\\\') // Escape backslashes first
                 .replace(/"/g, '\\"') // Escape double quotes
-                .replace(/\$/g, '\\$') // Escape dollar signs
-                .replace(/\n/g, ' ') // Replace newlines with spaces
-                .replace(/\r/g, ' '); // Replace carriage returns with spaces
+                .replace(/\$/g, '\\$'); // Escape dollar signs
+
+            if (!isProductExportTemplate) {
+                fileContent = fileContent
+                    .replace(/\n/g, ' ') // Replace newlines with spaces
+                    .replace(/\r/g, ' '); // Replace carriage returns with spaces
+            } else {
+                fileContent = fileContent
+                    .replace(/\r\n/g, '\\n') // Preserve Windows line endings (CRLF)
+                    .replace(/\n/g, '\\n'); // Preserve Unix/Mac line endings (LF)
+            }
 
             const code = `export default "${fileContent}"`;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When creating a new product comparison sales channel in Shopware 6.7, the product export template is not correctly formatted 

This is a regression from 6.6 where templates worked correctly.The issue occurs because:
- 6.6: Used Webpack by default, which preserved newlines
- 6.7: Migrated to Vite, which strips newlines via the TwigJs

### 2. What does this change do, exactly?
Add conditional handling to detect product export template files and preserve line breaks

### 3. Describe each step to reproduce the issue or behaviour.
Add a new product comparison sales channel
Fill out required fields (use Google Shopping as template)
Save and observe the template tab

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
