### PR TITLE
fix: Increase precision of product weights

### DIFF
--- a/changelog/_unreleased/2025-10-29-increase-product-weight-precision.md
+++ b/changelog/_unreleased/2025-10-29-increase-product-weight-precision.md
@@ -1,0 +1,10 @@
+---
+title: Increase precision of product weights
+issue: 13207
+---
+# Core
+* Added the migration `Migration1761739065IncreaseProductWeightPrecision` to update `product.weight` to `DECIMAL(15,6)` to avoid rounding gram-based weights stored in kilograms.
+___
+# Upgrade Information
+## Product weight precision
+The database column `product.weight` now uses `DECIMAL(15,6)` instead of `DECIMAL(10,3)` to keep gram-based measurements accurate when values are stored in kilograms.

--- a/src/Core/Migration/V6_7/Migration1761739065IncreaseProductWeightPrecision.php
+++ b/src/Core/Migration/V6_7/Migration1761739065IncreaseProductWeightPrecision.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1761739065IncreaseProductWeightPrecision extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1761739065;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if (!$this->isProductWeightUsingDefaultPrecision($connection)) {
+            return;
+        }
+
+        $connection->executeStatement(
+            'ALTER TABLE `product` MODIFY `weight` DECIMAL(15,6) UNSIGNED NULL'
+        );
+    }
+
+    private function isProductWeightUsingDefaultPrecision(Connection $connection): bool
+    {
+        $columnTypeQuery = <<<'SQL'
+            SELECT LOWER(COLUMN_TYPE)
+            FROM information_schema.columns
+            WHERE table_schema = :schema
+              AND table_name = 'product'
+              AND column_name = 'weight';
+        SQL;
+
+        $columnType = $connection->fetchOne($columnTypeQuery, ['schema' => $connection->getDatabase()]);
+
+        return \is_string($columnType) && \str_contains($columnType, 'decimal(10,3)');
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1761739065IncreaseProductWeightPrecisionTest.php
+++ b/tests/migration/Core/V6_7/Migration1761739065IncreaseProductWeightPrecisionTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_7\Migration1761739065IncreaseProductWeightPrecision;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1761739065IncreaseProductWeightPrecision::class)]
+class Migration1761739065IncreaseProductWeightPrecisionTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testUpdateIncreasesPrecision(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+
+        try {
+            $this->setProductWeightPrecision($connection, 'DECIMAL(10,3) UNSIGNED NULL');
+
+            $migration = new Migration1761739065IncreaseProductWeightPrecision();
+            $migration->update($connection);
+            $migration->update($connection);
+
+            static::assertSame(
+                'decimal(15,6) unsigned',
+                $this->getProductWeightColumnType($connection)
+            );
+        } finally {
+            $this->setProductWeightPrecision($connection, 'DECIMAL(15,6) UNSIGNED NULL');
+        }
+    }
+
+    public function testUpdateSkipsWhenPrecisionAlreadyExtended(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+
+        try {
+            $this->setProductWeightPrecision($connection, 'DECIMAL(20,8) UNSIGNED NULL');
+
+            $migration = new Migration1761739065IncreaseProductWeightPrecision();
+            $migration->update($connection);
+
+            static::assertSame(
+                'decimal(20,8) unsigned',
+                $this->getProductWeightColumnType($connection)
+            );
+        } finally {
+            $this->setProductWeightPrecision($connection, 'DECIMAL(15,6) UNSIGNED NULL');
+        }
+    }
+
+    private function setProductWeightPrecision(Connection $connection, string $definition): void
+    {
+        $connection->executeStatement(
+            \sprintf('ALTER TABLE `product` MODIFY `weight` %s', $definition)
+        );
+    }
+
+    private function getProductWeightColumnType(Connection $connection): string
+    {
+        $columnTypeQuery = <<<'SQL'
+            SELECT LOWER(COLUMN_TYPE)
+            FROM information_schema.columns
+            WHERE table_schema = :schema
+              AND table_name = 'product'
+              AND column_name = 'weight';
+        SQL;
+
+        $type = $connection->fetchOne($columnTypeQuery, ['schema' => $connection->getDatabase()]);
+
+        return \is_string($type) ? $type : '';
+    }
+}


### PR DESCRIPTION
> Why only weight but not height, length and width?

Since the weight is stored in kg, the smallest value you can represent is 0.001, which is 1 gram. If you need to store a weight of 0.5 grams, you cannot do so accurately in the default field.

Other dimension fields are stored in `mm`, so you can have 0.005mm by default, which is small enough for an ecommerce platform.

By changing the DECIMAL(10,3) to DECIMAL(15,6), we increase the storage size from 6 bytes to 7 bytes, which is insignificant, but we can define weight in a more precise number.
