### PR TITLE
fix: mark product number as required field

### DIFF
--- a/changelog/_unreleased/2025-10-30-mark-product-number-as-required-field.md
+++ b/changelog/_unreleased/2025-10-30-mark-product-number-as-required-field.md
@@ -1,0 +1,7 @@
+---
+title: Mark product number as required field
+author: Wanne Van Camp
+author_email: wanne.vancamp@meteor.be
+---
+# Administration
+* Changed productNumber to required field in `src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig`.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
@@ -63,6 +63,7 @@
 
         <mt-text-field
             v-model="product.productNumber"
+            required
             :error="productProductNumberError"
             :disabled="!allowEdit"
             :label="$tc('sw-product.basicForm.labelProductNumber')"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The product number is a required field, but the admin frontend doesn’t display any indication of this
<img width="330" height="222" alt="image" src="https://github.com/user-attachments/assets/20f17b15-0b7b-4e08-a03e-8538850100ea" />


### 2. What does this change do, exactly?
Before:
<img width="330" height="186" alt="image" src="https://github.com/user-attachments/assets/8dcc0b16-a250-40f6-9f78-c46af391f49e" />

After:
<img width="330" height="170" alt="image" src="https://github.com/user-attachments/assets/a0455c72-c452-4e62-93c2-287dfe3e2548" />

### 3. Describe each step to reproduce the issue or behaviour.
👀

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
