### PR TITLE
feat: Add generate blocks command to composer.json

### DIFF
--- a/changelog/_unreleased/2025-10-30-add-generate-blocks-command-to-composer-json.md
+++ b/changelog/_unreleased/2025-10-30-add-generate-blocks-command-to-composer-json.md
@@ -1,0 +1,9 @@
+---
+title: Add generate blocks command to composer.json
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Added the command `admin:generate-blocks-list` to the composer.json, which runs `npm run generate-blocks-list` for administration files
+* Changed the meta.spec.js to mention the composer command instead of the npm command

--- a/composer.json
+++ b/composer.json
@@ -241,6 +241,7 @@
     "scripts-descriptions": {
         "admin:code-mods": "Run admin code mods",
         "admin:create:test": "Create a admin test blueprint",
+        "admin:generate-blocks-list": "Generate the list of all blocks. Used to track block changes in the administration.",
         "admin:generate-data-set-list": "Generate the list of all data sets. Used to track breaking changes.",
         "admin:generate-entity-schema-types": "Generate the Typescript definition for the entity schema",
         "admin:generate-position-identifier-list": "Generate the list of all position identifiers. Used to track breaking changes.",
@@ -310,6 +311,7 @@
     "scripts": {
         "admin:code-mods": "@npm:admin run code-mods --",
         "admin:create:test": "@npm:admin run create-test",
+        "admin:generate-blocks-list": "@npm:admin run generate-blocks-list",
         "admin:generate-data-set-list": [
             "@npm:admin run generate-data-set-list"
         ],

--- a/src/Administration/Resources/app/administration/src/meta/meta.spec.js
+++ b/src/Administration/Resources/app/administration/src/meta/meta.spec.js
@@ -195,7 +195,7 @@ describe('Administration meta tests', () => {
 
             expect(
                 newBlocks,
-                `New blocks have been added. Please run 'generate-blocks-list' script to add them to the blocks list: \n${newBlocks.join(', ')}`,
+                `New blocks have been added. Please run 'composer admin:generate-blocks-list' script to add them to the blocks list: \n${newBlocks.join(', ')}`,
             ).toHaveLength(0);
         });
     });


### PR DESCRIPTION
### 1. Why is this change necessary?

The command often needs to be executed after administration changes. This change makes the command more accessible and removes the need to navigate to the correct folder. Additionally, it aligns with the other composer commands for the administration `admin:generate-data-set-list`, `admin:generate-entity-schema-types` and `admin:generate-position-identifier-list`.

### 2. What does this change do, exactly?

It adds the command `admin:generate-blocks-list` to the composer.json, which runs `npm run generate-blocks-list` for administration files.

It changes the meta.spec.js to mention the composer command instead of the `npm` command.

### 3. Describe each step to reproduce the issue or behavior.

1. Add a new block for an administration template, commit the changes
2. Make a PR
3. Fail the pipeline, because the block list is incomplete
4. Start searching for the correct folder to execute the command `generate-blocks-list` in
5. Generate the blocks list
6. Commit again, pipeline fixed

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
