### PR TITLE
fix: Reset canonical product id on product clone through the administration

### DIFF
--- a/changelog/_unreleased/2025-10-30-reset-canonical-product-id-on-product-clone.md
+++ b/changelog/_unreleased/2025-10-30-reset-canonical-product-id-on-product-clone.md
@@ -1,0 +1,8 @@
+---
+title: Reset canonical product id on product clone through the administration
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Administration
+* Added reset of `canonicalProductId` when cloning product through the administration

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
@@ -72,6 +72,7 @@ export default {
                     name: `${this.product.name} ${this.$tc('global.default.copy')}`,
                     active: false,
                     mainVariantId: null,
+                    canonicalProductId: null,
                     variantListingConfig: variantListingConfigOverwrite,
                     childCount: this.product.childCount,
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/sw-product-clone-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/sw-product-clone-modal.spec.js
@@ -62,6 +62,7 @@ describe('src/module/sw-product/component/sw-product-clone-modal', () => {
                 overwrites: {
                     active: false,
                     mainVariantId: null,
+                    canonicalProductId: null,
                     name: 'shirt global.default.copy',
                     productNumber: 250,
                     variantListingConfig: {


### PR DESCRIPTION
### 1. Why is this change necessary?

Cloning a product with variants, that has a canonical product set, does lead to canonicals that still target the old variant of the original product.

This becomes even worse when the original variant is deactivated, because now there are 404 canonicals.

### 2. What does this change do, exactly?

It resets the canonical product ID on product clone through the administration.

### 3. Describe each step to reproduce the issue or behavior.

1. New setup with demo data 
2. Set a canonical variant to the product "Main product with properties"
3. Save
4. Duplicate that product
5. Check the DB for the new product, it still has the old canonical product id

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
