### PR TITLE
feat: Sort sales channel selection options by name in administration

### DIFF
--- a/changelog/_unreleased/2025-10-31-sort-sales-channel-selection-options-by-name-in-administration.md
+++ b/changelog/_unreleased/2025-10-31-sort-sales-channel-selection-options-by-name-in-administration.md
@@ -1,0 +1,8 @@
+---
+title: Sort sales channel selection options by name in administration
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Administration
+* Changed the sorting of selection options to sort by name for components `sw-sales-channel-config`, `sw-sales-channel-switch`, `sw-order-list`, `sw-product-list`

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js
@@ -37,7 +37,7 @@ export default {
             type: Object,
             required: false,
             default: () => {
-                const criteria = new Criteria();
+                const criteria = new Criteria(1, 25);
                 criteria.addSorting(Criteria.sort('name'));
 
                 return criteria;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js
@@ -37,7 +37,10 @@ export default {
             type: Object,
             required: false,
             default: () => {
-                return new Criteria(1, 25);
+                const criteria = new Criteria();
+                criteria.addSorting(Criteria.sort('name'));
+
+                return criteria;
             },
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/index.js
@@ -46,7 +46,7 @@ export default {
             type: Object,
             required: false,
             default: () => {
-                const criteria = new Criteria();
+                const criteria = new Criteria(1, 25);
                 criteria.addSorting(Criteria.sort('name'));
 
                 return criteria;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/index.js
@@ -3,6 +3,7 @@
  */
 import template from './sw-sales-channel-switch.html.twig';
 
+const { Criteria } = Shopware.Data;
 const { debug } = Shopware.Utils;
 
 /**
@@ -40,6 +41,16 @@ export default {
             type: String,
             required: false,
             default: '',
+        },
+        salesChannelCriteria: {
+            type: Object,
+            required: false,
+            default: () => {
+                const criteria = new Criteria();
+                criteria.addSorting(Criteria.sort('name'));
+
+                return criteria;
+            },
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/sw-sales-channel-switch.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/sw-sales-channel-switch.html.twig
@@ -55,6 +55,7 @@
         :search-placeholder="$tc('sw-sales-channel-switch.placeholderSelect')"
         :reset-option="$tc('sw-sales-channel-switch.labelDefaultOption')"
         :value="salesChannelId"
+        :criteria="salesChannelCriteria"
         entity="sales_channel"
         show-clearable-button
         @update:value="onChange"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -126,6 +126,13 @@ export default {
             return criteria;
         },
 
+        salesChannelCriteria() {
+            const criteria = new Criteria();
+            criteria.addSorting(Criteria.sort('name'));
+
+            return criteria;
+        },
+
         /**
          * @deprecated tag:v6.8.0 - will be removed without replacement
          */
@@ -154,6 +161,7 @@ export default {
                     property: 'salesChannel',
                     label: this.$tc('sw-order.filters.salesChannelFilter.label'),
                     placeholder: this.$tc('sw-order.filters.salesChannelFilter.placeholder'),
+                    criteria: this.salesChannelCriteria,
                 },
                 'order-value-filter': {
                     property: 'amountTotal',

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -127,7 +127,7 @@ export default {
         },
 
         salesChannelCriteria() {
-            const criteria = new Criteria();
+            const criteria = new Criteria(1, 25);
             criteria.addSorting(Criteria.sort('name'));
 
             return criteria;

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -121,6 +121,13 @@ export default {
             return new Criteria(1, 500);
         },
 
+        salesChannelCriteria() {
+            const criteria = new Criteria();
+            criteria.addSorting(Criteria.sort('name'));
+
+            return criteria;
+        },
+
         showVariantModal() {
             return !!this.productEntityVariantModal;
         },
@@ -166,6 +173,7 @@ export default {
                     property: 'visibilities.salesChannel',
                     label: this.$tc('sw-product.filters.salesChannelsFilter.label'),
                     placeholder: this.$tc('sw-product.filters.salesChannelsFilter.placeholder'),
+                    criteria: this.salesChannelCriteria,
                 },
                 'categories-filter': {
                     property: 'categories',

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -122,7 +122,7 @@ export default {
         },
 
         salesChannelCriteria() {
-            const criteria = new Criteria();
+            const criteria = new Criteria(1, 25);
             criteria.addSorting(Criteria.sort('name'));
 
             return criteria;


### PR DESCRIPTION
### 1. Why is this change necessary?

Sales channel options in the admin get shown unsorted, which leads to confusion from users and bad UX, since shops with a lot of sales channels force the user to search or to scroll a long and unordered list

### 2. What does this change do, exactly?

It changed the sorting of selection options to sort by name for components `sw-sales-channel-config`, `sw-sales-channel-switch`, `sw-order-list`, `sw-product-list`

### 3. Describe each step to reproduce the issue or behavior.

Have a shop with a lot of sales channels. Try to select one, you need to start scrolling or searching manually.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
