### PR TITLE
feat: Empty Cart product add

### DIFF
--- a/changelog/_unreleased/2025-11-05-extract-add-product-by-number-checkout-cart.md
+++ b/changelog/_unreleased/2025-11-05-extract-add-product-by-number-checkout-cart.md
@@ -1,0 +1,39 @@
+---
+title: Extract add product by number checkout cart
+flag: V6_8_0_0
+author: Sebastian Seggewiss
+author_github: @seggewiss
+---
+# Storefront
+* Added `Resources/views/storefront/component/checkout/add-product-by-number.html.twig`
+* Deprecated the following Twig blocks in `Resources/views/storefront/page/checkout/cart/index.html.twig`
+  * `page_checkout_cart_add_product`
+  * `page_checkout_cart_add_product_redirect`
+  * `page_checkout_cart_add_product_label`
+  * `page_checkout_cart_add_product_input_group`
+  * `page_checkout_cart_add_product_input`
+  * `page_checkout_cart_add_product_submit`
+___
+# Upgrade Information
+## Changing cart add-product twig blocks
+Instead of overwriting any of the `page_checkout_cart_add_product*` blocks inside `@Storefront/storefront/page/checkout/cart/index.html.twig`,
+extend the new `@Storefront/storefront/component/checkout/add-product-by-number.html.twig` file using the same blocks.
+___
+# Next Major Version Changes
+## Changing cart add-product twig blocks:
+Change:
+```
+{% sw_extends '@Storefront/storefront/page/checkout/_page.html.twig' %}
+
+{% block page_checkout_cart_add_product %}
+    {# Your content #}
+{% endblock %}
+```
+to:
+```
+{% sw_extends '@Storefront/storefront/component/checkout/add-product-by-number.html.twig' %}
+
+{% block page_checkout_cart_add_product %}
+    {# Your content #}
+{% endblock %}
+```

--- a/src/Storefront/Resources/views/storefront/component/checkout/add-product-by-number.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/add-product-by-number.html.twig
@@ -1,0 +1,41 @@
+{% block page_checkout_cart_add_product %}
+<div class="col-md-5 cart-add-product-container">
+    <form action="{{ path('frontend.checkout.product.add-by-number') }}" method="post">
+        {% block page_checkout_cart_add_product_redirect %}
+            <input type="hidden"
+                   name="redirectTo"
+                   value="frontend.checkout.cart.page">
+        {% endblock %}
+
+        {% block page_checkout_cart_add_product_label %}
+            <label class="visually-hidden" for="addProductInput">
+                {{ 'checkout.addProductLabel'|trans|sw_sanitize }}
+            </label>
+        {% endblock %}
+
+        {% block page_checkout_cart_add_product_input_group %}
+            <div class="input-group">
+                {% block page_checkout_cart_add_product_input %}
+                    <input type="text"
+                           name="number"
+                           class="form-control"
+                           id="addProductInput"
+                           placeholder="{{ 'checkout.addProductPlaceholder'|trans|striptags }}"
+                           aria-label="{{ 'checkout.addProductLabel'|trans|striptags }}"
+                           aria-describedby="addProductButton"
+                           required="required">
+                {% endblock %}
+
+                {% block page_checkout_cart_add_product_submit %}
+                    <button class="btn btn-outline-secondary add-product-button"
+                            type="submit"
+                            aria-labelledby="addProductInput"
+                            id="addProductButton">
+                        {% sw_icon 'checkmark' %}
+                    </button>
+                {% endblock %}
+            </div>
+        {% endblock %}
+    </form>
+</div>
+{% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -14,6 +14,10 @@
                 {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: 'danger', list: messages.danger } %}
             </div>
         {% endif %}
+
+        <div class="row mt-4">
+            {% sw_include '@Storefront/storefront/component/checkout/add-product-by-number.html.twig' %}
+        </div>
     {% else %}
         {{ parent() }}
     {% endif %}
@@ -72,47 +76,57 @@
 
         {% block page_checkout_cart_add_product_and_shipping %}
             <div class="row">
-                {% block page_checkout_cart_add_product %}
-                    <div class="col-md-5 cart-add-product-container">
-                        <form action="{{ path('frontend.checkout.product.add-by-number') }}" method="post">
-                            {% block page_checkout_cart_add_product_redirect %}
-                                <input type="hidden"
-                                       name="redirectTo"
-                                       value="frontend.checkout.cart.page">
-                            {% endblock %}
+                {% if feature('v6.8.0.0') %}
+                    {% sw_include '@Storefront/storefront/component/checkout/add-product-by-number.html.twig' %}
+                {% else %}
+                    {# @deprecated tag:v6.8.0 - Block page_checkout_cart_add_product will be moved to add-product-by-number.html.twig #}
+                    {% block page_checkout_cart_add_product %}
+                        <div class="col-md-5 cart-add-product-container">
+                            <form action="{{ path('frontend.checkout.product.add-by-number') }}" method="post">
+                                {# @deprecated tag:v6.8.0 - Block page_checkout_cart_add_product_redirect will be moved to add-product-by-number.html.twig #}
+                                {% block page_checkout_cart_add_product_redirect %}
+                                    <input type="hidden"
+                                           name="redirectTo"
+                                           value="frontend.checkout.cart.page">
+                                {% endblock %}
 
-                            {% block page_checkout_cart_add_product_label %}
-                                <label class="visually-hidden" for="addProductInput">
-                                    {{ 'checkout.addProductLabel'|trans|sw_sanitize }}
-                                </label>
-                            {% endblock %}
+                                {# @deprecated tag:v6.8.0 - Block page_checkout_cart_add_product_label will be moved to add-product-by-number.html.twig #}
+                                {% block page_checkout_cart_add_product_label %}
+                                    <label class="visually-hidden" for="addProductInput">
+                                        {{ 'checkout.addProductLabel'|trans|sw_sanitize }}
+                                    </label>
+                                {% endblock %}
 
-                            {% block page_checkout_cart_add_product_input_group %}
-                                <div class="input-group">
-                                    {% block page_checkout_cart_add_product_input %}
-                                        <input type="text"
-                                               name="number"
-                                               class="form-control"
-                                               id="addProductInput"
-                                               placeholder="{{ 'checkout.addProductPlaceholder'|trans|striptags }}"
-                                               aria-label="{{ 'checkout.addProductLabel'|trans|striptags }}"
-                                               aria-describedby="addProductButton"
-                                               required="required">
-                                    {% endblock %}
+                                {# @deprecated tag:v6.8.0 - Block page_checkout_cart_add_product_input_group will be moved to add-product-by-number.html.twig #}
+                                {% block page_checkout_cart_add_product_input_group %}
+                                    <div class="input-group">
+                                        {# @deprecated tag:v6.8.0 - Block page_checkout_cart_add_product_input will be moved to add-product-by-number.html.twig #}
+                                        {% block page_checkout_cart_add_product_input %}
+                                            <input type="text"
+                                                   name="number"
+                                                   class="form-control"
+                                                   id="addProductInput"
+                                                   placeholder="{{ 'checkout.addProductPlaceholder'|trans|striptags }}"
+                                                   aria-label="{{ 'checkout.addProductLabel'|trans|striptags }}"
+                                                   aria-describedby="addProductButton"
+                                                   required="required">
+                                        {% endblock %}
 
-                                    {% block page_checkout_cart_add_product_submit %}
-                                        <button class="btn btn-outline-secondary add-product-button"
-                                                type="submit"
-                                                aria-labelledby="addProductInput"
-                                                id="addProductButton">
-                                            {% sw_icon 'checkmark' %}
-                                        </button>
-                                    {% endblock %}
-                                </div>
-                            {% endblock %}
-                        </form>
-                    </div>
-                {% endblock %}
+                                        {# @deprecated tag:v6.8.0 - Block page_checkout_cart_add_product_submit will be moved to add-product-by-number.html.twig #}
+                                        {% block page_checkout_cart_add_product_submit %}
+                                            <button class="btn btn-outline-secondary add-product-button"
+                                                    type="submit"
+                                                    aria-labelledby="addProductInput"
+                                                    id="addProductButton">
+                                                {% sw_icon 'checkmark' %}
+                                            </button>
+                                        {% endblock %}
+                                    </div>
+                                {% endblock %}
+                            </form>
+                        </div>
+                    {% endblock %}
+                {% endif %}
 
                 {% block page_checkout_cart_shipping_costs %}
                     <div class="col-md-7 cart-shipping-costs-container">


### PR DESCRIPTION
### 1. Why is this change necessary?
Although not wrong on a functional level, the current implementation hides the "Add product by number" form when the cart is empty. This creates a poor user experience: customers visiting /checkout/cart with an empty cart see only a message and must leave the page (e.g., go back to shop) to add items.
Shopware’s default behavior already shows the form when items exist, but there’s no technical reason to suppress it when the cart is empty — especially since the form works independently of cart contents.
This change improves usability and conversion by allowing users to add products directly from the empty cart state, without breaking existing logic or requiring large template overrides.

### 2. What does this change do, exactly?
- Extracts the "Add product by number" form into a reusable Twig partial.
- Includes this partial in two locations:
    - Inside the normal cart flow (when items exist) → unchanged behavior
    - In the empty cart state → now visible


- Keeps all functionality (form action, blocks) 100% identical
- Avoids duplicating code or deeply overriding core blocks

Result: The add-product form is always visible on the cart page, regardless of cart contents.

### 3. Describe each step to reproduce the issue or behaviour.
**Before (Current Behavior)**

1. Go to any product detail page
2. Do **not** add anything to cart
3. Navigate to /checkout/cart
4. Result: Only "Your cart is empty" message is shown → No way to add a product by number without leaving the page

**After (New Behavior)**
1. Navigate to /checkout/cart with empty cart
2. Result:
3. <img width="825" height="325" alt="image" src="https://github.com/user-attachments/assets/9e39d2e8-710b-4f87-b447-a33956008982" />
4. Enter a valid product number (e.g. SW10001) and submit
5. Result: Product is added → cart updates → full cart view appears

_No regression: when cart has items, behavior is identical to before._