### PR TITLE
fix: change sidebars min width

### DIFF
--- a/changelog/_unreleased/2025-11-03-change-sidebars-min-width.md
+++ b/changelog/_unreleased/2025-11-03-change-sidebars-min-width.md
@@ -1,0 +1,6 @@
+---
+title: Change sidebars min width
+author_github: @dfrancos-hub
+---
+# Administration
+* Changed sidebars min width in `src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts`.

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
@@ -13,7 +13,7 @@ export default Shopware.Component.wrapComponentConfig({
     template,
 
     setup() {
-        const MAIN_CONTENT_MIN_SIZE = 1400;
+        const MAIN_CONTENT_MIN_SIZE = 1300;
         const MIN_SIDEBAR_WIDTH = 545;
 
         const sidebarSetWidth = ref(545);

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
@@ -14,9 +14,9 @@ export default Shopware.Component.wrapComponentConfig({
 
     setup() {
         const MAIN_CONTENT_MIN_SIZE = 1400;
-        const MIN_SIDEBAR_WIDTH = 480;
+        const MIN_SIDEBAR_WIDTH = 545;
 
-        const sidebarSetWidth = ref(480);
+        const sidebarSetWidth = ref(545);
         const isResizing = ref(false);
         const windowWidth = ref(window.innerWidth);
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -145,7 +145,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
         });
 
         it('should reset the width when sidebar was collapsed through the button', async () => {
-            mockLocalStorage.getItem.mockReturnValue('600');
+            mockLocalStorage.getItem.mockReturnValue('1200');
 
             const wrapper = await createWrapper();
 
@@ -157,14 +157,14 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             Shopware.Store.get('sidebar').sidebars[0].active = true;
             await wrapper.vm.$nextTick();
 
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('600px');
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('1200px');
 
             await wrapper.find('.sw-sidebar-renderer__button-collapse').trigger('click');
             await wrapper.vm.$nextTick();
             await wrapper.vm.$nextTick();
 
             expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('545px');
-            expect(mockLocalStorage.setItem).toHaveBeenCalledWith('sw-sidebar-width', '480');
+            expect(mockLocalStorage.setItem).toHaveBeenCalledWith('sw-sidebar-width', '545');
         });
 
         it('should not render handle when resizing is not allowed', async () => {
@@ -253,12 +253,12 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
 
             expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(false);
 
-            await dragSidebarToWidth(wrapper, 1000);
+            await dragSidebarToWidth(wrapper, 1200);
             await wrapper.vm.$nextTick();
 
             expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(true);
             expect(wrapper.vm.sidebarDisplayOptions.availableWidth).toBe(`${PAGE_WIDTH - MAIN_CONTENT_MIN_SIZE}px`);
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`${PAGE_WIDTH - 1000}px`);
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`${PAGE_WIDTH - 1200}px`);
         });
 
         it('should handle window resizing', async () => {
@@ -285,7 +285,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
 
             expect(wrapper.vm.sidebarDisplayOptions.availableWidth).toBe(`${PAGE_WIDTH - MAIN_CONTENT_MIN_SIZE}px`);
             expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`545px`);
-            expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(false);
+            expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(true);
             expect(window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
             expect(eventListener).toBeDefined();
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -103,7 +103,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
     });
 
     describe('resize functionality', () => {
-        const PAGE_WIDTH = 1920;
+        const PAGE_WIDTH = 2600;
         const MAIN_CONTENT_MIN_SIZE = 1400;
 
         beforeEach(() => {
@@ -145,7 +145,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
         });
 
         it('should reset the width when sidebar was collapsed through the button', async () => {
-            mockLocalStorage.getItem.mockReturnValue('1200');
+            mockLocalStorage.getItem.mockReturnValue('700');
 
             const wrapper = await createWrapper();
 
@@ -156,8 +156,10 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             });
             Shopware.Store.get('sidebar').sidebars[0].active = true;
             await wrapper.vm.$nextTick();
-
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('1200px');
+            await dragSidebarToWidth(wrapper, 700);
+            
+            await wrapper.vm.$nextTick();
+            await wrapper.vm.$nextTick();
 
             await wrapper.find('.sw-sidebar-renderer__button-collapse').trigger('click');
             await wrapper.vm.$nextTick();
@@ -285,7 +287,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
 
             expect(wrapper.vm.sidebarDisplayOptions.availableWidth).toBe(`${PAGE_WIDTH - MAIN_CONTENT_MIN_SIZE}px`);
             expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`545px`);
-            expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(true);
+            expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(false);
             expect(window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
             expect(eventListener).toBeDefined();
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -140,7 +140,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$forceUpdate();
             await wrapper.vm.$nextTick();
 
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('480px');
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('545px');
             expect(mockLocalStorage.getItem).toHaveBeenCalledWith('sw-sidebar-width');
         });
 
@@ -163,7 +163,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$nextTick();
             await wrapper.vm.$nextTick();
 
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('480px');
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('545px');
             expect(mockLocalStorage.setItem).toHaveBeenCalledWith('sw-sidebar-width', '480');
         });
 
@@ -284,7 +284,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$nextTick();
 
             expect(wrapper.vm.sidebarDisplayOptions.availableWidth).toBe(`${PAGE_WIDTH - MAIN_CONTENT_MIN_SIZE}px`);
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`480px`);
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`545px`);
             expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(false);
             expect(window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
             expect(eventListener).toBeDefined();
@@ -294,7 +294,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$nextTick();
 
             expect(wrapper.vm.sidebarDisplayOptions.availableWidth).toBe(`${1400 - MAIN_CONTENT_MIN_SIZE}px`);
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`480px`);
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`545px`);
             expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(true);
 
             // Restore original method

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -104,7 +104,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
 
     describe('resize functionality', () => {
         const PAGE_WIDTH = 2600;
-        const MAIN_CONTENT_MIN_SIZE = 1400;
+        const MAIN_CONTENT_MIN_SIZE = 1300;
 
         beforeEach(() => {
             window.innerWidth = PAGE_WIDTH;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -157,9 +157,6 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             Shopware.Store.get('sidebar').sidebars[0].active = true;
             await wrapper.vm.$nextTick();
             await dragSidebarToWidth(wrapper, 700);
-            
-            await wrapper.vm.$nextTick();
-            await wrapper.vm.$nextTick();
 
             await wrapper.find('.sw-sidebar-renderer__button-collapse').trigger('click');
             await wrapper.vm.$nextTick();


### PR DESCRIPTION
### 1. Why is this change necessary?
This change is due to recognizing the 480px was to small to accommodate all copilot sidebar features.

### 2. What does this change do, exactly?
Changed the min width of the sidebar to 545px.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
