### PR TITLE
fix: Always overwrite currency id based on header

### DIFF
--- a/changelog/_unreleased/2025-11-03-sw-currency-header-always-overrides-context.md
+++ b/changelog/_unreleased/2025-11-03-sw-currency-header-always-overrides-context.md
@@ -5,7 +5,3 @@ title: sw-currency-id header always overrides context values
 * Added `\Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters::__construct(overwriteCurrencyId)` parameter to force overwrite of the currency id.
 * Changed `\Shopware\Core\Framework\Routing\SalesChannelRequestContextResolver::resolve()` to always set the overwrite currency id from the request header.
 * Changed `\Shopware\Core\System\SalesChannel\Context\SalesChannelContextService::get()` to always overwrite the currency id if the overwrite currency parameter is set.
-___
-# Upgrade Information
-## Product weight precision
-The database column `product.weight` now uses `DECIMAL(15,6)` instead of `DECIMAL(10,3)` to keep gram-based measurements accurate when values are stored in kilograms.

--- a/changelog/_unreleased/2025-11-03-sw-currency-header-always-overrides-context.md
+++ b/changelog/_unreleased/2025-11-03-sw-currency-header-always-overrides-context.md
@@ -1,0 +1,11 @@
+---
+title: sw-currency-id header always overrides context values
+---
+# Core
+* Added `\Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters::__construct(overwriteCurrencyId)` parameter to force overwrite of the currency id.
+* Changed `\Shopware\Core\Framework\Routing\SalesChannelRequestContextResolver::resolve()` to always set the overwrite currency id from the request header.
+* Changed `\Shopware\Core\System\SalesChannel\Context\SalesChannelContextService::get()` to always overwrite the currency id if the overwrite currency parameter is set.
+___
+# Upgrade Information
+## Product weight precision
+The database column `product.weight` now uses `DECIMAL(15,6)` instead of `DECIMAL(10,3)` to keep gram-based measurements accurate when values are stored in kilograms.

--- a/src/Core/Framework/Routing/SalesChannelRequestContextResolver.php
+++ b/src/Core/Framework/Routing/SalesChannelRequestContextResolver.php
@@ -54,21 +54,17 @@ class SalesChannelRequestContextResolver implements RequestContextResolverInterf
         // Retrieve context for current request
         $usedContextToken = (string) $request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN);
 
-        // Check for currency header first, fallback to domain currency attribute
-        $currencyId = $request->headers->get(PlatformRequest::HEADER_CURRENCY_ID);
-        if ($currencyId === null) {
-            $currencyId = $request->attributes->get(SalesChannelRequest::ATTRIBUTE_DOMAIN_CURRENCY_ID);
-        }
-
         $contextServiceParameters = new SalesChannelContextServiceParameters(
             (string) $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID),
             $usedContextToken,
             $request->headers->get(PlatformRequest::HEADER_LANGUAGE_ID),
-            $currencyId,
+            $request->attributes->get(SalesChannelRequest::ATTRIBUTE_DOMAIN_CURRENCY_ID),
             $request->attributes->get(SalesChannelRequest::ATTRIBUTE_DOMAIN_ID),
             $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT),
             null,
-            $session?->get(PlatformRequest::ATTRIBUTE_IMITATING_USER_ID)
+            $session?->get(PlatformRequest::ATTRIBUTE_IMITATING_USER_ID),
+            // overwrite currency id based on request header if it is set
+            $request->headers->get(PlatformRequest::HEADER_CURRENCY_ID)
         );
         $context = $this->contextService->get($contextServiceParameters);
 

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -86,7 +86,9 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
                 $session[self::LANGUAGE_ID] = $parameters->getLanguageId();
             }
 
-            if ($parameters->getCurrencyId() !== null && !\array_key_exists(self::CURRENCY_ID, $session)) {
+            if ($parameters->getOverwriteCurrencyId() !== null) {
+                $session[self::CURRENCY_ID] = $parameters->getOverwriteCurrencyId();
+            } elseif ($parameters->getCurrencyId() !== null && !\array_key_exists(self::CURRENCY_ID, $session)) {
                 $session[self::CURRENCY_ID] = $parameters->getCurrencyId();
             }
 

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextServiceParameters.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextServiceParameters.php
@@ -13,11 +13,13 @@ class SalesChannelContextServiceParameters extends Struct
         protected string $salesChannelId,
         protected string $token,
         protected ?string $languageId = null,
+        // used as fallback if no currency is set in the existing context
         protected ?string $currencyId = null,
         protected ?string $domainId = null,
         protected ?Context $originalContext = null,
         protected ?string $customerId = null,
-        protected ?string $imitatingUserId = null
+        protected ?string $imitatingUserId = null,
+        protected ?string $overwriteCurrencyId = null,
     ) {
     }
 
@@ -39,6 +41,11 @@ class SalesChannelContextServiceParameters extends Struct
     public function getCurrencyId(): ?string
     {
         return $this->currencyId;
+    }
+
+    public function getOverwriteCurrencyId(): ?string
+    {
+        return $this->overwriteCurrencyId;
     }
 
     public function getDomainId(): ?string


### PR DESCRIPTION
THe `sw-currency-id` header is designed to overwrite the currency of the context for the single request, however currently it does only work if no context specific currency is set
