### PR TITLE
fix: increase precision of kg unit to match database schema

### DIFF
--- a/changelog/_unreleased/2025-11-04-increase-kg-and-mm-precision-to-match-with-database-stored-schema.md
+++ b/changelog/_unreleased/2025-11-04-increase-kg-and-mm-precision-to-match-with-database-stored-schema.md
@@ -1,0 +1,6 @@
+---
+title: Increase kg and mm precision to match with database stored schema
+issue: #13198
+---
+# Core
+* Added a migration `\Shopware\Core\Migration\V6_7\Migration1762246952IncreaseKgDisplayPrecision` to increase the display precision of weight (kg) to `6` and dimensions (mm) to `3` to match the database stored schema.

--- a/src/Core/Migration/V6_7/Migration1762246952IncreaseKgDisplayPrecision.php
+++ b/src/Core/Migration/V6_7/Migration1762246952IncreaseKgDisplayPrecision.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class Migration1762246952IncreaseKgDisplayPrecision extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1762246952;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'UPDATE measurement_display_unit
+             SET `precision` = 6
+             WHERE `short_name` = :shortName
+               AND `updated_at` IS NULL
+               AND `precision` = 2',
+            ['shortName' => 'kg']
+        );
+
+        $connection->executeStatement(
+            'UPDATE measurement_display_unit
+             SET `precision` = 3
+             WHERE `short_name` = :shortName
+               AND `updated_at` IS NULL
+               AND `precision` = 2',
+            ['shortName' => 'mm']
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1762246952IncreaseKgDisplayPrecisionTest.php
+++ b/tests/migration/Core/V6_7/Migration1762246952IncreaseKgDisplayPrecisionTest.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_7\Migration1742199550MeasurementDisplayUnitTable;
+use Shopware\Core\Migration\V6_7\Migration1762246952IncreaseKgDisplayPrecision;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(Migration1762246952IncreaseKgDisplayPrecision::class)]
+class Migration1762246952IncreaseKgDisplayPrecisionTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+        $migration = new Migration1742199550MeasurementDisplayUnitTable();
+        $migration->update($this->connection);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE measurement_display_unit SET `precision` = :precision WHERE short_name = :shortName;',
+            [
+                'precision' => 2,
+                'shortName' => 'kg',
+            ],
+            [
+                'shortName' => ParameterType::STRING,
+            ],
+        );
+
+        $this->connection->executeStatement(
+            'UPDATE measurement_display_unit SET `precision` = :precision WHERE short_name = :shortName;',
+            [
+                'precision' => 2,
+                'shortName' => 'mm',
+            ],
+            [
+                'shortName' => ParameterType::STRING,
+            ],
+        );
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1762246952, (new Migration1762246952IncreaseKgDisplayPrecision())->getCreationTimestamp());
+    }
+
+    public function testMigrationIncreasesKgPrecision(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE measurement_display_unit SET `precision` = 2, updated_at = NULL WHERE short_name = :shortName',
+            [
+                'shortName' => 'kg',
+            ],
+            [
+                'shortName' => ParameterType::STRING,
+            ],
+        );
+
+        $migration = new Migration1762246952IncreaseKgDisplayPrecision();
+
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $precision = $this->connection->fetchOne(
+            'SELECT `precision` FROM measurement_display_unit WHERE short_name = :shortName',
+            [
+                'shortName' => 'kg',
+            ],
+            [
+                'shortName' => ParameterType::STRING,
+            ],
+        );
+
+        static::assertSame('6', (string) $precision);
+    }
+
+    public function testMigrationIncreasesMmPrecision(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE measurement_display_unit SET `precision` = 2, updated_at = NULL WHERE short_name = :shortName',
+            [
+                'shortName' => 'mm',
+            ],
+            [
+                'shortName' => ParameterType::STRING,
+            ],
+        );
+
+        $migration = new Migration1762246952IncreaseKgDisplayPrecision();
+
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $precision = $this->connection->fetchOne(
+            'SELECT `precision` FROM measurement_display_unit WHERE short_name = :shortName',
+            [
+                'shortName' => 'mm',
+            ],
+            [
+                'shortName' => ParameterType::STRING,
+            ]
+        );
+
+        static::assertSame('3', (string) $precision);
+    }
+
+    public function testMigrationDoesNotChangeUpdatedUnits(): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE measurement_display_unit SET `precision` = 2, updated_at = :now WHERE short_name = :shortName',
+            [
+                'shortName' => 'kg',
+                'now' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ],
+            [
+                'shortName' => ParameterType::STRING,
+            ],
+        );
+
+        $migration = new Migration1762246952IncreaseKgDisplayPrecision();
+
+        $migration->update($this->connection);
+
+        $precision = $this->connection->fetchOne(
+            'SELECT `precision` FROM measurement_display_unit WHERE short_name = :shortName',
+            [
+                'shortName' => 'kg',
+            ],
+            [
+                'shortName' => ParameterType::STRING,
+            ],
+        );
+
+        static::assertSame('2', (string) $precision);
+    }
+}


### PR DESCRIPTION
When saving width/weight to database, we converted them back to mm/kg, so we need to have the most precise digits as possible, in this case 6 for kg and 3 for mm

closes #13198