### PR TITLE
fix: positioning of partial review stars

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/page/product-detail/_review.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/product-detail/_review.scss
@@ -80,6 +80,8 @@
 
 .point-partial {
     position: absolute;
+    top: 0;
+    left: 0;
 }
 
 .product-detail-review-form-star {


### PR DESCRIPTION
resolves #13305

I removed `top: 0; left: 0;` in #13046 because I thought they would have no effect on `.point-rating`. What I missed was that `.point-partial` inherited this positioning and uses `position: absolute;`, which broke the display of partial stars.