### PR TITLE
fix: deprecate recurring data struct properties

### DIFF
--- a/changelog/_unreleased/2025-11-04-deprecate-recurring-data-struct-properties.md
+++ b/changelog/_unreleased/2025-11-04-deprecate-recurring-data-struct-properties.md
@@ -1,0 +1,8 @@
+---
+title: Deprecate recurring data struct properties
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Core
+* Changed `Shopware\Core\Checkout\Payment\Cart\Recurring\RecurringDataStruct` to deprecate `subscriptionId` and `nextSchedule` properties due to being specific to the commercial implementation.

--- a/src/Core/Checkout/Payment/Cart/Recurring/RecurringDataStruct.php
+++ b/src/Core/Checkout/Payment/Cart/Recurring/RecurringDataStruct.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Payment\Cart\Recurring;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
@@ -15,18 +16,34 @@ class RecurringDataStruct extends Struct
      * @internal
      */
     public function __construct(
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed without replacement
+         */
         protected string $subscriptionId,
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed without replacement
+         */
         protected \DateTimeInterface $nextSchedule,
     ) {
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
     public function getSubscriptionId(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'));
+
         return $this->subscriptionId;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
     public function getNextSchedule(): \DateTimeInterface
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'));
+
         return $this->nextSchedule;
     }
 }

--- a/tests/unit/Core/Checkout/Payment/Cart/Recurring/RecurringDataStructTest.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/Recurring/RecurringDataStructTest.php
@@ -6,14 +6,18 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Cart\Recurring\RecurringDataStruct;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
+ *
+ * @deprecated tag:v6.8.0 - Will be removed
  */
 #[Package('checkout')]
 #[CoversClass(RecurringDataStruct::class)]
 class RecurringDataStructTest extends TestCase
 {
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetters(): void
     {
         $time = new \DateTime();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The properties of `RecurringDataStruct` are most likely specific to the implementation used in our Commercial bundle.

### 2. What does this change do, exactly?
Deprecate these properties

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
