### PR TITLE
ci: update snapshot action

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -123,8 +123,8 @@ jobs:
 
   openapi-lint:
     runs-on: ubuntu-24.04
-    # permissions:
-    #   id-token: write
+    permissions:
+      id-token: write
     env:
       APP_ENV: prod
       APP_URL: http://localhost:8000
@@ -168,12 +168,10 @@ jobs:
           retention-days: 1
 
       - name: Run OpenAPI Snapshot Action
-        uses: patzick/explore-openapi-snapshot@5d02271994580c9e65222c55a6f3dfe19522de05 # v1.1.0
+        uses: patzick/explore-openapi-snapshot@7ea174b327803e6d4b5cfe98c3044edf011a874b # v2.0.0
         with:
           schema-file: "./api-types/storeApiSchema.json"
-          project: "shopware-store-api"
-          auth-token: ${{ secrets.EXPLORE_OPENAPI_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          project: "shopware/store-api"
 
       - name: Generate StoreAPI schema
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -123,8 +123,8 @@ jobs:
 
   openapi-lint:
     runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
+    # permissions:
+    #   id-token: write
     env:
       APP_ENV: prod
       APP_URL: http://localhost:8000

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -123,6 +123,8 @@ jobs:
 
   openapi-lint:
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     env:
       APP_ENV: prod
       APP_URL: http://localhost:8000


### PR DESCRIPTION
Update of the snapshot action:

https://github.com/patzick/explore-openapi-snapshot/releases/tag/v2.0.0

In combination with github action this update allow us to track changes also from the external contributions.