### PR TITLE
ci: use self-hosted octo-sts

### DIFF
--- a/.github/actions/ats/action.yaml
+++ b/.github/actions/ats/action.yaml
@@ -69,13 +69,13 @@ inputs:
         description: "Prefix for the artifact name"
 
 runs:
-    using: "composite"
-    steps:
-        - uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # v1.0.1
+  using: "composite"
+  steps:
+        - uses: shopware/octo-sts-action@main
           id: create-pr-token
           with:
-              scope: shopware
-              identity: CreatePR
+            scope: shopware
+            identity: CreatePR
           continue-on-error: true
 
         - name: Start redis

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -48,7 +48,7 @@ jobs:
       - id: sts
         if: ${{ !github.event.act }}
         continue-on-error: true
-        uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        uses: shopware/octo-sts-action@main
         with:
           scope: shopware
           identity: ReadCollaborators
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 4
       - id: sts
         continue-on-error: true
-        uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        uses: shopware/octo-sts-action@main
         with:
           scope: shopware
           identity: ManageProjects
@@ -170,7 +170,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 4
       - id: sts
         continue-on-error: true
-        uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        uses: shopware/octo-sts-action@main
         with:
           scope: shopware
           identity: ManageProjects

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           name: context
 
-      - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+      - uses: shopware/octo-sts-action@main
         id: sts-shopware-split
         with:
           scope: shopware

--- a/.github/workflows/05-publish-release.yml
+++ b/.github/workflows/05-publish-release.yml
@@ -43,7 +43,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_INFO_SECRET }}
             AWS_DEFAULT_REGION: eu-west-1
 
-        - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        - uses: shopware/octo-sts-action@main
           if: github.event.action == 'published'
           id: sts-store-api-reference
           with:
@@ -62,7 +62,7 @@ jobs:
             https://api.github.com/repos/shopware/store-api-reference/actions/workflows/manual_versioning.yml/dispatches \
             -d '{"ref": "latest", "inputs": {"shopware_version": "${{ github.event.release.tag_name }}"}}'
 
-        - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        - uses: shopware/octo-sts-action@main
           if: github.event.action == 'published'
           id: sts-admin-api-reference
           with:
@@ -81,7 +81,7 @@ jobs:
             https://api.github.com/repos/shopware/admin-api-reference/actions/workflows/manual_versioning.yml/dispatches \
             -d '{"ref": "latest", "inputs": {"shopware_version": "${{ github.event.release.tag_name }}"}}'
 
-        - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        - uses: shopware/octo-sts-action@main
           if: github.event.action == 'published'
           id: sts-production
           with:
@@ -99,7 +99,7 @@ jobs:
             -H "Content-Type: application/json" \
             https://api.github.com/repos/shopware/template/actions/workflows/update.yml/dispatches \
             -d '{"ref": "trunk"}'
-  
+
   publish-sbp-release:
     if: github.repository == 'shopware/shopware'
     strategy:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,7 +31,7 @@ jobs:
       owner: ${{ steps.issue.outputs.owner }}
       repository: ${{ steps.issue.outputs.repository }}
     steps:
-      - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+      - uses: shopware/octo-sts-action@main
         id: sts-shopware-backport
         if: ${{ !github.event.act }}
         with:
@@ -84,7 +84,7 @@ jobs:
       && needs.find-linked-issue.outputs.id
     needs: [ find-linked-issue ]
     steps:
-      - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+      - uses: shopware/octo-sts-action@main
         id: sts-shopware-backport
         if: ${{ !github.event.act }}
         with:
@@ -105,12 +105,12 @@ jobs:
               repo: process.env.ISSUE_REPOSITORY,
               issue_number: parseInt(process.env.ISSUE_NUMBER),
             });
-            
+
             if (issue.data.state === 'open') {
               core.info(`Issue #${process.env.ISSUE_NUMBER} is already open, no action needed.`);
               return;
             }
-            
+
             await github.rest.issues.update({
               owner: process.env.ISSUE_OWNER,
               repo: process.env.ISSUE_REPOSITORY,
@@ -118,7 +118,7 @@ jobs:
               state: 'open',
               state_reason: 'reopened',
             });
-            
+
             if (process.env.POST_COMMENT) {
               await github.rest.issues.createComment({
                 owner: process.env.ISSUE_OWNER,
@@ -154,15 +154,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const labels = JSON.parse(process.env.LABELS);
-            
+
             const targetBranches = labels
               .filter(label => label.name.startsWith('backport-'))
               .map(label => label.name.replace('backport-', ''));
-            
+
             const filteredLabels = labels
               .filter(label => !label.name.startsWith('backport-'))
               .map(label => label.name);
-            
+
             core.setOutput('target-branches', JSON.stringify(targetBranches));
             core.setOutput('labels', JSON.stringify(filteredLabels));
 
@@ -185,7 +185,7 @@ jobs:
         target-branch: ${{ fromJSON(needs.parse-labels.outputs.target-branches) }}
       fail-fast: true
     steps:
-      - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+      - uses: shopware/octo-sts-action@main
         id: sts-shopware-backport
         if: ${{ !github.event.act }}
         with:
@@ -204,7 +204,7 @@ jobs:
           body-prefix: | # Reference original PR, as well as the related issue, if available
             ${{ format('**Backport:** {0}', github.event.pull_request.html_url) }}
             ${{ needs.find-linked-issue.outputs.url && format('Resolves: {0}', needs.find-linked-issue.outputs.url) }}
-            
+
             ---
           assignees: >- # Inherit original assignees
             ${{ github.event.pull_request.assignees && join(github.event.pull_request.assignees.*.login, ',') || '' }}

--- a/.github/workflows/doc-task.yml
+++ b/.github/workflows/doc-task.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 4
       - id: sts
         continue-on-error: true
-        uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        uses: shopware/octo-sts-action@main
         with:
           scope: shopware
           identity: ManageProjects
@@ -34,13 +34,13 @@ jobs:
           github-token: ${{ steps.sts.outputs.token }}
           script: |
             const { createDocumentationTasksForProjects } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
-            
+
             const repoVars = JSON.parse(process.env.REPO_VARS);
             const docTaskProjects = repoVars.DOC_TASK_PROJECTS.split(',').map(i => parseInt(i));
             const docTaskProjectId = parseInt(repoVars.DOC_TASK_PROJECT_ID);
             const docTaskDescription = repoVars.DOC_TASK_DESCRIPTION;
             const docTaskReferenceCommentPrefix = repoVars.DOC_TASK_REFERENCE_COMMENT_PREFIX;
-            
+
             await createDocumentationTasksForProjects(
               {github, core, context, fetch},
               docTaskProjects,

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - id: sts
         continue-on-error: true
-        uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        uses: shopware/octo-sts-action@main
         with:
           scope: shopware
           identity: ShopwareDownstream
@@ -48,7 +48,7 @@ jobs:
     steps:
       - id: sts
         continue-on-error: true
-        uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        uses: shopware/octo-sts-action@main
         with:
           scope: shopware
           identity: ShopwareDownstream

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,10 @@ on:
         type: string
         default: ""
 
+permissions:
+    contents: read
+    id-token: write
+
 jobs:
   acceptance:
     runs-on: ubuntu-24.04

--- a/.github/workflows/manage-stale-prs.yml
+++ b/.github/workflows/manage-stale-prs.yml
@@ -16,7 +16,7 @@ jobs:
       - id: sts
         if: ${{ !github.event.act }}
         continue-on-error: true
-        uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+        uses: shopware/octo-sts-action@main
         with:
           scope: shopware
           identity: Reminder

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Delay
         run: sleep 20m
-      - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+      - uses: shopware/octo-sts-action@main
         id: sts
         with:
           scope: shopware

--- a/.github/workflows/saas-branch.yml
+++ b/.github/workflows/saas-branch.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+      - uses: shopware/octo-sts-action@main
         id: sts-shopware-private
         with:
           scope: shopware
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Checkout platform
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 4
-      - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+      - uses: shopware/octo-sts-action@main
         id: sts-shopware-private
         with:
           scope: shopware

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: octo-sts/action@a26b0c6455c7f13316f29a8766287f939e75f6c8 # 1.0.2
+      - uses: shopware/octo-sts-action@main
         id: sts-shopware-private
         with:
           scope: shopware


### PR DESCRIPTION
### 1. Why is this change necessary?
We hit the rate limit of the official octo-sts very often, so we decided to self-host it.

### 2. What does this change do, exactly?
Use a custom action, that first tries our self-hosted octo-sts and fall back to the official octo-sts if our octo-sts has problems.

### 3. Describe each step to reproduce the issue or behaviour.
Run a pipeline