### PR TITLE
fix: scroll to checkbox if validation failed

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-handler.plugin.js
@@ -67,6 +67,8 @@ export default class FormHandler extends Plugin {
         /**
          * Define the selector for gathering all fields of the form.
          *
+         * @deprecated tag:v6.8.0 - Default will be replaced with `null`
+         *
          * @type {string}
          */
         formFieldSelector: 'input, textarea, select',
@@ -91,7 +93,6 @@ export default class FormHandler extends Plugin {
         }
 
         this.form = this.el;
-        this.formFields = this.form.querySelectorAll(this.options.formFieldSelector);
         this.submitButtons = this._getSubmitButtons();
 
         // Will hold the instances of loading indicators for each submit button.
@@ -102,6 +103,19 @@ export default class FormHandler extends Plugin {
         }
 
         this._initFormEvents();
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
+    set formFields(formFields) {
+        this._formFields = formFields;
+    }
+
+    get formFields() {
+        return this.options.formFieldSelector
+            ? this.form.querySelectorAll(this.options.formFieldSelector)
+            : [...this.form.elements];
     }
 
     /**
@@ -174,8 +188,6 @@ export default class FormHandler extends Plugin {
         // Handle form validation
         if (this.options.validateOnSubmit === true) {
             // Form fields are always updated again, because there might be fields that where added async.
-            this.formFields = this.form.querySelectorAll(this.options.formFieldSelector);
-
             const invalidFields = window.formValidation.validateForm(this.form, this.formFields);
 
             if (invalidFields.length > 0) {
@@ -187,6 +199,8 @@ export default class FormHandler extends Plugin {
                 // The focus will be set to the first invalid field.
                 // The page will automatically scroll to the field with focus.
                 if (this.options.focusInvalidField === true) {
+                    // In Safari, focus alone may not scroll, so manual scrolling is needed.
+                    invalidFields[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
                     invalidFields[0].focus();
                 }
 
@@ -231,8 +245,6 @@ export default class FormHandler extends Plugin {
      */
     _checkValidity() {
         // Form fields are always updated again, because there might be fields that where added async.
-        this.formFields = this.form.querySelectorAll(this.options.formFieldSelector);
-
         const invalidFields = window.formValidation.validateForm(this.form, this.formFields);
 
         return invalidFields.length === 0;

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-handler.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-handler.plugin.test.js
@@ -92,6 +92,7 @@ describe('FormHandler Plugin', () => {
     });
 
     test('should validate form on submit', () => {
+        HTMLElement.prototype.scrollIntoView = jest.fn();
         const submitEvent = new Event('submit', { cancelable: true });
         const eventSpy = jest.spyOn(submitEvent, 'preventDefault');
 

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -224,7 +224,8 @@
         <form id="confirmOrderForm"
               action="{{ confirmOrderFormAction }}"
               data-form-preserver="true"
-              data-form-submit-loader="true"
+              data-form-handler="true"
+              data-form-handler-options="{{ { formFieldSelector: null }|json_encode }}"
               data-form-add-history="true"
               data-form-add-history-options="{{ formAddHistoryOptions|json_encode }}"
               method="post">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If you don't check the terms and conditions checkbox during checkout on an iPhone (tested in Safari and Chrome) and click “Confirm order,” nothing happens.
It does not automatically scroll up to the checkbox.

### 2. What does this change do, exactly?
Added manual scrolling

### 4. Please link to the relevant issues (if any).
Fixes #13047 
