### PR TITLE
refactor: use more CSS variables in filter components

### DIFF
--- a/src/Storefront/Resources/views/components/Sw/Filter/ActiveFilters.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Filter/ActiveFilters.html.twig
@@ -1,10 +1,10 @@
 {% set defaultAttributes = {
-    'class': 'sw-active-filters',
+    'class': 'sw-active-filters container',
     'data-component': 'ActiveFilters',
 } %}
 
 <div {{ attributes.defaults(defaultAttributes) }}>
-    <button class="sw-active-filters__btn-reset-all is--hidden" type="button">
+    <button class="sw-active-filters__btn-reset-all btn btn-outline-danger is--hidden" type="button">
         {{ 'listing.filterPanelResetAll'|trans|sw_sanitize }}
     </button>
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Filter/ActiveFilters.js
+++ b/src/Storefront/Resources/views/components/Sw/Filter/ActiveFilters.js
@@ -31,9 +31,9 @@ class ActiveFilters extends ShopwareComponent {
     }
 
     handleFilterChange({ paramName, value, label, option }) {
-        if (value === null || 
-            value === undefined || 
-            value === '' || 
+        if (value === null ||
+            value === undefined ||
+            value === '' ||
             value === false ||
             value.length === 0) {
             this.removeActiveFilterLabel({ paramName, label, option });
@@ -45,9 +45,9 @@ class ActiveFilters extends ShopwareComponent {
     }
 
     handleFilterInit({ paramName, value, label, option }) {
-        if (value === null || 
-            value === undefined || 
-            value === '' || 
+        if (value === null ||
+            value === undefined ||
+            value === '' ||
             value === false ||
             value.length === 0) {
             return;
@@ -68,9 +68,9 @@ class ActiveFilters extends ShopwareComponent {
             }
             filter.label = label;
         } else {
-            filter = { 
+            filter = {
                 paramName,
-                label, 
+                label,
                 option,
                 el: this.createActiveFilterEl({ paramName, label, option })
             };
@@ -112,7 +112,7 @@ class ActiveFilters extends ShopwareComponent {
     createActiveFilterEl({ paramName, label, option }) {
         const element = document.createElement('button');
 
-        element.classList.add('sw-active-filter__item');
+        element.classList.add('sw-active-filter__item', 'btn');
         element.setAttribute('data-filter', paramName);
         if (option) {
             element.setAttribute('data-option', option);

--- a/src/Storefront/Resources/views/components/Sw/Filter/ActiveFilters.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/ActiveFilters.scss
@@ -1,5 +1,4 @@
 .sw-active-filters {
-    @extend .container;
     display: flex;
     flex-flow: wrap;
     align-items: center;
@@ -9,18 +8,17 @@
 }
 
 .sw-active-filter__item {
-    --#{$prefix}btn-focus-box-shadow: #{$input-btn-focus-box-shadow};
-    --#{$prefix}btn-border-color: #{$input-border-color};
-    --#{$prefix}btn-hover-border-color: #{$primary};
-    --#{$prefix}btn-hover-color: #{$primary};
-    --#{$prefix}btn-hover-bg: #{$gray-100};
-    --#{$prefix}btn-active-border-color: #{$primary};
-    --#{$prefix}btn-active-color: #{$primary};
-    --#{$prefix}btn-font-weight: #{$font-weight-normal};
-    --#{$prefix}btn-border-radius: #{$border-radius-pill};
-    --#{$prefix}btn-padding-y: 0.125rem;
-    --#{$prefix}btn-line-height: 1.625rem;
-    @extend .btn;
+    --bs-btn-focus-box-shadow: 0 0 0 0.125rem var(--bs-white), 0 0 0 var(--bs-focus-ring-width) var(--bs-focus-ring-color);
+    --bs-btn-border-color: var(--bs-border-color);
+    --bs-btn-hover-border-color: var(--bs-primary);
+    --bs-btn-hover-color: var(--bs-primary);
+    --bs-btn-hover-bg: var(--bs-gray-100);
+    --bs-btn-active-border-color: var(--bs-primary);
+    --bs-btn-active-color: var(--bs-primary);
+    --bs-btn-font-weight: var(--bs-body-font-weight);
+    --bs-btn-border-radius: var(--bs-border-radius-pill);
+    --bs-btn-padding-y: 0.125rem;
+    --bs-btn-line-height: 1.625rem;
     display: flex;
     align-items: center;
 }
@@ -46,12 +44,10 @@
 }
 
 .sw-active-filters__btn-reset-all {
-    --#{$prefix}btn-font-weight: #{$font-weight-normal};
-    --#{$prefix}btn-border-radius: #{$border-radius-pill};
-    --#{$prefix}btn-padding-y: 0.125rem;
-    --#{$prefix}btn-line-height: 1.625rem;
-    @extend .btn;
-    @extend .btn-outline-danger;
+    --bs-btn-font-weight: var(--bs-body-font-weight);
+    --bs-btn-border-radius: var(--bs-border-radius-pill);
+    --bs-btn-padding-y: 0.125rem;
+    --bs-btn-line-height: 1.625rem;
 
     &.is--hidden {
         display: none;

--- a/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
@@ -73,7 +73,7 @@
     }
 
     &.show {
-        border-bottom-color: $body-bg;
+        border-bottom-color: var(--bs-body-bg);
         z-index: 1001;
 
         .icon-default-arrow-head-up {

--- a/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
@@ -3,7 +3,7 @@
     justify-content: space-between;
     align-items: start;
     gap: 0.5rem;
-    background-color: $white;
+    background-color: var(--bs-body-bg);
     position: sticky;
     top: 0;
     z-index: 2;


### PR DESCRIPTION
Only relevant for `8446/twig-ux-components`

Use more CSS custom properties over SCSS variables inside the filter SCSS, so it will be easier later to use native CSS.

