### PR TITLE
feat: Add v6.7.30 and v6.7.4.0 releases

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -102,4 +102,16 @@
     "extended_eol": false,
     "security_eol": "2027-02-28"
   }
+    {
+    "version": "6.7.3.0",
+    "release_date": "2025-10-06",
+    "extended_eol": false,
+    "security_eol": "2027-02-28"
+  }
+    {
+    "version": "6.7.4.0",
+    "release_date": "2025-11-04",
+    "extended_eol": false,
+    "security_eol": "2027-02-28"
+  }
 ]


### PR DESCRIPTION
### 1. Why is this change necessary?

Change updates releases.json with v6.7.3.0 and v6.7.4.0

### 2. What does this change do, exactly?

Entries with new versions

### 3. Describe each step to reproduce the issue or behaviour.

I recently had a closer look at https://developer.shopware.com/release-notes/ and suddenly, I recognized that the above named versions have not been mentioned yet.

### 4. Please link to the relevant issues (if any).

none

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them