### PR TITLE
ci: improve downstream

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Rufus
         uses: shopware/github-actions/downstream@main
         if: steps.sts.outputs.token
+        env:
+            NEW_LOGIC: 1
         with:
           repo: shopware/rufus
           workflow: .github/workflows/downstream.yml
@@ -39,7 +41,7 @@ jobs:
           token: ${{ steps.sts.outputs.token }}
           env:
             NIGHTLY=${{ inputs.nightly }}
-  
+
   commercial:
     name: Commercial
     runs-on: ubuntu-24.04
@@ -53,6 +55,8 @@ jobs:
       - name: Commercial
         uses: shopware/github-actions/downstream@main
         if: steps.sts.outputs.token
+        env:
+            NEW_LOGIC: 1
         with:
           repo: shopware/SwagCommercial
           workflow: Downstream

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -233,6 +233,7 @@ jobs:
           php-version: 8.4
           shopware-version: ${{ github.ref }}
           shopware-repository: ${{ github.repository }}
+          keep-composer-tools: true
 
       - name: Start Webserver
         run: symfony server:start -d


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently we try to get the logs of a run, which are first available after a job is done.
With every try we waste multiple API requests, which exhausts the API rate limit faster.

### 2. What does this change do, exactly?
With the new logic we get the run by the job title, which requires less requests.

### 3. Describe each step to reproduce the issue or behaviour.
Trigger a downstream pipeline

### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/github-actions/pull/109