### PR TITLE
fix: guest behavior for address edit

### DIFF
--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -245,7 +245,7 @@ abstract class StorefrontController extends AbstractController
                 if ($error instanceof AddressErrorInterface && $error->getAddressId() !== null) {
                     $parameters['%url%'] = $this->generateUrl('frontend.account.address.edit.page', [
                         'addressId' => $error->getAddressId(),
-                        'redirectTo' => $request->attributes->get('_route'),
+                        'redirectTo' => $request?->attributes->get('_route'),
                     ]);
                 }
 

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -243,7 +243,10 @@ abstract class StorefrontController extends AbstractController
                 });
 
                 if ($error instanceof AddressErrorInterface && $error->getAddressId() !== null) {
-                    $parameters['%url%'] = $this->generateUrl('frontend.account.address.edit.page', ['addressId' => $error->getAddressId()]);
+                    $parameters['%url%'] = $this->generateUrl('frontend.account.address.edit.page', [
+                        'addressId' => $error->getAddressId(),
+                        'redirectTo' => $request->attributes->get('_route'),
+                    ]);
                 }
 
                 $translatedMessage = $this->trans('checkout.' . $error->getMessageKey(), $parameters);

--- a/src/Storefront/Resources/views/storefront/page/account/addressbook/edit.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/addressbook/edit.html.twig
@@ -41,6 +41,10 @@
                                 </p>
                             {% endblock %}
 
+                            {% block page_account_address_form_redirect %}
+                                <input type="hidden" name="redirectTo" value="{{ redirectTo }}">
+                            {% endblock %}
+
                             {% block page_account_address_action_buttons %}
                                 <div class="address-form-actions d-flex justify-content-between">
                                     {% block page_account_address_action_button_back %}

--- a/tests/integration/Storefront/Controller/AddressControllerTest.php
+++ b/tests/integration/Storefront/Controller/AddressControllerTest.php
@@ -237,7 +237,7 @@ class AddressControllerTest extends TestCase
         static::getContainer()->get('request_stack')->push($request);
 
         /** @var RedirectResponse $response */
-        $response = $controller->saveAddress($dataBag, $context, $customer);
+        $response = $controller->saveAddress($dataBag, $context, $customer, new Request());
 
         $criteria = new Criteria([$id1]);
         $criteria->addAssociation('addresses');

--- a/tests/unit/Storefront/Controller/AddressControllerTest.php
+++ b/tests/unit/Storefront/Controller/AddressControllerTest.php
@@ -120,14 +120,15 @@ class AddressControllerTest extends TestCase
     {
         $customer = new CustomerEntity();
         $customer->setId(Uuid::randomHex());
-        $dataBag = new RequestDataBag();
-        $dataBag->set('address', new DataBag(['id' => Uuid::randomHex()]));
+        $request = new Request();
+        $request->request->set('redirectTo', 'foo');
 
-        $response = $this->controller->accountEditAddress(new Request(), Generator::generateSalesChannelContext(), $customer);
+        $response = $this->controller->accountEditAddress($request, Generator::generateSalesChannelContext(), $customer);
         $renderParams = $this->controller->renderStorefrontParameters;
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertArrayHasKey('page', $renderParams);
+        static::assertSame('foo', $renderParams['redirectTo'] ?? null);
     }
 
     public function testSwitchDefaultAddressThrowsException(): void

--- a/tests/unit/Storefront/Controller/AddressControllerTest.php
+++ b/tests/unit/Storefront/Controller/AddressControllerTest.php
@@ -348,11 +348,12 @@ class AddressControllerTest extends TestCase
     {
         $customer = new CustomerEntity();
         $customer->setId(Uuid::randomHex());
+        $customer->setGuest(false);
 
         $dataBag = new RequestDataBag();
         $dataBag->set('address', new DataBag(['id' => Uuid::randomHex()]));
 
-        $response = $this->controller->saveAddress($dataBag, Generator::generateSalesChannelContext(), $customer);
+        $response = $this->controller->saveAddress($dataBag, Generator::generateSalesChannelContext(), $customer, new Request());
         static::assertInstanceOf(RedirectResponse::class, $response);
 
         static::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
@@ -372,7 +373,7 @@ class AddressControllerTest extends TestCase
             ->method('upsert')
             ->willThrowException(new ConstraintViolationException(new ConstraintViolationList(), []));
 
-        $response = $this->controller->saveAddress($dataBag, Generator::generateSalesChannelContext(), $customer);
+        $response = $this->controller->saveAddress($dataBag, Generator::generateSalesChannelContext(), $customer, new Request());
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertSame('forward to frontend.account.address.edit.page', $response->getContent());
@@ -391,7 +392,7 @@ class AddressControllerTest extends TestCase
             ->method('upsert')
             ->willThrowException(new ConstraintViolationException(new ConstraintViolationList(), []));
 
-        $response = $this->controller->saveAddress($dataBag, Generator::generateSalesChannelContext(), $customer);
+        $response = $this->controller->saveAddress($dataBag, Generator::generateSalesChannelContext(), $customer, new Request());
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertSame('forward to frontend.account.address.create.page', $response->getContent());

--- a/tests/unit/Storefront/Controller/StorefrontControllerTest.php
+++ b/tests/unit/Storefront/Controller/StorefrontControllerTest.php
@@ -574,6 +574,7 @@ class StorefrontControllerTest extends TestCase
         $session = new Session(new TestSessionStorage());
 
         $request->setSession($session);
+        $request->attributes->set('_route', 'some.route');
 
         $stack = new RequestStack();
         $stack->push($request);
@@ -589,7 +590,7 @@ class StorefrontControllerTest extends TestCase
         $router
             ->expects($this->once())
             ->method('generate')
-            ->with('frontend.account.address.edit.page', ['addressId' => 'address-id-123'])
+            ->with('frontend.account.address.edit.page', ['addressId' => 'address-id-123', 'redirectTo' => 'some.route'])
             ->willReturn('errorUrl');
 
         $container = new ContainerBuilder();


### PR DESCRIPTION
### 1. Why is this change necessary?
Cart errors with invalid addresses contain links to editing the address.
This link is not reachable for guest customers.

### 2. What does this change do, exactly?
Allows for guest editing and sets up a redirect logic to previous page, as the address list (previous redirect after edit) is not reachable for guests.

### 3. Describe each step to reproduce the issue or behaviour.
- Register a guest customer
- Turn on phone number or birth date as required
- There should now be an address error on the checkout confirm page
- Try to edit the address to conform to the error

### 4. Please link to the relevant issues (if any).
relates to #13379

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
