### PR TITLE
fix(admin): settings storefront icon size

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/page/sw-settings-storefront-index/sw-settings-storefront-index.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/page/sw-settings-storefront-index/sw-settings-storefront-index.html.twig
@@ -7,9 +7,9 @@
         <h2>
             {% block sw_settings_storefront_smart_bar_header_title_text %}
             {{ $tc('sw-settings.index.title') }}
-            <sw-icon
+            <mt-icon
                 name="regular-chevron-right-xs"
-                small
+                size="12px"
             />
             {{ $tc('sw-settings-storefront.general.textHeadline') }}
             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
 
<img width="222" height="66" alt="image" src="https://github.com/user-attachments/assets/8669effd-def9-4b37-a899-501b7d8f9d31" />

Icon is to big

### 2. What does this change do, exactly?

Change the `sw-icon` to the new `mt-icon`

<img width="276" height="66" alt="image" src="https://github.com/user-attachments/assets/8a2a817f-0012-4238-98be-90059f1c1de9" />
