### PR TITLE
fix: storefront missing system services (Storefront Analytics / Google Analytics)

### DIFF
--- a/src/Storefront/Storefront.php
+++ b/src/Storefront/Storefront.php
@@ -31,6 +31,7 @@ class Storefront extends Bundle implements ThemeInterface
         $loader->load('seo.xml');
         $loader->load('controller.xml');
         $loader->load('theme.xml');
+        $loader->load('system.xml');
 
         $container->setParameter('storefrontRoot', $this->getPath());
 


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the `system` services in the storefront dependency injection is not loaded, as it is missing in the storefront bundle loading step
- This results in the problem, that the Storefront Analytics / Google Analytics subscriber is never loaded and all Storefront Analytics / Google Analytics are missing from the storefront -> no analytics data is collected!
- This PR fixes this problem

### 2. What does this change do, exactly?
- Added the missing `system` services in the storefront dependency injection

### 3. Describe each step to reproduce the issue or behaviour.
- Access a shopware storefront version 6.7.4.0
- Check dev tools, network tab or page head -> there is no Storefront Analytics / Google Analytics script tag

### 4. Please link to the relevant issues (if any).
- Fix #13387

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
