### PR TITLE
feat: allow overwriting wrapperClass on primary/replica mode

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -56,6 +56,21 @@ To add descriptions to fields in your custom entity definitions, use the `setDes
     ->setDescription('Customer group determining pricing and permissions')
 ```
 
+### Allow overwriting Doctrine wrapperClass on Primary/Replica setups
+
+It's now possible to overwrite the `wrapperClass` of the `Doctrine\DBAL\Connection` instance.
+This is useful if you want to use e.g. `Doctrine MySQL Comeback` to automatically reconnect if the MySQL connection is lost.
+
+```bash
+composer require facile-it/doctrine-mysql-come-back ^3.0
+```
+
+Then specify the `wrapperClass` in the `.env` file:
+
+```
+DATABASE_URL=mysql://root:root@database/shopware?driverOptions[x_reconnect_attempts]=5&wrapperClass=Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection
+```
+
 ### Robots.txt parsing
 
 A new `Shopware\Storefront\Page\Robots\Parser\RobotsDirectiveParser` has been introduced to parse `robots.txt` files. This new service provides improved error tracking and adds new events for better extensibility.

--- a/src/Core/Framework/Adapter/Database/MySQLFactory.php
+++ b/src/Core/Framework/Adapter/Database/MySQLFactory.php
@@ -77,7 +77,9 @@ class MySQLFactory
         }
 
         if ($replicaUrl) {
-            $parameters['wrapperClass'] = PrimaryReadReplicaConnection::class;
+            if (!isset($parameters['wrapperClass'])) {
+                $parameters['wrapperClass'] = PrimaryReadReplicaConnection::class;
+            }
 
             // Primary connection should use parameters from the main url
             $parameters['primary'] = array_merge([


### PR DESCRIPTION
### 1. Why is this change necessary?

Allows using wrapperClasses on primary replica setups.

### 2. What does this change do, exactly?

```
# .env
DATABASE_URL=mysql://root:root@database/shopware?driverOptions[x_reconnect_attempts]=5&wrapperClass=Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection
```


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
