### PR TITLE
fix: error messages when removing cms sections

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
@@ -570,6 +570,8 @@ export default Shopware.Component.wrapComponentConfig({
             if (!dragSectionHasBlock && !dropSectionHasBlock) {
                 this.page.sections![dragSectionIndex].blocks!.add(dragData.block);
             }
+
+            this.$emit('page-save');
         },
 
         onBlockStageDrop(dragData: DragData, dropData: DropData) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
@@ -885,4 +885,26 @@ describe('module/sw-cms/component/sw-cms-sidebar', () => {
         expect(wrapper.vm.$refs.itemConfigSidebar.isActive).toBeTruthy();
         expect(wrapper.vm.selectedSection.id).toBe('2222');
     });
+
+    it('should emit page-save when aborting block drop', async () => {
+        const wrapper = await createWrapper();
+
+        // Prepare drag data: block being dragged from section index 0
+        const dragData = {
+            block: getBlockData(0, 'dropAbortBlock'),
+            sectionIndex: 0,
+        };
+
+        // Prepare drop data: abort drop into a different section index
+        const dropData = {
+            block: getBlockData(0, 'dropAbortBlock'),
+            sectionIndex: 1,
+            dropIndex: 0,
+            section: null,
+            sectionPosition: '',
+        };
+
+        wrapper.vm.onBlockDropAbort(dragData, dropData);
+        expect(wrapper.emitted('page-save')).toBeTruthy();
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When blocks are moved between sections they should be saved, so that all the associations are correct while further editing the cms page.


### 2. What does this change do, exactly?
Save the changes when blocks are moved to other sections

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #12423 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
