### PR TITLE
fix: Allow html tags in app snippets

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -53,6 +53,9 @@ If the token has already been consumed, the user will be redirected directly to 
 To support this behavior, a new `consumed` flag has been added to the payment token struct, which indicates if the token has already been processed.
 Payment tokens are no longer deleted immediately after use. A new scheduled task automatically removes expired tokens to keep the `payment_token` table clean.
 
+### Added sanitized HTML tag support for app snippets
+Added sanitized HTML tag support for app snippets. App developers can now use HTML tags for better formatting within their snippets. The sanitizing uses the `basic` set of allowed HTML tags from the `html_sanitizer` config, ensuring that security-related tags such as `script` are automatically removed.
+
 ## Administration
 
 ## Storefront

--- a/src/Administration/Resources/config/services.xml
+++ b/src/Administration/Resources/config/services.xml
@@ -151,6 +151,7 @@
             <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="Shopware\Core\System\Snippet\Struct\TranslationConfig"/>
             <argument type="service" id="Shopware\Core\System\Snippet\Service\TranslationLoader"/>
+            <argument type="service" id="Shopware\Core\Framework\Util\HtmlSanitizer"/>
         </service>
 
         <service id="Shopware\Administration\Snippet\CachedSnippetFinder" decorates="Shopware\Administration\Snippet\SnippetFinder">

--- a/src/Administration/Snippet/AppAdministrationSnippetDefinition.php
+++ b/src/Administration/Snippet/AppAdministrationSnippetDefinition.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\App\AppDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowEmptyString;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
@@ -45,7 +46,7 @@ class AppAdministrationSnippetDefinition extends EntityDefinition
     {
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
-            (new LongTextField('value', 'value'))->addFlags(new ApiAware(), new Required(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING), new AllowEmptyString()),
+            (new LongTextField('value', 'value'))->addFlags(new ApiAware(), new Required(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING), new AllowEmptyString(), new AllowHtml()),
 
             (new FkField('app_id', 'appId', AppDefinition::class))->addFlags(new ApiAware(), new Required()),
             (new FkField('locale_id', 'localeId', LocaleDefinition::class))->addFlags(new ApiAware(), new Required()),

--- a/src/Administration/Snippet/SnippetFinder.php
+++ b/src/Administration/Snippet/SnippetFinder.php
@@ -38,6 +38,7 @@ class SnippetFinder implements SnippetFinderInterface
         private readonly Filesystem $translationReader,
         private readonly TranslationConfig $translationConfig,
         private readonly TranslationLoader $translationLoader,
+        private readonly HtmlSanitizer $htmlSanitizer,
     ) {
     }
 
@@ -283,12 +284,10 @@ class SnippetFinder implements SnippetFinderInterface
      */
     private function sanitizeAppSnippets(array $snippets): array
     {
-        $sanitizer = new HtmlSanitizer();
-
         $sanitizedSnippets = [];
         foreach ($snippets as $key => $value) {
             if (\is_string($value)) {
-                $sanitizedSnippets[$key] = $sanitizer->sanitize($value);
+                $sanitizedSnippets[$key] = $this->htmlSanitizer->sanitize($value);
 
                 continue;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, it is not possible to use HTML tags within theme app snippets. These tags could provide significant value, for example, by allowing for rich formatting of help texts. 

### 2. What does this change do, exactly?
I have added the `AllowHtml` flag to the `value` field within the `AppAdministrationSnippetDefinition`. This change allows for the storage of HTML tags in the `value` column of the `app_administration_snippet` table.
I also adjusted the `SnippetFinder` and modified how the HTML sanitizer is initialized. Previously, it was directly instantiated; now, it is loaded via Dependency Injection (DI). This ensures that our `shopware.yaml` configuration is correctly included, and all tags from the `basic` set defined in the HTML sanitizer configuration are properly utilized.

### 3. Describe each step to reproduce the issue or behaviour.
To verify the change, install an app theme that includes HTML tags in a snippet file (e.g., for help text). You will observe that the HTML tags are now correctly rendered and allowed
<img width="1284" height="588" alt="Bildschirmfoto 2025-11-10 um 14 09 54" src="https://github.com/user-attachments/assets/c33358a0-0d1a-46f7-9065-1abbb37a7370" />


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
