### PR TITLE
test: unit test ContextGatewayControllerTest is flaky

### DIFF
--- a/src/Core/Framework/Test/TestSessionStorage.php
+++ b/src/Core/Framework/Test/TestSessionStorage.php
@@ -20,11 +20,11 @@ class TestSessionStorage implements SessionStorageInterface
     /**
      * @var array<string, SessionBagInterface>
      */
-    private array $data = [];
+    private static array $data = [];
 
-    private string $id = 'test-id';
+    private static string $id = 'test-id';
 
-    private string $name = PlatformRequest::FALLBACK_SESSION_NAME;
+    private static string $name = PlatformRequest::FALLBACK_SESSION_NAME;
 
     public function start(): bool
     {
@@ -38,22 +38,22 @@ class TestSessionStorage implements SessionStorageInterface
 
     public function getId(): string
     {
-        return $this->id;
+        return self::$id;
     }
 
     public function setId(string $id): void
     {
-        $this->id = $id;
+        self::$id = $id;
     }
 
     public function getName(): string
     {
-        return $this->name;
+        return self::$name;
     }
 
     public function setName(string $name): void
     {
-        $this->name = $name;
+        self::$name = $name;
     }
 
     public function regenerate(bool $destroy = false, ?int $lifetime = null): bool
@@ -73,19 +73,19 @@ class TestSessionStorage implements SessionStorageInterface
 
     public function clear(): void
     {
-        foreach ($this->data as $bag) {
+        foreach (self::$data as $bag) {
             $bag->clear();
         }
     }
 
     public function getBag(string $name): SessionBagInterface
     {
-        return $this->data[$name] ?? new FlashBag();
+        return self::$data[$name] ?? new FlashBag();
     }
 
     public function registerBag(SessionBagInterface $bag): void
     {
-        if (isset($this->data[$bag->getName()])) {
+        if (isset(self::$data[$bag->getName()])) {
             /**
              * This early return protects multiple session objects to overwrite each others already filled bag
              *
@@ -94,7 +94,7 @@ class TestSessionStorage implements SessionStorageInterface
              *
              * To fix this behaviour we reference the new passed session bag data to the existing one in the sesion
              */
-            $oldBag = $this->data[$bag->getName()];
+            $oldBag = self::$data[$bag->getName()];
             if ($oldBag instanceof SessionBagProxy) {
                 $oldBagInner = $oldBag->getBag();
             } else {
@@ -128,7 +128,7 @@ class TestSessionStorage implements SessionStorageInterface
             return;
         }
 
-        $this->data[$bag->getName()] = $bag;
+        self::$data[$bag->getName()] = $bag;
     }
 
     public function getMetadataBag(): MetadataBag

--- a/src/Core/Framework/Test/TestSessionStorage.php
+++ b/src/Core/Framework/Test/TestSessionStorage.php
@@ -20,11 +20,11 @@ class TestSessionStorage implements SessionStorageInterface
     /**
      * @var array<string, SessionBagInterface>
      */
-    private static array $data = [];
+    private array $data = [];
 
-    private static string $id = 'test-id';
+    private string $id = 'test-id';
 
-    private static string $name = PlatformRequest::FALLBACK_SESSION_NAME;
+    private string $name = PlatformRequest::FALLBACK_SESSION_NAME;
 
     public function start(): bool
     {
@@ -38,22 +38,22 @@ class TestSessionStorage implements SessionStorageInterface
 
     public function getId(): string
     {
-        return self::$id;
+        return $this->id;
     }
 
     public function setId(string $id): void
     {
-        self::$id = $id;
+        $this->id = $id;
     }
 
     public function getName(): string
     {
-        return self::$name;
+        return $this->name;
     }
 
     public function setName(string $name): void
     {
-        self::$name = $name;
+        $this->name = $name;
     }
 
     public function regenerate(bool $destroy = false, ?int $lifetime = null): bool
@@ -73,19 +73,19 @@ class TestSessionStorage implements SessionStorageInterface
 
     public function clear(): void
     {
-        foreach (self::$data as $bag) {
+        foreach ($this->data as $bag) {
             $bag->clear();
         }
     }
 
     public function getBag(string $name): SessionBagInterface
     {
-        return self::$data[$name] ?? new FlashBag();
+        return $this->data[$name] ?? new FlashBag();
     }
 
     public function registerBag(SessionBagInterface $bag): void
     {
-        if (isset(self::$data[$bag->getName()])) {
+        if (isset($this->data[$bag->getName()])) {
             /**
              * This early return protects multiple session objects to overwrite each others already filled bag
              *
@@ -94,7 +94,7 @@ class TestSessionStorage implements SessionStorageInterface
              *
              * To fix this behaviour we reference the new passed session bag data to the existing one in the sesion
              */
-            $oldBag = self::$data[$bag->getName()];
+            $oldBag = $this->data[$bag->getName()];
             if ($oldBag instanceof SessionBagProxy) {
                 $oldBagInner = $oldBag->getBag();
             } else {
@@ -128,7 +128,7 @@ class TestSessionStorage implements SessionStorageInterface
             return;
         }
 
-        self::$data[$bag->getName()] = $bag;
+        $this->data[$bag->getName()] = $bag;
     }
 
     public function getMetadataBag(): MetadataBag

--- a/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php
+++ b/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php
@@ -146,8 +146,11 @@ class ContextGatewayControllerTest extends TestCase
 
     private function createStubContainerWithFlashBag(): ContainerInterface
     {
+        $storage = new TestSessionStorage();
+        $storage->clear(); // ensure a clean state since storage is a stub shared between tests
+
         $request = new Request();
-        $request->setSession(new Session(new TestSessionStorage()));
+        $request->setSession(new Session($storage));
 
         $requestStack = new RequestStack([$request]);
 

--- a/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php
+++ b/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php
@@ -148,7 +148,7 @@ class ContextGatewayControllerTest extends TestCase
     {
         $storage = new TestSessionStorage();
         $storage->clear(); // ensure a clean state since storage is a stub shared between tests
-        $session = new Session();
+        $session = new Session($storage);
         $request = new Request();
         $request->setSession($session);
 

--- a/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php
+++ b/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php
@@ -146,11 +146,8 @@ class ContextGatewayControllerTest extends TestCase
 
     private function createStubContainerWithFlashBag(): ContainerInterface
     {
-        $storage = new TestSessionStorage();
-        $storage->clear(); // ensure a clean state since storage is a stub shared between tests
-        $session = new Session($storage);
         $request = new Request();
-        $request->setSession($session);
+        $request->setSession(new Session(new TestSessionStorage()));
 
         $requestStack = new RequestStack([$request]);
 

--- a/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php
+++ b/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php
@@ -146,7 +146,9 @@ class ContextGatewayControllerTest extends TestCase
 
     private function createStubContainerWithFlashBag(): ContainerInterface
     {
-        $session = new Session(new TestSessionStorage());
+        $storage = new TestSessionStorage();
+        $storage->clear(); // ensure a clean state since storage is a stub shared between tests
+        $session = new Session();
         $request = new Request();
         $request->setSession($session);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Discovered from another PR, with complete unrelated changes: https://github.com/shopware/shopware/actions/runs/19234311071/job/54980108541?pr=13437

It is happening as `TestSessionStorage` is a local stub that can be shared between tests involving sessions (when StorefrontControllerTest is ran before ContextGatewayControllerTest)

### 2. What does this change do, exactly?

Clear the state before usage

Discarded approach:
Remove static usage for data, name, id of the stub `TestSessionStorage` as explained by @mstegmeyer" it is used in the Test Container, so integration tests will fail without this. See src/Core/Framework/DependencyInjection/services_test.xml line 17

### 3. Describe each step to reproduce the issue or behaviour.
Before change, run locally:

```
 php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "unit" --random-order-seed 1762783598

...

There was 1 failure:

1) Shopware\Tests\Unit\Storefront\Controller\ContextGatewayControllerTest::testGatewayWithGenericException
Failed asserting that actual size 1 matches expected size 0.

/Users/nfortier/Dev/platform/tests/unit/Storefront/Controller/ContextGatewayControllerTest.php:100
```

Rerun: No failure expected


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
