### PR TITLE
chore: test all supported opensearch versions

### DIFF
--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -10,7 +10,7 @@ if ($nightly) {
     $db = ['mysql:8.0', 'mariadb:11'];
 }
 
-echo \json_encode([
+$matrix = [
     'fail-fast' => false,
     'matrix' => [
         'test' => [
@@ -27,6 +27,7 @@ echo \json_encode([
         ],
         'php' => $php,
         'db' => $db,
+        'opensearch' => ['opensearchproject/opensearch:3'],
         'include' => [
             [
                 'test' => ['testsuite' => 'migration'],
@@ -35,4 +36,21 @@ echo \json_encode([
             ],
         ]
     ]
-], \JSON_THROW_ON_ERROR);
+];
+
+if ($nightly) {
+    $matrix['matrix']['include'][] = [
+        'test' => ['path' => '{Administration,Elasticsearch}'],
+        'php' => '8.4',
+        'db' => 'mysql:8.0',
+        'opensearch' => ['opensearchproject/opensearch:2'],
+    ];
+    $matrix['matrix']['include'][] = [
+        'test' => ['path' => '{Administration,Elasticsearch}'],
+        'php' => '8.4',
+        'db' => 'mysql:8.0',
+        'opensearch' => ['opensearchproject/opensearch:1'],
+    ];
+}
+
+echo \json_encode($matrix, \JSON_THROW_ON_ERROR);

--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -45,6 +45,7 @@ if ($nightly) {
         'db' => 'mysql:8.0',
         'opensearch' => ['opensearchproject/opensearch:2'],
     ];
+    /** @deprecated tag:v6.8.0 - Support for OpenSearch 1 will be removed in v6.8.0 (update the docs as well!) */
     $matrix['matrix']['include'][] = [
         'test' => ['path' => '{Administration,Elasticsearch}'],
         'php' => '8.4',

--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -43,14 +43,14 @@ if ($nightly) {
         'test' => ['path' => '{Administration,Elasticsearch}'],
         'php' => '8.4',
         'db' => 'mysql:8.0',
-        'opensearch' => ['opensearchproject/opensearch:2'],
+        'opensearch' => 'opensearchproject/opensearch:2',
     ];
     /** @deprecated tag:v6.8.0 - Support for OpenSearch 1 will be removed in v6.8.0 (update the docs as well!) */
     $matrix['matrix']['include'][] = [
         'test' => ['path' => '{Administration,Elasticsearch}'],
         'php' => '8.4',
         'db' => 'mysql:8.0',
-        'opensearch' => ['opensearchproject/opensearch:1'],
+        'opensearch' => 'opensearchproject/opensearch:1',
     ];
 }
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -123,7 +123,7 @@ jobs:
 
     services:
       elasticsearch:
-        image: ${{ matrix.test.path != '' && 'opensearchproject/opensearch:2' || 'alpine' }}
+        image: ${{ matrix.test.path != '' &&  matrix.opensearch || 'alpine' }}
         env:
           discovery.type: single-node
           plugins.security.disabled: "true"
@@ -392,7 +392,7 @@ jobs:
 
     services:
       elasticsearch:
-        image: "opensearchproject/opensearch:2"
+        image: "opensearchproject/opensearch:3"
         env:
           discovery.type: single-node
           plugins.security.disabled: "true"
@@ -450,7 +450,7 @@ jobs:
 
     services:
       elasticsearch:
-        image: "opensearchproject/opensearch:2"
+        image: "opensearchproject/opensearch:3"
         env:
           discovery.type: single-node
           plugins.security.disabled: "true"
@@ -530,7 +530,7 @@ jobs:
 
       services:
           elasticsearch:
-              image: "opensearchproject/opensearch:2"
+              image: "opensearchproject/opensearch:3"
               env:
                   discovery.type: single-node
                   plugins.security.disabled: "true"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -104,7 +104,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
   phpunit:
-    name: "${{ matrix.php}} ${{ matrix.test.testsuite }}${{ matrix.test.path }} ${{ matrix.db }}"
+    name: "${{ matrix.php}} ${{ matrix.test.testsuite }}${{ matrix.test.path }} ${{ matrix.db }} ${{ matrix.opensearch != 'opensearchproject/opensearch:3' && matrix.opensearch || '' }}"
     needs:
       - phpunit-matrix
     runs-on: ubuntu-24.04

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -625,6 +625,10 @@ The `CountryStateController` route `/country/country-state-data` now supports on
 
 <details>
 
+## Dropped support for OpenSearch 1.x
+
+OpenSearch 1.x reached end of life on 06 May 2025 is no longer supported. Please update OpenSearch to the latest supported Version.
+
 ## Removed configuration of Filesystem visibility in config array
 
 The visibility of filesystems cannot be configured in the config array anymore. Instead, it should be set on the same level as `type`. For example, instead of:


### PR DESCRIPTION
We only tested opensearch with 2.x, however we should be compatible with 1.x and 3.x as well 