### PR TITLE
fix(api): handle mixed struct/scalar arrays in encoder

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -29,6 +29,10 @@ curl -X POST "http://localhost:8000/api/_action/sync" \
 #...
 ```
 
+### Fixed mixed struct/scalar array encoding
+
+The `StructEncoder` now correctly handles arrays containing a mix of `Struct` objects and scalar values. Previously, the encoder would fail when scalar values appeared at the beginning or were interspersed with Struct instances in an array. The encoding logic now properly iterates through arrays and encodes only Struct objects while preserving scalar values.
+
 ## Core
 
 ### new JWT helper

--- a/src/Core/System/SalesChannel/Api/StructEncoder.php
+++ b/src/Core/System/SalesChannel/Api/StructEncoder.php
@@ -171,11 +171,16 @@ class StructEncoder implements ResetInterface
                 continue;
             }
 
-            // simple array of structs case
-            if ($this->isStructArray($object)) {
+            if ($this->containsAnyStruct($object)) {
                 $array = [];
                 foreach ($object as $key => $item) {
-                    $array[$key] = $this->encodeStruct($item, $fields, $value[$key]);
+                    if ($item instanceof Struct) {
+                        $array[$key] = $this->encodeStruct($item, $fields, $value[$key] ?? []);
+
+                        continue;
+                    }
+
+                    $array[$key] = $item;
                 }
 
                 $data[$property] = $array;
@@ -351,18 +356,22 @@ class StructEncoder implements ResetInterface
         return $value;
     }
 
-    private function isStructArray(mixed $object): bool
+    /**
+     * Checks if array contains at least one Struct object
+     */
+    private function containsAnyStruct(mixed $object): bool
     {
         if (!\is_array($object)) {
             return false;
         }
 
-        $values = array_values($object);
-        if (!isset($values[0])) {
-            return false;
+        foreach ($object as $item) {
+            if ($item instanceof Struct) {
+                return true;
+            }
         }
 
-        return $values[0] instanceof Struct;
+        return false;
     }
 
     private function fetchBlockedCustomFields(): void

--- a/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
+++ b/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
@@ -4,6 +4,8 @@ namespace Shopware\Tests\Unit\Core\System\SalesChannel\Api;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
@@ -292,6 +294,154 @@ class StructEncoderTest extends TestCase
         ];
 
         static::assertSame($expected, $encoded);
+    }
+
+    /**
+     * @param list<mixed> $mixedArray
+     * @param array<string, mixed> $expected
+     */
+    #[DataProvider('mixedArrayProvider')]
+    #[TestDox('Encodes mixed Struct/non-Struct arrays correctly')]
+    public function testMixedArrayEncoding(array $mixedArray, ResponseFields $responseFields, array $expected): void
+    {
+        $struct = new ArrayStruct(['items' => $mixedArray], 'test_struct');
+
+        $structEncoder = $this->createStructEncoder();
+
+        $encoded = $structEncoder->encode($struct, $responseFields);
+
+        static::assertSame($expected, $encoded);
+    }
+
+    /**
+     * @return \Generator<string, array{array<int|string, mixed>, ResponseFields, array<string, mixed>}>
+     */
+    public static function mixedArrayProvider(): \Generator
+    {
+        $manufacturer1 = (new ProductManufacturerEntity())->assign(['name' => 'Test Manufacturer']);
+        $manufacturer1->internalSetEntityData('product_manufacturer', new FieldVisibility([]));
+
+        yield 'struct at position 0' => [
+            [
+                $manufacturer1,
+                'text value',
+                42,
+            ],
+            new ResponseFields([]),
+            [
+                'apiAlias' => 'test_struct',
+                'items' => [
+                    [
+                        'versionId' => null,
+                        'translated' => [],
+                        'createdAt' => null,
+                        'updatedAt' => null,
+                        'mediaId' => null,
+                        'name' => 'Test Manufacturer',
+                        'link' => null,
+                        'description' => null,
+                        'media' => null,
+                        'translations' => null,
+                        'products' => null,
+                        'customFields' => null,
+                        'apiAlias' => 'product_manufacturer',
+                    ],
+                    'text value',
+                    42,
+                ],
+            ],
+        ];
+
+        $manufacturer2 = (new ProductManufacturerEntity())->assign(['name' => 'Test Manufacturer']);
+        $manufacturer2->internalSetEntityData('product_manufacturer', new FieldVisibility([]));
+
+        yield 'scalar at position 0' => [
+            [
+                'text value',
+                42,
+                $manufacturer2,
+            ],
+            new ResponseFields([]),
+            [
+                'apiAlias' => 'test_struct',
+                'items' => [
+                    'text value',
+                    42,
+                    [
+                        'versionId' => null,
+                        'translated' => [],
+                        'createdAt' => null,
+                        'updatedAt' => null,
+                        'mediaId' => null,
+                        'name' => 'Test Manufacturer',
+                        'link' => null,
+                        'description' => null,
+                        'media' => null,
+                        'translations' => null,
+                        'products' => null,
+                        'customFields' => null,
+                        'apiAlias' => 'product_manufacturer',
+                    ],
+                ],
+            ],
+        ];
+
+        $manufacturer3 = (new ProductManufacturerEntity())->assign(['name' => 'Test Manufacturer']);
+        $manufacturer3->internalSetEntityData('product_manufacturer', new FieldVisibility([]));
+
+        yield 'restricted fields' => [
+            [
+                $manufacturer3,
+                'text value',
+                42,
+            ],
+            new ResponseFields(['test_struct' => ['items'], 'product_manufacturer' => ['name']]),
+            [
+                'items' => [
+                    [
+                        'name' => 'Test Manufacturer',
+                        'apiAlias' => 'product_manufacturer',
+                    ],
+                    'text value',
+                    42,
+                ],
+                'apiAlias' => 'test_struct',
+            ],
+        ];
+
+        $manufacturer4 = (new ProductManufacturerEntity())->assign(['name' => 'Test Manufacturer']);
+        $manufacturer4->internalSetEntityData('product_manufacturer', new FieldVisibility([]));
+
+        yield 'associative array' => [
+            [
+                'manufacturer' => $manufacturer4,
+                'string-element' => 'text value',
+                'int-element' => 42,
+            ],
+            new ResponseFields([]),
+            [
+                'apiAlias' => 'test_struct',
+                'items' => [
+                    'manufacturer' => [
+                        'versionId' => null,
+                        'translated' => [],
+                        'createdAt' => null,
+                        'updatedAt' => null,
+                        'mediaId' => null,
+                        'name' => 'Test Manufacturer',
+                        'link' => null,
+                        'description' => null,
+                        'media' => null,
+                        'translations' => null,
+                        'products' => null,
+                        'customFields' => null,
+                        'apiAlias' => 'product_manufacturer',
+                    ],
+                    'string-element' => 'text value',
+                    'int-element' => 42,
+                ],
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
The StructEncoder incorrectly assumed arrays with Struct objects would always have a Struct at position 0. This caused encoding failures when mixed arrays contained scalars at the beginning or interspersed with Struct instances.

### 1. Why is this change necessary?

See #13461

### 2. What does this change do, exactly?

Refactored isStructArray() to containsAnyStruct() to check if any array element is a Struct rather than only checking position 0. Updated encoding logic to iterate through arrays and encode only Struct instances while preserving scalar values.

### 3. Describe each step to reproduce the issue or behaviour.

See #13461

### 4. Please link to the relevant issues (if any).

solves #13461

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
