### PR TITLE
fix: Remove superfluous service injections

### DIFF
--- a/src/Storefront/DependencyInjection/theme.xml
+++ b/src/Storefront/DependencyInjection/theme.xml
@@ -137,8 +137,6 @@
             <argument type="service" id="Shopware\Storefront\Theme\StorefrontPluginRegistry"/>
             <argument type="service" id="Shopware\Storefront\Theme\ThemeMergedConfigBuilder"/>
             <argument type="service" id="Shopware\Storefront\Theme\ThemeRuntimeConfigStorage"/>
-            <argument type="service" id="theme.repository"/>
-            <argument type="service" id="cache.object"/>
         </service>
 
         <service id="Shopware\Storefront\Theme\SeedingThemePathBuilder" lazy="true">


### PR DESCRIPTION
### 1. Why is this change necessary?
These are no arguments in the actual service implementation: https://github.com/shopware/shopware/blob/42794c5704b6ccc72a7f7b520f2f386602f0f193/src/Storefront/Theme/ThemeRuntimeConfigService.php#L33-L39

### 2. What does this change do, exactly?
Remove two not needed service injections.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
