### PR TITLE
fix: center empty state icon in cross selling page

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
@@ -48,4 +48,8 @@
         margin: 0 auto;
         width: fit-content;
     }
+
+    .sw-empty-state__icon {
+        display: inline-block;
+    }
 }


### PR DESCRIPTION
<img width="1095" height="759" alt="image" src="https://github.com/user-attachments/assets/c8ddcf79-e1a5-403c-a310-812925594759" />
