### PR TITLE
fix: fix wrong display type of svgs

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -158,3 +158,12 @@ a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button, .mt-lin
         overflow: hidden;
     }
 }
+
+/**
+ * Reset some global styling from
+ * the Meteor Component Library
+ */
+span svg {
+    display: initial;
+    vertical-align: initial;
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
<img width="1915" height="318" alt="Bildschirmfoto 2025-11-12 um 09 59 04" src="https://github.com/user-attachments/assets/d50fc707-d034-480c-990d-ba613892d2e2" />

Visual tests are showing wrong position of SVG icons

### 2. What does this change do, exactly?

It reverts the hardcoded global display type set from the Meteor component library.
