### PR TITLE
feat: new CSS loading

### DIFF
--- a/src/Storefront/Controller/NavigationController.php
+++ b/src/Storefront/Controller/NavigationController.php
@@ -71,7 +71,7 @@ class NavigationController extends StorefrontController
 
             return $this->renderStorefront(
                 '@Storefront/storefront/page/content/index.html.twig',
-                ['page' => $page, 'cmsPage' => $cmsPage]);
+                ['page' => $page, 'cmsPage' => $cmsPage, 'isNewContentStructure' => true]);
         }
 
         return $this->renderStorefront('@Storefront/storefront/page/content/index.html.twig', ['page' => $page]);
@@ -190,7 +190,7 @@ class NavigationController extends StorefrontController
                     'properties' => [
                         'columns' => '2',
                         'columnsLg' => '1',
-                        'gap' => '24',
+                        'gap' => 60,
                         'align' => 'start',
                         'alignContent' => 'start',
                         'justify' => 'stretch',
@@ -232,7 +232,7 @@ class NavigationController extends StorefrontController
                                             'id' => '123',
                                             'component' => 'Sw:Content:Text',
                                             'properties' => [
-                                                'text' => '<h1>Lorem ipsum dolor sit amet.</h1><p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>',
+                                                'text' => "<h1>Discover Your Summer Style</h1><p>Step into the sunshine with our Summer Fashion Collection! From breezy dresses and linen shirts to stylish sandals and bold accessories — everything you need to stay cool and look effortlessly chic all season long. Embrace vibrant colors, light fabrics, and timeless designs perfect for beach days, city strolls, and evening get-togethers. Your next favorite outfit is waiting — explore now and make this summer your most stylish one yet.</p><p>Each piece in our collection is carefully selected to combine comfort and elegance, using high-quality materials that feel as good as they look. Whether you're planning a weekend getaway or updating your everyday wardrobe, our summer essentials will keep you glowing with confidence and ready for every adventure under the sun.</p>",
                                             ],
                                         ],
                                         [
@@ -276,18 +276,7 @@ class NavigationController extends StorefrontController
                                     'filterAggregations' => $listingData->getAggregations(),
                                     'availableSortings' => $listingData->getAvailableSortings(),
                                 ],
-                                'slots' => [
-                                    // 'additional-filters-start' => [
-                                    //     [
-                                    //         'id' => '123',
-                                    //         'component' => 'Sw:Filter:Type:BooleanFilter',
-                                    //         'properties' => [
-                                    //             'name' => 'isCloseout',
-                                    //             'displayName' => 'Closeout',
-                                    //         ]
-                                    //     ]
-                                    // ]
-                                ]
+                                'slots' => []
                             ]
                         ],
                         'product-card' => []

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -108,6 +108,7 @@
             <argument type="service" id="Shopware\Storefront\Theme\ThemeConfigValueAccessor"/>
             <argument type="service" id="Shopware\Storefront\Theme\ThemeScripts" />
             <argument type="service" id="Shopware\Storefront\Framework\Twig\Components\TwigComponentRenderEventListener" />
+            <argument type="service" id="Shopware\Storefront\Framework\Twig\Components\TwigComponentHelper" />
         </service>
 
         <service id="Shopware\Storefront\Theme\ThemeConfigValueAccessor">

--- a/src/Storefront/Framework/Twig/Components/TwigComponentCollection.php
+++ b/src/Storefront/Framework/Twig/Components/TwigComponentCollection.php
@@ -18,14 +18,14 @@ class TwigComponentCollection extends Collection
         foreach ($elements as $element) {
             $this->validateType($element);
 
-            $this->set($element->getName(), $element);
+            $this->set($element->getTag(), $element);
         }
     }
 
     public function add($element): void
     {
         $this->validateType($element);
-        $this->set($element->getName(), $element);
+        $this->set($element->getTag(), $element);
     }
 
     protected function getExpectedClass(): string

--- a/src/Storefront/Framework/Twig/Extension/ConfigExtension.php
+++ b/src/Storefront/Framework/Twig/Extension/ConfigExtension.php
@@ -28,6 +28,7 @@ class ConfigExtension extends AbstractExtension
             new TwigFunction('theme_scripts', $this->scripts(...), ['needs_context' => true]),
             new TwigFunction('component_scripts', $this->componentScripts(...), ['needs_context' => true]),
             new TwigFunction('mounted_component_scripts', $this->mountedComponentScripts(...), ['needs_context' => true]),
+            new TwigFunction('mounted_component_styles', $this->mountedComponentStyles(...), ['needs_context' => true]),
         ];
     }
 
@@ -79,6 +80,16 @@ class ConfigExtension extends AbstractExtension
     public function mountedComponentScripts(): array
     {
         return $this->config->mountedComponentScripts();
+    }
+
+    /**
+     * Returns all styles of components that have been mounted in the template.
+     * 
+     * @return array<int, string>
+     */
+    public function mountedComponentStyles(): array
+    {
+        return $this->config->mountedComponentStyles();
     }
 
     /**

--- a/src/Storefront/Framework/Twig/TemplateConfigAccessor.php
+++ b/src/Storefront/Framework/Twig/TemplateConfigAccessor.php
@@ -8,6 +8,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Theme\ThemeConfigValueAccessor;
 use Shopware\Storefront\Theme\ThemeScripts;
 use Shopware\Storefront\Framework\Twig\Components\TwigComponentRenderEventListener;
+use Shopware\Storefront\Framework\Twig\Components\TwigComponentHelper;
 
 #[Package('framework')]
 class TemplateConfigAccessor
@@ -19,7 +20,8 @@ class TemplateConfigAccessor
         private readonly SystemConfigService $systemConfigService,
         private readonly ThemeConfigValueAccessor $themeConfigAccessor,
         private readonly ThemeScripts $themeScripts,
-        private readonly TwigComponentRenderEventListener $twigComponentRenderEventListener
+        private readonly TwigComponentRenderEventListener $twigComponentRenderEventListener,
+        private readonly TwigComponentHelper $twigComponentHelper
     ) {
     }
 
@@ -97,6 +99,26 @@ class TemplateConfigAccessor
         }
 
         return $scripts;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function mountedComponentStyles(): array
+    {
+        $styles = [];
+        $mountedComponents = $this->twigComponentRenderEventListener->getMountedComponents();
+        $components = $this->twigComponentHelper->getComponents();
+
+        foreach($mountedComponents as $mountedComponentName) {
+            $component = $components->get($mountedComponentName);
+
+            if ($component !== null && $component->getStylePath() !== null) {
+                $styles[] = 'css/components/'.str_replace(':', '/', $mountedComponentName).'.css';
+            }
+        }
+
+        return $styles;
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/scss/base.minimal.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/base.minimal.scss
@@ -1,0 +1,76 @@
+/*
+ *
+ * Minimal base styles
+ * -------------------
+ * This is a reduced set of base styles that are used on pages build with the new component system.
+ * Components are built individually and the styles are only imported when the component is used.
+ *
+ * @sw-package framework
+ */
+
+/*
+ * Variables, Mixins, Functions
+ * ---------------------------- */
+@import 'abstract/functions/feature';
+@import 'variables';
+@import 'abstract/mixins/truncate-multiline';
+
+/*
+ * Vendors
+ * ------- */
+@import 'vendor/bootstrap';
+
+ /*
+ * Base stuff
+ * ---------- */
+@import 'base/base';
+@import 'base/reboot';
+
+/**
+ * Components
+ *
+ * @ToDo: Remove after migration to the new component system.
+ * These have to be here, as parts of the page still use these styles. 
+ * ---------- */
+@import 'component/icon';
+@import 'skin/shopware/component/_button';
+@import 'component/_offcanvas.scss';
+@import 'component/_line-item.scss';
+@import 'component/_quantity-selector.scss';
+@import 'component/_delivery-status.scss';
+@import 'component/_flags.scss';
+@import 'component/product-wishlist';
+
+/*
+ * Layout-related sections
+ * 
+ * @ToDo: Remove after migration to the new component system.
+ * ----------------------- */
+@import 'layout/_container';
+@import 'layout/_header';
+@import 'layout/_header-minimal';
+@import 'layout/_footer';
+@import 'layout/_navigation-offcanvas';
+@import 'layout/_offcanvas-cart';
+@import 'layout/_account-menu';
+@import 'layout/_search-suggest';
+@import 'layout/_cookie-permission';
+@import 'layout/_cookie-configuration';
+@import 'layout/_scroll-up';
+@import 'page/checkout/_cart';
+
+/**
+ * Shopware Skin
+ * -------------- */
+@import 'skin/shopware/abstract/_variables';
+@import 'skin/shopware/vendor/_inter-fontface';
+@import 'skin/shopware/base/_base';
+@import 'skin/shopware/base/_typography';
+// @ToDo: Remove after migration to the new component system.
+@import 'skin/shopware/layout/_header';
+@import 'skin/shopware/layout/_footer';
+@import 'skin/shopware/layout/_main-navigation';
+@import 'skin/shopware/layout/_navigation-flyout';
+@import 'skin/shopware/layout/_navigation-offcanvas';
+@import 'skin/shopware/layout/_offcanvas-cart';
+@import 'skin/shopware/layout/_top-bar';

--- a/src/Storefront/Resources/theme.json
+++ b/src/Storefront/Resources/theme.json
@@ -22,6 +22,16 @@
     "@Components",
     "@Plugins"
   ],
+  "baseStyles": [
+    {
+      "app/storefront/src/scss/base.minimal.scss": {
+        "resolve": {
+          "vendor": "app/storefront/vendor"
+        }
+      }
+    },
+    "@Plugins"
+  ],
   "script": [
     "app/storefront/dist/storefront/storefront.js",
     "@Components",

--- a/src/Storefront/Resources/views/components/Sw/Button.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Button.html.twig
@@ -1,9 +1,91 @@
 {% props
     icon = null,
     variant = 'primary',
+    outline = false,
+    size = null,
     text = null,
 %}
 
-<button {{ attributes.defaults({class: 'btn btn-'~variant}) }}>
+{% set buttonCVA = cva({
+    base: 'sw-button btn',
+    variants: {
+        variant: {
+            buy: 'btn-buy',
+            link: 'btn-link',
+            inline: 'btn-link-inline',
+        },
+        size: {
+            sm: 'btn-sm',
+            lg: 'btn-lg',
+        },
+    },
+    compoundVariants: [{
+        variant: ['primary'],
+        outline: [false],
+        class: 'btn-primary',
+    }, {
+        variant: ['secondary'],
+        outline: [false],
+        class: 'btn-secondary',
+    }, {
+        variant: ['light'],
+        outline: [false],
+        class: 'btn-light',
+    }, {
+        variant: ['dark'],
+        outline: [false],
+        class: 'btn-dark',
+    }, {
+        variant: ['danger'],
+        outline: [false],
+        class: 'btn-danger',
+    }, {
+        variant: ['warning'],
+        outline: [false],
+        class: 'btn-warning',
+    }, {
+        variant: ['success'],
+        outline: [false],
+        class: 'btn-success',
+    }, {
+        variant: ['info'],
+        outline: [false],
+        class: 'btn-info',
+    }, {
+        variant: ['primary'],
+        outline: [true],
+        class: 'btn-outline-primary',
+    }, {
+        variant: ['secondary'],
+        outline: [true],
+        class: 'btn-outline-secondary',
+    }, {
+        variant: ['light'],
+        outline: [true],
+        class: 'btn-outline-light',
+    }, {
+        variant: ['dark'],
+        outline: [true],
+        class: 'btn-outline-dark',
+    }, {
+        variant: ['danger'],
+        outline: [true],
+        class: 'btn-outline-danger',
+    }, {
+        variant: ['warning'],
+        outline: [true],
+        class: 'btn-outline-warning',
+    }, {
+        variant: ['success'],
+        outline: [true],
+        class: 'btn-outline-success',
+    }, {
+        variant: ['info'],
+        outline: [true],
+        class: 'btn-outline-info',
+    }],
+}) %}
+
+<button {{ attributes.defaults({ class: buttonCVA.apply({ variant, outline, size }) }) }}>
     {% block content %}{{ text }}{% endblock %}
 </button>

--- a/src/Storefront/Resources/views/components/Sw/Button.scss
+++ b/src/Storefront/Resources/views/components/Sw/Button.scss
@@ -1,0 +1,45 @@
+.btn {
+    --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.btn-buy {
+    @include button-variant($buy-btn-bg, $buy-btn-bg, $buy-btn-color);
+
+    --#{$prefix}btn-focus-box-shadow: #{$focus-ring-box-shadow};
+
+    &.disabled,
+    &:disabled {
+        opacity: 1;
+        background: $disabled-btn-bg;
+        border-color: $disabled-btn-border-color;
+        color: $gray-300;
+    }
+}
+
+.btn-link {
+    --#{$prefix}btn-font-weight: #{$font-weight-semibold};
+    --#{$prefix}btn-focus-box-shadow: #{$input-btn-focus-box-shadow};
+}
+
+// Button styling with the appearance of a regular text link
+.btn-link-inline {
+    --#{$prefix}btn-color: #{$btn-link-color};
+    --#{$prefix}btn-hover-color: #{$btn-link-hover-color};
+    --#{$prefix}btn-font-weight: #{$font-weight-normal};
+    --#{$prefix}btn-font-size: inherit;
+    --#{$prefix}btn-focus-box-shadow: #{$input-btn-focus-box-shadow};
+    --#{$prefix}btn-line-height: #{$line-height-base};
+    --#{$prefix}btn-padding-y: 0;
+    --#{$prefix}btn-padding-x: 0;
+    --#{$prefix}btn-border-width: 0;
+    text-decoration: underline;
+    vertical-align: baseline;
+    text-align: left;
+    white-space: normal;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}

--- a/src/Storefront/Resources/views/components/Sw/Filter/Type/MultiSelectFilter.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Type/MultiSelectFilter.scss
@@ -76,15 +76,15 @@
     justify-content: center;
     transition: all 0.15s ease-in-out;
     opacity: 0;
-    background-color: $sw-color-brand-primary;
-    border: 0.125rem solid $sw-background-color;
+    background-color: var(--bs-primary);
+    border: 0.125rem solid var(--bs-body);
     top: 0;
     left: 1.813rem;
 
     .icon {
         width: 0.625rem;
         height: 0.625rem;
-        color: #fff;
+        color: var(--bs-white);
 
         svg {
             top: 0;

--- a/src/Storefront/Resources/views/components/Sw/Filter/Type/MultiSelectFilter.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Type/MultiSelectFilter.scss
@@ -76,15 +76,15 @@
     justify-content: center;
     transition: all 0.15s ease-in-out;
     opacity: 0;
-    background-color: $primary;
-    border: 0.125rem solid $body-bg;
+    background-color: $sw-color-brand-primary;
+    border: 0.125rem solid $sw-background-color;
     top: 0;
     left: 1.813rem;
 
     .icon {
         width: 0.625rem;
         height: 0.625rem;
-        color: $white;
+        color: #fff;
 
         svg {
             top: 0;

--- a/src/Storefront/Resources/views/components/Sw/Product/BuyButton.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/BuyButton.html.twig
@@ -48,9 +48,9 @@
 
      {% block buy_button %}
         <twig:Slot name="buy-button">
-            <button class="btn btn-primary">
+            <twig:Sw:Button variant="buy">
                 {{ 'listing.boxAddProduct'|trans|sw_sanitize }}
-            </button>
+            </twig:Sw:Button>
         </twig:Slot>
     {% endblock %}
 </form>

--- a/src/Storefront/Resources/views/components/Sw/Product/Card.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/Card.scss
@@ -15,8 +15,8 @@
     // Reset global core styling. Spacing with margin already defined by --bs-card-title-spacer-y
     padding-bottom: 0;
     font-weight: 600;
-    font-size: 1.125rem;
-    line-height: 1.2rem;
+    font-size: $font-size-lg;
+    line-height: $line-height-base;
 }
 
 .sw-product-card__title-link {

--- a/src/Storefront/Resources/views/components/Sw/Product/PriceDisplay.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/PriceDisplay.html.twig
@@ -106,17 +106,17 @@
             </div>
         {% endif %}
 
-        <a class="fs-6 d-block"
-           href="#"
-           role="button"
-           data-ajax-modal="true"
-           data-url="{{ path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}">
+        <twig:Sw:Button 
+            variant="inline"
+            class="fs-6"
+            data-ajax-modal="true"
+            data-url="{{ path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}">
             {% if context.taxState == 'gross' %}
                 {{ 'general.grossTaxInformationShort'|trans|sw_sanitize }}
             {% else %}
                 {{ 'general.netTaxInformationShort'|trans|sw_sanitize }}
             {% endif %}
-        </a>
+        </twig:Sw:Button>
 
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -107,11 +107,22 @@
         {% endif %}
     {% endblock %}
 
+    {% block base_component_styles %}
+        {% if feature('STOREFRONT_COMPONENTS') %}
+            {# Component styles are only loaded for components used within the page. #}
+            {% for style in mounted_component_styles() %}
+                <link rel="stylesheet" href="{{ asset(style, 'theme') }}">
+            {% endfor %}
+        {% endif %}
+    {% endblock %}
+
     {% block base_component_scripts %}
-        {# Component script files are only loaded for components used within the page. #}
-        {% for script in mounted_component_scripts() %}
-            <script type="text/javascript" src="{{ asset(script, 'theme') }}" defer></script>
-        {% endfor %}
+        {% if feature('STOREFRONT_COMPONENTS') %}
+            {# Component script files are only loaded for components used within the page. #}
+            {% for script in mounted_component_scripts() %}
+                <script type="text/javascript" src="{{ asset(script, 'theme') }}" defer></script>
+            {% endfor %}
+        {% endif %}
     {% endblock %}
 
     {% block base_body_script %}

--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -112,6 +112,8 @@
         {% block layout_head_stylesheet %}
             {% if isHMRMode %}
                 {# CSS will be loaded from the JS automatically #}
+            {% elseif isNewContentStructure %}
+                <link rel="stylesheet" href="{{ asset('css/minimal.css', 'theme') }}">
             {% else %}
                 {% set assets = theme_config('assets.css') %}
                 {% for file in assets %}

--- a/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfiguration.php
+++ b/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfiguration.php
@@ -31,6 +31,8 @@ class StorefrontPluginConfiguration extends Struct
 
     protected FileCollection $scriptFiles;
 
+    protected FileCollection $baseStyleFiles;
+
     protected ?string $storefrontEntryFilepath = null;
 
     /**
@@ -62,6 +64,7 @@ class StorefrontPluginConfiguration extends Struct
     {
         $this->styleFiles = new FileCollection();
         $this->scriptFiles = new FileCollection();
+        $this->baseStyleFiles = new FileCollection();
     }
 
     public function getTechnicalName(): string
@@ -117,6 +120,16 @@ class StorefrontPluginConfiguration extends Struct
     public function setScriptFiles(FileCollection $scriptFiles): void
     {
         $this->scriptFiles = $scriptFiles;
+    }
+
+    public function getBaseStyleFiles(): FileCollection
+    {
+        return $this->baseStyleFiles;
+    }
+
+    public function setBaseStyleFiles(FileCollection $baseStyleFiles): void
+    {
+        $this->baseStyleFiles = $baseStyleFiles;
     }
 
     public function getStorefrontEntryFilepath(): ?string
@@ -205,7 +218,7 @@ class StorefrontPluginConfiguration extends Struct
 
     public function hasFilesToCompile(): bool
     {
-        return \count($this->getStyleFiles()) !== 0 || \count($this->getScriptFiles()) !== 0;
+        return \count($this->getStyleFiles()) !== 0 || \count($this->getScriptFiles()) !== 0 || \count($this->getBaseStyleFiles()) !== 0;
     }
 
     /**

--- a/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+++ b/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
@@ -84,6 +84,10 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
                 $this->resolveStyleFiles($data['style'], $config);
             }
 
+            if (\array_key_exists('baseStyles', $data) && \is_array($data['baseStyles'])) {
+                $this->resolveBaseStyleFiles($data['baseStyles'], $config);
+            }
+
             if (\array_key_exists('script', $data) && \is_array($data['script'])) {
                 $fileCollection = FileCollection::createFromArray($data['script']);
                 $config->setScriptFiles($fileCollection);
@@ -254,5 +258,31 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
             }
         }
         $config->setStyleFiles($fileCollection);
+    }
+
+    /**
+     * @param array<string|array<array{resolve?: array<string, string>}>> $styles
+     */
+    private function resolveBaseStyleFiles(array $styles, StorefrontPluginConfiguration $config): void
+    {
+        $fileCollection = new FileCollection();
+        foreach ($styles as $style) {
+            if (!\is_array($style)) {
+                $fileCollection->add(new File($style));
+
+                continue;
+            }
+
+            foreach ($style as $filename => $additional) {
+                if (!\array_key_exists('resolve', $additional)) {
+                    $fileCollection->add(new File($filename));
+
+                    continue;
+                }
+
+                $fileCollection->add(new File($filename, $additional['resolve'] ?? []));
+            }
+        }
+        $config->setBaseStyleFiles($fileCollection);
     }
 }

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Event\ThemeCompilerConcatenatedStylesEvent;
+use Shopware\Storefront\Framework\Twig\Components\TwigComponentHelper;
 use Shopware\Storefront\Theme\Event\ThemeCompilerEnrichScssVariablesEvent;
 use Shopware\Storefront\Theme\Exception\ThemeException;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\File;
@@ -24,7 +25,6 @@ use Shopware\Storefront\Theme\StorefrontPluginConfiguration\FileCollection;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
 use Shopware\Storefront\Theme\Validator\SCSSValidator;
-use Shopware\Storefront\Framework\Twig\Components\TwigComponentHelper;
 use Symfony\Component\Asset\Package as AssetPackage;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
@@ -67,35 +67,6 @@ class ThemeCompiler implements ThemeCompilerInterface
         bool $withAssets,
         Context $context
     ): void {
-        try {
-            $styleFiles = $this->themeFileResolver->resolveStyleFiles($themeConfig, $configurationCollection, false);
-        } catch (\Throwable $e) {
-            throw ThemeException::themeCompileException(
-                $themeConfig->getName() ?? '',
-                'Files could not be resolved with error: ' . $e->getMessage(),
-                $e
-            );
-        }
-
-        try {
-            $concatenatedStyles = $this->concatenateStyles($styleFiles, $salesChannelId);
-        } catch (\Throwable $e) {
-            throw ThemeException::themeCompileException(
-                $themeConfig->getName() ?? '',
-                'Error while trying to concatenate Styles: ' . $e->getMessage(),
-                $e
-            );
-        }
-
-        $compiled = $this->compileStyles(
-            $concatenatedStyles,
-            $themeConfig,
-            $styleFiles->getResolveMappings(),
-            $salesChannelId,
-            $themeId,
-            $context
-        );
-
         $newThemeHash = Uuid::randomHex();
         $themePrefix = $this->themePathBuilder->generateNewPath($salesChannelId, $themeId, $newThemeHash);
         $oldThemePrefix = $this->themePathBuilder->assemblePath($salesChannelId, $themeId);
@@ -108,8 +79,22 @@ class ThemeCompiler implements ThemeCompilerInterface
             $this->filesystem->deleteDirectory($path);
         }
 
+        // Normal style files. Loaded for usual pages.
+        $compiledStyles = $this->getCompiledStyles(
+            $this->getResolvedStyleFiles($themeConfig, $configurationCollection),
+            $themeId,
+            $themeConfig,
+            $salesChannelId,
+            $context
+        );
+
         try {
-            $assets = $this->collectCompiledFiles($themePrefix, $themeId, $compiled, $withAssets, $themeConfig, $configurationCollection);
+            $styleCopyFiles = $this->getStyleCopyFiles($themePrefix, $compiledStyles);
+
+            $assetCopyFiles = [];
+            if ($withAssets) {
+                $assetCopyFiles = $this->getAssetCopyFiles($themeConfig, $configurationCollection, $themeId);
+            }
         } catch (\Throwable $e) {
             throw ThemeException::themeCompileException(
                 $themeConfig->getName() ?? '',
@@ -118,15 +103,54 @@ class ThemeCompiler implements ThemeCompilerInterface
             );
         }
 
-        $themeScriptCopyFiles = $this->copyScriptFilesToTheme($configurationCollection, $themePrefix);
-
+        /**
+         * New base style files.
+         * This is the new feature introduced with the new component system.
+         * You can define a minimal set of styles to be loaded for the theme.
+         */
+        $baseStyleCopyFiles = [];
         if (Feature::isActive('STOREFRONT_COMPONENTS')) {
-            $componentScriptCopyFiles = $this->copyComponentScriptFiles($themePrefix);
-        } else {
-            $componentScriptCopyFiles = [];
+            $compiledBaseStyles = $this->getCompiledStyles(
+                $this->getResolvedBaseStyleFiles($themeConfig, $configurationCollection),
+                $themeId,
+                $themeConfig,
+                $salesChannelId,
+                $context
+            );
+
+            try {
+                $baseStyleCopyFiles = $this->getStyleCopyFiles($themePrefix, $compiledBaseStyles, 'minimal.css');
+            } catch (\Throwable $e) {
+                throw ThemeException::themeCompileException(
+                    $themeConfig->getName() ?? '',
+                    'Error while trying to write base style files: ' . $e->getMessage(),
+                    $e
+                );
+            }
         }
 
-        CopyBatch::copy($this->filesystem, ...$assets, ...$themeScriptCopyFiles, ...$componentScriptCopyFiles);
+        // Individual component styles.
+        $componentStyleCopyFiles = [];
+        if (Feature::isActive('STOREFRONT_COMPONENTS')) {
+            $componentStyleCopyFiles = $this->getCompiledComponentStyles(
+                $themeId,
+                $themePrefix,
+                $themeConfig,
+                $salesChannelId,
+                $context
+            );
+        }
+
+        $scriptFiles = $this->getScriptCopyFiles($configurationCollection, $themePrefix);
+
+        CopyBatch::copy(
+            $this->filesystem,
+            ...$styleCopyFiles,
+            ...$baseStyleCopyFiles,
+            ...$componentStyleCopyFiles,
+            ...$assetCopyFiles,
+            ...$scriptFiles,
+        );
 
         $this->themePathBuilder->saveSeed($salesChannelId, $themeId, $newThemeHash);
 
@@ -500,16 +524,141 @@ PHP_EOL;
         return $concatenatedStylesEvent->getConcatenatedStyles();
     }
 
+    private function getResolvedStyleFiles(
+        StorefrontPluginConfiguration $themeConfig,
+        StorefrontPluginConfigurationCollection $configurationCollection,
+    ): FileCollection {
+        try {
+            return $this->themeFileResolver->resolveStyleFiles($themeConfig, $configurationCollection, false);
+        } catch (\Throwable $e) {
+            throw ThemeException::themeCompileException(
+                $themeConfig->getName() ?? '',
+                'Files could not be resolved with error: ' . $e->getMessage(),
+                $e
+            );
+        }
+    }
+
+    private function getResolvedBaseStyleFiles(
+        StorefrontPluginConfiguration $themeConfig,
+        StorefrontPluginConfigurationCollection $configurationCollection,
+    ): FileCollection {
+        try {
+            return $this->themeFileResolver->resolveBaseStyleFiles($themeConfig, $configurationCollection, false);
+        } catch (\Throwable $e) {
+            throw ThemeException::themeCompileException(
+                $themeConfig->getName() ?? '',
+                'Files could not be resolved with error: ' . $e->getMessage(),
+                $e
+            );
+        }
+    }
+
+    /**
+     * Concatenates all files of the provided collection and compiles the styles.
+     */
+    private function getCompiledStyles(
+        FileCollection $styleFiles,
+        string $themeId,
+        StorefrontPluginConfiguration $themeConfig,
+        string $salesChannelId,
+        Context $context,
+    ): string {
+        try {
+            $concatenatedStyles = $this->concatenateStyles($styleFiles, $salesChannelId);
+        } catch (\Throwable $e) {
+            throw ThemeException::themeCompileException(
+                $themeConfig->getName() ?? '',
+                'Error while trying to concatenate Styles: ' . $e->getMessage(),
+                $e
+            );
+        }
+
+        return $this->compileStyles(
+            $concatenatedStyles,
+            $themeConfig,
+            $styleFiles->getResolveMappings(),
+            $salesChannelId,
+            $themeId,
+            $context
+        );
+    }
+
+    /**
+     * Compiles the styles for each component and returns the copy files.
+     *
+     * @return list<CopyBatchInput>
+     */
+    private function getCompiledComponentStyles(
+        string $themeId,
+        string $themePrefix,
+        StorefrontPluginConfiguration $themeConfig,
+        string $salesChannelId,
+        Context $context,
+    ): array {
+        $componentStyleCopyFiles = [];
+        // The variables from the core Storefront are always added, so components can access them.
+        $variablesFilePath = __DIR__ . '/../Resources/app/storefront/src/scss/variables.scss';
+
+        // Resolve the vendor path from the core Storefront.
+        $resolveMapping = [
+            'vendor' => __DIR__ . '/../Resources/app/storefront/vendor',
+        ];
+
+        // Each component is compiled separately and a CSS file is created under the components namespace.
+        foreach ($this->twigComponentHelper->getComponents() as $component) {
+            $componentStylePath = $component->getStylePath();
+
+            if ($componentStylePath !== null) {
+                $styleString = \sprintf('@import \'%s\';', $variablesFilePath);
+                $styleString .= \sprintf('@import \'%s\';', $componentStylePath);
+
+                try {
+                    $compiledStyle = $this->compileStyles(
+                        $styleString,
+                        $themeConfig,
+                        $resolveMapping,
+                        $salesChannelId,
+                        $themeId,
+                        $context
+                    );
+                } catch (\Throwable $e) {
+                    throw ThemeException::themeCompileException(
+                        $themeConfig->getName() ?? '',
+                        'Error while trying to compile component styles: ' . $e->getMessage(),
+                        $e
+                    );
+                }
+
+                try {
+                    $componentStyleCopyFiles = [
+                        ...$componentStyleCopyFiles,
+                        ...$this->getStyleCopyFiles(
+                            $themePrefix,
+                            $compiledStyle,
+                            'components' . \DIRECTORY_SEPARATOR . $component->getRelativeNamespacePath() . '.css'
+                        ),
+                    ];
+                } catch (\Throwable $e) {
+                    throw ThemeException::themeCompileException(
+                        $themeConfig->getName() ?? '',
+                        'Error while trying to write component style files: ' . $e->getMessage(),
+                        $e
+                    );
+                }
+            }
+        }
+
+        return $componentStyleCopyFiles;
+    }
+
     /**
      * @return list<CopyBatchInput>
      */
-    private function collectCompiledFiles(
+    private function getStyleCopyFiles(
         string $themePrefix,
-        string $themeId,
         string $compiled,
-        bool $withAssets,
-        StorefrontPluginConfiguration $themeConfig,
-        StorefrontPluginConfigurationCollection $configurationCollection
+        string $fileName = 'all.css'
     ): array {
         $compileLocation = 'theme' . \DIRECTORY_SEPARATOR . $themePrefix;
 
@@ -523,24 +672,48 @@ PHP_EOL;
             new CopyBatchInput(
                 $tempStream,
                 [
-                    $compileLocation . \DIRECTORY_SEPARATOR . 'css' . \DIRECTORY_SEPARATOR . 'all.css',
+                    $compileLocation . \DIRECTORY_SEPARATOR . 'css' . \DIRECTORY_SEPARATOR . $fileName,
                 ],
                 $this->visibility
             ),
         ];
 
-        // assets
-        if ($withAssets) {
-            $assetPath = 'theme' . \DIRECTORY_SEPARATOR . $themeId;
+        return $files;
+    }
 
-            try {
-                $this->filesystem->deleteDirectory($assetPath);
-            } catch (UnableToDeleteDirectory) {
-            }
+    /**
+     * @return list<CopyBatchInput>
+     */
+    private function getAssetCopyFiles(
+        StorefrontPluginConfiguration $themeConfig,
+        StorefrontPluginConfigurationCollection $configurationCollection,
+        string $themeId
+    ): array {
+        $assetPath = 'theme' . \DIRECTORY_SEPARATOR . $themeId;
 
-            $files = [...$files, ...$this->getAssets($themeConfig, $configurationCollection, $assetPath)];
+        try {
+            $this->filesystem->deleteDirectory($assetPath);
+        } catch (UnableToDeleteDirectory) {
         }
 
-        return $files;
+        return $this->getAssets($themeConfig, $configurationCollection, $assetPath);
+    }
+
+    /**
+     * @return list<CopyBatchInput>
+     */
+    private function getScriptCopyFiles(
+        StorefrontPluginConfigurationCollection $configurationCollection,
+        string $themePrefix
+    ): array {
+        $themeScriptCopyFiles = $this->copyScriptFilesToTheme($configurationCollection, $themePrefix);
+
+        if (Feature::isActive('STOREFRONT_COMPONENTS')) {
+            $componentScriptCopyFiles = $this->copyComponentScriptFiles($themePrefix);
+        } else {
+            $componentScriptCopyFiles = [];
+        }
+
+        return [...$themeScriptCopyFiles, ...$componentScriptCopyFiles];
     }
 }

--- a/src/Storefront/Theme/ThemeFileResolver.php
+++ b/src/Storefront/Theme/ThemeFileResolver.php
@@ -18,6 +18,7 @@ class ThemeFileResolver
 {
     final public const SCRIPT_FILES = 'script';
     final public const STYLE_FILES = 'style';
+    final public const BASE_STYLE_FILES = 'baseStyles';
 
     /**
      * @internal
@@ -43,6 +44,11 @@ class ThemeFileResolver
                 $onlySourceFiles
             ),
             self::STYLE_FILES => $this->resolveStyleFiles(
+                $themeConfig,
+                $configurationCollection,
+                $onlySourceFiles
+            ),
+            self::BASE_STYLE_FILES => $this->resolveBaseStyleFiles(
                 $themeConfig,
                 $configurationCollection,
                 $onlySourceFiles
@@ -75,6 +81,20 @@ class ThemeFileResolver
             $configurationCollection,
             $onlySourceFiles,
             fn (StorefrontPluginConfiguration $configuration) => $configuration->getStyleFiles()
+        );
+    }
+
+    public function resolveBaseStyleFiles(
+        StorefrontPluginConfiguration $themeConfig,
+        StorefrontPluginConfigurationCollection $configurationCollection,
+        bool $onlySourceFiles
+    ): FileCollection {
+        return $this->resolve(
+            self::BASE_STYLE_FILES,
+            $themeConfig,
+            $configurationCollection,
+            $onlySourceFiles,
+            fn (StorefrontPluginConfiguration $configuration) => $configuration->getBaseStyleFiles()
         );
     }
 


### PR DESCRIPTION
## Introduction
The is a new optional CSS compiling and loading which is used by pages that are rendered via the new content system. Instead of bundling every style file into one large file, separate style files are generated for each component. Only the style files of the components that are rendered in the page are loaded. In addition, you can define a new base (minimal) CSS file in your theme, which will be loaded as a `minimal.css` instead of the large `all.css`. This can be used for basic styling or general frameworks, such as Bootstrap, which always have to be loaded.

## Defining Base Styles in your Theme

You can now define a base style file that is always loaded alongside the rendered components with the new `baseStyles` tag in your `theme.json`. It works the same as the current style configuration. 

```JSON
  "baseStyles": [
    {
      "app/storefront/src/scss/base.minimal.scss": {
        "resolve": {
          "vendor": "app/storefront/vendor"
        }
      }
    },
    "@Plugins"
  ],
```

## Component Styles
The style files for each component are compiled automatically and have access to the general Bootstrap and Theme config variables. If you need additional local variables or mixins that you defined in your custom SCSS, you must import those files explicitly in your component SCSS file. The compiled files are loaded automatically if your component is rendered on the page.

<img width="684" height="515" alt="image" src="https://github.com/user-attachments/assets/8e1d892a-5e0f-4a22-88bf-13b2ce2a47c0" />


