### PR TITLE
fix: fix multiple sw-single-select issue

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.html.twig
@@ -17,7 +17,7 @@
             {% block sw_single_select_single_selection_inner %}
             {% block sw_single_select_single_selection_inner_label %}
             <div
-                v-if="!isExpanded"
+                v-show="!isExpanded"
                 class="sw-single-select__selection-text"
                 :class="selectionTextClasses"
             >
@@ -26,7 +26,8 @@
                         name="selection-label-property"
                         v-bind="{ item: singleSelection, labelProperty, valueProperty, searchTerm, getKey }"
                     >
-                        {{ getKey(singleSelection, labelProperty) }}
+                        <!-- !isExpanded check is needed here for fixing acceptance test "getByText" selector -->
+                        {{ !isExpanded ? getKey(singleSelection, labelProperty) : '' }}
                     </slot>
                 </template>
                 <template v-else>

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.spec.js
@@ -224,4 +224,61 @@ describe('components/sw-single-select', () => {
         selectionText = wrapper.find('.sw-single-select__selection-text');
         expect(selectionText.text()).toBe('');
     });
+
+    it('should close first dropdown when clicking to open second dropdown', async () => {
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+
+        // Create first dropdown (Payment Status)
+        const firstDropdown = await createSingleSelect({
+            props: {
+                value: 'paid',
+                options: [
+                    { label: 'Paid', value: 'paid' },
+                    { label: 'Open', value: 'open' },
+                    { label: 'Cancelled', value: 'cancelled' },
+                ],
+            },
+            attachTo: container,
+        });
+
+        // Create second dropdown (Delivery Status)
+        const secondDropdown = await createSingleSelect({
+            props: {
+                value: 'shipped',
+                options: [
+                    { label: 'Shipped', value: 'shipped' },
+                    { label: 'Pending', value: 'pending' },
+                    { label: 'Delivered', value: 'delivered' },
+                ],
+            },
+            attachTo: container,
+        });
+
+        await flushPromises();
+
+        // User clicks the first dropdown to open it
+        const firstSelectionElement = firstDropdown.find('.sw-select__selection').element;
+        firstSelectionElement.click();
+        await flushPromises();
+
+        // First dropdown should be open
+        expect(firstDropdown.find('.sw-select-result-list__content').isVisible()).toBe(true);
+
+        // User clicks the second dropdown
+        const secondSelectionElement = secondDropdown.find('.sw-select__selection').element;
+        secondSelectionElement.click();
+        await flushPromises();
+
+        // First dropdown should now be closed
+        expect(firstDropdown.find('.sw-select-result-list__content').exists()).toBe(false);
+
+        // Second dropdown should be open
+        expect(secondDropdown.find('.sw-select-result-list__content').isVisible()).toBe(true);
+
+        // Cleanup
+        firstDropdown.unmount();
+        secondDropdown.unmount();
+        document.body.removeChild(container);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Fixes https://github.com/shopware/shopware/issues/13111

Is a little fix, but was hard to find the root issue 😄 

### 2. What does this change do, exactly?

The close behavior didn't work because the main clicked element was directly removed which caused issue with the event bubbling behavior. Changing it to v-show avoids this issue. Here is the result:

https://github.com/user-attachments/assets/c71ad596-13eb-44a1-87c8-3b54afe06c34


