### PR TITLE
chore: Revert "fix: dont expose context token in twig (#13272)"

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -112,11 +112,6 @@ Example usage:
 
 New extensible Twig blocks `layout_header_actions_language_widget_content_inner` and `layout_header_actions_languages_widget_form_items_flag_inner` have been added to the language selector to allow custom flag implementations.
 
-### `context.token` is no longer available in twig rendering context
-
-The `context.token` variable is no longer available in twig rendering context to prevent potential security vulnerabilities. If you need to access the token, consider using alternative methods that do not expose it in the rendered HTML.
-Usually inside the Twig storefront there is no need to handle the context token manually, as it is handled automatically via the session handling in the Storefront.
-
 ### Added specific `add-product-by-number` template
 The `page_checkout_cart_add_product*` blocks inside `@Storefront/storefront/page/checkout/cart/index.html.twig` are deprecated and a new template `@Storefront/storefront/component/checkout/add-product-by-number.html.twig` was added.
 

--- a/src/Core/System/SalesChannel/SalesChannelContext.php
+++ b/src/Core/System/SalesChannel/SalesChannelContext.php
@@ -13,7 +13,6 @@ use Shopware\Core\Content\MeasurementSystem\MeasurementUnits;
 use Shopware\Core\Content\MeasurementSystem\MeasurementUnitTypeEnum;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\StateAwareTrait;
@@ -218,15 +217,6 @@ class SalesChannelContext extends Struct
 
     public function getToken(): string
     {
-        /**
-         * @see \Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::getAttribute
-         * Inside Twig rendering context, the token is not allowed to be accessed as it might expose sensitive information
-         * when the data is dumped into outputted HTML.
-         */
-        if (FieldVisibility::$isInTwigRenderingContext) {
-            throw SalesChannelException::contextTokenNotAccessible();
-        }
-
         return $this->token;
     }
 

--- a/src/Core/System/SalesChannel/SalesChannelException.php
+++ b/src/Core/System/SalesChannel/SalesChannelException.php
@@ -37,7 +37,6 @@ class SalesChannelException extends HttpException
     final public const ENCODING_MISSING_AGGREGATION_EXCEPTION = 'SYSTEM__ENCODING_MISSING_AGGREGATION_EXCEPTION';
     final public const ORDER_NOT_FOUND_CODE = 'SYSTEM__ORDER_NOT_FOUND_CODE';
     final public const MISSING_ORDER_ASSOCIATION_CODE = 'SYSTEM__MISSING_ORDER_ASSOCIATION_CODE';
-    final public const CONTEXT_TOKEN_NOT_ACCESSIBLE = 'SYSTEM__CONTEXT_TOKEN_NOT_ACCESSIBLE';
     final public const SALES_CHANNEL_MAPPING_INVALID_OPERATION = 'SYSTEM__SALES_CHANNEL_MAPPING_INVALID_OPERATION';
     private const INVALID_UUID_MESSAGE_TEMPLATE = 'Provided %s is not a valid UUID';
 
@@ -260,15 +259,6 @@ class SalesChannelException extends HttpException
             self::ENCODING_INVALID_STRUCT_EXCEPTION,
             'Invalid struct: "{{ context }}"',
             ['context' => $context]
-        );
-    }
-
-    public static function contextTokenNotAccessible(): self
-    {
-        return new self(
-            Response::HTTP_BAD_REQUEST,
-            self::CONTEXT_TOKEN_NOT_ACCESSIBLE,
-            'The context token is not accessible in Twig rendering context, as the token should never be leaked in HTML content.',
         );
     }
 

--- a/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
@@ -6,11 +6,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\AbstractCartPersister;
 use Shopware\Core\Content\MeasurementSystem\MeasurementUnits;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SalesChannel\SalesChannelException;
 use Shopware\Core\Test\Generator;
 
 /**
@@ -20,12 +18,6 @@ use Shopware\Core\Test\Generator;
 #[CoversClass(SalesChannelContext::class)]
 class SalesChannelContextTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        // reset field visibility, see `testGetTokenIsNotAccessibleFromTwigRenderingContext()` test
-        FieldVisibility::$isInTwigRenderingContext = false;
-    }
-
     public function testGetRuleIdsByAreas(): void
     {
         $salesChannelContext = Generator::generateSalesChannelContext();
@@ -141,18 +133,5 @@ class SalesChannelContextTest extends TestCase
         static::assertTrue($salesChannelContext->getContext()->hasState($manualState));
         static::assertFalse($salesChannelContext->hasState($closureState));
         static::assertFalse($salesChannelContext->getContext()->hasState($closureState));
-    }
-
-    public function testGetTokenIsNotAccessibleFromTwigRenderingContext(): void
-    {
-        $salesChannelContext = Generator::generateSalesChannelContext();
-        // outside of twig rendering context, token is accessible
-        $salesChannelContext->getToken();
-
-        // fake twig rendering context, see `\Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::getAttribute()`
-        FieldVisibility::$isInTwigRenderingContext = true;
-
-        static::expectExceptionObject(SalesChannelException::contextTokenNotAccessible());
-        $salesChannelContext->getToken();
     }
 }

--- a/tests/unit/Core/System/SalesChannel/SalesChannelExceptionTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelExceptionTest.php
@@ -92,12 +92,5 @@ class SalesChannelExceptionTest extends TestCase
             'errorCode' => 'CHECKOUT__UNKNOWN_PAYMENT_METHOD',
             'message' => 'Could not find payment method with id "myCustomPaymentMethod"',
         ];
-
-        yield SalesChannelException::CONTEXT_TOKEN_NOT_ACCESSIBLE => [
-            'exception' => SalesChannelException::contextTokenNotAccessible(),
-            'statusCode' => Response::HTTP_BAD_REQUEST,
-            'errorCode' => SalesChannelException::CONTEXT_TOKEN_NOT_ACCESSIBLE,
-            'message' => 'The context token is not accessible in Twig rendering context, as the token should never be leaked in HTML content.',
-        ];
     }
 }


### PR DESCRIPTION
This reverts commit 2065de696d43c6231856d608dc1b9b058eacc13e.

commercial is broken with this
