### PR TITLE
fix: Trim spaces from promotion codes

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -108,6 +108,10 @@ Example usage:
 
 ## Storefront
 
+### Spaces are trimmed from promotion codes
+
+Spaces are now always trimmed from promotions codes, as in the past promotion codes with spaces lead to unexpected behavior and errors in the cart.
+
 ### Language selector twig blocks
 
 New extensible Twig blocks `layout_header_actions_language_widget_content_inner` and `layout_header_actions_languages_widget_form_items_flag_inner` have been added to the language selector to allow custom flag implementations.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -108,10 +108,6 @@ Example usage:
 
 ## Storefront
 
-### Spaces are trimmed from promotion codes
-
-Spaces are now always trimmed from promotions codes, as in the past promotion codes with spaces lead to unexpected behavior and errors in the cart.
-
 ### Language selector twig blocks
 
 New extensible Twig blocks `layout_header_actions_language_widget_content_inner` and `layout_header_actions_languages_widget_form_items_flag_inner` have been added to the language selector to allow custom flag implementations.

--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -119,7 +119,7 @@ class CartLineItemController extends StorefrontController
     {
         return Profiler::trace('cart::add-promotion', function () use ($cart, $request, $context) {
             try {
-                $code = (string) $request->request->get('code');
+                $code = trim((string) $request->request->get('code'));
 
                 if ($code === '') {
                     throw RoutingException::missingRequestParameter('code');

--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -119,7 +119,7 @@ class CartLineItemController extends StorefrontController
     {
         return Profiler::trace('cart::add-promotion', function () use ($cart, $request, $context) {
             try {
-                $code = trim((string) $request->request->get('code'));
+                $code = mb_trim((string) $request->request->get('code'));
 
                 if ($code === '') {
                     throw RoutingException::missingRequestParameter('code');


### PR DESCRIPTION
### 1. Why is this change necessary?
Add a promotion with an fixed code, and add this code with an additional space at the end to the cart, notice nothing happens, however the promotion code stays added in the cart. 

Add the same code again, but now without the space, and watch Shopware explode (fun story the error message is catched and not displayed, and it tries to increase the line item count to two of the promotion item).

### 2. What does this change do, exactly?
Trim the code when it is added.

### 3. Describe each step to reproduce the issue or behaviour.
See section 1.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
