### PR TITLE
fix: duplicate form submission with captcha

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/basic-captcha.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/basic-captcha.plugin.js
@@ -32,6 +32,7 @@ export default class BasicCaptchaPlugin extends Plugin {
 
         if (window.Feature.isActive('ACCESSIBILITY_TWEAKS')) {
             window.formValidation.addErrorMessage('basicCaptcha', this.options.invalidFeedbackMessage);
+            this._setBasicCaptchaHandleSubmit();
         }
 
         /**
@@ -160,6 +161,20 @@ export default class BasicCaptchaPlugin extends Plugin {
      */
     _isCmsForm() {
         return this.formPluginInstances.has('FormCmsHandler');
+    }
+
+    /**
+     * Sets the formSubmittedByCaptcha flag on form handler plugins to prevent duplicate submissions.
+     * This is similar to GoogleReCaptchaBasePlugin._setGoogleReCaptchaHandleSubmit().
+     *
+     * @private
+     */
+    _setBasicCaptchaHandleSubmit() {
+        window.PluginManager.getPluginInstancesFromElement(this._form).forEach((plugin) => {
+            if (typeof plugin.sendAjaxFormSubmit === 'function') {
+                plugin.formSubmittedByCaptcha = true;
+            }
+        });
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
@@ -20,6 +20,10 @@ export default class FormCmsHandler extends Plugin {
         this._registerEvents();
         this._getCmsBlock();
         this._getConfirmationText();
+
+        if (this.formSubmittedByCaptcha === undefined) {
+            this.formSubmittedByCaptcha = false;
+        }
     }
 
     sendAjaxFormSubmit() {
@@ -52,7 +56,9 @@ export default class FormCmsHandler extends Plugin {
         event.preventDefault();
 
         if (this.el.checkValidity()) {
-            this._submitForm();
+            if (!this.formSubmittedByCaptcha) {
+                this._submitForm();
+            }
         } else {
             this._showValidation();
         }

--- a/tests/acceptance/tests/Forms/ValidateBasicCaptchaInContactForm.spec.ts
+++ b/tests/acceptance/tests/Forms/ValidateBasicCaptchaInContactForm.spec.ts
@@ -1,9 +1,9 @@
-import { test, expect } from '@fixtures/AcceptanceTest';
+import { test } from '@fixtures/AcceptanceTest';
 
 test(
     'As a customer, I expect to see and use a basic captcha function on the contact form.',
     { tag: '@form @contact' },
-    async ({ ShopCustomer, StorefrontHome, StorefrontContactForm, DefaultSalesChannel, TestDataService, InstanceMeta }) => {
+    async ({ ShopCustomer, StorefrontHome, StorefrontContactForm, TestDataService, InstanceMeta }) => {
 
         test.skip(InstanceMeta.isSaaS, 'SaaS just support FriendlyCaptcha');
 
@@ -34,16 +34,21 @@ test(
         });
 
         await test.step('Send and validate the unaccomplished contact form.', async () => {
-            const contactFormPromise = StorefrontContactForm.page.waitForResponse(
-                `${process.env['APP_URL'] + 'test-' + DefaultSalesChannel.salesChannel.id}/form/contact`
-            );
+            // eslint-disable-next-line playwright/no-conditional-in-test
+            const formRoute = InstanceMeta.features['ACCESSIBILITY_TWEAKS'] ? '**/basic-captcha-validate' : '**/form/contact';
+
+            const formSubmitPromise = StorefrontContactForm.page.waitForResponse(formRoute);
             await StorefrontContactForm.submitButton.click();
-            const contactFormResponse = await contactFormPromise;
-            expect(contactFormResponse.ok()).toBeTruthy();
+            await formSubmitPromise;
 
             await ShopCustomer.expects(StorefrontContactForm.basicCaptchaInput).toHaveCSS('border-color', 'rgb(194, 0, 23)');
-            await ShopCustomer.expects(StorefrontContactForm.formAlert.last()).toBeVisible();
-            await ShopCustomer.expects(StorefrontContactForm.formAlert.last()).toContainText('Incorrect input. Please try again.');
+
+            if (InstanceMeta.features['ACCESSIBILITY_TWEAKS']) {
+                await ShopCustomer.expects(StorefrontContactForm.basicCaptchaInput).toHaveAccessibleDescription('Incorrect input. Please try again.');
+            } else {
+                await ShopCustomer.expects(StorefrontContactForm.formAlert.last()).toBeVisible();
+                await ShopCustomer.expects(StorefrontContactForm.formAlert.last()).toContainText('Incorrect input. Please try again.');
+            }
         });
     }
 );


### PR DESCRIPTION
### 1. Why is this change necessary?

When accessibility tweaks are enabled and captchas are set to basic captchas, submitting a CMS form may lead to a duplicate submission.

### 2. What does this change do, exactly?

This has been touched in `trunk` already and some related changes were backported. This PR ties up the loose ends by applying the `formSubmittedByCaptcha` flag to the `form-cms-handler` and `basic-captcha` plugins. 

### 3. Describe each step to reproduce the issue or behaviour.

see #10236 

> - Create a new 6.6.10.4 shop and enable ACCESSIBILITY_TWEAKS
> - Use a CMS form (contact, newsletter) or install CMS-Extensions and create a new custom form
> - Assign that custom form to a category
> - Select “Basic CAPTCHA” as the CAPTCHA within Settings > Basic information
> - For good measures, clear the cache
> - Open the form and submit it while watching the F12 network tab

### 4. Please link to the relevant issues (if any).
- closes #10236 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
