### PR TITLE
fix: FormFieldToggle plugin breaking with value="false"

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-field-toggle.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-field-toggle.plugin.js
@@ -144,13 +144,17 @@ export default class FormFieldTogglePlugin extends Plugin {
      */
     _shouldShowTarget() {
         const type = this.el.type;
-        if (type === 'checkbox' || type === 'radio') {
-            const booleanValue = (this._value === 'true' || this._value);
-            return this.el.checked === booleanValue;
-        } else {
+        if ('checkbox' !== type && 'radio' !== type) {
             return this.el.value === this._value;
         }
+    
+        if (!this._value) {
+            return this.el.checked;
+        }
+
+        return this.el.checked === ('true' === this._value);
     }
+
 
     /**
      * hides the given target element


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The current implementation has a bug in _shouldShowTarget(): const booleanValue = (this._value === 'true' || this._value);

When value="false", this evaluates to:
booleanValue = (false || "false") = "false" (string)

Comparing boolean === string always returns false, breaking the toggle.

### 2. What does this change do, exactly?
The fix ensures booleanValue is always a boolean, supporting both:
- value="true": show when checked (normal behavior)
- value="false": show when unchecked (inverted behavior)

### 3. Describe each step to reproduce the issue or behaviour.
Noted above, you need to create or customize any any for and try to use the false value.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
