### PR TITLE
fix(navbar): Navbar won't hide when passing an item without children

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -61,12 +61,6 @@ export default class NavbarPlugin extends Plugin {
     _toggleNavbar(topLevelLink, event) {
         const currentDropdown = window.bootstrap.Dropdown.getOrCreateInstance(topLevelLink);
         if (event.type === 'mouseenter') {
-            if (!currentDropdown?._menu) {
-                this._closeAllDropdowns();
-
-                return;
-            }
-
             this._isMouseOver = true;
             this._debounce(() => {
                 if (this._isMouseOver && currentDropdown?._menu && !currentDropdown._menu.classList.contains('show')) {

--- a/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
@@ -321,7 +321,7 @@ describe('NavbarPlugin', () => {
 
         jest.runAllTimers();
 
-        expect(navbarPlugin._closeAllDropdowns).toHaveBeenCalled();
+        expect(navbarPlugin._closeAllDropdowns).not.toHaveBeenCalled();
         expect(mockDropdown.hide).toHaveBeenCalled();
         expect(mockNoDropdown.show).not.toHaveBeenCalled();
     });

--- a/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
@@ -11,7 +11,8 @@
                  itemtype="https://schema.org/SiteNavigationElement"
                  data-navbar="true"
                  data-navbar-options="{{ navbarOptions|json_encode }}"
-                 aria-label="{{ 'header.navigationAriaLabel'|trans|striptags }}">
+                 aria-label="{{ 'header.navigationAriaLabel'|trans|striptags }}"
+            >
                 <div class="collapse navbar-collapse" id="main_nav">
                     <ul class="navbar-nav main-navigation-menu-list flex-wrap">
                         {% set homeLabel = context.salesChannel.translated.homeName|default('general.homeLink'|trans) %}
@@ -39,9 +40,9 @@
 
                                 {% block layout_navbar_menu_item %}
                                     {% if not itemSkipped %}
-                                        <li class="nav-item nav-item-{{ id }} {% if hasChildren %}dropdown position-static{% endif %}">
+                                        <li class="nav-item nav-item-{{ id }} dropdown position-static">
                                             {% block layout_navbar_menu_item_link %}
-                                                <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2{% if hasChildren %} dropdown-toggle{% endif %}"
+                                                <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2 {% if hasChildren %}dropdown-toggle{% else %}no-dropdown{% endif %}"
                                                    href="{{ category.seoUrl ?: '#' }}"
                                                    {% if hasChildren %}data-bs-toggle="dropdown"{% endif %}
                                                    {% if category.type != 'folder' and category.shouldOpenInNewTab %}target="_blank"{% endif %}


### PR DESCRIPTION
fixes #13388

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

## Demo

https://github.com/user-attachments/assets/54b79b92-1297-4b8e-bd5f-f7a9c718380e


### 1. Why is this change necessary?
When you open a category navbar flyout and pass an item without children, it closes immediatly

### 2. What does this change do, exactly?
Remove the closing condition, which only covers such cases

### 3. Describe each step to reproduce the issue or behaviour.
- Create multiple categories, so they break into a new line
- On e.g. the second line, there has to be an item without sub categories (See image)
- Toggle the flyout by hovering the item above one without children
- Move your mouse down towards the flyout, but pass the item without children on that way
- Before, it closed the flyout immediatly

<img width="1150" height="430" alt="image" src="https://github.com/user-attachments/assets/fa15ceea-9723-4fa8-8595-52f605fad0ea" />

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
