### PR TITLE
ci: set permissions for analyze job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -237,7 +237,9 @@ jobs:
       fail-fast: false
       matrix:
         language: [ "javascript" ]
-
+    permissions:
+        contents: read
+        security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 4


### PR DESCRIPTION
### 1. Why is this change necessary?
It seems like the merge queue uses only read permissions if an external creates an PR.
As this job requires the `security-events: write` permissions we will set them explicitly.

### 2. What does this change do, exactly?
Explicitly set `security-events: write` for the analyze job.

### 3. Describe each step to reproduce the issue or behaviour.
Try to merge a PR of an external.
