### PR TITLE
ci: activate slack release message

### DIFF
--- a/.github/workflows/05-publish-release.yml
+++ b/.github/workflows/05-publish-release.yml
@@ -128,4 +128,4 @@ jobs:
       - name: Post slack message
         run: |
             SLACK_PAYLOAD=$(jq --null-input --arg version "${{ github.ref_name }}" '{"version": $version, "github_url": "https://github.com/shopware/shopware/releases/tag/\($version)"}');
-            echo curl --silent --request POST --url "${{ secrets.SLACK_RELEASE_WORKFLOW_URL }}" --header "Content-Type: application/json" --data "${SLACK_PAYLOAD}"
+            curl --silent --request POST --url "${{ secrets.SLACK_RELEASE_WORKFLOW_URL }}" --header "Content-Type: application/json" --data "${SLACK_PAYLOAD}"


### PR DESCRIPTION
### 1. Why is this change necessary?
For initial debugging we only `echo`'d the curl command, but we want to let the workflow execute it.

### 2. What does this change do, exactly?
Remove the `echo` and let the workflow run the curl

### 3. Describe each step to reproduce the issue or behaviour.
It is only possible to reproduce it in a release.