### PR TITLE
Remove filterApiAwareFields in ImportExport::import (Fixes #13476)

### DIFF
--- a/src/Core/Content/ImportExport/ImportExport.php
+++ b/src/Core/Content/ImportExport/ImportExport.php
@@ -104,7 +104,6 @@ class ImportExport
         $resource = $this->filesystem->readStream($path);
 
         $config = Config::fromLog($this->logEntity);
-        $config = $this->filterApiAwareFields($config, $context);
 
         $overallResults = $this->logEntity->getResult();
 

--- a/tests/integration/Core/Content/ImportExport/ImportExportTest.php
+++ b/tests/integration/Core/Content/ImportExport/ImportExportTest.php
@@ -1354,11 +1354,11 @@ SWTEST;1;' . $productName . ';9.35;10;0c17372fe6aa46059a97fc28b40f46c4;7;7%%;%s'
         static::assertTrue($result->has('0a1dea4bd2de43929ac210fd17339dde'));
         $customerWithMultipleAddresses = $result->get('0a1dea4bd2de43929ac210fd17339dde');
 
-        $passwords = \array_values(array_map(fn (CustomerEntity $customer) => $customer->getPassword(), $result->getElements()));
+        $passwords = \array_filter(\array_values(array_map(fn (CustomerEntity $customer) => $customer->getPassword(), $result->getElements())));
         static::assertCount(3, $passwords);
-        static::assertNull($passwords[0]);
-        static::assertNull($passwords[1]);
-        static::assertNull($passwords[2]);
+        static::assertTrue(password_verify('shopware', $passwords[0]));
+        static::assertTrue(password_verify('shopware', $passwords[1]));
+        static::assertTrue(password_verify('shopware', $passwords[2]));
 
         static::assertInstanceOf(CustomerAddressCollection::class, $customerWithMultipleAddresses->getAddresses());
         static::assertCount(4, $customerWithMultipleAddresses->getAddresses());


### PR DESCRIPTION
### 1. Why is this change necessary?

Remove filterApiAwareFields in \Shopware\Core\Content\ImportExport\ImportExport::import to be able to import all fields again.

Example: passord and LegecyEncoder fields of Customer

### 2. What does this change do, exactly?

Removes the filterApiAwareFields call in \Shopware\Core\Content\ImportExport\ImportExport::import.

### 3. Describe each step to reproduce the issue or behaviour.

see #13476 and [Discord](https://discord.com/channels/1308047705309708348/1437794416008888371) 

### 4. Please link to the relevant issues (if any).

- fixes #13476

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
