### PR TITLE
fix: remove deprecated method ignore from GoogleStorageFactory

### DIFF
--- a/src/Core/Framework/Adapter/Filesystem/Adapter/GoogleStorageFactory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/GoogleStorageFactory.php
@@ -27,7 +27,6 @@ class GoogleStorageFactory implements AdapterFactoryInterface
             $storageConfig['keyFilePath'] = $options['keyFilePath'];
         }
 
-        // @phpstan-ignore method.deprecated
         $bucket = (new StorageClient($storageConfig))->bucket($options['bucket']);
 
         return new GoogleCloudStorageAdapter($bucket, $options['root']);


### PR DESCRIPTION
### 1. Why is this change necessary?

Fixes https://github.com/shopware/shopware/actions/runs/19415629620/job/55543457504

### 2. What does this change do, exactly?

Removes phpstan ignore deprecation

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
