### PR TITLE
fix: aria-controls attribute for shipping cost collapse

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -142,7 +142,7 @@
                                        href="#collapseShippingCost"
                                        role="button"
                                        aria-expanded="false"
-                                       aria-controls="collapseExample">
+                                       aria-controls="collapseShippingCost">
                                         {{ 'checkout.shippingCosts'|trans|sw_sanitize }}
                                     </a>
                                 {% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The aria-controls attribute value 'collapseExample' doesn't match the target element ID 'collapseShippingCost'.

### 2. What does this change do, exactly?
Align it

### 3. Describe each step to reproduce the issue or behaviour.


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [] I have updated developer-facing release notes if this change affects external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](../adr/2025-10-28-changelog-release-info-process.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
