### PR TITLE
fix: Adjust EOL because of skipped major release

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -15,103 +15,103 @@
     "version": "6.5.8.0",
     "release_date": "2024-01-15",
     "extended_eol": "2025-05-14",
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.0.0",
     "release_date": "2024-03-21",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.1.0",
     "release_date": "2024-04-09",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.2.0",
     "release_date": "2024-05-06",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.3.0",
     "release_date": "2024-06-04",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.4.0",
     "release_date": "2024-07-01",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.5.0",
     "release_date": "2024-08-06",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.6.0",
     "release_date": "2024-09-03",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.7.0",
     "release_date": "2024-10-14",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.8.0",
     "release_date": "2024-11-06",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.9.0",
     "release_date": "2024-12-03",
     "extended_eol": false,
-    "security_eol": "2026-02-28"
+    "security_eol": "2027-02-28"
   },
   {
     "version": "6.6.10.0",
     "release_date": "2025-02-03",
-    "extended_eol": "2026-02-28",
-    "security_eol": "2027-02-28"
+    "extended_eol": "2027-02-28",
+    "security_eol": "2028-02-28"
   },
   {
     "version": "6.7.0.0",
     "release_date": "2025-06-17",
     "extended_eol": false,
-    "security_eol": "2027-02-28"
+    "security_eol": "2028-02-28"
   },
   
   {
     "version": "6.7.1.0",
     "release_date": "2025-07-24",
     "extended_eol": false,
-    "security_eol": "2027-02-28"
+    "security_eol": "2028-02-28"
   },
   {
     "version": "6.7.2.0",
     "release_date": "2025-09-01",
     "extended_eol": false,
-    "security_eol": "2027-02-28"
+    "security_eol": "2028-02-28"
   },
   {
     "version": "6.7.3.0",
     "release_date": "2025-10-06",
     "extended_eol": false,
-    "security_eol": "2027-02-28"
+    "security_eol": "2028-02-28"
   },
   {
     "version": "6.7.4.0",
     "release_date": "2025-11-04",
     "extended_eol": false,
-    "security_eol": "2027-02-28"
+    "security_eol": "2028-02-28"
   }
 ]


### PR DESCRIPTION
6.6.10 will be supported one year longer per backports, which also means all previous 6.6.x versions and the last 6.5 version will get another year of security fixes over the plugin

