### PR TITLE
fix: remove html from plain text mail templates

### DIFF
--- a/src/Core/Migration/Fixtures/mails/customer.group.registration.accepted/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/customer.group.registration.accepted/de-plain.html.twig
@@ -1,5 +1,5 @@
-{{ customer.salutation.translated.letterName }} {{ customer.lastName }},<br/>
+{{ customer.salutation.translated.letterName }} {{ customer.lastName }},
 Ihr Account wurde für die Kundengruppe {{ customerGroup.translated.name }} freigeschaltet.
-Ab sofort kaufen Sie zu den neuen Konditionen dieser Kundengruppe ein.<br/><br/>
+Ab sofort kaufen Sie zu den neuen Konditionen dieser Kundengruppe ein.
 
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.

--- a/src/Core/Migration/Fixtures/mails/customer.group.registration.accepted/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/customer.group.registration.accepted/en-plain.html.twig
@@ -1,5 +1,5 @@
-Hello {{ customer.salutation.translated.letterName }} {{ customer.lastName }},<br/>
-Your account has been activated for the customer group {{ customerGroup.translated.name }}.<br/>
-From now on you can shop at the new conditions of this customer group.<br/><br/>
+Hello {{ customer.salutation.translated.letterName }} {{ customer.lastName }},
+Your account has been activated for the customer group {{ customerGroup.translated.name }}.
+From now on you can shop at the new conditions of this customer group.
 
 Please do not hesitate to contact us at any time if you have any questions.

--- a/src/Core/Migration/Fixtures/mails/customer.group.registration.declined/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/customer.group.registration.declined/de-plain.html.twig
@@ -1,5 +1,5 @@
-{{ customer.salutation.translated.letterName }} {{ customer.lastName }},<br/>
+{{ customer.salutation.translated.letterName }} {{ customer.lastName }},
 Vielen Dank für Ihr Interesse an den Konditionen für Kundengruppe  {{ customerGroup.translated.name }}.
-Leider können wir sie nicht für diese Kundengruppe freischalten.<br/>
+Leider können wir sie nicht für diese Kundengruppe freischalten.
 
 Bei Rückfragen aller Art können Sie uns gerne telefonisch oder per Mail diesbezüglich erreichen.

--- a/src/Core/Migration/Fixtures/mails/customer.group.registration.declined/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/customer.group.registration.declined/en-plain.html.twig
@@ -1,5 +1,5 @@
-{{ customer.salutation.translated.letterName }} {{ customer.lastName }},<br/>
-Thank you for your interest in the conditions for customer group {{ customerGroup.translated.name }}.<br/>
+{{ customer.salutation.translated.letterName }} {{ customer.lastName }},
+Thank you for your interest in the conditions for customer group {{ customerGroup.translated.name }}.
 Unfortunately we cannot activate your account for this customer group.
 
 If you have any questions, please feel free to contact us by phone or mail.

--- a/src/Core/Migration/V6_7/Migration1763544592UpdateGroupRegistrationMailTemplates.php
+++ b/src/Core/Migration/V6_7/Migration1763544592UpdateGroupRegistrationMailTemplates.php
@@ -27,22 +27,18 @@ class Migration1763544592UpdateGroupRegistrationMailTemplates extends MigrationS
     {
         $filesystem = new Filesystem();
 
-        $update = new MailUpdate(
-            MailTemplateTypes::MAILTYPE_CUSTOMER_GROUP_REGISTRATION_ACCEPTED,
-            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/en-plain.html.twig'),
-            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/en-html.html.twig'),
-            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/de-plain.html.twig'),
-            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/de-html.html.twig')
-        );
-        $this->updateMail($update, $connection);
+        $acceptedUpdate = new MailUpdate(MailTemplateTypes::MAILTYPE_CUSTOMER_GROUP_REGISTRATION_ACCEPTED);
+        $acceptedUpdate->setEnPlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/en-plain.html.twig'));
+        $acceptedUpdate->setEnHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/en-html.html.twig'));
+        $acceptedUpdate->setDePlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/de-plain.html.twig'));
+        $acceptedUpdate->setDeHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/de-html.html.twig'));
+        $this->updateMail($acceptedUpdate, $connection);
 
-        $update = new MailUpdate(
-            MailTemplateTypes::MAILTYPE_CUSTOMER_GROUP_REGISTRATION_DECLINED,
-            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/en-plain.html.twig'),
-            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/en-html.html.twig'),
-            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/de-plain.html.twig'),
-            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/de-html.html.twig')
-        );
-        $this->updateMail($update, $connection);
+        $declinedUpdate = new MailUpdate(MailTemplateTypes::MAILTYPE_CUSTOMER_GROUP_REGISTRATION_DECLINED);
+        $declinedUpdate->setEnPlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/en-plain.html.twig'));
+        $declinedUpdate->setEnHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/en-html.html.twig'));
+        $declinedUpdate->setDePlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/de-plain.html.twig'));
+        $declinedUpdate->setDeHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/de-html.html.twig'));
+        $this->updateMail($declinedUpdate, $connection);
     }
 }

--- a/src/Core/Migration/V6_7/Migration1763544592UpdateGroupRegistrationMailTemplates.php
+++ b/src/Core/Migration/V6_7/Migration1763544592UpdateGroupRegistrationMailTemplates.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Migration\Traits\MailUpdate;
+use Shopware\Core\Migration\Traits\UpdateMailTrait;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class Migration1763544592UpdateGroupRegistrationMailTemplates extends MigrationStep
+{
+    use UpdateMailTrait;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1763544592;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $filesystem = new Filesystem();
+
+        $update = new MailUpdate(
+            MailTemplateTypes::MAILTYPE_ORDER_CONFIRM,
+            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/en-plain.html.twig'),
+            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/en-html.html.twig'),
+            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/de-plain.html.twig'),
+            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/de-html.html.twig')
+        );
+        $this->updateMail($update, $connection);
+
+        $update = new MailUpdate(
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID,
+            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/en-plain.html.twig'),
+            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/en-html.html.twig'),
+            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/de-plain.html.twig'),
+            $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/de-html.html.twig')
+        );
+        $this->updateMail($update, $connection);
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1763544592UpdateGroupRegistrationMailTemplates.php
+++ b/src/Core/Migration/V6_7/Migration1763544592UpdateGroupRegistrationMailTemplates.php
@@ -28,7 +28,7 @@ class Migration1763544592UpdateGroupRegistrationMailTemplates extends MigrationS
         $filesystem = new Filesystem();
 
         $update = new MailUpdate(
-            MailTemplateTypes::MAILTYPE_ORDER_CONFIRM,
+            MailTemplateTypes::MAILTYPE_CUSTOMER_GROUP_REGISTRATION_ACCEPTED,
             $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/en-plain.html.twig'),
             $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/en-html.html.twig'),
             $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.accepted/de-plain.html.twig'),
@@ -37,7 +37,7 @@ class Migration1763544592UpdateGroupRegistrationMailTemplates extends MigrationS
         $this->updateMail($update, $connection);
 
         $update = new MailUpdate(
-            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID,
+            MailTemplateTypes::MAILTYPE_CUSTOMER_GROUP_REGISTRATION_DECLINED,
             $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/en-plain.html.twig'),
             $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/en-html.html.twig'),
             $filesystem->readFile(__DIR__ . '/../Fixtures/mails/customer.group.registration.declined/de-plain.html.twig'),

--- a/tests/migration/Core/V6_7/Migration1763544592UpdateGroupRegistrationMailTemplatesTest.php
+++ b/tests/migration/Core/V6_7/Migration1763544592UpdateGroupRegistrationMailTemplatesTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1763544592UpdateGroupRegistrationMailTemplates;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(Migration1763544592UpdateGroupRegistrationMailTemplates::class)]
+class Migration1763544592UpdateGroupRegistrationMailTemplatesTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testUpdate(): void
+    {
+        $migration = new Migration1763544592UpdateGroupRegistrationMailTemplates();
+
+        $error = [];
+        try {
+            $migration->update($this->connection);
+            $migration->update($this->connection);
+        } catch (\Throwable $e) {
+            $error[] = $e->getMessage();
+        }
+
+        static::assertCount(0, $error, print_r($error, true));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
HTML cannot be in plain text mail templates

### 2. What does this change do, exactly?
Remove HTML from plain-text mail templates

Closes: #5787 
