### PR TITLE
fix: number field in individual promotion code generation modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-generate-codes-modal/sw-promotion-v2-generate-codes-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-generate-codes-modal/sw-promotion-v2-generate-codes-modal.html.twig
@@ -47,6 +47,7 @@
             <mt-number-field
                 v-model="pattern.codeLength"
                 class="sw-promotion-v2-generate-codes-modal__replacement"
+                number-type="int"
                 :label="$tc('sw-promotion-v2.detail.base.codes.individual.generateModal.labelCodeLength')"
                 :min="1"
                 :max="20"
@@ -110,6 +111,7 @@
             <mt-number-field
                 v-model="codeAmount"
                 class="sw-promotion-v2-generate-codes-modal__code-amount"
+                number-type="int"
                 :label="$tc('sw-promotion-v2.detail.base.codes.individual.generateModal.labelCodeAmount')"
                 :min="1"
             />


### PR DESCRIPTION
### 1. Why is this change necessary?
Code length and amount of codes generated cannot be float.

### 2. What does this change do, exactly?
Make it int

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
