### PR TITLE
docs: move extending shopware in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ If you like Shopware 6, give us a&nbsp;⭐️ &nbsp;on GitHub!
 - [Project overview](#project-overview)
   - [Platform and Framework](#platform-and-framework)
 - [Installation](#installation)
-  - [Extending Shopware](#extending-shopware)
   - [Production setup](#production-setup)
   - [Code Contribution](#code-contribution)
     - [Contribution setup](#contribution-setup)
@@ -51,6 +50,7 @@ If you like Shopware 6, give us a&nbsp;⭐️ &nbsp;on GitHub!
 - [License](#license)
 - [Bugs \& Feedback](#bugs--feedback)
 - [Reporting security issues](#reporting-security-issues)
+- [Extending Shopware](#extending-shopware)
 
 ## Project overview
 
@@ -75,16 +75,6 @@ Shopware is:
 - headless if you need it to be.
 
 ## Installation
-
-### Extending Shopware
-
-There are already a lot of extensions available in the [Shopware store](https://store.shopware.com/).
-
-After setting up [Shopware locally for development](https://developer.shopware.com/docs/guides/installation), you can start with our extension guides in the documentation.
-
-The preferred way of extending Shopware is through the [App System](https://developer.shopware.com/docs/guides/plugins/apps/app-base-guide).
-If the feature you want to implement needs direct access to the Shopware process and the database, you can also use the [plugin system](https://developer.shopware.com/docs/guides/plugins/plugins/plugin-base-guide).    
-You can find an [overview and differentiation in the documentation](https://developer.shopware.com/docs/concepts/extensions).
 
 ### Production setup
 
@@ -140,3 +130,13 @@ If you want to suggest features or how certain parts of Shopware 6 work, we'd be
 ## Reporting security issues
 
 Please have a look at our [security policy](SECURITY.md).
+
+### Extending Shopware
+
+There are already a lot of extensions available in the [Shopware store](https://store.shopware.com/).
+
+After setting up [Shopware locally for development](https://developer.shopware.com/docs/guides/installation), you can start with our extension guides in the documentation.
+
+The preferred way of extending Shopware is through the [App System](https://developer.shopware.com/docs/guides/plugins/apps/app-base-guide).
+If the feature you want to implement needs direct access to the Shopware process and the database, you can also use the [plugin system](https://developer.shopware.com/docs/guides/plugins/plugins/plugin-base-guide).    
+You can find an [overview and differentiation in the documentation](https://developer.shopware.com/docs/concepts/extensions).


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Moving the section down improves the DX. Extending Shopware is different from setting the project up. Mixing the two gets confusing.

### 2. What does this change do, exactly?

I moved the "Extending Shopware" section further down, as it's not relevant for getting the project up and running.


### 3. Describe each step to reproduce the issue or behaviour.

I moved the "Extending Shopware" section


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
