### PR TITLE
refactor: use more native css and improve naming

### DIFF
--- a/src/Storefront/Controller/NavigationController.php
+++ b/src/Storefront/Controller/NavigationController.php
@@ -248,6 +248,7 @@ class NavigationController extends StorefrontController
                                                         'component' => 'Sw:Content:Text',
                                                         'properties' => [
                                                             'text' => 'Hello World',
+                                                            'inline' => true,
                                                         ],
                                                     ]
                                                 ]

--- a/src/Storefront/Resources/views/components/Sw/Alert.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Alert.html.twig
@@ -6,7 +6,7 @@
 %}
 
 {% set alert = cva({
-    base: 'alert',
+    base: 'sw-alert alert',
     variants: {
         variant: {
             primary: 'alert-primary',
@@ -27,6 +27,21 @@
 }) %}
 
 <div role="alert" {{ attributes.defaults({ class: alert.apply({ variant, size }) }) }}>
+
+    <twig:Sw:Icon name="info" color="primary"/>
+    <twig:Sw:Icon name="info" color="secondary"/>
+    <twig:Sw:Icon name="info" color="danger"/>
+    <twig:Sw:Icon name="info" color="success"/>
+    <twig:Sw:Icon name="info" color="warning"/>
+    <twig:Sw:Icon name="info" color="info"/>
+    <twig:Sw:Icon name="info" color="light"/>
+    <twig:Sw:Icon name="info" size="sm" color="dark"/>
+    <twig:Sw:Icon name="info" size="lg" color="review"/>
+    <twig:Sw:Icon name="warning" :rotation="90"/>
+    <twig:Sw:Icon name="warning" flip="vertical"/>
+
+    <div class="text-success">Heeee</div>
+
     {% block content %}
         <twig:Slot name="content">
             {{ text }}

--- a/src/Storefront/Resources/views/components/Sw/Alert.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Alert.html.twig
@@ -3,6 +3,7 @@
     size = 'text-md',
     text = null,
     slots = [],
+    icon = null,
 %}
 
 {% set alert = cva({
@@ -26,21 +27,26 @@
     }
 }) %}
 
+{% set defaultIcons = {
+    primary: 'info',
+    secondary: 'info',
+    warning: 'warning',
+    success: 'checkmark-circle',
+    info: 'info',
+    danger: 'blocked',
+    light: 'info',
+    dark: 'info',
+} %}
+
 <div role="alert" {{ attributes.defaults({ class: alert.apply({ variant, size }) }) }}>
 
-    <twig:Sw:Icon name="info" color="primary"/>
-    <twig:Sw:Icon name="info" color="secondary"/>
-    <twig:Sw:Icon name="info" color="danger"/>
-    <twig:Sw:Icon name="info" color="success"/>
-    <twig:Sw:Icon name="info" color="warning"/>
-    <twig:Sw:Icon name="info" color="info"/>
-    <twig:Sw:Icon name="info" color="light"/>
-    <twig:Sw:Icon name="info" size="sm" color="dark"/>
-    <twig:Sw:Icon name="info" size="lg" color="review"/>
-    <twig:Sw:Icon name="warning" :rotation="90"/>
-    <twig:Sw:Icon name="warning" flip="vertical"/>
-
-    <div class="text-success">Heeee</div>
+    {% block icon %}
+        {% if icon is not false and icon|length > 0 %}
+            <twig:Sw:Icon :name="icon" :color="variant" />
+        {% elseif icon is not false %}
+            <twig:Sw:Icon :name="defaultIcons[variant]" :color="variant" />
+        {% endif %}
+    {% endblock %}
 
     {% block content %}
         <twig:Slot name="content">

--- a/src/Storefront/Resources/views/components/Sw/Alert.scss
+++ b/src/Storefront/Resources/views/components/Sw/Alert.scss
@@ -1,0 +1,12 @@
+.sw-alert {
+    --bs-alert-padding-x: 0.6rem;
+    --bs-alert-padding-y: 0.6rem;
+
+    --bs-info-bg-subtle: color-mix(in oklab, var(--bs-info), hsl(195 120% 98%) 92%);
+    --bs-info-border-subtle: var(--bs-info);
+    --bs-info-text-emphasis: var(--bs-body-color);
+
+    .icon {
+        margin-right: 0.5rem;
+    }
+}

--- a/src/Storefront/Resources/views/components/Sw/Alert.scss
+++ b/src/Storefront/Resources/views/components/Sw/Alert.scss
@@ -1,12 +1,20 @@
 .sw-alert {
     --bs-alert-padding-x: 0.6rem;
     --bs-alert-padding-y: 0.6rem;
-
     --bs-info-bg-subtle: color-mix(in oklab, var(--bs-info), hsl(195 120% 98%) 92%);
     --bs-info-border-subtle: var(--bs-info);
     --bs-info-text-emphasis: var(--bs-body-color);
+    --bs-danger-bg-subtle: color-mix(in oklab, var(--bs-danger), hsl(195 120% 100%) 92%);
+    --bs-danger-border-subtle: var(--bs-danger);
+    --bs-danger-text-emphasis: var(--bs-body-color);
+    --bs-success-bg-subtle: color-mix(in oklab, var(--bs-success), hsl(195 120% 98%) 92%);
+    --bs-success-border-subtle: var(--bs-success);
+    --bs-success-text-emphasis: var(--bs-body-color);
+    --bs-warning-bg-subtle: color-mix(in oklab, var(--bs-warning), hsl(195 120% 101%) 95%);
+    --bs-warning-border-subtle: var(--bs-warning);
+    --bs-warning-text-emphasis: var(--bs-body-color);
 
-    .icon {
+    .sw-icon {
         margin-right: 0.5rem;
     }
 }

--- a/src/Storefront/Resources/views/components/Sw/Content/Pagination.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Content/Pagination.html.twig
@@ -26,22 +26,22 @@
         {% if totalPages > 1 %}
             <ul class="sw-pagination__list pagination">
                 <li class="sw-pagination__item page-item page-first{% if page == 1 %} disabled{% endif %}">
-                    <a href="{{ useHref ? '?' ~ pageParameter ~ '=1' ~ searchQuery : '#' }}" 
+                    <a href="{{ useHref ? '?' ~ pageParameter ~ '=1' ~ searchQuery : '#' }}"
                     class="sw-pagination__link page-link"
                     data-page="1"
                     aria-label="{{ 'general.pagination.first'|trans|striptags }}"
                     {% if page == 1 %} tabindex="-1" aria-disabled="true"{% endif %}>
-                        <twig:Sw:Icon name="arrow-medium-double-left" pack="solid" size="fluid" />
+                        <twig:Sw:Icon name="arrow-medium-double-left" pack="solid" size="xs" />
                     </a>
                 </li>
 
                 <li class="sw-pagination__item page-item page-prev{% if page == 1 %} disabled{% endif %}">
-                    <a href="{{ useHref ? '?' ~ pageParameter ~ '=' ~ (page - 1) ~ searchQuery : '#' }}" 
+                    <a href="{{ useHref ? '?' ~ pageParameter ~ '=' ~ (page - 1) ~ searchQuery : '#' }}"
                     class="sw-pagination__link page-link"
                     data-page="{{ page - 1 }}"
                     aria-label="{{ 'general.pagination.prev'|trans|striptags }}"
                     {% if page == 1 %} tabindex="-1" aria-disabled="true"{% endif %}>
-                        <twig:Sw:Icon name="arrow-medium-left" pack="solid" size="fluid" />
+                        <twig:Sw:Icon name="arrow-medium-left" pack="solid" size="xs" />
                     </a>
                 </li>
 
@@ -60,7 +60,7 @@
 
                 {% for pageItem in start..end %}
                     <li class="sw-pagination__item page-item page-{{ pageItem }}{% if page == pageItem %} active{% endif %}">
-                        <a href="{{ useHref ? '?' ~ pageParameter ~ '=' ~ pageItem ~ searchQuery : '#' }}" 
+                        <a href="{{ useHref ? '?' ~ pageParameter ~ '=' ~ pageItem ~ searchQuery : '#' }}"
                         class="sw-pagination__link page-link"
                         data-page="{{ pageItem }}"
                         {% if page == pageItem %} aria-current="page"{% endif %}>
@@ -70,22 +70,22 @@
                 {% endfor %}
 
                 <li class="sw-pagination__item page-item page-next{% if page == totalPages %} disabled{% endif %}">
-                    <a href="{{ useHref ? '?' ~ pageParameter ~ '=' ~ (page + 1) ~ searchQuery : '#' }}" 
+                    <a href="{{ useHref ? '?' ~ pageParameter ~ '=' ~ (page + 1) ~ searchQuery : '#' }}"
                     class="sw-pagination__link page-link"
                     data-page="{{ page + 1 }}"
                     aria-label="{{ 'general.pagination.next'|trans|striptags }}"
                     {% if page == totalPages %} tabindex="-1" aria-disabled="true"{% endif %}>
-                        <twig:Sw:Icon name="arrow-medium-right" pack="solid" size="fluid" />
+                        <twig:Sw:Icon name="arrow-medium-right" pack="solid" size="xs" />
                     </a>
                 </li>
 
                 <li class="sw-pagination__item page-item page-last{% if page == totalPages %} disabled{% endif %}">
-                    <a href="{{ useHref ? '?' ~ pageParameter ~ '=' ~ totalPages ~ searchQuery : '#' }}" 
+                    <a href="{{ useHref ? '?' ~ pageParameter ~ '=' ~ totalPages ~ searchQuery : '#' }}"
                     class="sw-pagination__link page-link"
                     data-page="{{ totalPages }}"
                     aria-label="{{ 'general.pagination.last'|trans|striptags }}"
                     {% if page == totalPages %} tabindex="-1" aria-disabled="true"{% endif %}>
-                        <twig:Sw:Icon name="arrow-medium-double-right" pack="solid" size="fluid" />
+                        <twig:Sw:Icon name="arrow-medium-double-right" pack="solid" size="xs" />
                     </a>
                 </li>
             </ul>

--- a/src/Storefront/Resources/views/components/Sw/Content/Pagination.scss
+++ b/src/Storefront/Resources/views/components/Sw/Content/Pagination.scss
@@ -4,3 +4,9 @@
     align-items: center;
     margin: 1rem auto;
 }
+
+.sw-pagination__link {
+    width: 40px;
+    height: 40px;
+    text-align: center;
+}

--- a/src/Storefront/Resources/views/components/Sw/Content/Text.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Content/Text.html.twig
@@ -1,13 +1,20 @@
 {% props
     text = null,
+    inline = false,
 %}
 
 {% set attributeDefaults = {} %}
 
 {% set textVariants = cva({
-    base: 'text'
+    base: 'sw-text',
+    variants: {
+        inline: {
+            false: null,
+            true: ['d-inline'],
+        },
+    },
 }) %}
 
-<div {{ attributes.defaults(attributeDefaults) }} class="{{ textVariants.apply({}) }}">
+<div {{ attributes.defaults(attributeDefaults) }} class="{{ textVariants.apply({ inline }) }}">
     {{ text|sw_sanitize|raw }}
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
@@ -93,6 +93,9 @@
 }
 
 .sw-filter-item__count {
+    --bs-badge-padding-x: 0.5rem;
+    --bs-badge-padding-y: 0.2rem;
+
     &.is--hidden {
         display: none;
     }

--- a/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
@@ -29,18 +29,12 @@
     text-align: left;
 
     &.btn .sw-icon {
-        color: currentColor;
         width: 0.8rem;
         height: 0.8rem;
         margin-left: 0.5rem;
         position: absolute;
         right: 0.8rem;
         top: 0.7rem;
-    }
-
-    &.btn .sw-icon > svg {
-        top: 0.2em !important;
-        fill: currentColor;
     }
 
     &.is--more {

--- a/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
@@ -28,7 +28,7 @@
     padding-right: 2.2rem;
     text-align: left;
 
-    &.btn .icon {
+    &.btn .sw-icon {
         color: currentColor;
         width: 0.8rem;
         height: 0.8rem;
@@ -38,7 +38,7 @@
         top: 0.7rem;
     }
 
-    &.btn .icon > svg {
+    &.btn .sw-icon > svg {
         top: 0.2em !important;
         fill: currentColor;
     }
@@ -50,13 +50,13 @@
         --bs-hover-color: var(--bs-primary);
     }
 
-    .icon-default-arrow-head-up {
+    .sw-icon--default-arrow-head-up {
         transition: all 0.3s cubic-bezier(0.65, 0, 0.35, 1);
         opacity: 0;
         transform: translateY(20px);
     }
 
-    .icon-default-arrow-head-down {
+    .sw-icon--default-arrow-head-down {
         transition: all 0.3s cubic-bezier(0.65, 0, 0.35, 1);
         opacity: 1;
         transform: translateY(0);
@@ -76,12 +76,12 @@
         border-bottom-color: var(--bs-body-bg);
         z-index: 1001;
 
-        .icon-default-arrow-head-up {
+        .sw-icon--default-arrow-head-up {
             opacity: 1;
             transform: translateY(0);
         }
 
-        .icon-default-arrow-head-down {
+        .sw-icon--default-arrow-head-down {
             opacity: 0;
             transform: translateY(-20px);
         }

--- a/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
@@ -41,8 +41,8 @@
     position: relative;
     padding-right: 2.2rem;
 
-    &.btn .icon {
-        color: currentColor;
+    &.btn .sw-icon {
+        //color: currentColor;
         width: 0.8rem;
         height: 0.8rem;
         margin-left: 0.5rem;
@@ -51,7 +51,7 @@
         top: 0.8rem;
     }
 
-    &.btn .icon > svg {
+    &.btn .sw-icon > svg {
         top: 0;
         fill: currentColor;
     }

--- a/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
@@ -42,18 +42,12 @@
     padding-right: 2.2rem;
 
     &.btn .sw-icon {
-        //color: currentColor;
         width: 0.8rem;
         height: 0.8rem;
         margin-left: 0.5rem;
         position: absolute;
         right: 0.8rem;
-        top: 0.8rem;
-    }
-
-    &.btn .sw-icon > svg {
-        top: 0;
-        fill: currentColor;
+        top: 0.7rem;
     }
 }
 

--- a/src/Storefront/Resources/views/components/Sw/Icon.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Icon.html.twig
@@ -1,5 +1,5 @@
-{# 
-@sw-package framework 
+{#
+@sw-package framework
 
 @prop name
 @prop pack = 'default'
@@ -21,36 +21,36 @@
 %}
 
 {% set iconVariants = cva({
-    base: 'icon icon-' ~ pack ~ ' icon-' ~ pack ~ '-' ~ name,
+    base: 'sw-icon sw-icon--' ~ pack ~ ' sw-icon--' ~ pack ~ '-' ~ name,
     variants: {
         size: {
-            fluid: 'icon-fluid',
-            lg: 'icon-lg',
-            sm: 'icon-sm',
-            xs: 'icon-xs',
-            '1x': 'icon-1x',
-            '2x': 'icon-2x',
-            '3x': 'icon-3x',
+            fluid: 'sw-icon--fluid',
+            lg: 'sw-icon--lg',
+            sm: 'sw-icon--sm',
+            xs: 'sw-icon--xs',
+            '1x': 'sw-icon--1x',
+            '2x': 'sw-icon--2x',
+            '3x': 'sw-icon--3x',
         },
         color: {
-            primary: 'icon-primary',
-            secondary: 'icon-secondary',
-            success: 'icon-success',
-            info: 'icon-info',
-            warning: 'icon-warning',
-            danger: 'icon-danger',
-            light: 'icon-light',
-            dark: 'icon-dark',
+            primary: 'text-primary',
+            secondary: 'text-secondary',
+            success: 'text-success',
+            info: 'text-info',
+            warning: 'text-warning',
+            danger: 'text-danger',
+            light: 'text-light',
+            dark: 'text-dark',
         },
         rotation: {
-            90: 'icon-rotate-90',
-            180: 'icon-rotate-180',
-            270: 'icon-rotate-270',
+            90: 'sw-icon--rotate-90',
+            180: 'sw-icon--rotate-180',
+            270: 'sw-icon--rotate-270',
         },
         flip: {
-            horizontal: 'icon-flip-horizontal',
-            vertical: 'icon-flip-vertical',
-            both: 'icon-flip-both',
+            horizontal: 'sw-icon--flip-horizontal',
+            vertical: 'sw-icon--flip-vertical',
+            both: 'sw-icon--flip-both',
         }
     }
 }) %}

--- a/src/Storefront/Resources/views/components/Sw/Icon.scss
+++ b/src/Storefront/Resources/views/components/Sw/Icon.scss
@@ -12,16 +12,14 @@ Credit: https://github.com/FortAwesome/Font-Awesome
     --sw-icon-base-size: 1.375rem;
     width: var(--sw-icon-base-size);
     height: var(--sw-icon-base-size);
-    display: inline-flex;
-    align-self: center;
-    font-size: inherit;
-    overflow: visible;
+    display: inline-block;
+    line-height: 1;
 
     > svg {
         width: 100%;
         height: 100%;
-        top: 0.25em;
-        position: relative;
+        vertical-align: middle;
+        display: inline-block;
         fill: currentColor;
 
         path,
@@ -35,7 +33,6 @@ Credit: https://github.com/FortAwesome/Font-Awesome
 // -------------------------
 
 .sw-icon--fluid {
-    //@include sw-icon-size(100%);
     width: 100%;
     height: 100%;
 }

--- a/src/Storefront/Resources/views/components/Sw/Icon.scss
+++ b/src/Storefront/Resources/views/components/Sw/Icon.scss
@@ -5,34 +5,17 @@ Basic styling for icon component plus helper classes for sizing and colors.
 Credit: https://github.com/FortAwesome/Font-Awesome
 */
 
-// Mixins
-// --------------------------
-
-@mixin sw-icon-rotate($degrees, $rotation) {
-    filter: 'progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation})';
-    transform: rotate($degrees);
-}
-
-@mixin sw-icon-flip($horiz, $vert, $rotation) {
-    filter: 'progid:DXImageTransform.Microsoft.BasicImage(rotation=#{$rotation}, mirror=1)';
-    transform: scale($horiz, $vert);
-}
-
-@mixin sw-icon-size($size) {
-    width: $size;
-    height: $size;
-}
-
 // Basics
 // --------------------------
 
-.icon {
-    @include sw-icon-size($icon-base-size);
+.sw-icon {
+    --sw-icon-base-size: 1.375rem;
+    width: var(--sw-icon-base-size);
+    height: var(--sw-icon-base-size);
     display: inline-flex;
     align-self: center;
     font-size: inherit;
     overflow: visible;
-    color: currentColor;
 
     > svg {
         width: 100%;
@@ -48,67 +31,32 @@ Credit: https://github.com/FortAwesome/Font-Awesome
     }
 }
 
-// Icon Colors
-// -------------------------
-
-.icon-primary {
-    color: var(--text-color-brand-primary);
-}
-
-.icon-secondary {
-    color: $secondary;
-}
-
-.icon-success {
-    color: $success;
-}
-
-.icon-info {
-    color: $info;
-}
-
-.icon-warning {
-    color: $warning;
-}
-
-.icon-danger {
-    color: $danger;
-}
-
-.icon-light {
-    color: $gray-200;
-}
-
-.icon-dark {
-    color: $dark;
-}
-
-.icon-review {
-    color: $icon-review-color;
-}
-
 // Icon Sizes
 // -------------------------
 
-.icon-fluid {
-    @include sw-icon-size(100%);
+.sw-icon--fluid {
+    //@include sw-icon-size(100%);
+    width: 100%;
+    height: 100%;
 }
 
-.icon-lg {
-    @include sw-icon-size($icon-base-size / 3 * 4);
+.sw-icon--lg {
+    width: calc(var(--sw-icon-base-size) * 1.33);
+    height: calc(var(--sw-icon-base-size) * 1.33);
 }
 
-// 33% bigger icon
-.icon-sm {
-    @include sw-icon-size($icon-base-size * 0.875);
+.sw-icon--sm {
+    width: calc(var(--sw-icon-base-size) * 0.875);
+    height: calc(var(--sw-icon-base-size) * 0.875);
 }
 
-.icon-xs {
-    @include sw-icon-size($icon-base-size * 0.75);
+.sw-icon--xs {
+    width: calc(var(--sw-icon-base-size) * 0.75);
+    height: calc(var(--sw-icon-base-size) * 0.75);
 }
 
 @for $i from 1 through 10 {
-    .icon-#{$i}x {
+    .sw-icon-#{$i}x {
         width: $i * $icon-base-size;
         height: $i * $icon-base-size;
     }
@@ -117,117 +65,39 @@ Credit: https://github.com/FortAwesome/Font-Awesome
 // Rotated & Flipped Icons
 // -------------------------
 
-.icon-rotate-90 {
+.sw-icon--rotate-90 {
     svg {
-        @include sw-icon-rotate(90deg, 1);
+        transform: rotate(90deg);
     }
 }
 
-.icon-rotate-180 {
+.sw-icon--rotate-180 {
     svg {
-        @include sw-icon-rotate(180deg, 2);
+        transform: rotate(180deg);
     }
 }
 
-.icon-rotate-270 {
+.sw-icon--rotate-270 {
     svg {
-        @include sw-icon-rotate(270deg, 3);
+        transform: rotate(270deg);
     }
 }
 
-.icon-flip-horizontal {
+.sw-icon--flip-horizontal {
     svg {
-        @include sw-icon-flip(-1, 1, 0);
+        transform: scale(-1, 1);
     }
 }
 
-.icon-flip-vertical {
+.sw-icon--flip-vertical {
     svg {
-        @include sw-icon-flip(1, -1, 2);
+        transform: scale(1, -1);
     }
 }
 
-.icon-flip-both,
-.icon-flip-horizontal.icon-flip-vertical {
+.sw-icon--flip-both,
+.sw-icon--flip-horizontal.sw-icon--flip-vertical {
     svg {
-        @include sw-icon-flip(-1, -1, 2);
-    }
-}
-
-// Hook for IE8-9
-// -------------------------
-
-:root {
-    .icon-rotate-90,
-    .icon-rotate-180,
-    .icon-rotate-270,
-    .icon-flip-horizontal,
-    .icon-flip-vertical,
-    .icon-flip-both {
-        svg {
-            filter: none;
-        }
-    }
-}
-
-// Make them work with bootstrap components
-// -------------------------
-
-@each $color, $value in $theme-colors {
-    .alert-#{$color} {
-        .icon {
-            color: $value;
-        }
-    }
-}
-
-@each $color, $value in $theme-colors {
-    .btn-#{$color} {
-        .icon {
-            color: color-contrast($value);
-        }
-    }
-}
-
-.btn {
-    .icon {
-        > svg {
-            top: 6px;
-        }
-    }
-}
-
-.pagination {
-    .icon {
-        width: 13px;
-        height: 13px;
-
-        > svg {
-            top: 2px;
-        }
-    }
-}
-
-.is-left,
-.offcanvas-start {
-    .offcanvas-close {
-        svg {
-            top: 0;
-        }
-    }
-}
-
-.is-right,
-.offcanvas-end {
-    .offcanvas-close {
-        svg {
-            top: 0.25rem;
-        }
-    }
-}
-
-.navigation-offcanvas-link-icon {
-    .icon > svg {
-        top: 0;
+        transform: scale(-1, -1);
     }
 }

--- a/src/Storefront/Resources/views/components/Sw/Icon.scss
+++ b/src/Storefront/Resources/views/components/Sw/Icon.scss
@@ -2,7 +2,6 @@
 Icons
 ==============================================
 Basic styling for icon component plus helper classes for sizing and colors.
-Credit: https://github.com/FortAwesome/Font-Awesome
 */
 
 // Basics

--- a/src/Storefront/Resources/views/components/Sw/Product/Card.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/Card.scss
@@ -6,7 +6,7 @@
     --bs-card-cap-padding-y: 1rem;
     --bs-card-cap-padding-x: 0;
     --bs-card-cap-bg: none;
-    --bs-card-bg: var(--bs-body);
+    --bs-card-bg: var(--bs-body-bg);
     --sw-product-card-media-height: 200px;
 
     &.has--border {


### PR DESCRIPTION
Only relevant for `8446/twig-ux-components`

* Adjust alert:
  * Use `sw-` naming
  * Fix colors, generate colors with CSS and color-mix
  * Add icon support and provide default icons
* Adjust icons:
  * Use `sw-` naming and make icons independent from old `.icon`
  * Remove unneeded CSS for IE etc.
  * Remove duplicated `icon-warning` etc. CVA classes, use existing bootstrap text color classes instead.
  * Remove mixins and size calculations and replace with native CSS.
  * Remove hard-coded relative position and top values, use inline-block instead
  * Dont use hard-coded color. Always inherit currentColor depending on the parent
* Text component: Add inline support and `sw-` naming
* Fix filter badge styling
* Fix missing card background



