### PR TITLE
fix: change native type of usageKey in PromotionDiscountEntity

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -55,5 +55,9 @@ return [
         preg_quote('REMOVED: Property Shopware\Core\Checkout\Payment\Cart\Token\TokenStruct#$consumed was removed'),
         preg_quote('REMOVED: Method Shopware\Core\Checkout\Payment\Cart\Token\TokenStruct#isConsumed() was removed'),
         preg_quote('REMOVED: Method Shopware\Core\Checkout\Payment\Cart\Token\TokenStruct#setConsumed() was removed'),
+
+        // Fix for promotion discount entity property initialization error - necessary to prevent runtime errors
+        preg_quote('CHANGED: Type of property Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity#$usageKey changed from string to string|null', '/'),
+        preg_quote('CHANGED: The parameter $usageKey of Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity#setUsageKey() changed from string to string|null', '/'),
     ],
 ];

--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -55,9 +55,5 @@ return [
         preg_quote('REMOVED: Property Shopware\Core\Checkout\Payment\Cart\Token\TokenStruct#$consumed was removed'),
         preg_quote('REMOVED: Method Shopware\Core\Checkout\Payment\Cart\Token\TokenStruct#isConsumed() was removed'),
         preg_quote('REMOVED: Method Shopware\Core\Checkout\Payment\Cart\Token\TokenStruct#setConsumed() was removed'),
-
-        // Fix for promotion discount entity property initialization error - necessary to prevent runtime errors
-        preg_quote('CHANGED: Type of property Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity#$usageKey changed from string to string|null', '/'),
-        preg_quote('CHANGED: The parameter $usageKey of Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity#setUsageKey() changed from string to string|null', '/'),
     ],
 ];

--- a/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountEntity.php
+++ b/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountEntity.php
@@ -258,9 +258,14 @@ class PromotionDiscountEntity extends Entity
         $this->applierKey = $applierKey;
     }
 
-    public function getUsageKey(): ?string
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return `?string` in the future
+     * @deprecated tag:v6.8.0 - reason:behavior-change - The fallback to empty string will be removed
+     */
+    public function getUsageKey(): string
     {
-        return $this->usageKey;
+        // @deprecated tag:v6.8.0 - The fallback to empty string will be removed
+        return $this->usageKey ?? '';
     }
 
     public function setUsageKey(?string $usageKey): void

--- a/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountEntity.php
+++ b/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountEntity.php
@@ -86,7 +86,7 @@ class PromotionDiscountEntity extends Entity
 
     protected ?string $applierKey = null;
 
-    protected string $usageKey;
+    protected ?string $usageKey = null;
 
     protected ?string $pickerKey = null;
 
@@ -258,12 +258,12 @@ class PromotionDiscountEntity extends Entity
         $this->applierKey = $applierKey;
     }
 
-    public function getUsageKey(): string
+    public function getUsageKey(): ?string
     {
         return $this->usageKey;
     }
 
-    public function setUsageKey(string $usageKey): void
+    public function setUsageKey(?string $usageKey): void
     {
         $this->usageKey = $usageKey;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

The native type of the `usageKey` in `PromotionDiscountEntity` is incorrect. It should be nullable because the field is not required in the entity definition.

https://github.com/shopware/shopware/blob/59727c21c5cc2683d1095bd3f13dab49166eb0f6/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountEntity.php#L89

https://github.com/shopware/shopware/blob/59727c21c5cc2683d1095bd3f13dab49166eb0f6/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountDefinition.php#L74

### 2. What does this change do, exactly?

Make the property nullable.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
