### PR TITLE
fix: ManyToMany association of inherited associations

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -229,6 +229,7 @@ class EntityReader implements EntityReaderInterface
                 /**
                  * When the association is filtered or sorted we do a seperate query to load the ids of the association.
                  * Therefore we do not need to add the select here to the main query.
+                 *
                  * @see self::loadManyToManyWithCriteria()
                  */
                 if ($this->isAssociationRestricted($criteria, $field->getPropertyName())) {
@@ -237,6 +238,7 @@ class EntityReader implements EntityReaderInterface
 
                 /**
                  * When the association is not filtered we select the ids of the association directly in the main query.
+                 *
                  * @see self::loadManyToManyOverExtension()
                  */
                 $this->addManyToManySelect($definition, $root, $field, $query, $context);

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -226,7 +226,7 @@ class EntityReader implements EntityReaderInterface
 
             // add sub select for many to many field
             if ($field instanceof ManyToManyAssociationField) {
-                if ($this->isAssociationRestricted($criteria, $field->getPropertyName()) && !$field->is(Inherited::class)) {
+                if ($this->isAssociationRestricted($criteria, $field->getPropertyName())) {
                     continue;
                 }
 
@@ -323,6 +323,7 @@ class EntityReader implements EntityReaderInterface
      */
     private function loadManyToMany(
         Criteria $criteria,
+        EntityDefinition $definition,
         ManyToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
@@ -339,7 +340,7 @@ class EntityReader implements EntityReaderInterface
         // check if the requested criteria is restricted (limit, offset, sorting, filtering)
         if ($this->isAssociationRestricted($criteria, $association->getPropertyName())) {
             // if restricted load paginated list of many to many
-            $this->loadManyToManyWithCriteria($associationCriteria, $association, $context, $collection, $partial);
+            $this->loadManyToManyWithCriteria($definition, $associationCriteria, $association, $context, $collection, $partial);
 
             return;
         }
@@ -741,6 +742,7 @@ class EntityReader implements EntityReaderInterface
      * @param array<string, mixed> $partial
      */
     private function loadManyToManyWithCriteria(
+        EntityDefinition $definition,
         Criteria $fieldCriteria,
         ManyToManyAssociationField $association,
         Context $context,
@@ -810,8 +812,21 @@ class EntityReader implements EntityReaderInterface
             $query->andWhere($root . '.' . $localColumn . ' IN (:localIds)');
             $query->setParameter('localIds', Uuid::fromHexToBytesList($collection->getIds()), ArrayParameterType::BINARY);
         } else {
-            $query->andWhere($root . '.' . $referenceColumn . ' IN (:mappingIds)');
-            $query->setParameter('mappingIds', Uuid::fromHexToBytesList($this->collectManyToManyIds($collection, $association)), ArrayParameterType::BINARY);
+            // When association is inherited, we need to join the base entity to the local table
+            $joinCondition = $root . '.' . $localColumn . ' = ' . EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.' . EntityDefinitionQueryHelper::escape($association->getPropertyName());
+
+            if ($definition->isVersionAware()) {
+                $joinCondition .= ' AND ' . $root . '.' . EntityDefinitionQueryHelper::escape($definition->getEntityName() . '_version_id') . ' = ' . EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.version_id';
+            }
+            $query->leftJoin(
+                $root,
+                EntityDefinitionQueryHelper::escape($definition->getEntityName()),
+                EntityDefinitionQueryHelper::escape($definition->getEntityName()),
+                $joinCondition
+            );
+
+            $query->andWhere(EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.id IN (:localIds)');
+            $query->setParameter('localIds', Uuid::fromHexToBytesList($collection->getIds()), ArrayParameterType::BINARY);
         }
 
         $orderBy = '';
@@ -821,6 +836,7 @@ class EntityReader implements EntityReaderInterface
             $query->resetOrderBy();
         }
         // order by is handled in group_concat
+        // Order of IDs in criteria will determine result order, when no order by is given
         $fieldCriteria->resetSorting();
 
         $query->select(
@@ -1267,7 +1283,7 @@ class EntityReader implements EntityReaderInterface
             }
 
             if ($association instanceof ManyToManyAssociationField) {
-                $this->loadManyToMany($criteria, $association, $context, $collection, $partial[$association->getPropertyName()] ?? []);
+                $this->loadManyToMany($criteria, $definition, $association, $context, $collection, $partial[$association->getPropertyName()] ?? []);
             }
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -226,12 +226,19 @@ class EntityReader implements EntityReaderInterface
 
             // add sub select for many to many field
             if ($field instanceof ManyToManyAssociationField) {
+                /**
+                 * When the association is filtered or sorted we do a seperate query to load the ids of the association.
+                 * Therefore we do not need to add the select here to the main query.
+                 * @see self::loadManyToManyWithCriteria()
+                 */
                 if ($this->isAssociationRestricted($criteria, $field->getPropertyName())) {
                     continue;
                 }
 
-                // requested a paginated, filtered or sorted list
-
+                /**
+                 * When the association is not filtered we select the ids of the association directly in the main query.
+                 * @see self::loadManyToManyOverExtension()
+                 */
                 $this->addManyToManySelect($definition, $root, $field, $query, $context);
 
                 continue;

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -812,13 +812,14 @@ class EntityReader implements EntityReaderInterface
             $query->andWhere($root . '.' . $localColumn . ' IN (:localIds)');
             $query->setParameter('localIds', Uuid::fromHexToBytesList($collection->getIds()), ArrayParameterType::BINARY);
         } else {
-            // When association is inherited, we need to join the base entity to the local table
+            // When the association is inherited, we need to join the base entity to the local table
+            // the "join column" (column name = property name) contains the id of the parent entity if the association is inherited
             $joinCondition = $root . '.' . $localColumn . ' = ' . EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.' . EntityDefinitionQueryHelper::escape($association->getPropertyName());
 
             if ($definition->isVersionAware()) {
                 $joinCondition .= ' AND ' . $root . '.' . EntityDefinitionQueryHelper::escape($definition->getEntityName() . '_version_id') . ' = ' . EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.version_id';
             }
-            $query->leftJoin(
+            $query->innerJoin(
                 $root,
                 EntityDefinitionQueryHelper::escape($definition->getEntityName()),
                 EntityDefinitionQueryHelper::escape($definition->getEntityName()),


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/11878

I fixed the original issue here https://github.com/shopware/shopware/issues/5328 in a way that loads way too many mapping entries which could have negative performance impacts

in short how it worked before:

for inherited associations we join the many to many to resolve the matching ids
when the association is filtered we do another query on the mapping table to apply filter, sorting etc with a filter on the ids we found in query one, however that let to the following issue:
Take for example the product category association:
We load the product with the category ids in query 1,
the category association is limited, therefore we do another query on the mapping to apply the limit with `WHERE category.id IN (...)` -> 💣  because now we also load stuff for all the products that are associated with that category


the new approach solves it in a way that we don't join the to many on the inital query if it is filtered
and then in query two we join back to the base table and use the `join` column there to resolve the inheritance
