### PR TITLE
fix: missing block address_item

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/account/addressbook/address-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/addressbook/address-item.html.twig
@@ -1,3 +1,4 @@
+{% block address_item %}
 <li class="col-12 col-lg-6 d-flex">
     <div class="p-3 border address-manager-select-address flex-fill">
         <div class="row h-100">
@@ -101,3 +102,4 @@
         </div>
     </div>
 </li>
+{% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
`src/Storefront/Resources/views/storefront/page/account/addressbook/address-item.html.twig` should be extendable

### 2. What does this change do, exactly?
Add a root twig block.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #13593 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
