### PR TITLE
test: add clean up for integration test ServiceDefinitionTest 

### DIFF
--- a/tests/integration/Core/Framework/ServiceDefinitionTest.php
+++ b/tests/integration/Core/Framework/ServiceDefinitionTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestKernel;
+use Shopware\Core\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -60,6 +61,9 @@ class ServiceDefinitionTest extends TestCase
         }
 
         static::assertCount(0, $errors, 'Found invalid services: ' . print_r($errors, true));
+        // Cleanup and reset kernel class
+        $separateKernel->shutdown();
+        KernelFactory::$kernelClass = Kernel::class;
     }
 
     public function testServiceDefinitionNaming(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Nightly is failing: 
https://github.com/shopware/shopware/actions/runs/19522295780/job/55888054543
https://github.com/shopware/shopware/actions/runs/19588179857/job/56101316784
https://github.com/shopware/shopware/actions/runs/19604042472/job/56139801399

https://github.com/shopware/shopware/blob/0e370df61b38344357892c6fa1ed0f7ba3cc3218/tests/integration/Core/Framework/ServiceDefinitionTest.php#L45-L46
We don't reset the static after and we don’t shut down this separate kernel.

When this `testEverythingIsInstantiatable` is executed before the tests involving the deprecated JWT service in `AppAsyncPaymentHandlerTest` https://github.com/shopware/shopware/blob/41be52eabaf89e925789edc1e53485b6b5966abc/tests/integration/Core/Framework/App/Payment/AppAsyncPaymentHandlerTest.php#L588
then it fails.

### 2. What does this change do, exactly?
It terminates the temporary kernel, and resets the override of static `$kernel` used for the Kernelfactory
Restoring the static `$kernel` is enough to fix it, shutting down is an extra.

### 3. Describe each step to reproduce the issue or behaviour.

- With trunk on local, run: 
```
php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "core-framework-batch1" --random-order-seed 1763732011
```
- Retrieve the same errors from the job 
- Repeat with this branch: no errors

Additionally, a nightly build will be run against this branch


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
