### PR TITLE
fix: add missing stateMachineState association

### DIFF
--- a/src/Core/Checkout/Payment/Controller/PaymentController.php
+++ b/src/Core/Checkout/Payment/Controller/PaymentController.php
@@ -231,7 +231,7 @@ class PaymentController extends AbstractController
 
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('transactions.id', $transactionId))
-            ->addAssociations(['transactions', 'orderCustomer']);
+            ->addAssociations(['transactions.stateMachineState', 'orderCustomer']);
 
         $order = $this->orderRepository->search($criteria, $context)->getEntities()->first();
         if (!$order) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Since the removed autoload on NEXT-25327 the association is not available anymore on the orders loaded in the PaymentController.

Because of that the orders passed to the orderConverter does not contain the state machine state causing an early break.

Trace:
PaymentController::assembleSalesChannelContext
OrderConverter::assembleSalesChannelContext
```
foreach ($order->getTransactions() as $transaction) {
            $options[SalesChannelContextService::PAYMENT_METHOD_ID] = $transaction->getPaymentMethodId();
            if (
                $transaction->getStateMachineState() !== null
                && $transaction->getStateMachineState()->getTechnicalName() !== OrderTransactionStates::STATE_PAID
                && $transaction->getStateMachineState()->getTechnicalName() !== OrderTransactionStates::STATE_CANCELLED
                && $transaction->getStateMachineState()->getTechnicalName() !== OrderTransactionStates::STATE_FAILED
            ) {
                break;
            }
        }
```


### 2. What does this change do, exactly?
Includes the stateMachineState back for properly order conversion.

### 3. Describe each step to reproduce the issue or behaviour.
I was able to verify this by placing an order with an async payment method but it could be the case on any payment method when the order is converted.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
