### PR TITLE
fix: DownloadResponseGenerator::getResponse in case of using external storage

### DIFF
--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -119,6 +119,7 @@
         </service>
 
         <service id="Shopware\Core\Content\Media\File\DownloadResponseGenerator">
+            <argument type="service" id="logger"/>
             <argument type="service" id="shopware.filesystem.public"/>
             <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="Shopware\Core\Content\Media\MediaService"/>

--- a/src/Core/Content/Media/File/DownloadResponseGenerator.php
+++ b/src/Core/Content/Media/File/DownloadResponseGenerator.php
@@ -4,7 +4,9 @@ namespace Shopware\Core\Content\Media\File;
 
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToGenerateTemporaryUrl;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator;
 use Shopware\Core\Content\Media\Core\Params\UrlParams;
 use Shopware\Core\Content\Media\MediaEntity;
@@ -30,6 +32,7 @@ class DownloadResponseGenerator
      * @internal
      */
     public function __construct(
+        private readonly LoggerInterface $logger,
         private readonly FilesystemOperator $filesystemPublic,
         private readonly FilesystemOperator $filesystemPrivate,
         private readonly MediaService $mediaService,
@@ -52,7 +55,10 @@ class DownloadResponseGenerator
             $url = $fileSystem->temporaryUrl($path, (new \DateTime())->modify($expiration));
 
             return new RedirectResponse($url);
-        } catch (\Throwable) {
+        } catch (UnableToGenerateTemporaryUrl $exception) {
+            $this->logger->warning($exception->getMessage(), ['exception' => $exception]);
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception->getMessage(), ['exception' => $exception]);
         }
 
         return $this->getDefaultResponse($media, $context, $fileSystem);

--- a/src/Core/Content/Media/File/DownloadResponseGenerator.php
+++ b/src/Core/Content/Media/File/DownloadResponseGenerator.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Content\Media\File;
 
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
-use League\Flysystem\UnableToGenerateTemporaryUrl;
 use Psr\Http\Message\StreamInterface;
 use Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator;
 use Shopware\Core\Content\Media\Core\Params\UrlParams;
@@ -53,7 +52,7 @@ class DownloadResponseGenerator
             $url = $fileSystem->temporaryUrl($path, (new \DateTime())->modify($expiration));
 
             return new RedirectResponse($url);
-        } catch (UnableToGenerateTemporaryUrl) {
+        } catch (\Throwable) {
         }
 
         return $this->getDefaultResponse($media, $context, $fileSystem);

--- a/tests/unit/Core/Content/Media/File/DownloadResponseGeneratorTest.php
+++ b/tests/unit/Core/Content/Media/File/DownloadResponseGeneratorTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator;
 use Shopware\Core\Content\Media\File\DownloadResponseGenerator;
 use Shopware\Core\Content\Media\MediaEntity;
@@ -47,6 +48,7 @@ class DownloadResponseGeneratorTest extends TestCase
         $publicFilesystem = $this->createMock(Filesystem::class);
 
         $this->downloadResponseGenerator = new DownloadResponseGenerator(
+            $this->createMock(LoggerInterface::class),
             $publicFilesystem,
             $this->privateFilesystem,
             $this->mediaService,
@@ -66,6 +68,7 @@ class DownloadResponseGeneratorTest extends TestCase
         $media->setPath('foobar.txt');
 
         $downloadResponseGenerator = new DownloadResponseGenerator(
+            $this->createMock(LoggerInterface::class),
             $this->createMock(FilesystemOperator::class),
             $this->createMock(FilesystemOperator::class),
             $this->mediaService,
@@ -110,6 +113,7 @@ class DownloadResponseGeneratorTest extends TestCase
         $generator->method('generate')->willReturn([$media->getId() => 'foobar.txt']);
 
         $this->downloadResponseGenerator = new DownloadResponseGenerator(
+            $this->createMock(LoggerInterface::class),
             $privateFilesystem,
             $publicFilesystem,
             $this->mediaService,
@@ -157,7 +161,15 @@ class DownloadResponseGeneratorTest extends TestCase
     public function testGetResponseUsingAzureBlobStorageWithUnsupportedAuth(): void
     {
         $fileSystem = $this->createMock(Filesystem::class);
-        $fileSystem->method('temporaryUrl')->willThrowException(new \Exception('UnableToGenerateSasException'));
+        $expectedException = new \Exception('UnableToGenerateSasException');
+        $fileSystem->method('temporaryUrl')->willThrowException($expectedException);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with(
+                static::equalTo('UnableToGenerateSasException'),
+                static::equalTo(['exception' => $expectedException]),
+            );
 
         $media = new MediaEntity();
         $media->setId(Uuid::randomHex());
@@ -170,6 +182,7 @@ class DownloadResponseGeneratorTest extends TestCase
         $generator->method('generate')->willReturn([$media->getId() => 'foobar.txt']);
 
         $downloadResponseGenerator = new DownloadResponseGenerator(
+            $logger,
             $fileSystem,
             $fileSystem,
             $this->mediaService,

--- a/tests/unit/Core/Content/Media/File/DownloadResponseGeneratorTest.php
+++ b/tests/unit/Core/Content/Media/File/DownloadResponseGeneratorTest.php
@@ -154,6 +154,39 @@ class DownloadResponseGeneratorTest extends TestCase
         yield 'public / local' => [false, 'local', new RedirectResponse('foobar.txt')];
     }
 
+    public function testGetResponseUsingAzureBlobStorageWithUnsupportedAuth(): void
+    {
+        $fileSystem = $this->createMock(Filesystem::class);
+        $fileSystem->method('temporaryUrl')->willThrowException(new \Exception('UnableToGenerateSasException'));
+
+        $media = new MediaEntity();
+        $media->setId(Uuid::randomHex());
+        $media->setFileName('foobar');
+        $media->setFileExtension('txt');
+        $media->setPrivate(true);
+        $media->setPath('foobar.txt');
+
+        $generator = $this->createMock(AbstractMediaUrlGenerator::class);
+        $generator->method('generate')->willReturn([$media->getId() => 'foobar.txt']);
+
+        $downloadResponseGenerator = new DownloadResponseGenerator(
+            $fileSystem,
+            $fileSystem,
+            $this->mediaService,
+            'php',
+            $generator,
+            ''
+        );
+
+        $streamInterface = $this->createMock(StreamInterface::class);
+        $streamInterface->method('detach')->willReturn(fopen('php://temp', 'r'));
+        $this->mediaService->method('loadFileStream')->willReturn($streamInterface);
+
+        $response = $downloadResponseGenerator->getResponse($media, $this->salesChannelContext);
+
+        AssertResponseHelper::assertResponseEquals(self::getExpectedStreamResponse(), $response);
+    }
+
     /**
      * @return Filesystem&MockObject
      */


### PR DESCRIPTION
### 1. Why is this change necessary?

When using the Azure blob file system, depending on the authentication method used, it may not be possible to create a temporary URL for downloading digital products.

Depending on the authentication method used, the `temporaryUrl` function is not supported by the Azure adapter.

<ins>**However, this problem can also occur with other external file systems.**</ins>

Trace:
- composer Package: `azure-oss/storage-blob-flysystem`
- `\AzureOss\FlysystemAzureBlobStorage\AzureBlobStorageAdapter::temporaryUrl`
- `\AzureOss\Storage\Blob\BlobClient::generateSasUri `
```php
if (! $this->credential instanceof StorageSharedKeyCredential) {
   throw new UnableToGenerateSasException();
}
```
- UnableToGenerateSasException extends `\Exception`


### 2. What does this change do, exactly?

The surrounding catch now catches not only `\League\Flysystem\UnableToGenerateTemporaryUrl`, but every `\Throwable`. This means that the fallback for the download response is then used.


### 3. Describe each step to reproduce the issue or behaviour.

- install composer package `azure-oss/storage-blob-flysystem`
- Configure your Shopware to use azure blob storage, use token authentification
- Create an order with digital product
- Open the download link for your purchase (e.g. via the link in the email).
- An `\AzureOss\Storage\Blob\Exceptions\UnableToGenerateSasException` is thrown.
This exception does not extend `\League\Flysystem\UnableToGenerateTemporaryUrl`, but rather `\Exception`. Therefore, it is not caught.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
