### PR TITLE
fix: Search keyword input wrong in admin if more keywords added

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-tag-select/sw-multi-tag-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-tag-select/sw-multi-tag-select.scss
@@ -12,6 +12,11 @@
     .sw-select-selection-list .sw-select-selection-list__item-holder {
         max-width: 16rem;
     }
+
+    .sw-block-field__block {
+        min-height: 48px;
+        height: auto;
+    }
 }
 
 .sw-multi-tag-select-validation-popover {


### PR DESCRIPTION
**Before** 
<img width="1025" height="287" alt="Screenshot 2025-11-26 at 10 08 46 AM" src="https://github.com/user-attachments/assets/fa9aca8d-d508-401c-9a8c-ee9a9c6f2cf1" />

**After**
<img width="1020" height="305" alt="Screenshot 2025-11-26 at 10 09 20 AM" src="https://github.com/user-attachments/assets/7574a308-4e4a-4ffd-8e7f-8cbcda64fb12" />

