### PR TITLE
feat: add delete cart endpoint for storefront

### DIFF
--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -70,6 +70,14 @@ class CartLineItemController extends StorefrontController
         });
     }
 
+    #[Route(path: '/checkout/cart/delete', name: 'frontend.checkout.cart.delete', defaults: ['XmlHttpRequest' => true], methods: ['POST'])]
+    public function deleteCart(Request $request, SalesChannelContext $context): Response
+    {
+        $this->cartService->deleteCart($context);
+
+        return $this->createActionResponse($request);
+    }
+
     /**
      * requires the provided items in the following form
      * 'ids' => [

--- a/tests/unit/Storefront/Controller/CartLineItemControllerTest.php
+++ b/tests/unit/Storefront/Controller/CartLineItemControllerTest.php
@@ -629,6 +629,18 @@ class CartLineItemControllerTest extends TestCase
         static::assertArrayHasKey('danger', $session->getFlashBag()->peekAll());
     }
 
+    public function testDeleteCart(): void
+    {
+        $request = new Request([], ['all' => true]);
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->cartService->expects($this->once())
+            ->method('deleteCart')
+            ->with($context);
+
+        $this->controller->deleteCart($request, $context);
+    }
+
     public function testUpdateLineItems(): void
     {
         $id1 = Uuid::randomHex();


### PR DESCRIPTION
### 1. Why is this change necessary?

There is nothing similar to `DELETE /store-api/checkout/cart` to delete an entire cart in our storefront API.


### 2. What does this change do, exactly?

Adds `POST /checkout/cart/delete` for XHR requests to wipe entire cart


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
