### PR TITLE
fix: Role detail page gets stuck in loading state when sw-verify-user-modal is closed

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/api/sso-settings.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/sso-settings.service.ts
@@ -1,3 +1,6 @@
+import type { AxiosInstance } from 'axios';
+import type { LoginService } from '../login.service';
+
 import ApiService from '../api.service';
 
 /**
@@ -8,14 +11,14 @@ import ApiService from '../api.service';
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default class SsoSettingsService extends ApiService {
-    constructor(httpClient, loginService, apiEndpoint = 'api') {
+    constructor(httpClient: AxiosInstance, loginService: LoginService, apiEndpoint = 'api') {
         super(httpClient, loginService, apiEndpoint, 'application/json');
         this.name = 'ssoSettingsService';
     }
 
     isSso() {
         return this.httpClient
-            .get('/_info/is-sso', {
+            .get<{ isSso: boolean }>('/_info/is-sso', {
                 headers: this.getBasicHeaders(),
             })
             .then((response) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-role-detail/sw-users-permissions-role-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-role-detail/sw-users-permissions-role-detail.html.twig
@@ -36,7 +36,7 @@
             class="sw-users-permissions-role-detail__button-save"
             :is-loading="isLoading"
             :process-success="isSaveSuccessful"
-            :disabled="isLoading || !acl.can('users_and_permissions.editor') || undefined"
+            :disabled="isLoading || !acl.can('users_and_permissions.editor')"
             variant="primary"
             @update:process-success="saveFinish"
             @click.prevent="onSave"

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-role-detail/sw-users-permissions-role-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-role-detail/sw-users-permissions-role-detail.spec.js
@@ -676,6 +676,9 @@ describe('module/sw-users-permissions/page/sw-users-permissions-role-detail', ()
 
         const passwordConfirmModal = wrapper.find('sw-verify-user-modal-stub');
 
+        expect(saveButton.attributes().disabled).toBeUndefined();
+        expect(wrapper.find('.sw-skeleton').exists()).toBe(false);
+
         expect(passwordConfirmModal.exists()).toBeTruthy();
         expect(saveFunction).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The role create/detail page in the admin gets stuck in a loading state if the user closes the user verification modal instead of entering their password.

### 2. What does this change do, exactly?

With the implementation of this PR, the loading state is removed after the first request (isSso check) and is only set during the saving process.

### 3. Describe each step to reproduce the issue or behaviour.

* navigate to Users and permissions
* create a new role or open the detail page of an existing role
* hit the save button
* close the modal by clicking the "cancel" button or by clicking outside of the modal

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
