### PR TITLE
refactor: improve listing appearance and unify component attributes

### DIFF
--- a/src/Storefront/Resources/views/components/Sw/Alert.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Alert.html.twig
@@ -27,6 +27,11 @@
     }
 }) %}
 
+{% set attributeDefaults = {
+    class: alert.apply({ variant, size }),
+    role: 'alert'
+} %}
+
 {% set defaultIcons = {
     primary: 'info',
     secondary: 'info',
@@ -38,7 +43,7 @@
     dark: 'info',
 } %}
 
-<div role="alert" {{ attributes.defaults({ class: alert.apply({ variant, size }) }) }}>
+<div {{ attributes.defaults(attributeDefaults) }}>
 
     {% block icon %}
         {% if icon is not false and icon|length > 0 %}

--- a/src/Storefront/Resources/views/components/Sw/Content/Pagination.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Content/Pagination.html.twig
@@ -9,19 +9,20 @@
     useHref = false,
 %}
 
-{% set attributeDefaults = {
-    class: 'sw-pagination sw-pagination__' ~ scope,
-    'aria-label': ('general.pagination.title'|trans|striptags),
-    'data-component': 'Sw:Content:Pagination',
-} %}
-
 {% set paginationOptions = {
     'useHref': useHref,
 } %}
 
+{% set attributeDefaults = {
+    class: 'sw-pagination sw-pagination__' ~ scope,
+    'aria-label': ('general.pagination.title'|trans|striptags),
+    'data-component': 'Sw:Content:Pagination',
+    'data-pagination-options': paginationOptions|json_encode
+} %}
+
 {% set totalPages = totalPages ?? (total / (limit ?: 1))|round(0, 'ceil') %}
 
-<nav {{ attributes.defaults(attributeDefaults) }} data-pagination-options="{{ paginationOptions|json_encode }}">
+<nav {{ attributes.defaults(attributeDefaults) }}>
     {% block content %}
         {% if totalPages > 1 %}
             <ul class="sw-pagination__list pagination">

--- a/src/Storefront/Resources/views/components/Sw/Content/Text.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Content/Text.html.twig
@@ -3,8 +3,6 @@
     inline = false,
 %}
 
-{% set attributeDefaults = {} %}
-
 {% set textVariants = cva({
     base: 'sw-text',
     variants: {
@@ -15,6 +13,10 @@
     },
 }) %}
 
-<div {{ attributes.defaults(attributeDefaults) }} class="{{ textVariants.apply({ inline }) }}">
+{% set attributeDefaults = {
+    class: textVariants.apply({ inline }),
+} %}
+
+<div {{ attributes.defaults(attributeDefaults) }}>
     {{ text|sw_sanitize|raw }}
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
@@ -6,7 +6,7 @@
     background-color: var(--bs-body-bg);
     position: sticky;
     top: 0;
-    z-index: 2;
+    z-index: 10;
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
     margin-bottom: 0.5rem;

--- a/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
@@ -202,22 +202,22 @@
 }) %}
 
 {% set attributeDefaults = {
-    'class': gridCVA.apply({ 
-        align, 
-        alignContent, 
-        justify, 
-        justifyContent, 
-        centered, 
-        columns, 
-        columnsSm, 
-        columnsMd, 
-        columnsLg, 
-        columnsXl, 
-        rows, 
-        rowsSm, 
-        rowsMd, 
-        rowsLg, 
-        rowsXl 
+    'class': gridCVA.apply({
+        align,
+        alignContent,
+        justify,
+        justifyContent,
+        centered,
+        columns,
+        columnsSm,
+        columnsMd,
+        columnsLg,
+        columnsXl,
+        rows,
+        rowsSm,
+        rowsMd,
+        rowsLg,
+        rowsXl
     }),
 } %}
 
@@ -239,7 +239,7 @@
 
 {% set gridStyle = columnSetting ? gridStyle ~ 'grid-template-columns: ' ~ columnSetting|trim ~ '; ' : gridStyle %}
 {% set gridStyle = rowSetting ? gridStyle ~ 'grid-template-rows: ' ~ rowSetting|trim ~ '; ' : gridStyle %}
-{% set gridStyle = gap ? gridStyle ~ 'gap: ' ~ gap ~ 'px; margin-bottom: ' ~ gap ~ 'px; ' : gridStyle %}
+{% set gridStyle = gap ? gridStyle ~ 'gap: ' ~ gap ~ '; margin-bottom: ' ~ gap ~ '; ' : gridStyle %}
 
 <div
     {{ attributes.defaults(attributeDefaults) }}

--- a/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
@@ -239,7 +239,7 @@
 
 {% set gridStyle = columnSetting ? gridStyle ~ 'grid-template-columns: ' ~ columnSetting|trim ~ '; ' : gridStyle %}
 {% set gridStyle = rowSetting ? gridStyle ~ 'grid-template-rows: ' ~ rowSetting|trim ~ '; ' : gridStyle %}
-{% set gridStyle = gap ? gridStyle ~ 'gap: ' ~ gap ~ '; margin-bottom: ' ~ gap ~ '; ' : gridStyle %}
+{% set gridStyle = gap ? gridStyle ~ 'gap: ' ~ gap ~ 'px; margin-bottom: ' ~ gap ~ 'px; ' : gridStyle %}
 
 <div
     {{ attributes.defaults(attributeDefaults) }}

--- a/src/Storefront/Resources/views/components/Sw/Icon.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Icon.html.twig
@@ -57,6 +57,7 @@
 
 {% set attributeDefaults = {
     'aria-hidden': true,
+    class: iconVariants.apply({size, color, rotation, flip}),
 } %}
 
 {%- if themeIconConfig[pack] is defined -%}
@@ -65,6 +66,6 @@
     {% set icon = source('@' ~ namespace ~ '/assets/icon/'~ pack ~'/'~ name ~'.svg', ignore_missing = true) %}
 {%- endif -%}
 
-<span {{ attributes.defaults(attributeDefaults) }} class="{{ iconVariants.apply({size, color, rotation, flip}) }}">
+<span {{ attributes.defaults(attributeDefaults) }}>
     {{ icon|sw_icon_cache|raw }}
 </span>

--- a/src/Storefront/Resources/views/components/Sw/Product/Badges.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/Badges.html.twig
@@ -2,7 +2,12 @@
     product,
 %}
 
-<div class="sw-product-card-badges d-flex gap-1">
+{% set attributeDefaults = {
+    class: 'sw-product-card-badges'
+} %}
+
+<div {{ attributes.defaults(attributeDefaults) }}>
+
     {% set price = product.calculatedPrice %}
     {% if product.calculatedPrices.count > 0 %}
         {% set price = product.calculatedPrices.last %}

--- a/src/Storefront/Resources/views/components/Sw/Product/Badges.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/Badges.scss
@@ -1,7 +1,10 @@
 .sw-product-card-badges {
     position: absolute;
-    left: 0;
-    bottom: calc(var(--bs-card-spacer-x) / 2);
+    left: 0.5rem;
+    top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
 }
 
 .sw-product-card-badges__badge {

--- a/src/Storefront/Resources/views/components/Sw/Product/BuyButton.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/BuyButton.html.twig
@@ -4,16 +4,17 @@
     jsOptions = {},
 %}
 
+{% set buyButtonCVA = cva({
+    base: 'sw-buy-widget d-grid',
+}) %}
+
 {% set attributeDefaults = {
-    'method': 'post',
-    'action': path('frontend.checkout.line-item.add'),
+    class: buyButtonCVA.apply({}),
+    method: 'post',
+    action: path('frontend.checkout.line-item.add'),
     'data-component': 'Sw:Product:BuyButton',
     'data-component-options': jsOptions|json_encode,
 } %}
-
-{% set buyButtonCVA = cva({
-    base: 'buy-widget d-grid',
-}) %}
 
 {% set formData = {
     'redirectTo': 'frontend.detail.page',
@@ -31,7 +32,7 @@
     {% set formData = formData|merge(extraFormData) %}
 {% endif %}
 
-<form {{ attributes.defaults(attributeDefaults) }} class="{{ buyButtonCVA.apply({}, attributes.render('class')) }}">
+<form {{ attributes.defaults(attributeDefaults) }}>
 
     {% block form_data_inputs %}
         {% for name, value in formData %}

--- a/src/Storefront/Resources/views/components/Sw/Product/Card.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/Card.html.twig
@@ -1,6 +1,6 @@
 {% props
     product,
-    mediaHeight = 240,
+    mediaHeight = 'auto',
     defaultRoute = seoUrl('frontend.detail.page', { productId: product.id }),
     slots = [],
     layout = 'default',
@@ -34,9 +34,13 @@
     }
 }) %}
 
+{% set attributeDefaults = {
+    class: cardCVA.apply({ layout, mediaObjectFit, border, rounded }),
+} %}
+
 {% set displayParent = product.variantListingConfig.displayParent and product.parentId === null %}
 
-<div class="{{ cardCVA.apply({ layout, mediaObjectFit, border, rounded }, attributes.render('class')) }}">
+<div {{ attributes.defaults(attributeDefaults) }}>
 
     <div class="sw-product-card__inner d-flex h-100">
 
@@ -88,14 +92,14 @@
 
                 {% if config('core.listing.showReview') and product.ratingAverage %}
                     <twig:Slot name="rating">
-                        <twig:Sw:Rating:Stars class="mb-2" :stars="product.ratingAverage" />
+                        <twig:Sw:Rating:Stars :stars="product.ratingAverage" />
                     </twig:Slot>
                 {% endif %}
 
                 {% if not displayParent %}
                     <twig:Slot name="variants">
                         {% if product.variation is not null %}
-                            <twig:Sw:Product:Variants :variants="product.variation" />
+                            <twig:Sw:Product:Variants :productVariants="product.variation" />
                         {% endif %}
                     </twig:Slot>
                 {% endif %}

--- a/src/Storefront/Resources/views/components/Sw/Product/Card.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/Card.html.twig
@@ -65,6 +65,10 @@
                 </twig:Slot>
             {% endblock %}
 
+            {% if config('core.cart.wishlistEnabled') %}
+                <twig:Sw:Product:WishlistButton :productId="product.id" />
+            {% endif %}
+
             <twig:Slot name="header-bottom"></twig:Slot>
         </div>
 

--- a/src/Storefront/Resources/views/components/Sw/Product/Card.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/Card.scss
@@ -3,7 +3,7 @@
     --bs-card-spacer-y: 1rem;
     --bs-card-spacer-x: 0;
     --bs-card-border-color: transparent;
-    --bs-card-cap-padding-y: 1rem;
+    --bs-card-cap-padding-y: 0;
     --bs-card-cap-padding-x: 0;
     --bs-card-cap-bg: none;
     --bs-card-bg: var(--bs-body-bg);
@@ -76,19 +76,31 @@
     .sw-product-card__description {
         display: none;
     }
+
+    .sw-product-card__footer {
+        position: relative;
+        z-index: 1;
+    }
 }
 
 .sw-product-card.is--layout-horizontal {
+    --bs-card-cap-padding-y: 0;
+    --bs-card-cap-padding-x: 1rem;
+    --bs-card-spacer-y: 0;
+    --bs-card-spacer-x: 1rem;
+
+    padding-bottom: 1rem;
+
     border-bottom: 1px solid var(--bs-border-color);
 
     // Apply .row styling
     .sw-product-card__inner {
         display: flex;
-        padding-bottom: 20px;
+        //padding-bottom: 20px;
         margin-top: calc(-1 * var(--bs-gutter-y));
         margin-right: calc(-.5 * var(--bs-gutter-x));
         margin-left: calc(-.5 * var(--bs-gutter-x));
-        gap: 2rem;
+        //gap: 2rem;
     }
 
     // Apply .col-3 styling
@@ -103,9 +115,9 @@
         width: 75%;
     }
 
-    .sw-product-card__footer {
-        padding-bottom: 0;
-    }
+    //.sw-product-card__footer {
+    //    padding-bottom: 0;
+    //}
 
     .stretched-link::after {
         width: 25%;

--- a/src/Storefront/Resources/views/components/Sw/Product/Card.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/Card.scss
@@ -8,6 +8,7 @@
     --bs-card-cap-bg: none;
     --bs-card-bg: var(--bs-body-bg);
     --sw-product-card-media-height: 200px;
+    --sw-product-card-horizontal-img-width: 18%;
 
     &.has--border {
         --bs-card-border-color: var(--bs-border-color);
@@ -89,38 +90,35 @@
     --bs-card-spacer-y: 0;
     --bs-card-spacer-x: 1rem;
 
-    padding-bottom: 1rem;
+    &.has--border {
+        --bs-card-cap-padding-y: 1rem;
+        --bs-card-spacer-y: 1rem;
+    }
 
-    border-bottom: 1px solid var(--bs-border-color);
+    &:not(&.has--border) {
+        padding-bottom: 1rem;
+    }
+
+    &:not(:last-child) {
+        border-bottom: 1px solid var(--bs-border-color);
+    }
 
     // Apply .row styling
     .sw-product-card__inner {
         display: flex;
-        //padding-bottom: 20px;
         margin-top: calc(-1 * var(--bs-gutter-y));
         margin-right: calc(-.5 * var(--bs-gutter-x));
         margin-left: calc(-.5 * var(--bs-gutter-x));
-        //gap: 2rem;
     }
 
-    // Apply .col-3 styling
+    // Apply .col styling
     .sw-product-card__header {
         flex: 0 0 auto;
-        width: 25%;
+        width: var(--sw-product-card-horizontal-img-width);
     }
-
-    // Apply .col-9 styling
-    .sw-product-card__content {
-        flex: 0 0 auto;
-        width: 75%;
-    }
-
-    //.sw-product-card__footer {
-    //    padding-bottom: 0;
-    //}
 
     .stretched-link::after {
-        width: 25%;
+        width: var(--sw-product-card-horizontal-img-width);
     }
 
     .sw-product-card__description {

--- a/src/Storefront/Resources/views/components/Sw/Product/Card.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/Card.scss
@@ -69,6 +69,16 @@
     }
 }
 
+.sw-product-card__media {
+    transition: all 0.3s cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+.sw-product-card__header:has(+ .sw-product-card__content .sw-product-card__title-link:hover) {
+    .sw-product-card__media {
+        transform: scale(105%);
+    }
+}
+
 .sw-product-card.is--layout-default {
     .sw-product-card__inner {
         flex-direction: column;

--- a/src/Storefront/Resources/views/components/Sw/Product/CardActions.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardActions.html.twig
@@ -4,7 +4,11 @@
     horizontal = false,
 %}
 
-<div class="sw-product-card-actions{% if not horizontal %} d-grid{% endif %}">
+{% set attributeDefaults = {
+    class: 'sw-product-card-actions' ~ (not horizontal ? ' d-grid' : ''),
+} %}
+
+<div {{ attributes.defaults(attributeDefaults) }}>
     {% set isAvailable = not product.isCloseout or (product.stock >= product.minPurchase) %}
     {% set displayFrom = product.calculatedPrices.count > 1 %}
     {% set displayBuyButton = isAvailable and not displayFrom and product.childCount <= 0 %}

--- a/src/Storefront/Resources/views/components/Sw/Product/CardLoader.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardLoader.html.twig
@@ -23,7 +23,6 @@
     </p>
 
     <a class="sw-product-card-loader__cta btn btn-light bg-secondary-subtle disabled placeholder col-12"
-       style="--bs-btn-disabled-bg: var(--bs-secondary-bg-subtle);"
        aria-disabled="true">
     </a>
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Product/CardLoader.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardLoader.html.twig
@@ -8,34 +8,22 @@
     animationType = 'wave',
 %}
 
-<div class="sw-product-card-loader position-absolute top-0 start-0 bottom-0 d-flex flex-column" aria-hidden="true">
-    <div class="card-img-top">
-        <svg class="bd-placeholder-img"
-             height="220"
-             preserveAspectRatio="xMidYMid slice"
-             role="img"
-             width="100%"
-             xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="var(--bs-secondary-bg-subtle)"></rect>
-        </svg>
-    </div>
+{% set attributeDefaults = {
+    class: 'sw-product-card-loader position-absolute start-0 bottom-0 d-flex flex-column w-100 pt-3',
+    'aria-hidden': true,
+} %}
 
-    <div class="card-body pb-2">
-        <h5 class="placeholder-{{ animationType }}">
-            <span class="placeholder placeholder-lg col-11"></span>
-        </h5>
-        <p class="card-text placeholder-{{ animationType }}">
-            <span class="placeholder placeholder-sm col-7"></span>
-            <span class="placeholder placeholder-sm col-4"></span>
-            <span class="placeholder placeholder-sm col-4"></span>
-            <span class="placeholder placeholder-sm col-6"></span>
-            <span class="placeholder placeholder-sm col-8"></span>
-        </p>
-    </div>
+<div {{ attributes.defaults(attributeDefaults) }}>
+    <h5 class="placeholder-{{ animationType }}">
+        <span class="placeholder placeholder-lg col-11"></span>
+    </h5>
+    <p class="card-text placeholder-{{ animationType }}">
+        <span class="placeholder placeholder-sm col-4"></span>
+        <span class="placeholder placeholder-sm col-6"></span>
+    </p>
 
-    <div class="card-footer border-0">
-        <a class="btn btn-light bg-secondary-subtle disabled placeholder col-12"
-           style="--bs-btn-disabled-bg: var(--bs-secondary-bg-subtle);"
-           aria-disabled="true">
-        </a>
-    </div>
+    <a class="btn btn-light bg-secondary-subtle disabled placeholder col-12"
+       style="--bs-btn-disabled-bg: var(--bs-secondary-bg-subtle);"
+       aria-disabled="true">
+    </a>
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Product/CardLoader.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardLoader.html.twig
@@ -14,15 +14,15 @@
 } %}
 
 <div {{ attributes.defaults(attributeDefaults) }}>
-    <h5 class="placeholder-{{ animationType }}">
+    <h5 class="sw-product-card-loader__title placeholder-{{ animationType }}">
         <span class="placeholder placeholder-lg col-11"></span>
     </h5>
-    <p class="card-text placeholder-{{ animationType }}">
+    <p class="sw-product-card-loader__text card-text placeholder-{{ animationType }}">
         <span class="placeholder placeholder-sm col-4"></span>
         <span class="placeholder placeholder-sm col-6"></span>
     </p>
 
-    <a class="btn btn-light bg-secondary-subtle disabled placeholder col-12"
+    <a class="sw-product-card-loader__cta btn btn-light bg-secondary-subtle disabled placeholder col-12"
        style="--bs-btn-disabled-bg: var(--bs-secondary-bg-subtle);"
        aria-disabled="true">
     </a>

--- a/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
@@ -16,6 +16,10 @@
 
     .sw-product-card__header {
         background: var(--bs-gray-300);
+        mask-image: linear-gradient(130deg, #000 55%, rgba(0, 0, 0, 0.8) 75%, #000 95%);
+        mask-size: 200% 100%;
+        animation: placeholder-wave 2s
+        linear infinite;
     }
 
     .sw-product-card-badges,

--- a/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
@@ -14,11 +14,34 @@
         background: var(--bs-gray-300);
     }
 
+    .sw-product-card-badges,
+    .product-wishlist-btn {
+        display: none;
+    }
+
     .sw-product-card__media {
         opacity: 0;
     }
 
     .sw-product-card-loader {
         visibility: visible;
+    }
+}
+
+.is--layout-horizontal {
+    .sw-product-card-loader {
+        padding-bottom: 1rem;
+        top: 0;
+        left: var(--sw-product-card-horizontal-img-width);
+        width: calc(100% - var(--sw-product-card-horizontal-img-width));
+        padding-left: 1rem;
+    }
+
+    .sw-product-card-loader__text {
+        flex-grow: 1;
+    }
+
+    .sw-product-card-loader__cta {
+        max-width: 280px;
     }
 }

--- a/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
@@ -4,6 +4,10 @@
     pointer-events: none;
 }
 
+.sw-product-card-loader__cta {
+    --bs-btn-disabled-bg: var(--bs-secondary-bg-subtle);
+}
+
 .has-element-loader {
     .sw-product-card__content {
         visibility: hidden;

--- a/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
@@ -1,12 +1,21 @@
 .sw-product-card-loader {
     visibility: hidden;
+    z-index: 2;
     pointer-events: none;
 }
 
 .has-element-loader {
-    .sw-product-card > :not(.sw-product-card-loader) {
+    .sw-product-card__content {
         visibility: hidden;
         pointer-events: none;
+    }
+
+    .sw-product-card__header {
+        background: var(--bs-gray-300);
+    }
+
+    .sw-product-card__media {
+        opacity: 0;
     }
 
     .sw-product-card-loader {

--- a/src/Storefront/Resources/views/components/Sw/Product/Listing.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/Listing.html.twig
@@ -40,7 +40,7 @@
                     :columnsXl="layout == 'horizontal' ? '1' : '3'"
                     :columnsLg="layout == 'horizontal' ? '1' : '2'"
                     :columnsSm="layout == 'horizontal' ? '1' : '2'"
-                    gap="1rem">
+                    gap="16">
                     {% for product in listing.elements %}
                         <twig:Sw:Product:Card
                             :product="product"

--- a/src/Storefront/Resources/views/components/Sw/Product/Listing.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/Listing.html.twig
@@ -3,17 +3,18 @@
     slots = [],
 %}
 
-{% set attributeDefaults = {
-    'data-component': 'Sw:Product:Listing',
-} %}
-
 {% set listingCVA = cva({
     base: 'product-listing',
 }) %}
 
+{% set attributeDefaults = {
+    class: listingCVA.apply({}),
+    'data-component': 'Sw:Product:Listing',
+} %}
+
 {% set layout = app.request.get('layout') %}
 
-<div {{ attributes.defaults(attributeDefaults) }} class="{{ listingCVA.apply({}, attributes.render('class')) }}">
+<div {{ attributes.defaults(attributeDefaults) }}>
 
     {% block filters %}
         <twig:Slot name="filters-panel">
@@ -39,19 +40,17 @@
                     :columnsXl="layout == 'horizontal' ? '1' : '3'"
                     :columnsLg="layout == 'horizontal' ? '1' : '2'"
                     :columnsSm="layout == 'horizontal' ? '1' : '2'"
-                    gap="20">
+                    gap="1rem">
                     {% for product in listing.elements %}
                         <twig:Sw:Product:Card
                             :product="product"
                             :layout="layout ? layout : 'default'"
-                            mediaHeight="340"
-                            mediaObjectFit="contain"
                         />
                     {% endfor %}
                 </twig:Sw:Grid:Container>
             </twig:Slot>
         {% else %}
-            <div class="product-listing__grid container">
+            <div class="sw-product-listing__grid container">
                 <twig:Sw:Alert type="info">
                     {{ 'listing.emptyResultMessage'|trans|sw_sanitize }}
                 </twig:Sw:Alert>

--- a/src/Storefront/Resources/views/components/Sw/Product/PriceDisplay.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/PriceDisplay.html.twig
@@ -3,6 +3,10 @@
     showTaxInfo = false,
 %}
 
+{% set attributeDefaults = {
+    class: 'sw-product-price-display mb-3 card-text',
+} %}
+
 {% block component_product_box_price_info %}
     {% set cheapest = product.calculatedCheapestPrice %}
 
@@ -23,7 +27,7 @@
         {% set hasDifferentPrice = totalVariants|filter(variant => variant.default != null)|length > 0 %}
     {% endif %}
 
-    <div class="sw-product-price-display mb-3 card-text">
+    <div {{ attributes.defaults(attributeDefaults) }}>
 
         {% if referencePrice is not null %}
             <p class="sw-product-price-display__reference-price">

--- a/src/Storefront/Resources/views/components/Sw/Product/Variants.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/Variants.html.twig
@@ -1,10 +1,13 @@
-{# @TODO: Naming conflict "variants" vs. UX component varians #}
 {% props
-    variants,
+    productVariants,
 %}
 
-<div class="sw-product-variants fs-6 d-flex flex-wrap text-light-emphasis">
-    {%- for variant in variants -%}
+{% set attributeDefaults = {
+    class: 'sw-product-variants fs-6 d-flex flex-wrap text-light-emphasis',
+} %}
+
+<div {{ attributes.defaults(attributeDefaults) }}>
+    {%- for variant in productVariants -%}
         <span class="sw-product-variants__variant me-1">
             {{ variant.group }}: {{ variant.option }}{% if variants|last != variant %},{% endif %}
         </span>

--- a/src/Storefront/Resources/views/components/Sw/Product/WishlistButton.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/WishlistButton.html.twig
@@ -1,0 +1,41 @@
+{% props
+    productId = null,
+    appearance = 'circle',
+    showText = false,
+    size = 'md',
+%}
+
+{% if productId is not empty %}
+    {% set addToWishlistOptions = {
+        productId: productId,
+        router: {
+            add: {
+                afterLoginPath: path('frontend.wishlist.add.after.login', { productId: productId }),
+                path: path('frontend.wishlist.product.add', { productId: productId }),
+            },
+            remove: {
+                path: path('frontend.wishlist.product.remove', { productId: productId }),
+            }
+        },
+        texts: {
+            add: 'listing.addToWishlist'|trans|sw_sanitize,
+            remove: 'listing.removeFromWishlist'|trans|sw_sanitize
+        },
+    } %}
+
+    <button
+        class="product-wishlist-{{ productId }} product-wishlist-action{% if appearance == 'circle' %}-circle product-wishlist-btn btn btn-light{% endif %} product-wishlist-not-added product-wishlist-loading z-2"
+        title="{{ 'listing.addToWishlist'|trans|sw_sanitize }}"
+        data-add-to-wishlist="true"
+        data-add-to-wishlist-options="{{ addToWishlistOptions|json_encode }}"
+    >
+        {% sw_icon 'heart-fill' style { class: 'wishlist icon-wishlist-added', size: size } %}
+        {% sw_icon 'heart' style { class: 'wishlist icon-wishlist-not-added', size: size } %}
+
+        {% if showText %}
+            <span class="product-wishlist-btn-content product-wishlist-btn-content-{{ size }}">
+                {{ 'listing.addToWishlist'|trans|sw_sanitize }}
+            </span>
+        {% endif %}
+    </button>
+{% endif %}

--- a/src/Storefront/Resources/views/components/Sw/Product/WishlistButton.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/WishlistButton.scss
@@ -5,14 +5,13 @@
     position: absolute;
     bottom: 0;
     right: 0;
-    z-index: 5;
+    z-index: 2;
 
     .icon {
         color: currentColor;
 
         svg {
             top: 0;
-
         }
     }
 }

--- a/src/Storefront/Resources/views/components/Sw/Product/WishlistButton.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/WishlistButton.scss
@@ -1,0 +1,18 @@
+.sw-product-card .product-wishlist-btn {
+    --bs-btn-border-radius: 0;
+    --bs-btn-bg: rgba(255, 255, 255, 0.8);
+    margin-top: 10px;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    z-index: 5;
+
+    .icon {
+        color: currentColor;
+
+        svg {
+            top: 0;
+
+        }
+    }
+}

--- a/src/Storefront/Resources/views/components/Sw/Rating/Stars.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Rating/Stars.html.twig
@@ -5,7 +5,11 @@
 
 {% set starsRounded = stars|round %}
 
-<div class="sw-rating-stars mb-2">
+{% set attributeDefaults = {
+    class: 'sw-rating-stars mb-2',
+} %}
+
+<div {{ attributes.defaults(attributeDefaults) }}>
     {# Actual rating stars #}
     {% for star in range(1, starsRounded) %}
         <twig:Sw:Icon name="star" pack="solid" size="xs" />


### PR DESCRIPTION
Only relevant for `8484/storefront-content-system`

* Unify twig attributes
* Use auto height as default for product images
* Fix buy-button not clickable when using auto height for images
* Fix spacings for horizontal layouts
* Prevent "jumping" of the card loading state
* Fix the horizontal loading state
* Add wishlist function

<img width="658" height="535" alt="image" src="https://github.com/user-attachments/assets/1d6b790f-6135-48c6-9325-30eb1348ed02" />

<img width="658" height="535" alt="image" src="https://github.com/user-attachments/assets/6d571539-ed5b-46d6-b629-aab2696d9227" />

----

<img width="1382" height="551" alt="image" src="https://github.com/user-attachments/assets/02a60aec-a4f5-4a95-b19f-5ed2c4fdeab3" />

<img width="1382" height="551" alt="image" src="https://github.com/user-attachments/assets/4dbfb91b-bcab-4e86-9476-69fe948a3642" />


