### PR TITLE
feat: Allow searching while quicksearch is still loading

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -2,7 +2,7 @@ import Plugin from 'src/plugin-system/plugin.class';
 import Debouncer from 'src/helper/debouncer.helper';
 /** @deprecated tag:v6.8.0 - HttpClient is deprecated. Use native fetch API instead. */
 import HttpClient from 'src/service/http-client.service';
-import ButtonLoadingIndicator from 'src/utility/loading-indicator/button-loading-indicator.util';
+import LoadingIndicatorUtil from 'src/utility/loading-indicator/loading-indicator.util';
 
 export default class SearchWidgetPlugin extends Plugin {
 
@@ -100,12 +100,12 @@ export default class SearchWidgetPlugin extends Plugin {
     /**
      * Handles the keydown event on the input field,
      * to focus into the search suggestions list.
-     * 
+     *
      * @param {Event} event
      * @private
      */
     _handleKeyEvent(event) {
-        if (event.key !== 'ArrowDown' || 
+        if (event.key !== 'ArrowDown' ||
             this._inputField.value.trim() === '') {
             return;
         }
@@ -122,17 +122,17 @@ export default class SearchWidgetPlugin extends Plugin {
     /**
      * Handles the keydown event on the search suggestions list,
      * to move the focus up or down the list.
-     * 
+     *
      * @param {number} index
      * @param {Event} event
      * @private
      */
     _handleSearchItemKeyEvent(index, event) {
-        if (event.key !== 'ArrowDown' && 
+        if (event.key !== 'ArrowDown' &&
             event.key !== 'ArrowUp') {
             return;
         }
- 
+
         event.preventDefault();
         event.stopPropagation();
         event.stopImmediatePropagation();
@@ -148,7 +148,7 @@ export default class SearchWidgetPlugin extends Plugin {
 
     /**
      * Moves the focus up the search results list.
-     * 
+     *
      * @param {number} currentIndex
      * @private
      */
@@ -164,7 +164,7 @@ export default class SearchWidgetPlugin extends Plugin {
 
     /**
      * Moves the focus down the search results list.
-     * 
+     *
      * @param {number} currentIndex
      * @private
      */
@@ -184,7 +184,7 @@ export default class SearchWidgetPlugin extends Plugin {
         const url = this._url + encodeURIComponent(value);
 
         // init loading indicator
-        const indicator = new ButtonLoadingIndicator(this._submitButton);
+        const indicator = new LoadingIndicatorUtil(this._submitButton);
         indicator.create();
 
         this.$emitter.publish('beforeSearch');
@@ -219,7 +219,7 @@ export default class SearchWidgetPlugin extends Plugin {
             .catch(() => {
                 // remove indicator
                 indicator.remove();
-                
+
                 // clear any existing results
                 this._clearSuggestResults();
             });


### PR DESCRIPTION
### 1. Why is this change necessary?

As an impatient user I type a search keyword and immediately press <kbd>ENTER</kbd>.

If I do this quick enough (suggest is not yet loading, no loading indicator) this works. But if the suggest is currently loading (indicator displayed), it doesn't.

This is confusing.

### 2. What does this change do, exactly?

It replaces the ButtonLoadingIndicator by the normal LoadingUtil which does not disable the button.

### 3. Describe each step to reproduce the issue or behaviour.

For easier repo, first patch the suggest route:

```php
#[Route(path: '/suggest', name: 'frontend.search.suggest', defaults: ['XmlHttpRequest' => true], methods: ['GET'])]
public function suggest(SalesChannelContext $context, Request $request): Response
{
    sleep(5);
```

Now enter a keyword in the search box, wait a small moment until the loading indicator appears and press enter -> nothing happens, after 5 seconds the quick search opens.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
