### PR TITLE
feat: add warning to order state change flow action

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-set-order-state-modal/sw-flow-set-order-state-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-set-order-state-modal/sw-flow-set-order-state-modal.html.twig
@@ -5,6 +5,15 @@
     :closable="false"
     @modal-close="onClose"
 >
+    <mt-banner
+        v-if="!config?.force_transition"
+        class="sw-flow-set-order-state-modal__warning-banner"
+        :title="$tc('sw-flow.modals.status.transitionWarning.title')"
+        variant="attention"
+    >
+        {{ $tc('sw-flow.modals.status.transitionWarning.message') }}
+    </mt-banner>
+
     {% block sw_flow_set_order_state_modal_content %}
     {% block sw_flow_set_order_state_modal_payment_status %}
     <mt-select

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-set-order-state-modal/sw-flow-set-order-state-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-set-order-state-modal/sw-flow-set-order-state-modal.spec.js
@@ -127,4 +127,17 @@ describe('module/sw-flow/component/sw-flow-set-order-state-modal', () => {
             },
         ]);
     });
+
+    it('should display warning when force transition is not selected', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        expect(wrapper.find('.sw-flow-set-order-state-modal__warning-banner').exists()).toBe(true);
+
+        await wrapper.find('.sw-flow-set-order-state-modal__force-transition input').setChecked(true);
+        await flushPromises();
+
+        expect(wrapper.vm.config.force_transition).toBe(true);
+        expect(wrapper.find('.sw-flow-set-order-state-modal__warning-banner').exists()).toBe(false);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/de.json
@@ -189,7 +189,11 @@
         "placeholderDeliveryStatus": "Versandstatus wählen ...",
         "messageNoStatusError": "Mindestens ein Status muss ausgewählt sein",
         "forceTransition": "Statuswechsel erzwingen",
-        "forceTransitionHelpText": "Statuswechsel werden durchgeführt, ohne den Ausgangspunkt oder die üblichen Übergangspfade (state machine) zu beachten."
+        "forceTransitionHelpText": "Statuswechsel werden durchgeführt, ohne den Ausgangspunkt oder die üblichen Übergangspfade (state machine) zu beachten.",
+        "transitionWarning": {
+          "title": "Warnung",
+          "message": "Vorsicht bei der Verwendung von Statuswechseln, da diese zu fehlerhaften Flows führen können, wenn der Statuswechsel nicht gültig ist. Um solche Probleme zu vermeiden, kann die Option „Statuswechsel erzwingen“ aktiviert werden."
+        }
       },
       "document": {
         "titleCreateDocument": "Dokumente erzeugen",

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/en.json
@@ -189,7 +189,11 @@
         "placeholderDeliveryStatus": "Select shipping status...",
         "messageNoStatusError": "At least one status must be selected",
         "forceTransition": "Force status transitions",
-        "forceTransitionHelpText": "Status changes will be made regardless of their starting point and neglecting the usually required transition paths (state machine)."
+        "forceTransitionHelpText": "Status changes will be made regardless of their starting point and neglecting the usually required transition paths (state machine).",
+        "transitionWarning": {
+          "title": "Warning",
+          "message": "Be careful when using status transitions, as they can lead to failing flows if the status transition isn't valid. Consider enabling 'Force status transitions' to avoid such issues."
+        }
       },
       "document": {
         "titleCreateDocument": "Generate documents",


### PR DESCRIPTION
resolves https://github.com/shopware/shopware/issues/8337

#### Changes:

- Added a warning banner to the `sw-flow-set-order-state-modal` component, which appears when `force_transition` is not selected, alerting users to potential issues with invalid status transitions.