### PR TITLE
feat: return generated codes in PromotionCodeService

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,6 +6,10 @@
 
 ## Core
 
+### `PromotionCodeService` now returns the generated codes
+
+The return type of `PromotionCodeService::addIndividualCodes()` and `PromotionCodeService::replaceIndividualCodes()` has been changed from `void` to `string[]`. These methods now return an array of generated codes to the caller.
+
 ### Deprecation of `sw-states` and `sw-currency` handling and new way to disable caching
 The `sw-states` and `sw-currency` handling is deprecated, which means by default the HTTP-Cache will also be active for logged in customers or when the cart is filled in the next major version.
 You can opt in to the new behaviour by activating either the `v6.8.0.0` (all upcoming breaking changes),  `PERFORMANCE_TWEAKS` (all performance related breaks) or `CACHE_REWORK` (only the HTTP-Cache related breaks) feature flag.

--- a/src/Core/Checkout/Promotion/Util/PromotionCodeService.php
+++ b/src/Core/Checkout/Promotion/Util/PromotionCodeService.php
@@ -90,7 +90,12 @@ class PromotionCodeService
         return array_diff($codes, $codeBlacklist);
     }
 
-    public function addIndividualCodes(string $promotionId, int $amount, Context $context): void
+    /**
+     * @throws PromotionException
+     *
+     * @return string[]
+     */
+    public function addIndividualCodes(string $promotionId, int $amount, Context $context): array
     {
         $criteria = (new Criteria([$promotionId]))
             ->addAssociation('individualCodes');
@@ -107,9 +112,7 @@ class PromotionCodeService
         }
 
         if ($promotion->getIndividualCodes() === null) {
-            $this->replaceIndividualCodes($promotionId, $pattern, $amount, $context);
-
-            return;
+            return $this->replaceIndividualCodes($promotionId, $pattern, $amount, $context);
         }
 
         $newCodes = $this->generateIndividualCodes(
@@ -120,12 +123,16 @@ class PromotionCodeService
 
         $codeEntries = $this->prepareCodeEntities($promotionId, $newCodes);
         $this->individualCodesRepository->upsert($codeEntries, $context);
+
+        return $newCodes;
     }
 
     /**
      * @throws PromotionException
+     *
+     * @return string[]
      */
-    public function replaceIndividualCodes(string $promotionId, string $pattern, int $amount, Context $context): void
+    public function replaceIndividualCodes(string $promotionId, string $pattern, int $amount, Context $context): array
     {
         if ($this->isCodePatternAlreadyInUse($pattern, $promotionId, $context)) {
             throw PromotionException::patternAlreadyInUse();
@@ -138,6 +145,8 @@ class PromotionCodeService
         $this->resetPromotionCodes($promotionId, $context);
 
         $this->individualCodesRepository->upsert($codeEntries, $context);
+
+        return $codes;
     }
 
     public function resetPromotionCodes(string $promotionId, Context $context): void

--- a/tests/unit/Core/Checkout/Promotion/Util/PromotionCodeServiceTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Util/PromotionCodeServiceTest.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionIndividualCode\PromotionIndividualCodeCollection;
-use Shopware\Core\Checkout\Promotion\Aggregate\PromotionIndividualCode\PromotionIndividualCodeEntity;
+use Shopware\Core\Checkout\Promotion\Exception\PatternNotComplexEnoughException;
 use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Checkout\Promotion\PromotionEntity;
 use Shopware\Core\Checkout\Promotion\PromotionException;
@@ -93,10 +93,11 @@ class PromotionCodeServiceTest extends TestCase
             $connection
         );
 
-        $codeService->addIndividualCodes($promotionId, 10, $context);
+        $codes = $codeService->addIndividualCodes($promotionId, 10, $context);
 
         static::assertNotEmpty($individualCodeRepository->upserts[0]);
         static::assertCount(10, $individualCodeRepository->upserts[0]);
+        static::assertCount(10, $codes);
     }
 
     public function testAddIndividualCodes(): void
@@ -107,11 +108,7 @@ class PromotionCodeServiceTest extends TestCase
         $promotion->setId('promotionId');
         $promotion->setIndividualCodePattern('%s');
 
-        $code = new PromotionIndividualCodeEntity();
-        $code->setId(Uuid::randomHex());
-        $code->setCode('code');
         $codes = new PromotionIndividualCodeCollection([]);
-
         $promotion->setIndividualCodes($codes);
 
         /** @var StaticEntityRepository<PromotionCollection> */
@@ -132,9 +129,43 @@ class PromotionCodeServiceTest extends TestCase
 
         $promotionId = Uuid::randomHex();
 
-        $codeService->addIndividualCodes($promotionId, 10, $context);
+        $codes = $codeService->addIndividualCodes($promotionId, 10, $context);
 
         static::assertNotEmpty($individualCodeRepository->upserts[0]);
         static::assertCount(10, $individualCodeRepository->upserts[0]);
+        static::assertCount(10, $codes);
+    }
+
+    public function testCodesNeedSufficientComplexity(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $promotion = new PromotionEntity();
+        $promotion->setId('promotionId');
+        $promotion->setIndividualCodePattern('%d');
+
+        $codes = new PromotionIndividualCodeCollection([]);
+        $promotion->setIndividualCodes($codes);
+
+        /** @var StaticEntityRepository<PromotionCollection> */
+        $promotionRepository = new StaticEntityRepository([
+            new PromotionCollection([$promotion]),
+            [],
+        ]);
+        /** @var StaticEntityRepository<PromotionIndividualCodeCollection> */
+        $individualCodeRepository = new StaticEntityRepository([new PromotionIndividualCodeCollection([])]);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeStatement');
+
+        $codeService = new PromotionCodeService(
+            $promotionRepository,
+            $individualCodeRepository,
+            $connection
+        );
+
+        $promotionId = Uuid::randomHex();
+        $this->expectException(PatternNotComplexEnoughException::class);
+
+        $codes = $codeService->addIndividualCodes($promotionId, 6, $context);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The `PromotionCodeService` can be used to generate individual codes for promotions. However the methods to do so, currently have a `void` return type. It would be better if these methods returned an array containing the codes which have been generated.

### 2. What does this change do, exactly?

Change the return types of `PromotionCodeService::addIndividualCodes()` and `PromotionCodeService::replaceIndividualCodes()` from `void` to `string[]`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
