### PR TITLE
fix: Make doctrine/dbal version narrower

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "cocur/slugify": "^4.3.0",
         "composer/composer": "^2.8.5",
         "composer/semver": "^3.4.0",
-        "doctrine/dbal": "^4.3.1",
+        "doctrine/dbal": "~4.3.1",
         "doctrine/inflector": "^2.0",
         "dompdf/dompdf": "3.1.0",
         "dragonmantank/cron-expression": "^3.3",

--- a/src/Administration/composer.json
+++ b/src/Administration/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "doctrine/dbal": "^4.3.1",
+        "doctrine/dbal": "~4.3.1",
         "lcobucci/jwt": "^5.5",
         "league/flysystem": "^3.13.0",
         "league/oauth2-server": "^9.1",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -66,7 +66,7 @@
         "cocur/slugify": "^4.3.0",
         "composer/composer": "^2.8.5",
         "composer/semver": "^3.4.0",
-        "doctrine/dbal": "^4.3.1",
+        "doctrine/dbal": "~4.3.1",
         "doctrine/inflector": "^2.0",
         "dompdf/dompdf": "3.1.0",
         "dragonmantank/cron-expression": "^3.3",

--- a/src/Elasticsearch/composer.json
+++ b/src/Elasticsearch/composer.json
@@ -29,7 +29,7 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-curl": "*",
         "async-aws/core": "^1.22",
-        "doctrine/dbal": "^4.3.1",
+        "doctrine/dbal": "~4.3.1",
         "monolog/monolog": "^3.3.1",
         "opensearch-project/opensearch-php": "^2.3.1",
         "shopware/core": "*",

--- a/src/Storefront/composer.json
+++ b/src/Storefront/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "cocur/slugify": "^4.3.0",
-        "doctrine/dbal": "^4.3.1",
+        "doctrine/dbal": "~4.3.1",
         "meyfa/php-svg": "^0.16.1",
         "scssphp/scssphp": "v1.12.0",
         "shopware/core": "*",


### PR DESCRIPTION
### 1. Why is this change necessary?

doctrine/dbal 4.4.0 introduced many deprecations, which made PHPStan fail. 

### 2. What does this change do, exactly?

Make the version constraint narrower, so the new minor version will not be installed.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
