### PR TITLE
fix: theme manager tabs not shown in 6.7

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -131,6 +131,22 @@
                         :items="tabItems"
                     >
 
+                        <template
+                            v-if="!feature.isActive('V6_8_0_0')"
+                            #default="{ active }"
+                        >
+                            <sw-tabs-item
+                                v-if="hasMoreThanOneTab"
+                                v-for="(tab, tabName) in structuredThemeFields.tabs"
+                                :key="tabName"
+                                :title="getTabLabel(tab.labelSnippetKey, tab.label)"
+                                :name="tabName"
+                                :active="active === tabName"
+                            >
+                                {{ getTabLabel(tab.labelSnippetKey, tab.label) }}
+                            </sw-tabs-item>
+                        </template>
+
                         <template #content="{ active }">
                             <template v-if="active === 'default'">
                                 <template v-if="isDerived">


### PR DESCRIPTION
fixes #13751

### 1. Why is this change necessary?

* The tabs from the theme configuration are not visible inside the administration.
* The tabs are defined in the theme.json, however they are not displayed in the admin theme details.




