### PR TITLE
fix: add missing `alt` attribute to order mail product images

### DIFF
--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-html.html.twig
@@ -32,7 +32,7 @@
             {% block lineItem %}
                 <tr>
                     <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" alt="" width="75" height="auto"/>{% endif %}</td>
                     <td>
                         {% if nestingLevel > 0 %}
                             {% for i in 1..nestingLevel %}

--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-html.html.twig
@@ -31,7 +31,7 @@
             {% block lineItem %}
                 <tr>
                     <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" alt="" width="75" height="auto"/>{% endif %}</td>
                     <td>
                         {% if nestingLevel > 0 %}
                             {% for i in 1..nestingLevel %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig
@@ -28,7 +28,7 @@
             {% block lineItem %}
                 <tr>
                     <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" alt="" width="75" height="auto"/>{% endif %}</td>
                     <td>
                         {% if nestingLevel > 0 %}
                             {% for i in 1..nestingLevel %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig
@@ -28,7 +28,7 @@
             {% block lineItem %}
                 <tr>
                     <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" alt="" width="75" height="auto"/>{% endif %}</td>
                     <td>
                         {% if nestingLevel > 0 %}
                             {% for i in 1..nestingLevel %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-html.html.twig
@@ -26,7 +26,7 @@
             {% block lineItem %}
                 <tr>
                     <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" alt="" width="75" height="auto"/>{% endif %}</td>
                     <td>
                         {% if nestingLevel > 0 %}
                             {% for i in 1..nestingLevel %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-html.html.twig
@@ -26,7 +26,7 @@
             {% block lineItem %}
                 <tr>
                     <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" alt="" width="75" height="auto"/>{% endif %}</td>
                     <td>
                         {% if nestingLevel > 0 %}
                             {% for i in 1..nestingLevel %}

--- a/src/Core/Migration/V6_7/Migration1764580028AddAltAttributeToOrderConfirmationMailImages.php
+++ b/src/Core/Migration/V6_7/Migration1764580028AddAltAttributeToOrderConfirmationMailImages.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Migration\Traits\MailUpdate;
+use Shopware\Core\Migration\Traits\UpdateMailTrait;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class Migration1764580028AddAltAttributeToOrderConfirmationMailImages extends MigrationStep
+{
+    use UpdateMailTrait;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1764580028;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $filesystem = new Filesystem();
+
+        $orderConfirmUpdate = new MailUpdate(MailTemplateTypes::MAILTYPE_ORDER_CONFIRM);
+        $orderConfirmUpdate->setEnPlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_confirmation_mail/en-plain.html.twig'));
+        $orderConfirmUpdate->setEnHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_confirmation_mail/en-html.html.twig'));
+        $orderConfirmUpdate->setDePlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_confirmation_mail/de-plain.html.twig'));
+        $orderConfirmUpdate->setDeHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_confirmation_mail/de-html.html.twig'));
+        $this->updateMail($orderConfirmUpdate, $connection);
+
+        $paidUpdate = new MailUpdate(MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID);
+        $paidUpdate->setEnPlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/en-plain.html.twig'));
+        $paidUpdate->setEnHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/en-html.html.twig'));
+        $paidUpdate->setDePlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/de-plain.html.twig'));
+        $paidUpdate->setDeHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/de-html.html.twig'));
+        $this->updateMail($paidUpdate, $connection);
+
+        $cancelledUpdate = new MailUpdate(MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CANCELLED);
+        $cancelledUpdate->setEnPlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig'));
+        $cancelledUpdate->setEnHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig'));
+        $cancelledUpdate->setDePlain($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig'));
+        $cancelledUpdate->setDeHtml($filesystem->readFile(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig'));
+        $this->updateMail($cancelledUpdate, $connection);
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1764580028AddAltAttributeToOrderConfirmationMailImagesTest.php
+++ b/tests/migration/Core/V6_7/Migration1764580028AddAltAttributeToOrderConfirmationMailImagesTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1764580028AddAltAttributeToOrderConfirmationMailImages;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(Migration1764580028AddAltAttributeToOrderConfirmationMailImages::class)]
+class Migration1764580028AddAltAttributeToOrderConfirmationMailImagesTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testMigrationOfUnmodifiedTranslation(): void
+    {
+        $migration = new Migration1764580028AddAltAttributeToOrderConfirmationMailImages();
+
+        $error = [];
+        try {
+            $migration->update($this->connection);
+            $migration->update($this->connection);
+        } catch (\Throwable $e) {
+            $error[] = $e->getMessage();
+        }
+
+        static::assertCount(0, $error, print_r($error, true));
+    }
+}


### PR DESCRIPTION
resolves #10785 

Adds missing `alt=""` to decorative product thumbnails in 3 email templates.