### PR TITLE
fix: typo in date range rule timezone field css class

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.html.twig
@@ -41,7 +41,7 @@
     {% block sw_condition_date_range_field_timezone %}
     <sw-single-select
         v-model:value="timezone"
-        class="sw*-condition-date-range__timezone"
+        class="sw-condition-date-range__timezone"
         name="sw-field--timezone"
         :options="timezoneOptions"
         :disabled="disabled || undefined"


### PR DESCRIPTION
noticed this typo in #13517

not sure if this is technically breaking since #13517 targeted 6.7.5.0 🤷‍♂️