### PR TITLE
fix: Update ATS for new web installer button name

### DIFF
--- a/tests/acceptance/tests/Update/Update.spec.ts
+++ b/tests/acceptance/tests/Update/Update.spec.ts
@@ -25,7 +25,7 @@ test(`Update an existing Shopware ${process.env.SHOPWARE_UPDATE_FROM} instance.`
     await page.getByRole('link', { name: 'Continue' }).click();
     await page.waitForLoadState('domcontentloaded')
 
-    await page.getByRole('button', { name: 'Save configuration' }).click();
+    await page.getByRole('button', { name: 'Continue' }).click();
     await page.waitForLoadState('domcontentloaded');
 
     await page.getByRole('button', { name: 'Update Shopware' }).click();


### PR DESCRIPTION
The button to continue was renamed. Use the new name in the test.

### 1. Why is this change necessary?

The button to continue was renamed from `Save configuration` to simply `Continue`

### 2. What does this change do, exactly?

It changes the test file to look for a button with the label `Continue`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/13743