### PR TITLE
fix: Fix EntityResolverContext code completion for cms extensions

### DIFF
--- a/src/Core/Content/Cms/Extension/CmsSlotsDataCollectExtension.php
+++ b/src/Core/Content/Cms/Extension/CmsSlotsDataCollectExtension.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Cms\Extension;
 
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Framework\Extensions\Extension;
 use Shopware\Core\Framework\Log\Package;
@@ -39,6 +40,8 @@ final class CmsSlotsDataCollectExtension extends Extension
          * @public
          *
          * @description Allows you to access to the current resolver-context
+         *
+         * @param ResolverContext|EntityResolverContext $resolverContext
          */
         public readonly ResolverContext $resolverContext,
     ) {

--- a/src/Core/Content/Cms/Extension/CmsSlotsDataEnrichExtension.php
+++ b/src/Core/Content/Cms/Extension/CmsSlotsDataEnrichExtension.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Cms\Extension;
 
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
@@ -66,6 +67,8 @@ final class CmsSlotsDataEnrichExtension extends Extension
          * @public
          *
          * @description Allows you to access to the current resolver-context
+         *
+         * @param ResolverContext|EntityResolverContext $resolverContext
          */
         public readonly ResolverContext $resolverContext,
     ) {

--- a/src/Core/Content/Cms/Extension/CmsSlotsDataResolveExtension.php
+++ b/src/Core/Content/Cms/Extension/CmsSlotsDataResolveExtension.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Cms\Extension;
 
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Framework\Extensions\Extension;
 use Shopware\Core\Framework\Log\Package;
@@ -37,6 +38,8 @@ final class CmsSlotsDataResolveExtension extends Extension
          * @public
          *
          * @description Allows you to access to the current resolver-context
+         *
+         * @param ResolverContext|EntityResolverContext $resolverContext
          */
         public readonly ResolverContext $resolverContext,
     ) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

###  1. Why is this change necessary?

When listening to certain CMS extension events, IDEs do not provide proper code completion for the resolver context. This is because the resolverContext may also be an instance of EntityResolverContext, which is not clearly indicated in the current type annotations. Improving this makes CMS extensions easier and safer to work with.

###  2. What does this change do, exactly?

This change adds and improves code annotations for the CMS extension layer, making it explicit that the resolver context can also be an EntityResolverContext. This enables proper IDE type-hinting and code completion. I keep the data type from the base resolver context because the entity resolver context inherits from it.

### 3. Steps to reproduce the issue or behaviour
// n/a


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
