### PR TITLE
fix: Update ATS for new web installer button name [6.6.x]

### DIFF
--- a/tests/acceptance/tests/Update/Update.spec.ts
+++ b/tests/acceptance/tests/Update/Update.spec.ts
@@ -25,7 +25,7 @@ test(`Update an existing Shopware ${process.env.SHOPWARE_UPDATE_FROM} instance.`
     await page.getByRole('link', { name: 'Continue' }).click();
     await page.waitForLoadState('domcontentloaded')
 
-    await page.getByRole('button', { name: 'Save configuration' }).click();
+    await page.getByRole('button', { name: 'Continue' }).click();
     await page.waitForLoadState('domcontentloaded');
 
     await page.getByRole('button', { name: 'Update Shopware' }).click();


### PR DESCRIPTION
The button to continue was renamed. Use the new name in the test.

This is a backport of #13773 

This is part of https://github.com/shopware/shopware/issues/13743