### PR TITLE
exp: moved internal annotation in CacheHashService

### DIFF
--- a/src/Core/Framework/Adapter/Cache/Http/CacheHashService.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheHashService.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-#[Package('framework')]
 /**
  * @internal
  */
+#[Package('framework')]
 class CacheHashService
 {
     /**


### PR DESCRIPTION
This was an experiment to confirm that location of the comment with `@internal` annotation influences bc checker output > it does, comment containing internal should come before class attributes.