### PR TITLE
fix: date range rule json serialization format

### DIFF
--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -96,4 +96,18 @@ class DateRangeRule extends Rule
             'timezone' => [new Timezone()],
         ];
     }
+
+    public function jsonSerialize(): array
+    {
+        $data = parent::jsonSerialize();
+
+        if ($this->fromDate instanceof \DateTimeInterface) {
+            $data['fromDate'] = $this->fromDate->format(self::DATETIME_FORMAT);
+        }
+        if ($this->toDate instanceof \DateTimeInterface) {
+            $data['toDate'] = $this->toDate->format(self::DATETIME_FORMAT);
+        }
+
+        return $data;
+    }
 }

--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -97,9 +97,9 @@ class DateRangeRule extends Rule
         ];
     }
 
-    public function assign(array $data): static
+    public function assign(array $options)
     {
-        parent::assign($data);
+        parent::assign($options);
 
         try {
             // convert string dates to DateTime objects

--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -97,6 +97,20 @@ class DateRangeRule extends Rule
         ];
     }
 
+    public function assign(array $data): static
+    {
+        parent::assign($data);
+
+        try {
+            // convert string dates to DateTime objects
+            $this->__wakeup();
+        } catch (\Exception) {
+            // let validators handle invalid formats
+        }
+
+        return $this;
+    }
+
     public function jsonSerialize(): array
     {
         $data = parent::jsonSerialize();

--- a/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
@@ -274,7 +274,10 @@ class DateRangeRuleTest extends TestCase
             new \DateTimeZone('UTC')
         );
 
-        $serialized = (string) json_encode($rule);
+        $serialized = json_encode($rule);
+
+        static::assertIsString($serialized);
+
         $data = json_decode($serialized, true);
 
         static::assertSame('2024-01-15T10:30:45', $data['fromDate']);

--- a/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\DateRangeRule;
 use Shopware\Core\Framework\Rule\RuleScope;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @internal
@@ -262,5 +263,27 @@ class DateRangeRuleTest extends TestCase
                 true,
             ],
         ];
+    }
+
+    public function testSerializationAndValidation(): void
+    {
+        $rule = new DateRangeRule(
+            new \DateTime('2024-01-15 10:30:45'),
+            new \DateTime('2024-01-31 23:59:59'),
+            true,
+            new \DateTimeZone('UTC')
+        );
+
+        $serialized = (string) json_encode($rule);
+        $data = json_decode($serialized, true);
+
+        static::assertSame('2024-01-15T10:30:45', $data['fromDate']);
+        static::assertSame('2024-01-31T23:59:59', $data['toDate']);
+
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $constraints = $rule->getConstraints();
+
+        static::assertCount(0, $validator->validate($data['fromDate'], $constraints['fromDate']));
+        static::assertCount(0, $validator->validate($data['toDate'], $constraints['toDate']));
     }
 }

--- a/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
@@ -286,4 +286,23 @@ class DateRangeRuleTest extends TestCase
         static::assertCount(0, $validator->validate($data['fromDate'], $constraints['fromDate']));
         static::assertCount(0, $validator->validate($data['toDate'], $constraints['toDate']));
     }
+
+    public function testAssignWithStringDatesConvertsToDateTime(): void
+    {
+        $rule = new DateRangeRule();
+
+        $rule->assign([
+            'fromDate' => '2024-01-15T10:30:45',
+            'toDate' => '2024-01-31T23:59:59',
+            'useTime' => true,
+            'timezone' => 'UTC',
+        ]);
+
+        $scopeMock = $this->createMock(RuleScope::class);
+        $scopeMock->method('getCurrentTime')->willReturn(new \DateTimeImmutable('2024-01-20 12:00:00'));
+
+        $result = $rule->match($scopeMock);
+
+        static::assertTrue($result);
+    }
 }


### PR DESCRIPTION
resolves #13642

Overrides `jsonSerialize` in `DateRangeRule` to format dates as `Y-m-d\TH:i:s` (`DateRangeRule::DATETIME_FORMAT`) instead of [`RFC3339_EXTENDED`](https://github.com/shopware/shopware/blob/8a5dcf63debb276e4fa1ca5a9392d4676b4c7d85/src/Core/Framework/Struct/JsonSerializableTrait.php#L28), matching the validation constraints.