### PR TITLE
feat: requested permissions admin

### DIFF
--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -14,7 +14,7 @@
     "create-test": "node ./scripts/create-spec-file/index.mjs",
     "dev": "export VITE_MODE=development && ts-node -T build.ts",
     "format": "prettier --check \"src/**/*.{js,ts}\" \"build/vite-plugins/**/*.{js,ts}\" \"build/plugins.vite.ts\" \"build.ts\"",
-    "format:fix": "prettier --write \"src/**/*.{js,ts}\" \"build/vite-plugins/**/*.{js,ts}\" \"build/plugins.vite.ts\" \"build.ts\" --cache",
+    "format:fix": "prettier --log-level=error --write \"src/**/*.{js,ts}\" \"build/vite-plugins/**/*.{js,ts}\" \"build/plugins.vite.ts\" \"build.ts\" --cache",
     "generate-api-docs": "./node_modules/.bin/jsdoc src -r -c jsdoc.config.js",
     "generate-component-import-resolver-map": "ts-node --transpileOnly ./scripts/componentImportResolver/generate.ts",
     "generate-data-set-list": "ts-node --transpileOnly ./scripts/generate-data-set-list/index.ts",

--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -1559,6 +1559,11 @@
         "textDetails": "Technische Details: Die Konfiguration der APP_URL ist fehlerhaft.",
         "labelLearnMoreButton": "Lerne mehr",
         "linkToDocsArticle": "https://docs.shopware.com/de/shopware-6-de/tutorials-und-faq/hinweise-zur-app-url"
+      },
+      "sw-app-privilege-request-banner": {
+        "title": "Neue Berechtigungen angefordert",
+        "explanation": "Eine Erweiterungen benötigen neue Berechtigungen, um aktualisiert zu werden. Bitte überprüfe die neuen Berechtigungen, um fortzufahren. | {n} Erweiterungen benötigen neue Berechtigungen, um aktualisiert zu werden. Bitte überprüfe die neuen Berechtigungen, um fortzufahren.",
+        "reviewButton": "Berechtigungen prüfen"
       }
     }
   },

--- a/src/Administration/Resources/app/administration/src/app/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en.json
@@ -1559,6 +1559,11 @@
         "textDetails": "Technical details: Wrong APP_URL configuration.",
         "labelLearnMoreButton": "Learn more",
         "linkToDocsArticle": "https://docs.shopware.com/en/shopware-6-en/tutorials-and-faq/notes-to-the-APP-URL"
+      },
+      "sw-app-privilege-request-banner": {
+        "title": "New permissions requested",
+        "explanation": "1 extension requires new permissions to be updated. Please review the new permissions to continue. | {n} extensions require new permissions to be updated. Please review the new permissions to continue.",
+        "reviewButton": "Review permissions"
       }
     }
   },

--- a/src/Administration/Resources/app/administration/src/core/service/api/app-privileges.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/app-privileges.service.spec.js
@@ -1,0 +1,33 @@
+/**
+ * @sw-package framework
+ */
+import AppPrivilegesService from 'src/core/service/api/app-privileges.service';
+import createLoginService from 'src/core/service/login.service';
+import createHTTPClient from 'src/core/factory/http.factory';
+import MockAdapter from 'axios-mock-adapter';
+
+function createAppPrivilegesService() {
+    const client = createHTTPClient();
+    const clientMock = new MockAdapter(client);
+    const loginService = createLoginService(client, Shopware.Context.api);
+    const appPrivilegesService = new AppPrivilegesService(client, loginService);
+    return { appPrivilegesService, clientMock };
+}
+
+describe('appPrivilegesService', () => {
+    it('is registered correctly', async () => {
+        const { appPrivilegesService } = createAppPrivilegesService();
+
+        expect(appPrivilegesService).toBeInstanceOf(AppPrivilegesService);
+    });
+
+    it('accepts privileges correctly', async () => {
+        const { appPrivilegesService, clientMock } = createAppPrivilegesService();
+
+        clientMock.onPatch('/app-system/SomeApp/privileges', { accept: ['product:read'] }).reply(200, {});
+
+        await appPrivilegesService.acceptPrivileges('SomeApp', ['product:read']);
+
+        expect(clientMock.history.patch).toHaveLength(1);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/core/service/api/app-privileges.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/app-privileges.service.ts
@@ -16,9 +16,9 @@ export default class AppPrivilegesService extends ApiService {
         this.name = 'appPrivilegesService';
     }
 
-    public async acceptPrivileges(name: string, privileges: string[]): Promise<void> {
+    public async acceptPrivileges(appName: string, privileges: string[]): Promise<void> {
         await this.httpClient.patch(
-            `app-system/${name}/privileges`,
+            `app-system/${appName}/privileges`,
             {
                 accept: privileges,
             },

--- a/src/Administration/Resources/app/administration/src/core/service/api/app-privileges.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/app-privileges.service.ts
@@ -1,0 +1,36 @@
+/**
+ * @sw-package framework
+ */
+import type { AxiosInstance } from 'axios';
+import type { LoginService } from '../login.service';
+import ApiService from '../api.service';
+
+/**
+ * @private
+ * @sw-package framework
+ * Gateway for the API end point "app-permissions"
+ */
+export default class AppPrivilegesService extends ApiService {
+    constructor(httpClient: AxiosInstance, loginService: LoginService) {
+        super(httpClient, loginService, '', 'application/json');
+        this.name = 'appPrivilegesService';
+    }
+
+    public async acceptPrivileges(name: string, privileges: string[]): Promise<void> {
+        await this.httpClient.patch(
+            `app-system/${name}/privileges`,
+            {
+                accept: privileges,
+            },
+            {
+                headers: this.getBasicHeaders(),
+            },
+        );
+    }
+}
+
+/**
+ * @private
+ * @sw-package framework
+ */
+export type { AppPrivilegesService };

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -143,6 +143,7 @@ import type CMSConstant from './module/sw-cms/constant/sw-cms.constant';
 import type CUSTOMERConstant from './module/sw-customer/constant/sw-customer.constant';
 import type FLOWConstant from './module/sw-flow/constant/flow.constant';
 import type SnippetApiService from './core/service/api/snippet.api.service';
+import type AppPrivilegesService from './core/service/api/app-privileges.service';
 
 // trick to make it an "external module" to support global type extension
 
@@ -297,6 +298,7 @@ declare global {
         ssoSettingsService: SsoSettingsService;
         ssoInvitationService: SsoInvitationService;
         shopIdChangeService: ShopIdChangeService;
+        appPrivilegesService: AppPrivilegesService;
     }
 
     interface MixinContainer {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
@@ -35,6 +35,7 @@ export default {
             showUninstallModal: false,
             showRemovalModal: false,
             showPermissionsModal: false,
+            showPrivilegesReviewModal: false,
             permissionsAccepted: false,
             showPrivacyModal: false,
             permissionModalActionLabel: null,
@@ -115,6 +116,14 @@ export default {
 
         permissions() {
             return Object.keys(this.extension.permissions).length ? this.extension.permissions : null;
+        },
+
+        requestedPrivileges() {
+            return Object.keys(this.extension.requestedPermissions || {}).length ? this.extension.requestedPermissions : [];
+        },
+
+        newPrivilegesRequested() {
+            return Object.keys(this.requestedPrivileges).length > 0;
         },
 
         assetFilter() {
@@ -379,6 +388,43 @@ export default {
             this.permissionsAccepted = true;
             this.closePermissionsModal();
             await this.installExtension();
+        },
+
+        openPrivilegesReviewModal() {
+            this.permissionModalActionLabel = this.$tc(
+                'sw-extension-store.component.sw-extension-card-base.labelAcceptRequestedPrivileges',
+            );
+            this.showPrivilegesReviewModal = true;
+        },
+
+        closePrivilegesReviewModal() {
+            this.permissionModalActionLabel = null;
+            this.showPrivilegesReviewModal = false;
+        },
+
+        async closePrivilegesReviewModalAndAcceptRequestedPrivileges() {
+            this.permissionsAccepted = true;
+            this.closePrivilegesReviewModal();
+
+            await this.acceptRequestedPrivileges(this.extension);
+        },
+
+        async acceptRequestedPrivileges(extension) {
+            try {
+                this.isLoading = true;
+
+                await this.shopwareExtensionService.acceptRequestedPrivilegesForExtension(
+                    extension.name,
+                    extension.type,
+                    extension.requestedPermissions,
+                );
+
+                await this.shopwareExtensionService.updateExtensionData();
+            } catch (e) {
+                this.showExtensionErrors(e);
+            } finally {
+                this.isLoading = false;
+            }
         },
 
         /*

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
@@ -391,7 +391,7 @@ export default {
         },
 
         openPrivilegesReviewModal() {
-            this.permissionModalActionLabel = this.$tc(
+            this.permissionModalActionLabel = this.$t(
                 'sw-extension-store.component.sw-extension-card-base.labelAcceptRequestedPrivileges',
             );
             this.showPrivilegesReviewModal = true;

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -113,7 +113,7 @@
             {{ $tc('sw-extension-store.component.sw-extension-card-base.installExtensionLabel') }}
         </span>
         <router-link
-            v-if="isInstalled"
+            v-else-if="extension.configurable"
             :to="{ name: 'sw.extension.config', params: { namespace: extension.name } }"
         >
             {{ $tc('sw-extension-store.component.sw-extension-card-base.contextMenu.config') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -44,12 +44,32 @@
     <div class="sw-extension-card-base__meta-info">
         {% block sw_extension_card_base_info_content %}
         <section>
-            <span
-                v-if="extension.version"
-                class="sw-extension-card-base__meta-info-version"
-            >
-                {{ $tc('sw-extension.my-extensions.listing.version') }}: {{ extension.version }}
-            </span>
+            <div>
+                <span
+                    v-if="newPrivilegesRequested"
+                    class="sw-extension-card-base__meta-info-privilege-review"
+                >
+                    {{ $tc('sw-extension.my-extensions.listing.privilege-review') }}
+                </span>
+
+                <span
+                    v-if="extension.version"
+                    class="sw-extension-card-base__meta-info-version"
+                >
+                    {{ $tc('sw-extension.my-extensions.listing.version') }}: {{ extension.version }}
+                </span>
+
+                <span
+                    v-if="newPrivilegesRequested"
+                    class="sw-extension-card-base__open-extension"
+                    role="button"
+                    tabindex="0"
+                    @click="openPrivilegesReviewModal"
+                    @keydown.enter="openPrivilegesReviewModal"
+                >
+                    {{ $tc('sw-extension-store.component.sw-extension-card-base.reviewNewPrivilegesLabel') }}
+                </span>
+            </div>
 
             <span v-if="!extensionManagementDisabled && isUpdateable">
                 <a
@@ -93,7 +113,7 @@
             {{ $tc('sw-extension-store.component.sw-extension-card-base.installExtensionLabel') }}
         </span>
         <router-link
-            v-else-if="extension.configurable"
+            v-if="isInstalled"
             :to="{ name: 'sw.extension.config', params: { namespace: extension.name } }"
         >
             {{ $tc('sw-extension-store.component.sw-extension-card-base.contextMenu.config') }}
@@ -207,6 +227,16 @@
         :action-label="permissionModalActionLabel"
         @modal-close="closePermissionsModal"
         @close-with-action="closePermissionsModalAndInstallExtension"
+    />
+
+    <sw-extension-permissions-modal
+        v-if="showPrivilegesReviewModal"
+        :extension-label="extension.label"
+        :permissions="requestedPrivileges"
+        :domains="extension.domains"
+        :action-label="permissionModalActionLabel"
+        @modal-close="closePrivilegesReviewModal"
+        @close-with-action="closePrivilegesReviewModalAndAcceptRequestedPrivileges"
     />
 
     <sw-extension-privacy-policy-extensions-modal

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -49,14 +49,14 @@
                     v-if="newPrivilegesRequested"
                     class="sw-extension-card-base__meta-info-privilege-review"
                 >
-                    {{ $tc('sw-extension.my-extensions.listing.privilege-review') }}
+                    {{ $t('sw-extension.my-extensions.listing.privilege-review') }}
                 </span>
 
                 <span
                     v-if="extension.version"
                     class="sw-extension-card-base__meta-info-version"
                 >
-                    {{ $tc('sw-extension.my-extensions.listing.version') }}: {{ extension.version }}
+                    {{ $t('sw-extension.my-extensions.listing.version') }}: {{ extension.version }}
                 </span>
 
                 <span
@@ -67,7 +67,7 @@
                     @click="openPrivilegesReviewModal"
                     @keydown.enter="openPrivilegesReviewModal"
                 >
-                    {{ $tc('sw-extension-store.component.sw-extension-card-base.reviewNewPrivilegesLabel') }}
+                    {{ $t('sw-extension-store.component.sw-extension-card-base.reviewNewPrivilegesLabel') }}
                 </span>
             </div>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
@@ -51,7 +51,7 @@
     .sw-meteor-card__content .sw-meteor-card__content-wrapper {
         display: grid;
         grid-column-gap: 24px;
-        grid-template-columns: 24px 56px 5fr 2fr minmax(min-content, 1fr) auto;
+        grid-template-columns: 24px 56px 4fr 3fr minmax(min-content, 1fr) auto;
         align-items: center;
         padding: 16px 32px;
         border: none;
@@ -91,6 +91,15 @@
 
         &-version {
             font-weight: $font-weight-semi-bold;
+        }
+
+        &-privilege-review {
+            font-size: 10px;
+            font-weight: $font-weight-semi-bold;
+            border-radius: $border-radius-pill;
+            background-color: var(--color-background-attention-default);
+            color: $color-black;
+            padding: 2px 4px;
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
@@ -94,11 +94,11 @@
         }
 
         &-privilege-review {
-            font-size: 10px;
-            font-weight: $font-weight-semi-bold;
-            border-radius: $border-radius-pill;
+            font-size: 0.625rem;
+            font-weight: var(--font-weight-semi-bold);
+            border-radius: var(--border-radius-l);
             background-color: var(--color-background-attention-default);
-            color: $color-black;
+            color: var(--color-black);
             padding: 2px 4px;
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
@@ -111,6 +111,7 @@ async function createWrapper(extension) {
                 shopwareExtensionService: Shopware.Service('shopwareExtensionService'),
                 extensionErrorService: Shopware.Service('extensionErrorService'),
                 cacheApiService: {},
+                appPrivilegesService: {},
                 shortcutService: {
                     stopEventListener: () => {},
                     startEventListener: () => {},

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-self-maintained-extension-card/sw-self-maintained-extension-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-self-maintained-extension-card/sw-self-maintained-extension-card.spec.js
@@ -38,6 +38,7 @@ async function createWrapper() {
                     extensionStoreActionService: {
                         downloadExtension: jest.fn(),
                     },
+                    appPrivilegesService: {},
                 },
             },
             props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/index.js
@@ -274,7 +274,7 @@ export default {
         },
 
         reviewPrivilegeRequests() {
-            this.privilegeModalActionLabel = this.$tc(
+            this.privilegeModalActionLabel = this.$t(
                 'sw-extension-store.component.sw-extension-card-base.labelAcceptRequestedPrivileges',
             );
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/index.js
@@ -10,10 +10,15 @@ export default {
 
     inject: ['shopwareExtensionService'],
 
+    mixins: ['sw-extension-error'],
+
     data() {
         return {
             filterByActiveState: false,
             sortingOption: 'updated-at',
+            extensionToReview: null,
+            showExtensionReviewModal: false,
+            privilegeModalActionLabel: null,
         };
     },
 
@@ -61,6 +66,16 @@ export default {
 
                 return label.toLowerCase().includes(searchTerm) || name.toLowerCase().includes(searchTerm);
             });
+        },
+
+        extensionListWithRequestedPrivileges() {
+            return this.extensionList.filter((extension) => {
+                return Object.keys(extension.requestedPermissions).length;
+            });
+        },
+
+        hasPrivilegeRequests() {
+            return this.extensionListWithRequestedPrivileges.length > 0;
         },
 
         isAppRoute() {
@@ -256,6 +271,48 @@ export default {
             return extensions.filter((extension) => {
                 return extension.active;
             });
+        },
+
+        reviewPrivilegeRequests() {
+            this.privilegeModalActionLabel = this.$tc(
+                'sw-extension-store.component.sw-extension-card-base.labelAcceptRequestedPrivileges',
+            );
+
+            if (this.extensionListWithRequestedPrivileges.length) {
+                this.extensionToReview = this.extensionListWithRequestedPrivileges[0];
+                this.showExtensionReviewModal = true;
+            } else {
+                this.shopwareExtensionService.updateExtensionData();
+            }
+        },
+
+        closePrivilegeReviewModal() {
+            this.privilegeModalActionLabel = null;
+            this.extensionToReview = null;
+            this.showExtensionReviewModal = false;
+        },
+
+        async acceptAndCheckNext() {
+            const extension = this.extensionToReview;
+            this.closePrivilegeReviewModal();
+
+            await this.acceptRequestedPrivileges(extension);
+
+            this.reviewPrivilegeRequests();
+        },
+
+        async acceptRequestedPrivileges(extension) {
+            try {
+                await this.shopwareExtensionService.acceptRequestedPrivilegesForExtension(
+                    extension.name,
+                    extension.type,
+                    extension.requestedPermissions,
+                );
+
+                extension.requestedPermissions = {};
+            } catch (e) {
+                this.showExtensionErrors(e);
+            }
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
@@ -49,12 +49,12 @@
             v-if="hasPrivilegeRequests"
             class="sw-extension-my-extensions-listing__privilege-request-warning"
             variant="attention"
-            :title="$tc('sw-app.component.sw-app-privilege-request-banner.title')"
+            :title="$t('sw-app.component.sw-app-privilege-request-banner.title')"
         >
 
             <template #default>
                 <div>
-                    {{ $tc('sw-app.component.sw-app-privilege-request-banner.explanation', extensionListWithRequestedPrivileges.length) }}
+                    {{ $t('sw-app.component.sw-app-privilege-request-banner.explanation', extensionListWithRequestedPrivileges.length) }}
                 </div>
 
                 <mt-button
@@ -64,7 +64,7 @@
                     ghost
                     @click="reviewPrivilegeRequests"
                 >
-                    {{ $tc('sw-app.component.sw-app-privilege-request-banner.reviewButton') }}
+                    {{ $t('sw-app.component.sw-app-privilege-request-banner.reviewButton') }}
                 </mt-button>
             </template>
         </mt-banner>

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
@@ -45,6 +45,30 @@
             </mt-link>
         </mt-banner>
 
+        <mt-banner
+            v-if="hasPrivilegeRequests"
+            class="sw-extension-my-extensions-listing__privilege-request-warning"
+            variant="attention"
+            :title="$tc('sw-app.component.sw-app-privilege-request-banner.title')"
+        >
+
+            <template #default>
+                <div>
+                    {{ $tc('sw-app.component.sw-app-privilege-request-banner.explanation', extensionListWithRequestedPrivileges.length) }}
+                </div>
+
+                <mt-button
+                    variant="secondary"
+                    size="x-small"
+                    class="sw-extension-my-extensions-listing__privilege-request-warning__review-button"
+                    ghost
+                    @click="reviewPrivilegeRequests"
+                >
+                    {{ $tc('sw-app.component.sw-app-privilege-request-banner.reviewButton') }}
+                </mt-button>
+            </template>
+        </mt-banner>
+
         {% block sw_extension_my_extensions_list_empty_state %}
 
         <sw-meteor-card
@@ -132,4 +156,14 @@
             </div>
         </template>
     </div>
+
+    <sw-extension-permissions-modal
+        v-if="showExtensionReviewModal"
+        :extension-label="extensionToReview.label"
+        :permissions="extensionToReview.requestedPermissions"
+        :domains="extensionToReview.domains"
+        :action-label="privilegeModalActionLabel"
+        @modal-close="closePrivilegeReviewModal"
+        @close-with-action="acceptAndCheckNext"
+    />
 </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.scss
@@ -41,7 +41,7 @@
 
         .sw-extension-my-extensions-listing__privilege-request-warning {
             max-width: 960px;
-            margin-bottom: 32px;
+            margin-bottom: var(--scale-size-32);
 
             .sw-extension-my-extensions-listing__privilege-request-warning__review-button {
                 margin-top: var(--scale-size-8);

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.scss
@@ -38,6 +38,15 @@
             max-width: 960px;
             margin-bottom: 32px;
         }
+
+        .sw-extension-my-extensions-listing__privilege-request-warning {
+            max-width: 960px;
+            margin-bottom: 32px;
+
+            .sw-extension-my-extensions-listing__privilege-request-warning__review-button {
+                margin-top: var(--scale-size-8);
+            }
+        }
     }
 
     &-empty-state {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.spec.js
@@ -71,6 +71,9 @@ async function createWrapper() {
                     'sw-help-text': true,
                     'sw-loader': true,
                     'sw-extension-component-section': true,
+                    'sw-extension-permissions-modal': {
+                        template: '<div class="sw-extension-permissions-modal"><slot></slot></div>',
+                    },
                 },
                 provide: {
                     repositoryFactory: {
@@ -91,8 +94,6 @@ async function createWrapper() {
  */
 describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () => {
     beforeAll(() => {
-        Shopware.Store.get('shopwareExtensions').setMyExtensions([{ name: 'Test', installedAt: null }]);
-
         if (Shopware.Store.get('context')) {
             Shopware.Store.unregister('context');
         }
@@ -119,6 +120,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
             {
                 name: 'Test',
                 installedAt: null,
+                requestedPermissions: {},
             },
         ]);
     });
@@ -193,6 +195,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
                 name: 'Test',
                 installedAt: 'some date',
                 isTheme: true,
+                requestedPermissions: {},
             },
         ]);
 
@@ -229,6 +232,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
                     name: `extension card number ${i}`,
                     installedAt: `foo-${i}`,
                     updatedAt: null,
+                    requestedPermissions: {},
                 };
             });
 
@@ -268,6 +272,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
                     name: `extension card number ${i}`,
                     installedAt: `foo-${i}`,
                     updatedAt: null,
+                    requestedPermissions: {},
                 };
             });
 
@@ -307,6 +312,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
                     installedAt: `foo-${i}`,
                     active: true,
                     updatedAt: null,
+                    requestedPermissions: {},
                 };
             });
 
@@ -320,6 +326,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
                     installedAt: `foo-${index}`,
                     active: false,
                     updatedAt: null,
+                    requestedPermissions: {},
                 };
             });
 
@@ -355,6 +362,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
                 installedAt: `foo-${i}`,
                 active: true,
                 updatedAt: null,
+                requestedPermissions: {},
             };
         });
 
@@ -396,6 +404,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
                 installedAt: `foo-${i}`,
                 active: true,
                 updatedAt: null,
+                requestedPermissions: {},
             };
         });
 
@@ -437,6 +446,7 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
                 installedAt: `foo-${i}`,
                 updatedAt: { date: updatedAtValue },
                 active: true,
+                requestedPermissions: {},
             };
         });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/index.ts
@@ -4,6 +4,7 @@ import type { App } from 'vue';
 import ExtensionStoreActionService from './extension-store-action.service';
 import ShopwareExtensionService from './shopware-extension.service';
 import ExtensionErrorService from './extension-error.service';
+import type { NotificationType, NotificationVariant } from '../../../app/store/notification.store';
 
 const { Application } = Shopware;
 
@@ -31,6 +32,7 @@ Application.addServiceProvider('shopwareExtensionService', () => {
         Shopware.Service('extensionStoreActionService'),
         Shopware.Service('shopwareDiscountCampaignService'),
         Shopware.Service('storeService'),
+        Shopware.Service('appPrivilegesService'),
     );
 });
 
@@ -73,3 +75,23 @@ Application.addServiceProvider('extensionErrorService', () => {
         },
     );
 });
+
+Shopware.Store.get('notification').registerTransformer(
+    'notification.privileges.requested',
+    (notification: NotificationType): NotificationType => {
+        const root = Shopware.Application.getApplicationRoot() as App<Element>;
+
+        return {
+            ...notification,
+            variant: 'warning' as NotificationVariant,
+            title: root.$tc('sw-extension.notifications.reviewPrivilegeRequests.title'),
+            message: root.$tc('sw-extension.notifications.reviewPrivilegeRequests.message'),
+            actions: [
+                {
+                    label: root.$tc('sw-extension.notifications.reviewPrivilegeRequests.action'),
+                    route: { name: 'sw.extension.my-extensions.listing' },
+                },
+            ],
+        };
+    },
+);

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/index.ts
@@ -84,11 +84,11 @@ Shopware.Store.get('notification').registerTransformer(
         return {
             ...notification,
             variant: 'warning' as NotificationVariant,
-            title: root.$tc('sw-extension.notifications.reviewPrivilegeRequests.title'),
-            message: root.$tc('sw-extension.notifications.reviewPrivilegeRequests.message'),
+            title: root.$t('sw-extension.notifications.reviewPrivilegeRequests.title'),
+            message: root.$t('sw-extension.notifications.reviewPrivilegeRequests.message'),
             actions: [
                 {
-                    label: root.$tc('sw-extension.notifications.reviewPrivilegeRequests.action'),
+                    label: root.$t('sw-extension.notifications.reviewPrivilegeRequests.action'),
                     route: { name: 'sw.extension.my-extensions.listing' },
                 },
             ],

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.ts
@@ -1,6 +1,7 @@
 import type { RouteLocationNamedRaw, RouteLocation } from 'vue-router';
 import type { AppModulesService, AppModuleDefinition } from 'src/core/service/api/app-modules.service';
 import type StoreApiService from 'src/core/service/api/store.api.service';
+import type AppPrivilegesService from 'src/core/service/api/app-privileges.service';
 import type { ShopwareDiscountCampaignService } from 'src/app/service/discount-campaign.service';
 import type {
     ExtensionStoreActionService,
@@ -22,6 +23,9 @@ interface LabeledLocation extends RouteLocation {
     label: string | null;
 }
 
+type PermissionEntry = { entity: string; operation: string };
+type PermissionsMap = Record<string, PermissionEntry[]>;
+
 /**
  * @sw-package checkout
  * @private
@@ -36,6 +40,7 @@ export default class ShopwareExtensionService {
         private readonly extensionStoreActionService: ExtensionStoreActionService,
         private readonly discountCampaignService: ShopwareDiscountCampaignService,
         private readonly storeApiService: StoreApiService,
+        private readonly appPrivilegesService: AppPrivilegesService,
     ) {
         this.EXTENSION_VARIANT_TYPES = Object.freeze({
             RENT: 'rent',
@@ -269,5 +274,23 @@ export default class ShopwareExtensionService {
         return valueTypes.map((type) => {
             return variants[type.index];
         });
+    }
+
+    public async acceptRequestedPrivilegesForExtension(
+        extensionName: string,
+        type: ExtensionType,
+        permissions: PermissionsMap,
+    ): Promise<void> {
+        if (type !== this.EXTENSION_TYPES.APP) {
+            return;
+        }
+
+        await this.appPrivilegesService.acceptPrivileges(extensionName, this.flattenPermissions(permissions));
+    }
+
+    private flattenPermissions(permissions: PermissionsMap): string[] {
+        return Object.values(permissions)
+            .flat()
+            .map(({ entity, operation }) => `${entity}:${operation}`);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de.json
@@ -23,7 +23,8 @@
           }
         },
         "version": "Version",
-        "update": "Aktualisierung"
+        "update": "Aktualisierung",
+        "privilege-review": "Neue berechtigungen"
       },
       "account": {
         "headline": "Shopware Account",
@@ -255,6 +256,8 @@
         "openExtensionLabel": "Öffnen",
         "installExtensionLabel": "Installieren",
         "labelAcceptAndInstall": "Akzeptieren und installieren",
+        "reviewNewPrivilegesLabel": "Überprüfen",
+        "labelAcceptRequestedPrivileges": "Akzeptieren",
         "allowDisableTooltip": "Diese App verwendet eigene Datenstrukturen, die sich auf Ihr System auswirken. Die App kann daher nicht deaktiviert werden.",
         "contextMenu": {
           "getHelpLabel": "Hilfe anfragen",

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/en.json
@@ -23,7 +23,8 @@
           }
         },
         "version": "Version",
-        "update": "Update"
+        "update": "Update",
+        "privilege-review": "New permissions"
       },
       "account": {
         "headline": "Shopware Account",
@@ -86,6 +87,13 @@
         "title": "Shopware Account session expired",
         "message": "Please log in to access your licensed extensions.",
         "actionLabel": "Login"
+      }
+    },
+    "notifications": {
+      "reviewPrivilegeRequests": {
+        "title": "New permissions requested",
+        "message": "One or more extensions requires new permissions to be updated. Please review the new permissions to continue.",
+        "action": "Review permissions"
       }
     },
     "mainMenu": {
@@ -255,6 +263,8 @@
         "openExtensionLabel": "Open",
         "installExtensionLabel": "Install",
         "labelAcceptAndInstall": "Accept and install",
+        "reviewNewPrivilegesLabel": "Review",
+        "labelAcceptRequestedPrivileges": "Accept",
         "allowDisableTooltip": "This app uses its own data structures, that affect your system. Therefore, the app cannot be deactivated.",
         "contextMenu": {
           "getHelpLabel": "Get help",

--- a/src/Core/Framework/App/Event/AppsUpdatedEvent.php
+++ b/src/Core/Framework/App/Event/AppsUpdatedEvent.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[Package('framework')]
+class AppsUpdatedEvent extends Event implements ShopwareEvent
+{
+    final public const NAME = 'apps.updated';
+
+    /**
+     * @param array<string> $appIds
+     */
+    public function __construct(
+        public readonly array $appIds,
+        private readonly Context $context,
+    ) {
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Framework/App/Lifecycle/Update/AppUpdater.php
+++ b/src/Core/Framework/App/Lifecycle/Update/AppUpdater.php
@@ -2,7 +2,9 @@
 
 namespace Shopware\Core\Framework\App\Lifecycle\Update;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\Event\AppsUpdatedEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -27,7 +29,8 @@ class AppUpdater extends AbstractAppUpdater
         private readonly AbstractExtensionDataProvider $extensionDataProvider,
         private readonly EntityRepository $appRepo,
         private readonly ExtensionDownloader $downloader,
-        private readonly AbstractStoreAppLifecycleService $appLifecycle
+        private readonly AbstractStoreAppLifecycleService $appLifecycle,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -37,6 +40,7 @@ class AppUpdater extends AbstractAppUpdater
         $extensions = $extensions->filterByType(ExtensionStruct::EXTENSION_TYPE_APP);
 
         $outdatedApps = [];
+        $updatedApps = [];
 
         foreach ($extensions as $extension) {
             $id = $extension->getLocalId();
@@ -62,9 +66,15 @@ class AppUpdater extends AbstractAppUpdater
 
             try {
                 $this->appLifecycle->updateExtension($app->getName(), false, $context);
+                $updatedApps[] = $app->getLocalId();
             } catch (ExtensionUpdateRequiresConsentAffirmationException) {
                 // Ignore updates that require consent
             }
+        }
+
+        /** @var list<string> $updatedApps */
+        if (!empty($updatedApps)) {
+            $this->eventDispatcher->dispatch(new AppsUpdatedEvent($updatedApps, $context));
         }
     }
 

--- a/src/Core/Framework/App/Subscriber/AppPrivilegesRequestedSubscriber.php
+++ b/src/Core/Framework/App/Subscriber/AppPrivilegesRequestedSubscriber.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Subscriber;
+
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Event\AppsUpdatedEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Notification\NotificationService;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+class AppPrivilegesRequestedSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param EntityRepository<AppCollection> $appRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $appRepository,
+        private readonly NotificationService $notificationService
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            AppsUpdatedEvent::class => 'onAppsUpdated',
+        ];
+    }
+
+    public function onAppsUpdated(AppsUpdatedEvent $event): void
+    {
+        if (\count($event->appIds) === 0) {
+            return;
+        }
+
+        $apps = $this->appRepository->search(new Criteria($event->appIds), $event->getContext())->getEntities();
+
+        $numAppsWithRequestedPrivileges = $apps->filter(fn (AppEntity $app) => \count($app->getRequestedPrivileges()) > 0)->count();
+
+        if ($numAppsWithRequestedPrivileges === 0) {
+            return;
+        }
+
+        $this->notificationService->createNotification(
+            [
+                'id' => Uuid::randomHex(),
+                'status' => 'warning',
+                'message' => 'notification.privileges.requested',
+                'adminOnly' => true,
+                'requiredPrivileges' => [],
+            ],
+            $event->getContext()
+        );
+    }
+}

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -298,6 +298,7 @@
             <argument type="service" id="app.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Store\Services\ExtensionDownloader"/>
             <argument type="service" id="Shopware\Core\Framework\Store\Services\AbstractStoreAppLifecycleService"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\ScheduledTask\UpdateAppsTask">

--- a/src/Core/Framework/Store/Struct/ExtensionStruct.php
+++ b/src/Core/Framework/Store/Struct/ExtensionStruct.php
@@ -425,10 +425,23 @@ class ExtensionStruct extends Struct
         return $this->permissions->getCategorizedPermissions();
     }
 
+    /**
+     * @return array<string, PermissionCollection>
+     */
+    public function getCategorizedRequestedPermissions(): array
+    {
+        if ($this->requestedPermissions === null) {
+            return [];
+        }
+
+        return $this->requestedPermissions->getCategorizedPermissions();
+    }
+
     public function jsonSerialize(): array
     {
         $vars = get_object_vars($this);
         $vars['permissions'] = $this->getCategorizedPermissions();
+        $vars['requestedPermissions'] = $this->getCategorizedRequestedPermissions();
 
         return $vars;
     }

--- a/tests/unit/Core/Framework/App/Lifecycle/Update/AppUpdaterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Update/AppUpdaterTest.php
@@ -1,0 +1,155 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Update;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Event\AppsUpdatedEvent;
+use Shopware\Core\Framework\App\Lifecycle\Update\AppUpdater;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
+use Shopware\Core\Framework\Store\Services\AbstractStoreAppLifecycleService;
+use Shopware\Core\Framework\Store\Services\ExtensionDownloader;
+use Shopware\Core\Framework\Store\Struct\ExtensionCollection;
+use Shopware\Core\Framework\Store\Struct\ExtensionStruct;
+use Shopware\Core\Framework\Store\Struct\PluginDownloadDataStruct;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+
+/**
+ * @internal
+ */
+#[CoversClass(AppUpdater::class)]
+class AppUpdaterTest extends TestCase
+{
+    private IdsCollection $ids;
+
+    private Context $context;
+
+    private CollectingEventDispatcher $eventDispatcher;
+
+    private AbstractExtensionDataProvider&MockObject $extensionDataProvider;
+
+    private ExtensionDownloader&MockObject $downloader;
+
+    private AbstractStoreAppLifecycleService&MockObject $appLifecycle;
+
+    protected function setUp(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->context = Context::createDefaultContext();
+        $this->eventDispatcher = new CollectingEventDispatcher();
+        $this->extensionDataProvider = $this->createMock(AbstractExtensionDataProvider::class);
+        $this->downloader = $this->createMock(ExtensionDownloader::class);
+        $this->appLifecycle = $this->createMock(AbstractStoreAppLifecycleService::class);
+    }
+
+    public function testEventIsDispatchedWhenAppsAreUpdated(): void
+    {
+        $extension1 = $this->createExtension('app1', $this->ids->get('app1'), '1.0.0', '2.0.0');
+        $extension2 = $this->createExtension('app2', $this->ids->get('app2'), '1.5.0', '2.5.0');
+
+        $this->extensionDataProvider->expects($this->once())
+            ->method('getInstalledExtensions')
+            ->with($this->context, true)
+            ->willReturn(new ExtensionCollection([$extension1, $extension2]));
+
+        $app1 = new AppEntity();
+        $app1->setId($this->ids->get('app1'));
+        $app1->setName('app1');
+        $app1->setVersion('1.0.0');
+
+        $app2 = new AppEntity();
+        $app2->setId($this->ids->get('app2'));
+        $app2->setName('app2');
+        $app2->setVersion('1.5.0');
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app1]),
+            new AppCollection([$app2]),
+        ]);
+
+        $this->downloader->expects($this->exactly(2))
+            ->method('download')
+            ->willReturnCallback(function (string $name) use ($extension1, $extension2): PluginDownloadDataStruct {
+                static::assertContains($name, [$extension1->getName(), $extension2->getName()]);
+
+                return new PluginDownloadDataStruct();
+            });
+
+        $this->appLifecycle->expects($this->exactly(2))
+            ->method('updateExtension')
+            ->willReturnCallback(function (string $name, bool $requireConsent) use ($extension1, $extension2): void {
+                static::assertContains($name, [$extension1->getName(), $extension2->getName()]);
+                static::assertFalse($requireConsent);
+            });
+
+        $appUpdater = new AppUpdater(
+            $this->extensionDataProvider,
+            $appRepo,
+            $this->downloader,
+            $this->appLifecycle,
+            $this->eventDispatcher
+        );
+
+        $appUpdater->updateApps($this->context);
+
+        $events = $this->eventDispatcher->getEvents();
+        static::assertCount(1, $events);
+        static::assertInstanceOf(AppsUpdatedEvent::class, $events[0]);
+
+        static::assertSame(array_values($this->ids->getList(['app1', 'app2'])), $events[0]->appIds);
+    }
+
+    public function testEventIsNotDispatchedWhenNoAppsAreUpdated(): void
+    {
+        $extension = $this->createExtension('app1', $this->ids->get('app1'), '1.0.0', '1.0.0');
+
+        $this->extensionDataProvider->expects($this->once())
+            ->method('getInstalledExtensions')
+            ->with($this->context, true)
+            ->willReturn(new ExtensionCollection([$extension]));
+
+        $app = new AppEntity();
+        $app->setId($this->ids->get('app1'));
+        $app->setName('app1');
+        $app->setVersion('1.0.0');
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app]),
+        ]);
+
+        $this->downloader->expects($this->never())->method('download');
+        $this->appLifecycle->expects($this->never())->method('updateExtension');
+
+        $appUpdater = new AppUpdater(
+            $this->extensionDataProvider,
+            $appRepo,
+            $this->downloader,
+            $this->appLifecycle,
+            $this->eventDispatcher
+        );
+
+        $appUpdater->updateApps($this->context);
+
+        static::assertCount(0, $this->eventDispatcher->getEvents());
+    }
+
+    private function createExtension(string $name, string $id, string $currentVersion, string $latestVersion): ExtensionStruct
+    {
+        $extension = new ExtensionStruct();
+        $extension->setName($name);
+        $extension->setLocalId($id);
+        $extension->setType(ExtensionStruct::EXTENSION_TYPE_APP);
+        $extension->setVersion($currentVersion);
+        $extension->setLatestVersion($latestVersion);
+
+        return $extension;
+    }
+}

--- a/tests/unit/Core/Framework/App/Subscriber/AppPrivilegesRequestedSubscriberTest.php
+++ b/tests/unit/Core/Framework/App/Subscriber/AppPrivilegesRequestedSubscriberTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Event\AppsUpdatedEvent;
+use Shopware\Core\Framework\App\Subscriber\AppPrivilegesRequestedSubscriber;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Notification\NotificationService;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[CoversClass(AppPrivilegesRequestedSubscriber::class)]
+class AppPrivilegesRequestedSubscriberTest extends TestCase
+{
+    private NotificationService&MockObject $notificationService;
+
+    protected function setUp(): void
+    {
+        $this->notificationService = $this->createMock(NotificationService::class);
+    }
+
+    public function testNotificationIsNotCreatedWhenNoAppsAreUpdated(): void
+    {
+        /** @var StaticEntityRepository<AppCollection> $appRepository */
+        $appRepository = new StaticEntityRepository([]);
+
+        $this->notificationService->expects($this->never())
+            ->method('createNotification');
+
+        $subscriber = new AppPrivilegesRequestedSubscriber($appRepository, $this->notificationService);
+
+        $event = new AppsUpdatedEvent([], Context::createDefaultContext());
+        $subscriber->onAppsUpdated($event);
+    }
+
+    public function testNotificationIsNotCreatedWhenNoPrivilegesRequested(): void
+    {
+        $appId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $app = new AppEntity();
+        $app->setId($appId);
+        $app->setRequestedPrivileges([]);
+
+        /** @var StaticEntityRepository<AppCollection> $appRepository */
+        $appRepository = new StaticEntityRepository([new AppCollection([$app])]);
+
+        $this->notificationService->expects($this->never())
+            ->method('createNotification');
+
+        $subscriber = new AppPrivilegesRequestedSubscriber($appRepository, $this->notificationService);
+
+        $event = new AppsUpdatedEvent([$appId], $context);
+        $subscriber->onAppsUpdated($event);
+    }
+
+    public function testNotificationIsCreatedWhenAppsRequestPrivileges(): void
+    {
+        $appId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $app = new AppEntity();
+        $app->setId($appId);
+        $app->setRequestedPrivileges(['read:product', 'write:product']);
+
+        /** @var StaticEntityRepository<AppCollection> $appRepository */
+        $appRepository = new StaticEntityRepository([new AppCollection([$app])]);
+
+        $this->notificationService->expects($this->once())
+            ->method('createNotification')
+            ->with(
+                static::callback(function (array $data) {
+                    return isset($data['id'])
+                        && $data['status'] === 'warning'
+                        && $data['message'] === 'notification.privileges.requested'
+                        && $data['adminOnly'] === true
+                        && $data['requiredPrivileges'] === [];
+                }),
+                $context
+            );
+
+        $subscriber = new AppPrivilegesRequestedSubscriber($appRepository, $this->notificationService);
+
+        $event = new AppsUpdatedEvent([$appId], $context);
+        $subscriber->onAppsUpdated($event);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

This is a WIP for the implementation of the "Decouple app permissions from app update process" https://github.com/shopware/shopware/discussions/7437.

<img width="1085" height="505" alt="Screenshot 2025-12-02 at 16 52 42" src="https://github.com/user-attachments/assets/306dad18-d78c-4aca-9d7d-aa2ab0fbf708" />


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
