### PR TITLE
fix: MariaDB syntax in DELETE statement in ProductSubscriber

### DIFF
--- a/src/Core/Content/Product/Subscriber/ProductSubscriber.php
+++ b/src/Core/Content/Product/Subscriber/ProductSubscriber.php
@@ -207,16 +207,16 @@ class ProductSubscriber implements EventSubscriberInterface
 
         // Clean up configurator settings for parents that no longer have variants using those options
         $this->connection->executeStatement(
-            'DELETE FROM product_configurator_setting pcs
-             WHERE pcs.product_id IN (:parentIds)
-             AND pcs.product_version_id = :versionId
+            'DELETE FROM product_configurator_setting
+             WHERE product_configurator_setting.product_id IN (:parentIds)
+             AND product_configurator_setting.product_version_id = :versionId
              AND NOT EXISTS (
                  SELECT 1
                  FROM product_option po
                  INNER JOIN product p ON p.id = po.product_id AND p.version_id = po.product_version_id
-                 WHERE p.parent_id = pcs.product_id
+                 WHERE p.parent_id = product_configurator_setting.product_id
                      AND p.version_id = :versionId
-                     AND po.property_group_option_id = pcs.property_group_option_id
+                     AND po.property_group_option_id = product_configurator_setting.property_group_option_id
                      AND po.product_version_id = :versionId
              )',
             [


### PR DESCRIPTION
### 1. Why is this change necessary?

This [commit](https://github.com/shopware/shopware/commit/fd8d804703cbedc95f8685eb38dfbb6f4fcd8179) introduced a `DELETE` statement with a table alias. This fails with MariaDB. Even though the [documentation](https://mariadb.com/docs/server/reference/sql-statements/data-manipulation/changing-deleting-data/delete) is not clear on this, you find similar issues reports online (e.g. [stack overflow](https://stackoverflow.com/questions/47457748/mariadb-delete-row-by-using-table-alias-doesn%C2%B4t-work)).

The execution results in this error:
```
│ Doctrine\DBAL\Exception\SyntaxErrorException: An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'pcs
│              WHERE pcs.product_id IN ('\0001??HF`qH???Y??U?')
│              AN...' at line 1
│
│ /home/runner/work/shopware-plugins/shopware-plugins/shopware-projects/plugin-integration-test/vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:78
│ /home/runner/work/shopware-plugins/shopware-plugins/shopware-projects/plugin-integration-test/vendor/doctrine/dbal/src/Connection.php:1456
│ /home/runner/work/shopware-plugins/shopware-plugins/shopware-projects/plugin-integration-test/vendor/doctrine/dbal/src/Connection.php:1392
│ /home/runner/work/shopware-plugins/shopware-plugins/shopware-projects/plugin-integration-test/vendor/doctrine/dbal/src/Connection.php:911
│ /home/runner/work/shopware-plugins/shopware-plugins/shopware-projects/plugin-integration-test/vendor/shopware/platform/src/Core/Content/Product/Subscriber/ProductSubscriber.php:209
...
```

You can reproduct this synthetically with this basic DELETE statement (the id value does not matter):
```
DELETE FROM product p WHERE p.id = UNHEX("019ae334b9557364a46e38a4568312a4");
```
However, _this_ does not fail:
```
DELETE FROM product WHERE product.id = UNHEX("019ae334b9557364a46e38a4568312a4");
```

### 2. What does this change do, exactly?

This PR removes the table alias from the `DELETE` statement to fix the syntax error.

### 3. Describe each step to reproduce the issue or behaviour.

Setup a shopware project with MariaDB 10.11.15
Create products with parent-child relations
Delete a product to trigger `ProductSubscriber:: cleanupConfiguratorSettings()`

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/13808

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Not sure if this checklist applies to this quick-fix. Please let me know if you want me to add changelog etc.
