### PR TITLE
Feat: product analytics auth with fetch interception

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,7 @@ services:
             MAILER_DSN: smtp://mailer:1025
             OPENSEARCH_URL: http://opensearch:9200
             ADMIN_OPENSEARCH_URL: http://opensearch:9200
+            PRODUCT_ANALYTICS_GATEWAY_URL: ${PRODUCT_ANALYTICS_GATEWAY_URL-https://product-analytics.staging.shopware.io}
         volumes:
             - .:/var/www/html
         depends_on:

--- a/devenv.nix
+++ b/devenv.nix
@@ -150,4 +150,7 @@ in {
 
   # Service Registry
   env.SERVICE_REGISTRY_URL = lib.mkDefault "https://registry.staging-services.shopware.io";
+
+  # Product Analytics Gateway
+  env.PRODUCT_ANALYTICS_GATEWAY_URL = lib.mkDefault "https://product-analytics.staging.shopware.io";
 }

--- a/src/Administration/Controller/AdministrationController.php
+++ b/src/Administration/Controller/AdministrationController.php
@@ -87,6 +87,7 @@ class AdministrationController extends AbstractController
         private readonly string $serviceRegistryUrl,
         private readonly EntityRepository $languageRepository,
         private readonly SymfonyBearerTokenValidator $tokenValidator,
+        private readonly string $analyticsGatewayUrl,
         private readonly string $refreshTokenTtl = 'P1W',
     ) {
         // param is only available if the elasticsearch bundle is enabled
@@ -126,6 +127,7 @@ class AdministrationController extends AbstractController
             'refreshTokenTtl' => $refreshTokenTtl * 1000,
             'serviceRegistryUrl' => $this->serviceRegistryUrl,
             'productStreamIndexingEnabled' => $this->productStreamIndexingEnabled,
+            'analyticsGatewayUrl' => $this->analyticsGatewayUrl,
         ]);
     }
 

--- a/src/Administration/Resources/app/administration/index.html
+++ b/src/Administration/Resources/app/administration/index.html
@@ -23,6 +23,7 @@
                 adminEsEnable: false,
                 storefrontEsEnable: false,
                 productStreamIndexingEnabled: true,
+                analyticsGatewayUrl: '<%- analyticsGatewayUrl %>',
             },
             apiContext: {
                 host: 'localhost',

--- a/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
@@ -51,6 +51,7 @@ export interface ContextState {
         systemCurrencyISOCode: null | string;
         systemCurrencyId: null | string;
         windowId: null | string;
+        analyticsGatewayUrl: null | string;
     };
     api: {
         apiPath: null | string;
@@ -96,6 +97,7 @@ const state: ContextState = reactive({
         systemCurrencyId: null,
         systemCurrencyISOCode: null,
         windowId: null,
+        analyticsGatewayUrl: null,
     },
     api: {
         apiPath: null,

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -2,10 +2,7 @@
  * @sw-package framework
  */
 import * as amplitude from '@amplitude/analytics-browser';
-import type { BaseEvent, TransportType, Transport, Payload, Response } from '@amplitude/analytics-core';
 import { string } from 'src/core/service/util.service';
-import { SendBeaconTransport } from '@amplitude/analytics-browser/lib/esm/transports/send-beacon';
-import { BaseTransport } from '@amplitude/analytics-core';
 import type { TelemetryEvent, EventTypes, TrackableType } from '../../core/telemetry/types';
 
 /**
@@ -55,7 +52,7 @@ export default async function (): Promise<void> {
 
     // check for consent
 
-    const amp = amplitude.init('placeholder-apikey', undefined, {
+    amplitude.init('a04bb926f471ce883bc219814fc9577', undefined, {
         autocapture: false,
         serverZone: 'EU',
         appVersion: Shopware.Store.get('context').app.config.version as string,
@@ -65,39 +62,8 @@ export default async function (): Promise<void> {
             platform: false,
         },
         fetchRemoteConfig: false,
-        serverUrl: 'http://localhost:8080/event',
-        transportProvider: (transport?: TransportType): Transport => {
-            if (transport === 'beacon') {
-                return new SendBeaconTransport();
-            }
-
-            return new class extends BaseTransport implements Transport {
-                async send(serverUrl: string, payload: Payload): Promise<Response | null> {
-                    const token = await Shopware.Service('analyticsService').getToken()
-
-                    const options: RequestInit = {
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'Authorisation': `Bearer ${token.token}`,
-                            Accept: '*/*',
-                        },
-                        body: JSON.stringify(payload),
-                        method: 'POST',
-                    };
-                    const response = await fetch(serverUrl, options);
-                    const responseText = await response.text();
-                    try {
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                        return this.buildResponse(JSON.parse(responseText));
-                    } catch {
-                        return this.buildResponse({ code: response.status });
-                    }
-                }
-            }
-        },
+        // serverUrl: use proxy server url here, e.g. usage-data.shopware.io/product-analytics,
     });
-
-
 
     // eslint-disable-next-line listeners/no-missing-remove-event-listener
     Shopware.Utils.EventBus.on('telemetry', pushTelemetryEventToAmplitude);

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -2,7 +2,10 @@
  * @sw-package framework
  */
 import * as amplitude from '@amplitude/analytics-browser';
+import type { BaseEvent, TransportType, Transport, Payload, Response } from '@amplitude/analytics-core';
 import { string } from 'src/core/service/util.service';
+import { SendBeaconTransport } from '@amplitude/analytics-browser/lib/esm/transports/send-beacon';
+import { BaseTransport } from '@amplitude/analytics-core';
 import type { TelemetryEvent, EventTypes, TrackableType } from '../../core/telemetry/types';
 
 /**
@@ -52,7 +55,7 @@ export default async function (): Promise<void> {
 
     // check for consent
 
-    amplitude.init('a04bb926f471ce883bc219814fc9577', undefined, {
+    const amp = amplitude.init('placeholder-apikey', undefined, {
         autocapture: false,
         serverZone: 'EU',
         appVersion: Shopware.Store.get('context').app.config.version as string,
@@ -62,8 +65,39 @@ export default async function (): Promise<void> {
             platform: false,
         },
         fetchRemoteConfig: false,
-        // serverUrl: use proxy server url here, e.g. usage-data.shopware.io/product-analytics,
+        serverUrl: 'http://localhost:8080/event',
+        transportProvider: (transport?: TransportType): Transport => {
+            if (transport === 'beacon') {
+                return new SendBeaconTransport();
+            }
+
+            return new class extends BaseTransport implements Transport {
+                async send(serverUrl: string, payload: Payload): Promise<Response | null> {
+                    const token = await Shopware.Service('analyticsService').getToken()
+
+                    const options: RequestInit = {
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Authorisation': `Bearer ${token.token}`,
+                            Accept: '*/*',
+                        },
+                        body: JSON.stringify(payload),
+                        method: 'POST',
+                    };
+                    const response = await fetch(serverUrl, options);
+                    const responseText = await response.text();
+                    try {
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                        return this.buildResponse(JSON.parse(responseText));
+                    } catch {
+                        return this.buildResponse({ code: response.status });
+                    }
+                }
+            }
+        },
     });
+
+
 
     // eslint-disable-next-line listeners/no-missing-remove-event-listener
     Shopware.Utils.EventBus.on('telemetry', pushTelemetryEventToAmplitude);

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -50,6 +50,31 @@ export default async function (): Promise<void> {
         },
     });
 
+    const originalFetch = globalThis.fetch;
+    const analyticsGatewayUrl = Shopware.Store.get('context').app.analyticsGatewayUrl;
+    const eventUrl = `${analyticsGatewayUrl}/event`;
+
+    globalThis.fetch = async function(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+        if (url.includes(eventUrl)) {
+            let tokenData;
+            try {
+                tokenData = await Shopware.Service('analyticsService').getToken();
+            } catch {
+                return new Response(JSON.stringify({ code: 503 }), { status: 503 });
+            }
+
+            init = init || {};
+            init.headers = {
+                ...init.headers,
+                'Authorization': `Bearer ${tokenData.token}`,
+            };
+        }
+
+        return originalFetch.call(this, input, init);
+    };
+
     // check for consent
 
     amplitude.init('a04bb926f471ce883bc219814fc9577', undefined, {
@@ -62,7 +87,7 @@ export default async function (): Promise<void> {
             platform: false,
         },
         fetchRemoteConfig: false,
-        // serverUrl: use proxy server url here, e.g. usage-data.shopware.io/product-analytics,
+        serverUrl: eventUrl,
     });
 
     // eslint-disable-next-line listeners/no-missing-remove-event-listener

--- a/src/Administration/Resources/app/administration/src/core/service/api/analytics.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/analytics.api.service.ts
@@ -1,0 +1,57 @@
+import type { AxiosInstance } from 'axios';
+import type { LoginService } from '../login.service';
+import ApiService from '../api.service';
+
+type AnalyticsToken = {
+    token: string;
+    expiresAt: number;
+};
+
+export default class AnalyticsApiService extends ApiService {
+    token: AnalyticsToken | null = null;
+
+    constructor(httpClient: AxiosInstance, loginService: LoginService, apiEndpoint = 'analytics') {
+        super(httpClient, loginService, apiEndpoint, 'application/json');
+
+        this.name = 'analyticsService';
+    }
+
+    public async getToken(): Promise<AnalyticsToken> {
+        if (this.token !== null) {
+            if (!this.isTokenValid(this.token.expiresAt)) {
+                this.token = await this.fetchToken();
+            }
+
+            return this.token;
+        }
+
+        this.token = await this.fetchToken();
+
+        return this.token;
+    }
+
+    private async fetchToken() : Promise<AnalyticsToken>
+    {
+        const headers = this.getBasicHeaders();
+        const params = {};
+
+        const { data } = await this.httpClient.get<AnalyticsToken>(`/${this.getApiBasePath()}/token`, {
+            params,
+            headers,
+        });
+
+        return data;
+    }
+
+    private isTokenValid(expiryTimestamp: number)
+    {
+        const currentTime = Math.floor(Date.now() / 1000);
+        return currentTime < expiryTimestamp;
+    }
+}
+
+/**
+ * @private
+ * @sw-package data-services
+ */
+export type { AnalyticsApiService, AnalyticsToken };

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -135,6 +135,7 @@ import type { SwProfileStore } from './module/sw-profile/store/sw-profile.store'
 import type { SwPromotionDetailStore } from './module/sw-promotion-v2/page/sw-promotion-v2-detail/store';
 import type { SwFlowStore } from './module/sw-flow/store/flow.store';
 import type { SwBulkStore } from './app/store/sw-bulk-edit.store';
+import type { AnalyticsApiService } from "./core/service/api/analytics.api.service";
 // eslint-disable-next-line max-len
 import type createTextEditorDataMappingButton from './app/component/meteor-wrapper/mt-text-editor/sw-text-editor-toolbar-button-cms-data-mapping';
 import type SsoSettingsService from './core/service/api/sso-settings.service';
@@ -297,6 +298,7 @@ declare global {
         ssoSettingsService: SsoSettingsService;
         ssoInvitationService: SsoInvitationService;
         shopIdChangeService: ShopIdChangeService;
+        analyticsService: AnalyticsApiService;
     }
 
     interface MixinContainer {

--- a/src/Administration/Resources/app/administration/vite.config.mts
+++ b/src/Administration/Resources/app/administration/vite.config.mts
@@ -125,6 +125,7 @@ export default defineConfig(({ command }) => {
                             data: {
                                 featureFlags: JSON.stringify(featureFlags),
                                 serviceRegistryUrl: process.env.SERVICE_REGISTRY_URL,
+                                analyticsGatewayUrl: process.env.PRODUCT_ANALYTICS_GATEWAY_URL,
                             },
                         },
                     }),

--- a/src/Administration/Resources/config/services.xml
+++ b/src/Administration/Resources/config/services.xml
@@ -50,6 +50,7 @@
             <argument type="string">%env(SERVICE_REGISTRY_URL)%</argument>
             <argument type="service" id="language.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Api\OAuth\SymfonyBearerTokenValidator"/>
+            <argument>%shopware.analytics.gateway_url%</argument>
             <argument type="string">%shopware.api.refresh_token_ttl%</argument>
 
             <call method="setContainer">

--- a/src/Administration/Resources/views/administration/index.html.twig
+++ b/src/Administration/Resources/views/administration/index.html.twig
@@ -68,6 +68,7 @@
                     adminEsEnable: {{ adminEsEnable ? 'true' : 'false' }},
                     storefrontEsEnable: {{ storefrontEsEnable ? 'true' : 'false' }},
                     productStreamIndexingEnabled: {{ productStreamIndexingEnabled ? 'true' : 'false' }},
+                    analyticsGatewayUrl: '{{ analyticsGatewayUrl }}',
                 }
             });
         };

--- a/src/Core/Framework/Analytics/Api/AnalyticsController.php
+++ b/src/Core/Framework/Analytics/Api/AnalyticsController.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Analytics\Api;
+
+use Shopware\Core\Framework\Analytics\TokenService;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\ApiRouteScope;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
+#[Package('data-services')]
+class AnalyticsController
+{
+    public function __construct(private readonly TokenService $tokenService)
+    {
+    }
+
+    #[Route(
+        path: 'api/analytics/token',
+        name: 'api.analytics.token',
+        methods: ['GET']
+    )]
+    public function token(Request $request): Response
+    {
+        $referer = $request->headers->get('referer');
+
+        if ($referer === null || $referer === '') {
+            return new JsonResponse([], Response::HTTP_SERVICE_UNAVAILABLE);
+        }
+
+        $token = $this->tokenService->generate($referer);
+        if ($token === null) {
+            return new JsonResponse([], Response::HTTP_SERVICE_UNAVAILABLE);
+        }
+
+        return new JsonResponse($token, Response::HTTP_OK);
+    }
+}

--- a/src/Core/Framework/Analytics/Token.php
+++ b/src/Core/Framework/Analytics/Token.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Analytics;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('data-services')]
+readonly class Token implements \JsonSerializable
+{
+    public function __construct(public string $token, public \DateTimeImmutable $expiresAt)
+    {
+    }
+
+    /**
+     * @return array{token: string, expiresAt: int}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'token' => $this->token,
+            'expiresAt' => $this->expiresAt->getTimestamp(),
+        ];
+    }
+}

--- a/src/Core/Framework/Analytics/TokenService.php
+++ b/src/Core/Framework/Analytics/TokenService.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Analytics;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+#[Package('data-services')]
+class TokenService
+{
+    private const CONFIG_KEY_ANALYTICS_SECRET = 'core.analytics.secret';
+
+    public function __construct(
+        private readonly SystemConfigService $systemConfigService,
+        private readonly HttpClientInterface $client
+    ) {
+    }
+
+    public function generate(string $referer): ?Token
+    {
+        $secret = $this->systemConfigService->get(self::CONFIG_KEY_ANALYTICS_SECRET);
+
+        if (!\is_string($secret) && $secret !== null) {
+            return null;
+        }
+
+        if ($secret === null) {
+            $secret = $this->generateAndPersistSecret();
+        }
+
+        $response = $this->fetchToken($secret, $referer);
+
+        if ($response->getStatusCode() === Response::HTTP_FORBIDDEN) {
+            // we need to rotate the secret
+            $secret = $this->generateAndPersistSecret();
+            $response = $this->fetchToken($secret, $referer);
+        }
+
+        if ($response->getStatusCode() !== Response::HTTP_OK) {
+            // TODO: log
+            return null;
+        }
+
+        return $this->parseToken($response);
+    }
+
+    private function generateAndPersistSecret(): string
+    {
+        $secret = bin2hex(random_bytes(16));
+
+        $this->systemConfigService->set(self::CONFIG_KEY_ANALYTICS_SECRET, $secret);
+
+        return $secret;
+    }
+
+    private function fetchToken(string $secret, string $referer): ResponseInterface
+    {
+        $url = 'http://localhost:8080/token';
+
+        return $this->client->request('POST', $url, [
+            'headers' => [
+                'X-Client-Secret' => $secret,
+                'Referer' => $referer,
+            ],
+        ]);
+    }
+
+    private function parseToken(ResponseInterface $response): ?Token
+    {
+        $data = $response->toArray();
+        if (!isset($data['token']) || !isset($data['expires_at'])) {
+            return null;
+        }
+
+        if (!\is_string($data['token']) || !\is_int($data['expires_at'])) {
+            return null;
+        }
+
+        $expiresAt = new \DateTimeImmutable('@' . $data['expires_at']);
+
+        return new Token($data['token'], $expiresAt);
+    }
+}

--- a/src/Core/Framework/Analytics/TokenService.php
+++ b/src/Core/Framework/Analytics/TokenService.php
@@ -5,6 +5,8 @@ namespace Shopware\Core\Framework\Analytics;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -13,9 +15,13 @@ class TokenService
 {
     private const CONFIG_KEY_ANALYTICS_SECRET = 'core.analytics.secret';
 
+    private const RESPONSE_KEY_TOKEN = 'token';
+    private const RESPONSE_KEY_EXPIRES_AT = 'expires_at';
+
     public function __construct(
         private readonly SystemConfigService $systemConfigService,
-        private readonly HttpClientInterface $client
+        private readonly HttpClientInterface $client,
+        private readonly string $gatewayBaseUrl
     ) {
     }
 
@@ -31,20 +37,26 @@ class TokenService
             $secret = $this->generateAndPersistSecret();
         }
 
-        $response = $this->fetchToken($secret, $referer);
-
-        if ($response->getStatusCode() === Response::HTTP_FORBIDDEN) {
-            // we need to rotate the secret
-            $secret = $this->generateAndPersistSecret();
+        try {
             $response = $this->fetchToken($secret, $referer);
-        }
 
-        if ($response->getStatusCode() !== Response::HTTP_OK) {
+            if ($response->getStatusCode() === Response::HTTP_FORBIDDEN) {
+                // we need to rotate the secret
+                $secret = $this->generateAndPersistSecret();
+                $response = $this->fetchToken($secret, $referer);
+            }
+
+            if ($response->getStatusCode() !== Response::HTTP_OK) {
+                // TODO: log
+                return null;
+            }
+
+            return $this->parseToken($response);
+        } catch (TransportExceptionInterface) {
             // TODO: log
+            // Gateway is unreachable
             return null;
         }
-
-        return $this->parseToken($response);
     }
 
     private function generateAndPersistSecret(): string
@@ -58,9 +70,7 @@ class TokenService
 
     private function fetchToken(string $secret, string $referer): ResponseInterface
     {
-        $url = 'http://localhost:8080/token';
-
-        return $this->client->request('POST', $url, [
+        return $this->client->request(Request::METHOD_POST, "{$this->gatewayBaseUrl}/token", [
             'headers' => [
                 'X-Client-Secret' => $secret,
                 'Referer' => $referer,
@@ -71,16 +81,16 @@ class TokenService
     private function parseToken(ResponseInterface $response): ?Token
     {
         $data = $response->toArray();
-        if (!isset($data['token']) || !isset($data['expires_at'])) {
+        if (!isset($data[self::RESPONSE_KEY_TOKEN]) || !isset($data[self::RESPONSE_KEY_EXPIRES_AT])) {
             return null;
         }
 
-        if (!\is_string($data['token']) || !\is_int($data['expires_at'])) {
+        if (!\is_string($data[self::RESPONSE_KEY_TOKEN]) || !\is_int($data[self::RESPONSE_KEY_EXPIRES_AT])) {
             return null;
         }
 
-        $expiresAt = new \DateTimeImmutable('@' . $data['expires_at']);
+        $expiresAt = new \DateTimeImmutable('@' . $data[self::RESPONSE_KEY_EXPIRES_AT]);
 
-        return new Token($data['token'], $expiresAt);
+        return new Token($data[self::RESPONSE_KEY_TOKEN], $expiresAt);
     }
 }

--- a/src/Core/Framework/DependencyInjection/analytics.xml
+++ b/src/Core/Framework/DependencyInjection/analytics.xml
@@ -2,6 +2,12 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="shopware.analytics.gateway_url_default">https://product-analytics.shopware.io</parameter>
+        <parameter key="shopware.analytics.gateway_url">%env(default:shopware.analytics.gateway_url_default:PRODUCT_ANALYTICS_GATEWAY_URL)%</parameter>
+    </parameters>
+
     <services>
         <service id="Shopware\Core\Framework\Analytics\Api\AnalyticsController" public="true">
             <argument type="service" id="Shopware\Core\Framework\Analytics\TokenService"/>
@@ -10,6 +16,7 @@
         <service id="Shopware\Core\Framework\Analytics\TokenService">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Symfony\Contracts\HttpClient\HttpClientInterface"/>
+            <argument>%shopware.analytics.gateway_url%</argument>
         </service>
     </services>
 </container>

--- a/src/Core/Framework/DependencyInjection/analytics.xml
+++ b/src/Core/Framework/DependencyInjection/analytics.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Shopware\Core\Framework\Analytics\Api\AnalyticsController" public="true">
+            <argument type="service" id="Shopware\Core\Framework\Analytics\TokenService"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Analytics\TokenService">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="Symfony\Contracts\HttpClient\HttpClientInterface"/>
+        </service>
+    </services>
+</container>

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -93,6 +93,7 @@ class Framework extends Bundle
         $loader->load('telemetry.xml');
         $loader->load('notification.xml');
         $loader->load('sso.xml');
+        $loader->load('analytics.xml');
 
         if ($container->getParameter('kernel.environment') === 'test') {
             $loader->load('services_test.xml');

--- a/src/Core/Framework/Resources/config/routes.xml
+++ b/src/Core/Framework/Resources/config/routes.xml
@@ -17,5 +17,7 @@
     <import resource="../../Rule/Api/*Controller.php" type="attribute" />
     <import resource="../../Gateway/**/*Route.php" type="attribute" />
     <import resource="../../Sso/Controller/**/*Controller.php" type="attribute" />
+    <import resource="../../Analytics/**/*Controller.php" type="attribute" />
+
 
 </routes>


### PR DESCRIPTION
We want to send the events to our gateway.
We need to first request a token and then send it as a header in each /event request.