### PR TITLE
chore: Ignore doctrine/dbal in danger.php

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -17,6 +17,7 @@ const COMPOSER_PACKAGE_EXCEPTIONS = [
         '^rector\/type-perfect$' => 'Even patch updates for PHPStan plugins may lead to a red CI pipeline, because of new static analysis errors',
         '^phpat\/phpat$' => 'Even patch updates for PHPStan plugins may lead to a red CI pipeline, because of new static analysis errors',
         '^dompdf\/dompdf$' => 'Patch updates of dompdf have let to a lot of issues in the past, therefore it is pinned.',
+        '^doctrine\/dbal$' => 'Minor updates often introduce deprecations, which cause PHPStan to fail.',
         '^scssphp\/scssphp$' => 'Patch updates of scssphp might lead to UI breaks, therefore it is pinned.',
         '^shopware\/conflicts$' => 'The shopware conflicts packages should be required in any version, so use `*` constraint',
         '^shopware\/core$' => 'The shopware core packages should be required in any version, so use `*` constraint, the version constraint will be automatically synced during the release process',


### PR DESCRIPTION
Minor updates of `doctrine/dbal` often introduce new deprecations, which then cause PHPStan to fail. This blocked the pipeline quite often in the past, so we are using a stricter version constraint.

