### PR TITLE
fix: Reset calculated LineItemGroupBuilder results

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -27,10 +27,6 @@ The following classes and constants were deprecated as they will not be used any
 Additionally, the following configuration was deprecated:
 * `shopware.cache.invalidation.http_cache`
 
-### Added ResetInterface to LineItemGroupBuilder
-
-For performance reasons, `LineItemGroupBuilder` calculates and stores the results of `LineItemGroupBuilderResult`'s. Problems may occur when adding or removing line items. The calculated results may then be incorrect. Therefore, the results are reset when a line item is added or removed.
-
 ## Administration
 
 ## Storefront

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -27,6 +27,10 @@ The following classes and constants were deprecated as they will not be used any
 Additionally, the following configuration was deprecated:
 * `shopware.cache.invalidation.http_cache`
 
+### Added ResetInterface to LineItemGroupBuilder
+
+For performance reasons, `LineItemGroupBuilder` calculates and stores the results of `LineItemGroupBuilderResult`'s. Problems may occur when adding or removing line items. The calculated results may then be incorrect. Therefore, the results are reset when a line item is added or removed.
+
 ## Administration
 
 ## Storefront

--- a/src/Core/Checkout/Cart/LineItem/Group/LineItemGroupBuilder.php
+++ b/src/Core/Checkout/Cart/LineItem/Group/LineItemGroupBuilder.php
@@ -9,9 +9,10 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItemFlatCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemQuantitySplitter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('checkout')]
-class LineItemGroupBuilder
+class LineItemGroupBuilder implements ResetInterface
 {
     /**
      * @var array<string, LineItemGroupBuilderResult|null>
@@ -27,6 +28,11 @@ class LineItemGroupBuilder
         private readonly LineItemQuantitySplitter $quantitySplitter,
         private readonly AbstractProductLineItemProvider $lineItemProvider
     ) {
+    }
+
+    public function reset(): void
+    {
+        $this->results = [];
     }
 
     /**

--- a/src/Core/Checkout/Cart/Subscriber/CartOrderEventSubscriber.php
+++ b/src/Core/Checkout/Cart/Subscriber/CartOrderEventSubscriber.php
@@ -2,8 +2,11 @@
 
 namespace Shopware\Core\Checkout\Cart\Subscriber;
 
+use Shopware\Core\Checkout\Cart\Event\BeforeLineItemAddedEvent;
+use Shopware\Core\Checkout\Cart\Event\BeforeLineItemRemovedEvent;
 use Shopware\Core\Checkout\Cart\Event\CartDeletedEvent;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
@@ -17,7 +20,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 readonly class CartOrderEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private AbstractContextSwitchRoute $contextSwitchRoute
+        private AbstractContextSwitchRoute $contextSwitchRoute,
+        private LineItemGroupBuilder $lineItemGroupBuilder
     ) {
     }
 
@@ -26,6 +30,8 @@ readonly class CartOrderEventSubscriber implements EventSubscriberInterface
         return [
             CartDeletedEvent::class => ['handleContextAddress', 1],
             CheckoutOrderPlacedEvent::class => ['handleContextAddress', 1],
+            BeforeLineItemAddedEvent::class => 'resetBuilder',
+            BeforeLineItemRemovedEvent::class => 'resetBuilder',
         ];
     }
 
@@ -35,5 +41,11 @@ readonly class CartOrderEventSubscriber implements EventSubscriberInterface
             SalesChannelContextService::SHIPPING_ADDRESS_ID => null,
             SalesChannelContextService::BILLING_ADDRESS_ID => null,
         ]), $event->getSalesChannelContext());
+    }
+
+    public function resetBuilder(BeforeLineItemAddedEvent|BeforeLineItemRemovedEvent $event): void
+    {
+        // We must reset the calculated results when an line item is added or removed.
+        $this->lineItemGroupBuilder->reset();
     }
 }

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -451,6 +451,8 @@
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\Group\RulesMatcher\AnyRuleMatcher"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\LineItemQuantitySplitter"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\Group\AbstractProductLineItemProvider"/>
+
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupServiceRegistry">
@@ -548,6 +550,8 @@
 
         <service id="Shopware\Core\Checkout\Cart\Subscriber\CartOrderEventSubscriber">
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder"/>
+
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
@@ -2,14 +2,17 @@
 
 namespace Shopware\Tests\Integration\Core\Checkout\Promotion\Cart;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartBehavior;
+use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Price\Struct\AbsolutePriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
@@ -18,13 +21,19 @@ use Shopware\Core\Checkout\Promotion\Cart\PromotionCalculator;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Checkout\Promotion\PromotionDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Integration\Traits\Promotion\PromotionTestFixtureBehaviour;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Unit\Core\Checkout\Cart\LineItem\Group\Helpers\Traits\LineItemTestFixtureBehaviour;
 
@@ -32,10 +41,12 @@ use Shopware\Tests\Unit\Core\Checkout\Cart\LineItem\Group\Helpers\Traits\LineIte
  * @internal
  */
 #[Package('checkout')]
+#[CoversClass(PromotionCalculator::class)]
 class PromotionCalculatorTest extends TestCase
 {
     use IntegrationTestBehaviour;
     use LineItemTestFixtureBehaviour;
+    use PromotionTestFixtureBehaviour;
 
     private PromotionCalculator $promotionCalculator;
 
@@ -262,6 +273,63 @@ class PromotionCalculatorTest extends TestCase
         static::assertCount(2, $toCalculate->getLineItems());
     }
 
+    public function testTest(): void
+    {
+        $promotionId = Uuid::randomHex();
+        $product1 = $this->createProduct();
+        $product2 = $this->createProduct();
+        $product3 = $this->createProduct();
+
+        /** @var AbstractSalesChannelContextFactory $factory */
+        $factory = static::getContainer()->get(SalesChannelContextFactory::class);
+        $context = $factory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+
+        $data = [
+            'id' => $promotionId,
+            'code' => 'Black Friday',
+            'useCodes' => true,
+            'useSetGroups' => true,
+        ];
+
+        $this->createPromotionWithCustomData($data, $this->promotionRepository, $context);
+        $this->createSetGroupDiscount($promotionId, 1, static::getContainer(), 50, null, applierKey: '2');
+        $this->createSetGroupFixture('COUNT', 2, 'PRICE_ASC', $promotionId, static::getContainer());
+
+        $promotion = new LineItem($promotionId, PromotionProcessor::LINE_ITEM_TYPE, 'Black Friday');
+
+        $lineItem = new LineItem($product1, LineItem::PRODUCT_LINE_ITEM_TYPE, $product1);
+        $lineItem->setRemovable(true);
+
+        $lineItem2 = new LineItem($product2, LineItem::PRODUCT_LINE_ITEM_TYPE, $product2);
+        $lineItem2->setRemovable(true);
+
+        $lineItem3 = new LineItem($product3, LineItem::PRODUCT_LINE_ITEM_TYPE, $product2);
+        $lineItem3->setRemovable(true);
+
+        /** @var CartService $cartService */
+        $cartService = static::getContainer()->get(CartService::class);
+        $cart = $cartService->createNew('test-token');
+
+        $firstCalculatedCard = $cartService->add($cart, [$lineItem, $lineItem2, $lineItem3, $promotion], $context);
+        static::assertNotNull($firstCalculatedCard->getErrors()->first());
+        static::assertSame('Discount Black Friday has been added', $firstCalculatedCard->getErrors()->first()->getMessage());
+        static::assertCount(4, $firstCalculatedCard->getLineItems());
+        static::assertSame(25.0, $firstCalculatedCard->getPrice()->getTotalPrice());
+
+        $firstCalculatedCard->setErrors(new ErrorCollection());
+
+        $secondCalculatedCard = $cartService->remove($firstCalculatedCard, $lineItem->getId(), $context);
+        static::assertCount(0, $secondCalculatedCard->getErrors());
+        static::assertCount(3, $secondCalculatedCard->getLineItems());
+        static::assertSame(15.0, $secondCalculatedCard->getPrice()->getTotalPrice());
+
+        $thirdCalculatedCard = $cartService->remove($secondCalculatedCard, $lineItem2->getId(), $context);
+        static::assertNotNull($thirdCalculatedCard->getErrors()->first());
+        static::assertSame('Promotion Black Friday not eligible for cart!', $thirdCalculatedCard->getErrors()->first()->getMessage());
+        static::assertCount(1, $thirdCalculatedCard->getLineItems());
+        static::assertSame(10.0, $thirdCalculatedCard->getPrice()->getTotalPrice());
+    }
+
     private function getPromotionId(bool $preventCombination = false, int $priority = 1, bool $useCodes = true, string $type = PromotionDiscountEntity::TYPE_ABSOLUTE): string
     {
         $promotionId = Uuid::randomHex();
@@ -314,5 +382,43 @@ class PromotionCalculatorTest extends TestCase
         $discountItemToBeExcluded->setPriceDefinition(new AbsolutePriceDefinition(-10.0));
 
         return $discountItemToBeExcluded;
+    }
+
+    private function createProduct(): string
+    {
+        $id = Uuid::randomHex();
+
+        static::getContainer()->get('product.repository')
+            ->create([
+                [
+                    'id' => $id,
+                    'name' => 'test',
+                    'productNumber' => Uuid::randomHex(),
+                    'stock' => 10,
+                    'price' => [
+                        ['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 7, 'linked' => false],
+                    ],
+                    'purchasePrices' => [
+                        ['currencyId' => Defaults::CURRENCY, 'gross' => 7.5, 'net' => 5, 'linked' => false],
+                        ['currencyId' => Uuid::randomHex(), 'gross' => 150, 'net' => 100, 'linked' => false],
+                    ],
+                    'active' => true,
+                    'taxId' => $this->getValidTaxId(),
+                    'weight' => 100,
+                    'height' => 101,
+                    'width' => 102,
+                    'length' => 103,
+                    'visibilities' => [
+                        ['salesChannelId' => TestDefaults::SALES_CHANNEL, 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
+                    ],
+                    'translations' => [
+                        Defaults::LANGUAGE_SYSTEM => [
+                            'name' => 'test',
+                        ],
+                    ],
+                ],
+            ], Context::createDefaultContext());
+
+        return $id;
     }
 }

--- a/tests/unit/Core/Checkout/Cart/Subscriber/CartOrderEventSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Cart/Subscriber/CartOrderEventSubscriberTest.php
@@ -5,8 +5,11 @@ namespace Shopware\Tests\Unit\Core\Checkout\Cart\Subscriber;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Event\BeforeLineItemAddedEvent;
+use Shopware\Core\Checkout\Cart\Event\BeforeLineItemRemovedEvent;
 use Shopware\Core\Checkout\Cart\Event\CartDeletedEvent;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
 use Shopware\Core\Checkout\Cart\Subscriber\CartOrderEventSubscriber;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Log\Package;
@@ -29,7 +32,7 @@ class CartOrderEventSubscriberTest extends TestCase
     protected function setUp(): void
     {
         $this->contextSwitchRoute = $this->createMock(AbstractContextSwitchRoute::class);
-        $this->subscriber = new CartOrderEventSubscriber($this->contextSwitchRoute);
+        $this->subscriber = new CartOrderEventSubscriber($this->contextSwitchRoute, $this->createMock(LineItemGroupBuilder::class));
     }
 
     public function testGetSubscribedEvents(): void
@@ -40,6 +43,8 @@ class CartOrderEventSubscriberTest extends TestCase
         static::assertArrayHasKey(CheckoutOrderPlacedEvent::class, $events);
         static::assertEquals(['handleContextAddress', 1], $events[CartDeletedEvent::class]);
         static::assertEquals(['handleContextAddress', 1], $events[CheckoutOrderPlacedEvent::class]);
+        static::assertEquals('resetBuilder', $events[BeforeLineItemAddedEvent::class]);
+        static::assertEquals('resetBuilder', $events[BeforeLineItemRemovedEvent::class]);
     }
 
     public function testHandleContextAddressWithCartDeletedEvent(): void
@@ -85,5 +90,16 @@ class CartOrderEventSubscriberTest extends TestCase
             );
 
         $this->subscriber->handleContextAddress($event);
+    }
+
+    public function testResetBuilder(): void
+    {
+        $builder = $this->createMock(LineItemGroupBuilder::class);
+        $builder
+            ->expects($this->once())
+            ->method('reset');
+
+        (new CartOrderEventSubscriber($this->createMock(AbstractContextSwitchRoute::class), $builder))
+            ->resetBuilder($this->createMock(BeforeLineItemAddedEvent::class));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
While removing line items in combination with promotions, type errors can occur

### 2. What does this change do, exactly?
Adds the `Symfony\Contracts\Service\ResetInterface` to `Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder`.
Before `LineItemAdded/-Removed` the saved `LineItemGroupBuilder` results will be reset. 

### 3. Describe each step to reproduce the issue or behaviour.
Create a promotion with the following configuration:
**Conditions**
    - Activate: Promote sets of products
    - Mode: Quantity
    - Value: 3
    - Sorting: Price, ascending
**Discounts**
    - Apply to: Set group-1
    - Activate: Apply only to a specific range of products only.
    - Apply to: 1. item
    - Max. number of uses: 1
    - Sort by: Price, ascending
    - Item selection mode: Vertical
    - Type: Percentage
    - Value: 100

In the storefront, you should now add 3 different products to the shopping cart, enter the code in the shopping cart, and try to remove one of the 3 products.

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/11553

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Release Notes & Changelog Process](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
