### PR TITLE
feat: apply ngram search for long term

### DIFF
--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -258,7 +258,6 @@
             <argument type="service" id="Shopware\Core\System\CustomField\CustomFieldService"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage" />
             <argument>%elasticsearch.analysis.filter.sw_ngram_filter.min_gram%</argument>
-            <argument>%elasticsearch.analysis.filter.sw_ngram_filter.max_gram%</argument>
         </service>
 
         <service id="Shopware\Elasticsearch\Product\CustomFieldUpdater">

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -117,11 +117,10 @@ class TokenQueryBuilder
             $searchField = $config->getField() . '.search';
             $operator = $config->isAndLogic() ? 'and' : 'or';
 
-            $tokens = \explode(' ', $token);
-            $tokens = preg_split('/\s+/u', $token, -1, PREG_SPLIT_NO_EMPTY);
+            $tokens = preg_split('/\s+/u', $token, -1, \PREG_SPLIT_NO_EMPTY) ?: [$token];
             $tokenCount = \count($tokens);
 
-            if ($tokenCount >= 1) {
+            if ($tokenCount > 1) {
                 $token = implode(' ', $tokens);
             }
 
@@ -207,7 +206,7 @@ class TokenQueryBuilder
 
             $languageQuery = $this->matchQuery($field, $token, $languageConfig);
 
-            $ranking = $ranking * 0.8; // for each language we go "deeper" in the translation, we reduce the ranking by 20%
+            $ranking *= 0.8; // for each language we go "deeper" in the translation, we reduce the ranking by 20%
 
             if (!$languageQuery) {
                 continue;

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -34,7 +34,7 @@ use Shopware\Elasticsearch\Product\SearchFieldConfig;
  *
  * @final
  */
-#[Package('framework')]
+#[Package('inventory')]
 class TokenQueryBuilder
 {
     /**
@@ -44,8 +44,7 @@ class TokenQueryBuilder
         private readonly DefinitionInstanceRegistry $definitionRegistry,
         private readonly CustomFieldService $customFieldService,
         private readonly AbstractKeyValueStorage $storage,
-        private readonly int $minGram = 4,
-        private readonly int $maxGram = 5
+        private readonly int $minGram = 4
     ) {
     }
 
@@ -149,16 +148,15 @@ class TokenQueryBuilder
 
             $tokenLength = mb_strlen($token);
 
-            // apply ngram search if tokenize is enabled and token length is between minGram and maxGram
-            if ($config->tokenize() && $tokenCount === 1 && $tokenLength >= $this->minGram && $tokenLength <= $this->maxGram) {
-                $queries[] = new TermQuery($config->getField() . '.ngram', $token, [
+            if ($config->tokenize() && $tokenCount === 1 && $tokenLength >= $this->minGram) {
+                $queries[] = new MatchQuery($config->getField() . '.ngram', $token, [
                     'boost' => 0.4,
                 ]);
             }
 
             // apply prefix search on a single token
-            if ($tokenCount === 1 && ($tokenLength < $this->minGram || $tokenLength > $this->maxGram)) {
-                // Prefix search on single tokens smaller than minGram or bigger than maxGram
+            if ($tokenCount === 1 && $tokenLength < $this->minGram) {
+                // Prefix search on single tokens smaller than minGram
                 $queries[] = new PrefixQuery($config->getField(), $token, [
                     'boost' => 0.4,
                 ]);

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -53,6 +53,7 @@ class TokenQueryBuilder
      */
     public function build(string $entity, string $token, array $configs, Context $context): ?BuilderInterface
     {
+        $token = mb_strtolower(trim($token));
         $languageIdChain = $context->getLanguageIdChain();
         $explainMode = $context->hasState(Context::ELASTICSEARCH_EXPLAIN_MODE);
 
@@ -117,7 +118,12 @@ class TokenQueryBuilder
             $operator = $config->isAndLogic() ? 'and' : 'or';
 
             $tokens = \explode(' ', $token);
+            $tokens = preg_split('/\s+/u', $token, -1, PREG_SPLIT_NO_EMPTY);
             $tokenCount = \count($tokens);
+
+            if ($tokenCount >= 1) {
+                $token = implode(' ', $tokens);
+            }
 
             // apply exact match
             $queries[] = $tokenCount === 1
@@ -138,11 +144,14 @@ class TokenQueryBuilder
             ]);
 
             // apply match phrase prefix for compound tokens
-            if ($config->usePrefixMatch() && $tokenCount > 1) {
-                $queries[] = new MatchPhrasePrefixQuery($searchField, $token, [
+            if ($config->usePrefixMatch()) {
+                // apply prefix search on a single token or match phrase prefix on multiple tokens
+                $queries[] = $tokenCount > 1 ? new MatchPhrasePrefixQuery($searchField, $token, [
                     'boost' => 0.6,
                     'slop' => 3,
                     'max_expansions' => $maxExpansions,
+                ]) : new PrefixQuery($config->getField(), $token, [
+                    'boost' => 0.4,
                 ]);
             }
 
@@ -150,14 +159,6 @@ class TokenQueryBuilder
 
             if ($config->tokenize() && $tokenCount === 1 && $tokenLength >= $this->minGram) {
                 $queries[] = new MatchQuery($config->getField() . '.ngram', $token, [
-                    'boost' => 0.4,
-                ]);
-            }
-
-            // apply prefix search on a single token
-            if ($tokenCount === 1 && $tokenLength < $this->minGram) {
-                // Prefix search on single tokens smaller than minGram
-                $queries[] = new PrefixQuery($config->getField(), $token, [
                     'boost' => 0.4,
                 ]);
             }
@@ -206,7 +207,7 @@ class TokenQueryBuilder
 
             $languageQuery = $this->matchQuery($field, $token, $languageConfig);
 
-            $ranking = $config->getRanking() * 0.8; // for each language we go "deeper" in the translation, we reduce the ranking by 20%
+            $ranking = $ranking * 0.8; // for each language we go "deeper" in the translation, we reduce the ranking by 20%
 
             if (!$languageQuery) {
                 continue;

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -205,15 +205,18 @@ class ProductSearchQueryBuilderTest extends TestCase
                         self::disMax([
                             self::term('name.' . Defaults::LANGUAGE_SYSTEM, '2023', 1),
                             self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.8, 0, 'and', 10),
+                            self::prefix('name.' . Defaults::LANGUAGE_SYSTEM, '2023', 0.4),
                         ], 1000),
                         self::disMax([
                             self::term('ean', '2023', 1),
                             self::match('ean.search', '2023', 0.8, 0, 'and', 10),
+                            self::prefix('ean', '2023', 0.4),
                         ], 2000),
                         self::term('restockTime', 2023, 1500),
                         self::nested('tags', self::disMax([
                             self::term('tags.name', '2023', 1),
                             self::match('tags.name.search', '2023', 0.8, 0, 'and', 10),
+                            self::prefix('tags.name', '2023', 0.4)
                         ], 500)),
                     ]),
                 ], BoolQuery::MUST),
@@ -274,6 +277,7 @@ class ProductSearchQueryBuilderTest extends TestCase
                         self::disMax([
                             self::term($prefix . 'evolvesText', '2023', 1),
                             self::match($prefix . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                            self::prefix($prefix . 'evolvesText', '2023', 0.4)
                         ], 500),
                         self::term($prefix . 'evolvesInt', 2023, 400),
                         self::term($prefix . 'evolvesFloat', 2023.0, 500),
@@ -360,15 +364,18 @@ class ProductSearchQueryBuilderTest extends TestCase
                         self::disMax([
                             self::term('name.' . Defaults::LANGUAGE_SYSTEM, '2023', 1),
                             self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.8, 0, 'and', 10),
+                            self::prefix('name.' . Defaults::LANGUAGE_SYSTEM, '2023', 0.4),
                         ], 1000),
                         self::disMax([
                             self::term('ean', '2023', 1),
                             self::match('ean.search', '2023', 0.8, 0, 'and', 10),
+                            self::prefix('ean', '2023', 0.4)
                         ], 2000),
                         self::term('restockTime', 2023, 1500),
                         self::nested('tags', self::disMax([
                             self::term('tags.name', '2023', 1),
                             self::match('tags.name.search', '2023', 0.8, 0, 'and', 10),
+                            self::prefix('tags.name', '2023', 0.4)
                         ], 500)),
                     ]),
                 ], BoolQuery::MUST),
@@ -419,10 +426,12 @@ class ProductSearchQueryBuilderTest extends TestCase
                             self::disMax([
                                 self::term($prefixCfLang1 . 'evolvesText', '2023', 1),
                                 self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                                self::prefix($prefixCfLang1 . 'evolvesText', '2023', 0.4)
                             ], 500),
                             self::disMax([
                                 self::term($prefixCfLang2 . 'evolvesText', '2023', 1),
                                 self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                                self::prefix($prefixCfLang2 . 'evolvesText', '2023', 0.4)
                             ], 400),
                         ]),
                         self::disMax([

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -216,7 +216,7 @@ class ProductSearchQueryBuilderTest extends TestCase
                         self::nested('tags', self::disMax([
                             self::term('tags.name', '2023', 1),
                             self::match('tags.name.search', '2023', 0.8, 0, 'and', 10),
-                            self::prefix('tags.name', '2023', 0.4)
+                            self::prefix('tags.name', '2023', 0.4),
                         ], 500)),
                     ]),
                 ], BoolQuery::MUST),
@@ -277,7 +277,7 @@ class ProductSearchQueryBuilderTest extends TestCase
                         self::disMax([
                             self::term($prefix . 'evolvesText', '2023', 1),
                             self::match($prefix . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
-                            self::prefix($prefix . 'evolvesText', '2023', 0.4)
+                            self::prefix($prefix . 'evolvesText', '2023', 0.4),
                         ], 500),
                         self::term($prefix . 'evolvesInt', 2023, 400),
                         self::term($prefix . 'evolvesFloat', 2023.0, 500),
@@ -369,13 +369,13 @@ class ProductSearchQueryBuilderTest extends TestCase
                         self::disMax([
                             self::term('ean', '2023', 1),
                             self::match('ean.search', '2023', 0.8, 0, 'and', 10),
-                            self::prefix('ean', '2023', 0.4)
+                            self::prefix('ean', '2023', 0.4),
                         ], 2000),
                         self::term('restockTime', 2023, 1500),
                         self::nested('tags', self::disMax([
                             self::term('tags.name', '2023', 1),
                             self::match('tags.name.search', '2023', 0.8, 0, 'and', 10),
-                            self::prefix('tags.name', '2023', 0.4)
+                            self::prefix('tags.name', '2023', 0.4),
                         ], 500)),
                     ]),
                 ], BoolQuery::MUST),
@@ -426,12 +426,12 @@ class ProductSearchQueryBuilderTest extends TestCase
                             self::disMax([
                                 self::term($prefixCfLang1 . 'evolvesText', '2023', 1),
                                 self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
-                                self::prefix($prefixCfLang1 . 'evolvesText', '2023', 0.4)
+                                self::prefix($prefixCfLang1 . 'evolvesText', '2023', 0.4),
                             ], 500),
                             self::disMax([
                                 self::term($prefixCfLang2 . 'evolvesText', '2023', 1),
                                 self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
-                                self::prefix($prefixCfLang2 . 'evolvesText', '2023', 0.4)
+                                self::prefix($prefixCfLang2 . 'evolvesText', '2023', 0.4),
                             ], 400),
                         ]),
                         self::disMax([

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -252,7 +252,7 @@ class TokenQueryBuilderTest extends TestCase
                 self::config(field: 'name', ranking: 1000, tokenize: true, and: false),
             ],
             'term' => ' FoO ',
-            'expected' =>                 self::disMax([
+            'expected' => self::disMax([
                 self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
                 self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                 self::prefix('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 0.4),
@@ -264,7 +264,7 @@ class TokenQueryBuilderTest extends TestCase
                 self::config(field: 'name', ranking: 1000, tokenize: true, and: false),
             ],
             'term' => ' FoO     BaR    Baz    ',
-            'expected' =>                 self::disMax([
+            'expected' => self::disMax([
                 self::terms('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', 'bar', 'baz'], 1),
                 self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo bar baz', 0.8, 'AUTO:3,8', 'or', 5),
                 self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo bar baz', 0.6, 3, 5),

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -242,6 +242,18 @@ class TokenQueryBuilderTest extends TestCase
             ]),
         ];
 
+        yield 'Tokenized field uses ngram match for long term' => [
+            'config' => [
+                self::config(field: 'name', ranking: 1000, tokenize: true, and: false),
+            ],
+            'term' => 'foooooooooo',
+            'expected' => self::disMax([
+                self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foooooooooo', 1),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 0.8, 'AUTO:3,8', 'or', 20),
+                self::matchSimple('name.' . Defaults::LANGUAGE_SYSTEM . '.ngram', 'foooooooooo', 0.4),
+            ], 1000),
+        ];
+
         yield 'Test multiple fields' => [
             'config' => [
                 self::config(field: 'name', ranking: 1000),
@@ -513,6 +525,18 @@ class TokenQueryBuilderTest extends TestCase
         return [
             'match' => [
                 $field => array_filter($payload, static fn ($value) => $value !== null),
+            ],
+        ];
+    }
+
+    private static function matchSimple(string $field, string $query, float $boost): array
+    {
+        return [
+            'match' => [
+                $field => [
+                    'query' => $query,
+                    'boost' => $boost,
+                ],
             ],
         ];
     }

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -145,7 +145,8 @@ class TokenQueryBuilderTest extends TestCase
     public function testBuildWithSynonyms(): void
     {
         $config = [
-            self::config(field: 'name', ranking: 1000, tokenize: true, and: false, prefixMatch: false),
+            self::config(field: 'name', ranking: 1000, tokenize: true, and: false, prefixMatch: true),
+            self::config(field: 'name', ranking: 800, tokenize: true, and: true, prefixMatch: false),
             self::config(field: 'tags.name', ranking: 500, tokenize: true, and: false),
         ];
 
@@ -169,6 +170,10 @@ class TokenQueryBuilderTest extends TestCase
                 self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
                 self::prefix('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 0.4),
             ], 1000),
+            self::disMax([
+                self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, $expectedFuzziness, 'and', $expectedMaxExpansions),
+            ], 800),
             self::nested('tags', self::disMax([
                 self::term('tags.name', 'foo', 1),
                 self::match('tags.name.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
@@ -242,6 +247,30 @@ class TokenQueryBuilderTest extends TestCase
             ]),
         ];
 
+        yield 'Test term is normalized' => [
+            'config' => [
+                self::config(field: 'name', ranking: 1000, tokenize: true, and: false),
+            ],
+            'term' => ' FoO ',
+            'expected' =>                 self::disMax([
+                self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                self::prefix('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 0.4),
+            ], 1000),
+        ];
+
+        yield 'Test term with spaces is normalized' => [
+            'config' => [
+                self::config(field: 'name', ranking: 1000, tokenize: true, and: false),
+            ],
+            'term' => ' FoO     BaR    Baz    ',
+            'expected' =>                 self::disMax([
+                self::terms('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', 'bar', 'baz'], 1),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo bar baz', 0.8, 'AUTO:3,8', 'or', 5),
+                self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo bar baz', 0.6, 3, 5),
+            ], 1000),
+        ];
+
         yield 'Tokenized field uses ngram match for long term' => [
             'config' => [
                 self::config(field: 'name', ranking: 1000, tokenize: true, and: false),
@@ -250,6 +279,7 @@ class TokenQueryBuilderTest extends TestCase
             'expected' => self::disMax([
                 self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foooooooooo', 1),
                 self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 0.8, 'AUTO:3,8', 'or', 20),
+                self::prefix('name.' . Defaults::LANGUAGE_SYSTEM, 'foooooooooo', 0.4),
                 self::matchSimple('name.' . Defaults::LANGUAGE_SYSTEM . '.ngram', 'foooooooooo', 0.4),
             ], 1000),
         ];
@@ -293,6 +323,7 @@ class TokenQueryBuilderTest extends TestCase
                 self::disMax([
                     self::term($prefix . 'evolvesText', '2023', 1),
                     self::match($prefix . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                    self::prefix($prefix . 'evolvesText', '2023', 0.4),
                 ], 500),
                 self::term($prefix . 'evolvesInt', 2023, 400),
                 self::term($prefix . 'evolvesFloat', 2023.0, 500),
@@ -382,10 +413,12 @@ class TokenQueryBuilderTest extends TestCase
                     self::disMax([
                         self::term($prefixCfLang1 . 'evolvesText', '2023', 1),
                         self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                        self::prefix($prefixCfLang1 . 'evolvesText', '2023', 0.4),
                     ], 500),
                     self::disMax([
                         self::term($prefixCfLang2 . 'evolvesText', '2023', 1),
                         self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                        self::prefix($prefixCfLang2 . 'evolvesText', '2023', 0.4),
                     ], 400),
                 ]),
                 self::disMax([
@@ -529,6 +562,9 @@ class TokenQueryBuilderTest extends TestCase
         ];
     }
 
+    /**
+     * @return array{match: array<string, array{query: string, boost: float}>}
+     */
     private static function matchSimple(string $field, string $query, float $boost): array
     {
         return [


### PR DESCRIPTION
In https://github.com/shopware/shopware/pull/12452, it was wrongly assumed that search term longer than configured max gram will not apply ngram search, but it's wrong, we should apply ngram search on longer term, mean it will break into small segments when apply ngram search