### PR TITLE
Add automated data attributes to components

### DIFF
--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -562,6 +562,11 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
         </service>
 
+        <service id="Shopware\Storefront\Framework\Twig\Components\TwigComponentRenderEventListener">
+            <argument>%kernel.environment%</argument>
+            <tag name="kernel.event_listener" />
+        </service>
+
         <service id="Shopware\Storefront\Framework\Routing\RobotsRouteScopeWhitelist">
             <tag name="shopware.route_scope_whitelist"/>
         </service>

--- a/src/Storefront/Framework/Twig/Components/TwigComponentRenderEventListener.php
+++ b/src/Storefront/Framework/Twig/Components/TwigComponentRenderEventListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\Twig\Components;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\UX\TwigComponent\Event\PreRenderEvent;
+
+#[Package('framework')]
+#[AsEventListener]
+class TwigComponentRenderEventListener
+{
+    /** @internal  */
+    public function __construct(
+        private readonly string $environment
+    ) {}
+
+    public function __invoke(PreRenderEvent $event): void
+    {
+        $mountedComponent = $event->getMountedComponent();
+        $variables = $event->getVariables();
+        $metadata = $event->getMetadata();
+        $attributesVar = $metadata->getAttributesVar();
+
+        // Get the current attributes
+        $attributes = $variables[$attributesVar] ?? null;
+
+        if ($attributes !== null) {
+            $additionalAttributes = [
+                'data-component-name' => $metadata->getName(),
+            ];
+
+            // If env = DEV add addtional attributes to the component
+            if ($this->environment === 'dev') {
+                $additionalAttributes['data-component-template'] = $metadata->getTemplate();
+
+                if ($mountedComponent->hasExtraMetadata('hostTemplate')) {
+                    $hostTemplate = $mountedComponent->getExtraMetadata('hostTemplate');
+                    $additionalAttributes['data-component-parent'] = $this->pathToComponentName($hostTemplate);
+                    $additionalAttributes['data-component-parent-template'] = $hostTemplate;
+                }
+            }
+
+            // Add additional attributes using defaults()
+            $newAttributes = $attributes->defaults($additionalAttributes);
+
+            // Update the variables with the new attributes
+            $variables[$attributesVar] = $newAttributes;
+            $event->setVariables($variables);
+        }
+    }
+
+    /**
+     * Converts a component path to a component name.
+     * 
+     * Example: "components/Sw/Filter/Panel.html.twig" -> "Sw:Filter:Panel"
+     * 
+     * @param string $path The component template path
+     * @return string The component name in format "Namespace:Component:Name"
+     */
+    private function pathToComponentName(string $path): string
+    {
+        $path = preg_replace('#^components/#', '', $path);
+        $path = preg_replace('#\.html\.twig$#', '', $path);
+        $parts = explode('/', $path);
+        return implode(':', $parts);
+    }
+}

--- a/src/Storefront/Resources/views/components/Slot.html.twig
+++ b/src/Storefront/Resources/views/components/Slot.html.twig
@@ -31,9 +31,7 @@
     {% block elements %}
         {% for element in elements %}
             {% set elementProperties = element.properties %}
-
             {% set elementProperties = elementProperties|merge({ 'data-element-id': element.id }) %}
-            {% set elementProperties = elementProperties|merge({ 'data-component-name': element.component }) %}
 
             {% if element.slots is not empty %}
                 {% set elementProperties = elementProperties|merge({ slots: element.slots }) %}

--- a/src/Storefront/Resources/views/components/Sw/Content/Page.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Content/Page.html.twig
@@ -5,9 +5,7 @@
 {% for element in page.elements %}
     {% set properties = element.properties %}
     {% set slots = element.slots %}
-
     {% set properties = properties|merge({ 'data-element-id': element.id }) %}
-    {% set properties = properties|merge({ 'data-component-name': element.component }) %}
 
     {% if slots is not empty %}
         {% set properties = properties|merge({ slots: slots }) %}


### PR DESCRIPTION
This PR automatically adds a `data-component-name` attribute to every rendered component root element.

Additionally, if the Shopware instance is in the development environment, there will be additional data attributes containing helpful information.
