### PR TITLE
ci: only use currents in scheduled nightly

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,7 +60,7 @@ jobs:
           workers: 1
           install: ${{ matrix.name != 'Install' && 'true' || 'false' }}
           extra-options: ${{ matrix.name != 'Install' && '' || '--trace=on' }}
-          use-currents: ${{ inputs.nightly == 'true' && matrix.no-currents != 'true' || '' }}
+          use-currents: ${{ inputs.nightly == 'true' && github.event_name == 'schedule' && matrix.no-currents != 'true' || '' }}
           currents-project-id: ${{ secrets.CURRENTS_PROJECT_ID }}
           currents-record-key: ${{ secrets.CURRENTS_RECORD_KEY }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
-      currents: true
+      currents: ${{ github.event_name == 'schedule' }}
   php:
     uses: ./.github/workflows/php.yml
     secrets: inherit


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when you trigger a nightly manually the currents reporting is active. We only want currents reporting on the scheduled nightly.

### 2. What does this change do, exactly?
Check if the nightly got triggered by the schedule.

### 3. Describe each step to reproduce the issue or behaviour.
Run the nightly.