### PR TITLE
feat: product analytics auth fetch transport

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -57,6 +57,9 @@
                 "store": {
                     "$ref": "#/definitions/shopware_store"
                 },
+                "analytics": {
+                    "$ref": "#/definitions/analytics"
+                },
                 "sitemap": {
                     "$ref": "#/definitions/sitemap"
                 },
@@ -1418,6 +1421,17 @@
                 }
             },
             "title": "Shopware store"
+        },
+        "analytics": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "gateway_url": {
+                    "type": "string",
+                    "description": "URL of the product analytics gateway"
+                }
+            },
+            "title": "Analytics"
         },
         "sales_channel_context": {
             "type": "object",

--- a/src/Administration/Controller/AdministrationController.php
+++ b/src/Administration/Controller/AdministrationController.php
@@ -90,6 +90,7 @@ class AdministrationController extends AbstractController
         private readonly string $serviceRegistryUrl,
         private readonly EntityRepository $languageRepository,
         private readonly SymfonyBearerTokenValidator $tokenValidator,
+        private readonly string $analyticsGatewayUrl,
         private readonly string $refreshTokenTtl = 'P1W',
     ) {
         // param is only available if the elasticsearch bundle is enabled
@@ -134,6 +135,7 @@ class AdministrationController extends AbstractController
             'refreshTokenTtl' => $refreshTokenTtl * 1000,
             'serviceRegistryUrl' => $this->serviceRegistryUrl,
             'productStreamIndexingEnabled' => $this->productStreamIndexingEnabled,
+            'analyticsGatewayUrl' => $this->analyticsGatewayUrl,
         ]);
 
         $response->setPublic();

--- a/src/Administration/Resources/app/administration/index.html
+++ b/src/Administration/Resources/app/administration/index.html
@@ -32,6 +32,7 @@
                 adminEsEnable: false,
                 storefrontEsEnable: false,
                 productStreamIndexingEnabled: true,
+                analyticsGatewayUrl: '<%- analyticsGatewayUrl %>',
             },
             apiContext: {
                 host: 'localhost',

--- a/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
@@ -51,6 +51,7 @@ export interface ContextState {
         systemCurrencyISOCode: null | string;
         systemCurrencyId: null | string;
         windowId: null | string;
+        analyticsGatewayUrl: null | string;
     };
     api: {
         apiPath: null | string;
@@ -96,6 +97,7 @@ const state: ContextState = reactive({
         systemCurrencyId: null,
         systemCurrencyISOCode: null,
         windowId: null,
+        analyticsGatewayUrl: null,
     },
     api: {
         apiPath: null,

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -1,36 +1,29 @@
+import * as amplitude from '@amplitude/analytics-browser';
 import initAmplitude from './amplitude.init';
 import { TelemetryEvent } from '../../core/telemetry/types';
 
-jest.mock('@amplitude/analytics-browser', () => ({
-    add: jest.fn(),
-    init: jest.fn(),
-    track: jest.fn(),
-    setUserId: jest.fn(),
-    getUserId: jest.fn(),
-    setTransport: jest.fn(),
-    flush: jest.fn(),
-    reset: jest.fn(),
-}));
+jest.mock('@amplitude/analytics-browser');
 
 describe('src/app/post-init/amplitude.init.ts', () => {
-    let mockLoginService;
-
     beforeEach(() => {
-        mockLoginService = {
-            addOnLogoutListener: jest.fn(),
-        };
-
-        Shopware.Service = jest.fn((serviceName) => {
-            if (serviceName === 'loginService') {
-                return mockLoginService;
-            }
-            return undefined;
-        });
-
+        amplitude.add.mockClear();
+        amplitude.init.mockClear();
+        amplitude.track.mockClear();
+        amplitude.setUserId.mockClear();
+        amplitude.getUserId.mockClear();
+        amplitude.flush.mockClear();
+        amplitude.reset.mockClear();
         global.Shopware = {
             ...global.Shopware,
-            Service: Shopware.Service,
+            Context: {
+                ...global.Shopware?.Context,
+                app: {
+                    systemCurrencyISOCode: 'EUR',
+                },
+            },
         };
+
+        Shopware.Store.get('context').app.analyticsGatewayUrl = 'https://analytics.example.com';
 
         global.repositoryFactoryMock.responses.addResponse({
             method: 'Post',
@@ -51,21 +44,19 @@ describe('src/app/post-init/amplitude.init.ts', () => {
 
     describe('initialization', () => {
         it('add enrichment plugin and calls initialization routine', async () => {
-            const { init, add } = await import('@amplitude/analytics-browser');
-
             await initAmplitude();
 
-            expect(add).toHaveBeenCalled();
-            expect(add).toHaveBeenCalledWith(
+            expect(amplitude.add).toHaveBeenCalled();
+            expect(amplitude.add).toHaveBeenCalledWith(
                 expect.objectContaining({
                     name: 'DefaultShopwareProperties',
                     execute: expect.any(Function),
                 }),
             );
 
-            expect(init).toHaveBeenCalled();
-            expect(init).toHaveBeenCalledWith(
-                expect.any(String),
+            expect(amplitude.init).toHaveBeenCalled();
+            expect(amplitude.init).toHaveBeenCalledWith(
+                'placeholder-apikey',
                 undefined,
                 expect.objectContaining({
                     autocapture: false,
@@ -79,6 +70,69 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                     fetchRemoteConfig: false,
                 }),
             );
+        });
+
+        it('should return early when analyticsGatewayUrl is not set', async () => {
+            Shopware.Store.get('context').app.analyticsGatewayUrl = null;
+
+            await initAmplitude();
+
+            expect(amplitude.init).not.toHaveBeenCalled();
+        });
+
+        it('should execute enrichment plugin with route properties when router is available', async () => {
+            Object.defineProperty(window.screen, 'orientation', {
+                value: { type: 'landscape-primary' },
+                configurable: true,
+            });
+
+            const mockRoute = {
+                value: {
+                    name: 'sw.product.detail',
+                    path: '/sw/product/detail/123',
+                    fullPath: '/sw/product/detail/123?tab=general',
+                },
+            };
+
+            Shopware.Application.view = {
+                router: {
+                    currentRoute: mockRoute,
+                },
+            };
+
+            await initAmplitude();
+
+            const enrichmentPlugin = amplitude.add.mock.calls[0][0];
+            const mockEvent = { event_properties: {} };
+            const result = await enrichmentPlugin.execute(mockEvent);
+
+            expect(result.event_properties).toEqual(
+                expect.objectContaining({
+                    sw_page_name: 'sw.product.detail',
+                    sw_page_path: '/sw/product/detail/123',
+                    sw_page_full_path: '/sw/product/detail/123?tab=general',
+                    sw_screen_orientation: 'landscape',
+                }),
+            );
+        });
+
+        it('should execute enrichment plugin without route properties when router is not available', async () => {
+            Object.defineProperty(window.screen, 'orientation', {
+                value: { type: 'portrait-primary' },
+                configurable: true,
+            });
+
+            Shopware.Application.view = null;
+
+            await initAmplitude();
+
+            const enrichmentPlugin = amplitude.add.mock.calls[0][0];
+            const mockEvent = { event_properties: {} };
+            const result = await enrichmentPlugin.execute(mockEvent);
+
+            expect(result.event_properties.sw_page_name).toBeUndefined();
+            expect(result.event_properties.sw_page_path).toBeUndefined();
+            expect(result.event_properties.sw_page_full_path).toBeUndefined();
         });
     });
 
@@ -152,14 +206,12 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                 },
             ],
         ])('handles event', async (telemetryEvent, trackedData) => {
-            const { track } = await import('@amplitude/analytics-browser');
-
             await initAmplitude();
 
             Shopware.Utils.EventBus.emit('telemetry', telemetryEvent);
 
-            expect(track).toHaveBeenCalled();
-            expect(track).toHaveBeenCalledWith(trackedData.eventName, trackedData.properties);
+            expect(amplitude.track).toHaveBeenCalled();
+            expect(amplitude.track).toHaveBeenCalledWith(trackedData.eventName, trackedData.properties);
         });
     });
 
@@ -174,8 +226,6 @@ describe('src/app/post-init/amplitude.init.ts', () => {
         });
 
         it('should set user ID in format "shopId:userId"', async () => {
-            const amplitude = await import('@amplitude/analytics-browser');
-
             await initAmplitude();
 
             const identifyEvent = new TelemetryEvent('identify', {
@@ -188,8 +238,6 @@ describe('src/app/post-init/amplitude.init.ts', () => {
         });
 
         it('should update user ID when a different user identifies', async () => {
-            const amplitude = await import('@amplitude/analytics-browser');
-
             await initAmplitude();
 
             const firstIdentifyEvent = new TelemetryEvent('identify', {
@@ -223,13 +271,11 @@ describe('src/app/post-init/amplitude.init.ts', () => {
         });
 
         it('should track Login event when a identify telemetry event with a different userId arrives', async () => {
-            const amplitude = await import('@amplitude/analytics-browser');
-
             let amplitudeUserId = null;
-            jest.spyOn(amplitude, 'setUserId').mockImplementation((userId) => {
+            amplitude.setUserId.mockImplementation((userId) => {
                 amplitudeUserId = userId;
             });
-            jest.spyOn(amplitude, 'getUserId').mockImplementation(() => amplitudeUserId);
+            amplitude.getUserId.mockImplementation(() => amplitudeUserId);
 
             await initAmplitude();
 
@@ -263,8 +309,6 @@ describe('src/app/post-init/amplitude.init.ts', () => {
         });
 
         it('should track Logout event when a reset telemetry event arrives', async () => {
-            const amplitude = await import('@amplitude/analytics-browser');
-
             await initAmplitude();
 
             const resetEvent = new TelemetryEvent('reset', {});
@@ -272,6 +316,26 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             Shopware.Utils.EventBus.emit('telemetry', resetEvent);
 
             expect(amplitude.track).toHaveBeenCalledWith('Logout');
+        });
+
+        it('should call flush and reset after Logout event', async () => {
+            jest.useFakeTimers();
+
+            await initAmplitude();
+
+            const resetEvent = new TelemetryEvent('reset', {});
+
+            Shopware.Utils.EventBus.emit('telemetry', resetEvent);
+
+            expect(amplitude.flush).not.toHaveBeenCalled();
+            expect(amplitude.reset).not.toHaveBeenCalled();
+
+            jest.runAllTimers();
+
+            expect(amplitude.flush).toHaveBeenCalled();
+            expect(amplitude.reset).toHaveBeenCalled();
+
+            jest.useRealTimers();
         });
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -1,6 +1,7 @@
 /**
  * @sw-package framework
  */
+import * as amplitude from '@amplitude/analytics-browser';
 import { string } from 'src/core/service/util.service';
 import type { TelemetryEvent, EventTypes, TrackableType } from '../../core/telemetry/types';
 
@@ -8,14 +9,12 @@ import type { TelemetryEvent, EventTypes, TrackableType } from '../../core/telem
  * @private
  */
 export default async function (): Promise<void> {
-    const amplitude = await import('@amplitude/analytics-browser');
-
-    Shopware.Service('loginService').addOnLogoutListener(() => {
-        amplitude.setTransport('beacon');
-    });
+    const analyticsGatewayUrl = Shopware.Store.get('context').app.analyticsGatewayUrl;
+    if (!analyticsGatewayUrl) {
+        return;
+    }
 
     let defaultLanguageName = '';
-
     try {
         defaultLanguageName = await getDefaultLanguageName();
     } catch {
@@ -53,7 +52,8 @@ export default async function (): Promise<void> {
 
     // check for consent
 
-    amplitude.init('a04bb926f471ce883bc219814fc9577', undefined, {
+    // The real key will be added by the gateway
+    amplitude.init('placeholder-apikey', undefined, {
         autocapture: false,
         serverZone: 'EU',
         appVersion: Shopware.Store.get('context').app.config.version as string,
@@ -63,7 +63,7 @@ export default async function (): Promise<void> {
             platform: false,
         },
         fetchRemoteConfig: false,
-        // serverUrl: use proxy server url here, e.g. usage-data.shopware.io/product-analytics,
+        serverUrl: `${analyticsGatewayUrl}/event`,
     });
 
     function pushTelemetryEventToAmplitude(telemetryEvent: TelemetryEvent<EventTypes>) {

--- a/src/Administration/Resources/app/administration/src/app/store/context.store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/context.store.spec.ts
@@ -37,6 +37,7 @@ describe('context.store', () => {
             systemCurrencyId: null,
             systemCurrencyISOCode: null,
             windowId: null,
+            analyticsGatewayUrl: null,
         });
 
         expect(store.api).toEqual(

--- a/src/Administration/Resources/app/administration/vite.config.mts
+++ b/src/Administration/Resources/app/administration/vite.config.mts
@@ -135,6 +135,7 @@ export default defineConfig(({ command }) => {
                             data: {
                                 featureFlags: JSON.stringify(featureFlags),
                                 serviceRegistryUrl: process.env.SERVICE_REGISTRY_URL,
+                                analyticsGatewayUrl: process.env.PRODUCT_ANALYTICS_GATEWAY_URL,
                                 pageLoadingScreen,
                             },
                         },

--- a/src/Administration/Resources/config/services.xml
+++ b/src/Administration/Resources/config/services.xml
@@ -51,6 +51,7 @@
             <argument type="string">%env(SERVICE_REGISTRY_URL)%</argument>
             <argument type="service" id="language.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Api\OAuth\SymfonyBearerTokenValidator"/>
+            <argument type="string">%env(PRODUCT_ANALYTICS_GATEWAY_URL)%</argument>
             <argument type="string">%shopware.api.refresh_token_ttl%</argument>
 
             <call method="setContainer">

--- a/src/Administration/Resources/views/administration/index.html.twig
+++ b/src/Administration/Resources/views/administration/index.html.twig
@@ -76,6 +76,7 @@
                     adminEsEnable: {{ adminEsEnable ? 'true' : 'false' }},
                     storefrontEsEnable: {{ storefrontEsEnable ? 'true' : 'false' }},
                     productStreamIndexingEnabled: {{ productStreamIndexingEnabled ? 'true' : 'false' }},
+                    analyticsGatewayUrl: '{{ analyticsGatewayUrl }}',
                 }
             });
         };

--- a/src/Core/Framework/Resources/config/packages/dev/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/dev/shopware.yaml
@@ -1,3 +1,6 @@
+parameters:
+    env(PRODUCT_ANALYTICS_GATEWAY_URL): ''
+
 shopware:
     api:
         api_browser:

--- a/src/Core/Framework/Resources/config/packages/e2e/e2e.yaml
+++ b/src/Core/Framework/Resources/config/packages/e2e/e2e.yaml
@@ -1,3 +1,6 @@
+parameters:
+    env(PRODUCT_ANALYTICS_GATEWAY_URL): ''
+
 framework:
     messenger:
         transports:

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -1,6 +1,7 @@
 parameters:
     default_cdn_strategy: "id"
     env(APP_URL): ''
+    env(PRODUCT_ANALYTICS_GATEWAY_URL): 'https://product-analytics-gateway.services.shopware.io'
     APP_URL: "%env(string:APP_URL)%"
     env(REDIS_PREFIX): ''
 

--- a/src/Core/Framework/Resources/config/packages/test/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/test/shopware.yaml
@@ -1,3 +1,6 @@
+parameters:
+    env(PRODUCT_ANALYTICS_GATEWAY_URL): ''
+
 shopware:
     filesystem:
         private:

--- a/tests/unit/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/unit/Administration/Controller/AdministrationControllerTest.php
@@ -84,6 +84,8 @@ class AdministrationControllerTest extends TestCase
 
     private string $refreshTokenTtl;
 
+    private string $analyticsGatewayUrl;
+
     private IdsCollection $ids;
 
     protected function setUp(): void
@@ -100,6 +102,7 @@ class AdministrationControllerTest extends TestCase
         $this->serviceRegistryUrl = 'https://registry.services.shopware.io';
         $this->languageRepository = $this->createMock(EntityRepository::class);
         $this->refreshTokenTtl = 'P1W';
+        $this->analyticsGatewayUrl = 'https://analytics-gateway.test.com';
 
         $this->ids = new IdsCollection();
     }
@@ -133,6 +136,7 @@ class AdministrationControllerTest extends TestCase
                     'serviceRegistryUrl' => $this->serviceRegistryUrl,
                     'refreshTokenTtl' => 7 * 86400 * 1000,
                     'productStreamIndexingEnabled' => true,
+                    'analyticsGatewayUrl' => $this->analyticsGatewayUrl,
                 ]
             );
 
@@ -699,6 +703,7 @@ class AdministrationControllerTest extends TestCase
             $this->serviceRegistryUrl,
             $languageRepository ?? $this->languageRepository,
             $tokenValidator ?? $this->createMock(SymfonyBearerTokenValidator::class),
+            $this->analyticsGatewayUrl,
             $this->refreshTokenTtl,
         );
     }


### PR DESCRIPTION
new description:

Adds the gateway url as an env var that can be configured and some tests for coverage.
The auth concept was discarded.

----------------------------------------------------------------------------------------------------------------------------------------------------------------------
old descripiton:

extend fetch transport to be able to send a token in the header of the request when sending events with amplitude's sdk

Information about the whole concept of Product Analytics:
https://shopware.atlassian.net/wiki/spaces/PRODUCT/pages/20506968300/Product+Analytics+PRA

Disclaimer: Not to confuse Product Analytics with Shopware Analytics
- Product Analytics aims to collect usage data of the admin and make it available for the teams in the Product department as insights for their features.
- Shopware Analytics is a Shopware app that aims to provide insights to the merchant. Specially about numbers in their shops and also about usage data of shoppers in their storefronts.