### PR TITLE
fix: Don't fall back to system default locale

### DIFF
--- a/src/Core/System/Snippet/DataTransfer/Language/Language.php
+++ b/src/Core/System/Snippet/DataTransfer/Language/Language.php
@@ -26,7 +26,7 @@ class Language
             $locale = str_replace('-', '_', $locale);
         }
 
-        if (!Locales::exists($locale)) {
+        if (!in_array($locale, Locales::getLocales(), true) && !in_array($locale, Locales::getAliases(), true)) {
             throw SnippetException::localeDoesNotExist($locale);
         }
     }

--- a/src/Core/System/Snippet/DataTransfer/Language/Language.php
+++ b/src/Core/System/Snippet/DataTransfer/Language/Language.php
@@ -26,7 +26,7 @@ class Language
             $locale = str_replace('-', '_', $locale);
         }
 
-        if (!in_array($locale, Locales::getLocales(), true) && !in_array($locale, Locales::getAliases(), true)) {
+        if (!\in_array($locale, Locales::getLocales(), true) && !\in_array($locale, Locales::getAliases(), true)) {
             throw SnippetException::localeDoesNotExist($locale);
         }
     }

--- a/tests/unit/Core/System/Snippet/DataTransfer/Language/LanguageTest.php
+++ b/tests/unit/Core/System/Snippet/DataTransfer/Language/LanguageTest.php
@@ -29,4 +29,11 @@ class LanguageTest extends TestCase
         static::assertSame('en-GB', $language->locale);
         static::assertSame('English', $language->name);
     }
+
+    public function testCreateLanguageWithValidLocaleAlias(): void
+    {
+        $language = new Language('bs_Latn_BA', 'Bosnian');
+        static::assertSame('bs_Latn_BA', $language->locale);
+        static::assertSame('Bosnian', $language->name);
+    }
 }


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/13067

THe original issue, there might be cases where system locale might not be set correctly leading to issues

@aragon999 might be interesting to hear your thoughts if you could reproduce the issue if it fixes that, i was not able to reproduce the issue in a test case by manually using `Locale::setDefault('');` or ini_set with an empty string

