### PR TITLE
perf: don't fetch child categories in seo url updater

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -32,6 +32,12 @@ The following classes and constants were deprecated as they will not be used any
 Additionally, the following configuration was deprecated:
 * `shopware.cache.invalidation.http_cache`
 
+### Performance improvements for generating category SEO-Urls
+
+We don't synchronously fetch and generate the SEO-Urls for all child categories anymore. 
+Instead, we rely on the CategoryIndexer to trigger the re-index of children asynchronously.
+This prevents cases where SEO-Urls were generated multiple times for the same category, and thus it considerably improves the performance of category indexing.
+
 ## Administration
 
 ## Storefront

--- a/src/Storefront/DependencyInjection/seo.xml
+++ b/src/Storefront/DependencyInjection/seo.xml
@@ -26,7 +26,6 @@
 
         <service id="Shopware\Storefront\Framework\Seo\SeoUrlRoute\SeoUrlUpdateListener">
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlUpdater"/>
-            <argument type="service" id="Doctrine\DBAL\Connection"/>
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListener.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListener.php
@@ -30,7 +30,6 @@ class SeoUrlUpdateListener implements EventSubscriberInterface
      */
     public function __construct(
         private readonly SeoUrlUpdater $seoUrlUpdater,
-        private readonly Connection $connection
     ) {
     }
 
@@ -52,12 +51,7 @@ class SeoUrlUpdateListener implements EventSubscriberInterface
             return;
         }
 
-        $ids = $event->getIds();
-        if (!$event->isFullIndexing) {
-            $ids = array_values(array_merge($ids, $this->getCategoryChildren($ids)));
-        }
-
-        $this->seoUrlUpdater->update(NavigationPageSeoUrlRoute::ROUTE_NAME, $ids);
+        $this->seoUrlUpdater->update(NavigationPageSeoUrlRoute::ROUTE_NAME, $event->getIds());
     }
 
     public function updateProductUrls(ProductIndexerEvent $event): void
@@ -76,38 +70,5 @@ class SeoUrlUpdateListener implements EventSubscriberInterface
         }
 
         $this->seoUrlUpdater->update(LandingPageSeoUrlRoute::ROUTE_NAME, array_values($event->getIds()));
-    }
-
-    /**
-     * @param list<string> $ids
-     *
-     * @return array<string>
-     */
-    private function getCategoryChildren(array $ids): array
-    {
-        if (empty($ids)) {
-            return [];
-        }
-
-        $query = $this->connection->createQueryBuilder();
-
-        $query->select('category.id');
-        $query->from('category');
-
-        foreach ($ids as $id) {
-            $key = 'id' . $id;
-            $query->orWhere('category.type != :type AND category.path LIKE :' . $key);
-            $query->setParameter($key, '%' . $id . '%');
-        }
-
-        $query->setParameter('type', CategoryDefinition::TYPE_LINK);
-
-        $children = $query->executeQuery()->fetchFirstColumn();
-
-        if (!$children) {
-            return [];
-        }
-
-        return Uuid::fromBytesToHexList($children);
     }
 }

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListener.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListener.php
@@ -2,8 +2,6 @@
 
 namespace Shopware\Storefront\Framework\Seo\SeoUrlRoute;
 
-use Doctrine\DBAL\Connection;
-use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEvents;
 use Shopware\Core\Content\Category\Event\CategoryIndexerEvent;
 use Shopware\Core\Content\LandingPage\Event\LandingPageIndexerEvent;
@@ -12,7 +10,6 @@ use Shopware\Core\Content\Product\Events\ProductIndexerEvent;
 use Shopware\Core\Content\Product\ProductEvents;
 use Shopware\Core\Content\Seo\SeoUrlUpdater;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListener.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListener.php
@@ -13,6 +13,10 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
+ * This listener updates the seo urls for the product, category and landing page routes when the corresponding entities are indexed.
+ * It assumes that for every parent child relation the indexer will take care of fetching the child ids
+ * and dispatching the event for the children as well.
+ *
  * @internal
  */
 #[Package('inventory')]

--- a/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListenerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListenerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Storefront\Framework\Seo\SeoUrlRoute;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -590,6 +591,86 @@ class SeoUrlUpdateListenerTest extends TestCase
         $canonical = $seoUrls->filterByProperty('isCanonical', true)->first();
         static::assertNotNull($canonical);
         static::assertSame('updated/C2', $canonical->getSeoPathInfo());
+    }
+
+    public function testChildCategorySeoUrlIndexing(): void
+    {
+        $parentId = Uuid::randomHex();
+        $child1Id = Uuid::randomHex();
+        $child2Id = Uuid::randomHex();
+
+        $context = Context::createDefaultContext();
+
+        $categoryRepository = $this->getContainer()->get('category.repository');
+        $categoryRepository->create([
+            [
+                'id' => $parentId,
+                'name' => 'parent',
+                'children' => [
+                    [
+                        'id' => $child1Id,
+                        'name' => 'child1',
+                    ],
+                    [
+                        'id' => $child2Id,
+                        'name' => 'child2',
+                    ],
+                ],
+            ],
+        ], $context);
+
+        // we don't check parent category here, because it's the home page and therefore has no seo url
+        $criteria = new Criteria([$child1Id, $child2Id]);
+        $criteria->addAssociation('seoUrls');
+        $categories = $categoryRepository->search($criteria, Context::createDefaultContext());
+
+        // check that seo Urls are empty, as the categories are not assigned to a sales channel yet
+        $child1 = $categories->get($child1Id);
+        static::assertInstanceOf(CategoryEntity::class, $child1);
+        $seoUrls = $child1->getSeoUrls();
+        static::assertInstanceOf(SeoUrlCollection::class, $seoUrls);
+        static::assertCount(0, $seoUrls);
+
+        $child2 = $categories->get($child2Id);
+        static::assertInstanceOf(CategoryEntity::class, $child2);
+        $seoUrls = $child2->getSeoUrls();
+        static::assertInstanceOf(SeoUrlCollection::class, $seoUrls);
+        static::assertCount(0, $seoUrls);
+
+        // assign categories to sales channel
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test', categoryEntrypoint: $parentId);
+
+        // update parent
+        $update = [
+            'id' => $parentId,
+            'name' => 'updated',
+        ];
+
+        $categoryRepository->update([$update], Context::createDefaultContext());
+
+        // we don't check parent category here, because it's the home page and therefore has no seo url
+        $criteria = new Criteria([$child1Id, $child2Id]);
+        $criteria->addAssociation('seoUrls');
+        $categories = $categoryRepository->search($criteria, Context::createDefaultContext());
+
+        $child1 = $categories->get($child1Id);
+        static::assertInstanceOf(CategoryEntity::class, $child1);
+        $seoUrls = $child1->getSeoUrls();
+        static::assertInstanceOf(SeoUrlCollection::class, $seoUrls);
+        static::assertCount(1, $seoUrls);
+        $seoUrl = $seoUrls->first();
+        static::assertInstanceOf(SeoUrlEntity::class, $seoUrl);
+        static::assertSame('child1/', $seoUrl->getSeoPathInfo());
+
+        $child2 = $categories->get($child2Id);
+        static::assertInstanceOf(CategoryEntity::class, $child2);
+        $seoUrls = $child2->getSeoUrls();
+        static::assertInstanceOf(SeoUrlCollection::class, $seoUrls);
+        static::assertCount(1, $seoUrls);
+        $seoUrl = $seoUrls->first();
+        static::assertInstanceOf(SeoUrlEntity::class, $seoUrl);
+        static::assertSame('child2/', $seoUrl->getSeoPathInfo());
     }
 
     public function testIndex(?int $seoUrlCount = 1): void

--- a/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListenerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListenerTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Integration\Storefront\Framework\Seo\DataAbstractionLayer\Indexing;
+namespace Shopware\Tests\Integration\Storefront\Framework\Seo\SeoUrlRoute;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Group;
@@ -36,7 +36,7 @@ use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
  */
 #[Package('inventory')]
 #[Group('slow')]
-class SeoUrlIndexerTest extends TestCase
+class SeoUrlUpdateListenerTest extends TestCase
 {
     use IntegrationTestBehaviour;
     use QueueTestBehaviour;

--- a/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListenerTest.php
+++ b/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListenerTest.php
@@ -2,17 +2,18 @@
 
 namespace Shopware\Tests\Unit\Storefront\Framework\Seo\SeoUrlRoute;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Event\CategoryIndexerEvent;
+use Shopware\Core\Content\LandingPage\Event\LandingPageIndexerEvent;
+use Shopware\Core\Content\Product\Events\ProductIndexerEvent;
 use Shopware\Core\Content\Seo\SeoUrlUpdater;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\SeoUrlUpdateListener;
 
 /**
@@ -23,56 +24,101 @@ class SeoUrlUpdateListenerTest extends TestCase
 {
     private SeoUrlUpdater&MockObject $seoUrlUpdater;
 
-    private Connection&MockObject $connection;
-
     private SeoUrlUpdateListener $listener;
 
     protected function setUp(): void
     {
         $this->seoUrlUpdater = $this->createMock(SeoUrlUpdater::class);
-        $this->connection = $this->createMock(Connection::class);
-        $this->listener = new SeoUrlUpdateListener($this->seoUrlUpdater, $this->connection);
+        $this->listener = new SeoUrlUpdateListener($this->seoUrlUpdater);
     }
 
-    public function testUpdateCategoryUrlsWithFullIndexing(): void
-    {
-        $childUuid = Uuid::randomHex();
-        $event = new CategoryIndexerEvent([$childUuid], Context::createDefaultContext(), [], true);
-
-        $this->connection->expects($this->never())->method('createQueryBuilder');
-        $this->seoUrlUpdater->expects($this->once())
-            ->method('update')
-            ->with(
-                NavigationPageSeoUrlRoute::ROUTE_NAME,
-                [$childUuid]
-            );
-
-        $this->listener->updateCategoryUrls($event);
-    }
-
-    public function testUpdateCategoryUrlsWithPartialIndexing(): void
+    public function testUpdateCategoryUrls(): void
     {
         $childUuid = Uuid::randomHex();
         $parentUuid = Uuid::randomHex();
 
-        $childId1 = Uuid::randomBytes();
-        $childId2 = Uuid::randomBytes();
-
-        $event = new CategoryIndexerEvent([$childUuid, $parentUuid], Context::createDefaultContext(), [], false);
-
-        $result = $this->createMock(Result::class);
-        $result->method('fetchFirstColumn')->willReturn([$childId1, $childId2]);
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('executeQuery')->willReturn($result);
-        $this->connection->method('createQueryBuilder')->willReturn($queryBuilder);
+        $event = new CategoryIndexerEvent([$parentUuid, $childUuid], Context::createDefaultContext());
 
         $this->seoUrlUpdater->expects($this->once())
             ->method('update')
             ->with(
                 NavigationPageSeoUrlRoute::ROUTE_NAME,
-                [$childUuid, $parentUuid, Uuid::fromBytesToHex($childId1), Uuid::fromBytesToHex($childId2)]
+                [$parentUuid, $childUuid]
             );
 
         $this->listener->updateCategoryUrls($event);
+    }
+
+    public function testUpdateCategoryUrlsSkipped(): void
+    {
+        $childUuid = Uuid::randomHex();
+        $parentUuid = Uuid::randomHex();
+
+        $event = new CategoryIndexerEvent([$parentUuid, $childUuid], Context::createDefaultContext(), [SeoUrlUpdateListener::CATEGORY_SEO_URL_UPDATER]);
+
+        $this->seoUrlUpdater->expects($this->never())
+            ->method('update');
+
+        $this->listener->updateCategoryUrls($event);
+    }
+
+    public function testUpdateProductUrls(): void
+    {
+        $childUuid = Uuid::randomHex();
+        $parentUuid = Uuid::randomHex();
+
+        $event = new ProductIndexerEvent([$parentUuid, $childUuid], Context::createDefaultContext());
+
+        $this->seoUrlUpdater->expects($this->once())
+            ->method('update')
+            ->with(
+                ProductPageSeoUrlRoute::ROUTE_NAME,
+                [$parentUuid, $childUuid]
+            );
+
+        $this->listener->updateProductUrls($event);
+    }
+
+    public function testUpdateProductUrlsSkips(): void
+    {
+        $childUuid = Uuid::randomHex();
+        $parentUuid = Uuid::randomHex();
+
+        $event = new ProductIndexerEvent([$parentUuid, $childUuid], Context::createDefaultContext(), [SeoUrlUpdateListener::PRODUCT_SEO_URL_UPDATER]);
+
+        $this->seoUrlUpdater->expects($this->never())
+            ->method('update');
+
+        $this->listener->updateProductUrls($event);
+    }
+
+    public function testUpdateLandingPageUrls(): void
+    {
+        $childUuid = Uuid::randomHex();
+        $parentUuid = Uuid::randomHex();
+
+        $event = new LandingPageIndexerEvent([$parentUuid, $childUuid], Context::createDefaultContext());
+
+        $this->seoUrlUpdater->expects($this->once())
+            ->method('update')
+            ->with(
+                LandingPageSeoUrlRoute::ROUTE_NAME,
+                [$parentUuid, $childUuid]
+            );
+
+        $this->listener->updateLandingPageUrls($event);
+    }
+
+    public function testUpdateLandingPageUrlsSkips(): void
+    {
+        $childUuid = Uuid::randomHex();
+        $parentUuid = Uuid::randomHex();
+
+        $event = new LandingPageIndexerEvent([$parentUuid, $childUuid], Context::createDefaultContext(), [SeoUrlUpdateListener::LANDING_PAGE_SEO_URL_UPDATER]);
+
+        $this->seoUrlUpdater->expects($this->never())
+            ->method('update');
+
+        $this->listener->updateLandingPageUrls($event);
     }
 }


### PR DESCRIPTION
The category indexer will already fetch the children and dispatch an indexing event for all children
Fixes: https://github.com/shopware/shopware/issues/3536

Here the category indexer already fetches the children: https://github.com/shopware/shopware/blob/trunk/src/Core/Content/Category/DataAbstractionLayer/CategoryIndexer.php#L118
We don't have to do it again

it seems that before we had a seo url indexer, that was independent of the category or product indexer, therefore we needed to fetch children there as well, now we rely on the base entity indexer for that 

We had a similiar change years back to remove fetching of product children here: https://github.com/shopware/shopware/commit/cfe5cf7dc800c40f94c426666650fbb339e6fe72

#noCodeIsFasterThanNoCode
