### PR TITLE
fix(sales-channel-products): Exchange `sw-empty-state` with `mt-empty-state`

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -19,10 +19,10 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
+        "lastModified": 1765121682,
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
         "type": "github"
       },
       "original": {
@@ -31,10 +31,31 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765016596,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "548fc44fca28a5e81c5d6b846e555e6b9c2a5a3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -66,32 +87,14 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762868777,
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "c5c3147730384576196fb5da048a6e45dee10d56",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     }
   },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-modal/sw-sales-channel-products-assignment-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-modal/sw-sales-channel-products-assignment-modal.html.twig
@@ -1,6 +1,7 @@
 {% block sw_sales_channel_products_assignment_modal %}
 <sw-modal
     class="sw-sales-channel-products-assignment-modal"
+    variant="large"
     :title="$tc('sw-sales-channel.detail.productAssignmentModal.title')"
     @modal-close="onCloseModal"
 >

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.html.twig
@@ -62,7 +62,7 @@
             <mt-empty-state
                 v-else
                 icon="solid-products"
-                :headline="$tc('sw-sales-channel.detail.products.titleEmptyState')"
+                :headline="$t('sw-sales-channel.detail.products.titleEmptyState')"
             />
             {% endblock %}
         </sw-card-section>

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.html.twig
@@ -30,7 +30,7 @@
                     {% block sw_sales_channel_detail_products_card_section_secondary_button %}
                     <mt-button
                         v-tooltip="{
-                            message: $tc('sw-privileges.tooltip.warning'),
+                            message: $t('sw-privileges.tooltip.warning'),
                             disabled: acl.can('sales_channel.editor'),
                             showOnDisabledElements: true
                         }"
@@ -40,7 +40,7 @@
                         variant="secondary"
                         @click="openAddProductsModal"
                     >
-                        {{ $tc('sw-sales-channel.detail.products.buttonAddProducts', {}, 0) }}
+                        {{ $t('sw-sales-channel.detail.products.buttonAddProducts', {}, 0) }}
                     </mt-button>
                     {% endblock %}
                 </sw-container>
@@ -76,7 +76,7 @@
                                 {% block sw_sales_channel_detail_products_listing_select_item_checkbox %}
                                 <mt-checkbox
                                     v-tooltip="{
-                                        message: $tc('sw-sales-channel.detail.products.inheritVariantNotRemovableTooltip'),
+                                        message: $t('sw-sales-channel.detail.products.inheritVariantNotRemovableTooltip'),
                                         disabled: isRecordSelectable(item),
                                         showOnDisabledElements: true
                                     }"
@@ -130,7 +130,7 @@
                             :disabled="!isProductRemovable(item)"
                             @click="onDeleteProduct(item)"
                         >
-                            {{ $tc('global.default.remove') }}
+                            {{ $t('global.default.remove') }}
                         </sw-context-menu-item>
                         {% endblock %}
                     </template>
@@ -144,7 +144,7 @@
                             @click="onDeleteProducts"
                             @keydown.enter="onDeleteProducts"
                         >
-                            {{ $tc('global.default.remove') }}
+                            {{ $t('global.default.remove') }}
                         </a>
                         {% endblock %}
                     </template>
@@ -152,20 +152,14 @@
                 {% endblock %}
 
                 {% block sw_sales_channel_detail_products_card_section_primary_empty_state %}
-                <sw-empty-state
+                <mt-empty-state
                     v-else
-                    :show-description="false"
-                    :title="$tc('sw-sales-channel.detail.products.titleEmptyStateTable')"
-                >
-                    <template #icon>
-                        {% block sw_sales_channel_detail_products_card_section_primary_image %}
-                        <img
-                            :src="assetFilter('/administration/administration/static/img/empty-states/products-empty-state.svg')"
-                            :alt="$tc('sw-sales-channel.detail.products.titleEmptyStateTable')"
-                        >
-                        {% endblock %}
-                    </template>
-                </sw-empty-state>
+                    icon="solid-products"
+                    :headline="$t('sw-sales-channel.detail.products.titleEmptyStateTable')"
+                />
+
+                {# @deprecated tag:v6.8.0 - Will be removed, use mt-button icon property of mt-empty-state instead #}
+                {% block sw_sales_channel_detail_products_card_section_primary_image %}{% endblock %}
                 {% endblock %}
             </sw-card-section>
             {% endblock %}
@@ -175,39 +169,32 @@
     {% endblock %}
 
     {% block sw_sales_channel_detail_products_empty_state %}
-    <sw-empty-state
+    <mt-empty-state
         v-if="products.length <= 0 && !searchTerm && !isLoading"
-        :show-description="false"
-        :absolute="false"
-        :title="$tc('sw-sales-channel.detail.products.titleEmptyState')"
+        icon="solid-products"
+        :headline="$t('sw-sales-channel.detail.products.titleEmptyState')"
     >
-        <template #icon>
-            {% block sw_sales_channel_detail_products_empty_state_image %}
-            <img
-                :src="assetFilter('/administration/administration/static/img/empty-states/products-empty-state.svg')"
-                :alt="$tc('sw-sales-channel.detail.products.titleEmptyState')"
-            >
-            {% endblock %}
-        </template>
-
-        <template #actions>
+        <template #button>
             {% block sw_sales_channel_detail_products_empty_state_button %}
             <mt-button
                 v-tooltip="{
-                    message: $tc('sw-privileges.tooltip.warning'),
+                    message: $t('sw-privileges.tooltip.warning'),
                     disabled: acl.can('sales_channel.editor'),
                     showOnDisabledElements: true
                 }"
-                ghost
                 :disabled="!acl.can('sales_channel.editor')"
+                ghost
                 variant="secondary"
                 @click="openAddProductsModal"
             >
-                {{ $tc('sw-sales-channel.detail.products.buttonAddProducts', {}, 0) }}
+                {{ $t('sw-sales-channel.detail.products.buttonAddProducts') }}
             </mt-button>
             {% endblock %}
         </template>
-    </sw-empty-state>
+    </mt-empty-state>
+
+    {# @deprecated tag:v6.8.0 - Will be removed, use mt-button icon property of mt-empty-state instead #}
+    {% block sw_sales_channel_detail_products_empty_state_image %}{% endblock %}
     {% endblock %}
 
     {% block sw_sales_channel_detail_products_assignment_modal %}

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.html.twig
@@ -40,7 +40,7 @@
                         variant="secondary"
                         @click="openAddProductsModal"
                     >
-                        {{ $t('sw-sales-channel.detail.products.buttonAddProducts', {}, 0) }}
+                        {{ $t('sw-sales-channel.detail.products.buttonAddProducts') }}
                     </mt-button>
                     {% endblock %}
                 </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.spec.js
@@ -506,7 +506,7 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         await flushPromises();
 
         expect(wrapper.getComponent('.mt-card').attributes('is-loading')).toBeUndefined();
-        expect(wrapper.find('.sw-empty-state').exists()).toBe(true);
+        expect(wrapper.find('.mt-empty-state').exists()).toBe(true);
     });
 
     it('should return filters from filter registry', async () => {


### PR DESCRIPTION
fixes #13712

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### Demo
https://github.com/user-attachments/assets/d814f875-091d-41b0-ad9c-dbfcdeb9f0e1

### 1. Why is this change necessary?
Old empty states are misaligned

### 2. What does this change do, exactly?
Change sw with mt component


### 3. Describe each step to reproduce the issue or behaviour.
- Go to sales-channel > Product
- **See the state without products**
- See the state with products
  - **Enter a search term so you find no products and see another empty state**

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
