### PR TITLE
feat: Allow disable search language analyzer via env variable

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -129,6 +129,16 @@ Admins can override policies per script using `route_policies` with `route#hook`
 
 ## Hosting & Configuration
 
+### Control language analyzer usage in Elasticsearch search queries
+
+A new environment variable `SHOPWARE_ES_USE_LANGUAGE_ANALYZER` has been added to control whether language-specific analyzers (like `sw_english_analyzer`, `sw_german_analyzer`) are used for search queries.
+
+By default (`SHOPWARE_ES_USE_LANGUAGE_ANALYZER=1`), search queries use the same analyzer as the indexed field, which includes language-specific features like stopword filtering and stemming. This provides broader, more fuzzy search results.
+
+When set to `0` (`SHOPWARE_ES_USE_LANGUAGE_ANALYZER=0`), search queries use `sw_whitespace_analyzer` instead, providing less fuzzy search results with fewer matches.
+
+**Note:** This setting only affects search queries, not indexing. Indexed data continues to use language analyzers for proper tokenization.
+
 ### Possibility to disable extensions when setting up staging mode
 
 A new config option `shopware.staging.extensions.disable` was added to allow configuring extensions that should be automatically disabled when the staging mode gets activated via `system:setup:staging` command.

--- a/config-schema.json
+++ b/config-schema.json
@@ -1630,6 +1630,11 @@
                 "dynamic_templates": {
                     "type": "array",
                     "title": "Dynamic Templates Config"
+                },
+                "use_language_analyzer": {
+                    "type": "boolean",
+                    "description": "Use language-specific analyzers for search queries. When disabled (false), searches use sw_whitespace_analyzer for more precise results.",
+                    "default": true
                 }
             }
         },

--- a/src/Elasticsearch/DependencyInjection/Configuration.php
+++ b/src/Elasticsearch/DependencyInjection/Configuration.php
@@ -47,6 +47,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('index_settings')->variablePrototype()->end()->end()
                 ->arrayNode('analysis')->performNoDeepMerging()->variablePrototype()->end()->end()
                 ->arrayNode('language_analyzer_mapping')->defaultValue([])->scalarPrototype()->end()->end()
+                ->booleanNode('use_language_analyzer')->defaultValue(true)->end()
                 ->arrayNode('dynamic_templates')->performNoDeepMerging()->variablePrototype()->end()->end()
                 ->arrayNode('product')
                     ->children()

--- a/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
@@ -99,6 +99,7 @@ elasticsearch:
         de: sw_german_analyzer
         gsw: sw_german_analyzer
         nds: sw_german_analyzer
+    use_language_analyzer: "%env(bool:SHOPWARE_ES_USE_LANGUAGE_ANALYZER)%"
     dynamic_templates:
         - keywords:
             match_mapping_type: string
@@ -125,3 +126,4 @@ parameters:
     env(SHOPWARE_ES_EXCLUDE_SOURCE): "0"
     env(SHOPWARE_ES_NGRAM_MIN_GRAM): "4"
     env(SHOPWARE_ES_NGRAM_MAX_GRAM): "5"
+    env(SHOPWARE_ES_USE_LANGUAGE_ANALYZER): "1"

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -258,6 +258,7 @@
             <argument type="service" id="Shopware\Core\System\CustomField\CustomFieldService"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage" />
             <argument>%elasticsearch.analysis.filter.sw_ngram_filter.min_gram%</argument>
+            <argument>%elasticsearch.use_language_analyzer%</argument>
         </service>
 
         <service id="Shopware\Elasticsearch\Product\CustomFieldUpdater">

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -44,7 +44,8 @@ class TokenQueryBuilder
         private readonly DefinitionInstanceRegistry $definitionRegistry,
         private readonly CustomFieldService $customFieldService,
         private readonly AbstractKeyValueStorage $storage,
-        private readonly int $minGram = 4
+        private readonly int $minGram = 4,
+        private readonly bool $useLanguageAnalyzer = true
     ) {
     }
 
@@ -133,25 +134,41 @@ class TokenQueryBuilder
             $maxExpansions = $this->getMaxExpansions($lastWord);
 
             // apply fuzzy search
-            $queries[] = new MatchQuery($searchField, $token, [
+            $matchQueryParams = [
                 'boost' => 0.8,
                 'fuzziness' => $config->getFuzziness($token),
                 'operator' => $operator,
                 'fuzzy_transpositions' => true, // treats "ab" and "ba" as a single edit
                 'max_expansions' => $maxExpansions, // limit the number of variations
                 'prefix_length' => 1, // reduce noise
-            ]);
+            ];
+
+            if (!$this->useLanguageAnalyzer) {
+                $matchQueryParams['analyzer'] = 'sw_whitespace_analyzer';
+            }
+
+            $queries[] = new MatchQuery($searchField, $token, $matchQueryParams);
 
             // apply match phrase prefix for compound tokens
             if ($config->usePrefixMatch()) {
                 // apply prefix search on a single token or match phrase prefix on multiple tokens
-                $queries[] = $tokenCount > 1 ? new MatchPhrasePrefixQuery($searchField, $token, [
-                    'boost' => 0.6,
-                    'slop' => 3,
-                    'max_expansions' => $maxExpansions,
-                ]) : new PrefixQuery($config->getField(), $token, [
-                    'boost' => 0.4,
-                ]);
+                if ($tokenCount > 1) {
+                    $matchPhrasePrefixParams = [
+                        'boost' => 0.6,
+                        'slop' => 3,
+                        'max_expansions' => $maxExpansions,
+                    ];
+
+                    if (!$this->useLanguageAnalyzer) {
+                        $matchPhrasePrefixParams['analyzer'] = 'sw_whitespace_analyzer';
+                    }
+
+                    $queries[] = new MatchPhrasePrefixQuery($searchField, $token, $matchPhrasePrefixParams);
+                } else {
+                    $queries[] = new PrefixQuery($config->getField(), $token, [
+                        'boost' => 0.4,
+                    ]);
+                }
             }
 
             $tokenLength = mb_strlen($token);

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -456,6 +456,48 @@ class TokenQueryBuilderTest extends TestCase
         ];
     }
 
+    public function testBuildWithLanguageAnalyzerDisabled(): void
+    {
+        $storage = new ArrayKeyValueStorage([ElasticsearchOptimizeSwitch::FLAG => true]);
+        $tokenQueryBuilder = new TokenQueryBuilder(
+            $this->getRegistry(),
+            new CustomFieldServiceMock([
+                'evolvesInt' => new IntField('evolvesInt', 'evolvesInt'),
+                'evolvesFloat' => new FloatField('evolvesFloat', 'evolvesFloat'),
+                'evolvesText' => new StringField('evolvesText', 'evolvesText'),
+            ]),
+            $storage,
+            4,
+            false
+        );
+
+        $context = Context::createDefaultContext();
+        $context->assign([
+            'languageIdChain' => [Defaults::LANGUAGE_SYSTEM],
+        ]);
+
+        $config = [
+            self::config(field: 'name', ranking: 1000, tokenize: true, and: false),
+        ];
+
+        $term = 'foo bar';
+        $query = $tokenQueryBuilder->build('product', $term, $config, $context);
+
+        static::assertNotNull($query);
+        $queryArray = $query->toArray();
+
+        $matchQuery = $queryArray['dis_max']['queries'][1]['match'] ?? null;
+        static::assertNotNull($matchQuery);
+        $searchField = 'name.' . Defaults::LANGUAGE_SYSTEM . '.search';
+        static::assertArrayHasKey($searchField, $matchQuery);
+        static::assertSame('sw_whitespace_analyzer', $matchQuery[$searchField]['analyzer'] ?? null);
+
+        $matchPhrasePrefixQuery = $queryArray['dis_max']['queries'][2]['match_phrase_prefix'] ?? null;
+        static::assertNotNull($matchPhrasePrefixQuery);
+        static::assertArrayHasKey($searchField, $matchPhrasePrefixQuery);
+        static::assertSame('sw_whitespace_analyzer', $matchPhrasePrefixQuery[$searchField]['analyzer'] ?? null);
+    }
+
     public function testDecoration(): void
     {
         $builder = new ProductSearchQueryBuilder(
@@ -543,7 +585,7 @@ class TokenQueryBuilderTest extends TestCase
     /**
      * @return array<mixed>
      */
-    private static function match(string $field, string|int|float $query, int|float $boost, int|string|null $fuzziness = null, string $operator = 'or', ?int $maxExpansions = null): array
+    private static function match(string $field, string|int|float $query, int|float $boost, int|string|null $fuzziness = null, string $operator = 'or', ?int $maxExpansions = null, ?string $analyzer = null): array
     {
         $payload = [
             'query' => $query,
@@ -553,6 +595,7 @@ class TokenQueryBuilderTest extends TestCase
             'fuzzy_transpositions' => true,
             'max_expansions' => $maxExpansions,
             'prefix_length' => 1,
+            'analyzer' => $analyzer,
         ];
 
         return [
@@ -614,16 +657,19 @@ class TokenQueryBuilderTest extends TestCase
     /**
      * @return array{match_phrase_prefix: array<string, array{query: string|int|float, boost: float, slop: int}>}
      */
-    private static function matchPhrasePrefix(string $field, string|int|float $query, float $boost, int $slop = 3, int $maxExpansion = 10): array
+    private static function matchPhrasePrefix(string $field, string|int|float $query, float $boost, int $slop = 3, int $maxExpansion = 10, ?string $analyzer = null): array
     {
+        $payload = [
+            'query' => $query,
+            'boost' => $boost,
+            'slop' => $slop,
+            'max_expansions' => $maxExpansion,
+            'analyzer' => $analyzer,
+        ];
+
         return [
             'match_phrase_prefix' => [
-                $field => [
-                    'query' => $query,
-                    'boost' => $boost,
-                    'slop' => $slop,
-                    'max_expansions' => $maxExpansion,
-                ],
+                $field => array_filter($payload, static fn ($value) => $value !== null),
             ],
         ];
     }


### PR DESCRIPTION
This pull request introduces a configuration option to control whether the language analyzer should be used in Elasticsearch queries, and updates the codebase to respect this setting. The main change is the addition of the `use_language_analyzer` flag, which allows switching between the default language analyzer and a whitespace analyzer for search queries. The PR also ensures this configuration is properly passed through dependency injection, and adds tests to verify the new behavior.

**Configuration and Dependency Injection:**

* Added a new boolean configuration option `use_language_analyzer` to `Configuration.php` and `elasticsearch.yaml`, with environment variable support for toggling its value. [[1]](diffhunk://#diff-f92f43ed64a5faea32840055b1561f1db5e571ea5652418c294cce7b7dc1d150R50) [[2]](diffhunk://#diff-f739c8ea3301da84876449ee86d13cdd6ab0b5c9955838205f9f50224a20316eR102) [[3]](diffhunk://#diff-f739c8ea3301da84876449ee86d13cdd6ab0b5c9955838205f9f50224a20316eR129)
* Passed the `elasticsearch.use_language_analyzer` parameter as a constructor argument in service definitions, ensuring it is available in relevant classes.

**Query Builder Logic:**

* Updated `TokenQueryBuilder` to accept the `useLanguageAnalyzer` flag and conditionally set the analyzer to `sw_whitespace_analyzer` when the flag is disabled for both match and match phrase prefix queries. [[1]](diffhunk://#diff-9c48eff1fdced4de4d952d1e387709003bb2e58eb383339b1a5b137fee6f513dL47-R48) [[2]](diffhunk://#diff-9c48eff1fdced4de4d952d1e387709003bb2e58eb383339b1a5b137fee6f513dL136-R172)