### PR TITLE
fix: Do not use newest PHP features in TestBootstrapper

### DIFF
--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -230,7 +230,7 @@ class TestBootstrapper
         }
 
         $parts = explode('\\', (string) $baseClass);
-        $pluginName = array_last($parts);
+        $pluginName = $parts[array_key_last($parts)];
 
         $this->addActivePlugins($pluginName);
 

--- a/tests/unit/Core/TestBootstrapperTest.php
+++ b/tests/unit/Core/TestBootstrapperTest.php
@@ -48,4 +48,14 @@ class TestBootstrapperTest extends TestCase
 
         static::assertSame('test', $testBootstrapper->getDatabaseUrl());
     }
+
+    public function testAddCallingPlugin(): void
+    {
+        $testBootstrapper = new TestBootstrapper();
+        $testBootstrapper->addCallingPlugin(__DIR__ . '/Framework/Plugin/Util/_fixture/LocallyInstalledPlugins/SwagTest/composer.json');
+
+        $activePlugins = (new \ReflectionProperty($testBootstrapper, 'activePlugins'))->getValue($testBootstrapper);
+
+        static::assertSame(['Test'], $activePlugins);
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

We are using polyfills to make newest PHP features available. If the TestBootstrapper is used on an older PHP version, it will fail, at it uses a PHP 8.5 feature (array_last). This is because the TestBootstrapper is usually used to prepare PHPUnit and PHPStan and loads as last step the vendor directory. So before that, the polyfills are not available and using such features will fail. 

### 2. What does this change do, exactly?

Replace `array_last` usage with older syntax

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/shopware/SwagPlatformSecurity/actions/runs/20099789148/job/57667328745?pr=113
