### PR TITLE
chore: use union merge strategy for release info files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,3 +34,7 @@
 /phpunit.xml.dist export-ignore
 /rector.php export-ignore
 /sonar-project.properties export-ignore
+
+# Use union merge strategy for these files to avoid merge conflicts
+/RELEASE_INFO-*.md merge=union
+/UPGRADE-*.md merge=union


### PR DESCRIPTION
Release info and upgrade files are written a lot simultaneously, which lead to merge conflicts

most often you want to keep both edits, as likely someone added a section and you added a section for another change in the same place 

Union merge strategy should help with that, as it should accept both edits and just put them below each other, which is what we want most of the time, see https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-union
