### PR TITLE
fix: Do not cache flash messages

### DIFF
--- a/src/Core/Framework/Adapter/Cache/Http/CacheHashService.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheHashService.php
@@ -10,9 +10,11 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Framework\Twig\TwigAppVariable;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[Package('framework')]
@@ -31,6 +33,7 @@ class CacheHashService
         private readonly CacheRelevantRulesResolver $ruleResolver,
         private readonly array $cookies,
         private readonly EventDispatcherInterface $dispatcher,
+        private readonly FlashBagAwareSessionInterface $session
     ) {
     }
 
@@ -115,6 +118,14 @@ class CacheHashService
         }
 
         $event = new HttpCacheCookieEvent($request, $context, $parts);
+
+        if ($this->session->getFlashBag()->keys() !== [] || TwigAppVariable::$displayed_flashes) {
+            // mark as uncacheable if there are any flash messages
+            // if the flashback is filled it means they will be displayed on the next request, e.g. on forwards
+            // therefore we need to change the cache hash, to pass the cache on the next request as well
+            $event->isCacheable = false;
+        }
+
         $this->dispatcher->dispatch($event);
 
         return $event->getHash();

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -503,6 +503,8 @@
         <service id="Shopware\Storefront\Framework\Twig\TwigAppVariable" decorates="twig.app_variable">
             <argument type="service" id="Shopware\Storefront\Framework\Twig\TwigAppVariable.inner"/>
             <argument>%shopware.twig.app_variable.allowed_server_params%</argument>
+
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="Shopware\Storefront\Framework\Routing\DomainNotMappedListener">

--- a/src/Storefront/Framework/Twig/TwigAppVariable.php
+++ b/src/Storefront/Framework/Twig/TwigAppVariable.php
@@ -11,13 +11,15 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * To allow custom server parameters,
  */
 #[Package('framework')]
-class TwigAppVariable extends AppVariable
+class TwigAppVariable extends AppVariable implements ResetInterface
 {
+    public static bool $displayed_flashes = false;
     private ?Request $request = null;
 
     /**
@@ -110,6 +112,17 @@ class TwigAppVariable extends AppVariable
      */
     public function getFlashes(string|array|null $types = null): array
     {
-        return $this->appVariable->getFlashes($types);
+        $flashes = $this->appVariable->getFlashes($types);
+
+        if ($flashes === []) {
+            self::$displayed_flashes = true;
+        }
+
+        return $flashes;
+    }
+
+    public function reset(): void
+    {
+        self::$displayed_flashes = false;
     }
 }


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/11799

Flashes should not be cached at all, when flashes are in the session that are not yet displayed we need to pass the cache on the next requests so the flashes can be shown
When the flashes where displayed in the current request we can not store the current response in the cache
