### PR TITLE
fix: add asset-css-postprocess-plugin to rewrite asset URLs in CSS

### DIFF
--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -24,6 +24,7 @@ import TwigPlugin from './vite-plugins/twigjs-plugin';
 import AssetPlugin from './vite-plugins/asset-plugin';
 import AssetPathPlugin from './vite-plugins/asset-path-plugin';
 import ExternalsPlugin from './vite-plugins/externals-plugin';
+import AssetCssPostprocessPlugin from './vite-plugins/asset-css-postprocess-plugin';
 import OverrideComponentRegisterPlugin from './vite-plugins/override-component-register';
 import { loadExtensions, getViteServerPorts, isInsideDockerContainer } from './vite-plugins/utils';
 import type { ExtensionDefinition } from './vite-plugins/utils';
@@ -68,6 +69,7 @@ const getBaseConfig = (extension: ExtensionDefinition, isProd = false) => {
             TwigPlugin(),
             AssetPlugin(!isDev, path.resolve(extension.basePath, 'Resources/app/administration')),
             AssetPathPlugin(extension.technicalFolderName),
+            AssetCssPostprocessPlugin(`/bundles/${extension.technicalFolderName}/administration/assets/`),
             svgLoader(),
             OverrideComponentRegisterPlugin({
                 root: extension.path,

--- a/src/Administration/Resources/app/administration/build/vite-plugins/asset-css-postprocess-plugin/index.spec.js
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/asset-css-postprocess-plugin/index.spec.js
@@ -13,12 +13,20 @@ describe('build/vite-plugins/asset-css-postprocess-plugin', () => {
         expect(typeof plugin.generateBundle).toBe('function');
     });
 
-    it('rewrites matching asset urls inside css assets', () => {
+    it('rewrites matching asset urls inside css assets when assets exist in same directory', () => {
         const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
         const bundle = {
             'style.css': {
                 type: 'asset',
                 source: 'body{background:url(/bundles/test/assets/icons/foo.svg) font:url(/bundles/test/assets/fonts/bar.woff2?v=3.19);}',
+            },
+            'icons/foo.svg': {
+                type: 'asset',
+                source: '<svg></svg>',
+            },
+            'fonts/bar.woff2': {
+                type: 'asset',
+                source: 'font-data',
             },
             'app.js': {
                 type: 'chunk',
@@ -50,5 +58,238 @@ describe('build/vite-plugins/asset-css-postprocess-plugin', () => {
 
         expect(bundle['fonts.woff2'].source).toBe('url(/bundles/test/assets/fonts/bar.woff2)');
         expect(bundle['style.css'].source).toBe(bufferSource);
+    });
+
+    it('does not rewrite asset urls when assets do not exist in the same directory', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url(/bundles/test/assets/icons/foo.svg) font:url(/bundles/test/assets/fonts/bar.woff2?v=3.19);}',
+            },
+            'app.js': {
+                type: 'chunk',
+                code: 'console.log("noop")',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        // URLs should remain unchanged because assets don't exist in bundle
+        expect(bundle['style.css'].source).toBe(
+            'body{background:url(/bundles/test/assets/icons/foo.svg) font:url(/bundles/test/assets/fonts/bar.woff2?v=3.19);}',
+        );
+        expect(bundle['app.js'].code).toBe('console.log("noop")');
+    });
+
+    it('does not rewrite asset urls when assets exist in a different directory', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url(/bundles/test/assets/icons/foo.svg);}',
+            },
+            'other-dir/icons/foo.svg': {
+                type: 'asset',
+                source: '<svg></svg>',
+            },
+            'app.js': {
+                type: 'chunk',
+                code: 'console.log("noop")',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        // URL should remain unchanged because asset is in different directory
+        expect(bundle['style.css'].source).toBe('body{background:url(/bundles/test/assets/icons/foo.svg);}');
+        expect(bundle['app.js'].code).toBe('console.log("noop")');
+    });
+
+    it('rewrites asset urls when CSS and assets are in a subdirectory', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'css/styles.css': {
+                type: 'asset',
+                source: 'body{background:url(/bundles/test/assets/images/logo.png?v=1.0);}',
+            },
+            'css/images/logo.png': {
+                type: 'asset',
+                source: 'image-data',
+            },
+            'app.js': {
+                type: 'chunk',
+                code: 'console.log("noop")',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        // URL should be rewritten because asset exists in same directory (css/)
+        expect(bundle['css/styles.css'].source).toBe('body{background:url(./images/logo.png?v=1.0);}');
+        expect(bundle['app.js'].code).toBe('console.log("noop")');
+    });
+
+    it('preserves query params and hash when rewriting asset urls', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url(/bundles/test/assets/font.woff2?v=3.19#hash);}',
+            },
+            'font.woff2': {
+                type: 'asset',
+                source: 'font-data',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        // Query params and hash should be preserved
+        expect(bundle['style.css'].source).toBe('body{background:url(./font.woff2?v=3.19#hash);}');
+    });
+
+    it('only rewrites urls for assets that exist, leaving others unchanged', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url(/bundles/test/assets/existing.svg) missing:url(/bundles/test/assets/missing.png);}',
+            },
+            'existing.svg': {
+                type: 'asset',
+                source: '<svg></svg>',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        // Only existing.svg should be rewritten, missing.png should remain unchanged
+        expect(bundle['style.css'].source).toBe(
+            'body{background:url(./existing.svg) missing:url(/bundles/test/assets/missing.png);}',
+        );
+    });
+
+    it('rewrites asset urls with single quotes', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: "body{background:url('/bundles/test/assets/icons/foo.svg') font:url('/bundles/test/assets/fonts/bar.woff2?v=3.19');}",
+            },
+            'icons/foo.svg': {
+                type: 'asset',
+                source: '<svg></svg>',
+            },
+            'fonts/bar.woff2': {
+                type: 'asset',
+                source: 'font-data',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        expect(bundle['style.css'].source).toBe(
+            "body{background:url('./icons/foo.svg') font:url('./fonts/bar.woff2?v=3.19');}",
+        );
+    });
+
+    it('rewrites asset urls with double quotes', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url("/bundles/test/assets/icons/foo.svg") font:url("/bundles/test/assets/fonts/bar.woff2?v=3.19");}',
+            },
+            'icons/foo.svg': {
+                type: 'asset',
+                source: '<svg></svg>',
+            },
+            'fonts/bar.woff2': {
+                type: 'asset',
+                source: 'font-data',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        expect(bundle['style.css'].source).toBe(
+            'body{background:url("./icons/foo.svg") font:url("./fonts/bar.woff2?v=3.19");}',
+        );
+    });
+
+    it('rewrites asset urls with mixed quote formats in same CSS', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url(/bundles/test/assets/unquoted.svg) single:url(\'/bundles/test/assets/single.svg\') double:url("/bundles/test/assets/double.svg");}',
+            },
+            'unquoted.svg': {
+                type: 'asset',
+                source: '<svg></svg>',
+            },
+            'single.svg': {
+                type: 'asset',
+                source: '<svg></svg>',
+            },
+            'double.svg': {
+                type: 'asset',
+                source: '<svg></svg>',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        expect(bundle['style.css'].source).toBe(
+            'body{background:url(./unquoted.svg) single:url(\'./single.svg\') double:url("./double.svg");}',
+        );
+    });
+
+    it('preserves query params and hash when rewriting quoted asset urls', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url(\'/bundles/test/assets/font.woff2?v=3.19#hash\') double:url("/bundles/test/assets/image.png?v=1.0#fragment");}',
+            },
+            'font.woff2': {
+                type: 'asset',
+                source: 'font-data',
+            },
+            'image.png': {
+                type: 'asset',
+                source: 'image-data',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        // Query params and hash should be preserved for both single and double quotes
+        expect(bundle['style.css'].source).toBe(
+            'body{background:url(\'./font.woff2?v=3.19#hash\') double:url("./image.png?v=1.0#fragment");}',
+        );
+    });
+
+    it('does not rewrite quoted asset urls when assets do not exist', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url(\'/bundles/test/assets/missing.svg\') double:url("/bundles/test/assets/missing.png");}',
+            },
+            'app.js': {
+                type: 'chunk',
+                code: 'console.log("noop")',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        // URLs should remain unchanged because assets don't exist in bundle
+        expect(bundle['style.css'].source).toBe(
+            'body{background:url(\'/bundles/test/assets/missing.svg\') double:url("/bundles/test/assets/missing.png");}',
+        );
+        expect(bundle['app.js'].code).toBe('console.log("noop")');
     });
 });

--- a/src/Administration/Resources/app/administration/build/vite-plugins/asset-css-postprocess-plugin/index.spec.js
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/asset-css-postprocess-plugin/index.spec.js
@@ -1,0 +1,54 @@
+/**
+ * @sw-package framework
+ */
+import stripAssetsFolderInCss from './index';
+
+describe('build/vite-plugins/asset-css-postprocess-plugin', () => {
+    it('exposes a named vite plugin with generateBundle hook', () => {
+        expect(typeof stripAssetsFolderInCss).toBe('function');
+
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+
+        expect(plugin.name).toBe('asset-css-postprocess-plugin');
+        expect(typeof plugin.generateBundle).toBe('function');
+    });
+
+    it('rewrites matching asset urls inside css assets', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bundle = {
+            'style.css': {
+                type: 'asset',
+                source: 'body{background:url(/bundles/test/assets/icons/foo.svg) font:url(/bundles/test/assets/fonts/bar.woff2?v=3.19);}',
+            },
+            'app.js': {
+                type: 'chunk',
+                code: 'console.log("noop")',
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        expect(bundle['style.css'].source).toBe('body{background:url(./icons/foo.svg) font:url(./fonts/bar.woff2?v=3.19);}');
+        expect(bundle['app.js'].code).toBe('console.log("noop")');
+    });
+
+    it('skips non-css filenames and non-string sources', () => {
+        const plugin = stripAssetsFolderInCss('/bundles/test/assets/');
+        const bufferSource = Buffer.from('binary');
+        const bundle = {
+            'fonts.woff2': {
+                type: 'asset',
+                source: 'url(/bundles/test/assets/fonts/bar.woff2)',
+            },
+            'style.css': {
+                type: 'asset',
+                source: bufferSource,
+            },
+        };
+
+        plugin.generateBundle({}, bundle);
+
+        expect(bundle['fonts.woff2'].source).toBe('url(/bundles/test/assets/fonts/bar.woff2)');
+        expect(bundle['style.css'].source).toBe(bufferSource);
+    });
+});

--- a/src/Administration/Resources/app/administration/build/vite-plugins/asset-css-postprocess-plugin/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/asset-css-postprocess-plugin/index.ts
@@ -1,0 +1,22 @@
+import { Plugin } from 'vite';
+
+/**
+ * Vite plugin that rewrites absolute asset URLs in generated CSS to be relative.
+ */
+export default function stripAssetsFolderInCss(folderToStrip: string): Plugin {
+    return {
+        name: 'asset-css-postprocess-plugin',
+        generateBundle(_, bundle) {
+            for (const [
+                fileName,
+                file,
+            ] of Object.entries(bundle)) {
+                if (fileName.endsWith('.css') && file.type === 'asset' && typeof file.source === 'string') {
+                    // Replace absolute prefixed URLs with relative ones
+                    // Example: url(/bundles/.../assets/Inter-XXX.woff2?v=3.19) -> url(./Inter-XXX.woff2?v=3.19)
+                    file.source = file.source.replace(new RegExp(`${folderToStrip}([^)"'\\s]+)`, 'g'), './$1');
+                }
+            }
+        },
+    };
+}

--- a/src/Administration/Resources/app/administration/build/vite-plugins/asset-css-postprocess-plugin/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/asset-css-postprocess-plugin/index.ts
@@ -1,4 +1,5 @@
 import { Plugin } from 'vite';
+import path from 'path';
 
 /**
  * Vite plugin that rewrites absolute asset URLs in generated CSS to be relative.
@@ -12,9 +13,38 @@ export default function stripAssetsFolderInCss(folderToStrip: string): Plugin {
                 file,
             ] of Object.entries(bundle)) {
                 if (fileName.endsWith('.css') && file.type === 'asset' && typeof file.source === 'string') {
+                    const cssDir = path.dirname(fileName);
+
                     // Replace absolute prefixed URLs with relative ones
                     // Example: url(/bundles/.../assets/Inter-XXX.woff2?v=3.19) -> url(./Inter-XXX.woff2?v=3.19)
-                    file.source = file.source.replace(new RegExp(`${folderToStrip}([^)"'\\s]+)`, 'g'), './$1');
+                    file.source = file.source.replace(
+                        new RegExp(`${folderToStrip}([^)"'\\s]+)`, 'g'),
+                        (match, assetPath) => {
+                            // Extract asset path from URL (remove query params and hash)
+                            const assetFileName = assetPath.split('?')[0].split('#')[0];
+
+                            // Check if the asset exists in the same directory as the CSS file
+                            // The assetFileName is relative to the assets folder, so we need to check
+                            // if it exists relative to the CSS file's directory
+                            const expectedAssetPath = path.join(cssDir, assetFileName).replace(/\\/g, '/');
+                            const assetExists = Object.keys(bundle).some((bundleFileName) => {
+                                const normalizedBundlePath = bundleFileName.replace(/\\/g, '/');
+                                return (
+                                    normalizedBundlePath === expectedAssetPath && bundle[bundleFileName]?.type === 'asset'
+                                );
+                            });
+
+                            // Only replace if the asset exists in the same directory
+                            if (assetExists) {
+                                // Replace with relative path from CSS file to asset
+                                // Preserve query params and hash from original assetPath
+                                return `./${assetPath}`;
+                            }
+
+                            // Return original match if asset doesn't exist in same directory
+                            return match;
+                        },
+                    );
                 }
             }
         },

--- a/src/Administration/Resources/app/administration/vite.config.mts
+++ b/src/Administration/Resources/app/administration/vite.config.mts
@@ -16,6 +16,7 @@ import TwigPlugin from './build/vite-plugins/twigjs-plugin';
 import AssetPlugin from './build/vite-plugins/asset-plugin';
 import AssetPathPlugin from './build/vite-plugins/asset-path-plugin';
 import ImageDeprecationPlugin from './build/vite-plugins/image-deprecation';
+import AssetCssPostprocessPlugin from './build/vite-plugins/asset-css-postprocess-plugin';
 
 console.log(colors.yellow('# Compiling Administration with Vite configuration'));
 
@@ -91,6 +92,7 @@ export default defineConfig(({ command }) => {
                 AssetPlugin(isProd, __dirname, extensions),
                 AssetPathPlugin(),
                 ImageDeprecationPlugin(__dirname),
+                AssetCssPostprocessPlugin('/bundles/administration/administration/assets/'),
 
                 // Twig.JS loads node modules, so we need to polyfill them
                 nodePolyfills({


### PR DESCRIPTION
### 1. Why is this change necessary?

Fixes https://github.com/shopware/shopware/issues/13991

### 2. What does this change do, exactly?

Add a Vite plugin which postprocess our CSS files to replace the URL imports with a relative path

### 3. Describe each step to reproduce the issue or behaviour.

See the issue
