### PR TITLE
ci: always install admin and storefont in ats action

### DIFF
--- a/.github/actions/ats/action.yaml
+++ b/.github/actions/ats/action.yaml
@@ -104,8 +104,8 @@ runs:
               shopware-version: ${{ github.ref }}
               shopware-repository: ${{ github.repository }}
               install: ${{ inputs.install }}
-              install-admin: ${{ inputs.install }}
-              install-storefront: ${{ inputs.install }}
+              install-admin: true
+              install-storefront: true
               env: prod
               composer-root-version: ${{ inputs.major != '' && '6.8.9999999-dev' || '.auto' }}
               php-version: ${{ inputs.php-version }}


### PR DESCRIPTION
### 1. Why is this change necessary?
We fixed some faulty if's in the `setup-shopware` action yesterday. This has caused some issues with the install ATS.

### 2. What does this change do, exactly?
Always install admin and storefront for ATS.

### 3. Describe each step to reproduce the issue or behaviour.
Run the integration tests
