### PR TITLE
docs: Update changelog.md references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > **Note on changelog structure (Shopware 6.7.5 and newer)**  
 >  
-> Starting with **Shopware 6.7.5**, this file is no longer the main source of truth for release changes.
+> Starting with **Shopware 6.7.5**, this file is no longer updated with the recent changes.
 >  
 > - **Curated, developer-facing release information** can be found in the versioned release info files, e.g.:  
 >   https://github.com/shopware/shopware/blob/trunk/RELEASE_INFO-6.7.md  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-> ⚠️ **Note on changelog structure (Shopware 6.7.5 and newer)**  
+> [!WARNING]
+> **Note on changelog structure (Shopware 6.7.5 and newer)**  
 >  
 > Starting with **Shopware 6.7.5**, this file is no longer the main source of truth for release changes.
 >  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 >  
 > Starting with **Shopware 6.7.5**, this file is no longer updated with the recent changes.
 >  
-
+>
 > - **Curated, developer-facing release information** can be found in the versioned [release info files](./RELEASE_INFO-6.7.md).  
 >   https://github.com/shopware/shopware/blob/trunk/RELEASE_INFO-6.7.md  
 >  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 >  
 > Starting with **Shopware 6.7.5**, this file is no longer updated with the recent changes.
 >  
-> - **Curated, developer-facing release information** can be found in the versioned release info files, e.g.:  
+
+> - **Curated, developer-facing release information** can be found in the versioned [release info files](./RELEASE_INFO-6.7.md).  
 >   https://github.com/shopware/shopware/blob/trunk/RELEASE_INFO-6.7.md  
 >  
 > - **The complete, raw changelog (all merged PRs)** is generated automatically and published with each release:  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
-This is the official changelog index of Shopware 6. Here you find a registry of all Shopware 6 releases with a reference to the detailed changelog of each version. If you want to know more about how the changelog is created have a look [here](/adr/workflow/2020-08-03-implement-New-Changelog.md).
+
+> ⚠️ **Note on changelog structure (Shopware 6.7.5 and newer)**  
+>  
+> Starting with **Shopware 6.7.5**, this file is no longer the main source of truth for release changes.
+>  
+> - **Curated, developer-facing release information** can be found in the versioned release info files, e.g.:  
+>   https://github.com/shopware/shopware/blob/trunk/RELEASE_INFO-6.7.md  
+>  
+> - **The complete, raw changelog (all merged PRs)** is generated automatically and published with each release:  
+>   https://github.com/shopware/shopware/releases  
+>  
+> This file is kept for historical reference and existing links.
+
 
 ## 6.7.4.2
 *  [#13416 - Improve shop id verification when used with atomic deployments](./changelog/release-6-7-4-2/2025-11-05-improve-shop-id-verification.md)


### PR DESCRIPTION
Updated changelog to reflect changes in release information.

### 1. Why is this change necessary?

With the release of 6.7.4, we've got our auto-generated GitHub Changelog and then our [release notes](https://github.com/shopware/shopware/releases/tag/v6.7.5.0), and the curated info lives in RELEASE_INFO / UPGRADE.
However, our CHANGELOG.md [file](https://github.com/shopware/shopware/blob/trunk/CHANGELOG.md) is stuck on 6.7.4.2, but it's still there as if it was the official one, and doesn’t point to the GitHub releases yet, which can be confusing for contributors.

### 2. What does this change do, exactly?

Update CHANGELOG.md with the actual references.

### 3. Describe each step to reproduce the issue or behaviour.

Refer to https://github.com/shopware/shopware/blob/trunk/CHANGELOG.md

### 4. Please link to the relevant issues (if any).

NA

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
