### PR TITLE
fix: migrate the correct delivery to primary_order_delivery_id

### DIFF
--- a/src/Core/Migration/V6_7/Migration1728040169AddPrimaryOrderDelivery.php
+++ b/src/Core/Migration/V6_7/Migration1728040169AddPrimaryOrderDelivery.php
@@ -61,7 +61,7 @@ class Migration1728040169AddPrimaryOrderDelivery extends MigrationStep
                             FROM `order_delivery`
                             WHERE `order_delivery`.`order_id` = `order`.`id`
                             AND `order_delivery`.`order_version_id` = `order`.`version_id`
-                            ORDER BY `order_delivery`.`created_at` DESC
+                            ORDER BY JSON_EXTRACT(`order_delivery`.`shipping_costs`, \'$.unitPrice\') DESC
                             LIMIT 1
                         )
                     SET `order`.`primary_order_delivery_id` = `primary_order_delivery`.`id`,


### PR DESCRIPTION
### 1. Why is this change necessary?

The primary delivery id is not determined by its creation date, but by its shipping costs. See here: https://github.com/shopware/shopware/blob/v6.6.10.10/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js#L126

### 2. What does this change do, exactly?

Change Migration from sorting by created_at to sorting by shipping costs. This might hurt performance, because we need to sort by a value inside a JSON column. However I do not currently see different way. 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
