### PR TITLE
fix: allow selecting read-only properties in import/export profiles

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-entity-path-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-entity-path-select/index.js
@@ -454,9 +454,15 @@ export default {
                 return false;
             }
 
-            const writeProtectedLength = property?.flags?.write_protected?.length || 0;
+            /**
+             * Allow read-only properties to be selectable.
+             * These properties are safe for export profiles.
+             */
+            return true;
 
-            return writeProtectedLength === 0;
+            // const writeProtectedLength = property?.flags?.write_protected?.length || 0;
+
+            // return writeProtectedLength === 0;
         },
 
         isSelected(item) {

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-entity-path-select/sw-import-export-entity-path-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-entity-path-select/sw-import-export-entity-path-select.spec.js
@@ -1177,4 +1177,20 @@ describe('module/sw-import-export/components/sw-import-export-entity-path-select
 
         expect(possibleSelectionResult).not.toContain('user');
     });
+
+    it('should not filter out read-only properties', async () => {
+        const wrapper = await createWrapper('customer');
+        await flushPromises();
+
+        const pathSelection = wrapper.find('.sw-import-export-entity-path-select__selection-input');
+        await pathSelection.trigger('click');
+        await flushPromises();
+
+        const possibleSelectionResult = wrapper.findAll('.sw-select-result').map((element) => element.text());
+
+        expect(possibleSelectionResult).toContain('lastOrderDate');
+        expect(possibleSelectionResult).toContain('orderCount');
+        expect(possibleSelectionResult).toContain('orderTotalAmount');
+        expect(possibleSelectionResult).toContain('reviewCount');
+    });
 });


### PR DESCRIPTION
following up on #13660, read-only properties are currently filtered out and not selectable, even though they are safe for and used in export-only profiles, e.g. `amountTotal` in the `default_orders` profile:

<img width="922" height="802" alt="image" src="https://github.com/user-attachments/assets/a4a4bc18-1c0d-4593-a43d-6a9c6e7742cf" />