### PR TITLE
feat: add allowEmpty config for numeric custom fields

### DIFF
--- a/changelog/_unreleased/2025-12-17-allow-empty-numer-custom-fields.md
+++ b/changelog/_unreleased/2025-12-17-allow-empty-numer-custom-fields.md
@@ -1,0 +1,8 @@
+---
+title: allow empty numer custom fields
+author: Philip Standt
+author_github: @Ocarthon
+---
+# Administration
+* Add `allowEmpty` switch field to the number custom field configuration
+  * With this option active, it is possible to clear the value of a numeric custom field, instead of it being filled with `0`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.html.twig
@@ -34,6 +34,14 @@
         :label="$tc('sw-settings-custom-field.customField.detail.labelMax')"
     />
     {% endblock %}
+
+    {% block sw_custom_field_type_number_container_allow_empty %}
+    <mt-switch
+        v-model="currentCustomField.config.allowEmpty"
+        bordered
+        :label="$tc('sw-settings-custom-field.customField.detail.labelAllowEmpty')"
+    />
+    {% endblock %}
 </sw-container>
 {% endblock %}
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/snippet/de.json
@@ -69,6 +69,7 @@
         "labelTimeForm": "24-Stunden-Zeitformat",
         "labelCustomFieldPosition": "Position",
         "labelMultiSelect": "Mehrfachauswahl",
+        "labelAllowEmpty": "Kann keinen Wert haben",
         "helpTextMultiSelect": "Die Mehrfachauswahloption kann nach Erstellen des Zusatzfeldes nicht mehr geändert werden.",
         "labelEntityTypeSelect": "Objekttyp",
         "helpTextEntitySelect": "Der Objekttyp kann nach Erstellen des Zusatzfeldes nicht mehr geändert werden.",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/snippet/en.json
@@ -69,6 +69,7 @@
         "labelTimeForm": "24-hour time format",
         "labelCustomFieldPosition": "Position",
         "labelMultiSelect": "Multi select",
+        "labelAllowEmpty": "Can have no value",
         "helpTextMultiSelect": "The multi select option cannot be toggled once the custom field has been created.",
         "labelEntityTypeSelect": "Entity type",
         "helpTextEntitySelect": "The entity type cannot be changed once the custom field has been created.",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfill our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When you have a numeric custom field, it is currently not possible to clear its value in administration, once a value has been set.

If you try to clear the input field, the value is automatically set to `0`. For some fields, you may need the differentiation between `0` and `null`.

### 2. What does this change do, exactly?

This add a switch field in the administration when configuration a numeric custom field. This maps to the custom field config field `allowEmpty`. If active, the input field for the custom field will also have `allowEmpty` set.

The config fields of custom fields get set as props on the custom field input fields, when they are rendered in the administration, so there is no change required here.

### 3. Describe each step to reproduce the issue or behaviour.
- Go to administration
- Create numeric custom field and set the allow empty checkbox
- Open entity with the custom field in the administration
- Set any value in the custom field input and save entitiy
- Clear custom field value
- Save entity
- Check if custom field stays empty

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
