### PR TITLE
test: remove obsolete ignore annotations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1573,84 +1573,6 @@ parameters:
 			path: src/Core/Framework/Store/Services/StoreSessionExpiredMiddleware.php
 
 		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionCollection\:\:getElementFromArray\(\) has parameter \$element with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartPositionCollection.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:getExtensionInformation\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:getVariant\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:setExtensionInformation\(\) has parameter \$extensionInformation with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:setVariant\(\) has parameter \$variant with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
-
-		-
-			message: '#^Property Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:\$extension type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
-
-		-
-			message: '#^Property Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:\$variant type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartStruct\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartStruct\:\:getShop\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartStruct\:\:setShop\(\) has parameter \$shop with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartStruct.php
-
-		-
-			message: '#^Property Shopware\\Core\\Framework\\Store\\Struct\\CartStruct\:\:\$shop type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/CartStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\PluginRegionStruct\:\:__construct\(\) has parameter \$categories with no value type specified in iterable type iterable\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/PluginRegionStruct.php
-
-		-
 			message: '#^Expected domain exception class Shopware\\Core\\Framework\\Store\\StoreException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
 			identifier: shopware.domainException
 			count: 4
@@ -1661,12 +1583,6 @@ parameters:
 			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Struct/ReviewStruct.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\StoreLicenseViolationStruct\:\:getActions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Store/Struct/StoreLicenseViolationStruct.php
 
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
@@ -1949,24 +1865,6 @@ parameters:
 			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
-
-		-
-			message: '#^Method Shopware\\Storefront\\Page\\Address\\AddressEditorModalStruct\:\:getMessages\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Storefront/Page/Address/AddressEditorModalStruct.php
-
-		-
-			message: '#^Method Shopware\\Storefront\\Page\\Address\\AddressEditorModalStruct\:\:setMessages\(\) has parameter \$messages with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Storefront/Page/Address/AddressEditorModalStruct.php
-
-		-
-			message: '#^Property Shopware\\Storefront\\Page\\Address\\AddressEditorModalStruct\:\:\$messages type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Storefront/Page/Address/AddressEditorModalStruct.php
 
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'

--- a/src/Core/Content/ImportExport/Event/ImportExportAfterProcessFinishedEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportAfterProcessFinishedEvent.php
@@ -8,9 +8,6 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('fundamentals@after-sales')]
 class ImportExportAfterProcessFinishedEvent extends Event
 {

--- a/src/Core/Framework/App/AppEntity.php
+++ b/src/Core/Framework/App/AppEntity.php
@@ -655,9 +655,6 @@ class AppEntity extends Entity
         return $this->templateLoadPriority;
     }
 
-    /**
-     * @codeCoverageIgnore
-     */
     public function setTemplateLoadPriority(int $templateLoadPriority): void
     {
         $this->templateLoadPriority = $templateLoadPriority;

--- a/src/Core/Framework/App/InAppPurchases/Event/InAppPurchasesGatewayEvent.php
+++ b/src/Core/Framework/App/InAppPurchases/Event/InAppPurchasesGatewayEvent.php
@@ -13,8 +13,6 @@ use Symfony\Contracts\EventDispatcher\Event;
  *
  * @internal
  *
- * @codeCoverageIgnore
- *
  * @see InAppPurchasesGateway::process() for an example implementation
  */
 #[Package('checkout')]

--- a/src/Core/Framework/App/Payload/AppPayloadStruct.php
+++ b/src/Core/Framework/App/Payload/AppPayloadStruct.php
@@ -10,8 +10,6 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 /**
  * @internal
  *
- * @codeCoverageIgnore
- *
  * @phpstan-type RequestOptions array{'app_request_context': Context, 'request_type': array{'app_secret': non-falsy-string, 'validated_response': true}, 'headers': array{Content-Type: string}, 'body': string, 'timeout'?: int}
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/AccessTokenStruct.php
+++ b/src/Core/Framework/Store/Struct/AccessTokenStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class AccessTokenStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/BinaryCollection.php
+++ b/src/Core/Framework/Store/Struct/BinaryCollection.php
@@ -5,8 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @codeCoverageIgnore
- *
  * @template-extends StoreCollection<BinaryStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/BinaryStruct.php
+++ b/src/Core/Framework/Store/Struct/BinaryStruct.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class BinaryStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/CartPositionCollection.php
+++ b/src/Core/Framework/Store/Struct/CartPositionCollection.php
@@ -6,8 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 
 /**
- * @codeCoverageIgnore
- *
  * @extends Collection<CartPositionStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/CartPositionCollection.php
+++ b/src/Core/Framework/Store/Struct/CartPositionCollection.php
@@ -27,6 +27,9 @@ class CartPositionCollection extends Collection
         return CartPositionStruct::class;
     }
 
+    /**
+     * @param array<string, mixed> $element
+     */
     protected function getElementFromArray(array $element): CartPositionStruct
     {
         return CartPositionStruct::fromArray($element);

--- a/src/Core/Framework/Store/Struct/CartPositionStruct.php
+++ b/src/Core/Framework/Store/Struct/CartPositionStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class CartPositionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/CartPositionStruct.php
+++ b/src/Core/Framework/Store/Struct/CartPositionStruct.php
@@ -20,20 +20,35 @@ class CartPositionStruct extends Struct
 
     protected int $discountAppliesForMonths;
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $extension;
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $variant;
 
+    /**
+     * @param array<string, mixed> $data
+     */
     public static function fromArray(array $data): CartPositionStruct
     {
         return (new self())->assign($data);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getExtensionInformation(): array
     {
         return $this->extension;
     }
 
+    /**
+     * @param array<string, mixed> $extensionInformation
+     */
     public function setExtensionInformation(array $extensionInformation): void
     {
         $this->extension = $extensionInformation;
@@ -49,11 +64,17 @@ class CartPositionStruct extends Struct
         return $this->getExtensionInformation()['name'];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getVariant(): array
     {
         return $this->variant;
     }
 
+    /**
+     * @param array<string, mixed> $variant
+     */
     public function setVariant(array $variant): void
     {
         $this->variant = $variant;

--- a/src/Core/Framework/Store/Struct/CartStruct.php
+++ b/src/Core/Framework/Store/Struct/CartStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class CartStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/CartStruct.php
+++ b/src/Core/Framework/Store/Struct/CartStruct.php
@@ -18,8 +18,14 @@ class CartStruct extends Struct
 
     protected CartPositionCollection $positions;
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $shop;
 
+    /**
+     * @param array<string, mixed> $data
+     */
     public static function fromArray(array $data): CartStruct
     {
         $data['positions'] = new CartPositionCollection($data['positions']);
@@ -77,11 +83,17 @@ class CartStruct extends Struct
         $this->positions = $positions;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getShop(): array
     {
         return $this->shop;
     }
 
+    /**
+     * @param array<string, mixed> $shop
+     */
     public function setShop(array $shop): void
     {
         $this->shop = $shop;

--- a/src/Core/Framework/Store/Struct/DiscountCampaignStruct.php
+++ b/src/Core/Framework/Store/Struct/DiscountCampaignStruct.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class DiscountCampaignStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/DomainVerificationRequestStruct.php
+++ b/src/Core/Framework/Store/Struct/DomainVerificationRequestStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class DomainVerificationRequestStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/ExtensionCollection.php
+++ b/src/Core/Framework/Store/Struct/ExtensionCollection.php
@@ -6,8 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 
 /**
- * @codeCoverageIgnore
- *
  * @extends Collection<ExtensionStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/ExtensionStruct.php
+++ b/src/Core/Framework/Store/Struct/ExtensionStruct.php
@@ -8,9 +8,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class ExtensionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/FaqCollection.php
+++ b/src/Core/Framework/Store/Struct/FaqCollection.php
@@ -5,8 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @codeCoverageIgnore
- *
  * @template-extends StoreCollection<FaqStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/FaqStruct.php
+++ b/src/Core/Framework/Store/Struct/FaqStruct.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class FaqStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/ImageCollection.php
+++ b/src/Core/Framework/Store/Struct/ImageCollection.php
@@ -5,8 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @codeCoverageIgnore
- *
  * @template-extends StoreCollection<ImageStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/ImageStruct.php
+++ b/src/Core/Framework/Store/Struct/ImageStruct.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class ImageStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/LicenseCollection.php
+++ b/src/Core/Framework/Store/Struct/LicenseCollection.php
@@ -6,8 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 
 /**
- * @codeCoverageIgnore
- *
  * @extends Collection<LicenseStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/LicenseDomainCollection.php
+++ b/src/Core/Framework/Store/Struct/LicenseDomainCollection.php
@@ -6,8 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 
 /**
- * @codeCoverageIgnore
- *
  * @extends Collection<LicenseDomainStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/LicenseDomainStruct.php
+++ b/src/Core/Framework/Store/Struct/LicenseDomainStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class LicenseDomainStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/LicenseStruct.php
+++ b/src/Core/Framework/Store/Struct/LicenseStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class LicenseStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/PermissionCollection.php
+++ b/src/Core/Framework/Store/Struct/PermissionCollection.php
@@ -7,8 +7,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Helper\PermissionCategorization;
 
 /**
- * @codeCoverageIgnore
- *
  * @template-extends StoreCollection<PermissionStruct>
  *
  * @phpstan-type PermissionArray array{entity: string, operation: AclRoleDefinition::PRIVILEGE_READ|AclRoleDefinition::PRIVILEGE_CREATE|AclRoleDefinition::PRIVILEGE_UPDATE|AclRoleDefinition::PRIVILEGE_DELETE}

--- a/src/Core/Framework/Store/Struct/PermissionStruct.php
+++ b/src/Core/Framework/Store/Struct/PermissionStruct.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class PermissionStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/PluginCategoryCollection.php
+++ b/src/Core/Framework/Store/Struct/PluginCategoryCollection.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 
 /**
- * @codeCoverageIgnore
  * Pseudo immutable collection
  *
  * @extends Collection<PluginCategoryStruct>

--- a/src/Core/Framework/Store/Struct/PluginCategoryStruct.php
+++ b/src/Core/Framework/Store/Struct/PluginCategoryStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class PluginCategoryStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/PluginDownloadDataStruct.php
+++ b/src/Core/Framework/Store/Struct/PluginDownloadDataStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class PluginDownloadDataStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/PluginRecommendationCollection.php
+++ b/src/Core/Framework/Store/Struct/PluginRecommendationCollection.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 
 /**
- * @codeCoverageIgnore
  * Pseudo immutable collection
  *
  * @extends Collection<StorePluginStruct>

--- a/src/Core/Framework/Store/Struct/PluginRegionCollection.php
+++ b/src/Core/Framework/Store/Struct/PluginRegionCollection.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 
 /**
- * @codeCoverageIgnore
  * Pseudo immutable collection
  *
  * @extends Collection<PluginRegionStruct>

--- a/src/Core/Framework/Store/Struct/PluginRegionStruct.php
+++ b/src/Core/Framework/Store/Struct/PluginRegionStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class PluginRegionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/PluginRegionStruct.php
+++ b/src/Core/Framework/Store/Struct/PluginRegionStruct.php
@@ -10,6 +10,9 @@ class PluginRegionStruct extends Struct
 {
     protected PluginCategoryCollection $categories;
 
+    /**
+     * @param iterable<PluginCategoryStruct> $categories
+     */
     public function __construct(
         protected string $name,
         protected string $label,

--- a/src/Core/Framework/Store/Struct/ReviewCollection.php
+++ b/src/Core/Framework/Store/Struct/ReviewCollection.php
@@ -5,8 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @codeCoverageIgnore
- *
  * @template-extends StoreCollection<ReviewStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/ReviewStruct.php
+++ b/src/Core/Framework/Store/Struct/ReviewStruct.php
@@ -7,9 +7,6 @@ use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Store\Exception\InvalidExtensionRatingValueException;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class ReviewStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/ReviewSummaryStruct.php
+++ b/src/Core/Framework/Store/Struct/ReviewSummaryStruct.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class ReviewSummaryStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/ShopUserTokenStruct.php
+++ b/src/Core/Framework/Store/Struct/ShopUserTokenStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class ShopUserTokenStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreActionStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreActionStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StoreActionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreCategoryCollection.php
+++ b/src/Core/Framework/Store/Struct/StoreCategoryCollection.php
@@ -5,8 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @codeCoverageIgnore
- *
  * @template-extends StoreCollection<StoreCategoryStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/StoreCategoryStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreCategoryStruct.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StoreCategoryStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/StoreCollection.php
+++ b/src/Core/Framework/Store/Struct/StoreCollection.php
@@ -6,8 +6,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 
 /**
- * @codeCoverageIgnore
- *
  * @template TElement of StoreStruct
  *
  * @template-extends Collection<TElement>

--- a/src/Core/Framework/Store/Struct/StoreLicenseStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StoreLicenseStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseSubscriptionStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseSubscriptionStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StoreLicenseSubscriptionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseTypeStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseTypeStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StoreLicenseTypeStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseViolationStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseViolationStruct.php
@@ -34,6 +34,9 @@ class StoreLicenseViolationStruct extends Struct
         return $this->text;
     }
 
+    /**
+     * @return array<StoreActionStruct>
+     */
     public function getActions(): array
     {
         return $this->actions;

--- a/src/Core/Framework/Store/Struct/StoreLicenseViolationStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseViolationStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StoreLicenseViolationStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseViolationTypeStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseViolationTypeStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StoreLicenseViolationTypeStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StorePluginStruct.php
+++ b/src/Core/Framework/Store/Struct/StorePluginStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StorePluginStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 abstract class StoreStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreUpdateStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreUpdateStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class StoreUpdateStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/VariantCollection.php
+++ b/src/Core/Framework/Store/Struct/VariantCollection.php
@@ -5,8 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @codeCoverageIgnore
- *
  * @template-extends StoreCollection<VariantStruct>
  */
 #[Package('checkout')]

--- a/src/Core/Framework/Store/Struct/VariantStruct.php
+++ b/src/Core/Framework/Store/Struct/VariantStruct.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class VariantStruct extends StoreStruct
 {

--- a/src/Core/Framework/Webhook/Event/PreWebhooksDispatchEvent.php
+++ b/src/Core/Framework/Webhook/Event/PreWebhooksDispatchEvent.php
@@ -7,8 +7,6 @@ use Shopware\Core\Framework\Webhook\Webhook;
 
 /**
  * @internal
- *
- * @codeCoverageIgnore
  */
 #[Package('framework')]
 class PreWebhooksDispatchEvent

--- a/src/Core/System/SalesChannel/Event/ContextCreatedEvent.php
+++ b/src/Core/System/SalesChannel/Event/ContextCreatedEvent.php
@@ -8,8 +8,6 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @codeCoverageIgnore
- *
  * This event can be used to react to the creation of a new context.
  * It must be used very carefully, as it practically effects every part of Shopware.
  */

--- a/src/Core/System/Snippet/Event/SnippetsThemeResolveEvent.php
+++ b/src/Core/System/Snippet/Event/SnippetsThemeResolveEvent.php
@@ -7,8 +7,6 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @internal
- *
- * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SnippetsThemeResolveEvent extends Event

--- a/src/Core/Test/Integration/PaymentHandler/TestPaymentHandler.php
+++ b/src/Core/Test/Integration/PaymentHandler/TestPaymentHandler.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  *
- * @codeCoverageIgnore this is only a fixture for the payment handler integration tests
+ * This is only a fixture for the payment handler integration tests
  */
 #[Package('checkout')]
 class TestPaymentHandler extends AbstractPaymentHandler

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/Event/ElasticsearchEntityAggregatorSearchedEvent.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/Event/ElasticsearchEntityAggregatorSearchedEvent.php
@@ -11,9 +11,6 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('framework')]
 class ElasticsearchEntityAggregatorSearchedEvent extends Event implements ShopwareEvent
 {

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/Event/ElasticsearchEntitySearcherSearchedEvent.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/Event/ElasticsearchEntitySearcherSearchedEvent.php
@@ -11,9 +11,6 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('framework')]
 class ElasticsearchEntitySearcherSearchedEvent extends Event implements ShopwareEvent
 {

--- a/src/Elasticsearch/Framework/Indexing/Event/ElasticsearchIndexIteratorEvent.php
+++ b/src/Elasticsearch/Framework/Indexing/Event/ElasticsearchIndexIteratorEvent.php
@@ -6,9 +6,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IterableQuery;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Elasticsearch\Framework\AbstractElasticsearchDefinition;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('framework')]
 class ElasticsearchIndexIteratorEvent
 {

--- a/src/Elasticsearch/Framework/Indexing/Event/ElasticsearchIndexingFinishedEvent.php
+++ b/src/Elasticsearch/Framework/Indexing/Event/ElasticsearchIndexingFinishedEvent.php
@@ -4,9 +4,6 @@ namespace Shopware\Elasticsearch\Framework\Indexing\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('framework')]
 class ElasticsearchIndexingFinishedEvent
 {

--- a/src/Storefront/Page/Address/AddressEditorModalStruct.php
+++ b/src/Storefront/Page/Address/AddressEditorModalStruct.php
@@ -18,6 +18,9 @@ class AddressEditorModalStruct extends Struct
 
     protected ?string $addressId = null;
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $messages = [];
 
     protected ?CustomerAddressEntity $address = null;
@@ -64,11 +67,17 @@ class AddressEditorModalStruct extends Struct
         $this->addressId = $addressId;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getMessages(): array
     {
         return $this->messages;
     }
 
+    /**
+     * @param array<string, mixed> $messages
+     */
     public function setMessages(array $messages): void
     {
         $this->messages = $messages;

--- a/src/Storefront/Page/Address/AddressEditorModalStruct.php
+++ b/src/Storefront/Page/Address/AddressEditorModalStruct.php
@@ -7,9 +7,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Storefront\Page\Page;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('framework')]
 class AddressEditorModalStruct extends Struct
 {

--- a/src/Storefront/Page/Robots/Event/RobotsUnknownDirectiveEvent.php
+++ b/src/Storefront/Page/Robots/Event/RobotsUnknownDirectiveEvent.php
@@ -16,7 +16,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  * - Prevent warnings for known-custom directives
  * - Set custom issues for specific directive types
  *
- * @codeCoverageIgnore Simple DTO with no business logic
+ *  Simple DTO with no business logic
  */
 #[Package('framework')]
 class RobotsUnknownDirectiveEvent extends Event implements ShopwareEvent

--- a/tests/unit/Core/Framework/Struct/AssignTestCollection.php
+++ b/tests/unit/Core/Framework/Struct/AssignTestCollection.php
@@ -7,8 +7,6 @@ use Shopware\Core\Framework\Struct\Collection;
 /**
  * @internal
  *
- * @codeCoverageIgnore
- *
  * @extends Collection<AssignTestStruct>
  */
 class AssignTestCollection extends Collection

--- a/tests/unit/Core/Framework/Struct/AssignTestStruct.php
+++ b/tests/unit/Core/Framework/Struct/AssignTestStruct.php
@@ -9,8 +9,6 @@ use Shopware\Core\Framework\Struct\Struct;
 
 /**
  * @internal
- *
- * @codeCoverageIgnore
  */
 class AssignTestStruct extends Struct
 {


### PR DESCRIPTION
### 1. Why is this change necessary?
We should never add `@codeCoverageIgnore` in `tests/` 
We should not have this annotation either in `src/` for all kind of files that are ignored in the phpunit.xml.dist (Struct, Entity, Collection ..)

### 2. What does this change do, exactly?
Removes the annotation `@codeCoverageIgnore` 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
