### PR TITLE
fix: update tests with ChangeStorefrontCurrency() to accommodate 6.6 without ACCESSIBILITY_TWEAKS flag

### DIFF
--- a/tests/acceptance/tests/Settings/CurrencyRoundingByCountry.spec.ts
+++ b/tests/acceptance/tests/Settings/CurrencyRoundingByCountry.spec.ts
@@ -1,22 +1,25 @@
 import { test } from '@fixtures/AcceptanceTest';
+import { satisfies } from 'compare-versions';
 
 test('As a merchant, I would be able to adjust storefront rounding for defined country', { tag: ['@Settings', '@Storefront'] }, async ({
     ShopCustomer,
     TestDataService,
     DefaultSalesChannel,
-    StorefrontProductDetail,
+    HomeProduct,
     StorefrontCheckoutConfirm,
     StorefrontCheckoutFinish,
-    ChangeStorefrontCurrency,
+    StorefrontHeader,
     StorefrontHome,
+    StorefrontProductDetail,
+    AddProductToCart,
+    ChangeStorefrontCurrency,
+    ConfirmTermsAndConditions,
     Login,
     ProceedFromProductToCheckout,
-    AddProductToCart,
-    ConfirmTermsAndConditions,
     SelectPaymentMethod,
     SelectShippingMethod,
     SubmitOrder,
-    HomeProduct,
+    InstanceMeta,
 }) => {
     const product = HomeProduct;
     const currency = await TestDataService.createCurrency({ factor: 2.25555 });
@@ -49,7 +52,16 @@ test('As a merchant, I would be able to adjust storefront rounding for defined c
 
     await ShopCustomer.attemptsTo(Login(customer));
     await ShopCustomer.goesTo(StorefrontHome.url());
-    await ShopCustomer.attemptsTo(ChangeStorefrontCurrency(currency.name));
+    
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (satisfies(InstanceMeta.version, '<6.7') && !InstanceMeta.features['ACCESSIBILITY_TWEAKS']) {
+        await StorefrontHeader.currenciesDropdown.click();
+        await StorefrontHeader.currenciesMenuOptions.getByText(currency.symbol).click();
+    }   
+    else {
+        await ShopCustomer.attemptsTo(ChangeStorefrontCurrency(currency.name));
+    }
+
     const productListingLocatorsByProductId = await StorefrontHome.getListingItemByProductName(product.name);
     await ShopCustomer.expects(productListingLocatorsByProductId.productPrice).toContainText(currency.isoCode + ' 22.556');
 

--- a/tests/acceptance/tests/Settings/TaxFreeCartForCurrency.spec.ts
+++ b/tests/acceptance/tests/Settings/TaxFreeCartForCurrency.spec.ts
@@ -6,14 +6,15 @@ test(
         ShopCustomer,
         TestDataService,
         DefaultSalesChannel,
-        StorefrontProductDetail,
         StorefrontCheckoutConfirm,
         StorefrontCheckoutFinish,
-        ChangeStorefrontCurrency,
-        Login,
+        StorefrontHeader,
+        StorefrontProductDetail,
         AddProductToCart,
-        ProceedFromProductToCheckout,
+        ChangeStorefrontCurrency,
         ConfirmTermsAndConditions,
+        Login,
+        ProceedFromProductToCheckout,
         SelectPaymentMethod,
         SelectShippingMethod,
         SubmitOrder,
@@ -27,8 +28,16 @@ test(
     await ShopCustomer.attemptsTo(Login(customer));
 
     await ShopCustomer.goesTo(StorefrontProductDetail.url(product));
-    await ShopCustomer.attemptsTo(ChangeStorefrontCurrency(currency.name));
 
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    if (satisfies(InstanceMeta.version, '<6.7') && !InstanceMeta.features['ACCESSIBILITY_TWEAKS']) {
+        await StorefrontHeader.currenciesDropdown.click();
+        await StorefrontHeader.currenciesMenuOptions.getByText(currency.symbol).click();
+    }   
+    else {
+        await ShopCustomer.attemptsTo(ChangeStorefrontCurrency(currency.name));
+    }
+    
     let productPrice = `${currency.isoCode} 24.00`;
     let totalPrice = `${currency.isoCode} 20.16`;
 


### PR DESCRIPTION


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

fixes: https://github.com/shopware/acceptance-test-suite/issues/546

### 2. What does this change do, exactly?

adds an exception so pipelines without the ACCESSIBILITY_TWEAKS flag will still work and the tests match for both 6.6 and 6.7

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
