### PR TITLE
chore: don't override routes in decorators

### DIFF
--- a/src/Core/Content/Category/SalesChannel/TreeBuildingNavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/TreeBuildingNavigationRoute.php
@@ -3,20 +3,15 @@
 namespace Shopware\Core\Content\Category\SalesChannel;
 
 use Shopware\Core\Content\Category\CategoryCollection;
-use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\CategoryException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\StoreApiRouteScope;
-use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
 #[Package('discovery')]
 class TreeBuildingNavigationRoute extends AbstractNavigationRoute
 {
@@ -32,12 +27,6 @@ class TreeBuildingNavigationRoute extends AbstractNavigationRoute
         return $this->decorated;
     }
 
-    #[Route(
-        path: '/store-api/navigation/{activeId}/{rootId}',
-        name: 'store-api.navigation',
-        methods: [Request::METHOD_GET, Request::METHOD_POST],
-        defaults: [PlatformRequest::ATTRIBUTE_ENTITY => CategoryDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true],
-    )]
     public function load(string $activeId, string $rootId, Request $request, SalesChannelContext $context, Criteria $criteria): NavigationRouteResponse
     {
         try {

--- a/src/Core/Content/Product/SalesChannel/Listing/ResolveCriteriaProductListingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ResolveCriteriaProductListingRoute.php
@@ -4,19 +4,14 @@ namespace Shopware\Core\Content\Product\SalesChannel\Listing;
 
 use Shopware\Core\Content\Product\Events\ProductListingCriteriaEvent;
 use Shopware\Core\Content\Product\Events\ProductListingResultEvent;
-use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Processor\CompositeListingProcessor;
 use Shopware\Core\Content\Product\SalesChannel\Search\ResolvedCriteriaProductSearchRoute;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\StoreApiRouteScope;
-use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
 #[Package('inventory')]
 class ResolveCriteriaProductListingRoute extends AbstractProductListingRoute
 {
@@ -37,12 +32,6 @@ class ResolveCriteriaProductListingRoute extends AbstractProductListingRoute
         return $this->decorated;
     }
 
-    #[Route(
-        path: '/store-api/product-listing/{categoryId}',
-        name: 'store-api.product.listing',
-        methods: [Request::METHOD_POST, Request::METHOD_GET],
-        defaults: [PlatformRequest::ATTRIBUTE_ENTITY => ProductDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true]
-    )]
     public function load(string $categoryId, Request $request, SalesChannelContext $context, Criteria $criteria): ProductListingRouteResponse
     {
         $criteria->addState(self::STATE);

--- a/src/Core/Content/Product/SalesChannel/Search/ResolvedCriteriaProductSearchRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Search/ResolvedCriteriaProductSearchRoute.php
@@ -4,21 +4,16 @@ namespace Shopware\Core\Content\Product\SalesChannel\Search;
 
 use Shopware\Core\Content\Product\Events\ProductSearchCriteriaEvent;
 use Shopware\Core\Content\Product\Events\ProductSearchResultEvent;
-use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEvents;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Processor\CompositeListingProcessor;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\StoreApiRouteScope;
-use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
 #[Package('inventory')]
 class ResolvedCriteriaProductSearchRoute extends AbstractProductSearchRoute
 {
@@ -42,12 +37,6 @@ class ResolvedCriteriaProductSearchRoute extends AbstractProductSearchRoute
         return $this->decorated;
     }
 
-    #[Route(
-        path: '/store-api/search',
-        name: 'store-api.search',
-        methods: [Request::METHOD_POST, Request::METHOD_GET],
-        defaults: [PlatformRequest::ATTRIBUTE_ENTITY => ProductDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true]
-    )]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): ProductSearchRouteResponse
     {
         $criteria->addState(self::STATE);

--- a/src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Content\Product\SalesChannel\Suggest;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Events\ProductSuggestCriteriaEvent;
 use Shopware\Core\Content\Product\Events\ProductSuggestResultEvent;
-use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEvents;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Processor\CompositeListingProcessor;
@@ -13,14 +12,10 @@ use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\StoreApiRouteScope;
-use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
 #[Package('discovery')]
 class ResolvedCriteriaProductSuggestRoute extends AbstractProductSuggestRoute
 {
@@ -40,12 +35,6 @@ class ResolvedCriteriaProductSuggestRoute extends AbstractProductSuggestRoute
         return $this->decorated;
     }
 
-    #[Route(
-        path: '/store-api/search-suggest',
-        name: 'store-api.search.suggest',
-        methods: [Request::METHOD_POST, Request::METHOD_GET],
-        defaults: [PlatformRequest::ATTRIBUTE_ENTITY => ProductDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true]
-    )]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): ProductSuggestRouteResponse
     {
         if (!$request->get('search')) {

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRouteOverrideInDecoratorsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRouteOverrideInDecoratorsRule.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Symfony\ServiceMap;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * @internal
+ *
+ * @implements Rule<InClassNode>
+ */
+#[Package('framework')]
+class NoRouteOverrideInDecoratorsRule implements Rule
+{
+    public function __construct(private readonly ServiceMap $serviceMap)
+    {
+    }
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof InClassNode) {
+            return [];
+        }
+
+        $reflection = $node->getClassReflection();
+
+        if ($this->isServiceDecorator($reflection->getName()) === false) {
+            return [];
+        }
+
+        if (!$this->definesRouteAttribute($reflection)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                \sprintf(
+                    'Service "%s" is a decorator but overrides @Route attributes (class or method-level). Decorators must not override or define routes, otherwise changes to the core route definition don\'t have any affect; only the core route should define the @Route attribute.',
+                    $reflection->getName(),
+                )
+            )
+            ->identifier('shopware.routeDecorator')
+            ->build(),
+        ];
+    }
+
+    public function definesRouteAttribute(ClassReflection $reflection): bool
+    {
+        $native = $reflection->getNativeReflection();
+        // check class level attributes for Route
+        if ($native->getAttributes(Route::class) !== []) {
+            return true;
+        }
+
+        // check method level attributes for Route
+        foreach ($native->getMethods() as $method) {
+            // only consider methods declared in this class
+            if ($method->getDeclaringClass()->getName() !== $native->getName()) {
+                continue;
+            }
+
+            if ($method->getAttributes(Route::class) !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isServiceDecorator(string $className): bool
+    {
+        $service = $this->serviceMap->getService($className);
+
+        if ($service === null) {
+            return false;
+        }
+
+        if (empty($service->getTags())) {
+            return false;
+        }
+
+        $decorates = null;
+
+        foreach ($service->getTags() as $tag) {
+            /** @phpstan-ignore phpstanApi.method */
+            if ($tag->getName() === 'container.decorator') {
+                /** @phpstan-ignore phpstanApi.method */
+                $decorates = $tag->getAttributes()['id'] ?? null;
+
+                break;
+            }
+        }
+
+        if ($decorates === null) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRouteOverrideInDecoratorsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRouteOverrideInDecoratorsRule.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Symfony\ServiceMap;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Annotation\Route as RouteAnnotation;
 
 /**
  * @internal
@@ -37,7 +38,7 @@ class NoRouteOverrideInDecoratorsRule implements Rule
 
         $reflection = $node->getClassReflection();
 
-        if ($this->isServiceDecorator($reflection->getName()) === false) {
+        if (!$this->isServiceDecorator($reflection->getName())) {
             return [];
         }
 
@@ -64,6 +65,9 @@ class NoRouteOverrideInDecoratorsRule implements Rule
         if ($native->getAttributes(Route::class) !== []) {
             return true;
         }
+        if ($native->getAttributes(RouteAnnotation::class) !== []) {
+            return true;
+        }
 
         // check method level attributes for Route
         foreach ($native->getMethods() as $method) {
@@ -73,6 +77,9 @@ class NoRouteOverrideInDecoratorsRule implements Rule
             }
 
             if ($method->getAttributes(Route::class) !== []) {
+                return true;
+            }
+            if ($method->getAttributes(RouteAnnotation::class) !== []) {
                 return true;
             }
         }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRouteOverrideInDecoratorsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRouteOverrideInDecoratorsRule.php
@@ -10,8 +10,8 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Symfony\ServiceMap;
 use Shopware\Core\Framework\Log\Package;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Annotation\Route as RouteAnnotation;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @internal

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
@@ -22,6 +22,7 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoAddCacheTagEventRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoUpdatesInExecuteQueryRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\PublicServiceDecoratorRule
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoRouteOverrideInDecoratorsRule
 
     # rules from https://github.com/symplify/phpstan-rules
     # domain

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoRouteOverrideInDecoratorsRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoRouteOverrideInDecoratorsRuleTest.php
@@ -31,6 +31,14 @@ class NoRouteOverrideInDecoratorsRuleTest extends RuleTestCase
                 11,
             ],
         ]);
+
+        // Test case where decorator does override #Routes (with old Attribute name) (should trigger error)
+        $this->analyse([__DIR__ . '/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithRouteOverridesViaDeprecatedAttributeClass.php'], [
+            [
+                'Service "Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\ControllerDecoratorWithRouteOverridesViaDeprecatedAttributeClass" is a decorator but overrides @Route attributes (class or method-level). Decorators must not override or define routes, otherwise changes to the core route definition don\'t have any affect; only the core route should define the @Route attribute.',
+                12,
+            ],
+        ]);
     }
 
     protected function getRule(): Rule

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoRouteOverrideInDecoratorsRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoRouteOverrideInDecoratorsRuleTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Symfony\XmlServiceMapFactory;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoRouteOverrideInDecoratorsRule;
+
+/**
+ * @internal
+ *
+ * @extends  RuleTestCase<NoRouteOverrideInDecoratorsRule>
+ */
+#[CoversClass(NoRouteOverrideInDecoratorsRule::class)]
+class NoRouteOverrideInDecoratorsRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        // Test case with dummy controller that does not decorate any service (should not trigger error)
+        $this->analyse([__DIR__ . '/data/NoRouteOverrideInDecoratorsRule/DummyController.php'], []);
+
+        // Test case where decorator does not override #Routes (should not trigger error)
+        $this->analyse([__DIR__ . '/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithoutRouteOverrides.php'], []);
+
+        // Test case where decorator does override #Routes (should trigger error)
+        $this->analyse([__DIR__ . '/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithRouteOverrides.php'], [
+            [
+                'Service "Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\ControllerDecoratorWithRouteOverrides" is a decorator but overrides @Route attributes (class or method-level). Decorators must not override or define routes, otherwise changes to the core route definition don\'t have any affect; only the core route should define the @Route attribute.',
+                11,
+            ],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        /** @phpstan-ignore phpstanApi.constructor */
+        $factory = new XmlServiceMapFactory(
+            __DIR__ . '/data/NoRouteOverrideInDecoratorsRule/services.xml'
+        );
+
+        /** @phpstan-ignore phpstanApi.method */
+        return new NoRouteOverrideInDecoratorsRule($factory->create());
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithRouteOverrides.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithRouteOverrides.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule;
+
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
+class ControllerDecoratorWithRouteOverrides
+{
+    #[Route(
+        path: '/store-api/navigation/{activeId}/{rootId}',
+        name: 'store-api.navigation',
+        methods: [Request::METHOD_GET, Request::METHOD_POST],
+        defaults: [PlatformRequest::ATTRIBUTE_ENTITY => CategoryDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true],
+    )]
+    public function dummy(): void
+    {
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithRouteOverridesViaDeprecatedAttributeClass.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithRouteOverridesViaDeprecatedAttributeClass.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule;
+
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+// note that we use Symfony\Component\Routing\Annotation\Route here and not the new one in attribute namespace
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
+class ControllerDecoratorWithRouteOverridesViaDeprecatedAttributeClass
+{
+    #[Route(
+        path: '/store-api/navigation/{activeId}/{rootId}',
+        name: 'store-api.navigation',
+        methods: [Request::METHOD_GET, Request::METHOD_POST],
+        defaults: [PlatformRequest::ATTRIBUTE_ENTITY => CategoryDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true],
+    )]
+    public function dummy(): void
+    {
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithoutRouteOverrides.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/ControllerDecoratorWithoutRouteOverrides.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule;
+
+class ControllerDecoratorWithoutRouteOverrides
+{
+    public function dummy(): void
+    {
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/DummyController.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/DummyController.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule;
+
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
+class DummyController
+{
+    #[Route(
+        path: '/store-api/navigation/{activeId}/{rootId}',
+        name: 'store-api.navigation',
+        methods: [Request::METHOD_GET, Request::METHOD_POST],
+        defaults: [PlatformRequest::ATTRIBUTE_ENTITY => CategoryDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true],
+    )]
+    public function dummy(): void
+    {
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/services.xml
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoRouteOverrideInDecoratorsRule/services.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <!-- Mock controller that gets decorated -->
+        <service id="Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\DummyController"/>
+
+        <!-- Test case 1: Decorator of controller without overriding #Routes should not trigger error -->
+        <service id="Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\ControllerDecoratorWithoutRouteOverrides"
+                 decorates="Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\DummyController">
+            <tag name="container.decorator" id="Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\DummyController" />
+        </service>
+
+        <!-- Test case 2: Decorator of controller with overriding #Routes should trigger error -->
+        <service id="Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\ControllerDecoratorWithRouteOverrides"
+                 decorates="Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\DummyController">
+            <tag name="container.decorator" id="Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoRouteOverrideInDecoratorsRule\DummyController" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Decorating a controller and overriding the #Route attribute is quite dangerous, as likely it will override the core config, whihc means when the core annotation changes, those changes don't have any affect

in fact copying the route attribute is not necessary in basically all cases, as symfony will read the core route definition to build and configure the router, the router will point to the core controller and then the symfony decoration kicks in 

also note that in the following ADR we described why we moved route meta configs (e.g. login required, cacheability) from custom attributes to routes, because those don't need to be present in all decorating classes: https://github.com/shopware/shopware/blob/trunk/adr/2022-02-09-controller-configuration-route-defaults.md

### 2. What does this change do, exactly?
Add a phpstan rule to check for occurences of services that decorate another service and define a route attribute.

Also this fixes the first occurences where we even overrode the route config for specific routes directly in the core.

### 3. Describe each step to reproduce the issue or behaviour.

Decorate a route, copy the route attribute over and override the core route definition
The core route definition changes (e.g. we make the route cacheable)
You decoration overrides the core change