### PR TITLE
fix: snippet inheritance

### DIFF
--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -14,6 +14,7 @@ use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\Locale\LocaleException;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Snippet\SnippetService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
@@ -318,7 +319,7 @@ class Translator extends AbstractTranslator
             return $this->isCustomized[$snippetSetId];
         }
 
-        $newCatalogue = $this->buildMergedCatalogue($catalogue, $snippetSetId, $fallbackLocale);
+        $newCatalogue = $this->buildMergedCatalogue($catalogue, $snippetSetId);
 
         return $this->isCustomized[$snippetSetId] = $newCatalogue;
     }
@@ -345,6 +346,13 @@ class Translator extends AbstractTranslator
 
     private function getFallbackLocale(?string $locale): string
     {
+        // Try to use configured language inheritance from SalesChannelContext
+        $fallbackFromInheritance = $this->getFallbackLocaleFromLanguageInheritance();
+        if ($fallbackFromInheritance !== null) {
+            return $fallbackFromInheritance;
+        }
+
+        // Fallback to locale prefix extraction (original behavior)
         if ($locale) {
             return explode('-', $locale)[0];
         }
@@ -354,6 +362,39 @@ class Translator extends AbstractTranslator
         } catch (ConnectionException|LocaleException) {
             // this allows us to use the translator even if there's no db connection or locale yet
             return 'en';
+        }
+    }
+
+    /**
+     * Gets the fallback locale from the configured language inheritance chain.
+     *
+     * When a language is configured with a parent language (e.g., Spanish inherits from English),
+     * this method returns the parent language's locale as the fallback, instead of just using
+     * the locale prefix (e.g., "es" from "es-ES").
+     *
+     * This ensures that snippet translations respect the language inheritance configured
+     * in the admin under Settings > Languages.
+     */
+    private function getFallbackLocaleFromLanguageInheritance(): ?string
+    {
+        $request = $this->requestStack->getMainRequest();
+        $salesChannelContext = $request?->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
+
+        if (!$salesChannelContext instanceof SalesChannelContext) {
+            return null;
+        }
+
+        $languageIdChain = $salesChannelContext->getLanguageIdChain();
+
+        // If there's no parent language in the chain, return null to use default behavior
+        if (\count($languageIdChain) < 2) {
+            return null;
+        }
+
+        try {
+            return $this->languageLocaleProvider->getLocaleForLanguageId($languageIdChain[1]);
+        } catch (LocaleException) {
+            return null;
         }
     }
 
@@ -372,14 +413,17 @@ class Translator extends AbstractTranslator
         $this->salesChannelId = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
     }
 
-    private function buildMergedCatalogue(MessageCatalogueInterface $catalogue, string $snippetSetId, ?string $fallbackLocale): MessageCatalogueInterface
+    private function buildMergedCatalogue(MessageCatalogueInterface $catalogue, string $snippetSetId): MessageCatalogueInterface
     {
         $newCatalogue = clone $catalogue;
 
-        // Recursively loading fallback snippets
+        // Recursively loading snippets for each catalogue in the fallback chain.
+        // Each catalogue loads its own locale's snippets (e.g., es-ES loads Spanish, en-GB loads English).
+        // The language inheritance fallback is handled by the catalogue chain itself,
+        // which is set up in getCatalogue() based on the configured parent language.
         $currentCatalogue = $newCatalogue;
         do {
-            $loadedSnippets = $this->loadSnippets($currentCatalogue, $snippetSetId, $fallbackLocale);
+            $loadedSnippets = $this->loadSnippets($currentCatalogue, $snippetSetId, null);
 
             if (!empty($loadedSnippets)) {
                 $currentCatalogue->add($loadedSnippets);

--- a/tests/unit/Core/Framework/Adapter/Translation/TranslatorLanguageInheritanceTest.php
+++ b/tests/unit/Core/Framework/Adapter/Translation/TranslatorLanguageInheritanceTest.php
@@ -1,0 +1,301 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Translation;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
+use Shopware\Core\Framework\Adapter\Translation\Translator;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\SalesChannelRequest;
+use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\Snippet\SnippetService;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Translator as SymfonyTranslator;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * Tests for the language inheritance fix in snippet fallback.
+ *
+ * This test verifies that when a language is configured with a parent language
+ * (e.g., Spanish inherits from English), the catalogue fallback chain is set up
+ * correctly so that snippets fall back to the parent language.
+ *
+ * The key behavior:
+ * - Each catalogue in the chain loads its own locale's snippets
+ * - The fallback mechanism works through the catalogue chain (e.g., es-ES -> en-GB)
+ * - This ensures Spanish views show English snippets when Spanish doesn't exist,
+ *   instead of falling back to German (system default)
+ *
+ * @internal
+ */
+#[CoversClass(Translator::class)]
+class TranslatorLanguageInheritanceTest extends TestCase
+{
+    /**
+     * Tests that when a language has a configured parent (via language chain),
+     * the catalogue fallback chain is set up correctly using language inheritance.
+     *
+     * Scenario:
+     * - Current language: Spanish (es-ES) with parent English (en-GB)
+     * - Language chain: [spanish-uuid, english-uuid]
+     * - Expected: es-ES catalogue has en-GB as fallback catalogue
+     * - Each catalogue loads its own locale's snippets
+     */
+    public function testGetCatalogueUsesLanguageInheritanceForFallback(): void
+    {
+        $spanishLanguageId = Uuid::randomHex();
+        $englishLanguageId = Uuid::randomHex();
+        $snippetSetId = Uuid::randomHex();
+
+        $decorated = $this->createMock(SymfonyTranslator::class);
+        $originCatalogue = new MessageCatalogue('es-ES', [
+            'messages' => [
+                'global.title' => 'Title in catalogue',
+            ],
+        ]);
+        $fallbackCatalogue = new MessageCatalogue('en-GB', [
+            'messages' => [
+                'global.title' => 'English title',
+            ],
+        ]);
+
+        // Return different catalogues for different locales to avoid circular reference
+        $decorated->method('getCatalogue')->willReturnCallback(
+            static fn (?string $locale = null) => $locale === 'en-GB' ? $fallbackCatalogue : $originCatalogue
+        );
+        $decorated->method('getLocale')->willReturn('es-ES');
+
+        // Create SalesChannelContext with language chain (Spanish -> English)
+        $context = $this->createMock(Context::class);
+        $context->method('getLanguageIdChain')->willReturn([$spanishLanguageId, $englishLanguageId]);
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getLanguageIdChain')->willReturn([$spanishLanguageId, $englishLanguageId]);
+        $salesChannelContext->method('getContext')->willReturn($context);
+
+        // Create request with SalesChannelContext
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
+        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_DOMAIN_SNIPPET_SET_ID, $snippetSetId);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        // Mock LanguageLocaleCodeProvider to return en-GB for the parent language
+        $localeCodeProvider = $this->createMock(LanguageLocaleCodeProvider::class);
+        $localeCodeProvider->method('getLocaleForLanguageId')
+            ->with($englishLanguageId)
+            ->willReturn('en-GB');
+
+        // Each catalogue loads its own locale's snippets
+        // The fallback mechanism works through the catalogue chain (es-ES -> en-GB)
+        $snippetService = $this->createMock(SnippetService::class);
+        $snippetService->expects($this->atLeastOnce())
+            ->method('getStorefrontSnippets')
+            ->willReturn([
+                'global.title' => 'Title from snippets',
+            ]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchFirstColumn')->willReturn([$snippetSetId]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $item = new CacheItem();
+        $property = new \ReflectionProperty(CacheItem::class, 'isTaggable');
+        $property->setValue($item, true);
+
+        $cache->method('get')->willReturnCallback(function (string $key, callable $callback) use ($item) {
+            return $callback($item);
+        });
+
+        $translator = new Translator(
+            $decorated,
+            $requestStack,
+            $cache,
+            $this->createMock(MessageFormatterInterface::class),
+            'prod',
+            $connection,
+            $localeCodeProvider,
+            $snippetService,
+            $this->createMock(CacheTagCollector::class),
+        );
+
+        $snippetSetIdProp = new \ReflectionProperty(Translator::class, 'snippetSetId');
+        $snippetSetIdProp->setValue($translator, $snippetSetId);
+
+        $catalogue = $translator->getCatalogue('es-ES');
+
+        // Verify catalogue was created with correct locale
+        static::assertNotNull($catalogue);
+        static::assertSame('es-ES', $catalogue->getLocale());
+
+        // Verify the language inheritance fallback chain is set up (es-ES -> en-GB)
+        $fallback = $catalogue->getFallbackCatalogue();
+        static::assertNotNull($fallback, 'Expected en-GB fallback catalogue based on language inheritance');
+        static::assertSame('en-GB', $fallback->getLocale());
+    }
+
+    /**
+     * Tests that when no SalesChannelContext is available,
+     * the translator falls back to the original behavior (locale prefix).
+     */
+    public function testGetCatalogueFallsBackToLocalePrefixWithoutSalesChannelContext(): void
+    {
+        $snippetSetId = Uuid::randomHex();
+
+        $decorated = $this->createMock(SymfonyTranslator::class);
+        $originCatalogue = new MessageCatalogue('es-ES', [
+            'messages' => [
+                'global.title' => 'Title in catalogue',
+            ],
+        ]);
+
+        $decorated->method('getCatalogue')->willReturn($originCatalogue);
+        $decorated->method('getLocale')->willReturn('es-ES');
+
+        // Create request WITHOUT SalesChannelContext
+        $request = new Request();
+        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_DOMAIN_SNIPPET_SET_ID, $snippetSetId);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $localeCodeProvider = $this->createMock(LanguageLocaleCodeProvider::class);
+
+        // Each catalogue loads its own locale's snippets
+        $snippetService = $this->createMock(SnippetService::class);
+        $snippetService->expects($this->once())
+            ->method('getStorefrontSnippets')
+            ->with(
+                static::anything(),
+                $snippetSetId,
+                'es-ES', // Catalogue loads snippets for its own locale
+                static::anything()
+            )
+            ->willReturn([
+                'global.title' => 'Title from snippets',
+            ]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchFirstColumn')->willReturn([$snippetSetId]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $item = new CacheItem();
+        $property = new \ReflectionProperty(CacheItem::class, 'isTaggable');
+        $property->setValue($item, true);
+
+        $cache->method('get')->willReturnCallback(function (string $key, callable $callback) use ($item) {
+            return $callback($item);
+        });
+
+        $translator = new Translator(
+            $decorated,
+            $requestStack,
+            $cache,
+            $this->createMock(MessageFormatterInterface::class),
+            'prod',
+            $connection,
+            $localeCodeProvider,
+            $snippetService,
+            $this->createMock(CacheTagCollector::class),
+        );
+
+        $snippetSetIdProp = new \ReflectionProperty(Translator::class, 'snippetSetId');
+        $snippetSetIdProp->setValue($translator, $snippetSetId);
+
+        $catalogue = $translator->getCatalogue('es-ES');
+
+        static::assertNotNull($catalogue);
+    }
+
+    /**
+     * Tests that when language chain has only one language (no parent),
+     * the translator falls back to the original behavior (locale prefix).
+     */
+    public function testGetCatalogueFallsBackToLocalePrefixWithNoParentLanguage(): void
+    {
+        $englishLanguageId = Uuid::randomHex();
+        $snippetSetId = Uuid::randomHex();
+
+        $decorated = $this->createMock(SymfonyTranslator::class);
+        $originCatalogue = new MessageCatalogue('en-GB', [
+            'messages' => [
+                'global.title' => 'Title in catalogue',
+            ],
+        ]);
+
+        $decorated->method('getCatalogue')->willReturn($originCatalogue);
+        $decorated->method('getLocale')->willReturn('en-GB');
+
+        // Create SalesChannelContext with single language (no parent)
+        $context = $this->createMock(Context::class);
+        $context->method('getLanguageIdChain')->willReturn([$englishLanguageId]);
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getLanguageIdChain')->willReturn([$englishLanguageId]);
+        $salesChannelContext->method('getContext')->willReturn($context);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
+        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_DOMAIN_SNIPPET_SET_ID, $snippetSetId);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $localeCodeProvider = $this->createMock(LanguageLocaleCodeProvider::class);
+
+        // Each catalogue loads its own locale's snippets
+        $snippetService = $this->createMock(SnippetService::class);
+        $snippetService->expects($this->once())
+            ->method('getStorefrontSnippets')
+            ->with(
+                static::anything(),
+                $snippetSetId,
+                'en-GB', // Catalogue loads snippets for its own locale
+                static::anything()
+            )
+            ->willReturn([
+                'global.title' => 'Title from snippets',
+            ]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchFirstColumn')->willReturn([$snippetSetId]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $item = new CacheItem();
+        $property = new \ReflectionProperty(CacheItem::class, 'isTaggable');
+        $property->setValue($item, true);
+
+        $cache->method('get')->willReturnCallback(function (string $key, callable $callback) use ($item) {
+            return $callback($item);
+        });
+
+        $translator = new Translator(
+            $decorated,
+            $requestStack,
+            $cache,
+            $this->createMock(MessageFormatterInterface::class),
+            'prod',
+            $connection,
+            $localeCodeProvider,
+            $snippetService,
+            $this->createMock(CacheTagCollector::class),
+        );
+
+        $snippetSetIdProp = new \ReflectionProperty(Translator::class, 'snippetSetId');
+        $snippetSetIdProp->setValue($translator, $snippetSetId);
+
+        $catalogue = $translator->getCatalogue('en-GB');
+
+        static::assertNotNull($catalogue);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

Text snippets do not respect the language inheritance settings configured under Settings > Languages. When a language (e.g., Spanish) is configured to inherit from another language (e.g., English), the storefront still falls back to the locale prefix instead of using the configured parent language.
                                                                                                                                                               
  Example:                                                                                                                                                     
  - Spanish configured with English as parent language                                                                                                         
  - Snippet not yet translated to Spanish                                                                                                                      
  - Expected: English fallback text is displayed                                                                                                               
  - Actual: Falls back to locale prefix "es", showing German default                                                                                           
                                                                                                                                                               
  This issue only affects snippets. Shopping Experiences correctly respect the language inheritance.                                                           
                                                                                                                                                               
  Solution                                                                                                                                                     
                                                                                                                                                               
  The Translator::getFallbackLocale() method now checks the SalesChannelContext's language inheritance chain before falling back to the locale prefix. If a parent language is configured, its locale is used as the fallback.
                                                                                                                                                               
  Changes                                                                                                                                                      
                                                                                                                                                               
  - Added getFallbackLocaleFromLanguageInheritance() method to Translator                                                                                      
  - Falls back to original behavior when no SalesChannelContext or parent language is available                                                                
                                                                                                                                                               
  Test coverage                                                                                                                                                
                                                                                                                                                               
  Added unit tests covering:                                                                                                                                   
  - Fallback uses parent language locale when configured                                                                                                       
  - Fallback uses locale prefix when no SalesChannelContext available                                                                                          
  - Fallback uses locale prefix when no parent language configured        

### 4. Please link to the relevant issues (if any).

Fixes #14130

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
