### PR TITLE
feat(consent): Rewrite consent history

### DIFF
--- a/src/Core/Migration/V6_7/Migration1765287397AddConsentTable.php
+++ b/src/Core/Migration/V6_7/Migration1765287397AddConsentTable.php
@@ -31,5 +31,15 @@ class Migration1765287397AddConsentTable extends MigrationStep
                 UNIQUE KEY `uniq.consent_state` (`name`, `identifier`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
         ');
+
+        $connection->executeStatement('
+            CREATE TABLE IF NOT EXISTS `consent_log` (
+                `id` BIGINT UNSIGNED AUTO_INCREMENT NOT NULL,
+                `consent_name` VARCHAR(100) NOT NULL,
+                `message` LONGTEXT NOT NULL,
+                PRIMARY KEY (`id`),
+                KEY `idx.consent_log.history` (`consent_name`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
     }
 }

--- a/src/Core/System/Consent/Event/ConsentAcceptedEvent.php
+++ b/src/Core/System/Consent/Event/ConsentAcceptedEvent.php
@@ -15,7 +15,8 @@ readonly class ConsentAcceptedEvent implements Hookable
     public function __construct(
         public string $consentName,
         public string $consentScope,
-        public string $identifier
+        public string $identifier,
+        public string $actorId
     ) {
     }
 
@@ -33,6 +34,7 @@ readonly class ConsentAcceptedEvent implements Hookable
             'consent' => $this->consentName,
             'scope' => $this->consentScope,
             'identifier' => $this->identifier,
+            'actorId' => $this->actorId,
         ];
     }
 

--- a/src/Core/System/Consent/Event/ConsentRevokedEvent.php
+++ b/src/Core/System/Consent/Event/ConsentRevokedEvent.php
@@ -15,7 +15,8 @@ readonly class ConsentRevokedEvent implements Hookable
     public function __construct(
         public string $consentName,
         public string $consentScope,
-        public string $identifier
+        public string $identifier,
+        public string $actorId
     ) {
     }
 
@@ -33,6 +34,7 @@ readonly class ConsentRevokedEvent implements Hookable
             'consent' => $this->consentName,
             'scope' => $this->consentScope,
             'identifier' => $this->identifier,
+            'actorId' => $this->actorId,
         ];
     }
 

--- a/src/Core/System/Consent/Log/ConsentChangedSubscriber.php
+++ b/src/Core/System/Consent/Log/ConsentChangedSubscriber.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Consent\Log;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Consent\ConsentStatus;
+use Shopware\Core\System\Consent\Event\ConsentAcceptedEvent;
+use Shopware\Core\System\Consent\Event\ConsentRevokedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+#[Package('data-services')]
+class ConsentChangedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly ?ConsentLogInterface $consentChangeLogger,
+    ) {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ConsentAcceptedEvent::EVENT_NAME => 'onConsentAccepted',
+            ConsentRevokedEvent::EVENT_NAME => 'onConsentRevoked',
+        ];
+    }
+
+    public function onConsentAccepted(ConsentAcceptedEvent $event): void
+    {
+        $this->logConsentChange(ConsentStatus::ACCEPTED, $event->consentName, $event->identifier, $event->actorId);
+    }
+
+    public function onConsentRevoked(ConsentRevokedEvent $event): void
+    {
+        $this->logConsentChange(ConsentStatus::REVOKED, $event->consentName, $event->identifier, $event->actorId);
+    }
+
+    private function logConsentChange(ConsentStatus $consentStatus, string $consentName, string $identifier, string $actorId): void
+    {
+        if ($this->consentChangeLogger === null) {
+            return;
+        }
+
+        $this->consentChangeLogger->log(
+            $consentStatus,
+            $consentName,
+            $identifier,
+            $actorId,
+        );
+    }
+}

--- a/src/Core/System/Consent/Log/ConsentLogInterface.php
+++ b/src/Core/System/Consent/Log/ConsentLogInterface.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Consent\Log;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Consent\ConsentStatus;
+
+#[Package('data-services')]
+interface ConsentLogInterface
+{
+    public function log(ConsentStatus $action, string $consentName, ?string $identifier, string $actorId): void;
+}

--- a/src/Core/System/Consent/Log/DatabaseLog.php
+++ b/src/Core/System/Consent/Log/DatabaseLog.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Consent\Log;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Consent\ConsentStatus;
+
+/**
+ * @internal
+ */
+#[Package('data-services')]
+class DatabaseLog implements ConsentLogInterface
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function log(ConsentStatus $action, string $consentName, ?string $identifier, string $actorId): void
+    {
+        $logEntry = [
+            'consent-name' => $consentName,
+            'action' => $action->value,
+            'identifier' => $identifier,
+            'actor-id' => $actorId,
+        ];
+
+        $this->connection->insert('consent_log', [
+            'consent_name' => $consentName,
+            'timestamp' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'message' => \json_encode($logEntry),
+        ]);
+    }
+}

--- a/src/Core/System/Consent/Service/ConsentService.php
+++ b/src/Core/System/Consent/Service/ConsentService.php
@@ -90,7 +90,8 @@ class ConsentService
     {
         $updatedState = $this->updateState($name, ConsentStatus::ACCEPTED, $context);
 
-        $this->eventDispatcher->dispatch(new ConsentAcceptedEvent($updatedState->name, $updatedState->scopeName, $updatedState->identifier));
+        \assert(\is_string($updatedState->actorId));
+        $this->eventDispatcher->dispatch(new ConsentAcceptedEvent($updatedState->name, $updatedState->scopeName, $updatedState->identifier, $updatedState->actorId));
 
         $this->invalidateState();
 
@@ -101,7 +102,8 @@ class ConsentService
     {
         $updatedState = $this->updateState($name, ConsentStatus::REVOKED, $context);
 
-        $this->eventDispatcher->dispatch(new ConsentRevokedEvent($updatedState->name, $updatedState->scopeName, $updatedState->identifier));
+        \assert(\is_string($updatedState->actorId));
+        $this->eventDispatcher->dispatch(new ConsentRevokedEvent($updatedState->name, $updatedState->scopeName, $updatedState->identifier, $updatedState->actorId));
 
         $this->invalidateState();
 

--- a/src/Core/System/DependencyInjection/consent.xml
+++ b/src/Core/System/DependencyInjection/consent.xml
@@ -34,5 +34,15 @@
             <argument type="service" id="Shopware\Core\System\Consent\ConsentRepository"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
+
+        <!-- Log -->
+        <service id="Shopware\Core\System\Consent\Log\ConsentLogInterface"
+                 class="Shopware\Core\System\Consent\Log\DatabaseLog">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
+
+        <service id="Shopware\Core\System\Consent\Log\ConsentChangedSubscriber">
+            <argument type="service" id="Shopware\Core\System\Consent\Log\ConsentLogInterface" on-invalid="null"/>
+        </service>
     </services>
 </container>

--- a/tests/migration/Core/V6_7/Migration1765287397AddConsentTableTest.php
+++ b/tests/migration/Core/V6_7/Migration1765287397AddConsentTableTest.php
@@ -31,6 +31,7 @@ class Migration1765287397AddConsentTableTest extends TestCase
 
     public function testMigration(): void
     {
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `consent_log`;');
         $this->connection->executeStatement('DROP TABLE IF EXISTS `consent_state`;');
 
         $migration = new Migration1765287397AddConsentTable();
@@ -43,5 +44,8 @@ class Migration1765287397AddConsentTableTest extends TestCase
 
         $consentStateCols = $sm->listTableColumns('consent_state');
         static::assertCount(6, $consentStateCols);
+
+        $consentLogCols = $sm->listTableColumns('consent_log');
+        static::assertCount(3, $consentLogCols);
     }
 }

--- a/tests/unit/Core/System/Consent/Event/ConsentAcceptedEventTest.php
+++ b/tests/unit/Core/System/Consent/Event/ConsentAcceptedEventTest.php
@@ -20,11 +20,13 @@ class ConsentAcceptedEventTest extends TestCase
         $event = new ConsentAcceptedEvent(
             'my-consent',
             ConsentScope\AdminUser::NAME,
+            'consent-identifier',
             'user-123'
         );
 
         static::assertSame('my-consent', $event->consentName);
         static::assertSame(ConsentScope\AdminUser::NAME, $event->consentScope);
-        static::assertSame('user-123', $event->identifier);
+        static::assertSame('consent-identifier', $event->identifier);
+        static::assertSame('user-123', $event->actorId);
     }
 }

--- a/tests/unit/Core/System/Consent/Event/ConsentRevokedEventTest.php
+++ b/tests/unit/Core/System/Consent/Event/ConsentRevokedEventTest.php
@@ -20,11 +20,13 @@ class ConsentRevokedEventTest extends TestCase
         $event = new ConsentRevokedEvent(
             'my-consent',
             ConsentScope\AdminUser::NAME,
+            'consent-identifier',
             'user-456'
         );
 
         static::assertSame('my-consent', $event->consentName);
         static::assertSame(ConsentScope\AdminUser::NAME, $event->consentScope);
-        static::assertSame('user-456', $event->identifier);
+        static::assertSame('consent-identifier', $event->identifier);
+        static::assertSame('user-456', $event->actorId);
     }
 }

--- a/tests/unit/Core/System/Consent/Log/ConsentChangedSubscriberTest.php
+++ b/tests/unit/Core/System/Consent/Log/ConsentChangedSubscriberTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\Consent\Log;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Consent\ConsentScope;
+use Shopware\Core\System\Consent\ConsentStatus;
+use Shopware\Core\System\Consent\Event\ConsentAcceptedEvent;
+use Shopware\Core\System\Consent\Event\ConsentRevokedEvent;
+use Shopware\Core\System\Consent\Log\ConsentChangedSubscriber;
+use Shopware\Core\System\Consent\Log\ConsentLogInterface;
+
+/**
+ * @internal
+ */
+#[Package('data-services')]
+#[CoversClass(ConsentChangedSubscriber::class)]
+class ConsentChangedSubscriberTest extends TestCase
+{
+    public function testSubscribedEvents(): void
+    {
+        $events = ConsentChangedSubscriber::getSubscribedEvents();
+
+        static::assertEquals([
+            ConsentAcceptedEvent::EVENT_NAME => 'onConsentAccepted',
+            ConsentRevokedEvent::EVENT_NAME => 'onConsentRevoked',
+        ], $events);
+    }
+
+    public function testConsentAccepted(): void
+    {
+        $logger = $this->createMock(ConsentLogInterface::class);
+        $logger->method('log')->with(
+            ConsentStatus::ACCEPTED,
+            'test-consent',
+            'identifier-123',
+            'actor-456'
+        );
+
+        $event = new ConsentAcceptedEvent(
+            'test-consent',
+            ConsentScope\System::NAME,
+            'identifier-123',
+            'actor-456'
+        );
+
+        $subscriber = new ConsentChangedSubscriber($logger);
+        $subscriber->onConsentAccepted($event);
+    }
+
+    public function testConsentRevoked(): void
+    {
+        $logger = $this->createMock(ConsentLogInterface::class);
+        $logger->method('log')->with(
+            ConsentStatus::REVOKED,
+            'test-consent',
+            'identifier-123',
+            'actor-456'
+        );
+
+        $event = new ConsentRevokedEvent(
+            'test-consent',
+            ConsentScope\System::NAME,
+            'identifier-123',
+            'actor-456'
+        );
+
+        $subscriber = new ConsentChangedSubscriber($logger);
+        $subscriber->onConsentRevoked($event);
+    }
+}

--- a/tests/unit/Core/System/Consent/Log/DatabaseLogTest.php
+++ b/tests/unit/Core/System/Consent/Log/DatabaseLogTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\Consent\Log;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Consent\ConsentStatus;
+use Shopware\Core\System\Consent\Log\DatabaseLog;
+
+/**
+ * @internal
+ */
+#[Package('data-services')]
+#[CoversClass(DatabaseLog::class)]
+class DatabaseLogTest extends TestCase
+{
+    public function testWritesToDB(): void
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $connection->method('insert')
+            ->with(
+                'consent_log',
+                static::callback(function (array $data) {
+                    static::assertArrayIsEqualToArrayOnlyConsideringListOfKeys([
+                        'consent_name' => 'test-consent',
+                        'timestamp' => $this->anything(),
+                        'message' => '{"consent-name":"test-consent","action":"accepted","identifier":"identifier-123","actor-id":"actor-456"}',
+                    ], $data, ['consent_name', 'message']);
+
+                    return true;
+                })
+            )
+            ->willReturn(1);
+
+        $logger = new DatabaseLog($connection);
+
+        $logger->log(ConsentStatus::ACCEPTED, 'test-consent', 'identifier-123', 'actor-456');
+    }
+}


### PR DESCRIPTION
This is a rewrite of the consent change history. IMO, we should not make it too big or spend too much effort on this. The logs are only used to track who changed the consent state and when. We will not display these changes in our UI (at least, that is not planned).

In addition, a `ConsentLogInterface` will be added. This is used to give merchants the option of storing the logs elsewhere than in their production database or changing the message format.

Closes shopware/SwagProductAnalytics#38