### PR TITLE
fix: shows a full response on error registration

### DIFF
--- a/src/Core/Framework/App/Lifecycle/Registration/AppRegistrationService.php
+++ b/src/Core/Framework/App/Lifecycle/Registration/AppRegistrationService.php
@@ -57,11 +57,14 @@ class AppRegistrationService
         } catch (RequestException $e) {
             if ($e->hasResponse() && $e->getResponse() !== null) {
                 $response = $e->getResponse();
-                $data = json_decode($response->getBody()->getContents(), true);
+                $responseBody = $response->getBody()->getContents();
+                $data = json_decode($responseBody, true);
 
                 if (isset($data['error']) && \is_string($data['error'])) {
                     throw AppException::registrationFailed($appName, $data['error']);
                 }
+
+                throw AppException::registrationFailed($appName, \sprintf('Got status code %d, with response: %s', $response->getStatusCode(), $responseBody));
             }
 
             throw AppException::registrationFailed($appName, $e->getMessage(), $e);

--- a/tests/unit/Core/Framework/App/Lifecycle/AppRegistrationServiceTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppRegistrationServiceTest.php
@@ -189,6 +189,50 @@ class AppRegistrationServiceTest extends TestCase
         $appRegistrationService->registerApp($manifest, 'id', 's3cr3t-4cc3s-k3y', Context::createDefaultContext());
     }
 
+    public function testThrowsAppRegistrationExceptionWithStatusCodeAndResponseBody(): void
+    {
+        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
+
+        $handshake = new PrivateHandshake(
+            'https://shopware.swag',
+            's3cr3t',
+            'https://app.server/register',
+            'test',
+            'shop-id',
+            '6.5.2.0',
+        );
+
+        $registrationRequest = $handshake->assembleRequest();
+
+        $handshakeMock = $this->createMock(PrivateHandshake::class);
+        $handshakeMock->method('assembleRequest')->willReturn($registrationRequest);
+
+        $handshakeFactory = $this->createMock(HandshakeFactory::class);
+        $handshakeFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($handshakeMock);
+
+        $responseBody = json_encode(['some' => 'data', 'without' => 'error field'], \JSON_THROW_ON_ERROR);
+
+        $httpClient = $this->createHttpClient([
+            new RequestException(
+                '',
+                $registrationRequest,
+                new Response(
+                    SymfonyResponse::HTTP_INTERNAL_SERVER_ERROR,
+                    body: $responseBody
+                )
+            ),
+        ]);
+
+        $appRegistrationService = $this->createAppRegistrationService($handshakeFactory, $httpClient);
+
+        $this->expectException(AppRegistrationException::class);
+        $this->expectExceptionMessage('App registration for "test" failed: Got status code 500, with response: ' . $responseBody);
+
+        $appRegistrationService->registerApp($manifest, 'id', 's3cr3t-4cc3s-k3y', Context::createDefaultContext());
+    }
+
     public function testThrowsAppRegistrationExceptionIfAppServerProvidesNoProof(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');


### PR DESCRIPTION
### 1. Why is this change necessary?

The error response from app server is truncated due to guzzle and on error case you cannot read the error at all


### 2. What does this change do, exactly?

Throw our own error, when we have a parsed JSON


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
