### PR TITLE
fix: mark translation association as required in attribute entities

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -288,6 +288,12 @@ class AttributeEntityCompiler
             $flags[Required::class] = ['class' => Required::class];
         }
 
+        // Translation association fields need to be marked as required,
+        // because otherwise required fields in the association are not validated
+        if ($field instanceof Translations) {
+            $flags[Required::class] = ['class' => Required::class];
+        }
+
         if ($this->getAttribute($property, PrimaryKeyAttr::class)) {
             $flags[PrimaryKey::class] = ['class' => PrimaryKey::class];
             $flags[Required::class] = ['class' => Required::class];

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -27,10 +27,12 @@ use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntity;
@@ -207,6 +209,36 @@ class AttributeEntityIntegrationTest extends TestCase
             ->search(new Criteria($ids->getList(['first-key'])), $context);
 
         static::assertCount(0, $search);
+    }
+
+    public function testRequiredTranslatedFieldFailsIfNotProvided(): void
+    {
+        $ids = new IdsCollection();
+
+        $context = Context::createDefaultContext();
+
+        $wasThrown = false;
+        try {
+            $this->repository('attribute_entity')->create([
+                [
+                    'id' => $ids->create('first-key'),
+                    'string' => 'string',
+                    'emptyString' => '',
+                    'htmlString' => '<p class="text-size-lg">Awesome string with <strong>HTML</strong>!</p>',
+                ],
+            ], $context);
+        } catch (WriteException $e) {
+            $wasThrown = true;
+
+            $innerExceptions = $e->getExceptions();
+            static::assertCount(1, $innerExceptions);
+
+            $innerException = $innerExceptions[0];
+            static::assertInstanceOf(WriteConstraintViolationException::class, $innerException);
+            static::assertSame('/0/translations/' . Defaults::LANGUAGE_SYSTEM, $innerException->getPath());
+        }
+
+        static::assertTrue($wasThrown);
     }
 
     public function testScalarValues(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/AttributeEntityCompilerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/AttributeEntityCompilerTest.php
@@ -72,6 +72,9 @@ class AttributeEntityCompilerTest extends TestCase
         static::assertSame($this->getExpectedCompilationResult(), $compiledResult);
     }
 
+    /**
+     * @return list<array<string, mixed>>
+     */
     private function getExpectedCompilationResult(): array
     {
         return [

--- a/tests/unit/Core/Framework/DataAbstractionLayer/AttributeEntityCompilerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/AttributeEntityCompilerTest.php
@@ -1,0 +1,846 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AutoIncrement;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\CustomFields as CustomFieldsAttr;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\FieldType;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ForeignKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ManyToMany;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ManyToOne;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\OneToMany;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\OneToOne;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Serialized;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\State;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Translations;
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeEntityCompiler;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\AutoIncrementField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateIntervalField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\EnumField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowEmptyString;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AsArray;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SetNullOnDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\SerializedField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StateMachineStateField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TimeZoneField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\PriceFieldSerializer;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntity;
+use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntityCollection;
+use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\StringEnum;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AttributeEntityCompiler::class)]
+class AttributeEntityCompilerTest extends TestCase
+{
+    public function testCompile(): void
+    {
+        $compiler = new AttributeEntityCompiler();
+
+        $compiledResult = $compiler->compile(AttributeEntity::class);
+
+        static::assertSame($this->getExpectedCompilationResult(), $compiledResult);
+    }
+
+    private function getExpectedCompilationResult(): array
+    {
+        return [
+            [
+                'type' => 'mapping',
+                'parent' => null,
+                'entity_class' => ArrayEntity::class,
+                'entity_name' => 'attribute_entity_currency',
+                'fields' => [
+                    [
+                        'class' => FkField::class,
+                        'translated' => false,
+                        'args' => [
+                            'attribute_entity_id',
+                            'attributeEntityId',
+                            'attribute_entity',
+                        ],
+                        'flags' => [
+                            PrimaryKey::class => [
+                                'class' => PrimaryKey::class,
+                            ],
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                        ],
+                    ],
+                    [
+                        'class' => FkField::class,
+                        'translated' => false,
+                        'args' => [
+                            'currency_id',
+                            'currencyId',
+                            'currency',
+                        ],
+                        'flags' => [
+                            PrimaryKey::class => [
+                                'class' => PrimaryKey::class,
+                            ],
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                        ],
+                    ],
+                    [
+                        'class' => ManyToOneAssociationField::class,
+                        'translated' => false,
+                        'args' => [
+                            'attributeEntity',
+                            'attribute_entity_id',
+                            'attribute_entity',
+                            'id',
+                        ],
+                        'flags' => [],
+                    ],
+                    [
+                        'class' => ManyToOneAssociationField::class,
+                        'translated' => false,
+                        'args' => [
+                            'currency',
+                            'currency_id',
+                            'currency',
+                            'id',
+                        ],
+                        'flags' => [],
+                    ],
+                ],
+                'source' => 'attribute_entity',
+                'reference' => 'currency',
+            ],
+            [
+                'type' => 'mapping',
+                'parent' => null,
+                'entity_class' => ArrayEntity::class,
+                'entity_name' => 'attribute_entity_order',
+                'fields' => [
+                    [
+                        'class' => FkField::class,
+                        'translated' => false,
+                        'args' => [
+                            'attribute_entity_id',
+                            'attributeEntityId',
+                            'attribute_entity',
+                        ],
+                        'flags' => [
+                            PrimaryKey::class => [
+                                'class' => PrimaryKey::class,
+                            ],
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                        ],
+                    ],
+                    [
+                        'class' => FkField::class,
+                        'translated' => false,
+                        'args' => [
+                            'order_id',
+                            'orderId',
+                            'order',
+                        ],
+                        'flags' => [
+                            PrimaryKey::class => [
+                                'class' => PrimaryKey::class,
+                            ],
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                        ],
+                    ],
+                    [
+                        'class' => ManyToOneAssociationField::class,
+                        'translated' => false,
+                        'args' => [
+                            'attributeEntity',
+                            'attribute_entity_id',
+                            'attribute_entity',
+                            'id',
+                        ],
+                        'flags' => [],
+                    ],
+                    [
+                        'class' => ManyToOneAssociationField::class,
+                        'translated' => false,
+                        'args' => [
+                            'order',
+                            'order_id',
+                            'order',
+                            'id',
+                        ],
+                        'flags' => [],
+                    ],
+                ],
+                'source' => 'attribute_entity',
+                'reference' => 'order',
+            ],
+            [
+                'type' => 'mapping',
+                'parent' => null,
+                'entity_class' => ArrayEntity::class,
+                'entity_name' => 'my_own_mapping_table_name',
+                'fields' => [
+                    [
+                        'class' => FkField::class,
+                        'translated' => false,
+                        'args' => [
+                            'attribute_entity_id',
+                            'attributeEntityId',
+                            'attribute_entity',
+                        ],
+                        'flags' => [
+                            PrimaryKey::class => [
+                                'class' => PrimaryKey::class,
+                            ],
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                        ],
+                    ],
+                    [
+                        'class' => FkField::class,
+                        'translated' => false,
+                        'args' => [
+                            'product_id',
+                            'productId',
+                            'product',
+                        ],
+                        'flags' => [
+                            PrimaryKey::class => [
+                                'class' => PrimaryKey::class,
+                            ],
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                        ],
+                    ],
+                    [
+                        'class' => ManyToOneAssociationField::class,
+                        'translated' => false,
+                        'args' => [
+                            'attributeEntity',
+                            'attribute_entity_id',
+                            'attribute_entity',
+                            'id',
+                        ],
+                        'flags' => [],
+                    ],
+                    [
+                        'class' => ManyToOneAssociationField::class,
+                        'translated' => false,
+                        'args' => [
+                            'product',
+                            'product_id',
+                            'product',
+                            'id',
+                        ],
+                        'flags' => [],
+                    ],
+                ],
+                'source' => 'attribute_entity',
+                'reference' => 'product',
+            ],
+            [
+                'type' => 'entity',
+                'since' => '6.6.3.0',
+                'parent' => null,
+                'entity_class' => AttributeEntity::class,
+                'entity_name' => 'attribute_entity',
+                'hydrator_class' => EntityHydrator::class,
+                'collection_class' => AttributeEntityCollection::class,
+                'fields' => [
+                    [
+                        'type' => FieldType::UUID,
+                        'name' => 'id',
+                        'class' => IdField::class,
+                        'flags' => [
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                            PrimaryKey::class => [
+                                'class' => PrimaryKey::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'id',
+                            'id',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::STRING,
+                        'name' => 'string',
+                        'class' => StringField::class,
+                        'flags' => [
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'string',
+                            'string',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::TEXT,
+                        'name' => 'text',
+                        'class' => LongTextField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'text',
+                            'text',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::INT,
+                        'name' => 'int',
+                        'class' => IntField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'int',
+                            'int',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::FLOAT,
+                        'name' => 'float',
+                        'class' => FloatField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'float',
+                            'float',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::BOOL,
+                        'name' => 'bool',
+                        'class' => BoolField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'bool',
+                            'bool',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::DATETIME,
+                        'name' => 'datetime',
+                        'class' => DateTimeField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'datetime',
+                            'datetime',
+                        ],
+                    ],
+                    [
+                        'type' => AutoIncrement::TYPE,
+                        'name' => 'autoIncrement',
+                        'class' => AutoIncrementField::class,
+                        'flags' => [
+                            ApiAware::class => [
+                                'class' => ApiAware::class,
+                                'args' => [],
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [],
+                    ],
+                    [
+                        'type' => FieldType::ENUM,
+                        'name' => 'enum',
+                        'class' => EnumField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'enum',
+                            'enum',
+                            StringEnum::A,
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::JSON,
+                        'name' => 'json',
+                        'class' => JsonField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'json',
+                            'json',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::DATE,
+                        'name' => 'date',
+                        'class' => DateField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'date',
+                            'date',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::DATE_INTERVAL,
+                        'name' => 'dateInterval',
+                        'class' => DateIntervalField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'date_interval',
+                            'dateInterval',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::TIME_ZONE,
+                        'name' => 'timeZone',
+                        'class' => TimeZoneField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'time_zone',
+                            'timeZone',
+                        ],
+                    ],
+                    [
+                        'type' => Serialized::TYPE,
+                        'name' => 'serialized',
+                        'class' => SerializedField::class,
+                        'flags' => [
+                            ApiAware::class => [
+                                'class' => ApiAware::class,
+                                'args' => [],
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'serialized',
+                            'serialized',
+                            PriceFieldSerializer::class,
+                        ],
+                    ],
+                    [
+                        'type' => PriceField::class,
+                        'name' => 'price',
+                        'class' => PriceField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'price',
+                            'price',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::STRING,
+                        'name' => 'transString',
+                        'class' => StringField::class,
+                        'flags' => [
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                        ],
+                        'translated' => true,
+                        'args' => [
+                            'trans_string',
+                            'transString',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::TEXT,
+                        'name' => 'transText',
+                        'class' => LongTextField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_text',
+                            'transText',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::INT,
+                        'name' => 'transInt',
+                        'class' => IntField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_int',
+                            'transInt',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::FLOAT,
+                        'name' => 'transFloat',
+                        'class' => FloatField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_float',
+                            'transFloat',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::BOOL,
+                        'name' => 'transBool',
+                        'class' => BoolField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_bool',
+                            'transBool',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::DATETIME,
+                        'name' => 'transDatetime',
+                        'class' => DateTimeField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_datetime',
+                            'transDatetime',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::JSON,
+                        'name' => 'transJson',
+                        'class' => JsonField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_json',
+                            'transJson',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::DATE,
+                        'name' => 'transDate',
+                        'class' => DateField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_date',
+                            'transDate',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::DATE_INTERVAL,
+                        'name' => 'transDateInterval',
+                        'class' => DateIntervalField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_date_interval',
+                            'transDateInterval',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::TIME_ZONE,
+                        'name' => 'transTimeZone',
+                        'class' => TimeZoneField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'trans_time_zone',
+                            'transTimeZone',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::STRING,
+                        'name' => 'differentName',
+                        'class' => StringField::class,
+                        'flags' => [],
+                        'translated' => true,
+                        'args' => [
+                            'another_column_name',
+                            'differentName',
+                        ],
+                    ],
+                    [
+                        'type' => ForeignKey::TYPE,
+                        'name' => 'currencyId',
+                        'class' => FkField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'currency_id',
+                            'currencyId',
+                            'currency',
+                        ],
+                    ],
+                    [
+                        'type' => State::TYPE,
+                        'name' => 'stateId',
+                        'class' => StateMachineStateField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'state_id',
+                            'stateId',
+                            'order.state',
+                            [
+                                'system',
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::STRING,
+                        'name' => 'emptyString',
+                        'class' => StringField::class,
+                        'flags' => [
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                            AllowEmptyString::class => [
+                                'class' => AllowEmptyString::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'empty_string',
+                            'emptyString',
+                        ],
+                    ],
+                    [
+                        'type' => ForeignKey::TYPE,
+                        'name' => 'followId',
+                        'class' => FkField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'follow_id',
+                            'followId',
+                            'currency',
+                        ],
+                    ],
+                    [
+                        'type' => ManyToOne::TYPE,
+                        'name' => 'currency',
+                        'class' => ManyToOneAssociationField::class,
+                        'flags' => [
+                            'cascade' => [
+                                'class' => RestrictDelete::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'currency',
+                            'currency_id',
+                            'currency',
+                            'id',
+                        ],
+                    ],
+                    [
+                        'type' => OneToOne::TYPE,
+                        'name' => 'follow',
+                        'class' => OneToOneAssociationField::class,
+                        'flags' => [
+                            'cascade' => [
+                                'class' => SetNullOnDelete::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'follow',
+                            'follow_id',
+                            'id',
+                            'currency',
+                            false,
+                        ],
+                    ],
+                    [
+                        'type' => ManyToOne::TYPE,
+                        'name' => 'state',
+                        'class' => ManyToOneAssociationField::class,
+                        'flags' => [],
+                        'translated' => false,
+                        'args' => [
+                            'state',
+                            'state_id',
+                            'state_machine_state',
+                            'id',
+                        ],
+                    ],
+                    [
+                        'type' => OneToMany::TYPE,
+                        'name' => 'aggs',
+                        'class' => OneToManyAssociationField::class,
+                        'flags' => [
+                            AsArray::class => [
+                                'class' => AsArray::class,
+                            ],
+                            'cascade' => [
+                                'class' => CascadeDelete::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'aggs',
+                            'attribute_entity_agg',
+                            'attribute_entity_id',
+                            'id',
+                        ],
+                    ],
+                    [
+                        'type' => ManyToMany::TYPE,
+                        'name' => 'currencies',
+                        'class' => ManyToManyAssociationField::class,
+                        'flags' => [
+                            AsArray::class => [
+                                'class' => AsArray::class,
+                            ],
+                            'cascade' => [
+                                'class' => CascadeDelete::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'currencies',
+                            'currency',
+                            'attribute_entity_currency',
+                            'attribute_entity_id',
+                            'currency_id',
+                        ],
+                    ],
+                    [
+                        'type' => ManyToMany::TYPE,
+                        'name' => 'orders',
+                        'class' => ManyToManyAssociationField::class,
+                        'flags' => [
+                            AsArray::class => [
+                                'class' => AsArray::class,
+                            ],
+                            'cascade' => [
+                                'class' => CascadeDelete::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'orders',
+                            'order',
+                            'attribute_entity_order',
+                            'attribute_entity_id',
+                            'order_id',
+                        ],
+                    ],
+                    [
+                        'type' => Translations::TYPE,
+                        'name' => 'translations',
+                        'class' => TranslationsAssociationField::class,
+                        'flags' => [
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                            ApiAware::class => [
+                                'class' => ApiAware::class,
+                                'args' => [],
+                            ],
+                            AsArray::class => [
+                                'class' => AsArray::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'attribute_entity_translation',
+                            'attribute_entity_id',
+                        ],
+                    ],
+                    [
+                        'type' => ManyToMany::TYPE,
+                        'name' => 'ownMapping',
+                        'class' => ManyToManyAssociationField::class,
+                        'flags' => [
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                            AsArray::class => [
+                                'class' => AsArray::class,
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'ownMapping',
+                            'product',
+                            'my_own_mapping_table_name',
+                            'attribute_entity_id',
+                            'product_id',
+                        ],
+                    ],
+                    [
+                        'type' => FieldType::STRING,
+                        'name' => 'htmlString',
+                        'class' => StringField::class,
+                        'flags' => [
+                            Required::class => [
+                                'class' => Required::class,
+                            ],
+                            AllowHtml::class => [
+                                'class' => AllowHtml::class,
+                                'args' => [
+                                    'sanitized' => false,
+                                ],
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'html_string',
+                            'htmlString',
+                        ],
+                    ],
+                    [
+                        'type' => CustomFieldsAttr::TYPE,
+                        'name' => 'customFields',
+                        'class' => CustomFields::class,
+                        'flags' => [
+                            ApiAware::class => [
+                                'class' => ApiAware::class,
+                                'args' => [],
+                            ],
+                        ],
+                        'translated' => false,
+                        'args' => [
+                            'custom_fields',
+                            'customFields',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
thus required translated fields are properly validated 

fixes https://github.com/shopware/shopware/issues/11595

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
see issue, required fields inside translations where not validated

### 2. What does this change do, exactly?
mark translation association as required in attribute entities

### 3. Describe each step to reproduce the issue or behaviour.
see issue

### 4. Please link to the relevant issues (if any).
 https://github.com/shopware/shopware/issues/11595

