### PR TITLE
fix: Fixes username placeholder text in sw-settings-mailer/.../en.json according to de.json

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/en.json
@@ -29,7 +29,7 @@
       "port": "Port",
       "port-placeholder": "Enter a port number...",
       "username": "Username",
-      "username-placeholder": "Enter a your username...",
+      "username-placeholder": "Enter a username...",
       "password": "Password",
       "password-placeholder": "Enter a password...",
       "oauth-url": "OAuth URL",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/en.json
@@ -29,7 +29,7 @@
       "port": "Port",
       "port-placeholder": "Enter a port number...",
       "username": "Username",
-      "username-placeholder": "Enter a username...",
+      "username-placeholder": "Enter your username...",
       "password": "Password",
       "password-placeholder": "Enter a password...",
       "oauth-url": "OAuth URL",


### PR DESCRIPTION


### 1. Why is this change necessary?
Clarity and unambiguity of the placeholder

### 2. What does this change do, exactly?
Aligns the placeholder text with that of the German template.

### 3. Describe each step to reproduce the issue or behaviour.
Before this change, the username placeholder in the "Mailer configuration", during the administration setup said "Enter a your username..." which was ambigues.

### 4. Please link to the relevant issues (if any).
> couldn't find an issue. Stumbled upon the unambiguity during playing around with the gui the first time

### 5. Checklist
* **Not a behavioural change**
* **checklist items do not apply**

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
