### PR TITLE
feat: implement outbox pattern for webhooks

### DIFF
--- a/adr/2025-12-24-use-outbox-pattern-for-webhooks.md
+++ b/adr/2025-12-24-use-outbox-pattern-for-webhooks.md
@@ -1,0 +1,401 @@
+---
+title: Use outbox pattern for webhooks
+date: 2025-12-24
+area: core
+tags: [webhook, outbox, messaging, reliability]
+---
+
+## Technical Summary
+We are implementing a **Partition-Leased Outbox** system to guarantee observability and best-effort ordering for webhooks.
+-   **Mechanism:** events are persisted to `webhook_event_log` (MySQL) before delivery.
+-   **Partitioning:** `webhook_stream` leases groups of events by `xxhash(app_name:partition_key)` to allow parallel processing while preserving order per entity.
+-   **Ordering:** `sequence_id` is added to payloads, and the Outbox worker optimizes for sequential delivery per partition in a best-effort fashion (retrying failures inline).
+-   **Outcome:** provides reasonable ordering guarantees and removes race conditions being the norm in webhook delivery.
+
+## Context
+Webhook delivery currently relies on Messenger retry behavior and concurrent workers and has some special use cases around lifecycle events. This introduces several critical gaps:
+
+- Sync path visibility (Lifecycle Events): synchronous webhooks are not logged, so there is no audit trail or retry option.
+- Ordering: parallel processing provides no FIFO guarantees, so events can arrive out of sequence.
+- Partition-based Ordering: currently there is no way to safely order messages based on logical partitions (e.g. `order.placed` then `order.paid`) without relying on advanced transport features (like consistent hashing) which are not available in all environments.
+- Messenger retry ordering: retry behavior depends on the transport implementation, introducing inconsistent sequencing on retry.
+- Failure handling: the system disables webhooks after 10 consecutive errors, requiring manual recovery.
+- Durability: delivery depends on transport configuration, which can lose messages.
+
+We also need a consistent way to record retries, schedule backoff, and reuse the same request-building logic for both synchronous and asynchronous delivery.
+
+## Decision
+We will introduce an outbox-driven webhook delivery flow that uses the existing `webhook_event_log` table as the source of truth for processing:
+
+- Persist each webhook event as a queued outbox entry with a serialized message, and add ordering + retry metadata (`sequence`, `execution_count`, `next_retry_at`, and the `pending_retry` status).
+- **Target Architecture (Partition Leasing):** Implement a "Leasing" pattern using a sidecar table `webhook_stream` to coordinate work.
+    - **Partition Key:** Derived from `PartitionAwareHookable::getPartitionKey()` and always scoped by `app_name` (hashed via xxhash). Defaults to `${app_name}:${webhook_id}`. This enables best-effort ordered delivery per logical entity per destination while preventing cross-app interference.
+    - **Status-Based Dispatch:** Workers claim a stream via `SKIP LOCKED` on the `webhook_stream` table and process events by `delivery_status` in sequence order, relying on an index like (`partition_key`, `delivery_status`, `sequence`) for efficient scans.
+    - **Lease & Heartbeat:** Streams are leased via `locked_by` and `lock_expires_at` and refreshed while processing (before each request). The lease TTL should exceed the HTTP timeout. Expired leases are reclaimable, removing the need for the global `webhook_outbox_worker` lock table.
+    - **Best-Effort Ordering:** Failed events are retried inline when new events arrive; if retries are exhausted, the event is skipped to prevent head-of-line blocking.
+- Trigger draining through a lightweight `WebhookOutboxSignalMessage` and a periodic `webhook_outbox.drain` scheduled task.
+- Gate the outbox flow behind the `SHOPWARE_WEBHOOK_OUTBOX` env flag to allow gradual rollout; the existing Messenger-based path remains available when the flag is disabled.
+
+### Flow overview
+```mermaid
+flowchart TD
+  A[Event] --> B[WebhookManager]
+  B -->|outbox enabled| C[WebhookOutboxWriter]
+  C --> D[webhook_event_log: queued<br/>partition_key]
+  D --> E[WebhookOutboxSignalMessage]
+  E --> F[WebhookOutboxProcessor]
+  F -->|claim stream via SKIP LOCKED| G[WebhookSender]
+  G -->|success| H[mark success]
+  G -->|failure| I[mark pending_retry<br/>continue to next]
+  B -->|outbox disabled| J[Messenger dispatch]
+```
+
+
+```mermaid
+sequenceDiagram
+  participant Worker as Drain Worker
+  participant Stream as webhook_stream
+  participant Log as webhook_event_log
+
+  Worker->>Stream: SELECT ... FOR UPDATE SKIP LOCKED
+  alt claimed stream
+    Worker->>Log: SELECT pending_retry (due), then queued ORDER BY sequence LIMIT 50
+    loop Process Batch
+        Worker->>Stream: UPDATE lock_expires_at (heartbeat)
+        Worker->>Endpoint: POST /webhook
+    end
+    Worker->>Stream: UPDATE lock fields (release)
+    Worker->>Stream: COMMIT (Release Lock)
+  else no streams available
+    Worker-->>Worker: sleep / exit
+  end
+```
+
+
+### High-level integration points
+```php
+if ($outboxEnabled) {
+    $outboxWriter->write($webhook, $message);
+    if ($requiresImmediateDrain) {
+        // flushes specific webhook IDs for immediate processing.
+        $processor->flush($webhookIds);
+    }
+
+    $bus->dispatch(new WebhookOutboxSignalMessage());
+} else {
+    $bus->dispatch($message);
+}
+```
+
+```php
+// Claim a healthy, unlocked or expired stream
+$stream = $connection->fetchAssociative('
+    SELECT * FROM webhook_stream
+    WHERE (locked_by IS NULL OR lock_expires_at <= NOW())
+    AND (status = "HEALTHY" OR next_retry_at <= NOW())
+    LIMIT 1 FOR UPDATE SKIP LOCKED
+');
+
+// Process pending retries first
+$pending = $connection->fetchAllAssociative('
+    SELECT * FROM webhook_event_log
+    WHERE partition_key = :partition
+    AND delivery_status = "pending_retry"
+    AND (next_retry_at IS NULL OR next_retry_at <= NOW())
+    ORDER BY sequence ASC
+    LIMIT :batchSize
+');
+
+// Then process queued events in sequence order
+$events = $connection->fetchAllAssociative('
+    SELECT * FROM webhook_event_log
+    WHERE partition_key = :partition
+    AND delivery_status = "queued"
+    ORDER BY sequence ASC
+    LIMIT :batchSize
+');
+```
+
+Indexing note: add a composite index on (`partition_key`, `delivery_status`, `sequence`) to keep status-based scans efficient.
+
+### How this addresses the critical gaps
+- Sync path visibility: all webhook events are stored as outbox entries before delivery.
+- Ordering: Best-Effort FIFO per `partition_key` is attempted; events are retried inline when new events arrive.
+- Failure Isolation: A failure in one partition does not block other partitions. Failed events are skipped after retry exhaustion.
+- Scalability: index-backed status scans keep processing stable.
+- Concurrency: Multiple workers can process different partitions in parallel using `SKIP LOCKED`.
+
+## Partition Key Interface
+To support custom ordering semantics, events can implement the `PartitionAwareHookable` interface to define their own partition key.
+
+```php
+interface PartitionAwareHookable extends Hookable
+{
+    /**
+     * Returns the partition key for this event.
+     * Events with the same partition key are delivered in best-effort order
+     * within the same app (app_name is always prefixed internally).
+     * Failures can cause skips and out-of-order delivery.
+     *
+     * @return string|null Partition key, or null to use the default (app_name + webhook_id).
+     */
+    public function getPartitionKey(): ?string;
+}
+```
+
+**Default Behavior:**
+- If the event does **not** implement `PartitionAwareHookable`, the partition key defaults to `${app_name}:${webhook_id}`.
+- If the event implements the interface and returns `null`, it also defaults to `${app_name}:${webhook_id}`.
+
+**Example (Entity Events):**
+```php
+class OrderWrittenEvent implements PartitionAwareHookable
+{
+    public function getPartitionKey(): ?string
+    {
+        // All events for the same Order will be processed in sequence per app.
+        return 'order_' . $this->orderId;
+    }
+}
+```
+
+**Example (Domain Events - No Ordering):**
+```php
+class UserPasswordResetRequestedEvent implements PartitionAwareHookable
+{
+    public function getPartitionKey(): ?string
+    {
+        // Each event gets its own partition within the app for maximum parallelism.
+        return Uuid::randomHex();
+    }
+}
+```
+
+**Partition Key Calculation:**
+The final `partition_key` stored in the database is calculated as:
+```php
+$appName = $webhook->appName;
+
+$eventPartitionKey = $event instanceof PartitionAwareHookable
+    ? $event->getPartitionKey()
+    : null;
+
+if ($eventPartitionKey !== null) {
+    // Use the event's partition key scoped by app_name.
+    // This allows cross-webhook ordering for dependent events within the same app.
+    // e.g., order.placed and order.paid for the same Order share a stream per app.
+    $finalKey = xxhash($appName . ':' . $eventPartitionKey);
+} else {
+    // Default: partition by app_name + webhook_id (one stream per webhook type per app).
+    $finalKey = xxhash($appName . ':' . $webhook->id);
+}
+```
+
+**Cross-Webhook Ordering:**
+By using the `partitionKey` directly (scoped by `app_name`), logically dependent events across *different* webhook types share the same stream within one app:
+- `order.placed` for `order_123` in `app_a` → Stream `xxhash(app_a:order_123)`
+- `order.paid` for `order_123` in `app_a` → Stream `xxhash(app_a:order_123)` (SAME!)
+- `order.paid` is expected to be delivered AFTER `order.placed` (best-effort; failures or delays can invert order).
+- `order.placed` for `order_123` in `app_b` → Stream `xxhash(app_b:order_123)` (DIFFERENT app, different stream)
+
+**Concurrency & Ordering Strategy:**
+- **Full Parallelism:** Each unique `finalKey` corresponds to a distinct stream. Workers process different streams concurrently using `SKIP LOCKED`.
+- **Best-Effort Ordering:** Events with the same `finalKey` are processed sequentially when available. Failures or delays can cause skips or out-of-order delivery, so consumers must be idempotent.
+- **Dynamic Growth:** The `webhook_stream` table creates streams on demand. Stale streams are automatically cleaned up (see Stream Cleanup).
+
+## Trade-offs & Alternatives Considered
+
+This section documents why we chose the full Outbox pattern.
+> **Note:** These alternatives are **not mutually exclusive**. Our final solution **integrates** both Partition Keys and Sequence IDs. The comparison below highlights the trade-off to help us assess if adding the outbox is worth it.
+
+Since Shopware always requires a backing database, the Outbox pattern doesn't introduce new infrastructure. It replaces an *implicit*, opaque database queue with an *explicit*, controllable, and observable one.
+
+### Fixing logging and lifecycle events visibility
+The most minimal fix to address the "Sync path visibility" for lifecycle events gap would be to add a single log call inside `WebhookManager::callWebhooksSynchronous()`. This is a 5-line change.
+
+| Concern                  | Minimal Fix (Log Only) | Outbox ADR     |
+|:-------------------------|:-----------------------|:---------------|
+| **Effort**               | Very Low               | High           |
+| **Solves Logging Gap**   | Yes                    | Yes            |
+| **Solves Ordering Gap**  | No                     | Best-Effort    |
+| **Solves Isolation Gap** | No                     | Yes            |
+
+
+### Adding sequence numbers to enable consumer-side ordering
+We could add a simple `sequence_id` to the webhook payload and let the transport deliver as fast as possible.
+
+| Concern                 | Sequence Numbers Only                                                                                    | Outbox ADR                                                                                                                        |
+|:------------------------|:---------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------|
+| **Effort**              | Low                                                                                                      | High                                                                                                                              |
+| **Consumer Complexity** | **High:** Consumer must always detect gaps, buffer out-of-order events, and implement re-ordering logic. | **Medium:** consumer still needs to be smart, but having an available consumer implementing last-write wins is mostly sufficient. |
+| **Delivery Behavior**   | **Luck based:** Race conditions are the norm not a fluke.                                                | **Controlled**: sequential delivery per partition. Consectuive errors on consumers can cause out-of-order                         |
+
+This Outbox also **include** adding a `sequence_id` to the payload, but relying on it *exclusively* for ordering is insufficient. Effective ordering 'takes two':
+1.  A **Smart Consumer** capable of buffering and re-ordering events.
+2.  A **Responsible Producer** that attempts to deliver in order.
+
+By pre-ordering delivery via the Outbox, we support the majority of "simple/stateless" consumers, while still providing sequence IDs for the "smart" consumers who want to verify data integrity. Relying solely on sequence IDs would force every app developer to implement complex buffering logic, which is a poor Developer Experience (DX).
+
+### Why Not Just Add Partition Key & Trust Transport?
+
+Another minimal approach would be to simply calculate the `partitionKey` and attach it to the message stamp, hoping the underlying transport (e.g., RabbitMQ, SQS) handles ordering.
+
+| Transport             | Supports Partition Key? | Notes                                                                                         |
+|:----------------------|:------------------------|:----------------------------------------------------------------------------------------------|
+| **Redis** (Messenger) | No                      | Not supported on standard Messenger configuration                                             |
+| **Doctrine** (DBAL)   | No                      | Standard DBAL transport selects any available message. No concept of partitioned consumption. |
+| **RabbitMQ**          | Yes                     | Requires `x-consistent-hash` configuration or similar.                                        |
+| **Kafka**             | Yes                     | Native support via topic partitions and consumer groups.                                      |
+
+Relying on "Transport Partitioning" fails for the default Shopware stack (MySQL). It only works if the shop uses (RabbitMQ/Kafka). The Outbox pattern provides this capability on standard infrastructure.
+
+
+### The "Best-Effort Ordering" Trade-off
+
+The ADR provides "Best-Effort FIFO" ordering. This is weaker than strict FIFO.
+
+| Approach                   | Ordering Guarantee | Availability | Trade-off |
+|:---------------------------|:-------------------|:-------------|:-----------|
+| **Strict FIFO**            | Guaranteed         | Head-of-line blocking | A single failing event blocks all subsequent events. |
+| **Best-Effort (This ADR)** | Preserved when possible | Always progresses | Failing events may be skipped; consumers may receive events out of order. |
+| **No Ordering**            | None               | Maximum      | No guarantees whatsoever. |
+
+> [!WARNING]
+> **Consumers MUST be designed to handle out-of-order delivery and idempotency.** The ordering guarantee is sender-side only. Network delays, consumer processing time, and retries on the receiver's side can still break ordering.
+
+For webhook delivery, availability typically outweighs strict ordering. Blocking all events for a single app because one event failed is worse than allowing progress with potential out-of-order delivery.
+
+### Summary Table
+
+| Feature               | Current (Default of Messenger DBAL)     | Proposed (Outbox)                                                       | External Broker                                         |
+|:----------------------|:----------------------------------------|:------------------------------------------------------------------------|:--------------------------------------------------------|
+| **Infrastructure**    | MySQL                                   | MySQL (same)                                                            | External brokers: Redis/RabbitMQ/Kafka (not guaranteed) |
+| **Ordering**          | None                                    | Best-Effort per partition                                               | Broker-dependent                                        |
+| **Visibility**        | Shared `messenger_messages` table       | Specialized `webhook_event_log` table. Can add metrics and dashboards   | Requires external tooling                               |
+| **Failure Isolation** | Highly available, per webhook isolation | Per-partition isolation                                                 | Per-queue isolation                                     |
+| **Retry Logic**       | Transport-specific retry stamps         | Explicit `execution_count`, `next_retry_at`                             | Broker-managed                                          |
+| **Control**           | Delegated to transport                  | Shopware owns the logic                                                 | Delegated to broker                                     |
+
+## Comparison to Current Shopware Architecture
+| Feature               | Current (Messenger)                                 | Proposed (Stream Leasing)                                  |
+|:----------------------|:----------------------------------------------------|:-----------------------------------------------------------|
+| **Ordering**          | Race conditions are the norm with parallel workers  | Best-Effort FIFO per partition key                         |
+| **Retry Ordering**    | Retries pushed to back of queue (DBAL, and Redis)   | Inline retry before new events                             |
+| **Failure Isolation** | Webhook fails and retries independently             | Per-Partition (Failing event skipped after retries)        |
+| **Scalability**       | Depends on Broker                                   | Index-backed status scan, MySQL only (limited by disk I/O) |
+| **Audit Trail**       | No logging for sync webhooks (fairly easy to solve) | All events logged in `webhook_event_log`                   |
+
+## Detailed Transport Comparison: The "Why"
+
+### 1. The Race Condition Reality
+In any standard Messenger setup with multiple workers (or even single workers with retries), race conditions are **the norm, not the exception**.
+- **Competing Consumers:** If `OrderCreated` and `OrderPaid` are dispatched milliseconds apart, two different workers can pick them up simultaneously.
+- **Latency Luck:** If Worker A (processing `OrderCreated`) hits a network snag, Worker B (processing `OrderPaid`) will finish first. The webhook consumer sees the wrong order.
+
+
+### 2. Transport-Specific Behaviors vs. Outbox
+
+The largest benefit of the Outbox pattern is that it **standardizes** the delivery semantics across all environments. Different transports have wildly different behaviors that impact ordering, retries, and visibility.
+
+| Feature                  | Doctrine Transport                                                                        | Redis Transport                                                                                      | HA Brokers (RabbitMQ/Kafka)                                                                    | Proposed Outbox                                                                   |
+|:-------------------------|:------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------|
+| **Visibility Mechanism** | **Database Lock:** Uses `SELECT ... FOR UPDATE` to hide rows.                             | **In-Memory Visibility:** Removes from Stream; hidden in ZSET (Delayed Set).                         | **Index/Offset:** Messages exist in log/queue until acknowledged/expired.                      | **Partition Lock:** Uses `SELECT ... FOR UPDATE SKIP LOCKED` on a *lease* table.  |
+| **Partition Ordering**   | **None:** Global queue.                                                                   | **None:** Standard Messenger Redis transport is not partition-aware.                                 | **Native:** Supports consistent hashing / partitions. (could require extra config)             | **Application Layer:** Partition key hash in `webhook_stream`.                    |
+| **Retry Behavior**       | **Updates Row:** Fails → Transaction Rollback → Updates `available_at`. Sequence is lost. | **Re-Queues:** Fails → Ack (Remove) → Add to ZSET → Worker resurrection. Sequence is lost.           | **Re-Queues:** Typically moves to DLQ or retry topic (losing sequence) unless strict blocking. | **Inline Retry:** Fails → Stays locked → Retried immediately. Sequence preserved. |
+| **Concurrency Risk**     | **High Contention:** Locks on the message table can degrade general DB performance.       | **High Race Probability:** Extreme speed increases chances of parallel execution on the same entity. | **Low:** Designed for massive concurrency.                                                     | **Isolated:** Locking `webhook_stream` partitions isolates contention.            |
+
+---
+
+## Details expanded.
+
+## Retry Mechanism: Best-Effort Ordered Delivery
+
+This architecture employs a **Best-Effort Ordered Delivery** pattern, balancing ordering guarantees with availability:
+
+### Delivery Semantics
+
+1. **Events are dispatched in sequence order within a partition, when available.**
+2. **If Event A fails:**
+    - When Event B arrives, we **retry A first** (inline retry).
+    - If A succeeds → dispatch B.
+    - If A fails again → increment A's retry count:
+        - **Retries exhausted** → mark A as `FAILED`, dispatch B.
+        - **Retries remaining** → dispatch B anyway (A stays `pending_retry` for next event or scheduled retry).
+3. **Scheduled `retry_at` is a fallback** when no new events arrive for a stream.
+
+### Why Best-Effort?
+
+| Approach                   | Ordering                | Availability        | Trade-off               |
+|----------------------------|-------------------------|---------------------|-------------------------|
+| **Strict FIFO**            | Guaranteed              | Blocked by failures | Head-of-line blocking   |
+| **Best-Effort (this ADR)** | Preserved when possible | Always progresses   | May skip failing events |
+| **No Ordering**            | None                    | Maximum             | No guarantees           |
+
+### Behavior Example
+
+```
+Stream: order_123
+──────────────────────────────────────────────────────
+t1: Event A arrives    → dispatch A    → FAILS (attempt 1)
+                       → mark A as pending_retry (next_retry_at = t1 + 5s)
+
+t2: Event B arrives    → retry A       → FAILS (attempt 2)
+                       → dispatch B    → SUCCESS
+                       → A stays pending_retry (next_retry_at = t2 + 10s)
+
+t3: Event C arrives    → retry A       → FAILS (attempt 3, exhausted)
+                       → mark A as FAILED
+                       → dispatch C    → SUCCESS
+
+Result: A=FAILED, B=SUCCESS, C=SUCCESS
+        Consumer received: B, C (A skipped after exhausting retries)
+```
+
+### Retry Configuration
+
+| Constant             | Value | Description                                     |
+|----------------------|-------|-------------------------------------------------|
+| `MAX_RETRIES`        | 5     | Maximum delivery attempts before marking FAILED |
+| `BASE_DELAY_SECONDS` | 5     | Initial backoff delay                           |
+| `DELAY_MULTIPLIER`   | 2     | Exponential backoff multiplier                  |
+
+### Flow Diagram
+
+```mermaid
+flowchart TD
+    A[New Event Arrives] --> B{Pending Retry in Stream?}
+    B -->|Yes| C[Retry Pending Event]
+    C -->|Success| D[Dispatch New Event]
+    C -->|Failure| E{Retries Exhausted?}
+    E -->|Yes| F[Mark Failed]
+    E -->|No| G[Keep Pending]
+    F --> D
+    G --> D
+    B -->|No| D
+    D -->|Success| H[Record Success]
+    D -->|Failure| I[Mark New Event Pending]
+```
+
+### Implications for Consumers
+
+Webhook consumers should be designed to handle:
+- **Idempotency:** Same event may be delivered multiple times (retries).
+- **Out-of-order delivery:** If event A fails permanently, B and C are delivered first.
+- **Missing events:** Failed events are not retried indefinitely; consumers should handle gaps.
+
+## Stream Cleanup
+When event logs are cleaned up, orphaned `webhook_stream` entries must be removed.
+
+**Cleanup Strategy:**
+The existing `WebhookCleanup` service (scheduled task) is extended to:
+1.  **Delete empty streams:** Remove `webhook_stream` rows that have no matching events in `webhook_event_log`.
+
+```sql
+-- Cleanup empty streams (no events remaining)
+DELETE s FROM webhook_stream s
+WHERE s.created_at < DATE_SUB(NOW(), INTERVAL 1 DAY)
+  AND NOT EXISTS (
+      SELECT 1 FROM webhook_event_log l
+      WHERE l.partition_key = s.partition_key
+  );
+```

--- a/src/Core/Framework/DependencyInjection/webhook.xml
+++ b/src/Core/Framework/DependencyInjection/webhook.xml
@@ -14,10 +14,14 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Webhook\Service\WebhookOutboxWriter">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <tag name="kernel.reset" method="reset"/>
+        </service>
+
         <service lazy="true" id="Shopware\Core\Framework\Webhook\Service\WebhookManager">
             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\WebhookLoader"/>
             <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\Webhook\Hookable\HookableEventFactory"/>
             <argument type="service" id="Shopware\Core\Framework\App\AppLocaleProvider"/>
             <argument type="service" id="Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper"/>
@@ -26,6 +30,9 @@
             <argument type="string">%env(APP_URL)%</argument>
             <argument>%kernel.shopware_version%</argument>
             <argument>%shopware.admin_worker.enable_admin_worker%</argument>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\WebhookOutboxProcessor"/>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\WebhookOutboxWriter"/>
+            <argument>%env(bool:default:defaults_bool_false:SHOPWARE_WEBHOOK_OUTBOX)%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Webhook\WebhookCacheClearer">
@@ -69,10 +76,72 @@
             <argument type="tagged_iterator" tag="shopware.entity.hookable"/>
         </service>
 
-        <service id="Shopware\Core\Framework\Webhook\Handler\WebhookEventMessageHandler">
+        <service id="Shopware\Core\Framework\Webhook\Service\WebhookSenderFactory">
             <argument type="service" id="shopware.app_system.guzzle"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\Service\WebhookSender">
+            <argument type="service" id="shopware.app_system.guzzle"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\Handler\WebhookEventMessageHandler">
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\WebhookSender"/>
             <argument type="service" id="webhook_event_log.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\RelatedWebhooks"/>
+
+            <tag name="messenger.message_handler"/>
+        </service>
+
+        <!--   Make configurable.     -->
+        <service id="Shopware\Core\Framework\Webhook\Service\Outbox\OutboxConfig">
+            <argument>5</argument> <!-- maxRetries -->
+            <argument>5</argument> <!-- baseDelaySeconds -->
+            <argument>2</argument> <!-- delayMultiplier -->
+            <argument>10</argument> <!-- batchSize -->
+            <argument>20</argument> <!-- timeLimitSeconds -->
+            <argument>3</argument> <!-- inlineRetryMinBackoffSeconds -->
+            <argument>10</argument> <!-- maxWebhookErrorCount -->
+            <argument>20</argument> <!-- requestTimeout -->
+            <argument>10</argument> <!-- connectTimeout -->
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\Service\Outbox\StreamLockService">
+             <argument type="service" id="Doctrine\DBAL\Connection"/>
+             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\OutboxConfig"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\Service\Outbox\OutboxEventRepository">
+             <argument type="service" id="Doctrine\DBAL\Connection"/>
+             <argument type="service" id="Psr\Clock\ClockInterface"/>
+             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\OutboxConfig"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\Service\Outbox\RetryCalculator">
+             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\OutboxConfig"/>
+             <argument type="service" id="Psr\Clock\ClockInterface"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\Service\Outbox\DeliveryExecutor">
+            <argument type="service">
+                <service class="Shopware\Core\Framework\Webhook\Service\WebhookSender">
+                    <factory service="Shopware\Core\Framework\Webhook\Service\WebhookSenderFactory" method="create"/>
+                </service>
+            </argument>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\RetryCalculator"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\Service\WebhookOutboxProcessor">
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\StreamLockService"/>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\OutboxEventRepository"/>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\DeliveryExecutor"/>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\RelatedWebhooks"/>
+            <argument type="service" id="Psr\Clock\ClockInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\OutboxConfig"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\Handler\WebhookOutboxSignalMessageHandler">
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\WebhookOutboxProcessor"/>
+            <argument type="service" id="Symfony\Component\Messenger\MessageBusInterface"/>
 
             <tag name="messenger.message_handler"/>
         </service>
@@ -97,6 +166,19 @@
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\WebhookCleanup"/>
+            <tag name="messenger.message_handler"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\ScheduledTask\DrainWebhookOutboxTask">
+            <tag name="shopware.scheduled.task" />
+        </service>
+
+        <service id="Shopware\Core\Framework\Webhook\ScheduledTask\DrainWebhookOutboxTaskHandler">
+            <argument type="service" id="scheduled_task.repository"/>
+            <argument type="service" id="logger"/>
+            <argument type="service" id="messenger.bus.default"/>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\Outbox\OutboxEventRepository"/>
+
             <tag name="messenger.message_handler"/>
         </service>
     </services>

--- a/src/Core/Framework/Webhook/EventLog/WebhookEventLogDefinition.php
+++ b/src/Core/Framework/Webhook/EventLog/WebhookEventLogDefinition.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BlobField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
@@ -24,6 +25,8 @@ class WebhookEventLogDefinition extends EntityDefinition
     final public const STATUS_QUEUED = 'queued';
 
     final public const STATUS_RUNNING = 'running';
+
+    final public const STATUS_PENDING_RETRY = 'pending_retry';
 
     final public const STATUS_FAILED = 'failed';
 
@@ -50,6 +53,7 @@ class WebhookEventLogDefinition extends EntityDefinition
     {
         return [
             'onlyLiveVersion' => false,
+            'executionCount' => 0,
         ];
     }
 
@@ -68,6 +72,11 @@ class WebhookEventLogDefinition extends EntityDefinition
             (new StringField('delivery_status', 'deliveryStatus'))->addFlags(new Required())->setDescription('Parameter that records \\\"success or failed\\\" status of the event.'),
             (new IntField('timestamp', 'timestamp'))->setDescription('Time at which the event occurred.'),
             (new IntField('processing_time', 'processingTime'))->setDescription('Time the event took to process.'),
+            (new StringField('partition_key', 'partitionKey')),
+            (new IntField('sequence', 'sequence'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE)),
+            (new IntField('execution_count', 'executionCount'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE)),
+            (new DateTimeField('next_retry_at', 'nextRetryAt'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE)),
+            (new DateTimeField('last_attempt_at', 'lastAttemptAt'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE)),
             (new StringField('app_version', 'appVersion'))->setDescription('Version of teh app.'),
             (new JsonField('request_content', 'requestContent'))->setDescription('Represents the content sent as part of the Request.'),
             (new JsonField('response_content', 'responseContent'))->setDescription('Represents the content sent as part of the Response.'),

--- a/src/Core/Framework/Webhook/EventLog/WebhookEventLogEntity.php
+++ b/src/Core/Framework/Webhook/EventLog/WebhookEventLogEntity.php
@@ -25,6 +25,10 @@ class WebhookEventLogEntity extends Entity
 
     protected ?int $processingTime = null;
 
+    protected int $executionCount = 0;
+
+    protected ?\DateTimeInterface $nextRetryAt = null;
+
     protected ?string $appVersion = null;
 
     /**
@@ -108,6 +112,26 @@ class WebhookEventLogEntity extends Entity
     public function setProcessingTime(?int $processingTime): void
     {
         $this->processingTime = $processingTime;
+    }
+
+    public function getExecutionCount(): int
+    {
+        return $this->executionCount;
+    }
+
+    public function setExecutionCount(int $executionCount): void
+    {
+        $this->executionCount = $executionCount;
+    }
+
+    public function getNextRetryAt(): ?\DateTimeInterface
+    {
+        return $this->nextRetryAt;
+    }
+
+    public function setNextRetryAt(?\DateTimeInterface $nextRetryAt): void
+    {
+        $this->nextRetryAt = $nextRetryAt;
     }
 
     public function getAppVersion(): ?string

--- a/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
+++ b/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
@@ -2,11 +2,8 @@
 
 namespace Shopware\Core\Framework\Webhook\Handler;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
-use Shopware\Core\Framework\App\Exception\AppNotFoundException;
-use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteTypeIntendException;
@@ -15,6 +12,7 @@ use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Service\RelatedWebhooks;
+use Shopware\Core\Framework\Webhook\Service\WebhookSender;
 use Shopware\Core\Framework\Webhook\WebhookException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -25,16 +23,13 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[Package('framework')]
 final readonly class WebhookEventMessageHandler
 {
-    private const TIMEOUT = 20;
-    private const CONNECT_TIMEOUT = 10;
-
     /**
      * @internal
      *
      * @param EntityRepository<ScheduledTaskCollection> $webhookEventLogRepository
      */
     public function __construct(
-        private Client $client,
+        private WebhookSender $webhookSender,
         private EntityRepository $webhookEventLogRepository,
         private RelatedWebhooks $relatedWebhooks,
     ) {
@@ -42,77 +37,40 @@ final readonly class WebhookEventMessageHandler
 
     public function __invoke(WebhookEventMessage $message): void
     {
-        $shopwareVersion = $message->getShopwareVersion();
-
-        $payload = $message->getPayload();
-        $url = $message->getUrl();
-
+        $webhookEventId = $message->getWebhookEventId();
+        $requestContent = $this->webhookSender->buildRequestOptions($message);
         $timestamp = time();
-        $payload['timestamp'] = $timestamp;
 
-        $jsonPayload = json_encode($payload, \JSON_THROW_ON_ERROR);
-
-        $headers = ['Content-Type' => 'application/json',
-            'sw-version' => $shopwareVersion, ];
-
-        // LanguageId and UserLocale will be required from 6.5.0 onward
-        if ($message->getLanguageId() && $message->getUserLocale()) {
-            $headers = array_merge($headers, [AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE => $message->getLanguageId(), AuthMiddleware::SHOPWARE_USER_LANGUAGE => $message->getUserLocale()]);
-        }
-
-        $requestContent = [
-            'headers' => $headers,
-            'body' => $jsonPayload,
-            'connect_timeout' => self::CONNECT_TIMEOUT,
-            'timeout' => self::TIMEOUT,
-        ];
-
-        if ($message->getSecret()) {
-            $requestContent[AuthMiddleware::APP_REQUEST_TYPE] = [
-                AuthMiddleware::APP_SECRET => $message->getSecret(),
-            ];
-        }
-
-        $context = Context::createDefaultContext();
-
-        $this->updateLogIfItExists(
-            [
-                'id' => $message->getWebhookEventId(),
-                'deliveryStatus' => WebhookEventLogDefinition::STATUS_RUNNING,
-                'timestamp' => $timestamp,
-                'requestContent' => $requestContent,
-            ],
-            $context
-        );
+        $this->updateLogIfItExists([
+            'id' => $webhookEventId,
+            'deliveryStatus' => WebhookEventLogDefinition::STATUS_RUNNING,
+            'timestamp' => $timestamp,
+            'requestContent' => $requestContent,
+        ], Context::createDefaultContext());
 
         try {
-            $response = $this->client->post($url, $requestContent);
+            $response = $this->webhookSender->send($message);
 
-            $this->updateLogIfItExists(
-                [
-                    'id' => $message->getWebhookEventId(),
-                    'deliveryStatus' => WebhookEventLogDefinition::STATUS_SUCCESS,
-                    'processingTime' => time() - $timestamp,
-                    'responseContent' => [
-                        'headers' => $response->getHeaders(),
-                        'body' => \json_decode($response->getBody()->getContents(), true),
-                    ],
-                    'responseStatusCode' => $response->getStatusCode(),
-                    'responseReasonPhrase' => $response->getReasonPhrase(),
+            $this->updateLogIfItExists([
+                'id' => $webhookEventId,
+                'deliveryStatus' => WebhookEventLogDefinition::STATUS_SUCCESS,
+                'processingTime' => time() - $timestamp,
+                'responseContent' => [
+                    'headers' => $response->getHeaders(),
+                    'body' => \json_decode($response->getBody()->getContents(), true),
                 ],
-                $context
-            );
+                'responseStatusCode' => $response->getStatusCode(),
+                'responseReasonPhrase' => $response->getReasonPhrase(),
+            ], Context::createDefaultContext());
 
             try {
-                $this->relatedWebhooks->updateRelated($message->getWebhookId(), ['error_count' => 0], $context);
-            } catch (AppNotFoundException|WriteTypeIntendException $e) {
-                // may happen if app or webhook got deleted in the meantime,
-                // we don't need to update the error-count in that case, so we can ignore the error
+                $this->relatedWebhooks->updateRelated($message->getWebhookId(), ['error_count' => 0], Context::createDefaultContext());
+            } catch (\Throwable) {
             }
         } catch (\Throwable $e) {
-            $payload = [
-                'id' => $message->getWebhookEventId(),
-                'deliveryStatus' => WebhookEventLogDefinition::STATUS_QUEUED, // we use the message retry mechanism to retry the message here so we set the status to queued, because it will be automatically executed again.
+            $updates = [
+                'id' => $webhookEventId,
+                'deliveryStatus' => WebhookEventLogDefinition::STATUS_QUEUED,
                 'processingTime' => time() - $timestamp,
             ];
 
@@ -122,17 +80,15 @@ final readonly class WebhookEventMessageHandler
                 if (json_validate($body)) {
                     $body = \json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
                 }
-                $payload = array_merge($payload, [
-                    'responseContent' => [
-                        'headers' => $response->getHeaders(),
-                        'body' => $body,
-                    ],
-                    'responseStatusCode' => $response->getStatusCode(),
-                    'responseReasonPhrase' => $response->getReasonPhrase(),
-                ]);
+                $updates['responseContent'] = [
+                    'headers' => $response->getHeaders(),
+                    'body' => $body,
+                ];
+                $updates['responseStatusCode'] = $response->getStatusCode();
+                $updates['responseReasonPhrase'] = $response->getReasonPhrase();
             }
 
-            $this->updateLogIfItExists($payload, $context);
+            $this->updateLogIfItExists($updates, Context::createDefaultContext());
 
             if ($e instanceof BadResponseException && $message->getAppId()) {
                 throw WebhookException::appWebhookFailedException($message->getWebhookId(), $message->getAppId(), $e);

--- a/src/Core/Framework/Webhook/Handler/WebhookOutboxSignalMessageHandler.php
+++ b/src/Core/Framework/Webhook/Handler/WebhookOutboxSignalMessageHandler.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Handler;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\Message\WebhookOutboxSignalMessage;
+use Shopware\Core\Framework\Webhook\Service\WebhookOutboxProcessor;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Handles the WebhookOutboxSignalMessage by draining the outbox and rescheduling if needed.
+ *
+ * The signal chain mechanism ensures continuous processing of the webhook outbox as long as there is work to be done,
+ * while preventing deep recursion and allowing other messages to be processed in between.
+ * - If work was done and more remains, dispatch a new signal immediately
+ * - If no work could be claimed, let the signal chain die (new webhooks trigger new signals)
+ *
+ * @internal
+ */
+#[AsMessageHandler]
+#[Package('framework')]
+final readonly class WebhookOutboxSignalMessageHandler
+{
+    /**
+     * Maximum depth before resetting to 0 to prevent potential stack issues
+     * and allow the message to be processed by a fresh worker.
+     */
+    private const MAX_SIGNAL_CHAIN = 10;
+
+    public function __construct(
+        private WebhookOutboxProcessor $processor,
+        private MessageBusInterface $bus,
+    ) {
+    }
+
+    public function __invoke(WebhookOutboxSignalMessage $message): void
+    {
+        $workerId = Uuid::randomHex();
+
+        $hasMore = $this->processor->drain($workerId);
+
+        if ($hasMore) {
+            $this->dispatchNextSignal($message);
+        }
+    }
+
+    private function dispatchNextSignal(WebhookOutboxSignalMessage $message): void
+    {
+        $nextDepth = $message->getDepth() + 1;
+        if ($nextDepth >= self::MAX_SIGNAL_CHAIN) {
+            // don't exceed max depth, yield to other messages. The drain task will be picked up again later.
+            return;
+        }
+
+        $this->bus->dispatch(new WebhookOutboxSignalMessage($nextDepth));
+    }
+}

--- a/src/Core/Framework/Webhook/Message/WebhookOutboxSignalMessage.php
+++ b/src/Core/Framework/Webhook/Message/WebhookOutboxSignalMessage.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Message;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\AsyncMessageInterface;
+use Shopware\Core\Framework\MessageQueue\DeduplicatableMessageInterface;
+
+/**
+ * Signal message to trigger draining the webhook outbox.
+ *
+ * @internal
+ */
+#[Package('framework')]
+final class WebhookOutboxSignalMessage implements AsyncMessageInterface, DeduplicatableMessageInterface
+{
+    /**
+     * @param int $depth Used to prevent infinite loops or excessive chaining of signal messages.
+     *                   When the outbox has more work, we re-dispatch this message with depth + 1.
+     *                   If depth reaches a threshold, we stop re-dispatching to yield to other messages.
+     */
+    public function __construct(
+        private readonly int $depth = 0,
+    ) {
+    }
+
+    public function getDepth(): int
+    {
+        return $this->depth;
+    }
+
+    public function deduplicationId(): string
+    {
+        return 'webhook-outbox-signal';
+    }
+}

--- a/src/Core/Framework/Webhook/PartitionAwareHookable.php
+++ b/src/Core/Framework/Webhook/PartitionAwareHookable.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+interface PartitionAwareHookable extends Hookable
+{
+    /**
+     * Returns the partition key for this event.
+     * Events with the same partition key are delivered in best-effort order
+     * within the same app (app_name is always prefixed internally).
+     * Failures can cause skips and out-of-order delivery.
+     *
+     * @return string|null Partition key, or null to use the default (app_name + webhook_id).
+     */
+    public function getPartitionKey(): ?string;
+}

--- a/src/Core/Framework/Webhook/ScheduledTask/DrainWebhookOutboxTask.php
+++ b/src/Core/Framework/Webhook/ScheduledTask/DrainWebhookOutboxTask.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\ScheduledTask;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class DrainWebhookOutboxTask extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'webhook_outbox.drain';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return self::MINUTELY * 5;
+    }
+
+    public static function shouldRescheduleOnFailure(): bool
+    {
+        return true;
+    }
+}

--- a/src/Core/Framework/Webhook/ScheduledTask/DrainWebhookOutboxTaskHandler.php
+++ b/src/Core/Framework/Webhook/ScheduledTask/DrainWebhookOutboxTaskHandler.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\ScheduledTask;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Shopware\Core\Framework\Webhook\Message\WebhookOutboxSignalMessage;
+use Shopware\Core\Framework\Webhook\Service\Outbox\OutboxEventRepository;
+use Shopware\Core\Framework\Webhook\Service\WebhookOutboxProcessor;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Scheduled task handler that triggers webhook outbox processing.
+ *
+ * This handler dispatches a signal message to start the outbox drain process.
+ * It also dynamically adjusts the next execution time based on pending retries
+ * ensuring that webhook retries happen at the correct time.
+ *
+ * @internal
+ */
+#[AsMessageHandler(handles: DrainWebhookOutboxTask::class)]
+#[Package('framework')]
+final class DrainWebhookOutboxTaskHandler extends ScheduledTaskHandler
+{
+    /**
+     * @internal
+     *
+     * @param EntityRepository<ScheduledTaskCollection> $repository
+     */
+    public function __construct(
+        EntityRepository $repository,
+        LoggerInterface $logger,
+        private readonly MessageBusInterface $bus,
+        private readonly OutboxEventRepository $outboxEventRepository,
+    ) {
+        parent::__construct($repository, $logger);
+    }
+
+    public function run(): void
+    {
+        if (! $this->outboxEventRepository->hasPendingWork()) {
+             return;
+        }
+
+        $this->bus->dispatch(new WebhookOutboxSignalMessage());
+    }
+
+    /**
+     * Override to dynamically adjust next execution time based on pending webhook retries.
+     *
+     * If there are webhooks waiting for retry with a specific next_retry_at time,
+     * we schedule this task to run at that time (if it's sooner than the default interval).
+     */
+    protected function rescheduleTask(ScheduledTask $task, ScheduledTaskEntity $taskEntity): void
+    {
+        $now = new \DateTimeImmutable();
+
+        // Calculate the default next execution time based on interval
+        $nextExecutionTimeString = $taskEntity->getNextExecutionTime()->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+        $defaultNextExecution = (new \DateTimeImmutable($nextExecutionTimeString))
+            ->modify(\sprintf('+%d seconds', $taskEntity->getRunInterval()));
+
+        if ($defaultNextExecution < $now) {
+            $defaultNextExecution = $now;
+        }
+
+        // Check if there's a pending retry that needs to happen sooner
+        $earliestRetry = $this->outboxEventRepository->getEarliestRetryTime();
+        $newNextExecutionTime = $defaultNextExecution;
+
+        if ($earliestRetry !== null) {
+            // Use the earlier of the two times
+            // Note: getEarliestRetryTime only returns future dates (> NOW)
+            if ($earliestRetry < $defaultNextExecution) {
+                $newNextExecutionTime = $earliestRetry;
+            }
+        }
+
+        $this->scheduledTaskRepository->update([
+            [
+                'id' => $task->getTaskId(),
+                'status' => ScheduledTaskDefinition::STATUS_SCHEDULED,
+                'lastExecutionTime' => $now,
+                'nextExecutionTime' => $newNextExecutionTime,
+            ],
+        ], Context::createCLIContext());
+    }
+}

--- a/src/Core/Framework/Webhook/Service/Outbox/DeliveryExecutor.php
+++ b/src/Core/Framework/Webhook/Service/Outbox/DeliveryExecutor.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service\Outbox;
+
+use GuzzleHttp\Exception\RequestException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Webhook\Service\Outbox\Dto\DeliveryOutcome;
+use Shopware\Core\Framework\Webhook\Service\Outbox\Dto\OutboxEntry;
+use Shopware\Core\Framework\Webhook\Service\WebhookSender;
+
+#[Package('framework')]
+class DeliveryExecutor
+{
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly WebhookSender $webhookSender,
+        private readonly RetryCalculator $retryCalculator
+    ) {
+    }
+
+    public function attempt(OutboxEntry $entry, int $timeout, int $connectTimeout): DeliveryOutcome
+    {
+        $message = $entry->message;
+        $executionCount = $entry->executionCount + 1;
+        $startTimestamp = time();
+
+        $requestData = $this->webhookSender->buildRequestOptions($message);
+
+        try {
+            $response = $this->webhookSender
+                ->withTimeout($timeout)
+                ->withConnectTimeout($connectTimeout)
+                ->send($message);
+
+            $body = $response->getBody()->getContents();
+
+            return new DeliveryOutcome(
+                DeliveryOutcome::STATUS_SUCCESS,
+                time() - $startTimestamp,
+                $requestData,
+                [
+                    'headers' => $response->getHeaders(),
+                    'body' => $this->decodeBodyIfJson($body),
+                ],
+                $response->getStatusCode(),
+                $response->getReasonPhrase()
+            );
+
+        } catch (\Throwable $e) {
+            $processingTime = time() - $startTimestamp;
+            $responseData = null;
+            $statusCode = null;
+            $reasonPhrase = null;
+
+            if ($e instanceof RequestException && $e->getResponse() !== null) {
+                $response = $e->getResponse();
+                $body = $response->getBody()->getContents();
+
+                $responseData = [
+                    'headers' => $response->getHeaders(),
+                    'body' => $this->decodeBodyIfJson($body),
+                ];
+                $statusCode = $response->getStatusCode();
+                $reasonPhrase = $response->getReasonPhrase();
+            }
+
+            $nextRetry = $this->retryCalculator->calculateNextRetry($executionCount);
+
+            if ($nextRetry) {
+                return new DeliveryOutcome(
+                    DeliveryOutcome::STATUS_RETRY,
+                    $processingTime,
+                    $requestData,
+                    $responseData,
+                    $statusCode,
+                    $reasonPhrase,
+                    $nextRetry
+                );
+            }
+
+            return new DeliveryOutcome(
+                DeliveryOutcome::STATUS_FAILED,
+                $processingTime,
+                $requestData,
+                $responseData,
+                $statusCode,
+                $reasonPhrase
+            );
+        }
+    }
+
+    private function decodeBodyIfJson(string $body): mixed
+    {
+        if ($body === '') {
+            return '';
+        }
+
+        try {
+            return \json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return $body;
+        }
+    }
+}

--- a/src/Core/Framework/Webhook/Service/Outbox/Dto/DeliveryOutcome.php
+++ b/src/Core/Framework/Webhook/Service/Outbox/Dto/DeliveryOutcome.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service\Outbox\Dto;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+readonly class DeliveryOutcome
+{
+    public const STATUS_SUCCESS = 'success';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_RETRY = 'retry';
+
+    /**
+     * @param array<string, mixed>|null $requestData
+     * @param array<string, mixed>|null $responseData
+     */
+    public function __construct(
+        public string $status,
+        public int $processingTime,
+        public ?array $requestData = null,
+        public ?array $responseData = null,
+        public ?int $responseStatusCode = null,
+        public ?string $responseReasonPhrase = null,
+        public ?\DateTimeImmutable $nextRetryAt = null,
+    ) {
+    }
+}

--- a/src/Core/Framework/Webhook/Service/Outbox/Dto/OutboxEntry.php
+++ b/src/Core/Framework/Webhook/Service/Outbox/Dto/OutboxEntry.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service\Outbox\Dto;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
+
+#[Package('framework')]
+readonly class OutboxEntry
+{
+    public function __construct(
+        public string $id,
+        public WebhookEventMessage $message,
+        public int $executionCount,
+        public ?\DateTimeImmutable $nextRetryAt,
+    ) {
+    }
+}

--- a/src/Core/Framework/Webhook/Service/Outbox/Dto/StreamContext.php
+++ b/src/Core/Framework/Webhook/Service/Outbox/Dto/StreamContext.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service\Outbox\Dto;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+readonly class StreamContext
+{
+    public function __construct(
+        public string $partitionKey,
+        public string $workerId,
+    ) {
+    }
+}

--- a/src/Core/Framework/Webhook/Service/Outbox/OutboxConfig.php
+++ b/src/Core/Framework/Webhook/Service/Outbox/OutboxConfig.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service\Outbox;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+readonly class OutboxConfig
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        public int $maxRetries = 5,
+        public int $baseDelaySeconds = 5,
+        public int $delayMultiplier = 2,
+        public int $batchSize = 10,
+        public int $timeLimitSeconds = 20,
+        public int $inlineRetryMinBackoffSeconds = 3,
+        public int $maxWebhookErrorCount = 10,
+        public int $requestTimeout = 20,
+        public int $connectTimeout = 10,
+    ) {
+    }
+}

--- a/src/Core/Framework/Webhook/Service/Outbox/OutboxEventRepository.php
+++ b/src/Core/Framework/Webhook/Service/Outbox/OutboxEventRepository.php
@@ -1,0 +1,332 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service\Outbox;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Psr\Clock\ClockInterface;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
+use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
+use Shopware\Core\Framework\Webhook\Service\Outbox\Dto\DeliveryOutcome;
+use Shopware\Core\Framework\Webhook\WebhookException;
+use Shopware\Core\Framework\Webhook\Service\Outbox\Dto\OutboxEntry;
+
+#[Package('framework')]
+class OutboxEventRepository
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly ClockInterface $clock,
+        private readonly OutboxConfig $config
+    ) {
+    }
+
+    public function hasPendingWork(): bool
+    {
+        $count = $this->connection->fetchOne(
+            <<<'SQL'
+                SELECT 1
+                FROM webhook_event_log
+                WHERE delivery_status IN (:statuses)
+                  AND (next_retry_at IS NULL OR next_retry_at <= NOW(3))
+                LIMIT 1
+            SQL,
+            ['statuses' => [WebhookEventLogDefinition::STATUS_QUEUED, WebhookEventLogDefinition::STATUS_PENDING_RETRY]],
+            ['statuses' => ArrayParameterType::STRING]
+        );
+
+        return $count !== false;
+    }
+
+    public function getEarliestRetryTime(): ?\DateTimeImmutable
+    {
+        $timeString = $this->connection->fetchOne(
+            <<<'SQL'
+                SELECT MIN(next_retry_at)
+                FROM webhook_event_log
+                WHERE delivery_status = :pending
+                  AND next_retry_at > NOW(3)
+            SQL,
+            ['pending' => WebhookEventLogDefinition::STATUS_PENDING_RETRY]
+        );
+
+        if ($timeString === false || $timeString === null) {
+            return null;
+        }
+
+        return new \DateTimeImmutable($timeString);
+    }
+
+    /**
+     * @return list<OutboxEntry>
+     */
+    public function fetchPendingRetries(string $partitionKey, int $limit): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT id, serialized_webhook_message, execution_count, sequence, next_retry_at
+                FROM webhook_event_log
+                WHERE partition_key = :key
+                  AND delivery_status = :pending
+                  AND (
+                    (next_retry_at IS NULL OR next_retry_at <= NOW(3))
+                    OR
+                    (last_attempt_at <= DATE_SUB(NOW(3), INTERVAL :min_backoff SECOND))
+                  )
+                ORDER BY sequence ASC
+                LIMIT :limit
+            SQL,
+            [
+                'key' => $partitionKey,
+                'pending' => WebhookEventLogDefinition::STATUS_PENDING_RETRY,
+                'limit' => $limit,
+                'min_backoff' => $this->config->inlineRetryMinBackoffSeconds,
+            ],
+            [
+                'limit' => ParameterType::INTEGER,
+                'min_backoff' => ParameterType::INTEGER,
+                'key' => ParameterType::BINARY,
+            ]
+        );
+
+        return $this->hydrateEntries($rows);
+    }
+
+    /**
+     * @return list<OutboxEntry>
+     */
+    public function fetchQueued(string $partitionKey, int $limit): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT id, serialized_webhook_message, execution_count, sequence, next_retry_at
+                FROM webhook_event_log
+                WHERE partition_key = :key
+                  AND delivery_status = :queued
+                ORDER BY sequence ASC
+                LIMIT :limit
+            SQL,
+            [
+                'key' => $partitionKey,
+                'queued' => WebhookEventLogDefinition::STATUS_QUEUED,
+                'limit' => $limit,
+            ],
+            [
+                'limit' => ParameterType::INTEGER,
+                'key' => ParameterType::BINARY,
+            ]
+        );
+
+        return $this->hydrateEntries($rows);
+    }
+
+    /**
+     * @param list<string> $ids
+     * @param list<string> $eventNames
+     *
+     * @return list<OutboxEntry>
+     */
+    public function fetchForFlush(array $ids, array $eventNames): array
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        $binaryIds = array_map(fn($id) => Uuid::fromHexToBytes($id), $ids);
+
+        // Step 1: Find the max sequence from the requested IDs as the boundary
+        $maxSequence = $this->connection->fetchOne(
+            'SELECT MAX(sequence) FROM webhook_event_log WHERE id IN (:ids)',
+            ['ids' => $binaryIds],
+            ['ids' => ArrayParameterType::STRING]
+        );
+
+        if ($maxSequence === false) {
+            return [];
+        }
+
+        $this->connection->beginTransaction();
+
+        try {
+            $rows = $this->connection->fetchAllAssociative(
+                <<<'SQL'
+                    SELECT id, serialized_webhook_message, execution_count, sequence, next_retry_at
+                    FROM webhook_event_log
+                    WHERE event_name IN (:event_names)
+                      AND sequence <= :max_sequence
+                      AND delivery_status IN (:statuses)
+                      AND (last_attempt_at IS NULL OR last_attempt_at <= DATE_SUB(NOW(3), INTERVAL :min_backoff SECOND))
+                    ORDER BY sequence ASC
+                    FOR UPDATE SKIP LOCKED
+                SQL,
+                [
+                    'event_names' => $eventNames,
+                    'max_sequence' => $maxSequence,
+                    'statuses' => [WebhookEventLogDefinition::STATUS_QUEUED, WebhookEventLogDefinition::STATUS_PENDING_RETRY],
+                    'min_backoff' => $this->config->inlineRetryMinBackoffSeconds,
+                ],
+                [
+                    'event_names' => ArrayParameterType::STRING,
+                    'statuses' => ArrayParameterType::STRING,
+                    'min_backoff' => ParameterType::INTEGER,
+                ]
+            );
+
+            if (!empty($rows)) {
+                $this->connection->executeStatement(
+                    'UPDATE webhook_event_log SET delivery_status = :status, last_attempt_at = :now WHERE id IN (:ids)',
+                    [
+                        'status' => WebhookEventLogDefinition::STATUS_RUNNING,
+                        'now' => $this->clock->now()->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                        'ids' => array_map(fn($e) => $e['id'], $rows),
+                    ],
+                    [
+                        'ids' => ArrayParameterType::BINARY,
+                    ]
+                );
+            }
+
+            $this->connection->commit();
+        } catch (\Throwable $e) {
+            $this->connection->rollBack();
+            throw $e;
+        }
+
+        return $this->hydrateEntries($rows);
+    }
+
+    public function markRunning(OutboxEntry $entry): void
+    {
+        $this->updateLog($entry->id, [
+            'delivery_status' => WebhookEventLogDefinition::STATUS_RUNNING,
+            'execution_count' => $entry->executionCount + 1,
+            'last_attempt_at' => $this->clock->now()->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+
+    public function markSuccess(OutboxEntry $entry, DeliveryOutcome $outcome): void
+    {
+        $this->updateLog($entry->id, [
+            'delivery_status' => WebhookEventLogDefinition::STATUS_SUCCESS,
+            'processing_time' => $outcome->processingTime,
+            'request_content' => json_encode($outcome->requestData),
+            'response_content' => json_encode($outcome->responseData),
+            'response_status_code' => $outcome->responseStatusCode,
+            'response_reason_phrase' => $outcome->responseReasonPhrase,
+            'next_retry_at' => null,
+        ]);
+    }
+
+    public function markPendingRetry(OutboxEntry $entry, DeliveryOutcome $outcome): void
+    {
+        $this->updateLog($entry->id, [
+            'delivery_status' => WebhookEventLogDefinition::STATUS_PENDING_RETRY,
+            'processing_time' => $outcome->processingTime,
+            'request_content' => json_encode($outcome->requestData),
+            'response_content' => json_encode($outcome->responseData),
+            'response_status_code' => $outcome->responseStatusCode,
+            'response_reason_phrase' => $outcome->responseReasonPhrase,
+            'next_retry_at' => $outcome->nextRetryAt?->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+
+    public function markFailed(OutboxEntry $entry, DeliveryOutcome $outcome): void
+    {
+        $this->updateLog($entry->id, [
+            'delivery_status' => WebhookEventLogDefinition::STATUS_FAILED,
+            'processing_time' => $outcome->processingTime,
+            'request_content' => json_encode($outcome->requestData),
+            'response_content' => json_encode($outcome->responseData),
+            'response_status_code' => $outcome->responseStatusCode,
+            'response_reason_phrase' => $outcome->responseReasonPhrase,
+            'next_retry_at' => null,
+        ]);
+    }
+
+    public function resetStaleEntries(): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                UPDATE webhook_event_log
+                SET delivery_status = :pending,
+                    next_retry_at = :now
+                WHERE delivery_status = :running
+                  AND last_attempt_at < DATE_SUB(NOW(3), INTERVAL 5 MINUTE)
+            SQL,
+            [
+                'pending' => WebhookEventLogDefinition::STATUS_PENDING_RETRY,
+                'running' => WebhookEventLogDefinition::STATUS_RUNNING,
+                'now' => $this->clock->now()->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+    }
+
+    /**
+     * @return array{active: bool, error_count: int}|null
+     */
+    public function getWebhookInfo(string $webhookId): ?array
+    {
+        $row = $this->connection->fetchAssociative(
+            'SELECT active, error_count FROM webhook WHERE id = :id',
+            ['id' => Uuid::fromHexToBytes($webhookId)]
+        );
+
+        if ($row === false) {
+            return null;
+        }
+
+        return [
+            'active' => (bool) $row['active'],
+            'error_count' => (int) $row['error_count'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function updateLog(string $id, array $data): void
+    {
+        $this->connection->update('webhook_event_log', $data, ['id' => Uuid::fromHexToBytes($id)]);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @return list<OutboxEntry>
+     */
+    private function hydrateEntries(array $rows): array
+    {
+        $entries = [];
+        foreach ($rows as $row) {
+            $payload = $row['serialized_webhook_message'] ?? null;
+
+            if ($payload === null) {
+                throw WebhookException::invalidSerializedMessage(Uuid::fromBytesToHex($row['id']), 'No serialized message found.');
+            }
+
+            $message = unserialize($payload, ['allowed_classes' => [WebhookEventMessage::class]]);
+
+            if (!$message instanceof WebhookEventMessage) {
+                throw WebhookException::invalidSerializedMessage(
+                    Uuid::fromBytesToHex($row['id']),
+                    sprintf('Expected %s, got %s.', WebhookEventMessage::class, get_debug_type($message))
+                );
+            }
+
+            $entries[] = new OutboxEntry(
+                Uuid::fromBytesToHex($row['id']),
+                $message,
+                (int) ($row['execution_count'] ?? 0),
+                isset($row['next_retry_at']) ? new \DateTimeImmutable($row['next_retry_at']) : null
+            );
+        }
+
+        return $entries;
+    }
+}

--- a/src/Core/Framework/Webhook/Service/Outbox/RetryCalculator.php
+++ b/src/Core/Framework/Webhook/Service/Outbox/RetryCalculator.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service\Outbox;
+
+use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+class RetryCalculator
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly OutboxConfig $config,
+        private readonly ClockInterface $clock
+    ) {
+    }
+
+    public function calculateNextRetry(int $currentExecutionCount): ?\DateTimeImmutable
+    {
+        if ($currentExecutionCount >= $this->config->maxRetries) {
+            return null;
+        }
+
+        $delaySeconds = (int) ($this->config->baseDelaySeconds * ($this->config->delayMultiplier ** $currentExecutionCount));
+
+        return $this->clock->now()->modify(sprintf('+%d seconds', $delaySeconds));
+    }
+}

--- a/src/Core/Framework/Webhook/Service/Outbox/StreamLockService.php
+++ b/src/Core/Framework/Webhook/Service/Outbox/StreamLockService.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service\Outbox;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
+use Shopware\Core\Framework\Webhook\Service\Outbox\Dto\StreamContext;
+
+#[Package('framework')]
+class StreamLockService
+{
+    private int $lockTtl;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly Connection $connection,
+        OutboxConfig $config
+    ) {
+        // Calculate lock TTL based on worst-case execution time for a full batch
+        // (connect + request) * batch items + small buffer
+        $singleRequestTime = $config->connectTimeout + $config->requestTimeout;
+        $this->lockTtl = ($singleRequestTime * $config->batchSize) + 5;
+    }
+
+    public function claimNext(string $workerId): ?StreamContext
+    {
+        $this->connection->beginTransaction();
+
+        try {
+            // Find an unlocked stream that has pending work (queued or valid retry)
+            $stream = $this->connection->fetchAssociative(
+                <<<'SQL'
+                    SELECT ws.partition_key
+                    FROM webhook_stream ws
+                    WHERE (ws.locked_by IS NULL OR ws.lock_expires_at <= NOW(3))
+                      AND EXISTS (
+                          SELECT 1 FROM webhook_event_log wel
+                          WHERE wel.partition_key = ws.partition_key
+                            AND (
+                                wel.delivery_status = :queued
+                                OR (wel.delivery_status = :pending AND (wel.next_retry_at IS NULL OR wel.next_retry_at <= NOW(3)))
+                            )
+                      )
+                    LIMIT 1
+                    FOR UPDATE SKIP LOCKED
+                SQL,
+                [
+                    'queued' => WebhookEventLogDefinition::STATUS_QUEUED,
+                    'pending' => WebhookEventLogDefinition::STATUS_PENDING_RETRY,
+                ]
+            );
+
+            if ($stream === false) {
+                $this->connection->commit();
+
+                return null;
+            }
+
+            $this->connection->executeStatement(
+                'UPDATE webhook_stream SET locked_by = :workerId, lock_expires_at = DATE_ADD(NOW(3), INTERVAL :ttl SECOND) WHERE partition_key = :key',
+                [
+                    'workerId' => $workerId,
+                    'ttl' => $this->lockTtl,
+                    'key' => $stream['partition_key'],
+                ],
+                [
+                    'key' => ParameterType::BINARY,
+                ]
+            );
+
+            $this->connection->commit();
+
+            return new StreamContext($stream['partition_key'], $workerId);
+        } catch (\Throwable $e) {
+            $this->connection->rollBack();
+            throw $e;
+        }
+    }
+
+    public function heartbeat(StreamContext $stream): bool
+    {
+        $count = $this->connection->executeStatement(
+            <<<'SQL'
+                UPDATE webhook_stream
+                SET lock_expires_at = DATE_ADD(NOW(3), INTERVAL :ttl SECOND)
+                WHERE partition_key = :key
+                  AND locked_by = :workerId
+            SQL,
+            [
+                'ttl' => $this->lockTtl,
+                'key' => $stream->partitionKey,
+                'workerId' => $stream->workerId,
+            ],
+            [
+                'key' => ParameterType::BINARY,
+            ]
+        );
+
+        return $count > 0;
+    }
+
+    public function release(StreamContext $stream): void
+    {
+        $this->connection->executeStatement(
+            <<<'SQL'
+                UPDATE webhook_stream
+                SET locked_by = NULL,
+                    lock_expires_at = NULL
+                WHERE partition_key = :key AND locked_by = :workerId
+            SQL,
+            [
+                'key' => $stream->partitionKey,
+                'workerId' => $stream->workerId,
+            ],
+            [
+                'key' => ParameterType::BINARY,
+            ]
+        );
+    }
+}

--- a/src/Core/Framework/Webhook/Service/WebhookCleanup.php
+++ b/src/Core/Framework/Webhook/Service/WebhookCleanup.php
@@ -42,7 +42,7 @@ class WebhookCleanup
         $this->deleteLogsOlderThanWithStatus($entryLifetimeSeconds, WebhookEventLogDefinition::STATUS_SUCCESS, WebhookEventLogDefinition::STATUS_FAILED);
         // after double the entry lifetime, we also delete queued entries,
         // because we assume they are stuck in queued state (as we rely on message retry to retry failed webhooks)
-        $this->deleteLogsOlderThanWithStatus($entryLifetimeSeconds * 2, WebhookEventLogDefinition::STATUS_QUEUED);
+        $this->deleteLogsOlderThanWithStatus($entryLifetimeSeconds * 2, WebhookEventLogDefinition::STATUS_QUEUED, WebhookEventLogDefinition::STATUS_PENDING_RETRY);
     }
 
     private function deleteLogsOlderThanWithStatus(int $entryLifetimeSeconds, string ...$status): void

--- a/src/Core/Framework/Webhook/Service/WebhookManager.php
+++ b/src/Core/Framework/Webhook/Service/WebhookManager.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\App\Event\AppChangedEvent;
 use Shopware\Core\Framework\App\Event\AppDeletedEvent;
 use Shopware\Core\Framework\App\Event\AppFlowActionEvent;
 use Shopware\Core\Framework\App\Event\AppPermissionsUpdated;
+use Shopware\Core\Framework\App\Event\ManifestChangedEvent;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\App\Hmac\RequestSigner;
@@ -24,11 +25,11 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 use Shopware\Core\Framework\Webhook\Event\PreWebhooksDispatchEvent;
-use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
 use Shopware\Core\Framework\Webhook\Hookable;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEntityWrittenEvent;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEventFactory;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
+use Shopware\Core\Framework\Webhook\Message\WebhookOutboxSignalMessage;
 use Shopware\Core\Framework\Webhook\Webhook;
 use Shopware\Core\Profiling\Profiler;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -53,7 +54,6 @@ class WebhookManager implements ResetInterface
     public function __construct(
         private readonly WebhookLoader $webhookLoader,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly Connection $connection,
         private readonly HookableEventFactory $eventFactory,
         private readonly AppLocaleProvider $appLocaleProvider,
         private readonly AppPayloadServiceHelper $appPayloadServiceHelper,
@@ -62,6 +62,9 @@ class WebhookManager implements ResetInterface
         private readonly string $shopUrl,
         private readonly string $shopwareVersion,
         private readonly bool $isAdminWorkerEnabled,
+        private readonly WebhookOutboxProcessor $outboxProcessor,
+        private readonly WebhookOutboxWriter $outboxWriter,
+        private readonly bool $outboxEnabled = false,
     ) {
     }
 
@@ -106,15 +109,33 @@ class WebhookManager implements ResetInterface
         $languageId = $context->getLanguageId();
         $userLocale = $this->appLocaleProvider->getLocaleFromContext($context);
 
-        $affectedRoleIds = array_values(array_filter(array_map(fn (Webhook $webhook) => $webhook->appAclRoleId, $webhooksForEvent)));
+        $affectedRoleIds = array_values(array_filter(array_map(fn(Webhook $webhook) => $webhook->appAclRoleId, $webhooksForEvent)));
         $this->loadPrivileges($event->getName(), $affectedRoleIds);
+
+        if ($this->outboxEnabled) {
+            $eventLogIds = $this->dispatchWebhooksToQueue($webhooksForEvent, $event, $languageId, $userLocale);
+
+            if ($this->isAdminWorkerEnabled || $event instanceof AppDeletedEvent || $event instanceof AppChangedEvent || $event instanceof AppPermissionsUpdated) {
+                if (\count($eventLogIds) === 0) {
+                    return;
+                }
+
+                $this->outboxProcessor->flush($eventLogIds, $this->getFlushEventNames($event));
+            }
+
+            if (\count($eventLogIds) > 0) {
+                $this->bus->dispatch(new WebhookOutboxSignalMessage());
+            }
+
+            return;
+        }
 
         // If the admin worker is enabled we send all events synchronously, as we can't guarantee timely delivery otherwise.
         // Additionally, all app lifecycle events are sent synchronously as those can lead to nasty race conditions otherwise.
         if ($this->isAdminWorkerEnabled || $event instanceof AppDeletedEvent || $event instanceof AppChangedEvent || $event instanceof AppPermissionsUpdated) {
             Profiler::trace(
                 'webhook::dispatch-sync',
-                fn () => $this->callWebhooksSynchronous($webhooksForEvent, $event, $languageId, $userLocale)
+                fn() => $this->callWebhooksSynchronous($webhooksForEvent, $event, $languageId, $userLocale)
             );
 
             return;
@@ -122,19 +143,23 @@ class WebhookManager implements ResetInterface
 
         Profiler::trace(
             'webhook::dispatch-async',
-            fn () => $this->dispatchWebhooksToQueue($webhooksForEvent, $event, $languageId, $userLocale)
+            fn() => $this->dispatchWebhooksToQueue($webhooksForEvent, $event, $languageId, $userLocale)
         );
     }
 
     /**
      * @param array<Webhook> $webhooksForEvent
+     *
+     * @return list<string> List of webhook event log IDs (hex)
      */
     private function dispatchWebhooksToQueue(
         array $webhooksForEvent,
         Hookable $event,
         string $languageId,
         string $userLocale
-    ): void {
+    ): array {
+        $eventLogIds = [];
+
         foreach ($webhooksForEvent as $webhook) {
             if (!$this->isEventDispatchingAllowed($webhook, $event)) {
                 continue;
@@ -156,32 +181,20 @@ class WebhookManager implements ResetInterface
                 $webhook->url,
                 $webhook->appSecret,
                 $languageId,
-                $userLocale
+                $userLocale,
             );
 
-            $this->logWebhookWithEvent($webhook, $webhookEventMessage);
+            $this->outboxWriter->write($webhook, $webhookEventMessage, $event);
+            $eventLogIds[] = $webhookEventMessage->getWebhookEventId();
+
+            if ($this->outboxEnabled) {
+                continue;
+            }
 
             $this->bus->dispatch($webhookEventMessage);
         }
-    }
 
-    private function logWebhookWithEvent(Webhook $webhook, WebhookEventMessage $webhookEventMessage): void
-    {
-        $this->connection->insert(
-            'webhook_event_log',
-            [
-                'id' => Uuid::fromHexToBytes($webhookEventMessage->getWebhookEventId()),
-                'app_name' => $webhook->appName,
-                'delivery_status' => WebhookEventLogDefinition::STATUS_QUEUED,
-                'webhook_name' => $webhook->webhookName,
-                'event_name' => $webhook->eventName,
-                'app_version' => $webhook->appVersion,
-                'url' => $webhook->url,
-                'only_live_version' => (int) $webhook->onlyLiveVersion,
-                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
-                'serialized_webhook_message' => serialize($webhookEventMessage),
-            ]
-        );
+        return $eventLogIds;
     }
 
     /**
@@ -243,6 +256,21 @@ class WebhookManager implements ResetInterface
             $pool = new Pool($this->guzzle, $requests);
             $pool->promise()->wait();
         }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getFlushEventNames(Hookable $event): array
+    {
+        if ($event instanceof AppChangedEvent || $event instanceof AppDeletedEvent || $event instanceof AppPermissionsUpdated) {
+            return array_values(array_unique(array_merge(
+                ManifestChangedEvent::LIFECYCLE_EVENTS,
+                [AppPermissionsUpdated::NAME]
+            )));
+        }
+
+        return [$event->getName()];
     }
 
     /**
@@ -383,4 +411,5 @@ class WebhookManager implements ResetInterface
             return !$isVersioned;
         }));
     }
+
 }

--- a/src/Core/Framework/Webhook/Service/WebhookOutboxProcessor.php
+++ b/src/Core/Framework/Webhook/Service/WebhookOutboxProcessor.php
@@ -1,0 +1,166 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service;
+
+use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Webhook\Service\Outbox\DeliveryExecutor;
+use Shopware\Core\Framework\Webhook\Service\Outbox\Dto\DeliveryOutcome;
+use Shopware\Core\Framework\Webhook\Service\Outbox\Dto\OutboxEntry;
+use Shopware\Core\Framework\Webhook\Service\Outbox\Dto\StreamContext;
+use Shopware\Core\Framework\Webhook\Service\Outbox\OutboxConfig;
+use Shopware\Core\Framework\Webhook\Service\Outbox\OutboxEventRepository;
+use Shopware\Core\Framework\Webhook\Service\Outbox\StreamLockService;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class WebhookOutboxProcessor
+{
+    public function __construct(
+        private readonly StreamLockService $lockService,
+        private readonly OutboxEventRepository $repository,
+        private readonly DeliveryExecutor $executor,
+        private readonly RelatedWebhooks $relatedWebhooks,
+        private readonly ClockInterface $clock,
+        private readonly OutboxConfig $config,
+    ) {
+    }
+
+    /**
+     * Drains the outbox by processing pending webhook entries.
+     *
+     * @return bool TRUE if more work remains (reschedule needed), FALSE if outbox is empty
+     */
+    public function drain(string $workerId): bool
+    {
+        $deadline = $this->clock->now()->modify(sprintf('+%d seconds', $this->config->timeLimitSeconds));
+        $this->repository->resetStaleEntries();
+
+        $remaining = $this->config->batchSize;
+
+        while ($this->clock->now() < $deadline && $remaining > 0) {
+            $stream = $this->lockService->claimNext($workerId);
+            if ($stream === null) {
+                // No more streams with pending work
+                return false;
+            }
+
+            try {
+                $remaining = $this->processStream($stream, $remaining);
+            } finally {
+                $this->lockService->release($stream);
+            }
+        }
+
+        // Exited due to deadline or batch exhaustion - more work likely remains
+        return $this->repository->hasPendingWork();
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:flush-is-special-case - Will be removed once outbox processing is fully unified.
+     *
+     * @param list<string> $ids
+     * @param list<string> $eventNames
+     */
+    public function flush(array $ids, array $eventNames): void
+    {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', 'The specific explicit flushing of webhooks is deprecated and will be removed.');
+
+        $entries = $this->repository->fetchForFlush($ids, $eventNames);
+
+        foreach ($entries as $entry) {
+            $this->repository->markRunning($entry);
+            $outcome = $this->executor->attempt(
+                $entry,
+                $this->config->requestTimeout,
+                $this->config->connectTimeout
+            );
+            $this->persistOutcome($entry, $outcome);
+        }
+    }
+
+    /**
+     * @return int Remaining batch budget after processing
+     */
+    private function processStream(StreamContext $stream, int $budget): int
+    {
+        $entries = $this->repository->fetchPendingRetries($stream->partitionKey, $budget);
+        $remaining = $budget - count($entries);
+
+        if ($remaining > 0) {
+            $entries = array_merge(
+                $entries,
+                $this->repository->fetchQueued($stream->partitionKey, $remaining)
+            );
+        }
+
+        foreach ($entries as $entry) {
+            if (!$this->lockService->heartbeat($stream)) {
+                break;
+            }
+
+            $this->repository->markRunning($entry);
+            $outcome = $this->executor->attempt(
+                $entry,
+                $this->config->requestTimeout,
+                $this->config->connectTimeout
+            );
+            $this->persistOutcome($entry, $outcome);
+            --$budget;
+        }
+
+        return $budget;
+    }
+
+    private function persistOutcome(OutboxEntry $entry, DeliveryOutcome $outcome): void
+    {
+        match ($outcome->status) {
+            DeliveryOutcome::STATUS_SUCCESS => $this->handleSuccess($entry, $outcome),
+            DeliveryOutcome::STATUS_RETRY => $this->repository->markPendingRetry($entry, $outcome),
+            DeliveryOutcome::STATUS_FAILED => $this->handleFailure($entry, $outcome),
+            default => null,
+        };
+    }
+
+    private function handleSuccess(OutboxEntry $entry, DeliveryOutcome $outcome): void
+    {
+        $this->repository->markSuccess($entry, $outcome);
+
+        $webhookId = $entry->message->getWebhookId();
+        try {
+            $this->relatedWebhooks->updateRelated($webhookId, ['error_count' => 0], Context::createDefaultContext());
+        } catch (\Throwable) {
+        }
+    }
+
+    private function handleFailure(OutboxEntry $entry, DeliveryOutcome $outcome): void
+    {
+        $this->repository->markFailed($entry, $outcome);
+
+        $webhookId = $entry->message->getWebhookId();
+        $webhookInfo = $this->repository->getWebhookInfo($webhookId);
+
+        if ($webhookInfo === null || !$webhookInfo['active']) {
+            return;
+        }
+
+        $webhookErrorCount = $webhookInfo['error_count'] + 1;
+        $params = ['error_count' => $webhookErrorCount];
+
+        if ($webhookErrorCount >= $this->config->maxWebhookErrorCount) {
+            $params = [
+                'error_count' => 0,
+                'active' => 0,
+            ];
+        }
+
+        try {
+            $this->relatedWebhooks->updateRelated($webhookId, $params, Context::createDefaultContext());
+        } catch (\Throwable) {
+        }
+    }
+}

--- a/src/Core/Framework/Webhook/Service/WebhookOutboxWriter.php
+++ b/src/Core/Framework/Webhook/Service/WebhookOutboxWriter.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
+use Shopware\Core\Framework\Webhook\Hookable;
+use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
+use Shopware\Core\Framework\Webhook\PartitionAwareHookable;
+use Shopware\Core\Framework\Webhook\Webhook;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @internal
+ */
+use Shopware\Core\Framework\Util\Hasher;
+
+#[Package('framework')]
+class WebhookOutboxWriter implements ResetInterface
+{
+    /**
+     * @var array<string, bool>
+     */
+    private array $seenKeys = [];
+
+    /**
+     * @internal
+     */
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function write(Webhook $webhook, WebhookEventMessage $message, ?Hookable $event = null): void
+    {
+        $partitionKey = $this->calculatePartitionKey($event, $webhook);
+
+        $this->connection->insert(
+            'webhook_event_log',
+            [
+                'id' => Uuid::fromHexToBytes($message->getWebhookEventId()),
+                'app_name' => $webhook->appName,
+                'delivery_status' => WebhookEventLogDefinition::STATUS_QUEUED,
+                'webhook_name' => $webhook->webhookName,
+                'event_name' => $webhook->eventName,
+                'app_version' => $webhook->appVersion,
+                'url' => $webhook->url,
+                'only_live_version' => (int) $webhook->onlyLiveVersion,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                'serialized_webhook_message' => serialize($message),
+                'execution_count' => 0,
+                'partition_key' => $partitionKey,
+            ]
+        );
+
+        if (isset($this->seenKeys[$partitionKey])) {
+            return;
+        }
+
+        $this->connection->executeStatement(
+            'INSERT IGNORE INTO `webhook_stream` (`partition_key`, `created_at`, `error_count`) VALUES (:key, :now, 0)',
+            [
+                'key' => $partitionKey,
+                'now' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+
+        $this->seenKeys[$partitionKey] = true;
+    }
+
+    public function reset(): void
+    {
+        $this->seenKeys = [];
+    }
+
+    private function calculatePartitionKey(?Hookable $event, Webhook $webhook): string
+    {
+        $appName = $webhook->appName;
+
+        $eventPartitionKey = $event instanceof PartitionAwareHookable
+            ? $event->getPartitionKey()
+            : null;
+
+        // Default: partition by app_name + "default" for app isolation by default
+        // If event provides key: partition by app_name + event_key for ordering within app
+        // We use a null byte as separator to avoid collisions if appName/eventKey contains the separator char
+        $raw = sprintf("%s\0%s", $appName, $eventPartitionKey ?? 'default');
+
+        // Why BINARY(8)?
+        // 1. Storage Efficiency: Fixed 8 bytes vs variable string. Prevents index bloat.
+        // 2. Performance: Numeric byte comparison avoids charset/collation overhead.
+        // 3. Stability: Avoids key-length limits (3072 bytes).
+        // 4. Algorithm: xxh3 (64-bit) ensures optimal distribution.
+        return substr(Hasher::hashBinary($raw, 'xxh3'), 0, 8);
+    }
+}

--- a/src/Core/Framework/Webhook/Service/WebhookSender.php
+++ b/src/Core/Framework/Webhook/Service/WebhookSender.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service;
+
+use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
+use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class WebhookSender
+{
+    private const TIMEOUT = 20;
+    private const CONNECT_TIMEOUT = 10;
+
+    private int $timeout = self::TIMEOUT;
+    private int $connectTimeout = self::CONNECT_TIMEOUT;
+
+    public function __construct(
+        private readonly Client $client,
+    ) {
+    }
+
+    public function withTimeout(int $timeout): self
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    public function withConnectTimeout(int $connectTimeout): self
+    {
+        $this->connectTimeout = $connectTimeout;
+
+        return $this;
+    }
+
+    public function send(WebhookEventMessage $message): ResponseInterface
+    {
+        $requestOptions = $this->buildRequestOptions($message);
+
+        return $this->client->post($message->getUrl(), $requestOptions);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildRequestOptions(WebhookEventMessage $message): array
+    {
+        $shopwareVersion = $message->getShopwareVersion();
+        $payload = $message->getPayload();
+
+        /**
+         * @TODO: logic of timetsamp doesn't seem valid - it's bound to the time of sending the request, not the event itself.
+         * This is the same in the processor (not sure if there's some reason behind it, need to double check)
+         */
+        $payload['timestamp'] = time();
+
+        $jsonPayload = json_encode($payload, \JSON_THROW_ON_ERROR);
+
+        $headers = [
+            'Content-Type' => 'application/json',
+            'sw-version' => $shopwareVersion,
+        ];
+
+        if ($message->getLanguageId() && $message->getUserLocale()) {
+            $headers = array_merge($headers, [
+                AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE => $message->getLanguageId(),
+                AuthMiddleware::SHOPWARE_USER_LANGUAGE => $message->getUserLocale(),
+            ]);
+        }
+
+        $requestContent = [
+            'headers' => $headers,
+            'body' => $jsonPayload,
+            'connect_timeout' => $this->connectTimeout,
+            'timeout' => $this->timeout,
+        ];
+
+        if ($message->getSecret()) {
+            $requestContent[AuthMiddleware::APP_REQUEST_TYPE] = [
+                AuthMiddleware::APP_SECRET => $message->getSecret(),
+            ];
+        }
+
+        return $requestContent;
+    }
+}

--- a/src/Core/Framework/Webhook/Service/WebhookSenderFactory.php
+++ b/src/Core/Framework/Webhook/Service/WebhookSenderFactory.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service;
+
+use GuzzleHttp\Client;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class WebhookSenderFactory
+{
+    public function __construct(
+        private readonly Client $client
+    ) {
+    }
+
+    public function create(): WebhookSender
+    {
+        return new WebhookSender($this->client);
+    }
+}

--- a/src/Core/Framework/Webhook/Subscriber/RetryWebhookMessageFailedSubscriber.php
+++ b/src/Core/Framework/Webhook/Subscriber/RetryWebhookMessageFailedSubscriber.php
@@ -25,7 +25,8 @@ class RetryWebhookMessageFailedSubscriber implements EventSubscriberInterface
      */
     public function __construct(
         private readonly Connection $connection,
-        private readonly RelatedWebhooks $relatedWebhooks
+        private readonly RelatedWebhooks $relatedWebhooks,
+        private readonly bool $isOutboxEnabled = false,
     ) {
     }
 
@@ -38,6 +39,11 @@ class RetryWebhookMessageFailedSubscriber implements EventSubscriberInterface
 
     public function failed(WorkerMessageFailedEvent $event): void
     {
+        if ($this->isOutboxEnabled) {
+            // when outbox is enabled, the failure is handled by the outbox mechanism.
+            return;
+        }
+
         if ($event->willRetry()) {
             return;
         }

--- a/src/Core/Framework/Webhook/WebhookException.php
+++ b/src/Core/Framework/Webhook/WebhookException.php
@@ -14,6 +14,17 @@ class WebhookException extends HttpException
     public const APP_WEBHOOK_FAILED = 'FRAMEWORK__APP_WEBHOOK_FAILED';
     public const INVALID_DATA_MAPPING = 'FRAMEWORK__WEBHOOK_INVALID_DATA_MAPPING';
     public const UNKNOWN_DATA_TYPE = 'FRAMEWORK__WEBHOOK_UNKNOWN_DATA_TYPE';
+    public const PROCESSING_ERROR = 'FRAMEWORK__WEBHOOK_PROCESSING_ERROR';
+
+    public static function invalidSerializedMessage(string $id, string $reason): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::PROCESSING_ERROR,
+            'Failed to process webhook entry "{{ id }}": {{ reason }}',
+            ['id' => $id, 'reason' => $reason]
+        );
+    }
 
     public static function webhookFailedException(string $webhookId, \Throwable $e): self
     {

--- a/src/Core/Migration/V6_7/Migration1765542000AddOutboxFieldsToWebhookEventLog.php
+++ b/src/Core/Migration/V6_7/Migration1765542000AddOutboxFieldsToWebhookEventLog.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1765542000AddOutboxFieldsToWebhookEventLog extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1765542000;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if (!$this->columnExists($connection, 'webhook_event_log', 'sequence')) {
+            // Sequence provides a stable FIFO order; the unique index supports fast ordering and prevents duplicates.
+            $connection->executeStatement(
+                'ALTER TABLE `webhook_event_log` ADD COLUMN `sequence` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, ADD UNIQUE INDEX `uniq.webhook_event_log_sequence` (`sequence`)'
+            );
+        }
+
+        $this->addColumn(
+            connection: $connection,
+            table: 'webhook_event_log',
+            column: 'execution_count',
+            type: 'INT',
+            nullable: false,
+            default: '0'
+        );
+
+        $this->addColumn(
+            connection: $connection,
+            table: 'webhook_event_log',
+            column: 'next_retry_at',
+            type: 'DATETIME(3)',
+            nullable: true
+        );
+
+        $this->addColumn(
+            connection: $connection,
+            table: 'webhook_event_log',
+            column: 'last_attempt_at',
+            type: 'DATETIME(3)',
+            nullable: true
+        );
+
+        if (!$this->indexExists($connection, 'webhook_event_log', 'idx_webhook_event_log_delivery_status_next_retry_at')) {
+            $connection->executeStatement('CREATE INDEX `idx_webhook_event_log_delivery_status_next_retry_at` ON `webhook_event_log` (`delivery_status`, `next_retry_at`)');
+        }
+
+        // Why BINARY(8)?
+        // 1. Storage Efficiency: Fixed 8 bytes vs variable string. Prevents index bloat as InnoDB secondary indexes include the PK.
+        // 2. Performance: Numeric byte comparison avoids charset/collation overhead.
+        // 3. Stability: Avoids key-length limits (3072 bytes) regardless of partition name length.
+        // 4. Algorithm: xxh3 (64-bit) ensures optimal distribution.
+        $this->addColumn(
+            connection: $connection,
+            table: 'webhook_event_log',
+            column: 'partition_key',
+            type: 'BINARY(8)',
+            nullable: true
+        );
+
+        // Primary outbox index: Covers fetchQueued, fetchPendingRetries, and EXISTS subqueries
+        // WHERE partition_key = ? AND delivery_status = ? ORDER BY sequence ASC
+        if (!$this->indexExists($connection, 'webhook_event_log', 'idx_webhook_event_log_partition_delivery_sequence')) {
+            $connection->executeStatement('CREATE INDEX `idx_webhook_event_log_partition_delivery_sequence` ON `webhook_event_log` (`partition_key`, `delivery_status`, `sequence`)');
+        }
+
+        // Index optimized for Auto-Recovery queries:
+        // FROM webhook_event_log
+        // WHERE delivery_status IN (:queued, :pending)
+        // AND created_at > DATE_SUB(NOW(3), INTERVAL 1 HOUR)
+        if (!$this->indexExists($connection, 'webhook_event_log', 'idx_webhook_event_log_execution_status_created_at')) {
+            $connection->executeStatement('CREATE INDEX `idx_webhook_event_log_execution_status_created_at` ON `webhook_event_log` (`delivery_status`, `created_at`, `partition_key`)');
+        }
+
+        if (!$this->indexExists($connection, 'webhook_event_log', 'idx_webhook_event_log_app_name_sequence')) {
+            // Matches partitioned FIFO lookups by app_name with ordering on sequence.
+            $connection->executeStatement('CREATE INDEX `idx_webhook_event_log_app_name_sequence` ON `webhook_event_log` (`app_name`, `sequence`)');
+        }
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1765542001AddWebhookStreamTable.php
+++ b/src/Core/Migration/V6_7/Migration1765542001AddWebhookStreamTable.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1765542001AddWebhookStreamTable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1765542001;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // partition_key is BINARY(8) to minimize index size (64-bit hash)
+        $connection->executeStatement('
+            CREATE TABLE IF NOT EXISTS `webhook_stream` (
+                `partition_key` BINARY(8) NOT NULL,
+                `locked_by` VARCHAR(255) NULL,
+                `lock_expires_at` DATETIME(3) NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                `error_count` INT NOT NULL DEFAULT 0,
+                PRIMARY KEY (`partition_key`),
+                INDEX `idx_webhook_stream_lock_expires_at` (`lock_expires_at`),
+                INDEX `idx_webhook_stream_locked_by` (`locked_by`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1765542002ImplementStreamLeasingSchema.php
+++ b/src/Core/Migration/V6_7/Migration1765542002ImplementStreamLeasingSchema.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1765542002ImplementStreamLeasingSchema extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1765542002;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // Create webhook_stream table for partition-based locking
+        $connection->executeStatement(
+            <<<SQL
+            CREATE TABLE IF NOT EXISTS `webhook_stream` (
+                `partition_key` BINARY(8) NOT NULL,
+                `last_processed_sequence_id` BIGINT UNSIGNED DEFAULT 0,
+                `locked_by` VARCHAR(255) NULL,
+                `lock_expires_at` DATETIME(3) NULL,
+                `status` ENUM('HEALTHY', 'SICK') DEFAULT 'HEALTHY',
+                `error_count` INT UNSIGNED DEFAULT 0,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`partition_key`),
+                INDEX `idx_webhook_stream_locked_by` (`locked_by`),
+                INDEX `idx_webhook_stream_lock_expires_at` (`lock_expires_at`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+            SQL
+        );
+    }
+}

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -40,6 +40,9 @@ use Shopware\Core\Framework\Webhook\Hookable\HookableEventFactory;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Service\WebhookLoader;
 use Shopware\Core\Framework\Webhook\Service\WebhookManager;
+use Shopware\Core\Framework\Webhook\Service\WebhookOutboxProcessor;
+use Shopware\Core\Framework\Webhook\Service\WebhookOutboxWriter;
+use Shopware\Core\Framework\Webhook\Service\WebhookWorkerRegistry;
 use Shopware\Core\Kernel;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -1060,7 +1063,6 @@ class WebhookManagerTest extends TestCase
         return new WebhookManager(
             static::getContainer()->get(WebhookLoader::class),
             static::getContainer()->get('event_dispatcher'),
-            static::getContainer()->get(Connection::class),
             static::getContainer()->get(HookableEventFactory::class),
             static::getContainer()->get(AppLocaleProvider::class),
             static::getContainer()->get(AppPayloadServiceHelper::class),
@@ -1068,7 +1070,10 @@ class WebhookManagerTest extends TestCase
             $this->bus,
             $this->shopUrl,
             Kernel::SHOPWARE_FALLBACK_VERSION,
-            $adminWorkerEnabled
+            $adminWorkerEnabled,
+            static::getContainer()->get(WebhookOutboxProcessor::class),
+            static::getContainer()->get(WebhookOutboxWriter::class),
+            false
         );
     }
 

--- a/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -30,6 +30,9 @@ use Shopware\Core\Framework\Webhook\Hookable\HookableEventFactory;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Service\WebhookLoader;
 use Shopware\Core\Framework\Webhook\Service\WebhookManager;
+use Shopware\Core\Framework\Webhook\Service\WebhookOutboxProcessor;
+use Shopware\Core\Framework\Webhook\Service\WebhookOutboxWriter;
+use Shopware\Core\Framework\Webhook\Service\WebhookWorkerRegistry;
 use Shopware\Core\Framework\Webhook\Webhook;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\MessageBus\CollectingMessageBus;
@@ -46,8 +49,6 @@ class WebhookManagerTest extends TestCase
 
     private EventDispatcherInterface&MockObject $eventDispatcher;
 
-    private Connection&MockObject $connection;
-
     private MockHandler $clientMock;
 
     private Client $client;
@@ -56,15 +57,20 @@ class WebhookManagerTest extends TestCase
 
     private CollectingMessageBus $bus;
 
+    private WebhookOutboxWriter&MockObject $outboxWriter;
+
+    private WebhookOutboxProcessor&MockObject $outboxProcessor;
+
     protected function setUp(): void
     {
         $this->webhookLoader = $this->createMock(WebhookLoader::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $this->connection = $this->createMock(Connection::class);
         $this->clientMock = new MockHandler([new Response(200)]);
         $this->client = new Client(['handler' => HandlerStack::create($this->clientMock)]);
         $this->eventFactory = $this->createMock(HookableEventFactory::class);
         $this->bus = new CollectingMessageBus();
+        $this->outboxWriter = $this->createMock(WebhookOutboxWriter::class);
+        $this->outboxProcessor = $this->createMock(WebhookOutboxProcessor::class);
     }
 
     public function testDispatchesTwoConsecutiveEventsCorrectly(): void
@@ -417,7 +423,6 @@ class WebhookManagerTest extends TestCase
         return new WebhookManager(
             $this->webhookLoader,
             $this->eventDispatcher,
-            $this->connection,
             $this->eventFactory,
             $this->createMock(AppLocaleProvider::class),
             $appPayloadServiceHelper,
@@ -425,7 +430,10 @@ class WebhookManagerTest extends TestCase
             $this->bus,
             'https://example.com',
             '0.0.0',
-            $isAdminWorkerEnabled
+            $isAdminWorkerEnabled,
+            $this->outboxProcessor,
+            $this->outboxWriter,
+            false
         );
     }
 


### PR DESCRIPTION
# Webhook Outbox Performance Analysis

This document provides empirical performance data supporting the architectural decisions in the Webhook Outbox Pattern implementation.

### Dataset Metadata
*   **Total Events**: ~5.6 Million rows
*   **Partitions**: 10 active partitions
    *   **Distribution**: Realistic skew (spanning 4% to 27% of total rows per partition)
    *   **Largest Partition**: ~1.5 million rows (`2EBE183CB9C28B41`)
*   **DB Engine**: MySQL 8.4.3
*   **Index Volume**: ~1.8 GB

## Overview
We tested two main scenarios: a "worst-case" backlog where almost everything is queued, and a realistic "steady-state" production environment where most events have been processed.

---

## 1. Scenario Analysis

### Scenario A: The Backlog Stress Test
This simulates a system that's falling behind or recovering from downtime.
*   **Conditions**: 5.6M rows total, 83% still queued for delivery.
*   **Why we test this**: To ensure valid pending events can be found quickly even when buried in a massive backlog.

#### Test Environment Breakdown
| Parameter | Value |
|-----------|-------|
| Queued Events | 4,700,778 (83.2%) |
| Pending Retry Events | 925,118 (16.4%) |
| Success/Failed | 24,008 (0.4%) |

#### Critical Path Analysis (Scenario A)

**1. Fetch Batch (`fetchQueued`)**

**SQL Pattern**:
```sql
SELECT * FROM webhook_event_log 
WHERE partition_key = ? 
  AND delivery_status = 'queued'
ORDER BY sequence ASC 
LIMIT 50
```

**Query Plan**:
```
type: ref
key: idx_webhook_event_log_partition_delivery_sequence
key_len: 1031
rows: 1,465,432
Extra: Using index condition
```

*   **Avg**: 0.092 ms
*   **Max**: 5.768 ms (cold cache)
*   **Observation**: First query shows cold cache effect, subsequent queries stabilize at sub-0.1ms.

**2. Fetch Retries (`fetchPendingRetries`)**

**SQL Pattern**:
```sql
SELECT * FROM webhook_event_log 
WHERE partition_key = ? 
  AND delivery_status = 'pending_retry'
  AND next_retry_at < NOW(3)
ORDER BY sequence ASC 
LIMIT 50
```

**Query Plan**:
```
type: ref
key: idx_webhook_event_log_partition_delivery_sequence
key_len: 1031
rows: 499,412
Extra: Using index condition; Using where
```

*   **Avg**: 0.020 ms
*   **Max**: 0.241 ms
*   **Observation**: Additional `next_retry_at` filter reduces result set; 16% of rows are `pending_retry`.

**3. Claim Stream (`claimNext`)**

**SQL Pattern**:
```sql
SELECT ws.partition_key 
FROM webhook_stream ws
WHERE (ws.locked_by IS NULL OR ws.lock_expires_at <= NOW(3))
  AND EXISTS (
      SELECT 1 FROM webhook_event_log wel 
      WHERE wel.partition_key = ws.partition_key 
        AND (wel.delivery_status = 'queued' 
             OR (wel.delivery_status = 'pending_retry' 
                 AND wel.next_retry_at <= NOW(3)))
  )
LIMIT 1
FOR UPDATE SKIP LOCKED
```

**Query Plan**:
```
table: ws
  type: ALL (10 rows)
  Extra: Using where

table: wel
  type: ref
  key: idx_webhook_event_log_partition_delivery_sequence
  Extra: Using index condition; Using where; FirstMatch(ws)
```

*   **Avg**: 0.007 ms
*   **Max**: 0.076 ms
*   **Observation**: `EXISTS` subquery uses `FirstMatch` optimization; terminates after finding first matching row.

### Scenario B: Realistic Production (Steady State)
This represents a healthy, running system.
*   **Conditions**: 5.6M rows total, but 74% are already `success` or `failed`. Only ~20% are queued.
*   **Why we test this**: Indices often behave differently when the target data is sparse. We need to verify that `success` rows don't bloat the index scans.

#### Test Environment Breakdown
| Parameter | Value |
|-----------|-------|
| Success Events | 3,204,508 (56.5%) |
| Failed Events | 1,012,100 (17.8%) |
| Queued Events | 1,109,178 (19.6%) |

#### SQL Benchmark Results (Scenario B)
| Query | Avg (ms) | Min (ms) | Max (ms) |
|-------|----------|----------|----------|
| fetchQueued | 0.027 | 0.001 | 1.207 |
| fetchPendingRetries | 0.005 | 0.001 | 0.046 |
| claimNext | 0.003 | 0.000 | 0.019 |

### Raw SQL Performance Comparison

| Query Operation | Backlog (Scenario A) | Steady State (Scenario B) | Improvement |
|-----------------|----------------------|---------------------------|-------------|
| **Fetch Batch** (`fetchQueued`) | 0.092 ms | **0.027 ms** | ~3.4x faster |
| **Fetch Retries** (`fetchPendingRetries`) | 0.020 ms | **0.005 ms** | ~4x faster |
| **Claim Stream** (`claimNext`) | 0.007 ms | **0.003 ms** | ~2x faster |

**What this tells us:**
The system actually gets *faster* as it processes more data. The composite index allows MySQL to efficiently ignore the millions of completed rows. We don't see any performance degradation as history accumulates.

### Maintenance Overhead
*   **Releasing Stream Lock**: ~0.25 ms (Update via Primary Key)
*   **Stream Heartbeat**: ~1.75 ms (Update via Primary Key)
*   **Stale Entry Reset**: ~0.27 ms (Bulk update scan, extremely fast when no rows are stuck)

---

## 2. End-to-End Application Benchmarks

We measured the full PHP application overhead (using `bin/console webhook:benchmark`), including Doctrine DBAL overhead, event dispatching, and transaction management.

### Baseline (Single Worker)
Without any contention, the application overhead is minimal:

| Operation | Metric | Avg Time | Throughput |
|-----------|--------|----------|------------|
| **Write** | Event Dispatch | **10.66 ms** | ~93 events/sec |
| **Consume** | Lock Acquisition | **1.33 ms** | - |
| **Consume** | Fetch Batch (50) | **10.95 ms** | - |
| **Consume** | Mark Processed | **2.30 ms** | ~430 events/sec |

### Stress Test
**100 concurrent writers vs. 10 consumers (110 Total Processes).**

Heavy I/O slowed ingestion and increased write latency significanty. However, consumers were largely unaffected, locking rows effectively with no deadlocks. `SKIP LOCKED` kept ingestion and processing independent.

| Metric | Baseline (Single) | Extreme Stress (110 Process) | Degradation |
|--------|-------------------|------------------------------|-------------|
| **Write Dispatch (Avg)** | 10.66 ms | **318 - 367 ms** | **~34x** |
| **Lock Acquisition (Avg)** | 1.33 ms | **7.5 - 11.4 ms** | **~8x** |
| **Fetch Batch (Avg)** | 10.95 ms | **24.5 - 45.1 ms** | **~3x** |

**Throughput Analysis:**
- **Total Write Throughput**: ~277 events/sec (sustained over 18s).
- **System Stability**: 0 Errors, 0 Deadlocks observed.

---

## 3. Key Observations & Takeaways

After reviewing the results, these points stand out:

- **SKIP LOCKED works as expected.** Even with 110 concurrent processes, consumers were not blocked. They skipped locked rows and continued processing, which is ideal for parallel workloads. Lock acquisition time remains under 12ms even with massive contention.

- **The index works because of good selectivity.** The `(partition_key, delivery_status, sequence)` index is very effective. In steady state, it jumps straight to the needed rows and ignores large amounts of old data.

- **Partition size had no impact.** Partitions ranged from 200k to 1.5M rows, but query times were the same. B-tree depth differences were negligible.

- **Write Path is the Bottleneck.** Under extreme stress, write latency degrades by ~34x due to I/O limits. However, the system degrades gracefully without crashing.

---

## Appendix: Technical Details

### Test Environment
*   **Database**: MySQL 8.4.3 (Docker)
*   **Dataset**: ~5.6 Million rows
*   **Partitions**: 10 distinct partitions

### Concurrency Stress Test
Simulates multiple workers competing for stream locks using `FOR UPDATE SKIP LOCKED`.

| Workers | Streams Locked | Avg (ms) | Min (ms) | Max (ms) |
|---------|----------------|----------|----------|----------|
| 2 | 1 | 0.008 | 0.001 | 0.070 |
| 4 | 3 | 0.007 | 0.001 | 0.059 |
| 6 | 5 | 0.007 | 0.001 | 0.061 |

**Conclusion**: Lock contention does not degrade query performance. Latency remains sub-0.15ms regardless of concurrent worker count.
