### PR TITLE
fix: rename criteria property in Admin API sync definition

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sync.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sync.json
@@ -66,7 +66,7 @@
                                                 "type": "object"
                                             }
                                         },
-                                        "filter": {
+                                        "criteria": {
                                             "description": "Only for delete operations: Instead of providing IDs in the payload, the filter by which should be deleted can be provided directly.",
                                             "type": "array",
                                             "items": {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The OpenAPI definition for `/api/_action/sync` does not match the related PHP code.

In the definition the property is called `filter`. In the code the value is actually read from the `criteria` property, see the [SyncOperation class](https://github.com/shopware/shopware/blob/trunk/src/Core/Framework/Api/Sync/SyncOperation.php#L131)

See also:

https://shopware.stoplight.io/docs/admin-api/faf8f8e4e13a0-bulk-payloads#deleting-mapping-entities-via-criteria


### 2. What does this change do, exactly?

Replace the property name `filter` with `criteria` in `src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sync.json`


### 3. Describe each step to reproduce the issue or behaviour.

Executing a delete action with the `filter` property will fail:

> Missing "payload"|"criteria" argument for operation with key "delete-with-criteria". It needs to be a non-empty array.

```bash
curl -X POST --location "http://localhost/api/_action/sync" \
-H "Accept: application/json" \
-H "Authorization: Bearer xxx" \
-H "Content-Type: application/json" \
-d '{
"delete-with-criteria": {
"entity": "product",
"action": "delete",
"filter": [
{
"type": "equals",
"field": "productNumber",
"value": "test"
}]}}'
```

Replace "filter" with "criteria" and it will work.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
