### PR TITLE
feat: Changed MaintenanceResolver to set current path for the user being redirected afterwards

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,6 +6,7 @@
 
 All symfony packages have been updated to version 7.4. 
 Take a look at the [Symfony 7.4 release post](https://symfony.com/blog/symfony-7-4-0-released) for more information.
+
 ### Changed maintenance mode redirect
 After maintenance ends, users are now redirected back to the page they were on before maintenance.
 Previously, users were always redirected to the shop homepage.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,6 +6,9 @@
 
 All symfony packages have been updated to version 7.4. 
 Take a look at the [Symfony 7.4 release post](https://symfony.com/blog/symfony-7-4-0-released) for more information.
+### Changed maintenance mode redirect
+After maintenance ends, users are now redirected back to the page they were on before maintenance.
+Previously, users were always redirected to the shop homepage.
 
 ### Support of media paths with up to 2046 characters
 Previously the maximum length for media paths was limited to 255 characters (due to default StringField limit) while the

--- a/src/Core/PlatformRequest.php
+++ b/src/Core/PlatformRequest.php
@@ -77,6 +77,18 @@ final class PlatformRequest
     public const ATTRIBUTE_LOGIN_REQUIRED_ALLOW_GUEST = '_loginRequiredAllowGuest';
     public const ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE = 'allow_maintenance';
 
+    public const ATTRIBUTE_INTERNAL_ROUTE_PARAMS = [
+        self::ATTRIBUTE_CAPTCHA,
+        self::ATTRIBUTE_ROUTE_SCOPE,
+        self::ATTRIBUTE_ENTITY,
+        self::ATTRIBUTE_NO_STORE,
+        self::ATTRIBUTE_HTTP_CACHE,
+        self::ATTRIBUTE_CONTEXT_TOKEN_REQUIRED,
+        self::ATTRIBUTE_LOGIN_REQUIRED,
+        self::ATTRIBUTE_LOGIN_REQUIRED_ALLOW_GUEST,
+        self::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE,
+    ];
+
     /**
      * CSP
      */

--- a/src/Storefront/Controller/MaintenanceController.php
+++ b/src/Storefront/Controller/MaintenanceController.php
@@ -46,13 +46,15 @@ class MaintenanceController extends StorefrontController
     )]
     public function renderMaintenancePage(Request $request, SalesChannelContext $context): ?Response
     {
-        $salesChannel = $context->getSalesChannel();
-
         if ($this->maintenanceModeResolver->shouldRedirectToShop($request)) {
+            if ($request->get('redirectTo')) {
+                return $this->createActionResponse($request);
+            }
+
             return $this->redirectToRoute('frontend.home.page');
         }
 
-        $salesChannelId = $salesChannel->getId();
+        $salesChannelId = $context->getSalesChannelId();
         $maintenanceLayoutId = $this->systemConfigService->getString('core.basicInformation.maintenancePage', $salesChannelId);
 
         if ($maintenanceLayoutId === '') {

--- a/src/Storefront/Controller/MaintenanceController.php
+++ b/src/Storefront/Controller/MaintenanceController.php
@@ -47,7 +47,7 @@ class MaintenanceController extends StorefrontController
     public function renderMaintenancePage(Request $request, SalesChannelContext $context): ?Response
     {
         if ($this->maintenanceModeResolver->shouldRedirectToShop($request)) {
-            if ($request->get('redirectTo')) {
+            if ($request->query->getString('redirectTo') !== '') {
                 return $this->createActionResponse($request);
             }
 

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -177,6 +177,7 @@
             <argument type="service" id="router"/>
             <argument type="service" id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="event_dispatcher"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Storefront/Event/MaintenanceRedirectEvent.php
+++ b/src/Storefront/Event/MaintenanceRedirectEvent.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Event;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+class MaintenanceRedirectEvent extends StorefrontRedirectEvent
+{
+}

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -17,6 +17,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -173,9 +174,22 @@ class StorefrontSubscriber implements EventSubscriberInterface
 
     public function maintenanceResolver(RequestEvent $event): void
     {
-        if ($this->maintenanceModeResolver->shouldRedirect($event->getRequest())) {
+        $request = $event->getRequest();
+
+        if ($this->maintenanceModeResolver->shouldRedirect($request)) {
+            $parameters = [];
+            $route = $request->attributes->get('_route');
+            if ($route !== null) {
+                $parameters['redirectTo'] = $route;
+                $requestParameters = $this->getRequestParameters($request);
+
+                if ($requestParameters !== []) {
+                    $parameters['redirectParameters'] = json_encode($requestParameters, \JSON_THROW_ON_ERROR);
+                }
+            }
+
             $event->setResponse(
-                new RedirectResponse($this->router->generate('frontend.maintenance.page'), Response::HTTP_TEMPORARY_REDIRECT)
+                new RedirectResponse($this->router->generate('frontend.maintenance.page', $parameters), Response::HTTP_TEMPORARY_REDIRECT)
             );
         }
     }
@@ -243,5 +257,24 @@ class StorefrontSubscriber implements EventSubscriberInterface
         }
 
         return false;
+    }
+
+    private function getRequestParameters(Request $request): array
+    {
+        $requestParameters = $request->query->all();
+        $routeParams = $request->attributes->get('_route_params');
+
+        if (\is_array($routeParams)) {
+            foreach ($routeParams as $key => $value) {
+                // we don't want any default route parameter, e.g. _httpCache or _store
+                if (\str_starts_with($key, '_')) {
+                    continue;
+                }
+
+                $requestParameters[$key] = $value;
+            }
+        }
+
+        return $requestParameters;
     }
 }

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -15,6 +15,7 @@ use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Storefront\Event\MaintenanceRedirectEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,6 +27,7 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
@@ -41,6 +43,7 @@ class StorefrontSubscriber implements EventSubscriberInterface
         private readonly RouterInterface $router,
         private readonly MaintenanceModeResolver $maintenanceModeResolver,
         private readonly SystemConfigService $systemConfigService,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -188,8 +191,11 @@ class StorefrontSubscriber implements EventSubscriberInterface
                 }
             }
 
+            $redirectEvent = new MaintenanceRedirectEvent('frontend.maintenance.page', $parameters, Response::HTTP_TEMPORARY_REDIRECT);
+            $this->eventDispatcher->dispatch($redirectEvent);
+
             $event->setResponse(
-                new RedirectResponse($this->router->generate('frontend.maintenance.page', $parameters), Response::HTTP_TEMPORARY_REDIRECT)
+                new RedirectResponse($this->router->generate($redirectEvent->getRoute(), $redirectEvent->getParameters()), $redirectEvent->getStatus())
             );
         }
     }

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -265,6 +265,9 @@ class StorefrontSubscriber implements EventSubscriberInterface
         return false;
     }
 
+    /**
+     * @return array<int|string, mixed>
+     */
     private function getRequestParameters(Request $request): array
     {
         $requestParameters = $request->query->all();

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -267,7 +267,7 @@ class StorefrontSubscriber implements EventSubscriberInterface
         if (\is_array($routeParams)) {
             foreach ($routeParams as $key => $value) {
                 // we don't want any default route parameter, e.g. _httpCache or _store
-                if (\str_starts_with($key, '_')) {
+                if (\in_array($key, PlatformRequest::ATTRIBUTE_INTERNAL_ROUTE_PARAMS, true)) {
                     continue;
                 }
 

--- a/tests/unit/Storefront/Controller/MaintenanceControllerTest.php
+++ b/tests/unit/Storefront/Controller/MaintenanceControllerTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\Generator;
+use Shopware\Storefront\Controller\MaintenanceController;
+use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
+use Shopware\Storefront\Page\Maintenance\MaintenancePageLoader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(MaintenanceController::class)]
+class MaintenanceControllerTest extends TestCase
+{
+    public function testMaintenanceRedirectToShopWithRedirectTo(): void
+    {
+        $maintenanceModeResolver = $this->createMock(MaintenanceModeResolver::class);
+        $maintenanceModeResolver->method('shouldRedirectToShop')
+            ->willReturn(true);
+
+        $controller = new MaintenanceController(
+            $this->createMock(SystemConfigService::class),
+            $this->createMock(MaintenancePageLoader::class),
+            $maintenanceModeResolver
+        );
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with('foo', ['foo' => 'bar'], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/foo/generated');
+
+        $request = new Request(
+            [
+                'redirectTo' => 'foo',
+                'redirectParameters' => ['foo' => 'bar'],
+            ]
+        );
+
+        $container = new ContainerBuilder();
+        $container->set('router', $router);
+        $container->set('event_dispatcher', $this->createMock(EventDispatcherInterface::class));
+
+        $controller->setContainer($container);
+
+        $context = Generator::generateSalesChannelContext();
+
+        $response = $controller->renderMaintenancePage($request, $context);
+
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/foo/generated', $response->getTargetUrl());
+    }
+}

--- a/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
+use Shopware\Storefront\Event\MaintenanceRedirectEvent;
 use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
 use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
 use Shopware\Storefront\Framework\Routing\StorefrontSubscriber;
@@ -85,17 +86,82 @@ class StorefrontSubscriberTest extends TestCase
             HttpKernelInterface::MAIN_REQUEST
         );
 
+        $eventDispatcher = new EventDispatcher();
+        $eventIsThrown = false;
+        $eventDispatcher->addListener(
+            MaintenanceRedirectEvent::class,
+            function () use (&$eventIsThrown): void {
+                $eventIsThrown = true;
+            }
+        );
+
         (new StorefrontSubscriber(
             new RequestStack(),
             $router,
             $maintenanceModeResolver,
             new StaticSystemConfigService(),
-            new EventDispatcher(),
+            $eventDispatcher,
         ))->maintenanceResolver($event);
 
         $response = $event->getResponse();
         static::assertInstanceOf(RedirectResponse::class, $response);
         static::assertSame('/maintenance', $response->getTargetUrl());
+        static::assertTrue($eventIsThrown);
+    }
+
+    public function testMaintenanceParametersRedirect(): void
+    {
+        $maintenanceModeResolver = $this->createMock(MaintenanceModeResolver::class);
+        $maintenanceModeResolver
+            ->method('shouldRedirect')
+            ->willReturn(true);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')->willReturn('/maintenance?foo=bar');
+
+        $request = new Request(
+            query: [
+                'bar' => 'foo',
+            ],
+            attributes: [
+                '_route' => 'product_page',
+                '_route_params' => [
+                    'foo' => 'bar',
+                    'productId' => 123,
+                    PlatformRequest::ATTRIBUTE_INTERNAL_ROUTE_PARAMS[0] => true,
+                    PlatformRequest::ATTRIBUTE_INTERNAL_ROUTE_PARAMS[1] => true,
+                ],
+            ],
+        );
+
+        $event = new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $eventDispatcher = new EventDispatcher();
+        $eventIsThrown = false;
+        $eventDispatcher->addListener(
+            MaintenanceRedirectEvent::class,
+            function (MaintenanceRedirectEvent $event) use (&$eventIsThrown): void {
+                $parameters = $event->getParameters();
+                static::assertEquals('product_page', $parameters['redirectTo']);
+                static::assertEquals('{"bar":"foo","foo":"bar","productId":123}', $parameters['redirectParameters']);
+
+                $eventIsThrown = true;
+            }
+        );
+
+        (new StorefrontSubscriber(
+            new RequestStack(),
+            $router,
+            $maintenanceModeResolver,
+            new StaticSystemConfigService(),
+            $eventDispatcher,
+        ))->maintenanceResolver($event);
+
+        static::assertTrue($eventIsThrown);
     }
 
     public function testRedirectLoginPageWhenCustomerNotLoggedInWithRoutingException(): void

--- a/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
 use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
 use Shopware\Storefront\Framework\Routing\StorefrontSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -89,6 +90,7 @@ class StorefrontSubscriberTest extends TestCase
             $router,
             $maintenanceModeResolver,
             new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->maintenanceResolver($event);
 
         $response = $event->getResponse();
@@ -120,6 +122,7 @@ class StorefrontSubscriberTest extends TestCase
             $router,
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->customerNotLoggedInHandler($event);
 
         static::assertInstanceOf(RedirectResponse::class, $event->getResponse());
@@ -139,6 +142,7 @@ class StorefrontSubscriberTest extends TestCase
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->customerNotLoggedInHandler($event);
 
         static::assertFalse($event->hasResponse());
@@ -168,6 +172,7 @@ class StorefrontSubscriberTest extends TestCase
             $router,
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->customerNotLoggedInHandler($event);
 
         static::assertInstanceOf(RedirectResponse::class, $event->getResponse());
@@ -193,6 +198,7 @@ class StorefrontSubscriberTest extends TestCase
             $router,
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->customerNotLoggedInHandler($event);
     }
 
@@ -221,6 +227,7 @@ class StorefrontSubscriberTest extends TestCase
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->preventPageLoadingFromXmlHttpRequest($event);
     }
 
@@ -272,6 +279,7 @@ class StorefrontSubscriberTest extends TestCase
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->startSession();
 
         static::assertTrue($request->getSession()->has('sessionId'));
@@ -298,6 +306,7 @@ class StorefrontSubscriberTest extends TestCase
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
             new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->startSession();
 
         $subRequestContextToken = $subRequest->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN);
@@ -313,7 +322,8 @@ class StorefrontSubscriberTest extends TestCase
             $requestStack,
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
-            new StaticSystemConfigService()
+            new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->updateSession(self::TEST_CONTEXT_TOKEN);
 
         static::assertNull($requestStack->getCurrentRequest());
@@ -327,7 +337,8 @@ class StorefrontSubscriberTest extends TestCase
             new RequestStack([$request]),
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
-            new StaticSystemConfigService()
+            new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->updateSession(self::TEST_CONTEXT_TOKEN);
 
         static::assertNull($request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
@@ -342,7 +353,8 @@ class StorefrontSubscriberTest extends TestCase
             $requestStack,
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
-            new StaticSystemConfigService()
+            new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->updateSession(self::TEST_CONTEXT_TOKEN);
 
         static::assertNull($request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
@@ -358,7 +370,8 @@ class StorefrontSubscriberTest extends TestCase
             $requestStack,
             $this->createMock(RouterInterface::class),
             $this->createMock(MaintenanceModeResolver::class),
-            new StaticSystemConfigService()
+            new StaticSystemConfigService(),
+            new EventDispatcher(),
         ))->updateSession(self::TEST_CONTEXT_TOKEN);
 
         static::assertSame(self::TEST_CONTEXT_TOKEN, $request->getSession()->get(PlatformRequest::HEADER_CONTEXT_TOKEN));


### PR DESCRIPTION
### 1. Why is this change necessary?

When the shop is in maintenance mode, the users are forwarded to "/maintenance".
After the maintenance the customers are just forwarded to the `home.page`, but not to the path they were on before.
This is frustrating for visitors.

### 2. What does this change do, exactly?

Set and handle `redirectTo` parameter.

### 3. Describe each step to reproduce the issue or behaviour.

- Visit product listing.
- activate maintenance mode
- click onto product detail
- being redirected to maintenace page
- disable maintenance mode
- wait 30 seconds (there is a auto-refresh via JS) or just press F5
- now: the user is forwarded back to his previous location (product detail)

https://github.com/user-attachments/assets/5873d8bd-413c-499d-ba44-d5b6a070306f



### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
