### PR TITLE
fix: Allow dynamic properties on test struct

### DIFF
--- a/tests/unit/Core/Framework/Struct/AssignArrayTraitTest.php
+++ b/tests/unit/Core/Framework/Struct/AssignArrayTraitTest.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Struct\AssignArrayTrait;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Tests\Unit\Core\Framework\Struct\Fixture\AssignTestCollection;
+use Shopware\Tests\Unit\Core\Framework\Struct\Fixture\AssignTestStruct;
 
 /**
  * @internal

--- a/tests/unit/Core/Framework/Struct/CloneStructTest.php
+++ b/tests/unit/Core/Framework/Struct/CloneStructTest.php
@@ -14,11 +14,11 @@ class CloneStructTest extends TestCase
 {
     public function testClone(): void
     {
-        $nestedStruct = new CloneStruct();
+        $nestedStruct = new Fixture\CloneStruct();
         $nestedStruct->backedEnum = CloneStructBackedEnum::Case;
         $nestedStruct->unitEnum = CloneStructUnitEnum::Case;
 
-        $original = new CloneStruct();
+        $original = new Fixture\CloneStruct();
         $original->arrayOfStructs = [$nestedStruct];
         $original->backedEnum = CloneStructBackedEnum::Case;
         $original->nestedStruct = $nestedStruct;
@@ -32,25 +32,6 @@ class CloneStructTest extends TestCase
         static::assertNotSame($original->arrayOfStructs[0], $clone->arrayOfStructs[0]);
         static::assertNotSame($original->nestedStruct, $clone->nestedStruct);
     }
-}
-
-/**
- * @internal
- */
-class CloneStruct
-{
-    use CloneTrait;
-
-    /**
-     * @var array<array-key, CloneStruct>
-     */
-    public array $arrayOfStructs;
-
-    public CloneStructBackedEnum $backedEnum;
-
-    public CloneStructUnitEnum $unitEnum;
-
-    public CloneStruct $nestedStruct;
 }
 
 /**

--- a/tests/unit/Core/Framework/Struct/CloneStructTest.php
+++ b/tests/unit/Core/Framework/Struct/CloneStructTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Struct\CloneTrait;
 use Shopware\Tests\Unit\Core\Framework\Struct\Fixture\CloneStruct;
+use Shopware\Tests\Unit\Core\Framework\Struct\Fixture\CloneStructBackedEnum;
+use Shopware\Tests\Unit\Core\Framework\Struct\Fixture\CloneStructUnitEnum;
 
 /**
  * @internal
@@ -16,14 +18,14 @@ class CloneStructTest extends TestCase
     public function testClone(): void
     {
         $nestedStruct = new CloneStruct();
-        $nestedStruct->backedEnum = Fixture\CloneStructBackedEnum::Case;
-        $nestedStruct->unitEnum = Fixture\CloneStructUnitEnum::Case;
+        $nestedStruct->backedEnum = CloneStructBackedEnum::Case;
+        $nestedStruct->unitEnum = CloneStructUnitEnum::Case;
 
         $original = new CloneStruct();
         $original->arrayOfStructs = [$nestedStruct];
-        $original->backedEnum = Fixture\CloneStructBackedEnum::Case;
+        $original->backedEnum = CloneStructBackedEnum::Case;
         $original->nestedStruct = $nestedStruct;
-        $original->unitEnum = Fixture\CloneStructUnitEnum::Case;
+        $original->unitEnum = CloneStructUnitEnum::Case;
 
         $clone = clone $original;
 

--- a/tests/unit/Core/Framework/Struct/CloneStructTest.php
+++ b/tests/unit/Core/Framework/Struct/CloneStructTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Framework\Struct;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Struct\CloneTrait;
+use Shopware\Tests\Unit\Core\Framework\Struct\Fixture\CloneStruct;
 
 /**
  * @internal
@@ -14,15 +15,15 @@ class CloneStructTest extends TestCase
 {
     public function testClone(): void
     {
-        $nestedStruct = new Fixture\CloneStruct();
-        $nestedStruct->backedEnum = CloneStructBackedEnum::Case;
-        $nestedStruct->unitEnum = CloneStructUnitEnum::Case;
+        $nestedStruct = new CloneStruct();
+        $nestedStruct->backedEnum = Fixture\CloneStructBackedEnum::Case;
+        $nestedStruct->unitEnum = Fixture\CloneStructUnitEnum::Case;
 
-        $original = new Fixture\CloneStruct();
+        $original = new CloneStruct();
         $original->arrayOfStructs = [$nestedStruct];
-        $original->backedEnum = CloneStructBackedEnum::Case;
+        $original->backedEnum = Fixture\CloneStructBackedEnum::Case;
         $original->nestedStruct = $nestedStruct;
-        $original->unitEnum = CloneStructUnitEnum::Case;
+        $original->unitEnum = Fixture\CloneStructUnitEnum::Case;
 
         $clone = clone $original;
 
@@ -32,20 +33,4 @@ class CloneStructTest extends TestCase
         static::assertNotSame($original->arrayOfStructs[0], $clone->arrayOfStructs[0]);
         static::assertNotSame($original->nestedStruct, $clone->nestedStruct);
     }
-}
-
-/**
- * @internal
- */
-enum CloneStructBackedEnum: int
-{
-    case Case = 1;
-}
-
-/**
- * @internal
- */
-enum CloneStructUnitEnum
-{
-    case Case;
 }

--- a/tests/unit/Core/Framework/Struct/CollectionTest.php
+++ b/tests/unit/Core/Framework/Struct/CollectionTest.php
@@ -21,7 +21,7 @@ class CollectionTest extends TestCase
     public function testConstructor(): void
     {
         $elements = ['a', 'b'];
-        $collection = new TestCollection($elements);
+        $collection = new Fixture\TestCollection($elements);
 
         static::assertSame($elements, $collection->getElements());
     }
@@ -29,14 +29,14 @@ class CollectionTest extends TestCase
     public function testConstructorKeepingKeys(): void
     {
         $elements = ['z' => 'a', 'y' => 'b'];
-        $collection = new TestCollection($elements);
+        $collection = new Fixture\TestCollection($elements);
 
         static::assertSame($elements, $collection->getElements());
     }
 
     public function testClear(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         $collection->add('a');
         $collection->add('b');
 
@@ -46,7 +46,7 @@ class CollectionTest extends TestCase
 
     public function testCount(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertCount(0, $collection);
 
         $collection->add('a');
@@ -56,7 +56,7 @@ class CollectionTest extends TestCase
 
     public function testGetNumericKeys(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertSame([], $collection->getKeys());
 
         $collection->add('a');
@@ -66,7 +66,7 @@ class CollectionTest extends TestCase
 
     public function testHasWithNumericKey(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertFalse($collection->has(0));
 
         $collection->add('a');
@@ -77,7 +77,7 @@ class CollectionTest extends TestCase
 
     public function testMap(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         $collection->map(function (): void {
             static::fail('map should not be called for empty collection');
         });
@@ -90,7 +90,7 @@ class CollectionTest extends TestCase
 
     public function testFmap(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         $collection->fmap(function (): void {
             static::fail('fmap should not be called for empty collection');
         });
@@ -103,7 +103,7 @@ class CollectionTest extends TestCase
 
     public function testSort(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
 
         $collection->sort(function (): void {
             static::fail('fmap should not be called for empty collection');
@@ -122,7 +122,7 @@ class CollectionTest extends TestCase
     {
         $productStruct = new ProductEntity();
         $categoryStruct = new CategoryEntity();
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertCount(0, $collection->filterInstance(ProductEntity::class));
 
         $collection->add('a');
@@ -135,7 +135,7 @@ class CollectionTest extends TestCase
 
     public function testFilter(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         $collection->filter(function (): void {
             static::fail('filter should not be called for empty collection');
         });
@@ -150,7 +150,7 @@ class CollectionTest extends TestCase
 
     public function testSlice(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertEmpty($collection->slice(0)->getElements());
 
         $collection->add('a');
@@ -164,7 +164,7 @@ class CollectionTest extends TestCase
     public function testGetElements(): void
     {
         $elements = ['a', 'b'];
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertSame([], $collection->getElements());
 
         $collection->add('a');
@@ -176,7 +176,7 @@ class CollectionTest extends TestCase
     public function testJsonSerialize(): void
     {
         $elements = ['a', 'b'];
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertSame(
             [],
             $collection->jsonSerialize()
@@ -193,7 +193,7 @@ class CollectionTest extends TestCase
 
     public function testFirst(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertNull($collection->first());
 
         $collection->add('a');
@@ -204,7 +204,7 @@ class CollectionTest extends TestCase
 
     public function testLast(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertNull($collection->last());
 
         $collection->add('a');
@@ -215,7 +215,7 @@ class CollectionTest extends TestCase
 
     public function testGetAt(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertFalse($collection->has(0));
 
         $collection->add('a');
@@ -226,13 +226,13 @@ class CollectionTest extends TestCase
 
     public function testFirstWhereWithEmptyCollectionWillReturnNull(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         static::assertNull($collection->firstWhere(fn ($element) => $element === 'a'));
     }
 
     public function testFirstWhereWithMatchingElementWillReturnFirstElement(): void
     {
-        $collection = new TestCollection();
+        $collection = new Fixture\TestCollection();
         $collection->add('a1');
         $collection->add('a2');
         $collection->add('a3');
@@ -249,7 +249,7 @@ class CollectionTest extends TestCase
             ['some' => 'value'],
         ];
 
-        $collection = (new TestCollection())->assignRecursive($data);
+        $collection = (new Fixture\TestCollection())->assignRecursive($data);
 
         static::assertCount(5, $collection);
 
@@ -265,7 +265,7 @@ class CollectionTest extends TestCase
         $data = [
             'some-string',
             new \stdClass(),
-            ['id' => Uuid::randomHex(), 'versionId' => Uuid::randomHex()], // Entity class has no setId method
+            ['versionId' => Uuid::randomHex()], // Entity class has no setId method
             ['_uniqueIdentifier' => Uuid::randomHex(), 'versionId' => Uuid::randomHex()],
         ];
 
@@ -275,15 +275,4 @@ class CollectionTest extends TestCase
         static::assertInstanceOf(Entity::class, $collection->first());
         static::assertNotNull($collection->first()->getVersionId());
     }
-}
-
-/**
- * @internal
- *
- * @template TElement
- *
- * @extends Collection<TElement>
- */
-class TestCollection extends Collection
-{
 }

--- a/tests/unit/Core/Framework/Struct/CollectionTest.php
+++ b/tests/unit/Core/Framework/Struct/CollectionTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Struct\Collection;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Tests\Unit\Core\Framework\Struct\Fixture\TestCollection;
 
 /**
  * @internal
@@ -21,7 +22,7 @@ class CollectionTest extends TestCase
     public function testConstructor(): void
     {
         $elements = ['a', 'b'];
-        $collection = new Fixture\TestCollection($elements);
+        $collection = new TestCollection($elements);
 
         static::assertSame($elements, $collection->getElements());
     }
@@ -29,14 +30,14 @@ class CollectionTest extends TestCase
     public function testConstructorKeepingKeys(): void
     {
         $elements = ['z' => 'a', 'y' => 'b'];
-        $collection = new Fixture\TestCollection($elements);
+        $collection = new TestCollection($elements);
 
         static::assertSame($elements, $collection->getElements());
     }
 
     public function testClear(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         $collection->add('a');
         $collection->add('b');
 
@@ -46,7 +47,7 @@ class CollectionTest extends TestCase
 
     public function testCount(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertCount(0, $collection);
 
         $collection->add('a');
@@ -56,7 +57,7 @@ class CollectionTest extends TestCase
 
     public function testGetNumericKeys(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertSame([], $collection->getKeys());
 
         $collection->add('a');
@@ -66,7 +67,7 @@ class CollectionTest extends TestCase
 
     public function testHasWithNumericKey(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertFalse($collection->has(0));
 
         $collection->add('a');
@@ -77,7 +78,7 @@ class CollectionTest extends TestCase
 
     public function testMap(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         $collection->map(function (): void {
             static::fail('map should not be called for empty collection');
         });
@@ -90,7 +91,7 @@ class CollectionTest extends TestCase
 
     public function testFmap(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         $collection->fmap(function (): void {
             static::fail('fmap should not be called for empty collection');
         });
@@ -103,7 +104,7 @@ class CollectionTest extends TestCase
 
     public function testSort(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
 
         $collection->sort(function (): void {
             static::fail('fmap should not be called for empty collection');
@@ -122,7 +123,7 @@ class CollectionTest extends TestCase
     {
         $productStruct = new ProductEntity();
         $categoryStruct = new CategoryEntity();
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertCount(0, $collection->filterInstance(ProductEntity::class));
 
         $collection->add('a');
@@ -135,7 +136,7 @@ class CollectionTest extends TestCase
 
     public function testFilter(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         $collection->filter(function (): void {
             static::fail('filter should not be called for empty collection');
         });
@@ -150,7 +151,7 @@ class CollectionTest extends TestCase
 
     public function testSlice(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertEmpty($collection->slice(0)->getElements());
 
         $collection->add('a');
@@ -164,7 +165,7 @@ class CollectionTest extends TestCase
     public function testGetElements(): void
     {
         $elements = ['a', 'b'];
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertSame([], $collection->getElements());
 
         $collection->add('a');
@@ -176,7 +177,7 @@ class CollectionTest extends TestCase
     public function testJsonSerialize(): void
     {
         $elements = ['a', 'b'];
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertSame(
             [],
             $collection->jsonSerialize()
@@ -193,7 +194,7 @@ class CollectionTest extends TestCase
 
     public function testFirst(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertNull($collection->first());
 
         $collection->add('a');
@@ -204,7 +205,7 @@ class CollectionTest extends TestCase
 
     public function testLast(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertNull($collection->last());
 
         $collection->add('a');
@@ -215,7 +216,7 @@ class CollectionTest extends TestCase
 
     public function testGetAt(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertFalse($collection->has(0));
 
         $collection->add('a');
@@ -226,13 +227,13 @@ class CollectionTest extends TestCase
 
     public function testFirstWhereWithEmptyCollectionWillReturnNull(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         static::assertNull($collection->firstWhere(fn ($element) => $element === 'a'));
     }
 
     public function testFirstWhereWithMatchingElementWillReturnFirstElement(): void
     {
-        $collection = new Fixture\TestCollection();
+        $collection = new TestCollection();
         $collection->add('a1');
         $collection->add('a2');
         $collection->add('a3');
@@ -249,7 +250,7 @@ class CollectionTest extends TestCase
             ['some' => 'value'],
         ];
 
-        $collection = (new Fixture\TestCollection())->assignRecursive($data);
+        $collection = (new TestCollection())->assignRecursive($data);
 
         static::assertCount(5, $collection);
 
@@ -265,7 +266,7 @@ class CollectionTest extends TestCase
         $data = [
             'some-string',
             new \stdClass(),
-            ['versionId' => Uuid::randomHex()], // Entity class has no setId method
+            ['versionId' => Uuid::randomHex()],
             ['_uniqueIdentifier' => Uuid::randomHex(), 'versionId' => Uuid::randomHex()],
         ];
 

--- a/tests/unit/Core/Framework/Struct/Fixture/AssignTestCollection.php
+++ b/tests/unit/Core/Framework/Struct/Fixture/AssignTestCollection.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Unit\Core\Framework\Struct;
+namespace Shopware\Tests\Unit\Core\Framework\Struct\Fixture;
 
 use Shopware\Core\Framework\Struct\Collection;
 

--- a/tests/unit/Core/Framework/Struct/Fixture/AssignTestStruct.php
+++ b/tests/unit/Core/Framework/Struct/Fixture/AssignTestStruct.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Unit\Core\Framework\Struct;
+namespace Shopware\Tests\Unit\Core\Framework\Struct\Fixture;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Struct\Struct;
 /**
  * @internal
  */
+#[\AllowDynamicProperties]
 class AssignTestStruct extends Struct
 {
     use EntityIdTrait;

--- a/tests/unit/Core/Framework/Struct/Fixture/CloneStruct.php
+++ b/tests/unit/Core/Framework/Struct/Fixture/CloneStruct.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct\Fixture;
+
+use Shopware\Core\Framework\Struct\CloneTrait;
+use Shopware\Tests\Unit\Core\Framework\Struct\CloneStructBackedEnum;
+use Shopware\Tests\Unit\Core\Framework\Struct\CloneStructUnitEnum;
+
+/**
+ * @internal
+ */
+class CloneStruct
+{
+    use CloneTrait;
+
+    /**
+     * @var array<array-key, CloneStruct>
+     */
+    public array $arrayOfStructs;
+
+    public CloneStructBackedEnum $backedEnum;
+
+    public CloneStructUnitEnum $unitEnum;
+
+    public CloneStruct $nestedStruct;
+}

--- a/tests/unit/Core/Framework/Struct/Fixture/CloneStruct.php
+++ b/tests/unit/Core/Framework/Struct/Fixture/CloneStruct.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Shopware\Tests\Unit\Core\Framework\Struct\Fixture;
 
 use Shopware\Core\Framework\Struct\CloneTrait;
-use Shopware\Tests\Unit\Core\Framework\Struct\CloneStructBackedEnum;
-use Shopware\Tests\Unit\Core\Framework\Struct\CloneStructUnitEnum;
 
 /**
  * @internal

--- a/tests/unit/Core/Framework/Struct/Fixture/CloneStructBackedEnum.php
+++ b/tests/unit/Core/Framework/Struct/Fixture/CloneStructBackedEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct\Fixture;
+
+/**
+ * @internal
+ */
+enum CloneStructBackedEnum: int
+{
+    case Case = 1;
+}

--- a/tests/unit/Core/Framework/Struct/Fixture/CloneStructUnitEnum.php
+++ b/tests/unit/Core/Framework/Struct/Fixture/CloneStructUnitEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct\Fixture;
+
+/**
+ * @internal
+ */
+enum CloneStructUnitEnum
+{
+    case Case;
+}

--- a/tests/unit/Core/Framework/Struct/Fixture/StateStruct.php
+++ b/tests/unit/Core/Framework/Struct/Fixture/StateStruct.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct\Fixture;
+
+use Shopware\Core\Framework\Struct\StateAwareTrait;
+
+/**
+ * @internal
+ */
+class StateStruct
+{
+    use StateAwareTrait;
+}

--- a/tests/unit/Core/Framework/Struct/Fixture/TestCollection.php
+++ b/tests/unit/Core/Framework/Struct/Fixture/TestCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct\Fixture;
+
+use Shopware\Core\Framework\Struct\Collection;
+
+/**
+ * @internal
+ *
+ * @template TElement
+ *
+ * @extends Collection<TElement>
+ */
+class TestCollection extends Collection
+{
+}

--- a/tests/unit/Core/Framework/Struct/StateAwareTraitTest.php
+++ b/tests/unit/Core/Framework/Struct/StateAwareTraitTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Framework\Struct;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Struct\StateAwareTrait;
+use Shopware\Tests\Unit\Core\Framework\Struct\Fixture\StateStruct;
 
 /**
  * @internal
@@ -14,7 +15,7 @@ class StateAwareTraitTest extends TestCase
 {
     public function testTrait(): void
     {
-        $struct = new Fixture\StateStruct();
+        $struct = new StateStruct();
 
         $struct->addState('foo');
 
@@ -45,7 +46,7 @@ class StateAwareTraitTest extends TestCase
         static::assertFalse($struct->hasState('foo', 'baz'));
 
         $value = $struct->state(
-            function (Fixture\StateStruct $state) {
+            function (StateStruct $state) {
                 return $state->hasState('baz');
             },
             'baz'
@@ -58,7 +59,7 @@ class StateAwareTraitTest extends TestCase
         static::assertFalse($struct->hasState('baz'), 'baz should not be set outside');
 
         $value = $struct->state(
-            function (Fixture\StateStruct $state) {
+            function (StateStruct $state) {
                 return $state->hasState('baz') && $state->hasState('foo');
             },
             'baz',
@@ -70,9 +71,9 @@ class StateAwareTraitTest extends TestCase
         static::assertSame(['bar'], $struct->getStates(), 'States do not match');
 
         $value = $struct->state(
-            function (Fixture\StateStruct $state) {
+            function (StateStruct $state) {
                 return $state->state(
-                    function (Fixture\StateStruct $state) {
+                    function (StateStruct $state) {
                         return $state->hasState('baz') && $state->hasState('foo');
                     },
                     'baz'

--- a/tests/unit/Core/Framework/Struct/StateAwareTraitTest.php
+++ b/tests/unit/Core/Framework/Struct/StateAwareTraitTest.php
@@ -14,7 +14,7 @@ class StateAwareTraitTest extends TestCase
 {
     public function testTrait(): void
     {
-        $struct = new StateStruct();
+        $struct = new Fixture\StateStruct();
 
         $struct->addState('foo');
 
@@ -45,7 +45,7 @@ class StateAwareTraitTest extends TestCase
         static::assertFalse($struct->hasState('foo', 'baz'));
 
         $value = $struct->state(
-            function (StateStruct $state) {
+            function (Fixture\StateStruct $state) {
                 return $state->hasState('baz');
             },
             'baz'
@@ -58,7 +58,7 @@ class StateAwareTraitTest extends TestCase
         static::assertFalse($struct->hasState('baz'), 'baz should not be set outside');
 
         $value = $struct->state(
-            function (StateStruct $state) {
+            function (Fixture\StateStruct $state) {
                 return $state->hasState('baz') && $state->hasState('foo');
             },
             'baz',
@@ -70,9 +70,9 @@ class StateAwareTraitTest extends TestCase
         static::assertSame(['bar'], $struct->getStates(), 'States do not match');
 
         $value = $struct->state(
-            function (StateStruct $state) {
+            function (Fixture\StateStruct $state) {
                 return $state->state(
-                    function (StateStruct $state) {
+                    function (Fixture\StateStruct $state) {
                         return $state->hasState('baz') && $state->hasState('foo');
                     },
                     'baz'
@@ -85,12 +85,4 @@ class StateAwareTraitTest extends TestCase
 
         static::assertSame(['bar'], $struct->getStates(), 'States do not match');
     }
-}
-
-/**
- * @internal
- */
-class StateStruct
-{
-    use StateAwareTrait;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The tests are causing PHP deprecation notices

### 2. What does this change do, exactly?

- Allow dynamic properties on test struct
- remove assignment of `id` property

### 3. Describe each step to reproduce the issue or behaviour.

Look at any current PHPUnit pipeline

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
