### PR TITLE
fix: Bump minimum version of `squirrelphp/twig-php-syntax` to 1.11.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
         "setasign/tfpdf": "^1.33",
         "shopware/conflicts": "0.5.1",
         "shyim/opensearch-php-dsl": "^1.0.5",
-        "squirrelphp/twig-php-syntax": "^1.8.0",
+        "squirrelphp/twig-php-syntax": "^1.11.0",
         "symfony/asset": "~7.3.0",
         "symfony/cache": "~7.3.0",
         "symfony/cache-contracts": "~3.6.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -95,7 +95,7 @@
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
         "shopware/conflicts": "0.5.1",
-        "squirrelphp/twig-php-syntax": "^1.8.0",
+        "squirrelphp/twig-php-syntax": "^1.11.0",
         "symfony/asset": "~7.3.0",
         "symfony/cache": "~7.3.0",
         "symfony/cache-contracts": "~3.6.0",


### PR DESCRIPTION
### 1. Why is this change necessary?
```
Fatal error: Access level to Squirrel\TwigPhpSyntax\TokenParser\ForeachTokenParser::parseAssignmentExpression() must be protected (as in class Twig\TokenParser\AbstractTokenParser) or weaker in /opt/shopware/vendor/squirrelphp/twig-php-syntax/src/TokenParser/ForeachTokenParser.php on line 68
```

See here: https://github.com/squirrelphp/twig-php-syntax/commit/2e3197281969b3f6c605832cbda05e1d2dfcf07f

### 2. What does this change do, exactly?
Bump the minimum required version of the package `squirrelphp/twig-php-syntax` to 1.11.

### 3. Describe each step to reproduce the issue or behaviour.
Install the composer packages with the lowest compatible version.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
