### PR TITLE
fix: Bump minimum version of `symfony/polyfill-php85` to 1.33.0 to support `array_first` and `array_last`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,7 +145,7 @@
         "symfony/options-resolver": "~7.3.0",
         "symfony/polyfill-php83": ">=1.31.0",
         "symfony/polyfill-php84": ">=1.31.0",
-        "symfony/polyfill-php85": ">=1.31.0",
+        "symfony/polyfill-php85": ">=1.33.0",
         "symfony/process": "~7.3.0",
         "symfony/property-access": "~7.3.0",
         "symfony/property-info": "~7.3.0",

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "composer/class-map-generator": "^1.7",
         "composer/composer": "^2.8.5",
         "composer/semver": "^3.4.0",
-        "doctrine/dbal": "^3.9",
+        "doctrine/dbal": "~3.9.0",
         "doctrine/inflector": "^2.0",
         "dompdf/dompdf": "2.0.4",
         "dragonmantank/cron-expression": "^3.3",

--- a/src/Administration/composer.json
+++ b/src/Administration/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-        "doctrine/dbal": "^3.9",
+        "doctrine/dbal": "~3.9.0",
         "pentatrion/vite-bundle": "^7.0",
         "shopware/core": "*",
         "symfony/framework-bundle": "~7.3.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -70,7 +70,7 @@
         "composer/class-map-generator": "^1.7",
         "composer/composer": "^2.8.5",
         "composer/semver": "^3.4.0",
-        "doctrine/dbal": "^3.9",
+        "doctrine/dbal": "~3.9.0",
         "doctrine/inflector": "^2.0",
         "dompdf/dompdf": "2.0.4",
         "dragonmantank/cron-expression": "^3.3",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -126,7 +126,7 @@
         "symfony/options-resolver": "~7.3.0",
         "symfony/polyfill-php83": ">=1.31.0",
         "symfony/polyfill-php84": ">=1.31.0",
-        "symfony/polyfill-php85": ">=1.31.0",
+        "symfony/polyfill-php85": ">=1.33.0",
         "symfony/process": "~7.3.0",
         "symfony/property-access": "~7.3.0",
         "symfony/property-info": "~7.3.0",

--- a/src/Elasticsearch/composer.json
+++ b/src/Elasticsearch/composer.json
@@ -32,7 +32,7 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-curl": "*",
         "async-aws/core": "^1.22",
-        "doctrine/dbal": "^3.9",
+        "doctrine/dbal": "~3.9.0",
         "monolog/monolog": "^3.3.1",
         "opensearch-project/opensearch-php": "^2.3.1",
         "shopware/core": "*",

--- a/src/Storefront/composer.json
+++ b/src/Storefront/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "cocur/slugify": "^4.7.0",
-        "doctrine/dbal": "^3.9",
+        "doctrine/dbal": "~3.9.0",
         "meyfa/php-svg": "^0.16.1",
         "padaliyajay/php-autoprefixer": "^1.4",
         "scssphp/scssphp": "v1.12.0",


### PR DESCRIPTION
### 1. Why is this change necessary?
To be compatible with the lowest versions: https://github.com/FriendsOfShopware/platform-plugin-dev-docker/actions/runs/20686701546/job/59388630863#step:5:1327

See the polyfill commit: https://github.com/symfony/polyfill-php85/commit/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91

### 2. What does this change do, exactly?
Bump the version.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
