### PR TITLE
fix: Update composer to ensure safe version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "async-aws/core": "^1.22",
         "cocur/slugify": "^4.7.0",
         "composer/class-map-generator": "^1.7",
-        "composer/composer": "^2.8.5",
+        "composer/composer": "^2.9.3",
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.3.1",
         "doctrine/inflector": "^2.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -66,7 +66,7 @@
         "composer-runtime-api": "^2.1",
         "cocur/slugify": "^4.7.0",
         "composer/class-map-generator": "^1.7",
-        "composer/composer": "^2.8.5",
+        "composer/composer": "^2.9.3",
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.3.1",
         "doctrine/inflector": "^2.0",


### PR DESCRIPTION
### 1. Why is this change necessary?

composer had a security release last week https://github.com/composer/composer/releases/tag/2.9.3

### 2. What does this change do, exactly?

Ensure, that we use a safe version
