### PR TITLE
fix: `checkPromotion` query param in AccountEditOrderPageLoader

### DIFF
--- a/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
@@ -129,7 +129,7 @@ class OrderRoute extends AbstractOrderRoute
         }
 
         $response = new OrderRouteResponse($orderResult);
-        if ($request->get('checkPromotion') === true) {
+        if ($request->query->getBoolean('checkPromotion') === true) {
             foreach ($orders as $order) {
                 $promotions = $this->getActivePromotions($order, $context);
                 $changeable = true;

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -112,7 +112,7 @@ class AccountEditOrderPageLoader
     {
         $criteria = $this->createCriteria($request, $context);
         $apiRequest = $request->duplicate();
-        $apiRequest->query->set('checkPromotion', 'true');
+        $apiRequest->query->set('checkPromotion', true);
 
         $event = new OrderRouteRequestEvent($request, $apiRequest, $context, $criteria);
         $this->eventDispatcher->dispatch($event);

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -339,17 +339,11 @@ class OrderRouteTest extends TestCase
         $this->browser
             ->request(
                 'POST',
-                '/store-api/order',
+                '/store-api/order?checkPromotion=true',
                 [],
                 [],
                 ['CONTENT_TYPE' => 'application/json'],
-                json_encode(
-                    array_merge(
-                        $this->requestCriteriaBuilder->toArray($criteria),
-                        ['checkPromotion' => true]
-                    ),
-                    \JSON_THROW_ON_ERROR
-                ) ?: ''
+                json_encode($this->requestCriteriaBuilder->toArray($criteria), \JSON_THROW_ON_ERROR) ?: ''
             );
 
         $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the `checkPromotion` query param which is set in the AccountEditOrderPageLoader does nothing
- See `2. What does this change do, exactly?`

### 2. What does this change do, exactly?
- Change the `checkPromotion` query param which is set in the AccountEditOrderPageLoader from type `string` to `bool` so this check doesn't fail anymore: https://github.com/shopware/shopware/blob/2800b80b6b4bc8e534b78f786dade880a1c3886f/src/Core/Checkout/Order/SalesChannel/OrderRoute.php#L138 as it checks for the type bool
- We could also change the OrderRoute to e.g. cast the request parameter to a bool

### 3. Describe each step to reproduce the issue or behaviour.
- Load a order on the order edit account page `/account/order/edit/[uuid]`

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
