### PR TITLE
chore: Deprecate unused import/export exceptions

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -311,6 +311,13 @@ Profiles are now identified and displayed only by their technical name.
 * You must pass the `confidential` parameter as the third parameter of the constructor.
 * You must pass the `name` parameter as the fourth parameter of the constructor.
 
+## Removed unused `ImportExport` exceptions
+
+The unused exceptions
+* `\Shopware\Core\Content\ImportExport\Exception\LogNotWritableException`
+* `\Shopware\Core\Content\ImportExport\Exception\MappingException`
+were removed.
+
 ## Removed SystemConfig exceptions
 
 The exceptions

--- a/src/Core/Content/ImportExport/Exception/LogNotWritableException.php
+++ b/src/Core/Content/ImportExport/Exception/LogNotWritableException.php
@@ -2,25 +2,35 @@
 
 namespace Shopware\Core\Content\ImportExport\Exception;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated tag:v6.8.0 - Unused exception will be removed
+ */
 #[Package('fundamentals@after-sales')]
 class LogNotWritableException extends ShopwareHttpException
 {
     public function __construct(array $ids)
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'));
+
         parent::__construct('Entity import_export_log is write-protected if not in system scope', ['ids' => $ids]);
     }
 
     public function getErrorCode(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'));
+
         return 'CONTENT__IMPORT_EXPORT_LOG_NOT_WRITABLE';
     }
 
     public function getStatusCode(): int
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'));
+
         return Response::HTTP_BAD_REQUEST;
     }
 }

--- a/src/Core/Content/ImportExport/Exception/MappingException.php
+++ b/src/Core/Content/ImportExport/Exception/MappingException.php
@@ -2,20 +2,33 @@
 
 namespace Shopware\Core\Content\ImportExport\Exception;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated tag:v6.8.0 - Unused exception will be removed
+ */
 #[Package('fundamentals@after-sales')]
 class MappingException extends ShopwareHttpException
 {
+    public function __construct()
+    {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'));
+    }
+
     public function getStatusCode(): int
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'));
+
         return Response::HTTP_BAD_REQUEST;
     }
 
     public function getErrorCode(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'));
+
         return 'CONTENT__IMPORT_EXPORT_MAPPING_EXCEPTION';
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
These exceptions are not used anymore, hence they should be deprecated.

### 2. What does this change do, exactly?
Deprecate the not used exceptions.

Note as they are not used, I just added them to the `UPGRADE-6.8.md` and not the `RELEASE_INFO-6.7.md` as I saw it was also the case for the cache key events.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug:

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
