### PR TITLE
fix: generate EXISTS conditions instead of left joins for nested filter groups in DAL criteria builder

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -136,6 +136,41 @@ When no `Accept` header is set or with `*/*`, `PDF` will be returned. (PR #12944
 ### PHP 8.5 support
 
 Shopware is now fully compatible with PHP 8.5.
+### Rework of DAL query generation for nested filters groups
+The DAL criteria builder has been adjusted to generate `EXISTS` subqueries instead of `LEFT JOIN`s for nested filter groups.
+
+Previously, each level of nested filters resulted in an additional `LEFT JOIN`, even when the join was only required to check for the existence of a related entity subject to some filter.
+In complex criteria trees with multiple filters on the same entity, this led to an exponential explosion of joins and significant performance degradation (e.g., the same table being joined multiple times only to evaluate existence conditions).
+
+The new approach rewrites such join groups into optimizer-friendly `EXISTS` conditions (see https://dev.mysql.com/doc/refman/8.0/en/semijoins.html. Note that these optimizations are not always applied, for example, when an `OR` condition is present, but we still avoid exponential join explosions).
+Conceptually, `LEFT JOIN`s that were only used for "does this relation exist" checks are now expressed as correlated subqueries.
+A nested filter on the tags of an order would previously generate a `LEFT JOIN` of a subquery:
+```sql
+SELECT /* ... */
+FROM `order`
+LEFT JOIN (
+    SELECT `order.tags.mapping`.`order_id` AS `id`, `order.tags.mapping`.`order_version_id`
+    FROM `order_tag` `order.tags.mapping`
+    LEFT JOIN `tag` `order.tags` ON `order.tags.mapping`.`tag_id` = `order.tags`.`id`
+    WHERE `order.tags`.`id` IN (0x0192688530A97384A2E01F0FF2B25141)
+) `order.tags_1`
+WHERE /* ... */ AND `order.tags_1`.`id` IS NOT NULL
+```
+but now, an `EXISTS` check on the same subquery is generated instead:
+```sql
+SELECT /* ... */
+FROM `order`
+WHERE /* ... */
+EXISTS (
+    SELECT 1
+    FROM `order_tag` `order.tags.mapping`
+    LEFT JOIN `tag` `order.tags` ON `order.tags.mapping`.`tag_id` = `order.tags`.`id`
+    WHERE `order`.`id` = `order.tags.mapping`.`order_id`
+        AND `order.tags`.`id` IN (0x0192688530A97384A2E01F0FF2B25141)
+)
+```
+
+This preserves the semantics defined in [adr/2020-11-19-dal-join-filter.md](adr/2020-11-19-dal-join-filter.md) while avoiding exponential join explosions when multiple different nested filters on the same entity are present.
 
 ### Deprecation of `sw-states` and `sw-currency` handling and new way to disable caching
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -23,35 +23,16 @@ The DAL criteria builder has been adjusted to generate `EXISTS` subqueries inste
 Previously, each level of nested filters resulted in an additional `LEFT JOIN`, even when the join was only required to check for the existence of a related entity subject to some filter.
 In complex criteria trees with multiple filters on the same entity, this led to an exponential explosion of joins and significant performance degradation (e.g., the same table being joined multiple times only to evaluate existence conditions).
 
-The new approach rewrites such join groups into optimizer-friendly `EXISTS` conditions (see https://dev.mysql.com/doc/refman/8.0/en/semijoins.html. Note that these optimizations are not always applied, for example, when an `OR` condition is present, but we still avoid exponential join explosions).
-Conceptually, `LEFT JOIN`s that were only used for "does this relation exist" checks are now expressed as correlated subqueries.
-A nested filter on the tags of an order would previously generate a `LEFT JOIN` of a subquery:
-```sql
-SELECT /* ... */
-FROM `order`
-LEFT JOIN (
-    SELECT `order.tags.mapping`.`order_id` AS `id`, `order.tags.mapping`.`order_version_id`
-    FROM `order_tag` `order.tags.mapping`
-    LEFT JOIN `tag` `order.tags` ON `order.tags.mapping`.`tag_id` = `order.tags`.`id`
-    WHERE `order.tags`.`id` IN (0x0192688530A97384A2E01F0FF2B25141)
-) `order.tags_1`
-WHERE /* ... */ AND `order.tags_1`.`id` IS NOT NULL
+An example of this is a query such as "find orders that have a line item of type A and one of type B and one of type C".
+According to [aadr/2020-11-19-dal-join-filter.md](adr/2020-11-19-dal-join-filter.md), this would look like:
+```php
+$criteria->addFilter(
+    new EqualsFilter('lineItems.type', 'product'),
+    new EqualsFilter('lineItems.type', 'custom'),
+    new EqualsFilter('lineItems.type', 'other'),
+);
 ```
-but now, an `EXISTS` check on the same subquery is generated instead:
-```sql
-SELECT /* ... */
-FROM `order`
-WHERE /* ... */
-EXISTS (
-    SELECT 1
-    FROM `order_tag` `order.tags.mapping`
-    LEFT JOIN `tag` `order.tags` ON `order.tags.mapping`.`tag_id` = `order.tags`.`id`
-    WHERE `order`.`id` = `order.tags.mapping`.`order_id`
-        AND `order.tags`.`id` IN (0x0192688530A97384A2E01F0FF2B25141)
-)
-```
-
-This preserves the semantics defined in [adr/2020-11-19-dal-join-filter.md](adr/2020-11-19-dal-join-filter.md) while avoiding exponential join explosions when multiple different nested filters on the same entity are present.
+Previously, the generated query would `LEFT JOIN` `order_line_item` multiple times onto `order`, causing the query to be extremely slow. The new `EXISTS` checks prevent this, making the query much faster.
 
 ### Introduce Immutable DAL flag
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -17,6 +17,42 @@ Custom fields are now **not searchable by default**. To make a custom field sear
 
 ## Core
 
+### Rework of DAL query generation for nested filters groups
+The DAL criteria builder has been adjusted to generate `EXISTS` subqueries instead of `LEFT JOIN`s for nested filter groups.
+
+Previously, each level of nested filters resulted in an additional `LEFT JOIN`, even when the join was only required to check for the existence of a related entity subject to some filter.
+In complex criteria trees with multiple filters on the same entity, this led to an exponential explosion of joins and significant performance degradation (e.g., the same table being joined multiple times only to evaluate existence conditions).
+
+The new approach rewrites such join groups into optimizer-friendly `EXISTS` conditions (see https://dev.mysql.com/doc/refman/8.0/en/semijoins.html. Note that these optimizations are not always applied, for example, when an `OR` condition is present, but we still avoid exponential join explosions).
+Conceptually, `LEFT JOIN`s that were only used for "does this relation exist" checks are now expressed as correlated subqueries.
+A nested filter on the tags of an order would previously generate a `LEFT JOIN` of a subquery:
+```sql
+SELECT /* ... */
+FROM `order`
+LEFT JOIN (
+    SELECT `order.tags.mapping`.`order_id` AS `id`, `order.tags.mapping`.`order_version_id`
+    FROM `order_tag` `order.tags.mapping`
+    LEFT JOIN `tag` `order.tags` ON `order.tags.mapping`.`tag_id` = `order.tags`.`id`
+    WHERE `order.tags`.`id` IN (0x0192688530A97384A2E01F0FF2B25141)
+) `order.tags_1`
+WHERE /* ... */ AND `order.tags_1`.`id` IS NOT NULL
+```
+but now, an `EXISTS` check on the same subquery is generated instead:
+```sql
+SELECT /* ... */
+FROM `order`
+WHERE /* ... */
+EXISTS (
+    SELECT 1
+    FROM `order_tag` `order.tags.mapping`
+    LEFT JOIN `tag` `order.tags` ON `order.tags.mapping`.`tag_id` = `order.tags`.`id`
+    WHERE `order`.`id` = `order.tags.mapping`.`order_id`
+        AND `order.tags`.`id` IN (0x0192688530A97384A2E01F0FF2B25141)
+)
+```
+
+This preserves the semantics defined in [adr/2020-11-19-dal-join-filter.md](adr/2020-11-19-dal-join-filter.md) while avoiding exponential join explosions when multiple different nested filters on the same entity are present.
+
 ### Introduce Immutable DAL flag
 
 A new `Immutable` flag is available for Data Abstraction Layer fields. Fields marked as immutable can be set during entity creation but cannot be updated later. This prevents accidental renames of technical identifiers that other subsystems rely on. Core entities now using the flag include:
@@ -136,41 +172,6 @@ When no `Accept` header is set or with `*/*`, `PDF` will be returned. (PR #12944
 ### PHP 8.5 support
 
 Shopware is now fully compatible with PHP 8.5.
-### Rework of DAL query generation for nested filters groups
-The DAL criteria builder has been adjusted to generate `EXISTS` subqueries instead of `LEFT JOIN`s for nested filter groups.
-
-Previously, each level of nested filters resulted in an additional `LEFT JOIN`, even when the join was only required to check for the existence of a related entity subject to some filter.
-In complex criteria trees with multiple filters on the same entity, this led to an exponential explosion of joins and significant performance degradation (e.g., the same table being joined multiple times only to evaluate existence conditions).
-
-The new approach rewrites such join groups into optimizer-friendly `EXISTS` conditions (see https://dev.mysql.com/doc/refman/8.0/en/semijoins.html. Note that these optimizations are not always applied, for example, when an `OR` condition is present, but we still avoid exponential join explosions).
-Conceptually, `LEFT JOIN`s that were only used for "does this relation exist" checks are now expressed as correlated subqueries.
-A nested filter on the tags of an order would previously generate a `LEFT JOIN` of a subquery:
-```sql
-SELECT /* ... */
-FROM `order`
-LEFT JOIN (
-    SELECT `order.tags.mapping`.`order_id` AS `id`, `order.tags.mapping`.`order_version_id`
-    FROM `order_tag` `order.tags.mapping`
-    LEFT JOIN `tag` `order.tags` ON `order.tags.mapping`.`tag_id` = `order.tags`.`id`
-    WHERE `order.tags`.`id` IN (0x0192688530A97384A2E01F0FF2B25141)
-) `order.tags_1`
-WHERE /* ... */ AND `order.tags_1`.`id` IS NOT NULL
-```
-but now, an `EXISTS` check on the same subquery is generated instead:
-```sql
-SELECT /* ... */
-FROM `order`
-WHERE /* ... */
-EXISTS (
-    SELECT 1
-    FROM `order_tag` `order.tags.mapping`
-    LEFT JOIN `tag` `order.tags` ON `order.tags.mapping`.`tag_id` = `order.tags`.`id`
-    WHERE `order`.`id` = `order.tags.mapping`.`order_id`
-        AND `order.tags`.`id` IN (0x0192688530A97384A2E01F0FF2B25141)
-)
-```
-
-This preserves the semantics defined in [adr/2020-11-19-dal-join-filter.md](adr/2020-11-19-dal-join-filter.md) while avoiding exponential join explosions when multiple different nested filters on the same entity are present.
 
 ### Deprecation of `sw-states` and `sw-currency` handling and new way to disable caching
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -939,12 +939,6 @@ parameters:
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
-			count: 3
-			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToManyAssociationFieldResolver.php
 

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -1099,7 +1099,7 @@ class DataAbstractionLayerException extends HttpException
     /**
      * @param class-string $associationClass
      */
-    public static function unexpectedAssociationFieldClass(string $associationClass): self|\RuntimeException
+    public static function unexpectedAssociationFieldClass(string $associationClass): self
     {
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
@@ -1112,7 +1112,7 @@ class DataAbstractionLayerException extends HttpException
     /**
      * @param class-string|null $fieldClass
      */
-    public static function expectedAssociationFieldInFirstLevelOfJoinGroup(?string $fieldClass): self|\RuntimeException
+    public static function expectedAssociationFieldInFirstLevelOfJoinGroup(?string $fieldClass): self
     {
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -131,6 +131,8 @@ class DataAbstractionLayerException extends HttpException
     public const DBAL_ONLY_STORAGE_AWARE_FIELDS_AS_TRANSLATED = 'FRAMEWORK__DBAL_ONLY_STORAGE_AWARE_FIELDS_AS_TRANSLATED';
     public const DBAL_FIELD_ACCESSOR_BUILDER_NOT_FOUND = 'FRAMEWORK__DBAL_FIELD_ACCESSOR_BUILDER_NOT_FOUND';
     public const DBAL_CANNOT_BUILD_ACCESSOR = 'FRAMEWORK__DBAL_CANNOT_BUILD_ACCESSOR';
+    public const DBAL_UNEXPECTED_ASSOCIATION_FIELD_CLASS = 'FRAMEWORK__DBAL_UNEXPECTED_ASSOCIATION_FIELD_CLASS';
+    public const DBAL_EXPECTED_ASSOCIATION_FIELD_IN_FIRST_LEVEL_OF_JOIN_GROUP = 'FRAMEWORK__DBAL_EXPECTED_ASSOCIATION_FIELD_IN_FIRST_LEVEL_OF_JOIN_GROUP';
     public const ENTITY_INDEXER_NOT_FOUND = 'FRAMEWORK__ENTITY_INDEXER_NOT_FOUND';
     public const INVALID_SYNC_OPERATION_EXCEPTION = 'FRAMEWORK__DAL_INVALID_SYNC_OPERATION';
 
@@ -1091,6 +1093,40 @@ class DataAbstractionLayerException extends HttpException
             self::DBAL_CANNOT_BUILD_ACCESSOR,
             'Can not build accessor for field "{{ propertyName }}" on root "{{ root }}"',
             ['propertyName' => $propertyName, 'root' => $root]
+        );
+    }
+
+    /**
+     * @param class-string $associationClass
+     */
+    public static function unexpectedAssociationFieldClass(string $associationClass): self|\RuntimeException
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new \RuntimeException(\sprintf('Unknown association class provided %s', $associationClass));
+        }
+
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::DBAL_UNEXPECTED_ASSOCIATION_FIELD_CLASS,
+            'Unknown association class provided "{{ associationClass }}"',
+            ['associationClass' => $associationClass]
+        );
+    }
+
+    /**
+     * @param class-string|null $fieldClass
+     */
+    public static function expectedAssociationFieldInFirstLevelOfJoinGroup(?string $fieldClass): self|\RuntimeException
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new \RuntimeException('Expect association field in first level of join group');
+        }
+
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::DBAL_EXPECTED_ASSOCIATION_FIELD_IN_FIRST_LEVEL_OF_JOIN_GROUP,
+            'Expected association field in first level of join group, got "{{ fieldClass }}"',
+            ['fieldClass' => $fieldClass]
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -1101,10 +1101,6 @@ class DataAbstractionLayerException extends HttpException
      */
     public static function unexpectedAssociationFieldClass(string $associationClass): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException(\sprintf('Unknown association class provided %s', $associationClass));
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_UNEXPECTED_ASSOCIATION_FIELD_CLASS,
@@ -1118,10 +1114,6 @@ class DataAbstractionLayerException extends HttpException
      */
     public static function expectedAssociationFieldInFirstLevelOfJoinGroup(?string $fieldClass): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException('Expect association field in first level of join group');
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_EXPECTED_ASSOCIATION_FIELD_IN_FIRST_LEVEL_OF_JOIN_GROUP,

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldResolver;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\JoinGroup;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
@@ -18,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\CriteriaPartInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SingleFieldFilter;
@@ -43,9 +45,7 @@ class CriteriaPartResolver
     {
         foreach ($parts as $part) {
             if ($part instanceof JoinGroup) {
-                $this->resolveSubJoin($part, $definition, $query, $context);
-
-                $query->addState(EntityDefinitionQueryHelper::HAS_TO_MANY_JOIN);
+                $this->resolveJoinGroup($part, $definition, $query, $context);
 
                 continue;
             }
@@ -59,54 +59,34 @@ class CriteriaPartResolver
         }
     }
 
-    private function resolveSubJoin(JoinGroup $group, EntityDefinition $definition, QueryBuilder $query, Context $context): void
+    private function resolveJoinGroup(JoinGroup $group, EntityDefinition $definition, QueryBuilder $query, Context $context): void
     {
         $fields = EntityDefinitionQueryHelper::getFieldsOfAccessor($definition, $group->getPath(), false);
 
         $first = array_shift($fields);
 
         if (!$first instanceof AssociationField) {
-            throw new \RuntimeException('Expect association field in first level of join group');
+            throw DataAbstractionLayerException::expectedAssociationFieldInFirstLevelOfJoinGroup($first ? $first::class : null);
         }
 
-        $nested = $this->createNestedQuery($first, $definition, $context);
+        $nestedQuery = $this->createNestedQuery($first, $definition, $context);
 
         foreach ($group->getFields() as $accessor) {
             if ($accessor === '_score') {
                 continue;
             }
-            $this->resolveField($group, $accessor, $definition, $nested, $context);
+            $this->resolveField($group, $accessor, $definition, $nestedQuery, $context);
         }
 
-        $alias = $definition->getEntityName() . '.' . $first->getPropertyName() . $group->getSuffix();
+        $this->parseAndResolveFilters($group, $definition, $nestedQuery, $context);
 
-        $this->parseFilter($group, $definition, $nested, $context, $alias);
-
-        $parameters = [
-            '#root#' => self::escape($definition->getEntityName()),
-            '#source_column#' => $this->getSourceColumn($first, $context),
-            '#alias#' => self::escape($alias),
-        ];
-
-        $query->leftJoin(
-            self::escape($definition->getEntityName()),
-            '(' . $nested->getSQL() . ')',
-            self::escape($alias),
-            str_replace(
-                array_keys($parameters),
-                array_values($parameters),
-                '#root#.#source_column# = #alias#.`id`'
-                . $this->buildVersionWhere($definition, $first)
-            )
-        );
-
-        foreach ($nested->getParameters() as $key => $value) {
-            $type = $nested->getParameterType($key);
+        foreach ($nestedQuery->getParameters() as $key => $value) {
+            $type = $nestedQuery->getParameterType($key);
             $query->setParameter($key, $value, $type);
         }
     }
 
-    private function parseFilter(JoinGroup $group, EntityDefinition $definition, QueryBuilder $query, Context $context, string $alias): void
+    private function parseAndResolveFilters(JoinGroup $group, EntityDefinition $definition, QueryBuilder $subQuery, Context $context): void
     {
         $filter = new AndFilter($group->getQueries());
         if ($group->getOperator() === MultiFilter::CONNECTION_OR) {
@@ -119,17 +99,34 @@ class CriteriaPartResolver
         }
 
         foreach ($parsed->getParameters() as $key => $value) {
-            $query->setParameter($key, $value, $parsed->getType($key));
+            $subQuery->setParameter($key, $value, $parsed->getType($key));
         }
 
-        foreach ($filter->getQueries() as $queryFilter) {
-            if (!$queryFilter instanceof SingleFieldFilter) {
-                continue;
-            }
-            $queryFilter->setResolved(self::escape($alias) . '.id IS NOT NULL');
+        $subQuery->andWhere(implode(' AND ', $parsed->getWheres()));
+
+        $singleFieldFilters = array_filter($filter->getQueries(), fn (Filter $filter): bool => $filter instanceof SingleFieldFilter);
+        if (empty($singleFieldFilters)) {
+            return;
         }
 
-        $query->andWhere(implode(' AND ', $parsed->getWheres()));
+        // We generate an EXISTS condition using our correlated subquery to avoid joining any table multiple
+        // times (even though it might be filtered). This avoids possible exponential join explosions. In some cases,
+        // MySQL/MariaDB will perform a semi-join optimization on these EXISTS conditions (see https://dev.mysql.com/doc/refman/8.0/en/semijoins.html).
+        // Since all single field filters will just be combined using AND/OR operators on the same level, we only
+        // need to include our EXISTS sub query for one of these filters. The where conditions actually representing
+        // these filters have been added to the subquery above.
+        array_shift($singleFieldFilters)->setResolved('EXISTS (' . $subQuery->getSQL() . ')');
+
+        // All other filters will be resolved to a constant value of FALSE or TRUE, depending on the operator used.
+        // For example, if the root filter has 3 queries:
+        // - ... and is an AND filter, we will generate `WHERE EXISTS(...) AND TRUE AND TRUE`
+        // - ... and is an OR filter, we will generate `WHERE EXISTS(...) OR FALSE OR FALSE`
+        // Simply, this no-op value puts the filters in a resolved state but is chosen in a way that it will not affect
+        // the result.
+        $noOpValue = $group->getOperator() === MultiFilter::CONNECTION_OR ? 'FALSE' : 'TRUE';
+        foreach ($singleFieldFilters as $singleFieldFilter) {
+            $singleFieldFilter->setResolved($noOpValue);
+        }
     }
 
     private function createNestedQuery(AssociationField $field, EntityDefinition $definition, Context $context): QueryBuilder
@@ -140,13 +137,23 @@ class CriteriaPartResolver
             $reference = $field->getReferenceDefinition();
             $alias = $definition->getEntityName() . '.' . $field->getPropertyName();
 
-            $query->addSelect(self::accessor($alias, $field->getReferenceField()) . ' as id');
-            if ($definition->isVersionAware() && $reference->getFields()->getByStorageName($definition->getEntityName() . '_version_id')) {
-                $query->addSelect(self::accessor($alias, $definition->getEntityName() . '_version_id'));
-            }
-
+            // Since this query only acts as an EXISTS check, we select a dummy value that will cause the EXISTS to be true.
+            $query->addSelect('1');
             $query->from(self::escape($reference->getEntityName()), self::escape($alias));
             $query->addState($alias);
+
+            $parameters = [
+                '#root#' => self::escape($definition->getEntityName()),
+                '#source_column#' => $this->getSourceColumn($field, $context),
+                '#alias#' => self::escape($alias),
+                '#reference_column#' => self::escape($field->getReferenceField()),
+            ];
+
+            $query->andWhere(str_replace(
+                array_keys($parameters),
+                array_values($parameters),
+                '#root#.#source_column# = #alias#.#reference_column#' . $this->buildVersionWhere($definition, $field),
+            ));
 
             return $query;
         }
@@ -155,25 +162,37 @@ class CriteriaPartResolver
             $reference = $field->getReferenceDefinition();
             $alias = $definition->getEntityName() . '.' . $field->getPropertyName();
 
-            $query->addSelect(self::accessor($alias, $field->getReferenceField()) . ' as id');
-            if ($reference->isVersionAware()) {
-                $version = 'version_id';
-                // it could be the case that we have a reverse join and the reference is the "parent" definition
-                if ($reference->getFields()->getByStorageName($definition->getEntityName() . '_version_id')) {
-                    $version = $definition->getEntityName() . '_version_id';
-                }
-
-                $query->addSelect(self::accessor($alias, $version));
-            }
-
+            // Since this query only acts as an EXISTS check, we select a dummy value that will cause the EXISTS to be true.
+            $query->addSelect('1');
             $query->from(self::escape($reference->getEntityName()), self::escape($alias));
             $query->addState($alias);
+
+            $versionWhere = '';
+            if ($reference->isVersionAware()) {
+                $aliasVersionId = $this->getVersionIdFieldForManyToOneRelation($reference, $definition);
+                $rootVersionId = $this->getVersionIdFieldForManyToOneRelation($definition, $reference);
+
+                $versionWhere = ' AND #root#.`' . $rootVersionId . '` = #alias#.`' . $aliasVersionId . '`';
+            }
+
+            $parameters = [
+                '#root#' => self::escape($definition->getEntityName()),
+                '#source_column#' => $this->getSourceColumn($field, $context),
+                '#alias#' => self::escape($alias),
+                '#reference_column#' => self::escape($field->getReferenceField()),
+            ];
+
+            $query->andWhere(str_replace(
+                array_keys($parameters),
+                array_values($parameters),
+                '#root#.#source_column# = #alias#.#reference_column#' . $versionWhere,
+            ));
 
             return $query;
         }
 
         if (!$field instanceof ManyToManyAssociationField) {
-            throw new \RuntimeException(\sprintf('Unknown association class provided %s', $field::class));
+            throw DataAbstractionLayerException::unexpectedAssociationFieldClass($field::class);
         }
 
         $reference = $field->getReferenceDefinition();
@@ -181,11 +200,8 @@ class CriteriaPartResolver
         $mappingAlias = $definition->getEntityName() . '.' . $field->getPropertyName() . '.mapping';
         $alias = $definition->getEntityName() . '.' . $field->getPropertyName();
 
-        $query->addSelect(self::accessor($mappingAlias, $field->getMappingLocalColumn()) . ' as id');
-        if ($definition->isVersionAware()) {
-            $query->addSelect(self::accessor($mappingAlias, $definition->getEntityName() . '_version_id'));
-        }
-
+        // Since this query only acts as an EXISTS check, we select a dummy value that will cause the EXISTS to be true.
+        $query->addSelect('1');
         $query->from(self::escape($reference->getEntityName()), self::escape($mappingAlias));
         $query->addState($alias);
 
@@ -207,6 +223,19 @@ class CriteriaPartResolver
                 . $this->buildMappingVersionWhere($field->getToManyReferenceDefinition(), $field)
             )
         );
+
+        $parameters = [
+            '#alias#' => self::escape($definition->getEntityName()),
+            '#source_column#' => $this->getSourceColumn($field, $context),
+            '#mapping#' => self::escape($mappingAlias),
+            '#reference_column#' => self::escape($field->getMappingLocalColumn()),
+        ];
+
+        $query->andWhere(str_replace(
+            array_keys($parameters),
+            array_values($parameters),
+            '#alias#.#source_column# = #mapping#.#reference_column#' . $this->buildMappingVersionWhere($definition, $field),
+        ));
 
         return $query;
     }
@@ -330,11 +359,6 @@ class CriteriaPartResolver
         return EntityDefinitionQueryHelper::escape($string);
     }
 
-    private static function accessor(string $alias, string $field): string
-    {
-        return self::escape($alias) . '.' . self::escape($field);
-    }
-
     private function getSourceColumn(AssociationField $association, Context $context): string
     {
         if ($association->is(Inherited::class) && $context->considerInheritance()) {
@@ -353,6 +377,17 @@ class CriteriaPartResolver
             return EntityDefinitionQueryHelper::escape($association->getLocalField());
         }
 
-        throw new \RuntimeException(\sprintf('Unknown association class provided %s', $association::class));
+        throw DataAbstractionLayerException::unexpectedAssociationFieldClass($association::class);
+    }
+
+    private function getVersionIdFieldForManyToOneRelation(EntityDefinition $definition, EntityDefinition $reference): string
+    {
+        $rootVersionId = 'version_id';
+        // it could be the case that we have a reverse join and the reference is the "parent" definition
+        if ($definition->getFields()->getByStorageName($reference->getEntityName() . '_version_id')) {
+            $rootVersionId = $reference->getEntityName() . '_version_id';
+        }
+
+        return $rootVersionId;
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
@@ -23,6 +23,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -84,6 +86,7 @@ class JoinFilterTest extends TestCase
                 ->price(15, 10)
                 ->manufacturer('manufacturer-2')
                 ->property('red', 'color')
+                ->property('S', 'size')
                 ->category('category-1')
                 ->category('category-3')
                 ->prices('rule-1', 150)
@@ -91,6 +94,7 @@ class JoinFilterTest extends TestCase
 
             (new ProductBuilder($ids, 'product-3', 3, 'tax'))
                 ->price(15, 10)
+                ->category('category-4')
                 ->build(),
         ];
 
@@ -366,10 +370,11 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertSame(1, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertFalse($result->has($ids->get('category-1')));
         static::assertFalse($result->has($ids->get('category-2')));
         static::assertTrue($result->has($ids->get('category-3')));
+        static::assertTrue($result->has($ids->get('category-4')));
     }
 
     #[Depends('testIndexing')]
@@ -426,6 +431,148 @@ class JoinFilterTest extends TestCase
     }
 
     #[Depends('testIndexing')]
+    public function testOneToManyWithSort(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithSortDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-2'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-1'), $result->getIds()[1]); // Rule 2 price is higher, but ignored because of filter
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithSortWithMultipleJoinGroups(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        // note that this is the same order then below, because apparently it uses both rule-1 price and rule-2 price
+        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
+        // however note that by the join group the lower rule-1 price should be filtered out
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithSortWithMultipleJoinGroupsDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        // note that this is the same order then above, because apparently it uses both rule-1 price and rule-2 price
+        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
+        // however note that by the join group the lower rule-1 price should be filtered out
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithGrouping(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(1, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
+
+        // we get an internal DBAL field mapping exception here,
+        // which is not optimal but at least indicates that this is not supported
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    #[Depends('testIndexing')]
     public function testOneToManyWithMultipleFilters(IdsCollection $ids): void
     {
         $criteria = new Criteria($ids->prefixed('product-'));
@@ -466,6 +613,87 @@ class JoinFilterTest extends TestCase
     }
 
     #[Depends('testIndexing')]
+    public function testManyToOneWithSort(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name'));
+
+        $result = static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(3, $result->getTotal());
+        static::assertSame($ids->get('category-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('category-2'), $result->getIds()[1]);
+        static::assertSame($ids->get('category-3'), $result->getIds()[2]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToOneWithSortDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(3, $result->getTotal());
+        static::assertSame($ids->get('category-1'), $result->getIds()[0]); // manufacturer-2 matches as well
+        static::assertSame($ids->get('category-3'), $result->getIds()[1]); // manufacturer-2
+        static::assertSame($ids->get('category-2'), $result->getIds()[2]); // manufacturer-1
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToOneWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('category.products.manufacturer.name'));
+
+        // we get an internal DBAL field mapping exception here,
+        // which is not optimal but at least indicates that this is not supported
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    #[Depends('testIndexing')]
     public function testManyToMany(IdsCollection $ids): void
     {
         $criteria = new Criteria($ids->prefixed('product-'));
@@ -482,6 +710,108 @@ class JoinFilterTest extends TestCase
         static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithMultiJoinGroup(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertTrue($result->has($ids->get('product-2')));
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithSort(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.properties.name'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithSortDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.properties.name', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithGroup(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.properties.name'));
+
+        // we get an internal DBAL field mapping exception here,
+        // which is not optimal but at least indicates that this is not supported
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
     }
 
     #[Depends('testIndexing')]

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
@@ -23,8 +23,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -86,7 +84,6 @@ class JoinFilterTest extends TestCase
                 ->price(15, 10)
                 ->manufacturer('manufacturer-2')
                 ->property('red', 'color')
-                ->property('S', 'size')
                 ->category('category-1')
                 ->category('category-3')
                 ->prices('rule-1', 150)
@@ -94,7 +91,6 @@ class JoinFilterTest extends TestCase
 
             (new ProductBuilder($ids, 'product-3', 3, 'tax'))
                 ->price(15, 10)
-                ->category('category-4')
                 ->build(),
         ];
 
@@ -370,11 +366,10 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertSame(2, $result->getTotal());
+        static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('category-1')));
         static::assertFalse($result->has($ids->get('category-2')));
         static::assertTrue($result->has($ids->get('category-3')));
-        static::assertTrue($result->has($ids->get('category-4')));
     }
 
     #[Depends('testIndexing')]
@@ -431,148 +426,6 @@ class JoinFilterTest extends TestCase
     }
 
     #[Depends('testIndexing')]
-    public function testOneToManyWithSort(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.prices.price'));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToManyWithSortDesc(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-2'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-1'), $result->getIds()[1]); // Rule 2 price is higher, but ignored because of filter
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToManyWithSortWithMultipleJoinGroups(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.prices.price'));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        // note that this is the same order then below, because apparently it uses both rule-1 price and rule-2 price
-        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
-        // however note that by the join group the lower rule-1 price should be filtered out
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToManyWithSortWithMultipleJoinGroupsDesc(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        // note that this is the same order then above, because apparently it uses both rule-1 price and rule-2 price
-        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
-        // however note that by the join group the lower rule-1 price should be filtered out
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToManyWithGrouping(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
-            ])
-        );
-        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(1, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToManyWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-            ])
-        );
-        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
-
-        // we get an internal DBAL field mapping exception here,
-        // which is not optimal but at least indicates that this is not supported
-        static::expectException(\Throwable::class);
-        static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-    }
-
-    #[Depends('testIndexing')]
     public function testOneToManyWithMultipleFilters(IdsCollection $ids): void
     {
         $criteria = new Criteria($ids->prefixed('product-'));
@@ -613,87 +466,6 @@ class JoinFilterTest extends TestCase
     }
 
     #[Depends('testIndexing')]
-    public function testManyToOneWithSort(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('category-'));
-
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name'));
-
-        $result = static::getContainer()->get('category.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(3, $result->getTotal());
-        static::assertSame($ids->get('category-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('category-2'), $result->getIds()[1]);
-        static::assertSame($ids->get('category-3'), $result->getIds()[2]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToOneWithSortDesc(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('category-'));
-
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name', FieldSorting::DESCENDING));
-
-        $result = static::getContainer()->get('category.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(3, $result->getTotal());
-        static::assertSame($ids->get('category-1'), $result->getIds()[0]); // manufacturer-2 matches as well
-        static::assertSame($ids->get('category-3'), $result->getIds()[1]); // manufacturer-2
-        static::assertSame($ids->get('category-2'), $result->getIds()[2]); // manufacturer-1
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToOneWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('category-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
-                ]),
-            ])
-        );
-        $criteria->addGroupField(new FieldGrouping('category.products.manufacturer.name'));
-
-        // we get an internal DBAL field mapping exception here,
-        // which is not optimal but at least indicates that this is not supported
-        static::expectException(\Throwable::class);
-        static::getContainer()->get('category.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-    }
-
-    #[Depends('testIndexing')]
     public function testManyToMany(IdsCollection $ids): void
     {
         $criteria = new Criteria($ids->prefixed('product-'));
@@ -710,108 +482,6 @@ class JoinFilterTest extends TestCase
         static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToManyWithMultiJoinGroup(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
-                    new EqualsFilter('product.properties.name', 'yellow'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
-                    new EqualsFilter('product.properties.name', 'S'),
-                ]),
-            ])
-        );
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-2')));
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToManyWithSort(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
-                    new EqualsFilter('product.properties.name', 'yellow'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
-                    new EqualsFilter('product.properties.name', 'S'),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.properties.name'));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToManyWithSortDesc(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
-                    new EqualsFilter('product.properties.name', 'yellow'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
-                    new EqualsFilter('product.properties.name', 'S'),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.properties.name', FieldSorting::DESCENDING));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToManyWithGroup(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
-                    new EqualsFilter('product.properties.name', 'yellow'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
-                    new EqualsFilter('product.properties.name', 'S'),
-                ]),
-            ])
-        );
-        $criteria->addGroupField(new FieldGrouping('product.properties.name'));
-
-        // we get an internal DBAL field mapping exception here,
-        // which is not optimal but at least indicates that this is not supported
-        static::expectException(\Throwable::class);
-        static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
     }
 
     #[Depends('testIndexing')]


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, it's possible for a DAL query to be generated where a table gets left joined multiple times using nested filters. Each level of nesting generated one more join (`JoinGroup` in the code). This leads to incredibly slow queries in some cases, because of exponential join explosions, as shown in https://github.com/shopware/shopware/issues/13707.

### 2. What does this change do, exactly?
The query generation is adjusted to generate `EXISTS(/* correlated sub query */)` conditions instead of left joins when processing `JoinGroup`s (explained in more detail here https://github.com/shopware/shopware/issues/13707#issuecomment-3580969587). In most cases, usually when only `AND` filters are present, MySQL/MariaDB can perform a semi-join optimization on these sub-queries to make them very fast.

### 3. Describe each step to reproduce the issue or behaviour.
See the original issue.

### 4. Please link to the relevant issues (if any).
- closes #13707

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
