### PR TITLE
fix: pass resizeWidth property to deprecated sw-popover component

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.html.twig
@@ -26,6 +26,7 @@
 <sw-popover-deprecated
     v-else
     v-bind="$attrs"
+    :resize-width="computedMatchReferenceWidth"
 >
     <slot></slot>
 </sw-popover-deprecated>

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.spec.js
@@ -162,5 +162,4 @@ describe('src/app/component/base/sw-popover', () => {
         const deprecatedPopover = wrapper.findComponent({ name: 'sw-popover-deprecated' });
         expect(deprecatedPopover.attributes('resize-width')).toBe('true');
     });
-
 });

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.spec.js
@@ -136,4 +136,31 @@ describe('src/app/component/base/sw-popover', () => {
         const floatingUi = wrapper.findComponent({ name: 'mt-floating-ui' });
         expect(floatingUi.attributes('match-reference-width')).toBe('true');
     });
+
+    it('should pass the "resizeWidth" prop to sw-popover-deprecated when feature flag is disabled and matchReferenceWidth is set', async () => {
+        global.activeFeatureFlags = [''];
+
+        const wrapper = await createWrapper({
+            attrs: {
+                matchReferenceWidth: true,
+            },
+        });
+
+        const deprecatedPopover = wrapper.findComponent({ name: 'sw-popover-deprecated' });
+        expect(deprecatedPopover.attributes('resize-width')).toBe('true');
+    });
+
+    it('should pass the "resizeWidth" prop to sw-popover-deprecated when feature flag is disabled and deprecated resizeWidth is set', async () => {
+        global.activeFeatureFlags = [''];
+
+        const wrapper = await createWrapper({
+            attrs: {
+                resizeWidth: true,
+            },
+        });
+
+        const deprecatedPopover = wrapper.findComponent({ name: 'sw-popover-deprecated' });
+        expect(deprecatedPopover.attributes('resize-width')).toBe('true');
+    });
+
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

In the current trunk the popover width did not align to the width of the dropdown inputs.


### 2. What does this change do, exactly?

The new matchReferenceWidth property has been added as an attribute to the deprecated sw-popover component, which is active if meteor design is disabled. 

<img width="1167" height="505" alt="Bildschirmfoto 2026-01-07 um 10 41 03" src="https://github.com/user-attachments/assets/663c8aee-5093-451f-a82c-5d097f899170" />



### 3. Describe each step to reproduce the issue or behaviour.

Open the product detail page in the administration and test the popovers of the select fields.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
Closes https://github.com/shopware/shopware/issues/13384
