### PR TITLE
fix(cms-slots): Replace v-show with v-if

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -165,7 +165,9 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         onCloseSettingsModal() {
-            if (!this.showElementSettings) return;
+            if (!this.showElementSettings) {
+                return;
+            }
 
             const childComponent = this.$refs.elementComponentRef as {
                 handleUpdateContent: () => void;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
@@ -105,7 +105,7 @@
 
     {% block sw_cms_slot_content_settings_modal %}
     <sw-modal
-        v-show="showElementSettings"
+        v-if="showElementSettings"
         class="sw-cms-slot__config-modal"
         :variant="modalVariant"
         :title="elementModalTitle"


### PR DESCRIPTION
fixes #11046

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Initilize Content in a clean state and reduce performance load

### 2. What does this change do, exactly?
Replace `v-show` with `v-if` for conditional rendering instead of pre-rendering everything

### 3. Describe each step to reproduce the issue or behaviour.
- Go to a cms layout (shopping experience)
- Place a random block
- See the config modal getting added to the Dom tree, while it is actually not open. It's only hidden via display: none

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
