### PR TITLE
fix: Add release information for version 6.7.6.0 and 6.7.7.0

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -119,5 +119,17 @@
     "release_date": "2025-12-02",
     "extended_eol": false,
     "security_eol": "2028-02-28"
+  },
+  {
+    "version": "6.7.6.0",
+    "release_date": "2026-01-12",
+    "extended_eol": false,
+    "security_eol": "2028-02-28"
+  },
+  {
+    "version": "6.7.7.0",
+    "release_date": "2026-02-02",
+    "extended_eol": false,
+    "security_eol": "2028-02-28"
   }
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
6.7.6.0 and 6.7.7.0 are missing from the Release Calendar.

### 2. What does this change do, exactly?
Includes 6.7.6.0 and 6.7.7.0 release date and EOL.

### 3. Describe each step to reproduce the issue or behaviour.
Please refer to https://developer.shopware.com/release-notes/.

### 4. Please link to the relevant issues (if any).
NA

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
