### PR TITLE
fix: add submit button functionality for password recovery

### DIFF
--- a/src/Administration/Resources/app/administration/AGENTS.md
+++ b/src/Administration/Resources/app/administration/AGENTS.md
@@ -68,6 +68,11 @@ composer format:admin:fix # Format code with Prettier and --write
 composer admin:unit # Run unit tests
 composer admin:unit:watch # Run unit tests in watch mode
 
+# Single jest test, run inside "src/Administration/Resources/app/administration" folder
+npx jest --collectCoverage=false src/core/factory/http.factory.spec.js # Example single test run
+# All jest tests without coverage for better readability, run inside "src/Administration/Resources/app/administration" folder 
+npx jest --collectCoverage=false
+
 # Build
 composer build:js:admin # Build the administration
 ```

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-recovery/sw-login-recovery-recovery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-recovery/sw-login-recovery-recovery.html.twig
@@ -39,6 +39,7 @@
                 <mt-button
                     variant="primary"
                     :disabled="!validatePasswords()"
+                    type="submit"
                 >
                     {{ $tc('sw-login.recovery.recovery.submit.label') }}
                 </mt-button>

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-recovery/sw-login-recovery-recovery.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-recovery/sw-login-recovery-recovery.spec.js
@@ -51,4 +51,28 @@ describe('src/module/sw-login/view/sw-login-recovery-recovery', () => {
         wrapper.vm.$router.push.mockRestore();
         wrapper.vm.userRecoveryService.updateUserPassword.mockRestore();
     });
+
+    it('should call updateUserPassword when submit button is clicked', async () => {
+        const testHash = 'test-hash-123';
+        const testPassword = 'testPassword123';
+
+        wrapper = await createWrapper();
+        await wrapper.setProps({ hash: testHash });
+
+        const updateUserPasswordSpy = jest.fn(() => Promise.resolve());
+        wrapper.vm.userRecoveryService.updateUserPassword = updateUserPasswordSpy;
+
+        const passwordInputs = wrapper.findAll('input[type="password"]');
+        const newPasswordInput = passwordInputs[0];
+        const confirmPasswordInput = passwordInputs[1];
+
+        await newPasswordInput.setValue(testPassword);
+        await confirmPasswordInput.setValue(testPassword);
+
+        const form = wrapper.find('form');
+        await form.trigger('submit');
+
+        expect(updateUserPasswordSpy).toHaveBeenCalledTimes(1);
+        expect(updateUserPasswordSpy).toHaveBeenCalledWith(testHash, testPassword, testPassword);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The password couldn't get updated because the button click doesn't do anything.

### 2. What does this change do, exactly?

Add the correct type "submit" to the button so that it triggers the form.

### 3. Describe each step to reproduce the issue or behaviour.

See the issue

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

Fixes https://github.com/shopware/shopware/issues/14225