### PR TITLE
chore: unified cache-control header processing

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -65,7 +65,10 @@ The following deprecations apply to `sw-mail-template-index`:
 
 The cookie consent dialog now uses toggle switches instead of checkboxes for a more modern look. The button layout has been improved with a clearer visual hierarchy, placing the primary action on the right side. Additionally, accessibility improvements were made by adding proper ARIA attributes (`role="switch"`, `aria-disabled`, `aria-labelledby`) and converting links to semantic buttons where appropriate.
 
-### HTTP caching policies now respect no-store attribute
+### HTTP caching policies update
+
+* HTTP caching policy system now takes into account `_noStore` route attribute to apply `no-store` directive in Cache-Control header.
+* Cache-control header set by policies is sent to the client for all responses, even when no reverse proxy is enabled.
 
 HTTP caching policy system now takes into account `_noStore` route attribute to apply `no-store` directive in Cache-Control header.
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -70,8 +70,6 @@ The cookie consent dialog now uses toggle switches instead of checkboxes for a m
 * HTTP caching policy system now takes into account `_noStore` route attribute to apply `no-store` directive in Cache-Control header.
 * Cache-control header set by policies is sent to the client for all responses, even when no reverse proxy is enabled.
 
-HTTP caching policy system now takes into account `_noStore` route attribute to apply `no-store` directive in Cache-Control header.
-
 ## App System
 
 ## Hosting & Configuration

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -65,6 +65,10 @@ The following deprecations apply to `sw-mail-template-index`:
 
 The cookie consent dialog now uses toggle switches instead of checkboxes for a more modern look. The button layout has been improved with a clearer visual hierarchy, placing the primary action on the right side. Additionally, accessibility improvements were made by adding proper ARIA attributes (`role="switch"`, `aria-disabled`, `aria-labelledby`) and converting links to semantic buttons where appropriate.
 
+### HTTP caching policies now respect no-store attribute
+
+HTTP caching policy system now takes into account `_noStore` route attribute to apply `no-store` directive in Cache-Control header.
+
 ## App System
 
 ## Hosting & Configuration

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -67,6 +67,8 @@ The cookie consent dialog now uses toggle switches instead of checkboxes for a m
 
 ### HTTP caching policies update
 
+The following changes are relevant when HTTP caching policies feature is enabled (`CACHE_REWORK` or `v6.8.0.0` feature flag):
+
 * HTTP caching policy system now takes into account `_noStore` route attribute to apply `no-store` directive in Cache-Control header.
 * `Cache-Control` header set by policies is sent to the client for all responses, even when no reverse proxy is enabled. Previously, headers were replaced with `no-cache` when no reverse proxy was configured. **Important**: Verify your cache policy configuration is appropriate for client-side caching, as browser caches cannot be invalidated on-demand unlike reverse proxies that use tag-based invalidation.
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -68,7 +68,7 @@ The cookie consent dialog now uses toggle switches instead of checkboxes for a m
 ### HTTP caching policies update
 
 * HTTP caching policy system now takes into account `_noStore` route attribute to apply `no-store` directive in Cache-Control header.
-* Cache-control header set by policies is sent to the client for all responses, even when no reverse proxy is enabled.
+* `Cache-Control` header set by policies is sent to the client for all responses, even when no reverse proxy is enabled. Previously, headers were replaced with `no-cache` when no reverse proxy was configured. **Important**: Verify your cache policy configuration is appropriate for client-side caching, as browser caches cannot be invalidated on-demand unlike reverse proxies that use tag-based invalidation.
 
 ## App System
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -816,6 +816,8 @@ Method `response.cache.invalidationState()` was removed. State-based invalidatio
 
 ## HTTP Cache Changes
 
+### Removed configuration parameters
+
 The following configuration parameters were removed:
 
 - `SHOPWARE_HTTP_DEFAULT_TTL` environment variable
@@ -847,6 +849,14 @@ The following configuration parameters were removed:
 +      storefront:
 +        cacheable: my_cacheable
 ```
+
+### CacheControlListener removal
+
+The `CacheControlListener` has been removed. Previously, when no reverse proxy was configured, this listener replaced all Cache-Control headers with `no-cache` before sending responses to clients.
+
+With this change, Cache-Control headers defined by cache policies are sent directly to browsers. This means:
+- Client-side caching (browser cache) now respects your configured policies.
+- Ensure your cache policies are configured appropriately for client exposure: unlike reverse proxies that use tag-based invalidation, browser caches cannot be invalidated on-demand.
 
 ## Dropped support for OpenSearch 1.x
 

--- a/src/Core/Framework/Adapter/Cache/Http/CacheControlListener.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheControlListener.php
@@ -5,11 +5,11 @@ namespace Shopware\Core\Framework\Adapter\Cache\Http;
 use Shopware\Core\Framework\Event\BeforeSendResponseEvent;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\StoreApiRouteScope;
-use Shopware\Core\PlatformRequest;
 
 /**
  * @internal
+ *
+ * @deprecated tag:v6.8.0 - Will be removed without replacement
  */
 #[Package('framework')]
 readonly class CacheControlListener
@@ -28,10 +28,7 @@ readonly class CacheControlListener
             return;
         }
 
-        if (
-            $this->isStoreApiRequest($event)
-            && (Feature::isActive('CACHE_REWORK') || Feature::isActive('v6.8.0.0'))
-        ) {
+        if (Feature::isActive('CACHE_REWORK') || Feature::isActive('v6.8.0.0')) {
             return;
         }
 
@@ -42,9 +39,7 @@ readonly class CacheControlListener
         // We don't want that the client will cache the website, if no reverse proxy is configured
         $response->headers->remove('cache-control');
 
-        if (!Feature::isActive('v6.8.0.0') && !Feature::isActive('PERFORMANCE_TWEAKS') && !Feature::isActive('CACHE_REWORK')) {
-            $response->headers->remove(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER);
-        }
+        $response->headers->remove(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER);
 
         $response->setPrivate();
 
@@ -53,16 +48,5 @@ readonly class CacheControlListener
         } else {
             $response->headers->addCacheControlDirective('no-cache');
         }
-    }
-
-    private function isStoreApiRequest(BeforeSendResponseEvent $event): bool
-    {
-        $request = $event->getRequest();
-
-        return \in_array(
-            StoreApiRouteScope::ID,
-            (array) $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
-            true
-        );
     }
 }

--- a/src/Core/Framework/Adapter/Cache/Http/CachePolicy.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CachePolicy.php
@@ -51,9 +51,9 @@ readonly class CachePolicy
     }
 
     /**
-     * Fallback no-cache policy when policy cannot be resolved
+     * Fallback no-store policy when policy cannot be resolved or NO_STORE is enforced.
      */
-    public static function noCache(): self
+    public static function noStore(): self
     {
         return new self(
             cacheControl: new CacheControlDirectives(
@@ -61,7 +61,6 @@ readonly class CachePolicy
                 noCache: true,
                 mustRevalidate: true,
                 maxAge: 0,
-                sMaxAge: 0,
             )
         );
     }

--- a/src/Core/Framework/Adapter/Cache/Http/CachePolicyProvider.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CachePolicyProvider.php
@@ -35,10 +35,11 @@ readonly class CachePolicyProvider
      * @param string $route Route name
      * @param string $area Area (storefront, store_api)
      * @param bool $cacheable Whether the response is cacheable
+     * @param bool $enforceNoStore Whether no-store should be enforced
      *
      * @return CachePolicy The resolved policy or default no-cache policy
      */
-    public function getPolicy(string $route, string $area, bool $cacheable, ?CacheAttribute $cacheAttribute = null): CachePolicy
+    public function getPolicy(string $route, string $area, bool $cacheable, ?CacheAttribute $cacheAttribute = null, bool $enforceNoStore = false): CachePolicy
     {
         $policyModifier = $cacheAttribute?->policyModifier;
 
@@ -69,7 +70,12 @@ readonly class CachePolicyProvider
 
         $policy = $this->policies[$policyName] ?? null;
         if ($policy === null) {
-            return CachePolicy::noCache();
+            return CachePolicy::noStore();
+        }
+
+        // When enforcing no-store, always return no-cache policy (merging makes no sense as other cache-control directives should be ignored in this case)
+        if ($enforceNoStore && $isDefaultPolicy) {
+            return CachePolicy::noStore();
         }
 
         // Override with CacheAttribute values if using default policy and cacheable

--- a/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
@@ -82,11 +82,16 @@ class CacheResponseSubscriber implements EventSubscriberInterface
 
         $this->cacheHeadersService->applyCacheHeaders($context, $response);
 
+        $area = $this->isStoreApi($request) ? self::POLICY_AREA_STORE_API : self::POLICY_AREA_STOREFRONT;
+
         if (!$this->httpCacheEnabled) {
+            // no-store attribute still has to be processed even in early return case
+            if ($request->attributes->has(PlatformRequest::ATTRIBUTE_NO_STORE)) {
+                $this->applyPolicy($request, $response, $area, false, null);
+            }
+
             return;
         }
-
-        $area = $this->isStoreApi($request) ? self::POLICY_AREA_STORE_API : self::POLICY_AREA_STOREFRONT;
 
         if (!$this->maintenanceResolver->shouldBeCached($request)) {
             $this->noCache($request, $response, $area);
@@ -243,8 +248,9 @@ class CacheResponseSubscriber implements EventSubscriberInterface
     private function applyPolicy(Request $request, Response $response, string $area, bool $cacheable, ?CacheAttribute $cacheAttribute): void
     {
         $route = (string) $request->attributes->get('_route', '');
+        $enforceNoStore = $request->attributes->has(PlatformRequest::ATTRIBUTE_NO_STORE);
 
-        $policy = $this->policyProvider->getPolicy($route, $area, $cacheable, $cacheAttribute);
+        $policy = $this->policyProvider->getPolicy($route, $area, $cacheable, $cacheAttribute, $enforceNoStore);
 
         // reset existing cache-control to avoid mixing policies
         $response->headers->remove('cache-control');

--- a/src/Storefront/Framework/Routing/ResponseHeaderListener.php
+++ b/src/Storefront/Framework/Routing/ResponseHeaderListener.php
@@ -5,7 +5,6 @@ namespace Shopware\Storefront\Framework\Routing;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\PlatformRequest;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
@@ -44,13 +43,7 @@ class ResponseHeaderListener implements EventSubscriberInterface
             return;
         }
 
-        $this->manipulateStorefrontHeader($event->getRequest(), $response);
-    }
-
-    private function manipulateStorefrontHeader(Request $request, Response $response): void
-    {
         $this->removeHeaders($response);
-        $this->addNoStoreHeader($request, $response);
     }
 
     private function removeHeaders(Response $response): void
@@ -58,18 +51,5 @@ class ResponseHeaderListener implements EventSubscriberInterface
         foreach (self::REMOVAL_HEADERS as $headerKey) {
             $response->headers->remove($headerKey);
         }
-    }
-
-    private function addNoStoreHeader(Request $request, Response $response): void
-    {
-        if (!$request->attributes->has(PlatformRequest::ATTRIBUTE_NO_STORE)) {
-            return;
-        }
-
-        $response->setMaxAge(0);
-        $response->headers->addCacheControlDirective('no-cache');
-        $response->headers->addCacheControlDirective('no-store');
-        $response->headers->addCacheControlDirective('must-revalidate');
-        $response->setExpires(new \DateTime('@0'));
     }
 }

--- a/tests/integration/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Adapter\Cache\Http;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
+
+/**
+ * @internal
+ */
+#[CoversClass(CacheResponseSubscriber::class)]
+class CacheResponseSubscriberTest extends TestCase
+{
+    use SalesChannelFunctionalTestBehaviour;
+    private const NO_STORE_ROUTES = [
+        'frontend.account.order.page' => [],
+        'frontend.account.order.single.page' => ['deepLinkCode' => 'abc'],
+        'frontend.account.edit-order.page' => ['orderId' => 'abc'],
+        'frontend.account.home.page' => [],
+        'frontend.account.profile.page' => [],
+        'frontend.account.address.page' => [],
+        'frontend.account.address.create.page' => [],
+        'frontend.account.address.edit.page' => ['addressId' => 'abc'],
+        'frontend.account.login.page' => [],
+        'frontend.account.guest.login.page' => [],
+        'frontend.checkout.cart.page' => [],
+        'frontend.checkout.confirm.page' => [],
+        'frontend.checkout.finish.page' => [],
+        'frontend.account.register.page' => [],
+        'frontend.checkout.register.page' => [],
+        'frontend.account.customer-group-registration.page' => ['customerGroupId' => 'abc'],
+    ];
+
+    /**
+     * @param array<string, string> $routeParameters
+     */
+    #[DataProvider('dataProviderNoStoreRoutes')]
+    public function testNoStoreHeaderPresent(string $routeName, array $routeParameters): void
+    {
+        $router = static::getContainer()->get('router');
+        $route = $router->generate($routeName, $routeParameters);
+
+        $browser = KernelLifecycleManager::createBrowser(KernelLifecycleManager::getKernel());
+        $browser->request('GET', $_SERVER['APP_URL'] . $route);
+        $response = $browser->getResponse();
+        static::assertTrue($response->headers->hasCacheControlDirective('no-store'));
+        static::assertTrue($response->headers->hasCacheControlDirective('private'));
+        static::assertFalse($response->isCacheable());
+    }
+
+    /**
+     * @return iterable<string, array{string, array<string>}>
+     */
+    public static function dataProviderNoStoreRoutes(): iterable
+    {
+        foreach (self::NO_STORE_ROUTES as $route => $parameters) {
+            yield $route => [$route, $parameters];
+        }
+    }
+}

--- a/tests/integration/Storefront/Framework/Routing/ResponseHeaderListenerTest.php
+++ b/tests/integration/Storefront/Framework/Routing/ResponseHeaderListenerTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Integration\Storefront\Framework\Routing;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -18,25 +17,6 @@ use Shopware\Storefront\Framework\Routing\NotFound\NotFoundSubscriber;
 class ResponseHeaderListenerTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;
-
-    private const REVALIDATE_ROUTES = [
-        'frontend.account.order.page' => [],
-        'frontend.account.order.single.page' => ['deepLinkCode' => 'abc'],
-        'frontend.account.edit-order.page' => ['orderId' => 'abc'],
-        'frontend.account.home.page' => [],
-        'frontend.account.profile.page' => [],
-        'frontend.account.address.page' => [],
-        'frontend.account.address.create.page' => [],
-        'frontend.account.address.edit.page' => ['addressId' => 'abc'],
-        'frontend.account.login.page' => [],
-        'frontend.account.guest.login.page' => [],
-        'frontend.checkout.cart.page' => [],
-        'frontend.checkout.confirm.page' => [],
-        'frontend.checkout.finish.page' => [],
-        'frontend.account.register.page' => [],
-        'frontend.checkout.register.page' => [],
-        'frontend.account.customer-group-registration.page' => ['customerGroupId' => 'abc'],
-    ];
 
     public function testHomeController(): void
     {
@@ -87,34 +67,6 @@ class ResponseHeaderListenerTest extends TestCase
         static::assertTrue($response->headers->has(PlatformRequest::HEADER_CONTEXT_TOKEN));
         static::assertTrue($response->headers->has(PlatformRequest::HEADER_VERSION_ID));
         static::assertTrue($response->headers->has(PlatformRequest::HEADER_LANGUAGE_ID));
-    }
-
-    /**
-     * @param array<string, string> $routeParameters
-     */
-    #[DataProvider('dataProviderRevalidateRoutes')]
-    public function testNoStoreHeaderPresent(string $routeName, array $routeParameters): void
-    {
-        $router = static::getContainer()->get('router');
-        $route = $router->generate($routeName, $routeParameters);
-
-        $browser = KernelLifecycleManager::createBrowser(KernelLifecycleManager::getKernel());
-        $browser->request('GET', $_SERVER['APP_URL'] . $route);
-        $response = $browser->getResponse();
-
-        static::assertTrue($response->headers->hasCacheControlDirective('no-store'));
-        static::assertTrue($response->headers->hasCacheControlDirective('private'));
-        static::assertFalse($response->isCacheable());
-    }
-
-    /**
-     * @return iterable<string, array{string, array<string>}>
-     */
-    public static function dataProviderRevalidateRoutes(): iterable
-    {
-        foreach (self::REVALIDATE_ROUTES as $route => $parameters) {
-            yield $route => [$route, $parameters];
-        }
     }
 
     /**

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheControlListenerTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheControlListenerTest.php
@@ -11,11 +11,14 @@ use Shopware\Core\Framework\Event\BeforeSendResponseEvent;
 use Shopware\Core\Framework\Routing\StoreApiRouteScope;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
+ *
+ * @deprecated tag:v6.8.0 - This test is deprecated because the CacheControlListener is deprecated.
  */
 #[CoversClass(CacheControlListener::class)]
 class CacheControlListenerTest extends TestCase
@@ -40,22 +43,6 @@ class CacheControlListenerTest extends TestCase
         if (!$reverseProxyEnabled) {
             static::assertFalse($response->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
         }
-    }
-
-    #[DataProvider('headerCases')]
-    public function testResponseHeaders(bool $reverseProxyEnabled, ?string $beforeHeader, string $afterHeader): void
-    {
-        $response = new Response();
-
-        if ($beforeHeader) {
-            $response->headers->set('cache-control', $beforeHeader);
-        }
-
-        $subscriber = new CacheControlListener($reverseProxyEnabled);
-
-        $subscriber->__invoke(new BeforeSendResponseEvent(new Request(), $response));
-
-        static::assertSame($afterHeader, $response->headers->get('cache-control'));
     }
 
     /**
@@ -107,33 +94,23 @@ class CacheControlListenerTest extends TestCase
         ];
     }
 
-    public function testStoreApiHeadersNotModified(): void
+    public function testHeadersNotModified(): void
     {
         $response = new Response();
         $response->headers->set('cache-control', 'public, s-maxage=64000');
 
-        $request = new Request();
-        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [StoreApiRouteScope::ID]);
-
         $subscriber = new CacheControlListener(false);
 
-        $subscriber->__invoke(new BeforeSendResponseEvent($request, $response));
-
+        // StoreAPI
+        $storeApiRequest = new Request();
+        $storeApiRequest->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [StoreApiRouteScope::ID]);
+        $subscriber->__invoke(new BeforeSendResponseEvent($storeApiRequest, $response));
         static::assertSame('public, s-maxage=64000', $response->headers->get('cache-control'));
-    }
 
-    #[DisabledFeatures(['CACHE_REWORK', 'v6.8.0.0'])]
-    public function testStoreApiHeadersWithoutFeatureFlags(): void
-    {
-        $response = new Response();
-        $response->headers->set('cache-control', 'public, s-maxage=64000');
-
-        $request = new Request();
-        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [StoreApiRouteScope::ID]);
-
-        $subscriber = new CacheControlListener(false);
-        $subscriber->__invoke(new BeforeSendResponseEvent(new Request(), $response));
-
-        static::assertSame('no-cache, private', $response->headers->get('cache-control'));
+        // Storefront
+        $storefrontRequest = new Request();
+        $storefrontRequest->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [StorefrontRouteScope::ID]);
+        $subscriber->__invoke(new BeforeSendResponseEvent($storefrontRequest, $response));
+        static::assertSame('public, s-maxage=64000', $response->headers->get('cache-control'));
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CachePolicyProviderTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CachePolicyProviderTest.php
@@ -32,10 +32,11 @@ class CachePolicyProviderTest extends TestCase
         bool $cacheable,
         ?CacheAttribute $cacheAttribute,
         CachePolicy $expectedPolicy,
+        bool $enforceNoStore = false,
     ): void {
         $provider = new CachePolicyProvider($policies, $routePolicies, $defaultPolicies);
 
-        $result = $provider->getPolicy($route, $area, $cacheable, $cacheAttribute);
+        $result = $provider->getPolicy($route, $area, $cacheable, $cacheAttribute, $enforceNoStore);
 
         static::assertEquals($expectedPolicy, $result);
     }
@@ -48,8 +49,9 @@ class CachePolicyProviderTest extends TestCase
      *     route: string,
      *     area: string,
      *     cacheable: bool,
-     *     cacheAttribute: CacheAttribute,
-     *     expectedPolicy: CachePolicy
+     *     cacheAttribute: ?CacheAttribute,
+     *     expectedPolicy: CachePolicy,
+     *     enforceNoStore?: bool
      * }>
      */
     public static function providePolicyResolutionCases(): iterable
@@ -196,7 +198,38 @@ class CachePolicyProviderTest extends TestCase
             'area' => 'unknown_area',
             'cacheable' => true,
             'cacheAttribute' => new CacheAttribute(),
-            'expectedPolicy' => CachePolicy::noCache(),
+            'expectedPolicy' => CachePolicy::noStore(),
+        ];
+
+        yield 'enforceNoStore with default policy returns noStore policy' => [
+            'policies' => ['default_policy' => $defaultPolicy],
+            'routePolicies' => [],
+            'defaultPolicies' => [
+                'storefront' => new DefaultPolicies('default_policy', 'default_policy'),
+            ],
+            'route' => 'some.route',
+            'area' => 'storefront',
+            'cacheable' => false,
+            'cacheAttribute' => null,
+            'expectedPolicy' => CachePolicy::noStore(),
+            'enforceNoStore' => true,
+        ];
+
+        yield 'enforceNoStore with route-specific policy returns original policy' => [
+            'policies' => [
+                'default_policy' => $defaultPolicy,
+                'specific_policy' => $specificPolicy,
+            ],
+            'routePolicies' => ['my.route' => 'specific_policy'],
+            'defaultPolicies' => [
+                'storefront' => new DefaultPolicies('default_policy', 'default_policy'),
+            ],
+            'route' => 'my.route',
+            'area' => 'storefront',
+            'cacheable' => false,
+            'cacheAttribute' => null,
+            'expectedPolicy' => $specificPolicy,
+            'enforceNoStore' => true,
         ];
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CachePolicyTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CachePolicyTest.php
@@ -66,15 +66,15 @@ class CachePolicyTest extends TestCase
         static::assertSame($cacheControl, $newPolicy->cacheControl);
     }
 
-    public function testNoCache(): void
+    public function testNoStore(): void
     {
-        $policy = CachePolicy::noCache();
+        $policy = CachePolicy::noStore();
         static::assertTrue($policy->cacheControl->noStore);
         static::assertTrue($policy->cacheControl->noCache);
         static::assertTrue($policy->cacheControl->mustRevalidate);
         static::assertSame(0, $policy->cacheControl->maxAge);
-        static::assertSame(0, $policy->cacheControl->sMaxAge);
         static::assertNull($policy->cacheControl->public);
         static::assertNull($policy->cacheControl->private);
+        static::assertNull($policy->cacheControl->sMaxAge); // in other case symfony will set response as public
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
@@ -90,17 +90,7 @@ class CacheResponseSubscriberTest extends TestCase
 
     public function testNoHeadersAreSetIfCacheIsDisabled(): void
     {
-        // manually create instance with cache disabled
-        $subscriber = new CacheResponseSubscriber(
-            $this->cartService,
-            100,
-            false,
-            new MaintenanceModeResolver($this->eventDispatcher),
-            null,
-            null,
-            $this->createMock(CacheHeadersService::class),
-            $this->createCachePolicyProvider(),
-        );
+        $subscriber = $this->getCacheResponseSubscriberWithCacheDisabled();
 
         $customer = new CustomerEntity();
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
@@ -119,6 +109,29 @@ class CacheResponseSubscriberTest extends TestCase
         static::assertSame($expectedHeaders, $response->headers->all());
     }
 
+    public function testNoStoreAppliedWhenCacheDisabled(): void
+    {
+        $subscriber = $this->getCacheResponseSubscriberWithCacheDisabled();
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_NO_STORE, true);
+
+        $response = new Response();
+
+        $event = $this->createResponseEvent($request, $response);
+
+        $subscriber->setResponseCache($event);
+
+        // Verify no-store headers are applied even when cache is disabled
+        static::assertTrue($response->headers->hasCacheControlDirective('no-store'));
+        static::assertTrue($response->headers->hasCacheControlDirective('no-cache'));
+        static::assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
+        static::assertFalse($response->isCacheable());
+    }
+
     public function testNoAutoCacheControlHeader(): void
     {
         $request = new Request();
@@ -135,17 +148,7 @@ class CacheResponseSubscriberTest extends TestCase
 
     public function testNoAutoCacheControlHeaderCacheDisabled(): void
     {
-        // manually create instance with cache disabled
-        $subscriber = new CacheResponseSubscriber(
-            $this->cartService,
-            100,
-            false,
-            new MaintenanceModeResolver($this->eventDispatcher),
-            null,
-            null,
-            $this->createMock(CacheHeadersService::class),
-            $this->createCachePolicyProvider(),
-        );
+        $subscriber = $this->getCacheResponseSubscriberWithCacheDisabled();
 
         $request = new Request();
         $request->attributes->add([PlatformRequest::ATTRIBUTE_HTTP_CACHE => true]);
@@ -675,6 +678,17 @@ class CacheResponseSubscriberTest extends TestCase
             ],
             'expectedCacheControl' => 'max-age=0, no-cache, private, s-maxage=0',
         ];
+
+        yield 'no-store attribute enforces noStore policy' => [
+            'requestResponseOptions' => array_merge($storefrontRequestAttributes, [
+                PlatformRequest::ATTRIBUTE_NO_STORE => true,
+            ]),
+            'subscriberConfig' => [
+                'policies' => $basePolicies,
+                'defaultPolicies' => $defaultPolicies,
+            ],
+            'expectedCacheControl' => 'max-age=0, must-revalidate, no-cache, no-store, private',
+        ];
     }
 
     /**
@@ -867,6 +881,20 @@ class CacheResponseSubscriberTest extends TestCase
             $request,
             HttpKernelInterface::MAIN_REQUEST,
             $response
+        );
+    }
+
+    private function getCacheResponseSubscriberWithCacheDisabled(): CacheResponseSubscriber
+    {
+        return new CacheResponseSubscriber(
+            $this->cartService,
+            100,
+            false,
+            new MaintenanceModeResolver($this->eventDispatcher),
+            null,
+            null,
+            $this->createMock(CacheHeadersService::class),
+            $this->createCachePolicyProvider(),
         );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

There are different places where `Cache-Control` header is processed.

### 2. What does this change do, exactly?

Put all cache-control headers processing into single `CacheResponseSubscriber` file.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/13352

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
