### PR TITLE
chore: add integration to multi join group limitations

### DIFF
--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
@@ -23,6 +23,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -84,6 +86,7 @@ class JoinFilterTest extends TestCase
                 ->price(15, 10)
                 ->manufacturer('manufacturer-2')
                 ->property('red', 'color')
+                ->property('S', 'size')
                 ->category('category-1')
                 ->category('category-3')
                 ->prices('rule-1', 150)
@@ -91,6 +94,7 @@ class JoinFilterTest extends TestCase
 
             (new ProductBuilder($ids, 'product-3', 3, 'tax'))
                 ->price(15, 10)
+                ->category('category-4')
                 ->build(),
         ];
 
@@ -366,10 +370,11 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertSame(1, $result->getTotal());
+        static::assertSame(2, $result->getTotal());
         static::assertFalse($result->has($ids->get('category-1')));
         static::assertFalse($result->has($ids->get('category-2')));
         static::assertTrue($result->has($ids->get('category-3')));
+        static::assertTrue($result->has($ids->get('category-4')));
     }
 
     #[Depends('testIndexing')]
@@ -426,6 +431,148 @@ class JoinFilterTest extends TestCase
     }
 
     #[Depends('testIndexing')]
+    public function testOneToManyWithSort(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithSortDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-2'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-1'), $result->getIds()[1]); // Rule 2 price is higher, but ignored because of filter
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithSortWithMultipleJoinGroups(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        // note that this is the same order then below, because apparently it uses both rule-1 price and rule-2 price
+        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
+        // however note that by the join group the lower rule-1 price should be filtered out
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithSortWithMultipleJoinGroupsDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        // note that this is the same order then above, because apparently it uses both rule-1 price and rule-2 price
+        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
+        // however note that by the join group the lower rule-1 price should be filtered out
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithGrouping(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(1, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
+
+        // we get an internal DBAL field mapping exception here,
+        // which is not optimal but at least indicates that this is not supported
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    #[Depends('testIndexing')]
     public function testOneToManyWithMultipleFilters(IdsCollection $ids): void
     {
         $criteria = new Criteria($ids->prefixed('product-'));
@@ -466,6 +613,87 @@ class JoinFilterTest extends TestCase
     }
 
     #[Depends('testIndexing')]
+    public function testManyToOneWithSort(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name'));
+
+        $result = static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(3, $result->getTotal());
+        static::assertSame($ids->get('category-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('category-2'), $result->getIds()[1]);
+        static::assertSame($ids->get('category-3'), $result->getIds()[2]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToOneWithSortDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(3, $result->getTotal());
+        static::assertSame($ids->get('category-1'), $result->getIds()[0]); // manufacturer-2 matches as well
+        static::assertSame($ids->get('category-3'), $result->getIds()[1]); // manufacturer-2
+        static::assertSame($ids->get('category-2'), $result->getIds()[2]); // manufacturer-1
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToOneWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('category.products.manufacturer.name'));
+
+        // we get an internal DBAL field mapping exception here,
+        // which is not optimal but at least indicates that this is not supported
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    #[Depends('testIndexing')]
     public function testManyToMany(IdsCollection $ids): void
     {
         $criteria = new Criteria($ids->prefixed('product-'));
@@ -482,6 +710,108 @@ class JoinFilterTest extends TestCase
         static::assertSame(1, $result->getTotal());
         static::assertFalse($result->has($ids->get('product-2')));
         static::assertTrue($result->has($ids->get('product-1')));
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithMultiJoinGroup(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertTrue($result->has($ids->get('product-2')));
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithSort(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.properties.name'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithSortDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.properties.name', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithGroup(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.properties.name'));
+
+        // we get an internal DBAL field mapping exception here,
+        // which is not optimal but at least indicates that this is not supported
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
     }
 
     #[Depends('testIndexing')]

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\AfterClass;
 use PHPUnit\Framework\Attributes\BeforeClass;
-use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
@@ -39,6 +38,8 @@ class JoinFilterTest extends TestCase
 {
     use KernelTestBehaviour;
 
+    private static IdsCollection $ids;
+
     #[BeforeClass]
     public static function startTransactionBefore(): void
     {
@@ -47,6 +48,11 @@ class JoinFilterTest extends TestCase
             ->get(Connection::class);
 
         $connection->beginTransaction();
+
+        self::$ids = new IdsCollection();
+
+        // performance optimization: only insert the test data once per test class and not before each test
+        self::insertTestData();
     }
 
     #[AfterClass]
@@ -59,81 +65,7 @@ class JoinFilterTest extends TestCase
         $connection->rollBack();
     }
 
-    /**
-     * @return IdsCollection
-     */
-    public function testIndexing()
-    {
-        $ids = new IdsCollection();
-
-        $products = [
-            (new ProductBuilder($ids, 'product-1', 10, 'tax'))
-                ->price(15, 10)
-                ->manufacturer('manufacturer-1')
-                ->property('red', 'color')
-                ->property('yellow', 'color')
-                ->property('XL', 'size')
-                ->property('L', 'size')
-                ->category('category-1')
-                ->category('category-2')
-                ->prices('rule-1', 100)
-                ->prices('rule-2', 150)
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-1-variant', 10, 'tax'))
-                ->parent('product-1')
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-2', 3, 'tax'))
-                ->price(15, 10)
-                ->manufacturer('manufacturer-2')
-                ->property('red', 'color')
-                ->property('S', 'size')
-                ->category('category-1')
-                ->category('category-3')
-                ->prices('rule-1', 150)
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-3', 3, 'tax'))
-                ->price(15, 10)
-                ->category('category-4')
-                ->build(),
-        ];
-
-        static::getContainer()->get('product.repository')
-            ->create($products, Context::createDefaultContext());
-
-        $userId = static::getContainer()->get(Connection::class)
-            ->fetchOne('SELECT LOWER(HEX(id)) FROM `user`');
-
-        $ids->set('user-id', $userId);
-
-        $media = [
-            ['id' => $ids->create('with-avatar')],
-            ['id' => $ids->create('without-avatar')],
-        ];
-
-        static::getContainer()->get('media.repository')
-            ->create($media, Context::createDefaultContext());
-
-        $avatar = [
-            'id' => $userId,
-            'avatarId' => $ids->get('with-avatar'),
-        ];
-
-        static::getContainer()->get('user.repository')
-            ->update([$avatar], Context::createDefaultContext());
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds(new Criteria($ids->prefixed('product-')), Context::createDefaultContext());
-
-        static::assertSame(\count($products), $result->getTotal());
-
-        return $ids;
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToOne(IdsCollection $ids): void
+    public function testOneToOne(): void
     {
         $criteria = new Criteria();
         $criteria->addFilter(
@@ -144,8 +76,8 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertCount(1, $media->getIds());
-        static::assertContains($ids->get('with-avatar'), $media->getIds());
-        static::assertNotContains($ids->get('without-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('with-avatar'), $media->getIds());
+        static::assertNotContains(self::$ids->get('without-avatar'), $media->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('avatarUsers.id', null));
@@ -154,8 +86,8 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertTrue(\count($media->getIds()) > 0);
-        static::assertContains($ids->get('without-avatar'), $media->getIds());
-        static::assertNotContains($ids->get('with-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('without-avatar'), $media->getIds());
+        static::assertNotContains(self::$ids->get('with-avatar'), $media->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(
@@ -169,8 +101,8 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertTrue(\count($media->getIds()) > 0);
-        static::assertContains($ids->get('with-avatar'), $media->getIds());
-        static::assertContains($ids->get('without-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('with-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('without-avatar'), $media->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(
@@ -181,16 +113,15 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertTrue(\count($media->getIds()) > 0);
-        static::assertContains($ids->get('with-avatar'), $media->getIds());
-        static::assertContains($ids->get('without-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('with-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('without-avatar'), $media->getIds());
     }
 
-    #[Depends('testIndexing')]
-    public function testAggregationWithFilter(IdsCollection $ids): void
+    public function testAggregationWithFilter(): void
     {
         $criteria = new Criteria();
         $criteria->addFilter(
-            new EqualsAnyFilter('properties.id', $ids->getList(['red']))
+            new EqualsAnyFilter('properties.id', self::$ids->getList(['red']))
         );
 
         $criteria->addAggregation(
@@ -206,19 +137,18 @@ class JoinFilterTest extends TestCase
 
         static::assertInstanceOf(TermsResult::class, $aggregation);
 
-        static::assertContains($ids->get('red'), $aggregation->getKeys());
-        static::assertContains($ids->get('yellow'), $aggregation->getKeys());
-        static::assertContains($ids->get('XL'), $aggregation->getKeys());
-        static::assertContains($ids->get('L'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('red'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('yellow'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('XL'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('L'), $aggregation->getKeys());
     }
 
-    #[Depends('testIndexing')]
-    public function testAggregationWithNegatedFilter(IdsCollection $ids): void
+    public function testAggregationWithNegatedFilter(): void
     {
         $criteria = new Criteria();
         $criteria->addFilter(
             new NandFilter([
-                new EqualsAnyFilter('properties.id', $ids->getList(['XL'])),
+                new EqualsAnyFilter('properties.id', self::$ids->getList(['XL'])),
             ])
         );
 
@@ -235,37 +165,35 @@ class JoinFilterTest extends TestCase
 
         static::assertInstanceOf(TermsResult::class, $aggregation);
 
-        static::assertContains($ids->get('red'), $aggregation->getKeys());
-        static::assertNotContains($ids->get('yellow'), $aggregation->getKeys());
-        static::assertNotContains($ids->get('XL'), $aggregation->getKeys());
-        static::assertNotContains($ids->get('L'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('red'), $aggregation->getKeys());
+        static::assertNotContains(self::$ids->get('yellow'), $aggregation->getKeys());
+        static::assertNotContains(self::$ids->get('XL'), $aggregation->getKeys());
+        static::assertNotContains(self::$ids->get('L'), $aggregation->getKeys());
     }
 
-    #[Depends('testIndexing')]
-    public function testNestedManyToMany(IdsCollection $ids): void
+    public function testNestedManyToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
-            new EqualsAnyFilter('category.products.properties.id', [$ids->get('red'), $ids->get('yellow')])
+            new EqualsAnyFilter('category.products.properties.id', [self::$ids->get('red'), self::$ids->get('yellow')])
         );
         $criteria->addFilter(
-            new EqualsAnyFilter('category.products.properties.id', [$ids->get('XL'), $ids->get('L')])
+            new EqualsAnyFilter('category.products.properties.id', [self::$ids->get('XL'), self::$ids->get('L')])
         );
 
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('category-1')));
-        static::assertTrue($result->has($ids->get('category-2')));
-        static::assertFalse($result->has($ids->get('category-3')));
+        static::assertTrue($result->has(self::$ids->get('category-1')));
+        static::assertTrue($result->has(self::$ids->get('category-2')));
+        static::assertFalse($result->has(self::$ids->get('category-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testTranslatedFields(IdsCollection $ids): void
+    public function testTranslatedFields(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.properties.name', 'red')
         );
@@ -277,14 +205,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testContainsFilter(IdsCollection $ids): void
+    public function testContainsFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new ContainsFilter('product.properties.name', 're')
         );
@@ -296,14 +223,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testPrefixFilter(IdsCollection $ids): void
+    public function testPrefixFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         // "re" refers to the property "red" of "product-1" and "product-2"
         $criteria->addFilter(
             new PrefixFilter('product.properties.name', 're')
@@ -317,14 +243,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testSuffixFilter(IdsCollection $ids): void
+    public function testSuffixFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         // "ed" refers to the property "red" of "product-1" and "product-2"
         $criteria->addFilter(
             new SuffixFilter('product.properties.name', 'ed')
@@ -338,14 +263,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testRangeFilter(IdsCollection $ids): void
+    public function testRangeFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
             new RangeFilter('category.products.stock', [RangeFilter::GTE => 5])
@@ -355,15 +279,14 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('category-1')));
-        static::assertTrue($result->has($ids->get('category-2')));
-        static::assertFalse($result->has($ids->get('category-3')));
+        static::assertTrue($result->has(self::$ids->get('category-1')));
+        static::assertTrue($result->has(self::$ids->get('category-2')));
+        static::assertFalse($result->has(self::$ids->get('category-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testNegatedRangeFilter(IdsCollection $ids): void
+    public function testNegatedRangeFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
             new NandFilter([new RangeFilter('category.products.stock', [RangeFilter::GTE => 5])])
@@ -373,20 +296,19 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertFalse($result->has($ids->get('category-1')));
-        static::assertFalse($result->has($ids->get('category-2')));
-        static::assertTrue($result->has($ids->get('category-3')));
-        static::assertTrue($result->has($ids->get('category-4')));
+        static::assertFalse($result->has(self::$ids->get('category-1')));
+        static::assertFalse($result->has(self::$ids->get('category-2')));
+        static::assertTrue($result->has(self::$ids->get('category-3')));
+        static::assertTrue($result->has(self::$ids->get('category-4')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOrFilter(IdsCollection $ids): void
+    public function testOrFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
-                new EqualsFilter('product.properties.id', $ids->get('red')),
-                new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                new EqualsFilter('product.properties.id', self::$ids->get('red')),
+                new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
             ])
         );
 
@@ -394,17 +316,16 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToMany(IdsCollection $ids): void
+    public function testOneToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
             ])
         );
@@ -413,13 +334,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
 
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::LTE => 100]),
             ])
         );
@@ -428,17 +349,16 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyWithSort(IdsCollection $ids): void
+    public function testOneToManyWithSort(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
             ])
         );
@@ -448,17 +368,16 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyWithSortDesc(IdsCollection $ids): void
+    public function testOneToManyWithSortDesc(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
             ])
         );
@@ -468,17 +387,16 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-2'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-1'), $result->getIds()[1]); // Rule 2 price is higher, but ignored because of filter
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[1]); // Rule 2 price is higher, but ignored because of filter
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyWithGrouping(IdsCollection $ids): void
+    public function testOneToManyWithGrouping(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
             ])
         );
@@ -488,35 +406,33 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyWithMultipleFilters(IdsCollection $ids): void
+    public function testOneToManyWithMultipleFilters(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
-            new EqualsFilter('product.prices.ruleId', $ids->get('rule-1'))
+            new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1'))
         );
         $criteria->addFilter(
-            new EqualsFilter('product.prices.ruleId', $ids->get('rule-2'))
+            new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-2'))
         );
 
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOne(IdsCollection $ids): void
+    public function testManyToOne(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
-            new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1'))
+            new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-1'))
         );
         $criteria->addFilter(
             new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1')
@@ -526,42 +442,40 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('category-1')));
-        static::assertTrue($result->has($ids->get('category-2')));
-        static::assertFalse($result->has($ids->get('category-3')));
+        static::assertTrue($result->has(self::$ids->get('category-1')));
+        static::assertTrue($result->has(self::$ids->get('category-2')));
+        static::assertFalse($result->has(self::$ids->get('category-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToMany(IdsCollection $ids): void
+    public function testManyToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
-            new EqualsFilter('product.properties.id', $ids->get('red'))
+            new EqualsFilter('product.properties.id', self::$ids->get('red'))
         );
         $criteria->addFilter(
-            new EqualsFilter('product.properties.id', $ids->get('yellow'))
+            new EqualsFilter('product.properties.id', self::$ids->get('yellow'))
         );
 
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyWithMultiJoinGroup(IdsCollection $ids): void
+    public function testManyToManyWithMultiJoinGroup(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
                     new EqualsFilter('product.properties.name', 'yellow'),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.id', self::$ids->get('S')),
                     new EqualsFilter('product.properties.name', 'S'),
                 ]),
             ])
@@ -571,17 +485,16 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyWithOneFilter(IdsCollection $ids): void
+    public function testManyToManyWithOneFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
                 new EqualsFilter('product.properties.name', 'yellow'),
             ])
         );
@@ -590,14 +503,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyTranslated(IdsCollection $ids): void
+    public function testOneToManyTranslated(): void
     {
-        $criteria = new Criteria($ids->prefixed('manufacturer-'));
+        $criteria = new Criteria(self::$ids->prefixed('manufacturer-'));
 
         $criteria->addFilter(
             new EqualsFilter('product_manufacturer.products.name', 'product-1')
@@ -610,10 +522,10 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('manufacturer-1')));
-        static::assertFalse($result->has($ids->get('manufacturer-2')));
+        static::assertTrue($result->has(self::$ids->get('manufacturer-1')));
+        static::assertFalse($result->has(self::$ids->get('manufacturer-2')));
 
-        $criteria = new Criteria($ids->prefixed('manufacturer-'));
+        $criteria = new Criteria(self::$ids->prefixed('manufacturer-'));
 
         $criteria->addFilter(
             new ContainsFilter('product_manufacturer.products.name', 'product')
@@ -626,14 +538,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('manufacturer-1')));
-        static::assertTrue($result->has($ids->get('manufacturer-2')));
+        static::assertTrue($result->has(self::$ids->get('manufacturer-1')));
+        static::assertTrue($result->has(self::$ids->get('manufacturer-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOneTranslated(IdsCollection $ids): void
+    public function testManyToOneTranslated(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NorFilter([
                 new EqualsFilter('product.manufacturer.id', null),
@@ -645,29 +556,28 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
 
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new ContainsFilter('product.manufacturer.name', 'manufacturer')
         );
         $criteria->addFilter(
-            new EqualsAnyFilter('product.manufacturer.id', $ids->getList(['manufacturer-1', 'manufacturer-2']))
+            new EqualsAnyFilter('product.manufacturer.id', self::$ids->getList(['manufacturer-1', 'manufacturer-2']))
         );
 
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyTranslated(IdsCollection $ids): void
+    public function testManyToManyTranslated(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.properties.name', 'red')
         );
@@ -679,17 +589,16 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyInherited(IdsCollection $ids): void
+    public function testOneToManyInherited(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
             ])
         );
@@ -698,18 +607,17 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, $context));
 
         static::assertSame(3, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOneInherited(IdsCollection $ids): void
+    public function testManyToOneInherited(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NandFilter([
-                new EqualsFilter('product.manufacturer.id', $ids->get('manufacturer-2')),
+                new EqualsFilter('product.manufacturer.id', self::$ids->get('manufacturer-2')),
             ])
         );
 
@@ -717,36 +625,34 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, $context));
 
         static::assertSame(3, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
-        static::assertTrue($result->has($ids->get('product-3')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
+        static::assertTrue($result->has(self::$ids->get('product-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyInherited(IdsCollection $ids): void
+    public function testManyToManyInherited(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
-            new EqualsFilter('product.properties.id', $ids->get('red'))
+            new EqualsFilter('product.properties.id', self::$ids->get('red'))
         );
         $criteria->addFilter(
-            new EqualsFilter('product.properties.id', $ids->get('yellow'))
+            new EqualsFilter('product.properties.id', self::$ids->get('yellow'))
         );
 
         $result = Context::createDefaultContext()->enableInheritance(fn (Context $context) => static::getContainer()->get('product.repository')
             ->searchIds($criteria, $context));
 
         static::assertSame(2, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasOneToMany(IdsCollection $ids): void
+    public function testHasOneToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NandFilter([
                 new EqualsFilter('product.prices.id', null),
@@ -757,14 +663,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasManyToOne(IdsCollection $ids): void
+    public function testHasManyToOne(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NandFilter([
                 new EqualsFilter('product.manufacturer.id', null),
@@ -775,14 +680,13 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasManyToMany(IdsCollection $ids): void
+    public function testHasManyToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NandFilter([
                 new EqualsFilter('product.manufacturer.id', null),
@@ -793,15 +697,14 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-3')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasNotOneToMany(IdsCollection $ids): void
+    public function testHasNotOneToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.prices.id', null)
         );
@@ -810,16 +713,15 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-3')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
-        static::assertFalse($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-3')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
+        static::assertFalse($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasNotManyToOne(IdsCollection $ids): void
+    public function testHasNotManyToOne(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.manufacturer.id', null)
         );
@@ -828,16 +730,15 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-3')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertFalse($result->has($ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-3')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertFalse($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasNotManyToMany(IdsCollection $ids): void
+    public function testHasNotManyToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.properties.id', null)
         );
@@ -846,10 +747,10 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertFalse($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-3')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertFalse($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-3')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
     }
 
     public function testEqualsNullWithUnmappedField(): void
@@ -860,5 +761,71 @@ class JoinFilterTest extends TestCase
         static::expectException(UnmappedFieldException::class);
         static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    private static function insertTestData(): void
+    {
+        $products = [
+            (new ProductBuilder(self::$ids, 'product-1', 10, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-1')
+                ->property('red', 'color')
+                ->property('yellow', 'color')
+                ->property('XL', 'size')
+                ->property('L', 'size')
+                ->category('category-1')
+                ->category('category-2')
+                ->prices('rule-1', 100)
+                ->prices('rule-2', 150)
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-1-variant', 10, 'tax'))
+                ->parent('product-1')
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-2', 3, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-2')
+                ->property('red', 'color')
+                ->property('S', 'size')
+                ->category('category-1')
+                ->category('category-3')
+                ->prices('rule-1', 150)
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-3', 3, 'tax'))
+                ->price(15, 10)
+                ->category('category-4')
+                ->build(),
+        ];
+
+        static::getContainer()->get('product.repository')
+            ->create($products, Context::createDefaultContext());
+
+        $userId = static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT LOWER(HEX(id)) FROM `user`');
+
+        self::$ids->set('user-id', $userId);
+
+        $media = [
+            ['id' => self::$ids->create('with-avatar')],
+            ['id' => self::$ids->create('without-avatar')],
+        ];
+
+        static::getContainer()->get('media.repository')
+            ->create($media, Context::createDefaultContext());
+
+        $avatar = [
+            'id' => $userId,
+            'avatarId' => self::$ids->get('with-avatar'),
+        ];
+
+        static::getContainer()->get('user.repository')
+            ->update([$avatar], Context::createDefaultContext());
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds(new Criteria(self::$ids->prefixed('product-')), Context::createDefaultContext());
+
+        static::assertSame(\count($products), $result->getTotal());
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
@@ -32,6 +32,8 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
+ *
+ * @see MultiJoinFilterLimitationTest for edge cases and limitations of multi join filters
  */
 class JoinFilterTest extends TestCase
 {
@@ -471,64 +473,6 @@ class JoinFilterTest extends TestCase
     }
 
     #[Depends('testIndexing')]
-    public function testOneToManyWithSortWithMultipleJoinGroups(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.prices.price'));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        // note that this is the same order then below, because apparently it uses both rule-1 price and rule-2 price
-        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
-        // however note that by the join group the lower rule-1 price should be filtered out
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToManyWithSortWithMultipleJoinGroupsDesc(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        // note that this is the same order then above, because apparently it uses both rule-1 price and rule-2 price
-        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
-        // however note that by the join group the lower rule-1 price should be filtered out
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
     public function testOneToManyWithGrouping(IdsCollection $ids): void
     {
         $criteria = new Criteria($ids->prefixed('product-'));
@@ -545,31 +489,6 @@ class JoinFilterTest extends TestCase
 
         static::assertSame(1, $result->getTotal());
         static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToManyWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
-                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
-                ]),
-            ])
-        );
-        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
-
-        // we get an internal DBAL field mapping exception here,
-        // which is not optimal but at least indicates that this is not supported
-        static::expectException(\Throwable::class);
-        static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
     }
 
     #[Depends('testIndexing')]
@@ -610,87 +529,6 @@ class JoinFilterTest extends TestCase
         static::assertTrue($result->has($ids->get('category-1')));
         static::assertTrue($result->has($ids->get('category-2')));
         static::assertFalse($result->has($ids->get('category-3')));
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToOneWithSort(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('category-'));
-
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name'));
-
-        $result = static::getContainer()->get('category.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(3, $result->getTotal());
-        static::assertSame($ids->get('category-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('category-2'), $result->getIds()[1]);
-        static::assertSame($ids->get('category-3'), $result->getIds()[2]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToOneWithSortDesc(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('category-'));
-
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name', FieldSorting::DESCENDING));
-
-        $result = static::getContainer()->get('category.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(3, $result->getTotal());
-        static::assertSame($ids->get('category-1'), $result->getIds()[0]); // manufacturer-2 matches as well
-        static::assertSame($ids->get('category-3'), $result->getIds()[1]); // manufacturer-2
-        static::assertSame($ids->get('category-2'), $result->getIds()[2]); // manufacturer-1
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToOneWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('category-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
-                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
-                ]),
-            ])
-        );
-        $criteria->addGroupField(new FieldGrouping('category.products.manufacturer.name'));
-
-        // we get an internal DBAL field mapping exception here,
-        // which is not optimal but at least indicates that this is not supported
-        static::expectException(\Throwable::class);
-        static::getContainer()->get('category.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
     }
 
     #[Depends('testIndexing')]
@@ -735,83 +573,6 @@ class JoinFilterTest extends TestCase
         static::assertSame(2, $result->getTotal());
         static::assertTrue($result->has($ids->get('product-1')));
         static::assertTrue($result->has($ids->get('product-2')));
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToManyWithSort(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
-                    new EqualsFilter('product.properties.name', 'yellow'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
-                    new EqualsFilter('product.properties.name', 'S'),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.properties.name'));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToManyWithSortDesc(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
-                    new EqualsFilter('product.properties.name', 'yellow'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
-                    new EqualsFilter('product.properties.name', 'S'),
-                ]),
-            ])
-        );
-        $criteria->addSorting(new FieldSorting('product.properties.name', FieldSorting::DESCENDING));
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
-
-        static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
-    }
-
-    #[Depends('testIndexing')]
-    public function testManyToManyWithGroup(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
-        $criteria->addFilter(
-            new OrFilter([
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
-                    new EqualsFilter('product.properties.name', 'yellow'),
-                ]),
-                new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
-                    new EqualsFilter('product.properties.name', 'S'),
-                ]),
-            ])
-        );
-        $criteria->addGroupField(new FieldGrouping('product.properties.name'));
-
-        // we get an internal DBAL field mapping exception here,
-        // which is not optimal but at least indicates that this is not supported
-        static::expectException(\Throwable::class);
-        static::getContainer()->get('product.repository')
-            ->searchIds($criteria, Context::createDefaultContext());
     }
 
     #[Depends('testIndexing')]

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
@@ -1,0 +1,368 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\BeforeClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+
+/**
+ * @internal
+ *
+ * This test case covers known limitations when using multiple join groups
+ * Due to conceptual reasons multi join groups won't do a "real join" to the filtered association,
+ * this means all other DAL features (e.g. sorting, grouping) won't work as expected in combination with multi join groups.
+ * Sorting is based on a unfiltered join (meaning all associated entities are considered for sorting, not just the filtered once).
+ * Grouping is only supported in conjunction with sorting in those cases, and would then also operate on the unfiltered join.
+ *
+ * The behaviour documented in test explicitly is not considered part of the public API and therefore might be fixed in future versions.
+ * The purpose of this test is mainly to make the current limitations explicit and to avoid accidental changes to the current behaviour.
+ *
+ * @see JoinFilterTest for the tests for all valid cases that are part of the public API.
+ */
+class MultiJoinFilterLimitationTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    #[BeforeClass]
+    public static function startTransactionBefore(): void
+    {
+        $connection = KernelLifecycleManager::getKernel()
+            ->getContainer()
+            ->get(Connection::class);
+
+        $connection->beginTransaction();
+    }
+
+    #[AfterClass]
+    public static function stopTransactionAfter(): void
+    {
+        $connection = KernelLifecycleManager::getKernel()
+            ->getContainer()
+            ->get(Connection::class);
+
+        $connection->rollBack();
+    }
+
+    /**
+     * @return IdsCollection
+     */
+    public function testIndexing()
+    {
+        $ids = new IdsCollection();
+
+        $products = [
+            (new ProductBuilder($ids, 'product-1', 10, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-1')
+                ->property('red', 'color')
+                ->property('yellow', 'color')
+                ->property('XL', 'size')
+                ->property('L', 'size')
+                ->category('category-1')
+                ->category('category-2')
+                ->prices('rule-1', 100)
+                ->prices('rule-2', 150)
+                ->build(),
+
+            (new ProductBuilder($ids, 'product-1-variant', 10, 'tax'))
+                ->parent('product-1')
+                ->build(),
+
+            (new ProductBuilder($ids, 'product-2', 3, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-2')
+                ->property('red', 'color')
+                ->property('S', 'size')
+                ->category('category-1')
+                ->category('category-3')
+                ->prices('rule-1', 150)
+                ->build(),
+
+            (new ProductBuilder($ids, 'product-3', 3, 'tax'))
+                ->price(15, 10)
+                ->category('category-4')
+                ->build(),
+        ];
+
+        static::getContainer()->get('product.repository')
+            ->create($products, Context::createDefaultContext());
+
+        $userId = static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT LOWER(HEX(id)) FROM `user`');
+
+        $ids->set('user-id', $userId);
+
+        $media = [
+            ['id' => $ids->create('with-avatar')],
+            ['id' => $ids->create('without-avatar')],
+        ];
+
+        static::getContainer()->get('media.repository')
+            ->create($media, Context::createDefaultContext());
+
+        $avatar = [
+            'id' => $userId,
+            'avatarId' => $ids->get('with-avatar'),
+        ];
+
+        static::getContainer()->get('user.repository')
+            ->update([$avatar], Context::createDefaultContext());
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds(new Criteria($ids->prefixed('product-')), Context::createDefaultContext());
+
+        static::assertSame(\count($products), $result->getTotal());
+
+        return $ids;
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithSortWithMultipleJoinGroups(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        // note that this is the same order then below, because apparently it uses both rule-1 price and rule-2 price
+        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
+        // however note that by the join group the lower rule-1 price should be filtered out
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithSortWithMultipleJoinGroupsDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        // note that this is the same order then above, because apparently it uses both rule-1 price and rule-2 price
+        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
+        // however note that by the join group the lower rule-1 price should be filtered out
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testOneToManyWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
+
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToOneWithSort(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name'));
+
+        $result = static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(3, $result->getTotal());
+        static::assertSame($ids->get('category-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('category-2'), $result->getIds()[1]);
+        static::assertSame($ids->get('category-3'), $result->getIds()[2]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToOneWithSortDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(3, $result->getTotal());
+        static::assertSame($ids->get('category-1'), $result->getIds()[0]); // manufacturer-2 matches as well
+        static::assertSame($ids->get('category-3'), $result->getIds()[1]); // manufacturer-2
+        static::assertSame($ids->get('category-2'), $result->getIds()[2]); // manufacturer-1
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToOneWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('category.products.manufacturer.name'));
+
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithSort(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.properties.name'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithSortDesc(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.properties.name', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    #[Depends('testIndexing')]
+    public function testManyToManyWithGroup(IdsCollection $ids): void
+    {
+        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.properties.name'));
+        
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+}

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\AfterClass;
 use PHPUnit\Framework\Attributes\BeforeClass;
-use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
@@ -38,6 +37,8 @@ class MultiJoinFilterLimitationTest extends TestCase
 {
     use KernelTestBehaviour;
 
+    private static IdsCollection $ids;
+
     #[BeforeClass]
     public static function startTransactionBefore(): void
     {
@@ -46,6 +47,11 @@ class MultiJoinFilterLimitationTest extends TestCase
             ->get(Connection::class);
 
         $connection->beginTransaction();
+
+        self::$ids = new IdsCollection();
+
+        // performance optimization: only insert the test data once per test class and not before each test
+        self::insertTestData();
     }
 
     #[AfterClass]
@@ -58,91 +64,17 @@ class MultiJoinFilterLimitationTest extends TestCase
         $connection->rollBack();
     }
 
-    /**
-     * @return IdsCollection
-     */
-    public function testIndexing()
+    public function testOneToManyWithSortWithMultipleJoinGroups(): void
     {
-        $ids = new IdsCollection();
-
-        $products = [
-            (new ProductBuilder($ids, 'product-1', 10, 'tax'))
-                ->price(15, 10)
-                ->manufacturer('manufacturer-1')
-                ->property('red', 'color')
-                ->property('yellow', 'color')
-                ->property('XL', 'size')
-                ->property('L', 'size')
-                ->category('category-1')
-                ->category('category-2')
-                ->prices('rule-1', 100)
-                ->prices('rule-2', 150)
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-1-variant', 10, 'tax'))
-                ->parent('product-1')
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-2', 3, 'tax'))
-                ->price(15, 10)
-                ->manufacturer('manufacturer-2')
-                ->property('red', 'color')
-                ->property('S', 'size')
-                ->category('category-1')
-                ->category('category-3')
-                ->prices('rule-1', 150)
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-3', 3, 'tax'))
-                ->price(15, 10)
-                ->category('category-4')
-                ->build(),
-        ];
-
-        static::getContainer()->get('product.repository')
-            ->create($products, Context::createDefaultContext());
-
-        $userId = static::getContainer()->get(Connection::class)
-            ->fetchOne('SELECT LOWER(HEX(id)) FROM `user`');
-
-        $ids->set('user-id', $userId);
-
-        $media = [
-            ['id' => $ids->create('with-avatar')],
-            ['id' => $ids->create('without-avatar')],
-        ];
-
-        static::getContainer()->get('media.repository')
-            ->create($media, Context::createDefaultContext());
-
-        $avatar = [
-            'id' => $userId,
-            'avatarId' => $ids->get('with-avatar'),
-        ];
-
-        static::getContainer()->get('user.repository')
-            ->update([$avatar], Context::createDefaultContext());
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds(new Criteria($ids->prefixed('product-')), Context::createDefaultContext());
-
-        static::assertSame(\count($products), $result->getTotal());
-
-        return $ids;
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToManyWithSortWithMultipleJoinGroups(IdsCollection $ids): void
-    {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-2')),
                     new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                     new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
                 ]),
             ])
@@ -156,22 +88,21 @@ class MultiJoinFilterLimitationTest extends TestCase
         // note that this is the same order then below, because apparently it uses both rule-1 price and rule-2 price
         // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
         // however note that by the join group the lower rule-1 price should be filtered out
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyWithSortWithMultipleJoinGroupsDesc(IdsCollection $ids): void
+    public function testOneToManyWithSortWithMultipleJoinGroupsDesc(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                     new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-2')),
                     new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
                 ]),
             ])
@@ -185,22 +116,21 @@ class MultiJoinFilterLimitationTest extends TestCase
         // note that this is the same order then above, because apparently it uses both rule-1 price and rule-2 price
         // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
         // however note that by the join group the lower rule-1 price should be filtered out
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
+    public function testOneToManyWithMultipleJoinGroupsAndGroupingIsNotSupported(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                     new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('product.prices.ruleId', $ids->get('rule-2')),
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-2')),
                     new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
                 ]),
             ])
@@ -212,19 +142,18 @@ class MultiJoinFilterLimitationTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOneWithSort(IdsCollection $ids): void
+    public function testManyToOneWithSort(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-1')),
                     new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-2')),
                     new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
                 ]),
             ])
@@ -235,24 +164,23 @@ class MultiJoinFilterLimitationTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(3, $result->getTotal());
-        static::assertSame($ids->get('category-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('category-2'), $result->getIds()[1]);
-        static::assertSame($ids->get('category-3'), $result->getIds()[2]);
+        static::assertSame(self::$ids->get('category-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('category-2'), $result->getIds()[1]);
+        static::assertSame(self::$ids->get('category-3'), $result->getIds()[2]);
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOneWithSortDesc(IdsCollection $ids): void
+    public function testManyToOneWithSortDesc(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-1')),
                     new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-2')),
                     new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
                 ]),
             ])
@@ -263,23 +191,22 @@ class MultiJoinFilterLimitationTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(3, $result->getTotal());
-        static::assertSame($ids->get('category-1'), $result->getIds()[0]); // manufacturer-2 matches as well
-        static::assertSame($ids->get('category-3'), $result->getIds()[1]); // manufacturer-2
-        static::assertSame($ids->get('category-2'), $result->getIds()[2]); // manufacturer-1
+        static::assertSame(self::$ids->get('category-1'), $result->getIds()[0]); // manufacturer-2 matches as well
+        static::assertSame(self::$ids->get('category-3'), $result->getIds()[1]); // manufacturer-2
+        static::assertSame(self::$ids->get('category-2'), $result->getIds()[2]); // manufacturer-1
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOneWithMultipleJoinGroupsAndGroupingIsNotSupported(IdsCollection $ids): void
+    public function testManyToOneWithMultipleJoinGroupsAndGroupingIsNotSupported(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-1')),
                     new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-2')),
                     new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
                 ]),
             ])
@@ -291,18 +218,17 @@ class MultiJoinFilterLimitationTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyWithSort(IdsCollection $ids): void
+    public function testManyToManyWithSort(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
                     new EqualsFilter('product.properties.name', 'yellow'),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.id', self::$ids->get('S')),
                     new EqualsFilter('product.properties.name', 'S'),
                 ]),
             ])
@@ -313,22 +239,21 @@ class MultiJoinFilterLimitationTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyWithSortDesc(IdsCollection $ids): void
+    public function testManyToManyWithSortDesc(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
                     new EqualsFilter('product.properties.name', 'yellow'),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.id', self::$ids->get('S')),
                     new EqualsFilter('product.properties.name', 'S'),
                 ]),
             ])
@@ -339,22 +264,21 @@ class MultiJoinFilterLimitationTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertSame(2, $result->getTotal());
-        static::assertSame($ids->get('product-1'), $result->getIds()[0]);
-        static::assertSame($ids->get('product-2'), $result->getIds()[1]);
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyWithGroup(IdsCollection $ids): void
+    public function testManyToManyWithGroup(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
                 new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                    new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
                     new EqualsFilter('product.properties.name', 'yellow'),
                 ]),
                 new AndFilter([
-                    new EqualsFilter('product.properties.id', $ids->get('S')),
+                    new EqualsFilter('product.properties.id', self::$ids->get('S')),
                     new EqualsFilter('product.properties.name', 'S'),
                 ]),
             ])
@@ -364,5 +288,71 @@ class MultiJoinFilterLimitationTest extends TestCase
         static::expectException(\Throwable::class);
         static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    private static function insertTestData(): void
+    {
+        $products = [
+            (new ProductBuilder(self::$ids, 'product-1', 10, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-1')
+                ->property('red', 'color')
+                ->property('yellow', 'color')
+                ->property('XL', 'size')
+                ->property('L', 'size')
+                ->category('category-1')
+                ->category('category-2')
+                ->prices('rule-1', 100)
+                ->prices('rule-2', 150)
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-1-variant', 10, 'tax'))
+                ->parent('product-1')
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-2', 3, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-2')
+                ->property('red', 'color')
+                ->property('S', 'size')
+                ->category('category-1')
+                ->category('category-3')
+                ->prices('rule-1', 150)
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-3', 3, 'tax'))
+                ->price(15, 10)
+                ->category('category-4')
+                ->build(),
+        ];
+
+        static::getContainer()->get('product.repository')
+            ->create($products, Context::createDefaultContext());
+
+        $userId = static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT LOWER(HEX(id)) FROM `user`');
+
+        self::$ids->set('user-id', $userId);
+
+        $media = [
+            ['id' => self::$ids->create('with-avatar')],
+            ['id' => self::$ids->create('without-avatar')],
+        ];
+
+        static::getContainer()->get('media.repository')
+            ->create($media, Context::createDefaultContext());
+
+        $avatar = [
+            'id' => $userId,
+            'avatarId' => self::$ids->get('with-avatar'),
+        ];
+
+        static::getContainer()->get('user.repository')
+            ->update([$avatar], Context::createDefaultContext());
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds(new Criteria(self::$ids->prefixed('product-')), Context::createDefaultContext());
+
+        static::assertSame(\count($products), $result->getTotal());
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
@@ -360,7 +360,7 @@ class MultiJoinFilterLimitationTest extends TestCase
             ])
         );
         $criteria->addGroupField(new FieldGrouping('product.properties.name'));
-        
+
         static::expectException(\Throwable::class);
         static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());


### PR DESCRIPTION
During the discussion for refactoring the multi join group filtering here: https://github.com/shopware/shopware/pull/14216

It was not obvious how multi join groups are working in combination with sorting or grouping

therefore we add tests to clarify and guarantee that behaviour and make sure that the new refactored version behaves the same.

In short with the tests the following behaviour is guaranteed:
* Sorting works in combination with Multi Join Groups, however the **multi joins are ignored for the sort**, which means sorting is done based on all associated entities and not just the filtered ones
* Grouping is not supported when JoinGroups are used as the base table is not joined, note that when you also add a sorting for the field you want to group for (leading to a new join to that association, grouping is working again)

**This means that when using criteria that needs a multi join group filter, sorting (and also grouping) is done based on a seperate not filtered join**
