### PR TITLE
feat: add default address bool to customer address

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/ListAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ListAddressRoute.php
@@ -6,13 +6,12 @@ use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCol
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\AddressListingCriteriaEvent;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\StoreApiRouteScope;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -25,10 +24,10 @@ class ListAddressRoute extends AbstractListAddressRoute
     /**
      * @internal
      *
-     * @param EntityRepository<CustomerAddressCollection> $addressRepository
+     * @param SalesChannelRepository<CustomerAddressCollection> $addressRepository
      */
     public function __construct(
-        private readonly EntityRepository $addressRepository,
+        private readonly SalesChannelRepository $addressRepository,
         private readonly EventDispatcherInterface $eventDispatcher
     ) {
     }
@@ -53,11 +52,10 @@ class ListAddressRoute extends AbstractListAddressRoute
         $criteria
             ->addAssociation('salutation')
             ->addAssociation('country')
-            ->addAssociation('countryState')
-            ->addFilter(new EqualsFilter('customer_address.customerId', $customer->getId()));
+            ->addAssociation('countryState');
 
         $this->eventDispatcher->dispatch(new AddressListingCriteriaEvent($criteria, $context));
 
-        return new ListAddressRouteResponse($this->addressRepository->search($criteria, $context->getContext()));
+        return new ListAddressRouteResponse($this->addressRepository->search($criteria, $context));
     }
 }

--- a/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressCollection.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressCollection.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Checkout\Customer\SalesChannel;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('inventory')]
+#[Package('checkout')]
 class SalesChannelCustomerAddressCollection extends CustomerAddressCollection
 {
     protected function getExpectedClass(): string

--- a/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressCollection.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressCollection.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\SalesChannel;
+
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('inventory')]
+class SalesChannelCustomerAddressCollection extends CustomerAddressCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return SalesChannelCustomerAddressEntity::class;
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinition.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinition.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\SalesChannel;
+
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Since;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+#[Package('inventory')]
+class SalesChannelCustomerAddressDefinition extends CustomerAddressDefinition implements SalesChannelDefinitionInterface
+{
+    public function getEntityClass(): string
+    {
+        return SalesChannelCustomerAddressEntity::class;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return SalesChannelCustomerAddressCollection::class;
+    }
+
+    public function processCriteria(Criteria $criteria, SalesChannelContext $context): void
+    {
+        $criteria->addFilter(new EqualsFilter('customerId', $context->getCustomer()?->getId()));
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        $fields = parent::defineFields();
+
+        $fields->add(
+            (new BoolField('is_default_billing_address', 'isDefaultBillingAddress'))->addFlags(new Runtime(), new ApiAware(), new Since('6.7.7.0'))
+        );
+        $fields->add(
+            (new BoolField('is_default_shipping_address', 'isDefaultShippingAddress'))->addFlags(new Runtime(), new ApiAware(), new Since('6.7.7.0'))
+        );
+
+        return $fields;
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinition.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinition.php
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-#[Package('inventory')]
+#[Package('checkout')]
 class SalesChannelCustomerAddressDefinition extends CustomerAddressDefinition implements SalesChannelDefinitionInterface
 {
     public function getEntityClass(): string

--- a/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressEntity.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressEntity.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\SalesChannel;
+
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+class SalesChannelCustomerAddressEntity extends CustomerAddressEntity
+{
+    protected bool $isDefaultBillingAddress = false;
+
+    protected bool $isDefaultShippingAddress = false;
+
+    public function isDefaultBillingAddress(): bool
+    {
+        return $this->isDefaultBillingAddress;
+    }
+
+    public function setIsDefaultBillingAddress(bool $isDefaultBillingAddress): void
+    {
+        $this->isDefaultBillingAddress = $isDefaultBillingAddress;
+    }
+
+    public function isDefaultShippingAddress(): bool
+    {
+        return $this->isDefaultShippingAddress;
+    }
+
+    public function setIsDefaultShippingAddress(bool $isDefaultShippingAddress): void
+    {
+        $this->isDefaultShippingAddress = $isDefaultShippingAddress;
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
@@ -40,11 +40,11 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
     use CustomerAddressValidationTrait;
 
     /**
+     * @internal
+     *
      * @param EntityRepository<CustomerAddressCollection> $addressRepository
      * @param SalesChannelRepository<CustomerAddressCollection> $salesChannelAddressRepository
      * @param EntityRepository<SalutationCollection> $salutationRepository
-     *
-     *@internal
      */
     public function __construct(
         private readonly EntityRepository $addressRepository,

--- a/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidationFactoryInterface;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper;
 use Shopware\Core\System\Salutation\SalutationCollection;
@@ -39,13 +40,15 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
     use CustomerAddressValidationTrait;
 
     /**
-     * @internal
-     *
      * @param EntityRepository<CustomerAddressCollection> $addressRepository
+     * @param SalesChannelRepository<CustomerAddressCollection> $salesChannelAddressRepository
      * @param EntityRepository<SalutationCollection> $salutationRepository
+     *
+     *@internal
      */
     public function __construct(
         private readonly EntityRepository $addressRepository,
+        private readonly SalesChannelRepository $salesChannelAddressRepository,
         private readonly DataValidator $validator,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly DataValidationFactoryInterface $addressValidationFactory,
@@ -137,7 +140,7 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
 
         $this->addressRepository->upsert([$addressData], $context->getContext());
 
-        $address = $this->addressRepository->search(new Criteria([$addressId]), $context->getContext())->getEntities()->first();
+        $address = $this->salesChannelAddressRepository->search(new Criteria([$addressId]), $context)->getEntities()->first();
         \assert($address !== null);
 
         return new UpsertAddressRouteResponse($address);

--- a/src/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriber.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Subscriber;
+
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Checkout\Customer\CustomerEvents;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelEntityLoadedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class CustomerAddressSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'sales_channel.' . CustomerEvents::CUSTOMER_ADDRESS_LOADED_EVENT => 'salesChannelLoaded',
+            'sales_channel.customer_address.partial_loaded' => 'salesChannelLoaded',
+        ];
+    }
+
+    /**
+     * @param SalesChannelEntityLoadedEvent<CustomerAddressEntity|PartialEntity> $event
+     */
+    public function salesChannelLoaded(SalesChannelEntityLoadedEvent $event): void
+    {
+        if (!$event->getSalesChannelContext()->getCustomer()) {
+            return;
+        }
+
+        foreach ($event->getEntities() as $customerAddress) {
+            if ($customerAddress->getId() === $event->getSalesChannelContext()->getCustomer()->getDefaultBillingAddressId()) {
+                $customerAddress->assign(['isDefaultBillingAddress' => true]);
+            }
+
+            if ($customerAddress->getId() === $event->getSalesChannelContext()->getCustomer()->getDefaultShippingAddressId()) {
+                $customerAddress->assign(['isDefaultShippingAddress' => true]);
+            }
+        }
+    }
+}

--- a/src/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriber.php
@@ -12,7 +12,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('checkout')]
 class CustomerAddressSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
@@ -33,9 +33,12 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
         }
 
         foreach ($event->getEntities() as $customerAddress) {
+            $defaultBillingAddressId = $event->getSalesChannelContext()->getCustomer()->getDefaultBillingAddressId();
+            $defaultShippingAddressId = $event->getSalesChannelContext()->getCustomer()->getDefaultShippingAddressId();
+
             $customerAddress->assign([
-                'isDefaultBillingAddress' => $customerAddress->getId() === $event->getSalesChannelContext()->getCustomer()->getDefaultBillingAddressId(),
-                'isDefaultShippingAddress' => $customerAddress->getId() === $event->getSalesChannelContext()->getCustomer()->getDefaultShippingAddressId(),
+                'isDefaultBillingAddress' => $customerAddress->getId() === $defaultBillingAddressId,
+                'isDefaultShippingAddress' => $customerAddress->getId() === $defaultShippingAddressId,
             ]);
         }
     }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriber.php
@@ -33,13 +33,10 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
         }
 
         foreach ($event->getEntities() as $customerAddress) {
-            if ($customerAddress->getId() === $event->getSalesChannelContext()->getCustomer()->getDefaultBillingAddressId()) {
-                $customerAddress->assign(['isDefaultBillingAddress' => true]);
-            }
-
-            if ($customerAddress->getId() === $event->getSalesChannelContext()->getCustomer()->getDefaultShippingAddressId()) {
-                $customerAddress->assign(['isDefaultShippingAddress' => true]);
-            }
+            $customerAddress->assign([
+                'isDefaultBillingAddress' => $customerAddress->getId() === $event->getSalesChannelContext()->getCustomer()->getDefaultBillingAddressId(),
+                'isDefaultShippingAddress' => $customerAddress->getId() === $event->getSalesChannelContext()->getCustomer()->getDefaultShippingAddressId(),
+            ]);
         }
     }
 }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriber.php
@@ -32,10 +32,10 @@ class CustomerAddressSubscriber implements EventSubscriberInterface
             return;
         }
 
-        foreach ($event->getEntities() as $customerAddress) {
-            $defaultBillingAddressId = $event->getSalesChannelContext()->getCustomer()->getDefaultBillingAddressId();
-            $defaultShippingAddressId = $event->getSalesChannelContext()->getCustomer()->getDefaultShippingAddressId();
+        $defaultBillingAddressId = $event->getSalesChannelContext()->getCustomer()->getDefaultBillingAddressId();
+        $defaultShippingAddressId = $event->getSalesChannelContext()->getCustomer()->getDefaultShippingAddressId();
 
+        foreach ($event->getEntities() as $customerAddress) {
             $customerAddress->assign([
                 'isDefaultBillingAddress' => $customerAddress->getId() === $defaultBillingAddressId,
                 'isDefaultShippingAddress' => $customerAddress->getId() === $defaultShippingAddressId,

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -269,7 +269,7 @@
         </service>
 
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\ListAddressRoute" public="true">
-            <argument type="service" id="customer_address.repository"/>
+            <argument type="service" id="sales_channel.customer_address.repository"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
 
@@ -295,6 +295,10 @@
 
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\CustomerGroupRegistrationSettingsRoute" public="true">
             <argument type="service" id="customer_group.repository"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Customer\SalesChannel\SalesChannelCustomerAddressDefinition">
+            <tag name="shopware.sales_channel.entity.definition"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Customer\DataAbstractionLayer\CustomerIndexer">
@@ -421,6 +425,10 @@
 
         <service id="Shopware\Core\Checkout\Customer\Subscriber\CustomerSalutationSubscriber">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Customer\Subscriber\CustomerAddressSubscriber">
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -275,6 +275,7 @@
 
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\UpsertAddressRoute" public="true">
             <argument type="service" id="customer_address.repository"/>
+            <argument type="service" id="sales_channel.customer_address.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Validation\DataValidator"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\Validation\AddressValidationFactory"/>

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ListAddressRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ListAddressRouteTest.php
@@ -78,6 +78,8 @@ class ListAddressRouteTest extends TestCase
         static::assertSame('12345', $response['elements'][0]['zipcode']);
         static::assertSame($this->getValidCountryId(), $response['elements'][0]['countryId']);
         static::assertSame($this->getValidSalutationId(), $response['elements'][0]['salutation']['id']);
+        static::assertTrue($response['elements'][0]['isDefaultBillingAddress']);
+        static::assertTrue($response['elements'][0]['isDefaultShippingAddress']);
     }
 
     public function testListAddressesIncludes(): void

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/UpsertAddressRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/UpsertAddressRouteTest.php
@@ -2,33 +2,20 @@
 
 namespace Shopware\Tests\Integration\Core\Checkout\Customer\SalesChannel;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
-use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressDefinition;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
-use Shopware\Core\Checkout\Customer\CustomerEntity;
-use Shopware\Core\Checkout\Customer\SalesChannel\UpsertAddressRoute;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
-use Shopware\Core\Framework\Validation\DataValidationFactoryInterface;
-use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\PlatformRequest;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Integration\Traits\CustomerTestTrait;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -241,77 +228,6 @@ class UpsertAddressRouteTest extends TestCase
         foreach ($data as $key => $val) {
             static::assertSame($val, $address->jsonSerialize()[$key]);
         }
-    }
-
-    public function testCustomFields(): void
-    {
-        $addressRepository = $this->createMock(EntityRepository::class);
-        $addressRepository
-            ->method('searchIds')
-            ->willReturn(new IdSearchResult(1, ['address-1' => ['data' => [], 'primaryKey' => 'address-1']], new Criteria(), Context::createDefaultContext()));
-
-        $customerAddress = new CustomerAddressEntity();
-        $customerAddress->setId('test');
-
-        $result = $this->createMock(EntitySearchResult::class);
-        $result->method('getEntities')
-            ->willReturn(new CustomerAddressCollection([$customerAddress]));
-
-        $addressRepository
-            ->method('search')
-            ->willReturn($result);
-
-        $addressRepository
-            ->method('upsert')
-            ->with([
-                [
-                    'salutationId' => '1',
-                    'firstName' => null,
-                    'lastName' => null,
-                    'street' => null,
-                    'city' => null,
-                    'zipcode' => null,
-                    'countryId' => null,
-                    'countryStateId' => null,
-                    'company' => null,
-                    'department' => null,
-                    'title' => null,
-                    'phoneNumber' => null,
-                    'additionalAddressLine1' => null,
-                    'additionalAddressLine2' => null,
-                    'id' => 'test',
-                    'customerId' => 'test',
-                    'customFields' => [
-                        'mapped' => 1,
-                    ],
-                ],
-            ]);
-
-        $customFieldMapper = new StoreApiCustomFieldMapper($this->createMock(Connection::class), [
-            CustomerAddressDefinition::ENTITY_NAME => [
-                ['name' => 'mapped', 'type' => 'int'],
-            ],
-        ]);
-
-        $route = new UpsertAddressRoute(
-            $addressRepository,
-            $this->createMock(DataValidator::class),
-            new EventDispatcher(),
-            $this->createMock(DataValidationFactoryInterface::class),
-            $this->createMock(SystemConfigService::class),
-            $customFieldMapper,
-            $this->createMock(EntityRepository::class),
-        );
-
-        $customer = new CustomerEntity();
-        $customer->setId('test');
-        $route->upsert('test', new RequestDataBag([
-            'customFields' => [
-                'bla' => 'bla',
-                'mapped' => '1',
-            ],
-            'salutationId' => '1',
-        ]), $this->createMock(SalesChannelContext::class), $customer);
     }
 
     public static function addressDataProvider(): \Generator

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/ListAddressRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/ListAddressRouteTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressCollection;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Checkout\Customer\Event\AddressListingCriteriaEvent;
+use Shopware\Core\Checkout\Customer\SalesChannel\ListAddressRoute;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
+
+/**
+ * @internal
+ */
+#[CoversClass(ListAddressRoute::class)]
+#[Package('checkout')]
+class ListAddressRouteTest extends TestCase
+{
+    /**
+     * @var MockObject&SalesChannelRepository<CustomerAddressCollection>
+     */
+    private MockObject&SalesChannelRepository $addressRepository;
+
+    private CollectingEventDispatcher $eventDispatcher;
+
+    private ListAddressRoute $route;
+
+    protected function setUp(): void
+    {
+        $this->addressRepository = $this->createMock(SalesChannelRepository::class);
+        $this->eventDispatcher = new CollectingEventDispatcher();
+
+        $this->route = new ListAddressRoute(
+            $this->addressRepository,
+            $this->eventDispatcher
+        );
+    }
+
+    public function testGetDecoratedThrowsException(): void
+    {
+        $this->expectException(DecorationPatternException::class);
+        $this->route->getDecorated();
+    }
+
+    public function testLoad(): void
+    {
+        $criteria = new Criteria();
+        $context = Generator::generateSalesChannelContext();
+        $customer = $context->getCustomer();
+        static::assertNotNull($customer);
+
+        $searchResult = $this->createMock(EntitySearchResult::class);
+        $searchResult->method('getEntities')->willReturn(
+            new CustomerAddressCollection([$context->getShippingLocation()->getAddress() ?? new CustomerAddressEntity()])
+        );
+
+        $this->addressRepository->expects($this->once())
+            ->method('search')
+            ->with(
+                static::callback(function (Criteria $criteria) {
+                    return $criteria->hasAssociation('salutation')
+                        && $criteria->hasAssociation('country')
+                        && $criteria->hasAssociation('countryState');
+                }),
+                $context
+            )
+            ->willReturn($searchResult);
+
+        $response = $this->route->load($criteria, $context, $customer);
+
+        static::assertCount(1, $response->getAddressCollection());
+
+        $events = $this->eventDispatcher->getEvents();
+        static::assertInstanceOf(AddressListingCriteriaEvent::class, $events[0]);
+        static::assertSame($criteria, $events[0]->getCriteria());
+        static::assertSame($context, $events[0]->getSalesChannelContext());
+    }
+}

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinitionTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinitionTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\SalesChannel\SalesChannelCustomerAddressDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(SalesChannelCustomerAddressDefinition::class)]
+class SalesChannelCustomerAddressDefinitionTest extends TestCase
+{
+    public function testProcessCriteria(): void
+    {
+        $definition = new SalesChannelCustomerAddressDefinition();
+        $criteria = new Criteria();
+        $context = Generator::generateSalesChannelContext();
+
+        $definition->processCriteria($criteria, $context);
+
+        static::assertNotEmpty($criteria->getFilters());
+
+        $filter = $criteria->getFilters()[0] ?? null;
+        static::assertInstanceOf(EqualsFilter::class, $filter);
+        static::assertSame('customerId', $filter->getField());
+        static::assertSame($context->getCustomer()?->getId(), $filter->getValue());
+    }
+
+    public function testDefineFields(): void
+    {
+        $definition = new SalesChannelCustomerAddressDefinition();
+
+        $registry = new StaticDefinitionInstanceRegistry(
+            [$definition],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGateway::class),
+        );
+
+        $definition->compile($registry);
+        $fields = $definition->getFields();
+
+        $billingField = $fields->get('isDefaultBillingAddress');
+        static::assertInstanceOf(BoolField::class, $billingField);
+        static::assertTrue($billingField->is(Runtime::class));
+        static::assertTrue($billingField->is(ApiAware::class));
+
+        $shippingField = $fields->get('isDefaultShippingAddress');
+        static::assertInstanceOf(BoolField::class, $shippingField);
+        static::assertTrue($shippingField->is(Runtime::class));
+        static::assertTrue($shippingField->is(ApiAware::class));
+    }
+}

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinitionTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinitionTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -19,6 +20,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @internal
  */
 #[CoversClass(SalesChannelCustomerAddressDefinition::class)]
+#[Package('checkout')]
 class SalesChannelCustomerAddressDefinitionTest extends TestCase
 {
     public function testProcessCriteria(): void

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/UpsertAddressRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/UpsertAddressRouteTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationFactoryInterface;
 use Shopware\Core\Framework\Validation\DataValidator;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -48,8 +49,10 @@ class UpsertAddressRouteTest extends TestCase
         $address->setId(Uuid::randomHex());
         $result->method('getEntities')->willReturn(new CustomerAddressCollection([$address]));
 
+        $salesChannelAddressRepository = $this->createMock(SalesChannelRepository::class);
+        $salesChannelAddressRepository->method('search')->willReturn($result);
+
         $addressRepository = $this->createMock(EntityRepository::class);
-        $addressRepository->method('search')->willReturn($result);
         $addressRepository
             ->expects($this->once())
             ->method('upsert')
@@ -67,6 +70,7 @@ class UpsertAddressRouteTest extends TestCase
 
         $upsert = new UpsertAddressRoute(
             $addressRepository,
+            $salesChannelAddressRepository,
             $this->createMock(DataValidator::class),
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(DataValidationFactoryInterface::class),
@@ -112,7 +116,8 @@ class UpsertAddressRouteTest extends TestCase
         $address->setId(Uuid::randomHex());
         $address->setSalutationId($salutationId);
 
-        $addressRepository->expects($this->once())->method('search')->willReturn(
+        $salesChannelAddressRepository = $this->createMock(SalesChannelRepository::class);
+        $salesChannelAddressRepository->expects($this->once())->method('search')->willReturn(
             new EntitySearchResult(
                 'customer_address',
                 1,
@@ -137,6 +142,7 @@ class UpsertAddressRouteTest extends TestCase
 
         $upsert = new UpsertAddressRoute(
             $addressRepository,
+            $salesChannelAddressRepository,
             $this->createMock(DataValidator::class),
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(DataValidationFactoryInterface::class),

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriberTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Customer\CustomerEvents;
 use Shopware\Core\Checkout\Customer\SalesChannel\SalesChannelCustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\Subscriber\CustomerAddressSubscriber;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelEntityLoadedEvent;
 use Shopware\Core\Test\Generator;
@@ -19,6 +20,7 @@ use Shopware\Core\Test\Generator;
  * @internal
  */
 #[CoversClass(CustomerAddressSubscriber::class)]
+#[Package('checkout')]
 class CustomerAddressSubscriberTest extends TestCase
 {
     public function testGetSubscribedEvents(): void

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerAddressSubscriberTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressDefinition;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\CustomerEvents;
+use Shopware\Core\Checkout\Customer\SalesChannel\SalesChannelCustomerAddressEntity;
+use Shopware\Core\Checkout\Customer\Subscriber\CustomerAddressSubscriber;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelEntityLoadedEvent;
+use Shopware\Core\Test\Generator;
+
+/**
+ * @internal
+ */
+#[CoversClass(CustomerAddressSubscriber::class)]
+class CustomerAddressSubscriberTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = CustomerAddressSubscriber::getSubscribedEvents();
+
+        static::assertArrayHasKey('sales_channel.' . CustomerEvents::CUSTOMER_ADDRESS_LOADED_EVENT, $events);
+        static::assertArrayHasKey('sales_channel.customer_address.partial_loaded', $events);
+    }
+
+    public function testSalesChannelLoadedDoesNothingWithoutCustomer(): void
+    {
+        $subscriber = new CustomerAddressSubscriber();
+
+        $context = Generator::generateSalesChannelContext();
+        $context->assign(['customer' => null]);
+
+        $address = new SalesChannelCustomerAddressEntity();
+        $address->setId(Uuid::randomHex());
+
+        /** @var SalesChannelEntityLoadedEvent<CustomerAddressEntity|PartialEntity> $event */
+        $event = new SalesChannelEntityLoadedEvent(
+            new CustomerAddressDefinition(),
+            [$address],
+            $context
+        );
+
+        $subscriber->salesChannelLoaded($event);
+
+        static::assertFalse($address->isDefaultBillingAddress());
+        static::assertFalse($address->isDefaultShippingAddress());
+    }
+
+    public function testSalesChannelLoadedAssignsDefaults(): void
+    {
+        $subscriber = new CustomerAddressSubscriber();
+        $billingId = Uuid::randomHex();
+        $shippingId = Uuid::randomHex();
+        $otherId = Uuid::randomHex();
+
+        $customer = new CustomerEntity();
+        $customer->setDefaultBillingAddressId($billingId);
+        $customer->setDefaultShippingAddressId($shippingId);
+
+        $context = Generator::generateSalesChannelContext(customer: $customer);
+
+        $billingAddress = new SalesChannelCustomerAddressEntity();
+        $billingAddress->setId($billingId);
+
+        $shippingAddress = new SalesChannelCustomerAddressEntity();
+        $shippingAddress->setId($shippingId);
+
+        $otherAddress = new SalesChannelCustomerAddressEntity();
+        $otherAddress->setId($otherId);
+
+        /** @var SalesChannelEntityLoadedEvent<CustomerAddressEntity|PartialEntity> $event */
+        $event = new SalesChannelEntityLoadedEvent(
+            new CustomerAddressDefinition(),
+            [$billingAddress, $shippingAddress, $otherAddress],
+            $context
+        );
+
+        $subscriber->salesChannelLoaded($event);
+
+        static::assertTrue($billingAddress->isDefaultBillingAddress());
+        static::assertFalse($billingAddress->isDefaultShippingAddress());
+
+        static::assertFalse($shippingAddress->isDefaultBillingAddress());
+        static::assertTrue($shippingAddress->isDefaultShippingAddress());
+
+        static::assertFalse($otherAddress->isDefaultBillingAddress());
+        static::assertFalse($otherAddress->isDefaultShippingAddress());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
We want to add the flag `isDefaultBillingAddress` and `isDefaultShippingAddress` to results of the `ListAddressRoute`. Since the result is only a collection of entities, this needs to be part of the entity.

### 2. What does this change do, exactly?
Create a sub-entity in the `SalesChannelDefinition` schema, creating additional Runtime properties to an existing entity.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
closes #12611 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
