### PR TITLE
chore: don't create runtime exceptions in domain exceptions

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -43,6 +43,33 @@ As part of this change, the following deprecations were made:
 If you are using the rule `LineItemProductStatesRule`, product stream filters, or product listing filters that rely on `product.states`, you should update them to use the new `product.type` field instead.
 If you create digital products using admin api, you should explicitly set the `type` field to `digital` when creating new products instead of relying on backend handling.
 
+### DomainExceptions don't create \RuntimeException anymore
+
+All factory methods for domain exceptions now return specific exception classes instead of creating a generic `\RuntimeException`.
+Changing the type of the thrown exception from `\RuntimeException` to a specific domain exception is not considered a breaking change, since all Domain Exceptions extend from `\RuntimeException`.
+
+This means code like this will stay valid:
+```php
+try {
+    $this->someService->willThrowDomainException();
+} catch (\RuntimeException $e) {
+    // handle exception
+}
+```
+
+Additionally all changed factory methods were marked as deprecated, because the `\RuntimeException` return type will be removed in the next major release.
+This affects the following exception factory methods:
+* `DataAbstractionLayerException::cannotBuildAccessor(...)`
+* `DataAbstractionLayerException::onlyStorageAwareFieldsAsTranslated(...)`
+* `DataAbstractionLayerException::onlyStorageAwareFieldsInReadCondition(...)`
+* `DataAbstractionLayerException::primaryKeyNotStorageAware(...)`
+* `DataAbstractionLayerException::missingTranslatedStorageAwareProperty(...)`
+* `DataAbstractionLayerException::noTranslationDefinition(...)`
+* `DataAbstractionLayerException::missingVersionField(...)`
+* `DataAbstractionLayerException::unexpectedFieldType(...)`
+* `WebhookException::invalidDataMapping(...)`
+* `WebhookException::unknownEventDataType(...)`
+
 ## Administration
 
 ### Deprecations in mail template components

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRuntimeExceptionInDomainExceptionsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRuntimeExceptionInDomainExceptionsRule.php
@@ -105,6 +105,6 @@ class NoRuntimeExceptionInDomainExceptionsRule implements Rule
         $methodCallable = $classReflection->getName()::$methodName(...);
 
         /** @phpstan-ignore function.strict (the compare of callables only works with strict = false) */
-        return \in_array($methodCallable, $knownViolations, true);
+        return \in_array($methodCallable, $knownViolations, false);
     }
 }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRuntimeExceptionInDomainExceptionsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRuntimeExceptionInDomainExceptionsRule.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\HttpException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Webhook\WebhookException;
+
+/**
+ * @implements Rule<ClassMethod>
+ *
+ * @internal
+ */
+#[Package('framework')]
+class NoRuntimeExceptionInDomainExceptionsRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return array<int, \PHPStan\Rules\RuleError|string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // Only care about static methods
+        if (!$node instanceof ClassMethod || !$node->isStatic()) {
+            return [];
+        }
+
+        // Not inside a class
+        if (!$scope->isInClass()) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        // Only classes that extend Shopware\Core\Framework\HttpException
+        if (!$classReflection->is(HttpException::class)) {
+            return [];
+        }
+
+        // No declared return type -> nothing to check
+        if ($node->returnType === null) {
+            return [];
+        }
+
+        $method = $classReflection->getMethod($node->name->name, $scope);
+        foreach ($method->getVariants() as $variant) {
+            if ($variant->getReturnType()->isSuperTypeOf(new ObjectType(\RuntimeException::class))->yes()) {
+                /** @deprecated tag:v6.8.0 - known violations will be fixed with 6.8.0 so this if can be removed */
+                if ($this->isAKnownViolation($method, $classReflection)) {
+                    return [];
+                }
+
+                return [
+                    RuleErrorBuilder::message(
+                        \sprintf(
+                            'Domain exception factory method %s::%s() might return \RuntimeException, however the ExceptionClass itself already extends \RuntimeException, therefore it should only return self.',
+                            $classReflection->getName(),
+                            $node->name,
+                        )
+                    )->identifier('shopware.noRuntimeExceptionInDomainExceptions')->line($node->getStartLine())
+                        ->build(),
+                ];
+            }
+        }
+
+        return [];
+    }
+
+    private function isAKnownViolation(ExtendedMethodReflection $method, ClassReflection $classReflection): bool
+    {
+        // List of known violations that are allowed to return RuntimeException for now
+        // All of those already only return the specific domain exception in reality
+        // However changing the return type would be a breaking change, so all of them are marked as deprecated
+        // and RuntimeException return type will be removed in 6.8.0.0
+        $knownViolations = [
+            DataAbstractionLayerException::cannotBuildAccessor(...),
+            DataAbstractionLayerException::onlyStorageAwareFieldsAsTranslated(...),
+            DataAbstractionLayerException::onlyStorageAwareFieldsInReadCondition(...),
+            DataAbstractionLayerException::primaryKeyNotStorageAware(...),
+            DataAbstractionLayerException::missingTranslatedStorageAwareProperty(...),
+            DataAbstractionLayerException::noTranslationDefinition(...),
+            DataAbstractionLayerException::missingVersionField(...),
+            DataAbstractionLayerException::unexpectedFieldType(...),
+            WebhookException::invalidDataMapping(...),
+            WebhookException::unknownEventDataType(...),
+        ];
+
+        $methodName = $method->getName();
+        /** @phpstan-ignore staticMethod.dynamicName */
+        $methodCallable = $classReflection->getName()::$methodName(...);
+
+        /** @phpstan-ignore function.strict (the compare of callables only works with strict = false) */
+        return \in_array($methodCallable, $knownViolations, true);
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
@@ -19,6 +19,7 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AttributeFinalRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NameConstantEntityDefinition
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\StorefrontRouteUsageRule
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoRuntimeExceptionInDomainExceptionsRule
 
 services:
     -

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -937,14 +937,10 @@ class DataAbstractionLayerException extends HttpException
     }
 
     /**
-     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self only
      */
     public static function unexpectedFieldType(string $field, string $expectedField): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException(\sprintf('Expected field "%s" to be instance of %s', $field, $expectedField));
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_UNEXPECTED_FIELD_TYPE,
@@ -967,12 +963,11 @@ class DataAbstractionLayerException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self only
+     */
     public static function missingVersionField(string $definitionClass): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException('Missing `VersionField` in `' . $definitionClass . '`');
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_MISSING_VERSION_FIELD,
@@ -999,12 +994,11 @@ class DataAbstractionLayerException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self only
+     */
     public static function noTranslationDefinition(string $entityName): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException(\sprintf('Entity %s has no translation definition', $entityName));
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_NO_TRANSLATION_DEFINITION,
@@ -1013,12 +1007,11 @@ class DataAbstractionLayerException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self only
+     */
     public static function missingTranslatedStorageAwareProperty(string $propertyName, string $translationEntityName): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException(\sprintf('Missing translated storage aware property %s in %s', $propertyName, $translationEntityName));
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_MISSING_TRANSLATED_STORAGE_AWARE_PROPERTY,
@@ -1027,12 +1020,11 @@ class DataAbstractionLayerException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self only
+     */
     public static function primaryKeyNotStorageAware(): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException('Primary key fields has to be an instance of StorageAware');
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_PRIMARY_KEY_NOT_STORAGE_AWARE,
@@ -1040,12 +1032,11 @@ class DataAbstractionLayerException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self only
+     */
     public static function onlyStorageAwareFieldsInReadCondition(): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException('Only storage aware fields are supported in read condition');
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_ONLY_STORAGE_AWARE_FIELDS_IN_READ_CONDITION,
@@ -1053,12 +1044,11 @@ class DataAbstractionLayerException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self only
+     */
     public static function onlyStorageAwareFieldsAsTranslated(): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException('Only storage aware fields are supported as translated field');
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_ONLY_STORAGE_AWARE_FIELDS_AS_TRANSLATED,
@@ -1080,12 +1070,11 @@ class DataAbstractionLayerException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self only
+     */
     public static function cannotBuildAccessor(string $propertyName, string $root): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException(\sprintf('Can not build accessor for field "%s" on root "%s"', $propertyName, $root));
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_CANNOT_BUILD_ACCESSOR,

--- a/src/Core/Framework/Webhook/WebhookException.php
+++ b/src/Core/Framework/Webhook/WebhookException.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Framework\Webhook;
 
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,16 +41,6 @@ class WebhookException extends HttpException
      */
     public static function invalidDataMapping(string $propertyName, string $className): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException(
-                \sprintf(
-                    'Invalid available DataMapping, could not get property "%s" on instance of %s',
-                    $propertyName,
-                    $className
-                )
-            );
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::INVALID_DATA_MAPPING,
@@ -65,10 +54,6 @@ class WebhookException extends HttpException
      */
     public static function unknownEventDataType(string $type): self|\RuntimeException
     {
-        if (!Feature::isActive('v6.8.0.0')) {
-            return new \RuntimeException('Unknown EventDataType: ' . $type);
-        }
-
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::UNKNOWN_DATA_TYPE,

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoStaticRuntimeExceptionReturnRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoStaticRuntimeExceptionReturnRuleTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoRuntimeExceptionInDomainExceptionsRule;
+
+/**
+ * @internal
+ *
+ * @extends RuleTestCase<NoRuntimeExceptionInDomainExceptionsRule>
+ */
+#[CoversClass(NoRuntimeExceptionInDomainExceptionsRule::class)]
+class NoStaticRuntimeExceptionReturnRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        // If the class does not extend HttpException, skip
+        $this->analyse([__DIR__ . '/data/NoStaticRuntimeExceptionReturnRuleTest/NotException.php'], []);
+
+        $this->analyse([
+            __DIR__ . '/data/NoStaticRuntimeExceptionReturnRuleTest/DummyException.php',
+        ], [
+            [
+                'Domain exception factory method Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoStaticRuntimeExceptionReturnRuleTest\DummyException::runtimeException() might return \RuntimeException, however the ExceptionClass itself already extends \RuntimeException, therefore it should only return self.',
+                9,
+            ],
+            [
+                'Domain exception factory method Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoStaticRuntimeExceptionReturnRuleTest\DummyException::runtimeExceptionOrSelf() might return \RuntimeException, however the ExceptionClass itself already extends \RuntimeException, therefore it should only return self.',
+                14,
+            ],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoRuntimeExceptionInDomainExceptionsRule();
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoStaticRuntimeExceptionReturnRuleTest/DummyException.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoStaticRuntimeExceptionReturnRuleTest/DummyException.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoStaticRuntimeExceptionReturnRuleTest;
+
+use Shopware\Core\Framework\HttpException;
+
+class DummyException extends HttpException
+{
+    public static function runtimeException(): \RuntimeException
+    {
+        return new \RuntimeException('bad');
+    }
+
+    public static function runtimeExceptionOrSelf(): self|\RuntimeException
+    {
+        return new \RuntimeException('bad');
+    }
+
+    public static function self(): self
+    {
+        return new self(200, 'ERROR_CODE', 'message');
+    }
+
+    public static function invalidArgumentOrSelf(): self|\InvalidArgumentException
+    {
+        return new self(200, 'ERROR_CODE', 'message');
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoStaticRuntimeExceptionReturnRuleTest/NotException.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoStaticRuntimeExceptionReturnRuleTest/NotException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoStaticRuntimeExceptionReturnRuleTest;
+
+class NotException
+{
+    public static function create(): \RuntimeException
+    {
+        return new \RuntimeException('ok');
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
There were some weird cases where new domain exceptions created RuntimeExceptions, apparently for BC reasons, however throwing a domain exception instead of a generic RuntimeException is no breaking change

### 2. What does this change do, exactly?
Always create the concrete domain exception and never create runtime exceptions from within domain exceptions

also deprecates all the wrong cases to remove the type hint with the next major (as that is a break now)

additionally adds phpstan rule to ensure this does not happen again

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
see https://github.com/shopware/shopware/pull/14216#discussion_r2667960316

