### PR TITLE
fix: correct display of company address in letter header in 6.6

### DIFF
--- a/changelog/_unreleased/2026-01-08-correct-display-of-company-address-in-letter-header.md
+++ b/changelog/_unreleased/2026-01-08-correct-display-of-company-address-in-letter-header.md
@@ -1,8 +1,0 @@
----
-title: Correct display of company address in letter header
-author: Marcus Müller
-author_email: 25648755+M-arcus@users.noreply.github.com
-author_github: @M-arcus
----
-# Core
-* Changed the order the twig modifiers are applied when rendering the company address in the letter header to ensure that line breaks are correctly rendered in the address

--- a/changelog/_unreleased/2026-01-08-correct-display-of-company-address-in-letter-header.md
+++ b/changelog/_unreleased/2026-01-08-correct-display-of-company-address-in-letter-header.md
@@ -1,0 +1,8 @@
+---
+title: Correct display of company address in letter header
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Changed the order the twig modifiers are applied when rendering the company address in the letter header to ensure that line breaks are correctly rendered in the address

--- a/src/Core/Framework/Resources/views/documents/includes/letter_header.html.twig
+++ b/src/Core/Framework/Resources/views/documents/includes/letter_header.html.twig
@@ -67,7 +67,7 @@ All blocks of this template are available in the template which renders this tem
                         <tr>
                             <td>
                                 {% if config.displayCompanyAddress and config.companyAddress is not empty %}
-                                    {{ config.companyAddress|replace({' - ': '</td></tr><tr><td>'})|raw|sw_sanitize(null, true) }}
+                                    {{ config.companyAddress|sw_sanitize(null, true)|replace({' - ': '</td></tr><tr><td>'})|raw }}
                                 {% endif %}
                             </td>
                         </tr>


### PR DESCRIPTION
### 1. Why is this change necessary?

The company address gets modified with `</td></tr><tr><td>` which get removed when sw_sanitize is applied.

Only happens in 6.6 from 6.6.10.7 and up, introduced in https://github.com/shopware/shopware/commit/cf16e821d7ff3aaede4ebb9ee7de11ffc49c82a8#diff-ae3ef434ddec3c9867931034739c4631ee499ca2950fd15b35769718b73ea0e3R68

### 2. What does this change do, exactly?

Changed the order of the `sw_sanitize` and `replace` Twig modifiers in `letter_header.html.twig` so that the address is sanitized before line breaks are inserted, ensuring correct display of line breaks in the company address.

### 3. Describe each step to reproduce the issue or behaviour.

Render a document with a company address that includes ' - '.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
