### PR TITLE
fix: remove settings card border

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
@@ -7,16 +7,20 @@
     <template #content>
         <sw-card-view class="sw-settings-index__card-view">
             {% block sw_settings_content_card_view %}
-            <mt-card
-                class="sw-settings__card--hero"
-                position-identifier="sw-settings-index"
-            >
+            <div class="sw-settings__card--hero">
+                <sw-extension-component-section
+                    position-identifier="sw-settings-index"
+                />
+
                 {% block sw_settings_content_card_view_header %}
                 <div class="sw-settings__content-header">
-                    <h1>{{ $tc('sw-settings.index.title') }}</h1>
+                    <h1 class="sw-settings__content-header-title">
+                        {{ $tc('sw-settings.index.title') }}
+                    </h1>
 
                     <mt-search
                         v-model="searchQuery"
+                        class="sw-settings__content-header-search"
                         :placeholder="$t('sw-settings.index.search.placeholder')"
                         size="small"
                     />
@@ -45,13 +49,12 @@
                         :key="settingsGroup"
                         class="sw-settings__content-group"
                     >
-                        <h2>
+                        <span class="sw-settings__content-group-title">
                             <sw-highlight-text
                                 :text="getGroupLabel(settingsGroup)"
                                 :search-term="searchQuery"
                             />
-                            {{''}} {# show eslint that there is content for h2 (which will be provided by sw-highlighted-text but it can't detect that) #}
-                        </h2>
+                        </span>
 
                         <sw-settings-item
                             v-for="settingsItem in settingsItems"
@@ -93,7 +96,7 @@
                     />
                 </div>
                 {% endblock %}
-            </mt-card>
+            </div>
             {% endblock %}
         </sw-card-view>
     </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
@@ -8,7 +8,6 @@
         <sw-card-view class="sw-settings-index__card-view">
             {% block sw_settings_content_card_view %}
             <mt-card
-                hero
                 class="sw-settings__card--hero"
                 position-identifier="sw-settings-index"
             >

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
@@ -3,7 +3,6 @@
     class="sw-settings-index"
     :show-smart-bar="false"
 >
-
     {% block sw_settings_content %}
     <template #content>
         <sw-card-view class="sw-settings-index__card-view">
@@ -15,9 +14,8 @@
             >
                 {% block sw_settings_content_card_view_header %}
                 <div class="sw-settings__content-header">
-                    <h1>
-                        {{ $tc('sw-settings.index.title') }}
-                    </h1>
+                    <h1>{{ $tc('sw-settings.index.title') }}</h1>
+
                     <mt-search
                         v-model="searchQuery"
                         :placeholder="$t('sw-settings.index.search.placeholder')"
@@ -34,8 +32,7 @@
                     closable
                     @close="onCloseSettingRenameBanner"
                 >
-                    <p v-html="$t('sw-settings.index.textSettingRenameBanner')">
-                    </p>
+                    <p v-html="$t('sw-settings.index.textSettingRenameBanner')"></p>
                 </mt-banner>
 
                 {% block sw_settings_content_card_content_grid %}
@@ -69,12 +66,14 @@
                                     :is="settingsItem.iconComponent"
                                     v-if="settingsItem.iconComponent"
                                 />
+
                                 <mt-icon
                                     v-else
                                     :name="settingsItem.icon"
                                     size="16px"
                                 />
                             </template>
+
                             <template #label>
                                 <sw-highlight-text
                                     :text="getLabel(settingsItem)"
@@ -84,6 +83,7 @@
                         </sw-settings-item>
                     </div>
                 </div>
+
                 <div class="sw-settings-index__empty-state">
                     <mt-empty-state
                         v-if="Object.keys(settingsGroups).length === 0"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
@@ -13,31 +13,20 @@
 
     .sw-settings__card--hero {
         container-type: inline-size;
-        color: var(--color-text-primary-default);
-        background: transparent;
-        border: none !important;
-
-        h1,
-        h2 {
-            font-weight: var(--font-weight-bold);
-        }
-
-        h2 {
-            font-size: var(--font-size-s);
-            line-height: var(--font-line-height-s);
-            margin-bottom: var(--scale-size-12);
-        }
-
-        h1 {
-            font-size: var(--font-size-xl);
-            line-height: var(--font-line-height-xl);
-        }
+        max-width: 60rem;
+        margin: var(--scale-size-24) auto var(--scale-size-40);
 
         .sw-settings__content-header {
             text-align: left;
             margin-bottom: var(--scale-size-48);
             display: flex;
             flex-direction: column;
+
+            &-title {
+                font-size: var(--font-size-xl);
+                font-weight: var(--font-weight-bold);
+                line-height: var(--font-line-height-xl);
+            }
 
             @container (min-width: 31.25rem) {
                 flex-direction: row;
@@ -73,6 +62,13 @@
             flex-direction: column;
             gap: var(--scale-size-2);
             padding-bottom: var(--scale-size-48);
+
+            &-title {
+                font-size: var(--font-size-s);
+                font-weight: var(--font-weight-bold);
+                line-height: var(--font-line-height-s);
+                margin-bottom: var(--scale-size-12);
+            }
 
             @container (max-width: 31.25rem) {
                 padding-bottom: var(--scale-size-32);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-settings-index {
     &__card-view {
         background-color: var(--color-elevation-surface-default);
@@ -15,38 +13,37 @@
 
     .sw-settings__card--hero {
         container-type: inline-size;
-        color: var(--color-text-primary-default, #2d2e32);
+        color: var(--color-text-primary-default);
         background: transparent;
-        border: none;
+        border: none !important;
 
         h1,
         h2 {
-            color: var(--color-text-primary-default, #2d2e32);
-            font-weight: 700;
+            font-weight: var(--font-weight-bold);
         }
 
         h2 {
-            line-height: 145%;
-            font-size: 16px;
-            margin-bottom: 12px;
+            font-size: var(--font-size-s);
+            line-height: var(--font-line-height-s);
+            margin-bottom: var(--scale-size-12);
         }
 
         h1 {
-            line-height: 140%;
-            font-size: 24px;
+            font-size: var(--font-size-xl);
+            line-height: var(--font-line-height-xl);
         }
 
         .sw-settings__content-header {
             text-align: left;
-            margin-bottom: 48px;
+            margin-bottom: var(--scale-size-48);
             display: flex;
             flex-direction: column;
 
-            @container (min-width: 500px) {
+            @container (min-width: 31.25rem) {
                 flex-direction: row;
                 justify-content: space-between;
                 align-items: start;
-                gap: 10rem;
+                gap: var(--scale-size-160);
 
                 .mt-text-field {
                     width: 30rem;
@@ -57,14 +54,14 @@
         .sw-settings__content-grid {
             columns: 3;
             text-align: left;
-            column-gap: 64px;
-            max-width: 960px;
+            column-gap: var(--scale-size-64);
+            max-width: 60rem;
 
-            @container (max-width: 940px) {
+            @container (max-width: 58.75rem) {
                 columns: 2;
             }
 
-            @container (max-width: 500px) {
+            @container (max-width: 31.25rem) {
                 columns: 1;
             }
         }
@@ -74,11 +71,11 @@
             height: fit-content;
             display: flex;
             flex-direction: column;
-            gap: 2px;
-            padding-bottom: 48px;
+            gap: var(--scale-size-2);
+            padding-bottom: var(--scale-size-48);
 
-            @container (max-width: 500px) {
-                padding-bottom: 32px;
+            @container (max-width: 31.25rem) {
+                padding-bottom: var(--scale-size-32);
             }
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
@@ -23,6 +23,7 @@
             flex-direction: column;
 
             &-title {
+                color: var(--color-text-primary-default);
                 font-size: var(--font-size-xl);
                 font-weight: var(--font-weight-bold);
                 line-height: var(--font-line-height-xl);
@@ -64,6 +65,7 @@
             padding-bottom: var(--scale-size-48);
 
             &-title {
+                color: var(--color-text-primary-default);
                 font-size: var(--font-size-s);
                 font-weight: var(--font-weight-bold);
                 line-height: var(--font-line-height-s);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.spec.js
@@ -131,9 +131,6 @@ async function createWrapper(
                     'sw-tabs': await wrapTestComponent('sw-tabs'),
                     'sw-tabs-deprecated': await wrapTestComponent('sw-tabs-deprecated', { sync: true }),
                     'sw-tabs-item': await wrapTestComponent('sw-tabs-item'),
-                    'mt-card': {
-                        template: '<div class="mt-card"><slot></slot></div>',
-                    },
                     'sw-settings-item': await wrapTestComponent('sw-settings-item'),
                     'mt-search': {
                         template: '<div class="mt-search"><slot></slot></div>',


### PR DESCRIPTION
The settings index card sometimes got a border, cause of override (see screen).

#### Changes

- added `!important`
- used meteor tokens

##### before (with border issue)

<img width="1126" height="1203" alt="Screenshot 2026-01-09 at 14 20 31" src="https://github.com/user-attachments/assets/eeb9a7b5-f330-4117-bbb4-c3b30d60fdea" />

##### after

<img width="1126" height="1203" alt="Screenshot 2026-01-09 at 14 21 49" src="https://github.com/user-attachments/assets/0e844c6f-c95c-4738-be7d-9390d5de4408" />
