### PR TITLE
fix: set requestedGroupId to null on change customer group flow action

### DIFF
--- a/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupAction.php
@@ -65,6 +65,7 @@ class ChangeCustomerGroupAction extends FlowAction implements DelayableAction
             [
                 'id' => $customerId,
                 'groupId' => $customerGroupId,
+                'requestedGroupId' => null,
             ],
         ], $context);
     }

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupActionTest.php
@@ -57,7 +57,7 @@ class ChangeCustomerGroupActionTest extends TestCase
 
         $this->repository->expects($this->once())
             ->method('update')
-            ->with([['id' => $customerId, 'groupId' => $groupId]]);
+            ->with([['id' => $customerId, 'groupId' => $groupId, 'requestedGroupId' => null]]);
 
         $this->action->handleFlow($flow);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

By using the `ChangeCustomerGroupAction` flow builder action users can configure actions to automatically set a customers customer group. However if the customer has a pending request to a requested customer group, the action will set the `customerGroupId` but leaves the `requestedCustomerGroupId` as is. This leads to the action being able to actually set the customer group but not being able to remove the `requestedCustomerGroupId` in the process.

This is crucial if a user wants to use the action to automatically handle requests to customer groups when customers are registering. See image:

<img width="849" height="433" alt="SCR-20260112-jkrh" src="https://github.com/user-attachments/assets/33fca647-4bf1-43ea-98a7-b1901c2cb972" />

### 2. What does this change do, exactly?

It additionally sets the `requestedCustomerGroupId` to `null` when the customer is updated.

### 3. Describe each step to reproduce the issue or behaviour.

See configured flow in image.

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
