### PR TITLE
feat(consent): hide-header and remove close on click

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal/sw-settings-usage-data-consent-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal/sw-settings-usage-data-consent-modal.html.twig
@@ -1,9 +1,12 @@
 <mt-modal-root
     :is-open="showConsentModal"
+    :closable="false"
 >
     <mt-modal
         width="s"
         :title="$t('sw-settings-usage-data.consent-modal.title')"
+        :closable="false"
+        hide-header
     >
         <template #default>
             <div class="sw-settings-usage-data-consent-modal__content">


### PR DESCRIPTION
Resolves shopware/services-roadmap#264

Removes the header from the consent modal and restricts closing it by clicking on the backdrop