### PR TITLE
fix: set updatedAt when it has a required flag

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/UpdatedAtFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/UpdatedAtFieldSerializer.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer;
 
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
@@ -28,7 +29,7 @@ class UpdatedAtFieldSerializer extends DateTimeFieldSerializer
         if (!$field instanceof UpdatedAtField) {
             throw DataAbstractionLayerException::invalidSerializerField(UpdatedAtField::class, $field);
         }
-        if (!$existence->exists()) {
+        if (!$existence->exists() && !$field->getFlag(Required::class)) {
             return;
         }
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/RequiredUpdatedAtDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/RequiredUpdatedAtDefinition.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+/**
+ * @internal
+ */
+class RequiredUpdatedAtDefinition extends EntityDefinition
+{
+    final public const ENTITY_NAME = 'required_updated_at_test';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function since(): ?string
+    {
+        return '6.0.0.0';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey()),
+            new StringField('name', 'name'),
+            new CreatedAtField(),
+            (new UpdatedAtField())->addFlags(new Required()),
+        ]);
+    }
+}

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreateAtAndUpdatedAtFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreateAtAndUpdatedAtFieldTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\DateTimeDefinition;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\RequiredUpdatedAtDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -244,5 +245,58 @@ EOF;
             $date->format('Y-m-d'),
             $entity->get('updatedAt')->format('Y-m-d')
         );
+    }
+
+    public function testUpdatedAtIsSetOnCreateWhenRequired(): void
+    {
+        $this->connection->rollBack();
+        $this->connection->executeStatement('DROP TABLE `date_time_test`');
+
+        $requiredTable = <<<EOF
+DROP TABLE IF EXISTS `required_updated_at_test`;
+CREATE TABLE IF NOT EXISTS `required_updated_at_test` (
+  `id` varbinary(16) NOT NULL,
+  `name` varchar(500) NULL,
+  `created_at` datetime(3) NOT NULL,
+  `updated_at` datetime(3) NOT NULL,
+  PRIMARY KEY `id` (`id`)
+);
+EOF;
+        $this->connection->executeStatement($requiredTable);
+
+        $definition = $this->registerDefinition(RequiredUpdatedAtDefinition::class);
+        $repository = new EntityRepository(
+            $definition,
+            static::getContainer()->get(EntityReaderInterface::class),
+            static::getContainer()->get(VersionManager::class),
+            static::getContainer()->get(EntitySearcherInterface::class),
+            static::getContainer()->get(EntityAggregatorInterface::class),
+            static::getContainer()->get('event_dispatcher'),
+            static::getContainer()->get(EntityLoadedEventFactory::class)
+        );
+
+        $id = Uuid::randomHex();
+        $data = ['id' => $id];
+
+        $context = Context::createDefaultContext();
+        $repository->create([$data], $context);
+
+        $entities = $repository->search(new Criteria([$id]), $context);
+
+        static::assertTrue($entities->has($id));
+
+        $entity = $entities->get($id);
+        static::assertInstanceOf(ArrayEntity::class, $entity);
+        static::assertNotNull($entity->get('createdAt'));
+        static::assertNotNull($entity->get('updatedAt'));
+        static::assertInstanceOf(\DateTimeInterface::class, $entity->get('updatedAt'));
+
+        // updatedAt should be approximately equal to createdAt on creation
+        static::assertSame(
+            $entity->get('createdAt')->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            $entity->get('updatedAt')->format(Defaults::STORAGE_DATE_TIME_FORMAT)
+        );
+
+        $this->connection->executeStatement('DROP TABLE `required_updated_at_test`');
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When you set a required flag on an updatedAt field, it should be filled in on create. This way the updatedAt field is the same as the createdAt field on creation. This can be very convenient for sorting purposes.

### 2. What does this change do, exactly?
This allows the creation of the updatedAt field when the field is required.

### 3. Describe each step to reproduce the issue or behaviour.
Add entity A
Wait a day
Update entity A
Add entity B
wait a day
Add entity C

Sort on updatedAt field DESC
You would expect CBA
You would get ABC or ACB (since B and C does not have an updatedAt field, it is sorted on id)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
