### PR TITLE
chore: Fix Choice constraint constructor

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -341,7 +341,7 @@ class RegisterRoute extends AbstractRegisterRoute
 
         if ($validateStorefrontUrl) {
             $definition
-                ->add('storefrontUrl', new NotBlank(), new Choice($this->getDomainUrls($context)));
+                ->add('storefrontUrl', new NotBlank(), new Choice(choices: $this->getDomainUrls($context)));
         }
 
         $accountType = $data->get('accountType', CustomerEntity::ACCOUNT_TYPE_PRIVATE);

--- a/src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
@@ -132,7 +132,7 @@ class SendPasswordRecoveryMailRoute extends AbstractSendPasswordRecoveryMailRout
 
         if ($validateStorefrontUrl) {
             $validation
-                ->add('storefrontUrl', new NotBlank(), new Choice(array_values($this->getDomainUrls($context))));
+                ->add('storefrontUrl', new NotBlank(), new Choice(choices: array_values($this->getDomainUrls($context))));
         }
 
         $this->dispatchValidationEvent($validation, $data, $context->getContext());

--- a/src/Core/Checkout/Customer/Validation/CustomerProfileValidationFactory.php
+++ b/src/Core/Checkout/Customer/Validation/CustomerProfileValidationFactory.php
@@ -55,7 +55,7 @@ class CustomerProfileValidationFactory implements DataValidationFactoryInterface
             ->add('title', new Length(max: CustomerDefinition::MAX_LENGTH_TITLE))
             ->add('firstName', new NotBlank(), new Length(max: CustomerDefinition::MAX_LENGTH_FIRST_NAME))
             ->add('lastName', new NotBlank(), new Length(max: CustomerDefinition::MAX_LENGTH_LAST_NAME))
-            ->add('accountType', new Choice($this->accountTypes));
+            ->add('accountType', new Choice(choices: $this->accountTypes));
 
         $salesChannelId = $context->getSalesChannelId();
 

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -229,7 +229,7 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
     {
         $definition = new DataValidationDefinition('newsletter_recipient.create');
         $definition->add('email', new NotBlank(), new Email())
-            ->add('option', new NotBlank(), new Choice(array_keys($this->getOptionSelection($context, $dataBag->get('email')))));
+            ->add('option', new NotBlank(), new Choice(choices: array_keys($this->getOptionSelection($context, $dataBag->get('email')))));
 
         if (!empty($dataBag->get('firstName'))) {
             $definition->add('firstName', new NotBlank(), new Regex(pattern: self::DOMAIN_NAME_REGEX, match: false));
@@ -241,7 +241,7 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
 
         if ($validateStorefrontUrl) {
             $definition
-                ->add('storefrontUrl', new NotBlank(), new Choice(array_values($this->getDomainUrls($context))));
+                ->add('storefrontUrl', new NotBlank(), new Choice(choices: array_values($this->getDomainUrls($context))));
         }
 
         $validationEvent = new BuildValidationEvent($definition, $dataBag, $context->getContext());

--- a/src/Core/Framework/App/Lifecycle/Persister/RuleConditionPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/RuleConditionPersister.php
@@ -186,13 +186,13 @@ class RuleConditionPersister
             }
 
             if ($field instanceof MultiSelectField) {
-                $constraints[$field->getName()][] = new All(constraints: new Choice(array_keys($field->getOptions())));
+                $constraints[$field->getName()][] = new All(constraints: new Choice(choices: array_keys($field->getOptions())));
 
                 continue;
             }
 
             if ($field instanceof SingleSelectField) {
-                $constraints[$field->getName()][] = new Choice(array_keys($field->getOptions()));
+                $constraints[$field->getName()][] = new Choice(choices: array_keys($field->getOptions()));
 
                 continue;
             }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
@@ -128,11 +128,11 @@ class ConstraintBuilder
 
     /**
      * @param array<string> $values
-     *                              Set prop must be in array
+     * Set prop must be in array
      */
     public function isInArray(array $values): self
     {
-        $this->addConstraint(new Choice($values));
+        $this->addConstraint(new Choice(choices: $values));
 
         return $this;
     }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
@@ -127,8 +127,9 @@ class ConstraintBuilder
     }
 
     /**
-     * @param array<string> $values
      * Set prop must be in array
+     *
+     * @param array<string> $values
      */
     public function isInArray(array $values): self
     {

--- a/src/Core/Framework/Rule/CustomFieldRule.php
+++ b/src/Core/Framework/Rule/CustomFieldRule.php
@@ -38,7 +38,7 @@ class CustomFieldRule
             'operator' => [
                 new NotBlank(),
                 new Choice(
-                    [
+                    choices: [
                         Rule::OPERATOR_NEQ,
                         Rule::OPERATOR_GTE,
                         Rule::OPERATOR_LTE,

--- a/src/Core/Framework/Rule/RuleConstraints.php
+++ b/src/Core/Framework/Rule/RuleConstraints.php
@@ -93,7 +93,7 @@ class RuleConstraints
      */
     public static function choice(array $choices): array
     {
-        return [new NotBlank(), new Choice($choices)];
+        return [new NotBlank(), new Choice(choices: $choices)];
     }
 
     /**
@@ -116,7 +116,7 @@ class RuleConstraints
 
         return [
             new NotBlank(),
-            new Choice($operators),
+            new Choice(choices: $operators),
         ];
     }
 
@@ -136,7 +136,7 @@ class RuleConstraints
 
         return [
             new NotBlank(),
-            new Choice($operators),
+            new Choice(choices: $operators),
         ];
     }
 
@@ -156,7 +156,7 @@ class RuleConstraints
 
         return [
             new NotBlank(),
-            new Choice($operators),
+            new Choice(choices: $operators),
         ];
     }
 
@@ -180,7 +180,7 @@ class RuleConstraints
 
         return [
             new NotBlank(),
-            new Choice($operators),
+            new Choice(choices: $operators),
         ];
     }
 

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemCreationDateRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemCreationDateRuleTest.php
@@ -73,7 +73,7 @@ class LineItemCreationDateRuleTest extends TestCase
         static::assertEquals(new Type(type: 'string'), $date[1]);
 
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionWidthRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionWidthRuleTest.php
@@ -353,7 +353,7 @@ class LineItemDimensionWidthRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         $this->rule->assign(['operator' => Rule::OPERATOR_EQ]);
         static::assertArrayHasKey('amount', $ruleConstraints, 'Constraint amount not found in Rule');

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemInCategoryRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemInCategoryRuleTest.php
@@ -206,7 +206,7 @@ class LineItemInCategoryRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         $this->rule->assign(['operator' => Rule::OPERATOR_EQ]);
         static::assertArrayHasKey('categoryIds', $ruleConstraints, 'Constraint categoryIds not found in Rule');

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemInProductStreamRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemInProductStreamRuleTest.php
@@ -194,7 +194,7 @@ class LineItemInProductStreamRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         $this->rule->assign(['operator' => Rule::OPERATOR_EQ]);
         static::assertArrayHasKey('streamIds', $ruleConstraints, 'Constraint streamIds not found in Rule');

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemReleaseDateRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemReleaseDateRuleTest.php
@@ -72,7 +72,7 @@ class LineItemReleaseDateRuleTest extends TestCase
         static::assertEquals(new Type(type: 'string'), $date[1]);
 
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemTagRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemTagRuleTest.php
@@ -203,7 +203,7 @@ class LineItemTagRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('identifiers', $ruleConstraints, 'Constraint identifiers not found in Rule');
         $identifiers = $ruleConstraints['identifiers'];

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerBirthdayRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerBirthdayRuleTest.php
@@ -61,7 +61,7 @@ class CustomerBirthdayRuleTest extends TestCase
         static::assertArrayHasKey('operator', $constraints, 'operator constraints not found');
 
         static::assertEquals(new Type(type: 'string'), $constraints['birthday'][1]);
-        static::assertEquals(new Choice($operators), $constraints['operator'][1]);
+        static::assertEquals(new Choice(choices: $operators), $constraints['operator'][1]);
     }
 
     #[DataProvider('getMatchBirthdayValues')]

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerTagRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerTagRuleTest.php
@@ -70,7 +70,7 @@ class CustomerTagRuleTest extends TestCase
         static::assertArrayHasKey('operator', $constraints, 'operator constraints not found');
 
         static::assertEquals(new ArrayOfUuid(), $constraints['identifiers'][1]);
-        static::assertEquals(new Choice($operators), $constraints['operator'][1]);
+        static::assertEquals(new Choice(choices: $operators), $constraints['operator'][1]);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Customer/Rule/DaysSinceLastOrderRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/DaysSinceLastOrderRuleTest.php
@@ -219,7 +219,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         $this->rule->assign(['operator' => Rule::OPERATOR_EQ]);
         static::assertArrayHasKey('daysPassed', $ruleConstraints, 'Constraint daysPassed not found in Rule');

--- a/tests/unit/Core/Checkout/Customer/Rule/EmailRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/EmailRuleTest.php
@@ -73,7 +73,7 @@ class EmailRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('email', $ruleConstraints, 'Constraint email not found in Rule');
         $email = $ruleConstraints['email'];

--- a/tests/unit/Core/Checkout/Customer/Rule/ShippingCityRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/ShippingCityRuleTest.php
@@ -49,7 +49,7 @@ class ShippingCityRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         $this->rule->assign(['operator' => Rule::OPERATOR_EQ]);
         static::assertArrayHasKey('cityName', $ruleConstraints, 'Constraint cityName not found in Rule');

--- a/tests/unit/Core/Checkout/Customer/Rule/ShippingStateRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/ShippingStateRuleTest.php
@@ -47,7 +47,7 @@ class ShippingStateRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         $this->rule->assign(['operator' => Rule::OPERATOR_EQ]);
         static::assertArrayHasKey('stateIds', $ruleConstraints, 'Constraint stateIds not found in Rule');

--- a/tests/unit/Core/Checkout/Customer/Validation/CustomerProfileValidationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Customer/Validation/CustomerProfileValidationFactoryTest.php
@@ -218,7 +218,7 @@ class CustomerProfileValidationFactoryTest extends TestCase
             ->add('salutationId', new EntityExists(entity: SalutationDefinition::ENTITY_NAME, context: $context->getContext()))
             ->add('firstName', new NotBlank())
             ->add('lastName', new NotBlank())
-            ->add('accountType', new Choice($this->accountTypes))
+            ->add('accountType', new Choice(choices: $this->accountTypes))
             ->add('title', new Length(max: CustomerDefinition::MAX_LENGTH_TITLE))
             ->add('firstName', new Length(max: CustomerDefinition::MAX_LENGTH_FIRST_NAME))
             ->add('lastName', new Length(max: CustomerDefinition::MAX_LENGTH_LAST_NAME));

--- a/tests/unit/Core/Checkout/Rule/Rule/Context/BillingCountryRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Context/BillingCountryRuleTest.php
@@ -135,7 +135,7 @@ class BillingCountryRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('countryIds', $ruleConstraints, 'Constraint countryIds not found in Rule');
         $countryIds = $ruleConstraints['countryIds'];

--- a/tests/unit/Core/Checkout/Rule/Rule/Context/BillingStreetRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Context/BillingStreetRuleTest.php
@@ -155,7 +155,7 @@ class BillingStreetRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('streetName', $ruleConstraints, 'Constraint streetName not found in Rule');
         $streetName = $ruleConstraints['streetName'];

--- a/tests/unit/Core/Checkout/Rule/Rule/Context/BillingZipCodeRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Context/BillingZipCodeRuleTest.php
@@ -128,7 +128,7 @@ class BillingZipCodeRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('zipCodes', $ruleConstraints, 'Constraint zipCodes not found in Rule');
         $zipCodes = $ruleConstraints['zipCodes'];

--- a/tests/unit/Core/Checkout/Rule/Rule/Context/ShippingCountryRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Context/ShippingCountryRuleTest.php
@@ -215,7 +215,7 @@ class ShippingCountryRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('countryIds', $ruleConstraints, 'Constraint countryIds not found in Rule');
         $countryIds = $ruleConstraints['countryIds'];

--- a/tests/unit/Core/Checkout/Rule/Rule/Context/ShippingStreetRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Context/ShippingStreetRuleTest.php
@@ -153,7 +153,7 @@ class ShippingStreetRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('streetName', $ruleConstraints, 'Constraint streetName not found in Rule');
         $streetName = $ruleConstraints['streetName'];

--- a/tests/unit/Core/Checkout/Rule/Rule/Context/ShippingZipCodeRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Context/ShippingZipCodeRuleTest.php
@@ -163,7 +163,7 @@ class ShippingZipCodeRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('zipCodes', $ruleConstraints, 'Constraint zipCodes not found in Rule');
         $zipCodes = $ruleConstraints['zipCodes'];

--- a/tests/unit/Core/Content/Flow/Rule/OrderDocumentTypeRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderDocumentTypeRuleTest.php
@@ -55,7 +55,7 @@ class OrderDocumentTypeRuleTest extends TestCase
         static::assertArrayHasKey('operator', $constraints, 'operator constraints not found');
 
         static::assertEquals([new NotBlank(), new ArrayOfUuid()], $constraints['documentIds']);
-        static::assertEquals([new NotBlank(), new Choice($operators)], $constraints['operator']);
+        static::assertEquals([new NotBlank(), new Choice(choices: $operators)], $constraints['operator']);
     }
 
     /**

--- a/tests/unit/Core/Content/Flow/Rule/OrderDocumentTypeSentRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderDocumentTypeSentRuleTest.php
@@ -56,7 +56,7 @@ class OrderDocumentTypeSentRuleTest extends TestCase
         static::assertArrayHasKey('operator', $constraints, 'operator constraints not found');
 
         static::assertEquals([new NotBlank(), new ArrayOfUuid()], $constraints['documentIds']);
-        static::assertEquals([new NotBlank(), new Choice($operators)], $constraints['operator']);
+        static::assertEquals([new NotBlank(), new Choice(choices: $operators)], $constraints['operator']);
     }
 
     public function testConstraintsEmpty(): void
@@ -72,7 +72,7 @@ class OrderDocumentTypeSentRuleTest extends TestCase
 
         static::assertArrayNotHasKey('documentIds', $constraints, 'documentIds constraint found');
         static::assertArrayHasKey('operator', $constraints, 'operator constraints not found');
-        static::assertEquals([new NotBlank(), new Choice($operators)], $constraints['operator']);
+        static::assertEquals([new NotBlank(), new Choice(choices: $operators)], $constraints['operator']);
     }
 
     /**

--- a/tests/unit/Core/Content/Flow/Rule/OrderTagRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderTagRuleTest.php
@@ -80,7 +80,7 @@ class OrderTagRuleTest extends TestCase
         static::assertArrayHasKey('operator', $constraints, 'operator constraints not found');
 
         static::assertEquals([new NotBlank(), new ArrayOfUuid()], $constraints['identifiers']);
-        static::assertEquals([new NotBlank(), new Choice($operators)], $constraints['operator']);
+        static::assertEquals([new NotBlank(), new Choice(choices: $operators)], $constraints['operator']);
     }
 
     /**

--- a/tests/unit/Core/Framework/Rule/RuleConstraintsTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleConstraintsTest.php
@@ -55,7 +55,7 @@ class RuleConstraintsTest extends TestCase
         static::assertCount(2, $operators);
         static::assertInstanceOf(NotBlank::class, $operators[0]);
         static::assertInstanceOf(Choice::class, $operators[1]);
-        static::assertEquals(new Choice($this->defaultOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $this->defaultOperators), $operators[1]);
 
         $operators = RuleConstraints::dateOperators();
 
@@ -75,7 +75,7 @@ class RuleConstraintsTest extends TestCase
         static::assertCount(2, $operators);
         static::assertInstanceOf(NotBlank::class, $operators[0]);
         static::assertInstanceOf(Choice::class, $operators[1]);
-        static::assertEquals(new Choice($this->defaultOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $this->defaultOperators), $operators[1]);
 
         $operators = RuleConstraints::datetimeOperators();
 

--- a/tests/unit/Core/System/Language/Rule/LanguageRuleTest.php
+++ b/tests/unit/Core/System/Language/Rule/LanguageRuleTest.php
@@ -38,7 +38,7 @@ class LanguageRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Constraint operator not found in Rule');
         $operators = $ruleConstraints['operator'];
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
 
         static::assertArrayHasKey('languageIds', $ruleConstraints, 'Constraint languageIds not found in Rule');
         $languageIds = $ruleConstraints['languageIds'];


### PR DESCRIPTION


### 1. Why is this change necessary?
providing choices as first param is deprecated

### 2. What does this change do, exactly?
use named param, to make it safe for more constructor changes (that's already best practice for constraints)


### 4. Please link to the relevant issues (if any).
Part of symfony 7.4 update (extracted from main PR, to make it easier to review)
https://github.com/shopware/shopware/pull/14319