### PR TITLE
fix: #14332 Filter by id and product_id first in ProductCategoryDenormalizer

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -56,6 +56,12 @@ A new `Immutable` flag is available for Data Abstraction Layer fields. Fields ma
 
 Trying to update these columns now results in a `WriteConstraintViolationException` with the message `The field foo is immutable and cannot be updated.`, giving developers clear feedback when attempting to change these values.
 
+### Performance Improvement for `ProductCategoryDenormalizer`
+
+The SQL Query inside the `ProductCategoryDenormalizer` has been optimized to run faster, especially on large catalogues.
+Previously MySql needed to perform a full table scan based on the where condition, now the result set is already limited by indexed columns.
+This lead to performance improvements from up to 3s for the query down to less than 1ms on large catalogues (3000%).
+
 ### Deprecation of product states in favor of the new product type
 
 The `product.states` field is deprecated and will be removed in the next major release.

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
@@ -132,9 +132,15 @@ class ProductCategoryDenormalizer
 
         $query->addGroupBy('product.id');
 
+        // Performance optimization: Reduce the number of products to check by filtering for products via indexed columns
         $query->andWhere('product.id IN (:ids) OR product.parent_id IN (:ids)');
 
+        // This where condition alone leads to a full table scan, which will be very slow on large datasets,
+        // therefore we already filter for product.id and product.parent_id above (which is indexed and therefore much faster)
+        // product.categories will only ever contain the product id (for non-variant products, or when categories are not inherited)
+        // or the parent id (for variant products inheriting categories from their parent)
         $query->andWhere('product.categories IN (:ids)');
+
         $query->andWhere('product.version_id = :version');
 
         $query->setParameter('version', Uuid::fromHexToBytes($context->getVersionId()));

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
@@ -132,6 +132,8 @@ class ProductCategoryDenormalizer
 
         $query->addGroupBy('product.id');
 
+        $query->andWhere('product.id IN (:ids) OR product.parent_id IN (:ids)');
+
         $query->andWhere('product.categories IN (:ids)');
         $query->andWhere('product.version_id = :version');
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The product indexer (ProductCategoryDenormalizer) executes a query that becomes a major performance bottleneck on large catalogues.
The root cause is a filter on the unindexed product.categories field, which leads to slow full table scans.

### 2. What does this change do, exactly?
The `categories` field is either the `id` or `parent_id`. Since these fields are already indexed, it is much faster to filter on. This PR adds a filter to these fields before filtering (in the subset of rows) on the `categories`. 

### 3. Describe each step to reproduce the issue or behaviour.
See #14332 

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
Closes #14332 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
