### PR TITLE
fix: NotificationController in API  tests

### DIFF
--- a/src/Core/Framework/Notification/Api/NotificationController.php
+++ b/src/Core/Framework/Notification/Api/NotificationController.php
@@ -47,12 +47,14 @@ class NotificationController extends AbstractController
     )]
     public function saveNotification(Request $request, Context $context): Response
     {
-        $status = (string) $request->request->get('status');
-        $message = (string) $request->request->get('message');
-        $adminOnly = (bool) $request->request->get('adminOnly', false);
+        $payload = $request->getPayload();
+
+        $status = (string) $payload->get('status');
+        $message = (string) $payload->get('message');
+        $adminOnly = (bool) $payload->get('adminOnly', false);
 
         try {
-            $requiredPrivileges = $request->request->all('requiredPrivileges');
+            $requiredPrivileges = $payload->all('requiredPrivileges');
         } catch (BadRequestException) {
             throw NotificationException::invalidRequestParameter('requiredPrivileges');
         }

--- a/tests/integration/Core/Framework/Notification/Api/NotificationControllerTest.php
+++ b/tests/integration/Core/Framework/Notification/Api/NotificationControllerTest.php
@@ -107,12 +107,10 @@ class NotificationControllerTest extends TestCase
     public static function saveNotificationProvider(): array
     {
         return [
-            // TODO: fix with shopware/shopware#12950
-            // ['integration', 'success', 'This is a notification', false, ['cache:clear'], true],
+            ['integration', 'success', 'This is a notification', false, ['cache:clear'], true],
             ['integration', '', 'This is a notification', false, ['cache:clear'], false],
             ['integration', 'success', '', false, ['cache:clear'], false],
-            // TODO: fix with shopware/shopware#12950
-            // ['browser', 'success', 'This is a notification', true, [], true],
+            ['browser', 'success', 'This is a notification', true, [], true],
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
During the restoration of some tests in integration, https://github.com/shopware/shopware/pull/12940 2 cases were constantly failing and muted. We should not let this indefinitely.

Those tests were failing from the start, but initially not run in the pipeline (the PR was created before the check about missing integration folder was in place), except in the nightly after merge.

### 2. What does this change do, exactly?
- Enforces json_decode through getPayload() from Request, since the tests are sending a json encoded string
- Restores the 2 cases of integration initially written


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/12950

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
