### PR TITLE
fix: Enable long runner support (RoadRunner, FrankenPHP, Swoole)

### DIFF
--- a/.github/bin/blue-green-check.php
+++ b/.github/bin/blue-green-check.php
@@ -3,9 +3,9 @@
 
 declare(strict_types=1);
 
+use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
-use Shopware\Core\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -19,7 +19,7 @@ if (is_file(__DIR__ . '/../../.env')) {
     (new Dotenv())->usePutenv()->bootEnv(__DIR__ . '/../../.env');
 }
 
-$pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());
+$pluginLoader = new DbalKernelPluginLoader($classLoader, null, MySQLFactory::getConnection());
 
 $kernel = KernelFactory::create('dev', true, $classLoader, $pluginLoader);
 

--- a/.gitlab/bin/blue-green-check.php
+++ b/.gitlab/bin/blue-green-check.php
@@ -3,9 +3,9 @@
 
 declare(strict_types=1);
 
+use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
-use Shopware\Core\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -19,7 +19,7 @@ if (is_file(__DIR__ . '/../../.env')) {
     (new Dotenv())->usePutenv()->bootEnv(__DIR__ . '/../../.env');
 }
 
-$pluginLoader = new DbalKernelPluginLoader($classLoader, null, Kernel::getConnection());
+$pluginLoader = new DbalKernelPluginLoader($classLoader, null, MySQLFactory::getConnection());
 
 $kernel = KernelFactory::create('dev', true, $classLoader, $pluginLoader);
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -29,6 +29,18 @@ Next routes now support cache tagging, enabling automatic invalidation when rele
 
 ## Core
 
+### Long Runner Support (RoadRunner, FrankenPHP, Swoole)
+
+Shopware now fully supports long-running PHP servers. The Kernel no longer overrides Symfony's `handle()` method, enabling proper service reset between requests via `ResetInterface`. Additionally, the Twig escape filter cache is now properly cleared between requests to prevent memory leaks.
+
+Database connections can now be configured with an idle timeout via `idle_connection_ttl` parameter in `DATABASE_URL`:
+```
+DATABASE_URL="mysql://user:pass@host:3306/dbname?idle_connection_ttl=60"
+```
+This prevents "MySQL server has gone away" errors by proactively closing connections that have been idle longer than the specified TTL (in seconds). Set to `0` or omit to disable (default).
+
+**For extension developers:** If your services cache request-specific data, implement `Symfony\Contracts\Service\ResetInterface` and register with the `kernel.reset` tag to ensure proper cleanup between requests.
+
 ### Rework of DAL query generation for nested filters groups
 The DAL criteria builder has been adjusted to generate `EXISTS` subqueries instead of `LEFT JOIN`s for nested filter groups.
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -31,6 +31,67 @@ The Store API route `/store-api/document/download` returns now a standard Shopwa
 
 <details>
 
+## Long Runner Support (RoadRunner, FrankenPHP, Swoole)
+
+Shopware now supports long-running PHP servers like RoadRunner, FrankenPHP, and Swoole. This required several breaking changes:
+
+### Deprecated `Kernel::$connection` property
+
+The static `$connection` property in `Shopware\Core\Kernel` is deprecated and will be removed in v6.8.0. Use `Kernel::getConnection()` or `MySQLFactory::getConnection()` instead.
+
+**Before:**
+```php
+$connection = Kernel::$connection;
+```
+
+**After:**
+```php
+$connection = Kernel::getConnection();
+// or
+$connection = MySQLFactory::getConnection();
+```
+
+Note: The property still exists for backwards compatibility but is automatically synchronized with `MySQLFactory::getConnection()`.
+
+### Removed `Kernel::handle()` override
+
+The `handle()` method override has been removed from `Shopware\Core\Kernel`. This enables Symfony's native service reset mechanism between requests, which is required for long-running servers.
+
+### Changed `KernelFactory::create()` signature
+
+The `$connection` parameter has been removed from `KernelFactory::create()`. The connection is now automatically obtained from `MySQLFactory`.
+
+**Before:**
+```php
+KernelFactory::create(
+    environment: $env,
+    debug: $debug,
+    classLoader: $classLoader,
+    pluginLoader: $pluginLoader,
+    connection: $connection
+);
+```
+
+**After:**
+```php
+KernelFactory::create(
+    environment: $env,
+    debug: $debug,
+    classLoader: $classLoader,
+    pluginLoader: $pluginLoader
+);
+```
+
+### New `idle_connection_ttl` DATABASE_URL parameter
+
+For long-running servers, you can configure automatic database connection recycling to prevent "MySQL server has gone away" errors:
+
+```
+DATABASE_URL=mysql://user:pass@host:3306/db?idle_connection_ttl=300
+```
+
+This closes connections that have been idle for the specified number of seconds.
+
 ## Multiple payment finalize calls allowed
 Multiple calls to the `/payment-finalize` endpoint using the same payment token are now allowed.
 If the token has already been consumed, the user is redirected to the finish page without triggering a PaymentException.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -136,6 +136,7 @@
             <file>tests/integration/Core/Framework/AdditionalPermissionValidationTest.php</file>
             <file>tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php</file>
             <file>tests/integration/Core/Framework/KernelTest.php</file>
+            <file>tests/integration/Core/Framework/LongRunnerMemoryTest.php</file>
             <file>tests/integration/Core/Framework/ServiceDefinitionTest.php</file>
             <directory>tests/integration/Core/Framework/Adapter</directory>
             <directory>tests/integration/Core/Framework/Api</directory>

--- a/src/Core/Framework/Adapter/Database/MySQLFactory.php
+++ b/src/Core/Framework/Adapter/Database/MySQLFactory.php
@@ -18,6 +18,46 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 class MySQLFactory
 {
+    private static ?Connection $connection = null;
+
+    private static int $lastUsedAt = 0;
+
+    private static int $idleConnectionTtl = 0;
+
+    /**
+     * @param array<Middleware> $middlewares
+     */
+    public static function getConnection(array $middlewares = []): Connection
+    {
+        $now = time();
+
+        // Check if existing connection has been idle too long
+        if (self::$connection !== null && self::$idleConnectionTtl > 0 && self::$lastUsedAt > 0) {
+            if (($now - self::$lastUsedAt) >= self::$idleConnectionTtl) {
+                self::$connection->close();
+                self::$connection = null;
+            }
+        }
+
+        // Create new connection if needed
+        if (self::$connection === null) {
+            self::$connection = self::create($middlewares);
+        }
+
+        self::$lastUsedAt = $now;
+
+        return self::$connection;
+    }
+
+    public static function resetConnection(): void
+    {
+        if (self::$connection !== null) {
+            self::$connection->close();
+            self::$connection = null;
+        }
+        self::$lastUsedAt = 0;
+    }
+
     /**
      * @param array<Middleware> $middlewares
      */
@@ -35,6 +75,11 @@ class MySQLFactory
 
         $dsnParser = new DsnParser(['mysql' => 'pdo_mysql']);
         $dsnParameters = $dsnParser->parse($url);
+
+        if (isset($dsnParameters['idle_connection_ttl'])) {
+            self::$idleConnectionTtl = (int) $dsnParameters['idle_connection_ttl'];
+            unset($dsnParameters['idle_connection_ttl']);
+        }
 
         $parameters = array_merge([
             'charset' => 'utf8mb4',

--- a/src/Core/Framework/Adapter/Database/ReplicaConnection.php
+++ b/src/Core/Framework/Adapter/Database/ReplicaConnection.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\Adapter\Database;
 
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Kernel;
 
 /**
  * @internal
@@ -14,7 +13,7 @@ class ReplicaConnection
 {
     public static function ensurePrimary(): void
     {
-        $connection = Kernel::getConnection();
+        $connection = MySQLFactory::getConnection();
 
         if ($connection instanceof PrimaryReadReplicaConnection) {
             $connection->ensureConnectedToPrimary();

--- a/src/Core/Framework/Adapter/Kernel/KernelFactory.php
+++ b/src/Core/Framework/Adapter/Kernel/KernelFactory.php
@@ -52,7 +52,7 @@ class KernelFactory
             $middlewares = [new ProfilingMiddleware()];
         }
 
-        $connection ??= MySQLFactory::create($middlewares);
+        $connection ??= MySQLFactory::getConnection($middlewares);
 
         $pluginLoader ??= new DbalKernelPluginLoader($classLoader, null, $connection);
 
@@ -64,7 +64,6 @@ class KernelFactory
             $pluginLoader,
             $cacheId,
             $shopwareVersion,
-            $connection,
             self::getProjectDir()
         );
 

--- a/src/Core/Framework/Adapter/Twig/SwTwigFunction.php
+++ b/src/Core/Framework/Adapter/Twig/SwTwigFunction.php
@@ -23,6 +23,14 @@ class SwTwigFunction
     public static mixed $macroResult = null;
 
     /**
+     * Cache for escaped strings to avoid repeated escaping of the same content.
+     * Reset between requests via SwTwigFunctionResetter for long runner compatibility.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private static array $escapeCache = [];
+
+    /**
      * Returns the attribute value for a given array/object.
      *
      * @param mixed $object The object or array from where to get the item
@@ -92,12 +100,11 @@ class SwTwigFunction
         if (\is_int($string)) {
             $string = (string) $string;
         }
-        static $strings = [];
 
         $isString = \is_string($string);
 
-        if ($isString && isset($strings[$string][$strategy])) {
-            return $strings[$string][$strategy];
+        if ($isString && isset(self::$escapeCache[$string][$strategy])) {
+            return self::$escapeCache[$string][$strategy];
         }
 
         $result = $env->getRuntime(EscaperRuntime::class)->escape($string, $strategy, $charset, $autoescape);
@@ -106,8 +113,20 @@ class SwTwigFunction
             return $result;
         }
 
-        $strings[$string][$strategy] = $result;
+        self::$escapeCache[$string][$strategy] = $result;
 
         return $result;
+    }
+
+    /**
+     * Resets the escape filter cache.
+     *
+     * This method is called by SwTwigFunctionResetter between requests
+     * in long runner environments (RoadRunner, FrankenPHP, Swoole) to prevent
+     * memory leaks from unbounded cache growth.
+     */
+    public static function resetEscapeCache(): void
+    {
+        self::$escapeCache = [];
     }
 }

--- a/src/Core/Framework/Adapter/Twig/SwTwigFunctionResetter.php
+++ b/src/Core/Framework/Adapter/Twig/SwTwigFunctionResetter.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Twig;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Resets SwTwigFunction static caches between requests.
+ *
+ * This is essential for long runner environments (RoadRunner, FrankenPHP, Swoole)
+ * where the same PHP process handles multiple requests. Without reset,
+ * the escape filter cache in SwTwigFunction would grow unbounded,
+ * causing memory leaks.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class SwTwigFunctionResetter implements ResetInterface
+{
+    public function reset(): void
+    {
+        SwTwigFunction::resetEscapeCache();
+    }
+}

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -68,7 +68,7 @@ frame-ancestors 'none';
     <services>
         <!-- Database / Doctrine -->
         <service id="Doctrine\DBAL\Connection" public="true">
-            <factory class="Shopware\Core\Kernel" method="getConnection"/>
+            <factory class="Shopware\Core\Framework\Adapter\Database\MySQLFactory" method="getConnection"/>
         </service>
 
         <service id="Shopware\Core\Framework\Routing\QueryDataBagResolver">
@@ -357,6 +357,10 @@ frame-ancestors 'none';
                       id="Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector"/>
 
+            <tag name="kernel.reset" method="reset"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Adapter\Twig\SwTwigFunctionResetter">
             <tag name="kernel.reset" method="reset"/>
         </service>
 

--- a/src/Core/Framework/Increment/MySQLIncrementer.php
+++ b/src/Core/Framework/Increment/MySQLIncrementer.php
@@ -119,8 +119,13 @@ class MySQLIncrementer extends AbstractIncrementer
             ];
         }
 
-        /** @var array<string, array{count: int, key: string, cluster: string, pool: string}> $result */
+        /** @var array<string, array{count: string, key: string, cluster: string, pool: string}> $result */
         $result = $this->connection->fetchAllAssociativeIndexed($sql, $payload, $types);
+
+        // Cast count to int for consistency with ArrayIncrementer
+        foreach ($result as $key => $row) {
+            $result[$key]['count'] = max(0, (int) $row['count']);
+        }
 
         return $result;
     }

--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework;
 
+use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
 use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
@@ -9,7 +10,6 @@ use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
 use Shopware\Core\Framework\Plugin\PluginException;
-use Shopware\Core\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 #[Package('framework')]
@@ -101,7 +101,7 @@ abstract class Plugin extends Bundle
         }
 
         $class = addcslashes($this->getMigrationNamespace(), '\\_%') . '%';
-        Kernel::getConnection()->executeStatement('DELETE FROM migration WHERE class LIKE :class', ['class' => $class]);
+        MySQLFactory::getConnection()->executeStatement('DELETE FROM migration WHERE class LIKE :class', ['class' => $class]);
     }
 
     public function getBasePath(): string

--- a/src/Core/Framework/Resources/config/packages/framework.yaml
+++ b/src/Core/Framework/Resources/config/packages/framework.yaml
@@ -14,7 +14,7 @@ framework:
     fragments: ~
     assets: ~
     http_cache:
-        enabled: true
+        enabled: false
     session:
         name: 'session-'
         handler_id: ~

--- a/src/Core/Framework/Resources/config/packages/test/framework.yaml
+++ b/src/Core/Framework/Resources/config/packages/test/framework.yaml
@@ -27,3 +27,9 @@ framework:
             # Rate limiter needs persistent storage because ArrayAdapter is reset between requests
             cache.rate_limiter:
                 adapter: cache.adapter.filesystem
+            # HTTP and object caches need persistent storage because ArrayAdapter is reset between requests
+            # This ensures cache hit/miss tests work correctly with service reset enabled
+            cache.http:
+                adapter: cache.adapter.filesystem
+            cache.object:
+                adapter: cache.adapter.filesystem

--- a/src/Core/Framework/Resources/config/packages/test/framework.yaml
+++ b/src/Core/Framework/Resources/config/packages/test/framework.yaml
@@ -5,8 +5,7 @@ parameters:
 framework:
     test: true
     http_cache:
-        enabled: true
-        debug: true
+        enabled: false
     session:
         storage_factory_id: session.storage.factory.mock_file
     profiler:
@@ -25,3 +24,6 @@ framework:
                 adapter: cache.adapter.array
             cache.property_access:
                 adapter: cache.adapter.array
+            # Rate limiter needs persistent storage because ArrayAdapter is reset between requests
+            cache.rate_limiter:
+                adapter: cache.adapter.filesystem

--- a/src/Core/Framework/Resources/config/packages/test/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/test/shopware.yaml
@@ -17,10 +17,10 @@ shopware:
 
     increment:
         user_activity:
-            type: 'array'
+            type: 'mysql'
 
         message_queue:
-            type: 'array'
+            type: 'mysql'
 
     admin_worker:
         poll_interval: 1

--- a/src/Core/Framework/Test/TestCaseBase/KernelLifecycleManager.php
+++ b/src/Core/Framework/Test/TestCaseBase/KernelLifecycleManager.php
@@ -201,7 +201,7 @@ class KernelLifecycleManager
     public static function getConnection(): Connection
     {
         if (!static::$connection) {
-            static::$connection = MySQLFactory::create();
+            static::$connection = MySQLFactory::getConnection();
         }
 
         return static::$connection;

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -23,10 +23,7 @@ use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel as HttpKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\Route;
@@ -43,6 +40,10 @@ class Kernel extends HttpKernel
      */
     final public const SHOPWARE_FALLBACK_VERSION = '6.7.9999999-dev';
 
+    /**
+     * @deprecated tag:v6.8.0 - Use Kernel::getConnection() or MySQLFactory::getConnection() instead.
+     * This property exists for backwards compatibility and will be removed in v6.8.0.
+     */
     protected static ?Connection $connection = null;
 
     protected string $shopwareVersion;
@@ -62,13 +63,11 @@ class Kernel extends HttpKernel
         protected KernelPluginLoader $pluginLoader,
         private string $cacheId,
         string $version,
-        Connection $connection,
         protected string $projectDir,
     ) {
         date_default_timezone_set('UTC');
 
         parent::__construct($environment, $debug);
-        self::$connection = $connection;
 
         $versionArray = VersionParser::parseShopwareVersion($version);
         $this->shopwareVersion = $versionArray['version'];
@@ -122,13 +121,6 @@ class Kernel extends HttpKernel
         return $this->projectDir;
     }
 
-    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
-    {
-        $this->boot();
-
-        return $this->getHttpKernel()->handle($request, $type, $catch);
-    }
-
     public function boot(): void
     {
         if (!$this->booted) {
@@ -151,13 +143,13 @@ class Kernel extends HttpKernel
 
     public static function getConnection(): Connection
     {
-        if (self::$connection) {
-            return self::$connection;
-        }
+        $connection = MySQLFactory::getConnection();
 
-        self::$connection = MySQLFactory::create();
+        // Keep static property in sync for backwards compatibility
+        // @deprecated tag:v6.8.0 - Remove this line when $connection property is removed
+        self::$connection = $connection;
 
-        return self::$connection;
+        return $connection;
     }
 
     public function getCacheDir(): string
@@ -195,9 +187,10 @@ class Kernel extends HttpKernel
             return;
         }
 
-        // keep connection when rebooting
+        // Reset connection when not rebooting (traditional PHP-FPM)
+        // In long-runner environments, the connection is kept alive
         if (!$this->rebooting) {
-            self::$connection = null;
+            MySQLFactory::resetConnection();
         }
 
         parent::shutdown();
@@ -315,8 +308,6 @@ class Kernel extends HttpKernel
             'v6.8.0.0',
             'The method initializeDatabaseConnectionVariables is deprecated and will be removed in 6.8.0.0. All MySQL connection variables are configured in ' . MySQLFactory::class
         );
-
-        self::$connection = self::getConnection();
     }
 
     protected function dumpContainer(ConfigCache $cache, ContainerBuilder $container, string $class, string $baseClass): void

--- a/src/Core/Test/AppSystemTestBehaviour.php
+++ b/src/Core/Test/AppSystemTestBehaviour.php
@@ -59,9 +59,9 @@ trait AppSystemTestBehaviour
     /**
      * @return array<string, mixed>
      */
-    protected function getScriptTraces(): array
+    protected function getScriptTraces(?ContainerInterface $container = null): array
     {
-        return static::getContainer()
+        return ($container ?? static::getContainer())
             ->get(ScriptTraces::class)
             ->getTraces();
     }

--- a/src/Core/Test/PHPUnit/Extension/DatabaseDiff/DatabaseDiffExtension.php
+++ b/src/Core/Test/PHPUnit/Extension/DatabaseDiff/DatabaseDiffExtension.php
@@ -6,8 +6,8 @@ use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
+use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Kernel;
 use Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\Subscriber\BeforeTestMethodCalledSubscriber;
 use Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\Subscriber\TestFinishedSubscriber;
 
@@ -19,7 +19,7 @@ class DatabaseDiffExtension implements Extension
 {
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
-        $dbState = new DbState(Kernel::getConnection());
+        $dbState = new DbState(MySQLFactory::getConnection());
 
         $facade->registerSubscribers(
             new BeforeTestMethodCalledSubscriber($dbState),

--- a/src/Core/Test/Stub/Symfony/StubKernel.php
+++ b/src/Core/Test/Stub/Symfony/StubKernel.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Test\Stub\Symfony;
 use Composer\Autoload\ClassLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\Kernel;
-use Shopware\Core\Test\Stub\Doctrine\FakeConnection;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class StubKernel extends Kernel
@@ -21,7 +20,6 @@ class StubKernel extends Kernel
             new ComposerPluginLoader(new ClassLoader(__DIR__)),
             '',
             '',
-            new FakeConnection([]),
             __DIR__
         );
 

--- a/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
+++ b/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Test\Controller;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -25,6 +26,15 @@ trait StorefrontControllerTestBehaviour
         $browser->request($method, EnvironmentHelper::getVariable('APP_URL') . '/' . $path, $data, $files, $server, $content, $changeHistory);
 
         return $browser->getResponse();
+    }
+
+    /**
+     * Create a browser for storefront requests.
+     * Use $browser->getContainer() to access services without triggering service reset.
+     */
+    public function createStorefrontBrowser(): TestBrowser
+    {
+        return KernelLifecycleManager::createBrowser($this->getKernel());
     }
 
     public function getSalesChannelId(): string

--- a/tests/integration/Core/Checkout/Payment/SalesChannel/PaymentMethodRouteTest.php
+++ b/tests/integration/Core/Checkout/Payment/SalesChannel/PaymentMethodRouteTest.php
@@ -60,7 +60,7 @@ class PaymentMethodRouteTest extends TestCase
         static::assertContains($this->ids->get('payment2'), $ids);
         static::assertContains($this->ids->get('payment3'), $ids);
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $this->browser->getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(PaymentMethodRouteHook::HOOK_NAME, $traces);
     }
 

--- a/tests/integration/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteTest.php
+++ b/tests/integration/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteTest.php
@@ -65,7 +65,7 @@ class ShippingMethodRouteTest extends TestCase
         static::assertContains($this->ids->get('shipping2'), $ids);
         static::assertEmpty($response['elements'][0]['availabilityRule']);
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $this->browser->getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(ShippingMethodRouteHook::HOOK_NAME, $traces);
     }
 

--- a/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
@@ -76,7 +76,7 @@ class CacheControllerTest extends TestCase
         static::assertArrayHasKey('httpCache', $decodedContent);
         static::assertIsBool($decodedContent['httpCache']);
         static::assertArrayHasKey('cacheAdapter', $decodedContent);
-        static::assertSame('Array', $decodedContent['cacheAdapter']);
+        static::assertSame('Filesystem', $decodedContent['cacheAdapter']);
     }
 
     public function testCacheIndexEndpoint(): void

--- a/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
+++ b/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
@@ -37,13 +37,6 @@ class IncrementApiControllerTest extends TestCase
         $this->getGateway($this->getBrowser())->reset($this->userId, 'foo');
     }
 
-    private function getGateway(KernelBrowser $browser): AbstractIncrementer
-    {
-        $gatewayRegistry = $browser->getContainer()->get('shopware.increment.gateway.registry');
-
-        return $gatewayRegistry->get(IncrementGatewayRegistry::USER_ACTIVITY_POOL);
-    }
-
     public function testListEndpoint(): void
     {
         $client = $this->getBrowser();
@@ -302,5 +295,12 @@ class IncrementApiControllerTest extends TestCase
         $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertEmpty($entries);
+    }
+
+    private function getGateway(KernelBrowser $browser): AbstractIncrementer
+    {
+        $gatewayRegistry = $browser->getContainer()->get('shopware.increment.gateway.registry');
+
+        return $gatewayRegistry->get(IncrementGatewayRegistry::USER_ACTIVITY_POOL);
     }
 }

--- a/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
+++ b/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -21,18 +22,10 @@ class IncrementApiControllerTest extends TestCase
     use AdminFunctionalTestBehaviour;
     use IntegrationTestBehaviour;
 
-    private AbstractIncrementer $gateway;
-
     private string $userId;
 
     protected function setUp(): void
     {
-        $gatewayRegistry = static::getContainer()->get('shopware.increment.gateway.registry');
-
-        $gateway = $gatewayRegistry->get(IncrementGatewayRegistry::USER_ACTIVITY_POOL);
-
-        $this->gateway = $gateway;
-
         /** @var Context $context */
         $context = $this->getBrowser()->getServerParameter(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
 
@@ -41,17 +34,26 @@ class IncrementApiControllerTest extends TestCase
         static::assertNotNull($source->getUserId());
         $this->userId = Uuid::fromBytesToHex($source->getUserId());
 
-        $this->gateway->reset($this->userId, 'foo');
+        $this->getGateway($this->getBrowser())->reset($this->userId, 'foo');
+    }
+
+    private function getGateway(KernelBrowser $browser): AbstractIncrementer
+    {
+        $gatewayRegistry = $browser->getContainer()->get('shopware.increment.gateway.registry');
+
+        return $gatewayRegistry->get(IncrementGatewayRegistry::USER_ACTIVITY_POOL);
     }
 
     public function testListEndpoint(): void
     {
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'bar');
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
+
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'bar');
 
         $url = '/api/_action/increment/user_activity?cluster=' . $this->userId;
-        $client = $this->getBrowser();
         $client->request('GET', $url);
 
         static::assertSame(200, $client->getResponse()->getStatusCode());
@@ -111,7 +113,7 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertTrue($entries['success']);
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertSame(1, $entries['foo']['count']);
@@ -119,16 +121,18 @@ class IncrementApiControllerTest extends TestCase
 
     public function testDecrementEndpoint(): void
     {
-        $this->gateway->increment($this->userId, 'foo');
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
 
-        $entries = $this->gateway->list($this->userId);
+        $gateway->increment($this->userId, 'foo');
+
+        $entries = $gateway->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertSame(1, $entries['foo']['count']);
 
         $url = '/api/_action/decrement/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('POST', $url, [
             'key' => 'foo',
             'cluster' => $this->userId,
@@ -140,7 +144,7 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertTrue($entries['success']);
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertSame(0, $entries['foo']['count']);
@@ -148,11 +152,14 @@ class IncrementApiControllerTest extends TestCase
 
     public function testResetEndpoint(): void
     {
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'bar');
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
 
-        $entries = $this->gateway->list($this->userId);
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'bar');
+
+        $entries = $gateway->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertArrayHasKey('bar', $entries);
@@ -161,7 +168,6 @@ class IncrementApiControllerTest extends TestCase
 
         $url = '/api/_action/reset-increment/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('POST', $url, [
             'cluster' => $this->userId,
         ]);
@@ -172,7 +178,7 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertTrue($entries['success']);
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertArrayHasKey('bar', $entries);
@@ -183,11 +189,13 @@ class IncrementApiControllerTest extends TestCase
     public function testIncrementEndpointWithCustomCluster(): void
     {
         $clusterName = 'customer-cluster';
-        $this->gateway->reset($clusterName, 'foo');
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
+
+        $gateway->reset($clusterName, 'foo');
 
         $url = '/api/_action/increment/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('POST', $url, [
             'key' => 'foo',
             'cluster' => $clusterName,
@@ -199,14 +207,13 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertTrue($entries['success']);
 
-        $entries = $this->gateway->list($clusterName);
+        $entries = $this->getGateway($client)->list($clusterName);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertSame(1, $entries['foo']['count']);
 
         $url = '/api/_action/increment/user_activity?cluster=' . $clusterName;
 
-        $client = $this->getBrowser();
         $client->request('GET', $url);
 
         $entries = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -236,19 +243,21 @@ class IncrementApiControllerTest extends TestCase
 
     public function testDeleteEndpointWithKeys(): void
     {
-        $this->gateway->reset($this->userId);
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
 
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'baz');
-        $this->gateway->increment($this->userId, 'bar');
+        $gateway->reset($this->userId);
 
-        $entries = $this->gateway->list($this->userId);
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'baz');
+        $gateway->increment($this->userId, 'bar');
+
+        $entries = $gateway->list($this->userId);
 
         static::assertCount(3, $entries);
 
         $url = '/api/_action/delete-increment/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('DELETE', $url, [
             'cluster' => $this->userId,
             'keys' => ['foo', 'bar'],
@@ -256,7 +265,7 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertCount(1, $entries);
 
@@ -267,28 +276,30 @@ class IncrementApiControllerTest extends TestCase
 
     public function testDeleteEndpointWithOnlyCluster(): void
     {
-        $this->gateway->reset($this->userId);
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
 
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'baz');
-        $this->gateway->increment($this->userId, 'bar');
+        $gateway->reset($this->userId);
 
-        $entries = $this->gateway->list($this->userId);
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'baz');
+        $gateway->increment($this->userId, 'bar');
+
+        $entries = $gateway->list($this->userId);
 
         static::assertCount(3, $entries);
 
-        $this->gateway->reset($this->userId, 'foo');
+        $gateway->reset($this->userId, 'foo');
 
         $url = '/api/_action/delete-increment/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('DELETE', $url, [
             'cluster' => $this->userId,
         ]);
 
         static::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertEmpty($entries);
     }

--- a/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
+++ b/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
@@ -29,13 +29,13 @@ class MySQLIncrementerTest extends TestCase
         $list = $this->mysqlIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertSame('1', $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('2', $list['sw.product.index']['count']);
+        static::assertSame(2, $list['sw.product.index']['count']);
     }
 
     public function testDecrement(): void
@@ -46,13 +46,13 @@ class MySQLIncrementerTest extends TestCase
         $list = $this->mysqlIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertSame('2', $list['sw.product.index']['count']);
+        static::assertSame(2, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->decrement('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
     }
 
     public function testList(): void
@@ -63,9 +63,9 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('2', array_values($list)[0]['count']);
+        static::assertSame(2, array_values($list)[0]['count']);
         static::assertSame('sw.product.index', array_values($list)[0]['key']);
-        static::assertSame('1', array_values($list)[1]['count']);
+        static::assertSame(1, array_values($list)[1]['count']);
 
         // List will return in DESC order of record's count
         $this->mysqlIncrementer->increment('test-user-1', 'sw.order.index');
@@ -73,9 +73,9 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('3', array_values($list)[0]['count']);
+        static::assertSame(3, array_values($list)[0]['count']);
         static::assertSame('sw.order.index', array_values($list)[0]['key']);
-        static::assertSame('2', array_values($list)[1]['count']);
+        static::assertSame(2, array_values($list)[1]['count']);
     }
 
     public function testReset(): void
@@ -91,22 +91,22 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('0', $list['sw.product.index']['count']);
+        static::assertSame(0, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->increment('test-user-1', 'sw.order.index');
         $this->mysqlIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
-        static::assertSame('1', $list['sw.order.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.order.index']['count']);
 
         $this->mysqlIncrementer->reset('test-user-1', 'sw.order.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
-        static::assertSame('0', $list['sw.order.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
+        static::assertSame(0, $list['sw.order.index']['count']);
     }
 
     public function testDeleteKeys(): void
@@ -127,7 +127,7 @@ class MySQLIncrementerTest extends TestCase
                 'pool' => 'user-activity-pool',
                 'cluster' => 'test-user-1',
                 'key' => 'sw.product.create',
-                'count' => '1',
+                'count' => 1,
             ],
         ], $list);
     }

--- a/tests/integration/Core/Framework/KernelTest.php
+++ b/tests/integration/Core/Framework/KernelTest.php
@@ -21,4 +21,51 @@ class KernelTest extends TestCase
 
         static::assertSame($c->fetchOne('SELECT @@session.time_zone'), '+00:00');
     }
+
+    /**
+     * Symfony's http_cache service must NOT exist in the container.
+     *
+     * Shopware uses its own HttpCacheKernel (registered as http_kernel.cache decorator).
+     * If Symfony's http_cache service exists, it would bypass Shopware's caching layer
+     * and break the request handling flow.
+     *
+     * This also ensures long runner compatibility (RoadRunner, FrankenPHP, Swoole):
+     * Without http_cache, Symfony Kernel::handle() properly manages requestStackSize
+     * and resetServices flags, which are required for service reset between requests.
+     *
+     * @see \Symfony\Component\HttpKernel\Kernel::handle()
+     * @see \Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel
+     */
+    public function testSymfonyHttpCacheServiceDoesNotExist(): void
+    {
+        $container = static::getContainer();
+
+        static::assertFalse(
+            $container->has('http_cache'),
+            'Symfony http_cache service must NOT exist. '
+            . 'Shopware uses its own HttpCacheKernel (http_kernel.cache decorator). '
+            . 'If http_cache exists, it breaks long runner support and bypasses Shopware caching.'
+        );
+    }
+
+    /**
+     * Shopware's HttpCacheKernel must be registered as a decorator of http_kernel.
+     */
+    public function testShopwareHttpCacheKernelIsRegistered(): void
+    {
+        $container = static::getContainer();
+
+        static::assertTrue(
+            $container->has('http_kernel'),
+            'http_kernel service must exist'
+        );
+
+        $httpKernel = $container->get('http_kernel');
+
+        static::assertInstanceOf(
+            \Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel::class,
+            $httpKernel,
+            'http_kernel should be decorated by Shopware HttpCacheKernel'
+        );
+    }
 }

--- a/tests/integration/Core/Framework/LongRunnerMemoryTest.php
+++ b/tests/integration/Core/Framework/LongRunnerMemoryTest.php
@@ -1,0 +1,271 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests to verify Shopware is ready for long runners (RoadRunner, FrankenPHP, Swoole).
+ *
+ * These tests simulate multiple requests handled by the same Kernel instance
+ * to detect memory leaks and state pollution between requests.
+ *
+ * @internal
+ */
+#[Package('framework')]
+#[Group('long-runner')]
+class LongRunnerMemoryTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    /**
+     * Maximum allowed memory growth per request (in bytes).
+     * If memory grows more than this per request on average, we likely have a leak.
+     */
+    private const MAX_MEMORY_GROWTH_PER_REQUEST = 100 * 1024; // 100 KB
+
+    /**
+     * Number of requests to simulate for memory leak detection.
+     */
+    private const REQUEST_COUNT = 50;
+
+    /**
+     * Tests that memory usage remains stable across multiple requests.
+     *
+     * In long runner environments, the same PHP process handles multiple requests.
+     * If services or caches accumulate data without proper reset, memory will grow
+     * unbounded, eventually causing OOM errors.
+     *
+     * This test detects such memory leaks by:
+     * 1. Running multiple requests through the kernel
+     * 2. Measuring memory growth
+     * 3. Failing if growth exceeds threshold
+     */
+    public function testMemoryRemainsStableAcrossMultipleRequests(): void
+    {
+        $kernel = KernelLifecycleManager::getKernel();
+
+        // Warm up - run a few requests to stabilize memory
+        for ($i = 0; $i < 5; ++$i) {
+            $request = Request::create('/api/_info/version');
+            $response = $kernel->handle($request);
+            $kernel->terminate($request, $response);
+        }
+
+        // Force garbage collection before measurement
+        gc_collect_cycles();
+        $initialMemory = memory_get_usage(true);
+
+        // Run test requests
+        for ($i = 0; $i < self::REQUEST_COUNT; ++$i) {
+            $request = Request::create('/api/_info/version');
+            $response = $kernel->handle($request);
+            $kernel->terminate($request, $response);
+        }
+
+        // Force garbage collection after measurement
+        gc_collect_cycles();
+        $finalMemory = memory_get_usage(true);
+
+        $memoryGrowth = $finalMemory - $initialMemory;
+        $growthPerRequest = $memoryGrowth / self::REQUEST_COUNT;
+        $maxAllowedGrowth = self::MAX_MEMORY_GROWTH_PER_REQUEST * self::REQUEST_COUNT;
+
+        static::assertLessThan(
+            $maxAllowedGrowth,
+            $memoryGrowth,
+            \sprintf(
+                "Memory leak detected!\n"
+                . "Initial memory: %s\n"
+                . "Final memory: %s\n"
+                . "Total growth: %s (%d bytes)\n"
+                . "Growth per request: %s\n"
+                . "Max allowed per request: %s\n"
+                . 'Requests: %d',
+                $this->formatBytes($initialMemory),
+                $this->formatBytes($finalMemory),
+                $this->formatBytes($memoryGrowth),
+                $memoryGrowth,
+                $this->formatBytes((int) $growthPerRequest),
+                $this->formatBytes(self::MAX_MEMORY_GROWTH_PER_REQUEST),
+                self::REQUEST_COUNT
+            )
+        );
+    }
+
+    /**
+     * Tests that SwTwigFunction escape cache can be reset and SwTwigFunctionResetter is registered.
+     *
+     * This test verifies:
+     * 1. SwTwigFunction::resetEscapeCache() properly clears the static cache
+     * 2. SwTwigFunctionResetter is registered with kernel.reset tag
+     *
+     * The actual service reset integration is handled by Symfony's ServicesResetter
+     * and triggered during Kernel::boot() when resetServices flag is set.
+     */
+    public function testSwTwigFunctionEscapeCacheCanBeReset(): void
+    {
+        $kernel = KernelLifecycleManager::getKernel();
+        $container = $kernel->getContainer();
+
+        // Verify services_resetter exists (prerequisite for long runner support)
+        static::assertTrue(
+            $container->has('services_resetter'),
+            'services_resetter service should exist in container'
+        );
+
+        // Populate the escape cache with test data via reflection
+        $reflection = new \ReflectionClass(\Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::class);
+        $cacheProperty = $reflection->getProperty('escapeCache');
+        $cacheProperty->setValue(null, ['test_key' => 'test_value']);
+
+        // Verify cache is populated
+        static::assertNotEmpty(
+            $cacheProperty->getValue(null),
+            'Escape cache should have test data before reset'
+        );
+
+        // Call the public reset method directly
+        \Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::resetEscapeCache();
+
+        // Verify cache was cleared
+        static::assertEmpty(
+            $cacheProperty->getValue(null),
+            'SwTwigFunction::$escapeCache should be empty after resetEscapeCache()'
+        );
+    }
+
+    /**
+     * Tests memory stability with diverse content to stress-test caches.
+     *
+     * Some caches (like escape filter cache) grow with unique content.
+     * This test generates diverse requests to detect such issues.
+     */
+    public function testMemoryStabilityWithDiverseRequests(): void
+    {
+        $kernel = KernelLifecycleManager::getKernel();
+
+        // Warm up
+        for ($i = 0; $i < 3; ++$i) {
+            $request = Request::create('/api/_info/version');
+            $response = $kernel->handle($request);
+            $kernel->terminate($request, $response);
+        }
+
+        gc_collect_cycles();
+        $initialMemory = memory_get_usage(true);
+
+        // Various endpoints to trigger different code paths
+        $endpoints = [
+            '/api/_info/version',
+            '/api/_info/config',
+        ];
+
+        for ($i = 0; $i < self::REQUEST_COUNT; ++$i) {
+            $endpoint = $endpoints[$i % \count($endpoints)];
+
+            // Add unique query parameter to prevent response caching
+            $request = Request::create($endpoint . '?_=' . $i . '_' . uniqid());
+            $response = $kernel->handle($request);
+            $kernel->terminate($request, $response);
+        }
+
+        gc_collect_cycles();
+        $finalMemory = memory_get_usage(true);
+
+        $memoryGrowth = $finalMemory - $initialMemory;
+        $maxAllowedGrowth = self::MAX_MEMORY_GROWTH_PER_REQUEST * self::REQUEST_COUNT;
+
+        static::assertLessThan(
+            $maxAllowedGrowth,
+            $memoryGrowth,
+            \sprintf(
+                'Memory leak detected with diverse requests!'
+                . ' Growth: %s (max allowed: %s)',
+                $this->formatBytes($memoryGrowth),
+                $this->formatBytes($maxAllowedGrowth)
+            )
+        );
+    }
+
+    /**
+     * Tests that MySQLFactory properly manages idle database connections.
+     *
+     * MySQLFactory::getConnection() proactively closes idle connections to prevent
+     * "MySQL server has gone away" errors in long runner environments.
+     */
+    public function testMySQLFactoryIdleConnectionManagement(): void
+    {
+        // Verify MySQLFactory::getConnection() returns a valid connection
+        $connection = \Shopware\Core\Framework\Adapter\Database\MySQLFactory::getConnection();
+
+        // Verify the connection works
+        $result = $connection->executeQuery('SELECT 1')->fetchOne();
+        static::assertSame('1', $result);
+
+        // Verify getConnection() returns the same instance (connection caching)
+        $connection2 = \Shopware\Core\Framework\Adapter\Database\MySQLFactory::getConnection();
+        static::assertSame($connection, $connection2);
+    }
+
+    /**
+     * Tests that requestStackSize is properly managed.
+     *
+     * Symfony Kernel tracks nested requests via requestStackSize.
+     * After each request cycle (handle + terminate), this should return to 0.
+     */
+    public function testRequestStackSizeIsProperlyManaged(): void
+    {
+        $kernel = KernelLifecycleManager::getKernel();
+
+        // Use reflection to check requestStackSize
+        $reflection = new \ReflectionClass($kernel);
+
+        // Find requestStackSize property (it's in parent Symfony Kernel)
+        $parent = $reflection->getParentClass();
+        while ($parent && !$parent->hasProperty('requestStackSize')) {
+            $parent = $parent->getParentClass();
+        }
+
+        if (!$parent) {
+            static::markTestSkipped('Could not find requestStackSize property in Kernel hierarchy');
+        }
+
+        $stackSizeProperty = $parent->getProperty('requestStackSize');
+
+        // Run a request
+        $request = Request::create('/api/_info/version');
+        $response = $kernel->handle($request);
+
+        // During request handling, stack size should be >= 1
+        // (we can't easily check this during handle, but after terminate it should be 0)
+
+        $kernel->terminate($request, $response);
+
+        $stackSizeAfter = $stackSizeProperty->getValue($kernel);
+
+        static::assertSame(
+            0,
+            $stackSizeAfter,
+            'requestStackSize should be 0 after request cycle completes'
+        );
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' B';
+        }
+
+        if ($bytes < 1024 * 1024) {
+            return round($bytes / 1024, 2) . ' KB';
+        }
+
+        return round($bytes / 1024 / 1024, 2) . ' MB';
+    }
+}

--- a/tests/integration/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexingMessage;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Increment\AbstractIncrementer;
 use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
@@ -23,13 +22,6 @@ class ConsumeMessagesControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;
     use QueueTestBehaviour;
-
-    private AbstractIncrementer $incrementer;
-
-    protected function setUp(): void
-    {
-        $this->incrementer = static::getContainer()->get('shopware.increment.gateway.registry')->get(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL);
-    }
 
     public function testConsumeMessages(): void
     {
@@ -57,7 +49,6 @@ class ConsumeMessagesControllerTest extends TestCase
 
         // consume the queued task
         $url = '/api/_action/message-queue/consume';
-        $client = $this->getBrowser();
         $client->request('POST', $url, ['receiver' => 'async']);
 
         $response = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -69,21 +60,23 @@ class ConsumeMessagesControllerTest extends TestCase
 
     public function testMessageStatsDecrement(): void
     {
-        $messageBus = static::getContainer()->get('messenger.default_bus');
+        $client = $this->getBrowser();
+
+        $messageBus = $client->getContainer()->get('messenger.default_bus');
         $message = new ProductIndexingMessage([Uuid::randomHex()]);
         $messageBus->dispatch($message);
 
-        $gateway = static::getContainer()->get('shopware.increment.gateway.registry');
+        $gateway = $client->getContainer()->get('shopware.increment.gateway.registry');
         $entries = $gateway->get(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL)->list('message_queue_stats');
 
         static::assertArrayHasKey(ProductIndexingMessage::class, $entries);
         static::assertGreaterThan(0, $entries[ProductIndexingMessage::class]['count']);
 
         $url = '/api/_action/message-queue/consume';
-        $client = $this->getBrowser();
         $client->request('POST', $url, ['receiver' => 'async']);
 
-        $entries = $this->incrementer->list('message_queue_stats');
+        $incrementer = $client->getContainer()->get('shopware.increment.gateway.registry')->get(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL);
+        $entries = $incrementer->list('message_queue_stats');
 
         static::assertArrayHasKey(ProductIndexingMessage::class, $entries);
         static::assertSame(0, $entries[ProductIndexingMessage::class]['count']);

--- a/tests/integration/Core/Framework/MessageQueue/Api/MessageQueueEndpointTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Api/MessageQueueEndpointTest.php
@@ -19,7 +19,9 @@ class MessageQueueEndpointTest extends TestCase
 
     public function testEndpoint(): void
     {
-        $gatewayRegistry = static::getContainer()->get('shopware.increment.gateway.registry');
+        $client = $this->getBrowser();
+
+        $gatewayRegistry = $client->getContainer()->get('shopware.increment.gateway.registry');
 
         $gateway = $gatewayRegistry->get(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL);
 
@@ -30,7 +32,6 @@ class MessageQueueEndpointTest extends TestCase
         $gateway->increment('message_queue_stats', 'bar');
 
         $url = '/api/_info/queue.json';
-        $client = $this->getBrowser();
         $client->request('GET', $url);
 
         static::assertSame(200, $client->getResponse()->getStatusCode());

--- a/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
@@ -35,7 +35,7 @@ class ScriptApiRouteTest extends TestCase
         $response = \json_decode($browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), print_r($response, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('api-simple-script', $traces);
         static::assertCount(1, $traces['api-simple-script']);
         static::assertSame('some debug information', $traces['api-simple-script'][0]['output'][0]);
@@ -55,7 +55,7 @@ class ScriptApiRouteTest extends TestCase
         $response = \json_decode($browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), print_r($response, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('api-simple-script', $traces);
         static::assertCount(1, $traces['api-simple-script']);
         static::assertSame('some debug information', $traces['api-simple-script'][0]['output'][0]);

--- a/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
@@ -41,7 +41,7 @@ class ScriptStoreApiRouteTest extends TestCase
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-simple-script::response', $traces);
         static::assertCount(1, $traces['store-api-simple-script::response']);
         static::assertSame('some debug information', $traces['store-api-simple-script::response'][0]['output'][0]);
@@ -63,7 +63,7 @@ class ScriptStoreApiRouteTest extends TestCase
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-simple-script::response', $traces);
         static::assertCount(1, $traces['store-api-simple-script::response']);
         static::assertSame('some debug information', $traces['store-api-simple-script::response'][0]['output'][0]);
@@ -195,13 +195,14 @@ class ScriptStoreApiRouteTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/_fixtures');
 
+        // First request - script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script?query-param=1');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
         static::assertCount(1, $traces['store-api-cache-script::response']);
         static::assertSame('some debug information', $traces['store-api-cache-script::response'][0]['output'][0]);
@@ -216,16 +217,17 @@ class ScriptStoreApiRouteTest extends TestCase
             static::assertFalse($this->browser->getResponse()->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
         }
 
+        // Second request with same query param - response should be cached, script NOT executed
         $this->browser->request('GET', '/store-api/script/cache-script?query-param=1');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
-        static::assertArrayHasKey('store-api-cache-script::response', $traces);
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         // assert that the response was cached, and thus the script was not called again
-        static::assertCount(1, $traces['store-api-cache-script::response']);
+        // traces should NOT have this key because script was not executed (cache hit)
+        static::assertArrayNotHasKey('store-api-cache-script::response', $traces);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -237,16 +239,17 @@ class ScriptStoreApiRouteTest extends TestCase
             static::assertFalse($this->browser->getResponse()->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
         }
 
+        // Third request with different query param - cache miss, script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script?query-param=2');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
-        // assert that when the query param changes the script is executed again
-        static::assertCount(2, $traces['store-api-cache-script::response']);
+        // assert that when the query param changes the script is executed again (1 execution in this request)
+        static::assertCount(1, $traces['store-api-cache-script::response']);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -259,13 +262,14 @@ class ScriptStoreApiRouteTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/_fixtures');
 
+        // First request - script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
         static::assertCount(1, $traces['store-api-cache-script::response']);
         static::assertSame('some debug information', $traces['store-api-cache-script::response'][0]['output'][0]);
@@ -276,16 +280,16 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
+        // Second request - cache hit, script NOT executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
-        static::assertArrayHasKey('store-api-cache-script::response', $traces);
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         // assert that the response was cached, and thus the script was not called again
-        static::assertCount(1, $traces['store-api-cache-script::response']);
+        static::assertArrayNotHasKey('store-api-cache-script::response', $traces);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -294,19 +298,20 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
         // invalidate the custom cache tag
-        $cacheInvalidator = static::getContainer()->get(CacheInvalidator::class);
+        $cacheInvalidator = $this->browser->getContainer()->get(CacheInvalidator::class);
         $cacheInvalidator->invalidate(['my-custom-tag'], true);
 
+        // Third request after invalidation - script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
-        // assert that when the cache tag was invalidated the script is executed again
-        static::assertCount(2, $traces['store-api-cache-script::response']);
+        // assert that when the cache tag was invalidated the script is executed again (1 execution in this request)
+        static::assertCount(1, $traces['store-api-cache-script::response']);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -319,13 +324,14 @@ class ScriptStoreApiRouteTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/_fixtures');
 
+        // First request - script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
         static::assertCount(1, $traces['store-api-cache-script::response']);
         static::assertSame('some debug information', $traces['store-api-cache-script::response'][0]['output'][0]);
@@ -336,16 +342,16 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
+        // Second request - cache hit, script NOT executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
-        static::assertArrayHasKey('store-api-cache-script::response', $traces);
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         // assert that the response was cached, and thus the script was not called again
-        static::assertCount(1, $traces['store-api-cache-script::response']);
+        static::assertArrayNotHasKey('store-api-cache-script::response', $traces);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -356,16 +362,17 @@ class ScriptStoreApiRouteTest extends TestCase
         // Login to get the `logged-in` invalidation state
         $this->login();
 
+        // Third request after login - script should be executed due to invalidation state
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
-        // assert that when the invalidation state is present the response is not cached
-        static::assertCount(2, $traces['store-api-cache-script::response']);
+        // assert that when the invalidation state is present the response is not cached (1 execution in this request)
+        static::assertCount(1, $traces['store-api-cache-script::response']);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);

--- a/tests/integration/Storefront/Controller/AccountOrderControllerTest.php
+++ b/tests/integration/Storefront/Controller/AccountOrderControllerTest.php
@@ -298,7 +298,7 @@ class AccountOrderControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountOrderPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -326,7 +326,7 @@ class AccountOrderControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountOrderPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -367,7 +367,7 @@ class AccountOrderControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountOrderDetailPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -406,7 +406,7 @@ class AccountOrderControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), $url . $response->getContent());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountEditOrderPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/AccountProfileControllerTest.php
+++ b/tests/integration/Storefront/Controller/AccountProfileControllerTest.php
@@ -57,7 +57,7 @@ class AccountProfileControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('account-overview-page-loaded', $traces);
     }
@@ -74,7 +74,7 @@ class AccountProfileControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('account-profile-page-loaded', $traces);
     }

--- a/tests/integration/Storefront/Controller/AddressControllerTest.php
+++ b/tests/integration/Storefront/Controller/AddressControllerTest.php
@@ -119,7 +119,7 @@ class AddressControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('address-listing-page-loaded', $traces);
     }
@@ -133,7 +133,7 @@ class AddressControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('address-detail-page-loaded', $traces);
     }
@@ -147,7 +147,7 @@ class AddressControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('address-detail-page-loaded', $traces);
     }

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -326,9 +326,10 @@ class AuthControllerTest extends TestCase
 
     public function testAccountLoginPageLoadedHookScriptsAreExecuted(): void
     {
-        $this->request('GET', '/account/login', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/account/login');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountLoginPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -588,9 +589,10 @@ class AuthControllerTest extends TestCase
 
     public function testAccountGuestLoginPageLoadedHookScriptsAreExecuted(): void
     {
-        $this->request('GET', '/account/guest/login', ['redirectTo' => 'foo']);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/account/guest/login?redirectTo=foo');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountGuestLoginPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/CheckoutControllerTest.php
+++ b/tests/integration/Storefront/Controller/CheckoutControllerTest.php
@@ -537,7 +537,7 @@ class CheckoutControllerTest extends TestCase
             '/checkout/cart'
         );
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CheckoutCartPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/CmsControllerTest.php
+++ b/tests/integration/Storefront/Controller/CmsControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
@@ -31,30 +32,36 @@ class CmsControllerTest extends TestCase
 
     public function testCmsPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/widgets/cms/' . $this->ids->get('page'), []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/widgets/cms/' . $this->ids->get('page'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CmsPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testCmsPageLoadedHookScriptsAreExecutedForFullPage(): void
     {
-        $response = $this->request('GET', '/page/cms/' . $this->ids->get('page'), []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/page/cms/' . $this->ids->get('page'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CmsPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testCmsPageLoadedHookScriptsAreExecutedForCategory(): void
     {
-        $response = $this->request('GET', '/widgets/cms/navigation/' . $this->ids->get('category'), []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/widgets/cms/navigation/' . $this->ids->get('category'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CmsPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/LandingPageControllerTest.php
+++ b/tests/integration/Storefront/Controller/LandingPageControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -35,11 +36,12 @@ class LandingPageControllerTest extends TestCase
 
     public function testLandingPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/myUrl', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/myUrl');
 
-        static::assertSame(200, $response->getStatusCode());
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(LandingPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/MaintenanceControllerTest.php
+++ b/tests/integration/Storefront/Controller/MaintenanceControllerTest.php
@@ -47,17 +47,19 @@ class MaintenanceControllerTest extends TestCase
 
         static::assertSame(503, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(MaintenancePageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testMaintenancePageLoadedHookScriptsAreExecutedForSinglePage(): void
     {
-        $response = $this->request('GET', '/maintenance/singlepage/' . $this->ids->get('page'), []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/maintenance/singlepage/' . $this->ids->get('page'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(MaintenancePageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -34,31 +35,36 @@ class NavigationControllerTest extends TestCase
 
     public function testNavigationPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(NavigationPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testNavigationPageLoadedHookScriptsAreExecutedForCategory(): void
     {
-        $response = $this->request('GET', '/my-navigation/', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/my-navigation/');
 
-        static::assertSame(200, $response->getStatusCode(), print_r($response->getContent(), true));
+        static::assertSame(200, $browser->getResponse()->getStatusCode(), print_r($browser->getResponse()->getContent(), true));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(NavigationPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testMenuOffcanvasPageletLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/widgets/menu/offcanvas', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/widgets/menu/offcanvas');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(MenuOffcanvasPageletLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -314,15 +314,12 @@ class ProductControllerTest extends TestCase
     {
         $productId = $this->createProduct();
 
-        $response = $this->request(
-            'GET',
-            '/my-product/' . $productId,
-            []
-        );
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/my-product/' . $productId);
 
-        $this->checkStatusCode($response);
+        $this->checkStatusCode($browser->getResponse());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('product-page-loaded', $traces);
     }
@@ -331,15 +328,12 @@ class ProductControllerTest extends TestCase
     {
         $productId = $this->createProduct();
 
-        $response = $this->request(
-            'GET',
-            '/quickview/' . $productId,
-            []
-        );
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/quickview/' . $productId);
 
-        $this->checkStatusCode($response);
+        $this->checkStatusCode($browser->getResponse());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(ProductQuickViewWidgetLoadedHook::HOOK_NAME, $traces);
     }
@@ -348,15 +342,13 @@ class ProductControllerTest extends TestCase
     {
         $productId = $this->createProduct();
 
-        $response = $this->request(
-            'GET',
-            '/product/' . $productId . '/reviews',
-            []
-        );
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/product/' . $productId . '/reviews');
 
+        $response = $browser->getResponse();
         $this->checkStatusCode($response);
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(ProductReviewsWidgetLoadedHook::HOOK_NAME, $traces);
 

--- a/tests/integration/Storefront/Controller/RegisterControllerTest.php
+++ b/tests/integration/Storefront/Controller/RegisterControllerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Defaults;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -263,10 +264,12 @@ class RegisterControllerTest extends TestCase
 
     public function testAccountRegisterPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/account/register', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/account/register');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountRegisterPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -276,10 +279,12 @@ class RegisterControllerTest extends TestCase
         $ids = new IdsCollection();
         $this->createCustomerGroup($ids);
 
-        $response = $this->request('GET', 'customer-group-registration/' . $ids->get('group'), []);
-        static::assertSame(200, $response->getStatusCode(), print_r($response->getContent(), true));
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/customer-group-registration/' . $ids->get('group'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode(), print_r($browser->getResponse()->getContent(), true));
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CustomerGroupRegistrationPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -290,18 +295,19 @@ class RegisterControllerTest extends TestCase
 
         $this->createProduct(Uuid::randomHex(), $productNumber);
 
-        $this->request(
+        $browser = $this->createStorefrontBrowser();
+        $browser->request(
             'POST',
-            '/checkout/product/add-by-number',
+            EnvironmentHelper::getVariable('APP_URL') . '/checkout/product/add-by-number',
             $this->tokenize('frontend.checkout.product.add-by-number', [
                 'number' => $productNumber,
             ])
         );
 
-        $response = $this->request('GET', '/checkout/register', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/checkout/register');
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CheckoutRegisterPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/ScriptControllerTest.php
+++ b/tests/integration/Storefront/Controller/ScriptControllerTest.php
@@ -31,13 +31,15 @@ class ScriptControllerTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/fixtures/Apps');
 
-        $response = $this->request('GET', '/storefront/script/json-response', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/storefront/script/json-response');
+        $response = $browser->getResponse();
         static::assertNotFalse($response->getContent());
 
         $body = \json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), print_r($body, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('storefront-json-response', $traces);
         static::assertCount(1, $traces['storefront-json-response']);
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);
@@ -50,13 +52,15 @@ class ScriptControllerTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/fixtures/Apps');
 
-        $response = $this->request('GET', '/storefront/script/json/response', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/storefront/script/json/response');
+        $response = $browser->getResponse();
         static::assertNotFalse($response->getContent());
 
         $body = \json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), print_r($body, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('storefront-json-response', $traces);
         static::assertCount(1, $traces['storefront-json-response']);
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);
@@ -69,18 +73,20 @@ class ScriptControllerTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/fixtures/Apps');
 
-        $response = $this->request(
+        $browser = $this->createStorefrontBrowser();
+        $browser->request(
             'POST',
-            '/storefront/script/json-response',
+            EnvironmentHelper::getVariable('APP_URL') . '/storefront/script/json-response',
             $this->tokenize('frontend.script_endpoint', [])
         );
+        $response = $browser->getResponse();
 
         static::assertNotFalse($response->getContent());
 
         $body = \json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), print_r($body, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('storefront-json-response', $traces);
         static::assertCount(1, $traces['storefront-json-response']);
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);

--- a/tests/integration/Storefront/Controller/SearchControllerTest.php
+++ b/tests/integration/Storefront/Controller/SearchControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -51,30 +52,36 @@ class SearchControllerTest extends TestCase
 
     public function testSearchPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/search', ['search' => 'test']);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/search?search=test');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(SearchPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testSuggestPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/suggest', ['search' => 'test']);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/suggest?search=test');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(SuggestPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testSearchWidgetLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/widgets/search', ['search' => 'test']);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/widgets/search?search=test');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(SearchWidgetLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/SitemapControllerTest.php
+++ b/tests/integration/Storefront/Controller/SitemapControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Sitemap\SitemapPageLoadedHook;
@@ -18,10 +19,12 @@ class SitemapControllerTest extends TestCase
 
     public function testSitemapPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/sitemap.xml', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/sitemap.xml');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(SitemapPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/WishlistControllerTest.php
+++ b/tests/integration/Storefront/Controller/WishlistControllerTest.php
@@ -241,17 +241,19 @@ class WishlistControllerTest extends TestCase
         $response = $browser->getResponse();
         static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(WishlistPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testGuestWishlistPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/wishlist', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/wishlist');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(GuestWishlistPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -268,7 +270,7 @@ class WishlistControllerTest extends TestCase
 
         static::assertSame(200, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(GuestWishlistPageletLoadedHook::HOOK_NAME, $traces);
     }
@@ -281,7 +283,7 @@ class WishlistControllerTest extends TestCase
         $response = $browser->getResponse();
         static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(WishlistPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -294,7 +296,7 @@ class WishlistControllerTest extends TestCase
         $response = $browser->getResponse();
         static::assertSame(200, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(WishlistWidgetLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -157,6 +157,166 @@ class MySQLFactoryTest extends TestCase
         static::assertSame('1', $params['replica'][0]['driverOptions'][$replicaCustomOption]);
     }
 
+    public function testResetConnectionClearsState(): void
+    {
+        // Use reflection to check the static state
+        $reflection = new \ReflectionClass(MySQLFactory::class);
+        $connectionProperty = $reflection->getProperty('connection');
+        $lastUsedAtProperty = $reflection->getProperty('lastUsedAt');
+
+        // Set some test state
+        $mockConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $mockConnection->expects($this->once())->method('close');
+        $connectionProperty->setValue(null, $mockConnection);
+        $lastUsedAtProperty->setValue(null, time());
+
+        // Call resetConnection
+        MySQLFactory::resetConnection();
+
+        // Verify state is cleared
+        static::assertNull($connectionProperty->getValue(null));
+        static::assertSame(0, $lastUsedAtProperty->getValue(null));
+    }
+
+    public function testGetConnectionCreatesNewConnectionWhenNoneExists(): void
+    {
+        // Reset any existing state first
+        MySQLFactory::resetConnection();
+
+        // Use reflection to verify no connection exists
+        $reflection = new \ReflectionClass(MySQLFactory::class);
+        $connectionProperty = $reflection->getProperty('connection');
+        $lastUsedAtProperty = $reflection->getProperty('lastUsedAt');
+
+        static::assertNull($connectionProperty->getValue(null));
+        static::assertSame(0, $lastUsedAtProperty->getValue(null));
+
+        // Call getConnection - this will create a real connection
+        $connection = MySQLFactory::getConnection();
+
+        // Verify connection was created and cached
+        static::assertSame($connection, $connectionProperty->getValue(null));
+        static::assertGreaterThan(0, $lastUsedAtProperty->getValue(null));
+
+        // Clean up
+        MySQLFactory::resetConnection();
+    }
+
+    public function testGetConnectionReturnsCachedConnection(): void
+    {
+        // Reset any existing state first
+        MySQLFactory::resetConnection();
+
+        // Get first connection
+        $connection1 = MySQLFactory::getConnection();
+
+        // Get second connection - should be same instance
+        $connection2 = MySQLFactory::getConnection();
+
+        static::assertSame($connection1, $connection2);
+
+        // Clean up
+        MySQLFactory::resetConnection();
+    }
+
+    public function testGetConnectionClosesIdleConnection(): void
+    {
+        // Reset and set TTL to 1 second via DATABASE_URL
+        MySQLFactory::resetConnection();
+        $this->setEnvVars(['DATABASE_URL' => 'mysql://root:shopware@127.0.0.1:3306/shopware?idle_connection_ttl=1']);
+
+        // Use reflection to manipulate state
+        $reflection = new \ReflectionClass(MySQLFactory::class);
+        $connectionProperty = $reflection->getProperty('connection');
+        $lastUsedAtProperty = $reflection->getProperty('lastUsedAt');
+        $ttlProperty = $reflection->getProperty('idleConnectionTtl');
+
+        // First create a connection to parse the TTL from URL
+        MySQLFactory::create();
+        static::assertSame(1, $ttlProperty->getValue(null));
+
+        // Create a mock connection
+        $mockConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $mockConnection->expects($this->once())->method('close');
+        $connectionProperty->setValue(null, $mockConnection);
+
+        // Set lastUsedAt to a time in the past (older than TTL)
+        $lastUsedAtProperty->setValue(null, time() - 10);
+
+        // Call getConnection - should close old connection and create new one
+        $newConnection = MySQLFactory::getConnection();
+
+        // Verify we got a new connection (not the mock)
+        static::assertNotSame($mockConnection, $newConnection);
+
+        // Clean up
+        MySQLFactory::resetConnection();
+        $ttlProperty->setValue(null, 0);
+    }
+
+    public function testGetConnectionDoesNotCloseRecentConnection(): void
+    {
+        // Reset and set TTL to 60 seconds via DATABASE_URL
+        MySQLFactory::resetConnection();
+        $this->setEnvVars(['DATABASE_URL' => 'mysql://root:shopware@127.0.0.1:3306/shopware?idle_connection_ttl=60']);
+
+        // Use reflection
+        $reflection = new \ReflectionClass(MySQLFactory::class);
+        $lastUsedAtProperty = $reflection->getProperty('lastUsedAt');
+        $ttlProperty = $reflection->getProperty('idleConnectionTtl');
+
+        // Get first connection (this also parses TTL from URL)
+        $connection1 = MySQLFactory::getConnection();
+
+        // Verify TTL was parsed
+        static::assertSame(60, $ttlProperty->getValue(null));
+
+        // Check lastUsedAt is set
+        $lastUsedAt = $lastUsedAtProperty->getValue(null);
+        static::assertGreaterThan(0, $lastUsedAt);
+
+        // Get another connection - should be same instance since not idle
+        $connection2 = MySQLFactory::getConnection();
+
+        static::assertSame($connection1, $connection2);
+
+        // Clean up
+        MySQLFactory::resetConnection();
+        $ttlProperty->setValue(null, 0);
+    }
+
+    public function testGetConnectionWithTtlDisabled(): void
+    {
+        // Reset - no idle_connection_ttl in URL means TTL is disabled (default 0)
+        MySQLFactory::resetConnection();
+        $this->setEnvVars(['DATABASE_URL' => 'mysql://root:shopware@127.0.0.1:3306/shopware']);
+
+        // Use reflection
+        $reflection = new \ReflectionClass(MySQLFactory::class);
+        $lastUsedAtProperty = $reflection->getProperty('lastUsedAt');
+        $ttlProperty = $reflection->getProperty('idleConnectionTtl');
+
+        // Reset TTL to 0 (in case previous test set it)
+        $ttlProperty->setValue(null, 0);
+
+        // Create first connection
+        $connection1 = MySQLFactory::getConnection();
+
+        // Verify TTL is 0 (disabled)
+        static::assertSame(0, $ttlProperty->getValue(null));
+
+        // Manually set lastUsedAt to old time
+        $lastUsedAtProperty->setValue(null, time() - 3600); // 1 hour ago
+
+        // Get another connection - should be same instance since TTL is disabled
+        $connection2 = MySQLFactory::getConnection();
+
+        static::assertSame($connection1, $connection2);
+
+        // Clean up
+        MySQLFactory::resetConnection();
+    }
+
     /**
      * @param array<string, mixed> $actualParams
      * @param array<string, mixed> $expectedParams

--- a/tests/unit/Core/Framework/Adapter/Kernel/KernelFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Kernel/KernelFactoryTest.php
@@ -7,6 +7,7 @@ use Composer\InstalledVersions;
 use Doctrine\DBAL\Driver\Middleware;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Kernel;
@@ -21,6 +22,8 @@ class KernelFactoryTest extends TestCase
 {
     public function testProfilingMiddlewareIsAddedWhenFlagPresent(): void
     {
+        // Reset cached connection to ensure fresh connection with middleware
+        MySQLFactory::resetConnection();
         if (!InstalledVersions::isInstalled('symfony/doctrine-bridge')) {
             static::markTestSkipped('profiler not installed');
         }

--- a/tests/unit/Core/Framework/Adapter/Twig/SwTwigFunctionResetterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/SwTwigFunctionResetterTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Twig\SwTwigFunction;
+use Shopware\Core\Framework\Adapter\Twig\SwTwigFunctionResetter;
+use Twig\Environment;
+use Twig\Runtime\EscaperRuntime;
+
+/**
+ * @internal
+ */
+#[CoversClass(SwTwigFunctionResetter::class)]
+class SwTwigFunctionResetterTest extends TestCase
+{
+    private MockObject&Environment $environmentMock;
+
+    protected function setUp(): void
+    {
+        $this->environmentMock = $this->createMock(Environment::class);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up static cache after each test
+        SwTwigFunction::resetEscapeCache();
+    }
+
+    public function testResetCallsSwTwigFunctionResetEscapeCache(): void
+    {
+        $env = $this->environmentMock;
+        $runtimeCallCount = 0;
+
+        $escaperRuntime = new EscaperRuntime($env);
+        $env->method('getRuntime')->willReturnCallback(function () use ($escaperRuntime, &$runtimeCallCount) {
+            ++$runtimeCallCount;
+
+            return $escaperRuntime;
+        });
+
+        // Populate the cache
+        SwTwigFunction::escapeFilter($env, 'resetter_test_string', 'html', 'UTF-8');
+        static::assertSame(1, $runtimeCallCount);
+
+        // Verify cache is used
+        SwTwigFunction::escapeFilter($env, 'resetter_test_string', 'html', 'UTF-8');
+        // @phpstan-ignore staticMethod.alreadyNarrowedType (PHPStan doesn't track reference through callback)
+        static::assertSame(1, $runtimeCallCount, 'Cache should be used');
+
+        // Call resetter
+        $resetter = new SwTwigFunctionResetter();
+        $resetter->reset();
+
+        // After reset, cache should be cleared
+        SwTwigFunction::escapeFilter($env, 'resetter_test_string', 'html', 'UTF-8');
+        // @phpstan-ignore staticMethod.impossibleType (PHPStan doesn't track reference through callback)
+        static::assertSame(2, $runtimeCallCount, 'After resetter->reset(), cache should be cleared');
+    }
+
+    public function testResetterImplementsResetInterface(): void
+    {
+        $resetter = new SwTwigFunctionResetter();
+
+        // @phpstan-ignore staticMethod.alreadyNarrowedType (test documents the contract)
+        static::assertInstanceOf(\Symfony\Contracts\Service\ResetInterface::class, $resetter);
+    }
+}

--- a/tests/unit/Core/Framework/Adapter/Twig/SwTwigFunctionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/SwTwigFunctionTest.php
@@ -29,6 +29,12 @@ class SwTwigFunctionTest extends TestCase
         class_exists(CoreExtension::class);
     }
 
+    protected function tearDown(): void
+    {
+        // Clean up static cache after each test to avoid test pollution
+        SwTwigFunction::resetEscapeCache();
+    }
+
     public function testSwGetAttributeValueNull(): void
     {
         $object = new ArrayStruct(['test' => null]);
@@ -145,6 +151,36 @@ class SwTwigFunctionTest extends TestCase
         $result = SwTwigFunction::escapeFilter($env, 'cached_string', 'html', 'UTF-8');
 
         static::assertSame('cached_string', $result);
+    }
+
+    public function testResetEscapeCacheClearsCache(): void
+    {
+        $env = $this->environmentMock;
+        $runtimeCallCount = 0;
+
+        $escaperRuntime = new EscaperRuntime($env);
+        $env->method('getRuntime')->willReturnCallback(function () use ($escaperRuntime, &$runtimeCallCount) {
+            ++$runtimeCallCount;
+
+            return $escaperRuntime;
+        });
+
+        // First call - should call getRuntime
+        SwTwigFunction::escapeFilter($env, 'test_reset_string', 'html', 'UTF-8');
+        static::assertSame(1, $runtimeCallCount);
+
+        // Second call - should use cache, NOT call getRuntime
+        SwTwigFunction::escapeFilter($env, 'test_reset_string', 'html', 'UTF-8');
+        // @phpstan-ignore staticMethod.alreadyNarrowedType (PHPStan doesn't track reference through callback)
+        static::assertSame(1, $runtimeCallCount, 'Second call should use cache');
+
+        // Reset the cache
+        SwTwigFunction::resetEscapeCache();
+
+        // Third call after reset - should call getRuntime again
+        SwTwigFunction::escapeFilter($env, 'test_reset_string', 'html', 'UTF-8');
+        // @phpstan-ignore staticMethod.impossibleType (PHPStan doesn't track reference through callback)
+        static::assertSame(2, $runtimeCallCount, 'After reset, cache should be empty and getRuntime called again');
     }
 }
 

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopware\Tests\Unit\Core;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
@@ -86,7 +85,6 @@ class KernelTest extends TestCase
             $this->createMock(StaticKernelPluginLoader::class),
             'cacheId',
             '6.6.6',
-            $this->createMock(Connection::class),
             $this->tmpProjectDir,
         );
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware currently doesn't support long-running PHP servers (RoadRunner, FrankenPHP, Swoole) because the `Kernel::handle()` override bypasses Symfony's native service reset mechanism.

In Symfony's `HttpKernel::handle()`, there's critical logic that:
1. Tracks `requestStackSize` to know when all requests are complete
2. Sets `resetServices = true` flag
3. Calls `ServicesResetter` on next `boot()` when stack is empty

Shopware's override skipped this entirely, causing:
- Services implementing `ResetInterface` were never reset between requests
- Memory leaks from unbounded cache growth (e.g., `SwTwigFunction::$strings`)
- State pollution between requests

Additionally, in long-running environments, database connections can become stale if the worker is idle for extended periods, causing "MySQL server has gone away" errors.

### 2. What does this change do, exactly?

1. **Removes `Kernel::handle()` override** - enables Symfony's native request lifecycle with proper `requestStackSize` tracking and `resetServices` flag

2. **Sets `http_cache.enabled: false`** - prevents Symfony from wrapping the kernel with its own `HttpCache`. Shopware already uses its own `HttpCacheKernel` registered as `http_kernel.cache` decorator

3. **Fixes `SwTwigFunction` memory leak** - the escape filter used a function-level `static $strings = []` cache that grew unbounded. Changed to class-level static property with `resetEscapeCache()` method

4. **Adds `SwTwigFunctionResetter` service** - implements `ResetInterface` and is tagged with `kernel.reset` to clear the escape cache between requests

5. **Adds idle connection TTL to `MySQLFactory`** - automatically closes database connections that have been idle too long, preventing "MySQL server has gone away" errors. Configurable via `idle_connection_ttl` parameter in DATABASE_URL:
   ```
   DATABASE_URL=mysql://user:pass@host:3306/db?idle_connection_ttl=300
   ```

6. **Fixes ~40 integration tests** - tests checking `ScriptTraces` after HTTP requests were failing because `static::getContainer()` triggers Symfony's service reset. Changed tests to use `$browser->getContainer()` which returns the container directly without triggering `boot()` and the associated reset. Added `createStorefrontBrowser()` helper method to `StorefrontControllerTestBehaviour` trait.

7. **Adds integration tests** - `LongRunnerMemoryTest` verifies memory stability across multiple requests and proper service reset

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure Shopware with FrankenPHP in worker mode:
   ```yaml
   # compose.frankenphp.yaml
   services:
       web:
           image: ghcr.io/shopware/docker-base:8.4-frankenphp
           environment:
               APP_RUNTIME: Runtime\FrankenPhpSymfony\Runtime
               FRANKENPHP_CONFIG: "worker /var/www/html/public/index.php 2"
   ```

2. Start the application:
   ```bash
   composer require runtime/frankenphp-symfony
   docker compose -f compose.yaml -f compose.frankenphp.yaml up -d
   ```

3. Send multiple requests and observe memory:
   ```bash
   ab -n 1000 -c 10 http://localhost:8000/api/_info/version
   docker stats shopware6-web-1
   ```

4. **Before fix:** Memory grows continuously, services like `CartService` retain state between requests
5. **After fix:** Memory stabilizes after warm-up, services are properly reset

### 4. Please link to the relevant issues (if any).

- closes #13921
- relates #11215
- relates #11217
- relates #12501

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed related commits into one, where suitable
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them