### PR TITLE
fix: generate EXISTS conditions instead of left joins for nested filter groups in DAL criteria builder 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,7 @@ devenv.local.nix
 
 # danger.php
 danger.phar
+
+# 6.7 Vite deps - added to make switching branches easier
+**/.tmp/vite/*
+**/build/vite-plugins/*

--- a/changelog/_unreleased/2026-01-14-multi-join-exists.md
+++ b/changelog/_unreleased/2026-01-14-multi-join-exists.md
@@ -1,0 +1,6 @@
+---
+title: Generate EXISTS conditions instead of left joins for nested filter groups in DAL criteria builder
+issue: 13707
+---
+# Core
+* Changed `\Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldResolver\CriteriaPartResolver` to generate exists queries for multi join groups instead of left joins, thus fixing a performance issue where the number of joins exploded when you have multiple join filters on the same entity.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1977,11 +1977,6 @@ parameters:
 
 		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 3
-			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToManyAssociationFieldResolver.php
 

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -100,6 +100,8 @@ class DataAbstractionLayerException extends HttpException
     public const FRAMEWORK_DEPRECATED_DEFINITION_CALL = 'FRAMEWORK__DEPRECATED_DEFINITION_CALL';
     public const UNSUPPORTED_QUERY_FILTER = 'FRAMEWORK__UNSUPPORTED_QUERY_FILTER';
     public const PRODUCT_SEARCH_CONFIGURATION_NOT_FOUND = 'FRAMEWORK__PRODUCT_SEARCH_CONFIGURATION_NOT_FOUND';
+    public const DBAL_UNEXPECTED_ASSOCIATION_FIELD_CLASS = 'FRAMEWORK__DBAL_UNEXPECTED_ASSOCIATION_FIELD_CLASS';
+    public const DBAL_EXPECTED_ASSOCIATION_FIELD_IN_FIRST_LEVEL_OF_JOIN_GROUP = 'FRAMEWORK__DBAL_EXPECTED_ASSOCIATION_FIELD_IN_FIRST_LEVEL_OF_JOIN_GROUP';
 
     public static function invalidSerializerField(string $expectedClass, Field $field): self
     {
@@ -933,6 +935,32 @@ class DataAbstractionLayerException extends HttpException
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::PRODUCT_SEARCH_CONFIGURATION_NOT_FOUND,
             'Configuration for product search definition not found',
+        );
+    }
+
+    /**
+     * @param class-string $associationClass
+     */
+    public static function unexpectedAssociationFieldClass(string $associationClass): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::DBAL_UNEXPECTED_ASSOCIATION_FIELD_CLASS,
+            'Unknown association class provided "{{ associationClass }}"',
+            ['associationClass' => $associationClass]
+        );
+    }
+
+    /**
+     * @param class-string|null $fieldClass
+     */
+    public static function expectedAssociationFieldInFirstLevelOfJoinGroup(?string $fieldClass): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::DBAL_EXPECTED_ASSOCIATION_FIELD_IN_FIRST_LEVEL_OF_JOIN_GROUP,
+            'Expected association field in first level of join group, got "{{ fieldClass }}"',
+            ['fieldClass' => $fieldClass]
         );
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldResolver;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\JoinGroup;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
@@ -18,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\CriteriaPartInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SingleFieldFilter;
@@ -43,9 +45,7 @@ class CriteriaPartResolver
     {
         foreach ($parts as $part) {
             if ($part instanceof JoinGroup) {
-                $this->resolveSubJoin($part, $definition, $query, $context);
-
-                $query->addState(EntityDefinitionQueryHelper::HAS_TO_MANY_JOIN);
+                $this->resolveJoinGroup($part, $definition, $query, $context);
 
                 continue;
             }
@@ -59,54 +59,34 @@ class CriteriaPartResolver
         }
     }
 
-    private function resolveSubJoin(JoinGroup $group, EntityDefinition $definition, QueryBuilder $query, Context $context): void
+    private function resolveJoinGroup(JoinGroup $group, EntityDefinition $definition, QueryBuilder $query, Context $context): void
     {
         $fields = EntityDefinitionQueryHelper::getFieldsOfAccessor($definition, $group->getPath(), false);
 
         $first = array_shift($fields);
 
         if (!$first instanceof AssociationField) {
-            throw new \RuntimeException('Expect association field in first level of join group');
+            throw DataAbstractionLayerException::expectedAssociationFieldInFirstLevelOfJoinGroup($first ? $first::class : null);
         }
 
-        $nested = $this->createNestedQuery($first, $definition, $context);
+        $nestedQuery = $this->createNestedQuery($first, $definition, $context);
 
         foreach ($group->getFields() as $accessor) {
             if ($accessor === '_score') {
                 continue;
             }
-            $this->resolveField($group, $accessor, $definition, $nested, $context);
+            $this->resolveField($group, $accessor, $definition, $nestedQuery, $context);
         }
 
-        $alias = $definition->getEntityName() . '.' . $first->getPropertyName() . $group->getSuffix();
+        $this->parseAndResolveFilters($group, $definition, $nestedQuery, $context);
 
-        $this->parseFilter($group, $definition, $nested, $context, $alias);
-
-        $parameters = [
-            '#root#' => self::escape($definition->getEntityName()),
-            '#source_column#' => $this->getSourceColumn($first, $context),
-            '#alias#' => self::escape($alias),
-        ];
-
-        $query->leftJoin(
-            self::escape($definition->getEntityName()),
-            '(' . $nested->getSQL() . ')',
-            self::escape($alias),
-            str_replace(
-                array_keys($parameters),
-                array_values($parameters),
-                '#root#.#source_column# = #alias#.`id`'
-                . $this->buildVersionWhere($definition, $first)
-            )
-        );
-
-        foreach ($nested->getParameters() as $key => $value) {
-            $type = $nested->getParameterType($key);
+        foreach ($nestedQuery->getParameters() as $key => $value) {
+            $type = $nestedQuery->getParameterType($key);
             $query->setParameter($key, $value, $type);
         }
     }
 
-    private function parseFilter(JoinGroup $group, EntityDefinition $definition, QueryBuilder $query, Context $context, string $alias): void
+    private function parseAndResolveFilters(JoinGroup $group, EntityDefinition $definition, QueryBuilder $subQuery, Context $context): void
     {
         $filter = new AndFilter($group->getQueries());
         if ($group->getOperator() === MultiFilter::CONNECTION_OR) {
@@ -119,17 +99,34 @@ class CriteriaPartResolver
         }
 
         foreach ($parsed->getParameters() as $key => $value) {
-            $query->setParameter($key, $value, $parsed->getType($key));
+            $subQuery->setParameter($key, $value, $parsed->getType($key));
         }
 
-        foreach ($filter->getQueries() as $filter) {
-            if (!$filter instanceof SingleFieldFilter) {
-                continue;
-            }
-            $filter->setResolved(self::escape($alias) . '.id IS NOT NULL');
+        $subQuery->andWhere(implode(' AND ', $parsed->getWheres()));
+
+        $singleFieldFilters = array_filter($filter->getQueries(), fn (Filter $filter): bool => $filter instanceof SingleFieldFilter);
+        if (empty($singleFieldFilters)) {
+            return;
         }
 
-        $query->andWhere(implode(' AND ', $parsed->getWheres()));
+        // We generate an EXISTS condition using our correlated subquery to avoid joining any table multiple
+        // times (even though it might be filtered). This avoids possible exponential join explosions. In some cases,
+        // MySQL/MariaDB will perform a semi-join optimization on these EXISTS conditions (see https://dev.mysql.com/doc/refman/8.0/en/semijoins.html).
+        // Since all single field filters will just be combined using AND/OR operators on the same level, we only
+        // need to include our EXISTS sub query for one of these filters. The where conditions actually representing
+        // these filters have been added to the subquery above.
+        array_shift($singleFieldFilters)->setResolved('EXISTS (' . $subQuery->getSQL() . ')');
+
+        // All other filters will be resolved to a constant value of FALSE or TRUE, depending on the operator used.
+        // For example, if the root filter has 3 queries:
+        // - ... and is an AND filter, we will generate `WHERE EXISTS(...) AND TRUE AND TRUE`
+        // - ... and is an OR filter, we will generate `WHERE EXISTS(...) OR FALSE OR FALSE`
+        // Simply, this no-op value puts the filters in a resolved state but is chosen in a way that it will not affect
+        // the result.
+        $noOpValue = $group->getOperator() === MultiFilter::CONNECTION_OR ? 'FALSE' : 'TRUE';
+        foreach ($singleFieldFilters as $singleFieldFilter) {
+            $singleFieldFilter->setResolved($noOpValue);
+        }
     }
 
     private function createNestedQuery(AssociationField $field, EntityDefinition $definition, Context $context): QueryBuilder
@@ -140,13 +137,23 @@ class CriteriaPartResolver
             $reference = $field->getReferenceDefinition();
             $alias = $definition->getEntityName() . '.' . $field->getPropertyName();
 
-            $query->addSelect(self::accessor($alias, $field->getReferenceField()) . ' as id');
-            if ($definition->isVersionAware() && $reference->getFields()->getByStorageName($definition->getEntityName() . '_version_id')) {
-                $query->addSelect(self::accessor($alias, $definition->getEntityName() . '_version_id'));
-            }
-
+            // Since this query only acts as an EXISTS check, we select a dummy value that will cause the EXISTS to be true.
+            $query->addSelect('1');
             $query->from(self::escape($reference->getEntityName()), self::escape($alias));
             $query->addState($alias);
+
+            $parameters = [
+                '#root#' => self::escape($definition->getEntityName()),
+                '#source_column#' => $this->getSourceColumn($field, $context),
+                '#alias#' => self::escape($alias),
+                '#reference_column#' => self::escape($field->getReferenceField()),
+            ];
+
+            $query->andWhere(str_replace(
+                array_keys($parameters),
+                array_values($parameters),
+                '#root#.#source_column# = #alias#.#reference_column#' . $this->buildVersionWhere($definition, $field),
+            ));
 
             return $query;
         }
@@ -155,25 +162,37 @@ class CriteriaPartResolver
             $reference = $field->getReferenceDefinition();
             $alias = $definition->getEntityName() . '.' . $field->getPropertyName();
 
-            $query->addSelect(self::accessor($alias, $field->getReferenceField()) . ' as id');
-            if ($reference->isVersionAware()) {
-                $version = 'version_id';
-                // it could be the case that we have a reverse join and the reference is the "parent" definition
-                if ($reference->getFields()->getByStorageName($definition->getEntityName() . '_version_id')) {
-                    $version = $definition->getEntityName() . '_version_id';
-                }
-
-                $query->addSelect(self::accessor($alias, $version));
-            }
-
+            // Since this query only acts as an EXISTS check, we select a dummy value that will cause the EXISTS to be true.
+            $query->addSelect('1');
             $query->from(self::escape($reference->getEntityName()), self::escape($alias));
             $query->addState($alias);
+
+            $versionWhere = '';
+            if ($reference->isVersionAware()) {
+                $aliasVersionId = $this->getVersionIdFieldForManyToOneRelation($reference, $definition);
+                $rootVersionId = $this->getVersionIdFieldForManyToOneRelation($definition, $reference);
+
+                $versionWhere = ' AND #root#.`' . $rootVersionId . '` = #alias#.`' . $aliasVersionId . '`';
+            }
+
+            $parameters = [
+                '#root#' => self::escape($definition->getEntityName()),
+                '#source_column#' => $this->getSourceColumn($field, $context),
+                '#alias#' => self::escape($alias),
+                '#reference_column#' => self::escape($field->getReferenceField()),
+            ];
+
+            $query->andWhere(str_replace(
+                array_keys($parameters),
+                array_values($parameters),
+                '#root#.#source_column# = #alias#.#reference_column#' . $versionWhere,
+            ));
 
             return $query;
         }
 
         if (!$field instanceof ManyToManyAssociationField) {
-            throw new \RuntimeException(\sprintf('Unknown association class provided %s', $field::class));
+            throw DataAbstractionLayerException::unexpectedAssociationFieldClass($field::class);
         }
 
         $reference = $field->getReferenceDefinition();
@@ -181,11 +200,8 @@ class CriteriaPartResolver
         $mappingAlias = $definition->getEntityName() . '.' . $field->getPropertyName() . '.mapping';
         $alias = $definition->getEntityName() . '.' . $field->getPropertyName();
 
-        $query->addSelect(self::accessor($mappingAlias, $field->getMappingLocalColumn()) . ' as id');
-        if ($definition->isVersionAware()) {
-            $query->addSelect(self::accessor($mappingAlias, $definition->getEntityName() . '_version_id'));
-        }
-
+        // Since this query only acts as an EXISTS check, we select a dummy value that will cause the EXISTS to be true.
+        $query->addSelect('1');
         $query->from(self::escape($reference->getEntityName()), self::escape($mappingAlias));
         $query->addState($alias);
 
@@ -207,6 +223,19 @@ class CriteriaPartResolver
                 . $this->buildMappingVersionWhere($field->getToManyReferenceDefinition(), $field)
             )
         );
+
+        $parameters = [
+            '#alias#' => self::escape($definition->getEntityName()),
+            '#source_column#' => $this->getSourceColumn($field, $context),
+            '#mapping#' => self::escape($mappingAlias),
+            '#reference_column#' => self::escape($field->getMappingLocalColumn()),
+        ];
+
+        $query->andWhere(str_replace(
+            array_keys($parameters),
+            array_values($parameters),
+            '#alias#.#source_column# = #mapping#.#reference_column#' . $this->buildMappingVersionWhere($definition, $field),
+        ));
 
         return $query;
     }
@@ -330,11 +359,6 @@ class CriteriaPartResolver
         return EntityDefinitionQueryHelper::escape($string);
     }
 
-    private static function accessor(string $alias, string $field): string
-    {
-        return self::escape($alias) . '.' . self::escape($field);
-    }
-
     private function getSourceColumn(AssociationField $association, Context $context): string
     {
         if ($association->is(Inherited::class) && $context->considerInheritance()) {
@@ -353,6 +377,17 @@ class CriteriaPartResolver
             return EntityDefinitionQueryHelper::escape($association->getLocalField());
         }
 
-        throw new \RuntimeException(\sprintf('Unknown association class provided %s', $association::class));
+        throw DataAbstractionLayerException::unexpectedAssociationFieldClass($association::class);
+    }
+
+    private function getVersionIdFieldForManyToOneRelation(EntityDefinition $definition, EntityDefinition $reference): string
+    {
+        $rootVersionId = 'version_id';
+        // it could be the case that we have a reverse join and the reference is the "parent" definition
+        if ($definition->getFields()->getByStorageName($reference->getEntityName() . '_version_id')) {
+            $rootVersionId = $reference->getEntityName() . '_version_id';
+        }
+
+        return $rootVersionId;
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\AfterClass;
 use PHPUnit\Framework\Attributes\BeforeClass;
-use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
@@ -23,6 +22,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -30,10 +31,14 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
+ *
+ * @see MultiJoinFilterLimitationTest for edge cases and limitations of multi join filters
  */
 class JoinFilterTest extends TestCase
 {
     use KernelTestBehaviour;
+
+    private static IdsCollection $ids;
 
     #[BeforeClass]
     public static function startTransactionBefore(): void
@@ -43,6 +48,11 @@ class JoinFilterTest extends TestCase
             ->get(Connection::class);
 
         $connection->beginTransaction();
+
+        self::$ids = new IdsCollection();
+
+        // performance optimization: only insert the test data once per test class and not before each test
+        self::insertTestData();
     }
 
     #[AfterClass]
@@ -55,79 +65,7 @@ class JoinFilterTest extends TestCase
         $connection->rollBack();
     }
 
-    /**
-     * @return IdsCollection
-     */
-    public function testIndexing()
-    {
-        $ids = new IdsCollection();
-
-        $products = [
-            (new ProductBuilder($ids, 'product-1', 10, 'tax'))
-                ->price(15, 10)
-                ->manufacturer('manufacturer-1')
-                ->property('red', 'color')
-                ->property('yellow', 'color')
-                ->property('XL', 'size')
-                ->property('L', 'size')
-                ->category('category-1')
-                ->category('category-2')
-                ->prices('rule-1', 100)
-                ->prices('rule-2', 150)
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-1-variant', 10, 'tax'))
-                ->parent('product-1')
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-2', 3, 'tax'))
-                ->price(15, 10)
-                ->manufacturer('manufacturer-2')
-                ->property('red', 'color')
-                ->category('category-1')
-                ->category('category-3')
-                ->prices('rule-1', 150)
-                ->build(),
-
-            (new ProductBuilder($ids, 'product-3', 3, 'tax'))
-                ->price(15, 10)
-                ->build(),
-        ];
-
-        static::getContainer()->get('product.repository')
-            ->create($products, Context::createDefaultContext());
-
-        $userId = static::getContainer()->get(Connection::class)
-            ->fetchOne('SELECT LOWER(HEX(id)) FROM `user`');
-
-        $ids->set('user-id', $userId);
-
-        $media = [
-            ['id' => $ids->create('with-avatar')],
-            ['id' => $ids->create('without-avatar')],
-        ];
-
-        static::getContainer()->get('media.repository')
-            ->create($media, Context::createDefaultContext());
-
-        $avatar = [
-            'id' => $userId,
-            'avatarId' => $ids->get('with-avatar'),
-        ];
-
-        static::getContainer()->get('user.repository')
-            ->update([$avatar], Context::createDefaultContext());
-
-        $result = static::getContainer()->get('product.repository')
-            ->searchIds(new Criteria($ids->prefixed('product-')), Context::createDefaultContext());
-
-        static::assertEquals(\count($products), $result->getTotal());
-
-        return $ids;
-    }
-
-    #[Depends('testIndexing')]
-    public function testOneToOne(IdsCollection $ids): void
+    public function testOneToOne(): void
     {
         $criteria = new Criteria();
         $criteria->addFilter(
@@ -138,8 +76,8 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertCount(1, $media->getIds());
-        static::assertContains($ids->get('with-avatar'), $media->getIds());
-        static::assertNotContains($ids->get('without-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('with-avatar'), $media->getIds());
+        static::assertNotContains(self::$ids->get('without-avatar'), $media->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('avatarUsers.id', null));
@@ -148,8 +86,8 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertTrue(\count($media->getIds()) > 0);
-        static::assertContains($ids->get('without-avatar'), $media->getIds());
-        static::assertNotContains($ids->get('with-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('without-avatar'), $media->getIds());
+        static::assertNotContains(self::$ids->get('with-avatar'), $media->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(
@@ -163,8 +101,8 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertTrue(\count($media->getIds()) > 0);
-        static::assertContains($ids->get('with-avatar'), $media->getIds());
-        static::assertContains($ids->get('without-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('with-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('without-avatar'), $media->getIds());
 
         $criteria = new Criteria();
         $criteria->addFilter(
@@ -175,16 +113,15 @@ class JoinFilterTest extends TestCase
             ->searchIds($criteria, Context::createDefaultContext());
 
         static::assertTrue(\count($media->getIds()) > 0);
-        static::assertContains($ids->get('with-avatar'), $media->getIds());
-        static::assertContains($ids->get('without-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('with-avatar'), $media->getIds());
+        static::assertContains(self::$ids->get('without-avatar'), $media->getIds());
     }
 
-    #[Depends('testIndexing')]
-    public function testAggregationWithFilter(IdsCollection $ids): void
+    public function testAggregationWithFilter(): void
     {
         $criteria = new Criteria();
         $criteria->addFilter(
-            new EqualsAnyFilter('properties.id', $ids->getList(['red']))
+            new EqualsAnyFilter('properties.id', self::$ids->getList(['red']))
         );
 
         $criteria->addAggregation(
@@ -200,19 +137,18 @@ class JoinFilterTest extends TestCase
 
         static::assertInstanceOf(TermsResult::class, $aggregation);
 
-        static::assertContains($ids->get('red'), $aggregation->getKeys());
-        static::assertContains($ids->get('yellow'), $aggregation->getKeys());
-        static::assertContains($ids->get('XL'), $aggregation->getKeys());
-        static::assertContains($ids->get('L'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('red'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('yellow'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('XL'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('L'), $aggregation->getKeys());
     }
 
-    #[Depends('testIndexing')]
-    public function testAggregationWithNegatedFilter(IdsCollection $ids): void
+    public function testAggregationWithNegatedFilter(): void
     {
         $criteria = new Criteria();
         $criteria->addFilter(
             new NandFilter([
-                new EqualsAnyFilter('properties.id', $ids->getList(['XL'])),
+                new EqualsAnyFilter('properties.id', self::$ids->getList(['XL'])),
             ])
         );
 
@@ -229,37 +165,35 @@ class JoinFilterTest extends TestCase
 
         static::assertInstanceOf(TermsResult::class, $aggregation);
 
-        static::assertContains($ids->get('red'), $aggregation->getKeys());
-        static::assertNotContains($ids->get('yellow'), $aggregation->getKeys());
-        static::assertNotContains($ids->get('XL'), $aggregation->getKeys());
-        static::assertNotContains($ids->get('L'), $aggregation->getKeys());
+        static::assertContains(self::$ids->get('red'), $aggregation->getKeys());
+        static::assertNotContains(self::$ids->get('yellow'), $aggregation->getKeys());
+        static::assertNotContains(self::$ids->get('XL'), $aggregation->getKeys());
+        static::assertNotContains(self::$ids->get('L'), $aggregation->getKeys());
     }
 
-    #[Depends('testIndexing')]
-    public function testNestedManyToMany(IdsCollection $ids): void
+    public function testNestedManyToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
-            new EqualsAnyFilter('category.products.properties.id', [$ids->get('red'), $ids->get('yellow')])
+            new EqualsAnyFilter('category.products.properties.id', [self::$ids->get('red'), self::$ids->get('yellow')])
         );
         $criteria->addFilter(
-            new EqualsAnyFilter('category.products.properties.id', [$ids->get('XL'), $ids->get('L')])
+            new EqualsAnyFilter('category.products.properties.id', [self::$ids->get('XL'), self::$ids->get('L')])
         );
 
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('category-1')));
-        static::assertTrue($result->has($ids->get('category-2')));
-        static::assertFalse($result->has($ids->get('category-3')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('category-1')));
+        static::assertTrue($result->has(self::$ids->get('category-2')));
+        static::assertFalse($result->has(self::$ids->get('category-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testTranslatedFields(IdsCollection $ids): void
+    public function testTranslatedFields(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.properties.name', 'red')
         );
@@ -270,15 +204,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(1, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testContainsFilter(IdsCollection $ids): void
+    public function testContainsFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new ContainsFilter('product.properties.name', 're')
         );
@@ -289,15 +222,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertSame(1, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testPrefixFilter(IdsCollection $ids): void
+    public function testPrefixFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         // "re" refers to the property "red" of "product-1" and "product-2"
         $criteria->addFilter(
             new PrefixFilter('product.properties.name', 're')
@@ -310,15 +242,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertSame(1, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testSuffixFilter(IdsCollection $ids): void
+    public function testSuffixFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         // "ed" refers to the property "red" of "product-1" and "product-2"
         $criteria->addFilter(
             new SuffixFilter('product.properties.name', 'ed')
@@ -331,15 +262,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertSame(1, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testRangeFilter(IdsCollection $ids): void
+    public function testRangeFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
             new RangeFilter('category.products.stock', [RangeFilter::GTE => 5])
@@ -348,16 +278,15 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('category-1')));
-        static::assertTrue($result->has($ids->get('category-2')));
-        static::assertFalse($result->has($ids->get('category-3')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('category-1')));
+        static::assertTrue($result->has(self::$ids->get('category-2')));
+        static::assertFalse($result->has(self::$ids->get('category-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testNegatedRangeFilter(IdsCollection $ids): void
+    public function testNegatedRangeFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
             new NandFilter([new RangeFilter('category.products.stock', [RangeFilter::GTE => 5])])
@@ -366,38 +295,37 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('category-1')));
-        static::assertFalse($result->has($ids->get('category-2')));
-        static::assertTrue($result->has($ids->get('category-3')));
+        static::assertSame(2, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('category-1')));
+        static::assertFalse($result->has(self::$ids->get('category-2')));
+        static::assertTrue($result->has(self::$ids->get('category-3')));
+        static::assertTrue($result->has(self::$ids->get('category-4')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOrFilter(IdsCollection $ids): void
+    public function testOrFilter(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new OrFilter([
-                new EqualsFilter('product.properties.id', $ids->get('red')),
-                new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                new EqualsFilter('product.properties.id', self::$ids->get('red')),
+                new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
             ])
         );
 
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToMany(IdsCollection $ids): void
+    public function testOneToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
             ])
         );
@@ -405,14 +333,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
 
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::LTE => 100]),
             ])
         );
@@ -420,37 +348,91 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(1, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyWithMultipleFilters(IdsCollection $ids): void
+    public function testOneToManyWithSort(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
-            new EqualsFilter('product.prices.ruleId', $ids->get('rule-1'))
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    public function testOneToManyWithSortDesc(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[1]); // Rule 2 price is higher, but ignored because of filter
+    }
+
+    public function testOneToManyWithGrouping(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new AndFilter([
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
+                new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(1, $result->getTotal());
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+    }
+
+    public function testOneToManyWithMultipleFilters(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1'))
         );
         $criteria->addFilter(
-            new EqualsFilter('product.prices.ruleId', $ids->get('rule-2'))
+            new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-2'))
         );
 
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(1, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOne(IdsCollection $ids): void
+    public function testManyToOne(): void
     {
-        $criteria = new Criteria($ids->prefixed('category-'));
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
 
         $criteria->addFilter(
-            new EqualsFilter('category.products.manufacturer.id', $ids->get('manufacturer-1'))
+            new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-1'))
         );
         $criteria->addFilter(
             new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1')
@@ -459,38 +441,60 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('category.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('category-1')));
-        static::assertTrue($result->has($ids->get('category-2')));
-        static::assertFalse($result->has($ids->get('category-3')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('category-1')));
+        static::assertTrue($result->has(self::$ids->get('category-2')));
+        static::assertFalse($result->has(self::$ids->get('category-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToMany(IdsCollection $ids): void
+    public function testManyToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
-            new EqualsFilter('product.properties.id', $ids->get('red'))
+            new EqualsFilter('product.properties.id', self::$ids->get('red'))
         );
         $criteria->addFilter(
-            new EqualsFilter('product.properties.id', $ids->get('yellow'))
+            new EqualsFilter('product.properties.id', self::$ids->get('yellow'))
         );
 
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(1, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyWithOneFilter(IdsCollection $ids): void
+    public function testManyToManyWithMultiJoinGroup(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', self::$ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+    }
+
+    public function testManyToManyWithOneFilter(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.properties.id', $ids->get('yellow')),
+                new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
                 new EqualsFilter('product.properties.name', 'yellow'),
             ])
         );
@@ -498,15 +502,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(1, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyTranslated(IdsCollection $ids): void
+    public function testOneToManyTranslated(): void
     {
-        $criteria = new Criteria($ids->prefixed('manufacturer-'));
+        $criteria = new Criteria(self::$ids->prefixed('manufacturer-'));
 
         $criteria->addFilter(
             new EqualsFilter('product_manufacturer.products.name', 'product-1')
@@ -518,11 +521,11 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product_manufacturer.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('manufacturer-1')));
-        static::assertFalse($result->has($ids->get('manufacturer-2')));
+        static::assertSame(1, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('manufacturer-1')));
+        static::assertFalse($result->has(self::$ids->get('manufacturer-2')));
 
-        $criteria = new Criteria($ids->prefixed('manufacturer-'));
+        $criteria = new Criteria(self::$ids->prefixed('manufacturer-'));
 
         $criteria->addFilter(
             new ContainsFilter('product_manufacturer.products.name', 'product')
@@ -534,15 +537,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product_manufacturer.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('manufacturer-1')));
-        static::assertTrue($result->has($ids->get('manufacturer-2')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('manufacturer-1')));
+        static::assertTrue($result->has(self::$ids->get('manufacturer-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOneTranslated(IdsCollection $ids): void
+    public function testManyToOneTranslated(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NorFilter([
                 new EqualsFilter('product.manufacturer.id', null),
@@ -553,30 +555,29 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
 
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new ContainsFilter('product.manufacturer.name', 'manufacturer')
         );
         $criteria->addFilter(
-            new EqualsAnyFilter('product.manufacturer.id', $ids->getList(['manufacturer-1', 'manufacturer-2']))
+            new EqualsAnyFilter('product.manufacturer.id', self::$ids->getList(['manufacturer-1', 'manufacturer-2']))
         );
 
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyTranslated(IdsCollection $ids): void
+    public function testManyToManyTranslated(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.properties.name', 'red')
         );
@@ -587,18 +588,17 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(1, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertSame(1, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testOneToManyInherited(IdsCollection $ids): void
+    public function testOneToManyInherited(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new AndFilter([
-                new EqualsFilter('product.prices.ruleId', $ids->get('rule-1')),
+                new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
                 new RangeFilter('product.prices.price', [RangeFilter::GTE => 100]),
             ])
         );
@@ -606,56 +606,53 @@ class JoinFilterTest extends TestCase
         $result = Context::createDefaultContext()->enableInheritance(fn (Context $context) => static::getContainer()->get('product.repository')
             ->searchIds($criteria, $context));
 
-        static::assertEquals(3, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
+        static::assertSame(3, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToOneInherited(IdsCollection $ids): void
+    public function testManyToOneInherited(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NandFilter([
-                new EqualsFilter('product.manufacturer.id', $ids->get('manufacturer-2')),
+                new EqualsFilter('product.manufacturer.id', self::$ids->get('manufacturer-2')),
             ])
         );
 
         $result = Context::createDefaultContext()->enableInheritance(fn (Context $context) => static::getContainer()->get('product.repository')
             ->searchIds($criteria, $context));
 
-        static::assertEquals(3, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
-        static::assertTrue($result->has($ids->get('product-3')));
+        static::assertSame(3, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
+        static::assertTrue($result->has(self::$ids->get('product-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testManyToManyInherited(IdsCollection $ids): void
+    public function testManyToManyInherited(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
-            new EqualsFilter('product.properties.id', $ids->get('red'))
+            new EqualsFilter('product.properties.id', self::$ids->get('red'))
         );
         $criteria->addFilter(
-            new EqualsFilter('product.properties.id', $ids->get('yellow'))
+            new EqualsFilter('product.properties.id', self::$ids->get('yellow'))
         );
 
         $result = Context::createDefaultContext()->enableInheritance(fn (Context $context) => static::getContainer()->get('product.repository')
             ->searchIds($criteria, $context));
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
+        static::assertSame(2, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasOneToMany(IdsCollection $ids): void
+    public function testHasOneToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NandFilter([
                 new EqualsFilter('product.prices.id', null),
@@ -665,15 +662,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasManyToOne(IdsCollection $ids): void
+    public function testHasManyToOne(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NandFilter([
                 new EqualsFilter('product.manufacturer.id', null),
@@ -683,15 +679,14 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasManyToMany(IdsCollection $ids): void
+    public function testHasManyToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new NandFilter([
                 new EqualsFilter('product.manufacturer.id', null),
@@ -701,16 +696,15 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-2')));
-        static::assertTrue($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-3')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-2')));
+        static::assertTrue($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-3')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasNotOneToMany(IdsCollection $ids): void
+    public function testHasNotOneToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.prices.id', null)
         );
@@ -718,17 +712,16 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-3')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
-        static::assertFalse($result->has($ids->get('product-1')));
-        static::assertFalse($result->has($ids->get('product-2')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-3')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
+        static::assertFalse($result->has(self::$ids->get('product-1')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasNotManyToOne(IdsCollection $ids): void
+    public function testHasNotManyToOne(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.manufacturer.id', null)
         );
@@ -736,17 +729,16 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertTrue($result->has($ids->get('product-3')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertFalse($result->has($ids->get('product-1')));
+        static::assertSame(2, $result->getTotal());
+        static::assertTrue($result->has(self::$ids->get('product-3')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertFalse($result->has(self::$ids->get('product-1')));
     }
 
-    #[Depends('testIndexing')]
-    public function testHasNotManyToMany(IdsCollection $ids): void
+    public function testHasNotManyToMany(): void
     {
-        $criteria = new Criteria($ids->prefixed('product-'));
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
         $criteria->addFilter(
             new EqualsFilter('product.properties.id', null)
         );
@@ -754,11 +746,11 @@ class JoinFilterTest extends TestCase
         $result = static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
 
-        static::assertEquals(2, $result->getTotal());
-        static::assertFalse($result->has($ids->get('product-2')));
-        static::assertFalse($result->has($ids->get('product-1')));
-        static::assertTrue($result->has($ids->get('product-3')));
-        static::assertTrue($result->has($ids->get('product-1-variant')));
+        static::assertSame(2, $result->getTotal());
+        static::assertFalse($result->has(self::$ids->get('product-2')));
+        static::assertFalse($result->has(self::$ids->get('product-1')));
+        static::assertTrue($result->has(self::$ids->get('product-3')));
+        static::assertTrue($result->has(self::$ids->get('product-1-variant')));
     }
 
     public function testEqualsNullWithUnmappedField(): void
@@ -769,5 +761,71 @@ class JoinFilterTest extends TestCase
         static::expectException(UnmappedFieldException::class);
         static::getContainer()->get('product.repository')
             ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    private static function insertTestData(): void
+    {
+        $products = [
+            (new ProductBuilder(self::$ids, 'product-1', 10, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-1')
+                ->property('red', 'color')
+                ->property('yellow', 'color')
+                ->property('XL', 'size')
+                ->property('L', 'size')
+                ->category('category-1')
+                ->category('category-2')
+                ->prices('rule-1', 100)
+                ->prices('rule-2', 150)
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-1-variant', 10, 'tax'))
+                ->parent('product-1')
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-2', 3, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-2')
+                ->property('red', 'color')
+                ->property('S', 'size')
+                ->category('category-1')
+                ->category('category-3')
+                ->prices('rule-1', 150)
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-3', 3, 'tax'))
+                ->price(15, 10)
+                ->category('category-4')
+                ->build(),
+        ];
+
+        static::getContainer()->get('product.repository')
+            ->create($products, Context::createDefaultContext());
+
+        $userId = static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT LOWER(HEX(id)) FROM `user`');
+
+        self::$ids->set('user-id', $userId);
+
+        $media = [
+            ['id' => self::$ids->create('with-avatar')],
+            ['id' => self::$ids->create('without-avatar')],
+        ];
+
+        static::getContainer()->get('media.repository')
+            ->create($media, Context::createDefaultContext());
+
+        $avatar = [
+            'id' => $userId,
+            'avatarId' => self::$ids->get('with-avatar'),
+        ];
+
+        static::getContainer()->get('user.repository')
+            ->update([$avatar], Context::createDefaultContext());
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds(new Criteria(self::$ids->prefixed('product-')), Context::createDefaultContext());
+
+        static::assertSame(\count($products), $result->getTotal());
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
@@ -1,0 +1,358 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\BeforeClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+
+/**
+ * @internal
+ *
+ * This test case covers known limitations when using multiple join groups
+ * Due to conceptual reasons multi join groups won't do a "real join" to the filtered association,
+ * this means all other DAL features (e.g. sorting, grouping) won't work as expected in combination with multi join groups.
+ * Sorting is based on a unfiltered join (meaning all associated entities are considered for sorting, not just the filtered once).
+ * Grouping is only supported in conjunction with sorting in those cases, and would then also operate on the unfiltered join.
+ *
+ * The behaviour documented in test explicitly is not considered part of the public API and therefore might be fixed in future versions.
+ * The purpose of this test is mainly to make the current limitations explicit and to avoid accidental changes to the current behaviour.
+ *
+ * @see JoinFilterTest for the tests for all valid cases that are part of the public API.
+ */
+class MultiJoinFilterLimitationTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private static IdsCollection $ids;
+
+    #[BeforeClass]
+    public static function startTransactionBefore(): void
+    {
+        $connection = KernelLifecycleManager::getKernel()
+            ->getContainer()
+            ->get(Connection::class);
+
+        $connection->beginTransaction();
+
+        self::$ids = new IdsCollection();
+
+        // performance optimization: only insert the test data once per test class and not before each test
+        self::insertTestData();
+    }
+
+    #[AfterClass]
+    public static function stopTransactionAfter(): void
+    {
+        $connection = KernelLifecycleManager::getKernel()
+            ->getContainer()
+            ->get(Connection::class);
+
+        $connection->rollBack();
+    }
+
+    public function testOneToManyWithSortWithMultipleJoinGroups(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        // note that this is the same order then below, because apparently it uses both rule-1 price and rule-2 price
+        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
+        // however note that by the join group the lower rule-1 price should be filtered out
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    public function testOneToManyWithSortWithMultipleJoinGroupsDesc(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.prices.price', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        // note that this is the same order then above, because apparently it uses both rule-1 price and rule-2 price
+        // for sorting, therefore product-1 comes first in both cases, as it has same higher and lower price
+        // however note that by the join group the lower rule-1 price should be filtered out
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    public function testOneToManyWithMultipleJoinGroupsAndGroupingIsNotSupported(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-1')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.prices.ruleId', self::$ids->get('rule-2')),
+                    new RangeFilter('product.prices.price', [RangeFilter::GTE => 150]),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.prices.ruleId'));
+
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    public function testManyToOneWithSort(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
+
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name'));
+
+        $result = static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(3, $result->getTotal());
+        static::assertSame(self::$ids->get('category-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('category-2'), $result->getIds()[1]);
+        static::assertSame(self::$ids->get('category-3'), $result->getIds()[2]);
+    }
+
+    public function testManyToOneWithSortDesc(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
+
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('category.products.manufacturer.name', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(3, $result->getTotal());
+        static::assertSame(self::$ids->get('category-1'), $result->getIds()[0]); // manufacturer-2 matches as well
+        static::assertSame(self::$ids->get('category-3'), $result->getIds()[1]); // manufacturer-2
+        static::assertSame(self::$ids->get('category-2'), $result->getIds()[2]); // manufacturer-1
+    }
+
+    public function testManyToOneWithMultipleJoinGroupsAndGroupingIsNotSupported(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('category-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-1')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-1'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('category.products.manufacturer.id', self::$ids->get('manufacturer-2')),
+                    new EqualsFilter('category.products.manufacturer.name', 'manufacturer-2'),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('category.products.manufacturer.name'));
+
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('category.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    public function testManyToManyWithSort(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', self::$ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.properties.name'));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    public function testManyToManyWithSortDesc(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', self::$ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addSorting(new FieldSorting('product.properties.name', FieldSorting::DESCENDING));
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertSame(self::$ids->get('product-1'), $result->getIds()[0]);
+        static::assertSame(self::$ids->get('product-2'), $result->getIds()[1]);
+    }
+
+    public function testManyToManyWithGroup(): void
+    {
+        $criteria = new Criteria(self::$ids->prefixed('product-'));
+        $criteria->addFilter(
+            new OrFilter([
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', self::$ids->get('yellow')),
+                    new EqualsFilter('product.properties.name', 'yellow'),
+                ]),
+                new AndFilter([
+                    new EqualsFilter('product.properties.id', self::$ids->get('S')),
+                    new EqualsFilter('product.properties.name', 'S'),
+                ]),
+            ])
+        );
+        $criteria->addGroupField(new FieldGrouping('product.properties.name'));
+
+        static::expectException(\Throwable::class);
+        static::getContainer()->get('product.repository')
+            ->searchIds($criteria, Context::createDefaultContext());
+    }
+
+    private static function insertTestData(): void
+    {
+        $products = [
+            (new ProductBuilder(self::$ids, 'product-1', 10, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-1')
+                ->property('red', 'color')
+                ->property('yellow', 'color')
+                ->property('XL', 'size')
+                ->property('L', 'size')
+                ->category('category-1')
+                ->category('category-2')
+                ->prices('rule-1', 100)
+                ->prices('rule-2', 150)
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-1-variant', 10, 'tax'))
+                ->parent('product-1')
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-2', 3, 'tax'))
+                ->price(15, 10)
+                ->manufacturer('manufacturer-2')
+                ->property('red', 'color')
+                ->property('S', 'size')
+                ->category('category-1')
+                ->category('category-3')
+                ->prices('rule-1', 150)
+                ->build(),
+
+            (new ProductBuilder(self::$ids, 'product-3', 3, 'tax'))
+                ->price(15, 10)
+                ->category('category-4')
+                ->build(),
+        ];
+
+        static::getContainer()->get('product.repository')
+            ->create($products, Context::createDefaultContext());
+
+        $userId = static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT LOWER(HEX(id)) FROM `user`');
+
+        self::$ids->set('user-id', $userId);
+
+        $media = [
+            ['id' => self::$ids->create('with-avatar')],
+            ['id' => self::$ids->create('without-avatar')],
+        ];
+
+        static::getContainer()->get('media.repository')
+            ->create($media, Context::createDefaultContext());
+
+        $avatar = [
+            'id' => $userId,
+            'avatarId' => self::$ids->get('with-avatar'),
+        ];
+
+        static::getContainer()->get('user.repository')
+            ->update([$avatar], Context::createDefaultContext());
+
+        $result = static::getContainer()->get('product.repository')
+            ->searchIds(new Criteria(self::$ids->prefixed('product-')), Context::createDefaultContext());
+
+        static::assertSame(\count($products), $result->getTotal());
+    }
+}


### PR DESCRIPTION
…er groups in DAL criteria builder (#14216)

manual backport from https://github.com/shopware/shopware/pull/14216
