### PR TITLE
fix: property type mismatch entity defintion

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -72,5 +72,12 @@ return [
         // Inherited attribute $reversed parameter removed - attribute inheritance never worked before, so no BC break
         preg_quote('REMOVED: Property Shopware\Core\Framework\DataAbstractionLayer\Attribute\Inherited#$reversed was removed'),
         preg_quote('Shopware\Core\Framework\DataAbstractionLayer\Attribute\Inherited#__construct()'),
+
+        // Defined entity property mismatch the entity class property type
+        preg_quote('CHANGED: Type of property Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureEntity#$stateMachineState changed from Shopware\Core\System\StateMachine\StateMachineEntity|null to Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity|null', '/'),
+        preg_quote('CHANGED: The return type of Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureEntity#getStateMachineState() changed from Shopware\Core\System\StateMachine\StateMachineEntity|null to Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity|null', '/'),
+        preg_quote('CHANGED: The return type of Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureEntity#getStateMachineState() changed from Shopware\Core\System\StateMachine\StateMachineEntity|null to the non-covariant Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity|null', '/'),
+        preg_quote('CHANGED: The parameter $stateMachineState of Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureEntity#setStateMachineState() changed from Shopware\Core\System\StateMachine\StateMachineEntity|null to Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity|null', '/'),
+        preg_quote('CHANGED: The parameter $stateMachineState of Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureEntity#setStateMachineState() changed from Shopware\Core\System\StateMachine\StateMachineEntity|null to a non-contravariant Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity|null', '/'),
     ],
 ];

--- a/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureEntity.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\StateMachine\StateMachineEntity;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 
 #[Package('checkout')]
 class OrderTransactionCaptureEntity extends Entity
@@ -29,7 +29,7 @@ class OrderTransactionCaptureEntity extends Entity
 
     protected ?OrderTransactionEntity $transaction = null;
 
-    protected ?StateMachineEntity $stateMachineState = null;
+    protected ?StateMachineStateEntity $stateMachineState = null;
 
     protected ?OrderTransactionCaptureRefundCollection $refunds = null;
 
@@ -83,12 +83,12 @@ class OrderTransactionCaptureEntity extends Entity
         $this->transaction = $transaction;
     }
 
-    public function getStateMachineState(): ?StateMachineEntity
+    public function getStateMachineState(): ?StateMachineStateEntity
     {
         return $this->stateMachineState;
     }
 
-    public function setStateMachineState(?StateMachineEntity $stateMachineState): void
+    public function setStateMachineState(?StateMachineStateEntity $stateMachineState): void
     {
         $this->stateMachineState = $stateMachineState;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The `stateMachineState` is defined as `StateMachineStateDefinition` https://github.com/shopware/shopware/blob/trunk/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureDefinition.php#L65

Accordingly, that means `OrderTransactionCaptureEntity::stateMachineState` should be `StateMachineStateEntity`

### 2. What does this change do, exactly?
Change the `OrderTransactionCaptureEntity::stateMachineState` property from `StateMachineEntity` to `StateMachineStateEntity`. As well as the setter and getter

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/11943
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
