### PR TITLE
fix: media folder settings can inherit from parent (#9889)

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-settings/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-settings/index.js
@@ -230,6 +230,8 @@ export default {
         },
 
         async onChangeInheritance(value) {
+            this.mediaFolder.useParentConfiguration = value;
+
             if (value === true) {
                 this.originalConfiguration = this.configuration;
                 this.configuration = this.parent.configuration;
@@ -251,6 +253,10 @@ export default {
                 newConfiguration[key] = this.configuration[key];
             });
             this.configuration = newConfiguration;
+        },
+
+        onChangeCreateThumbnails(value) {
+            this.configuration.createThumbnails = value;
         },
 
         async onClickSave() {

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-settings/sw-media-modal-folder-settings.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-settings/sw-media-modal-folder-settings.html.twig
@@ -105,21 +105,20 @@
                 {% block sw_media_modal_folder_settings_tab_content_thumbnails_left_container %}
                 <div class="sw-media-modal-folder-settings__thumbnails-left-container">
                     {% block sw_media_modal_folder_settings_inherit_settings_field %}
-                    <sw-field
-                        v-model:value="mediaFolder.useParentConfiguration"
-                        type="switch"
+                    <mt-switch
+                        :checked="mediaFolder.useParentConfiguration"
                         :label="$tc('global.sw-media-modal-folder-settings.labelInheritSettings')"
                         :disabled="mediaFolder.parentId === null"
-                        @update:value="onChangeInheritance"
+                        @change="onChangeInheritance"
                     />
                     {% endblock %}
 
                     {% block sw_media_modal_folder_settings_generate_thumbnails_field %}
-                    <sw-field
-                        v-model:value="configuration.createThumbnails"
-                        type="switch"
+                    <mt-switch
+                        :checked="configuration.createThumbnails"
                         :label="$tc('global.sw-media-modal-folder-settings.labelGenerateThumbnails')"
                         :disabled="mediaFolder.useParentConfiguration || disabled"
+                        @change="onChangeCreateThumbnails"
                     />
                     {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?                                                                                                            
                                                                                                                                                  
  In Shopware 6.6.x, the two switch options "Inherit settings from parent folder" and "Generate thumbnails for this folder" are not displayed     
  correctly in the media folder settings modal. The switches are present in the HTML but not initialized properly, making it impossible to        
  configure thumbnail settings for folders.                                                                                                       
                                                                                                                                                  
  ### 2. What does this change do, exactly?                                                                                                       
                                                                                                                                                  
  Replaces the broken `sw-field type="switch"` components with `mt-switch` components using the correct binding syntax:                           
  - Changed `v-model:value` to `:checked` for proper value binding                                                                                
  - Changed `@update:value` to `@change` for proper event handling                                                                                
  - Added `onChangeCreateThumbnails` method to handle the createThumbnails toggle                                                                 
  - Extended `onChangeInheritance` to explicitly set `mediaFolder.useParentConfiguration`                                                         
                                                                                                                                                  
  ### 3. Describe each step to reproduce the issue or behaviour.                                                                                  
                                                                                                                                                  
  1. Set up a Shopware 6.6.x shop                                                                                                                 
  2. Go to Content → Media                                                                                                                        
  3. Click on a folder's settings (gear icon)                                                                                                     
  4. Switch to "Thumbnails" tab                                                                                                                   
  5. Observe that "Inherit settings from parent folder" and "Generate thumbnails" switches are not visible/functional                             
                                                                                                                                                  
  ### 4. Please link to the relevant issues (if any).      

fixes #9889                                                                                        
                                                                                                                                                  
  Backport of trunk fix: #7611     