### PR TITLE
fix: flyout navigation correctly closes on mouseleave

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -6,7 +6,7 @@ export default class NavbarPlugin extends Plugin {
         /**
          * Hover debounce delay.
          */
-        debounceTime: 125,
+        debounceTime: 200,
         /**
          * Class to select the main navigation items, which contain both the top level link and the dropdown navigation.
          */
@@ -64,10 +64,14 @@ export default class NavbarPlugin extends Plugin {
         if (event.type === 'mouseenter') {
             this._isMouseOver = true;
             this._debounce(() => {
-                if (this._isMouseOver && currentDropdown?._menu && !currentDropdown._menu.classList.contains('show')) {
+                if (this._isMouseOver) {
                     this._closeAllDropdowns();
-                    currentDropdown.show();
-                    topLevelLink.blur();
+
+                    if (currentDropdown?._menu && !currentDropdown._menu.classList.contains('show')) {
+                        currentDropdown.show();
+                        topLevelLink.blur();
+                    }
+
                     this.$emitter.publish('showDropdown');
                 }
             }, this.options.debounceTime);

--- a/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
@@ -316,7 +316,7 @@ describe('NavbarPlugin', () => {
         const mockDropdown = {
             show: jest.fn(),
             hide: jest.fn(),
-            _menu: {classList: {contains: jest.fn().mockReturnValueOnce(false).mockReturnValueOnce(true)}},
+            _menu: {classList: {contains: jest.fn().mockReturnValueOnce(false).mockReturnValueOnce(false).mockReturnValueOnce(true)}},
         };
         const mockNoDropdown = {
             show: jest.fn(),
@@ -347,7 +347,7 @@ describe('NavbarPlugin', () => {
 
         jest.runAllTimers();
 
-        expect(navbarPlugin._closeAllDropdowns).not.toHaveBeenCalled();
+        expect(navbarPlugin._closeAllDropdowns).toHaveBeenCalled();
         expect(mockDropdown.hide).toHaveBeenCalled();
         expect(mockNoDropdown.show).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Navigation flyout is not closing on mouseleave, if the mouse is staying within the navigation container.

### 2. What does this change do, exactly?

- Adjust an if condition so flyouts are correctly closed even if no new flyout will be displayed.
- Increase debounce timer to prevent the flyout from accidentally closing when having a "multi line" navigation container.

### 3. Describe each step to reproduce the issue or behaviour.
see #14122 for details.

### 4. Please link to the relevant issues (if any).
– closes #14122 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
