### PR TITLE
fix: Allow filter zero and negative value for stock

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/index.js
@@ -65,7 +65,7 @@ export default {
         },
 
         updateFilter(params) {
-            if (!this.numberValue.from && !this.numberValue.to) {
+            if (this.numberValue.from == null && this.numberValue.to == null) {
                 this.$emit('filter-reset', this.filter.name);
                 return;
             }

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/sw-number-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/sw-number-filter.spec.js
@@ -131,4 +131,28 @@ describe('components/sw-number-filter', () => {
 
         expect(wrapper.emitted()['filter-reset']).toBeTruthy();
     });
+
+    it('should emit `filter-update` event when user input both `From` and `To` fields with value 0', async () => {
+        const { wrapper, inputFrom, inputTo } = await createWrapper();
+
+        // type "0" in From field
+        await inputFrom.setValue('0');
+        await inputFrom.trigger('change');
+
+        expect(wrapper.emitted('filter-update')[0]).toEqual([
+            'stock',
+            [Criteria.range('stock', { gte: 0 })],
+            { from: 0, to: null },
+        ]);
+
+        // type "0" in To field
+        await inputTo.setValue('0');
+        await inputTo.trigger('change');
+
+        expect(wrapper.emitted()['filter-update'][1]).toEqual([
+            'stock',
+            [Criteria.range('stock', { gte: 0, lte: 0 })],
+            { from: 0, to: 0 },
+        ]);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/index.js
@@ -50,8 +50,8 @@ export default {
     methods: {
         updateFilter(range) {
             const params = {
-                ...(range.from ? { gte: range.from } : {}),
-                ...(range.to ? { lte: range.to } : {}),
+                ...(range.from != null ? { gte: range.from } : {}),
+                ...(range.to != null ? { lte: range.to } : {}),
             };
 
             const filterCriteria = [Criteria.range(this.property, params)];

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/sw-range-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/sw-range-filter.spec.js
@@ -109,4 +109,20 @@ describe('src/app/component/filter/sw-range-filter', () => {
         expect(divider.exists()).toBeFalsy();
         expect(container.classes()).not.toContain('sw-container--has-divider');
     });
+
+    it('should emit `filter-update` event when `From` and `To` values are both 0', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.setProps({
+            value: {
+                from: 0,
+                to: 0,
+            },
+            property: 'stock',
+        });
+
+        expect(wrapper.emitted()['filter-update'][0]).toEqual([
+            [Criteria.range('stock', { gte: 0, lte: 0 })],
+        ]);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -171,7 +171,6 @@ export default {
                     label: this.$tc('sw-product.filters.stockFilter.label'),
                     numberType: 'int',
                     step: 1,
-                    min: 0,
                     fromPlaceholder: this.$tc('sw-product.filters.fromPlaceholder'),
                     toPlaceholder: this.$tc('sw-product.filters.toPlaceholder'),
                 },


### PR DESCRIPTION
### Description
The code used truthy checks (range.from ? ...), so when `from` was `0`, it was treated as `falsy` and the `gte` parameter wasn't added, allowing negative values.

### Solution 

https://github.com/user-attachments/assets/49c6e96e-74c7-460d-a7bf-af4e5d655366

