### PR TITLE
fix: allow bulk edit stock with negative value

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
@@ -368,7 +368,6 @@ export default {
                         allowEmpty: true,
                         allowOverwrite: true,
                         allowClear: true,
-                        min: 0,
                     },
                 },
                 {


### PR DESCRIPTION
<img width="1256" height="506" alt="Screenshot 2026-01-15 at 5 37 24 PM" src="https://github.com/user-attachments/assets/a26c66bd-5e69-4922-856e-652efed9fb96" />
