### PR TITLE
fix: Critical dive canvas resize bug.

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@amplitude/analytics-browser": "2.24.2",
-        "@shopware-ag/dive": "2.2.19",
+        "@shopware-ag/dive": "2.2.20",
         "@shopware-ag/meteor-admin-sdk": "6.4.0",
         "@shopware-ag/meteor-component-library": "4.24.0",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
@@ -5419,9 +5419,9 @@
       }
     },
     "node_modules/@shopware-ag/dive": {
-      "version": "2.2.19",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.19.tgz",
-      "integrity": "sha512-RgGDQ45RMaBT7AG4NkJ8nJCKE+65XNYJ+WMr8TMhPKcEWlX1r12nJDP0r03+75XNzUyMNbThK0RpdpSIIyosxQ==",
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.20.tgz",
+      "integrity": "sha512-/cew4NKfwI256v+Mk4rivzfNOJDaEXUlHw2cVOco2NOLCVJ11uMQm4gj/ZJsPG9E0SFBdJVCZ27n6oGL6LKM6A==",
       "license": "MIT",
       "dependencies": {
         "@tweenjs/tween.js": "^23.1.1",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@amplitude/analytics-browser": "2.24.2",
-    "@shopware-ag/dive": "2.2.19",
+    "@shopware-ag/dive": "2.2.20",
     "@shopware-ag/meteor-admin-sdk": "6.4.0",
     "@shopware-ag/meteor-component-library": "4.24.0",
     "@shopware-ag/meteor-icon-kit": "5.4.0",

--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
-        "@shopware-ag/dive": "2.2.18",
+        "@shopware-ag/dive": "2.2.20",
         "@swc/core": "1.10.14",
         "autoprefixer": "10.4.13",
         "bootstrap": "5.3.3",
@@ -3280,9 +3280,10 @@
       }
     },
     "node_modules/@shopware-ag/dive": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.18.tgz",
-      "integrity": "sha512-AwwqTvbDZrrGqGkGgInibB70orbSP0/xIz9QUuGmU9/Y38wim9xah4jmUJJ3G/UaL+hi3+z9QZ4kyp6nJleztw==",
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.20.tgz",
+      "integrity": "sha512-/cew4NKfwI256v+Mk4rivzfNOJDaEXUlHw2cVOco2NOLCVJ11uMQm4gj/ZJsPG9E0SFBdJVCZ27n6oGL6LKM6A==",
+      "license": "MIT",
       "dependencies": {
         "@tweenjs/tween.js": "^23.1.1",
         "lodash": "^4.17.21",
@@ -16544,9 +16545,9 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@shopware-ag/dive": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.18.tgz",
-      "integrity": "sha512-AwwqTvbDZrrGqGkGgInibB70orbSP0/xIz9QUuGmU9/Y38wim9xah4jmUJJ3G/UaL+hi3+z9QZ4kyp6nJleztw==",
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/dive/-/dive-2.2.20.tgz",
+      "integrity": "sha512-/cew4NKfwI256v+Mk4rivzfNOJDaEXUlHw2cVOco2NOLCVJ11uMQm4gj/ZJsPG9E0SFBdJVCZ27n6oGL6LKM6A==",
       "requires": {
         "@tweenjs/tween.js": "^23.1.1",
         "lodash": "^4.17.21",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@popperjs/core": "2.11.8",
-    "@shopware-ag/dive": "2.2.18",
+    "@shopware-ag/dive": "2.2.20",
     "@swc/core": "1.10.14",
     "autoprefixer": "10.4.13",
     "bootstrap": "5.3.3",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Dive displays the canvas with a wrong style on machines with a pixel ratio > 1.0. 

### 2. What does this change do, exactly?
The fix has been rolled out in the dive package, it has to be upgraded in shopware.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
