### PR TITLE
feat: use abstract class to make TranslationLoader decoratable

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -68,6 +68,10 @@ As part of this change, the following deprecations were made:
 If you are using the rule `LineItemProductStatesRule`, product stream filters, or product listing filters that rely on `product.states`, you should update them to use the new `product.type` field instead.
 If you create digital products using admin api, you should explicitly set the `type` field to `digital` when creating new products instead of relying on backend handling.
 
+### The `TranslationLoader` class is now decoratable
+
+The `TranslationLoader` class extends from the new `AbstractTranslationLoader` class and implements the decoratable pattern. This allows third-party developers to decorate the loader to add custom logic when a translation is loaded.
+
 ### DomainExceptions don't create \RuntimeException anymore
 
 All factory methods for domain exceptions now return specific exception classes instead of creating a generic `\RuntimeException`.

--- a/src/Administration/Snippet/SnippetFinder.php
+++ b/src/Administration/Snippet/SnippetFinder.php
@@ -11,7 +11,7 @@ use Shopware\Core\Kernel;
 use Shopware\Core\System\Snippet\DataTransfer\SnippetPath\SnippetPath;
 use Shopware\Core\System\Snippet\DataTransfer\SnippetPath\SnippetPathCollection;
 use Shopware\Core\System\Snippet\Files\SnippetFileLoader;
-use Shopware\Core\System\Snippet\Service\TranslationLoader;
+use Shopware\Core\System\Snippet\Service\AbstractTranslationLoader;
 use Shopware\Core\System\Snippet\Struct\TranslationConfig;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Symfony\Component\Filesystem\Path;
@@ -37,7 +37,7 @@ class SnippetFinder implements SnippetFinderInterface
         private readonly Connection $connection,
         private readonly Filesystem $translationReader,
         private readonly TranslationConfig $translationConfig,
-        private readonly TranslationLoader $translationLoader,
+        private readonly AbstractTranslationLoader $translationLoader,
         private readonly HtmlSanitizer $htmlSanitizer,
     ) {
     }

--- a/src/Core/System/Snippet/Command/InstallTranslationCommand.php
+++ b/src/Core/System/Snippet/Command/InstallTranslationCommand.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\System\Snippet\Command;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Command\Util\TranslationCommandHelper;
-use Shopware\Core\System\Snippet\Service\TranslationLoader;
+use Shopware\Core\System\Snippet\Service\AbstractTranslationLoader;
 use Shopware\Core\System\Snippet\Service\TranslationMetadataLoader;
 use Shopware\Core\System\Snippet\SnippetException;
 use Shopware\Core\System\Snippet\Struct\TranslationConfig;
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class InstallTranslationCommand extends Command
 {
     public function __construct(
-        private readonly TranslationLoader $translationLoader,
+        private readonly AbstractTranslationLoader $translationLoader,
         private readonly TranslationConfig $config,
         private readonly TranslationMetadataLoader $metadataLoader,
     ) {

--- a/src/Core/System/Snippet/Command/UpdateTranslationCommand.php
+++ b/src/Core/System/Snippet/Command/UpdateTranslationCommand.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\System\Snippet\Command;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Command\Util\TranslationCommandHelper;
-use Shopware\Core\System\Snippet\Service\TranslationLoader;
+use Shopware\Core\System\Snippet\Service\AbstractTranslationLoader;
 use Shopware\Core\System\Snippet\Service\TranslationMetadataLoader;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class UpdateTranslationCommand extends Command
 {
     public function __construct(
-        private readonly TranslationLoader $translationLoader,
+        private readonly AbstractTranslationLoader $translationLoader,
         private readonly TranslationMetadataLoader $metadataLoader,
     ) {
         parent::__construct();

--- a/src/Core/System/Snippet/Files/SnippetFileLoader.php
+++ b/src/Core/System/Snippet/Files/SnippetFileLoader.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Bundle;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Kernel;
-use Shopware\Core\System\Snippet\Service\TranslationLoader;
+use Shopware\Core\System\Snippet\Service\AbstractTranslationLoader;
 use Shopware\Core\System\Snippet\Struct\TranslationConfig;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
@@ -37,7 +37,7 @@ class SnippetFileLoader implements SnippetFileLoaderInterface
         private readonly AppSnippetFileLoader $appSnippetFileLoader,
         private readonly ActiveAppsLoader $activeAppsLoader,
         private readonly TranslationConfig $config,
-        private readonly TranslationLoader $translationLoader,
+        private readonly AbstractTranslationLoader $translationLoader,
         private readonly Filesystem $translationReader,
     ) {
     }

--- a/src/Core/System/Snippet/Service/AbstractTranslationLoader.php
+++ b/src/Core/System/Snippet/Service/AbstractTranslationLoader.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Snippet\Service;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+
+#[Package('discovery')]
+abstract class AbstractTranslationLoader
+{
+    public const TRANSLATION_DIR = '/translation';
+    public const TRANSLATION_LOCALE_SUB_DIR = 'locale';
+
+    abstract public function getDecorated(): AbstractTranslationLoader;
+
+    abstract public function load(string $locale, Context $context, bool $activate = true): void;
+
+    abstract public function pluginTranslationExists(Plugin $plugin): bool;
+
+    abstract public function getLocalesBasePath(): string;
+
+    abstract public function getLocalePath(string $locale): string;
+}

--- a/src/Core/System/Snippet/Service/TranslationLoader.php
+++ b/src/Core/System/Snippet/Service/TranslationLoader.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Locale\LocaleCollection;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetCollection;
@@ -26,11 +27,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @internal
  */
 #[Package('discovery')]
-class TranslationLoader
+class TranslationLoader extends AbstractTranslationLoader
 {
-    public const TRANSLATION_DIR = '/translation';
-    public const TRANSLATION_LOCALE_SUB_DIR = 'locale';
-
     private const PLATFORM_BUNDLES = [
         'Administration' => 'administration.json',
         'Core' => 'messages.json',
@@ -56,6 +54,11 @@ class TranslationLoader
         private readonly TranslationConfig $config,
         private readonly ValidatorInterface $validator,
     ) {
+    }
+
+    public function getDecorated(): AbstractTranslationLoader
+    {
+        throw new DecorationPatternException(self::class);
     }
 
     public function load(string $locale, Context $context, bool $activate = true): void
@@ -93,7 +96,7 @@ class TranslationLoader
 
     public function getLocalesBasePath(): string
     {
-        return Path::join(self::TRANSLATION_DIR, self::TRANSLATION_LOCALE_SUB_DIR);
+        return Path::join(static::TRANSLATION_DIR, static::TRANSLATION_LOCALE_SUB_DIR);
     }
 
     public function getLocalePath(string $locale): string
@@ -105,7 +108,7 @@ class TranslationLoader
             return '';
         }
 
-        return Path::join(self::TRANSLATION_DIR, self::TRANSLATION_LOCALE_SUB_DIR, $locale);
+        return Path::join(static::TRANSLATION_DIR, static::TRANSLATION_LOCALE_SUB_DIR, $locale);
     }
 
     private function fetchPluginSnippets(string $locale): void

--- a/src/Core/System/Snippet/Service/TranslationMetadataLoader.php
+++ b/src/Core/System/Snippet/Service/TranslationMetadataLoader.php
@@ -71,7 +71,7 @@ class TranslationMetadataLoader
 
     protected function getPath(): string
     {
-        return Path::join(TranslationLoader::TRANSLATION_DIR, self::CROWDIN_METADATA_LOCK);
+        return Path::join(AbstractTranslationLoader::TRANSLATION_DIR, self::CROWDIN_METADATA_LOCK);
     }
 
     private function downloadFile(): ResponseInterface

--- a/tests/unit/Core/System/Snippet/Service/TranslationLoaderTest.php
+++ b/tests/unit/Core/System/Snippet/Service/TranslationLoaderTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Locale\LocaleCollection;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetCollection;
@@ -293,6 +294,42 @@ class TranslationLoaderTest extends TestCase
         static::assertSame('Español', $language['name']);
         static::assertSame($this->ids->get('locale'), $language['localeId']);
         static::assertFalse($language['active']);
+    }
+
+    public function testSnippetSetOnlyCreatedOnce(): void
+    {
+        $this->localeRepository = new StaticEntityRepository([
+            $this->getSearchResult('locale'),
+            $this->getSearchResult('locale'),
+        ]);
+
+        $this->languageRepository = new StaticEntityRepository([
+            $this->getSearchResult('language'),
+            $this->getSearchResult('language'),
+        ]);
+
+        $this->snippetSetRepository = new StaticEntityRepository([
+            $this->getEmptySearchResult(),
+            $this->getSearchResult('snippet-set'),
+        ]);
+
+        $loader = $this->getTranslationLoader();
+
+        $loader->load('es-ES', $this->context);
+
+        static::assertCount(1, $this->snippetSetRepository->creates);
+        $createdSnippetSets = $this->snippetSetRepository->creates[0];
+        static::assertIsArray($createdSnippetSets);
+        static::assertCount(1, $createdSnippetSets);
+
+        $loader->load('es-ES', $this->context);
+        static::assertCount(1, $this->snippetSetRepository->creates);
+    }
+
+    public function testGetDecoratedThrowsException(): void
+    {
+        static::expectException(DecorationPatternException::class);
+        $this->getTranslationLoader()->getDecorated();
     }
 
     private function getTranslationLoader(): TranslationLoader


### PR DESCRIPTION
### 1. Why is this change necessary?

To allow easier extension of the `TranslationLoader` class, the decoratable pattern is applied. This allows plugins, like the language pack, to integrate into translation loading and react.

### 2. What does this change do, exactly?

Define the public API of `TranslationLoader` in the new class `AbstractTranslationLoader` and add the decoratable pattern to make it easier to decorate the class. Public constants moved to the abstract class.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

- Relates to https://github.com/shopware/shopware/issues/13621

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
