### PR TITLE
fix: double slash in path for migration

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateMigrationCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -134,7 +135,7 @@ class CreateMigrationCommand extends Command
         $queries = $this->queryGenerator->generateQueries($entityDefinition);
 
         if (!empty($queries)) {
-            $path = $directory . '/' . MigrationFileRenderer::createMigrationClassName($timestamp, $entity) . '.php';
+            $path = Path::join($directory, MigrationFileRenderer::createMigrationClassName($timestamp, $entity) . '.php');
 
             $className = MigrationFileRenderer::createMigrationClassName($timestamp, $entity);
             $content = $this->migrationFileRenderer->render($namespace, $className, $timestamp, $queries, $package);


### PR DESCRIPTION
### 1. Why is this change necessary?

there is a double slash in file path, just a style fix, triggered me


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
