### PR TITLE
test: skip flaky review test

### DIFF
--- a/tests/acceptance/tests/Product/ProductReview.spec.ts
+++ b/tests/acceptance/tests/Product/ProductReview.spec.ts
@@ -113,7 +113,7 @@ test('As a shop customer, I want to submit a review, so that I can share my expe
     });
 });
 
-test('As a shop customer, I want to filter reviews, so that I can find the content of a specific rating', {
+test.skip('As a shop customer, I want to filter reviews, so that I can find the content of a specific rating', {
     tag: ['@Product', '@Reviews', '@Storefront'],
 }, async ({
     ShopCustomer,

--- a/tests/acceptance/tests/Product/ProductReview.spec.ts
+++ b/tests/acceptance/tests/Product/ProductReview.spec.ts
@@ -115,6 +115,10 @@ test('As a shop customer, I want to submit a review, so that I can share my expe
 
 test.skip('As a shop customer, I want to filter reviews, so that I can find the content of a specific rating', {
     tag: ['@Product', '@Reviews', '@Storefront'],
+    annotation: {
+        type: 'issue',
+        description: 'https://github.com/shopware/shopware/issues/14414',
+  },
 }, async ({
     ShopCustomer,
     TestDataService,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

ProductReview test is flaky in the pipelines as it does not account for the loading states between checking/unchecking review filters

### 2. What does this change do, exactly?

Skips test

### 3. Describe each step to reproduce the issue or behaviour.

Failing trace
[trace.zip](https://github.com/user-attachments/files/24719645/trace.zip)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

Issue created: https://github.com/shopware/shopware/issues/14414

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
