### PR TITLE
chore: manual backport 6.6.x deprecations fix for Symfony constraints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2544,16 +2544,6 @@ parameters:
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\ConstraintBuilder\\:\\:isInArray\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
-
-		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\ConstraintBuilder\\:\\:\\$constraints type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\RestrictDeleteViolation\\:\\:getRestrictions\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/RestrictDeleteViolation.php

--- a/src/Core/Checkout/Customer/Rule/BillingCityRule.php
+++ b/src/Core/Checkout/Customer/Rule/BillingCityRule.php
@@ -57,7 +57,7 @@ class BillingCityRule extends Rule
         $constraints = [
             'operator' => [
                 new NotBlank(),
-                new Choice([Rule::OPERATOR_EQ, Rule::OPERATOR_NEQ, Rule::OPERATOR_EMPTY]),
+                new Choice(choices: [Rule::OPERATOR_EQ, Rule::OPERATOR_NEQ, Rule::OPERATOR_EMPTY]),
             ],
         ];
 

--- a/src/Core/Checkout/Customer/Rule/BillingStateRule.php
+++ b/src/Core/Checkout/Customer/Rule/BillingStateRule.php
@@ -65,7 +65,7 @@ class BillingStateRule extends Rule
         $constraints = [
             'operator' => [
                 new NotBlank(),
-                new Choice([self::OPERATOR_EQ, self::OPERATOR_NEQ, self::OPERATOR_EMPTY]),
+                new Choice(choices: [self::OPERATOR_EQ, self::OPERATOR_NEQ, self::OPERATOR_EMPTY]),
             ],
         ];
 

--- a/src/Core/Checkout/Customer/Rule/ShippingCityRule.php
+++ b/src/Core/Checkout/Customer/Rule/ShippingCityRule.php
@@ -53,7 +53,7 @@ class ShippingCityRule extends Rule
         $constraints = [
             'operator' => [
                 new NotBlank(),
-                new Choice([Rule::OPERATOR_EQ, Rule::OPERATOR_NEQ, Rule::OPERATOR_EMPTY]),
+                new Choice(choices: [Rule::OPERATOR_EQ, Rule::OPERATOR_NEQ, Rule::OPERATOR_EMPTY]),
             ],
         ];
 

--- a/src/Core/Checkout/Customer/Rule/ShippingStateRule.php
+++ b/src/Core/Checkout/Customer/Rule/ShippingStateRule.php
@@ -61,7 +61,7 @@ class ShippingStateRule extends Rule
         $constraints = [
             'operator' => [
                 new NotBlank(),
-                new Choice([self::OPERATOR_EQ, self::OPERATOR_NEQ, self::OPERATOR_EMPTY]),
+                new Choice(choices: [self::OPERATOR_EQ, self::OPERATOR_NEQ, self::OPERATOR_EMPTY]),
             ],
         ];
 

--- a/src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
@@ -86,7 +86,7 @@ class ChangeEmailRoute extends AbstractChangeEmailRoute
             ->add(
                 'email',
                 new Email(),
-                new EqualTo(['propertyPath' => 'emailConfirmation']),
+                new EqualTo(propertyPath: 'emailConfirmation'),
                 new CustomerEmailUnique($options)
             )
             ->add('password', new CustomerPasswordMatches(['context' => $context]));

--- a/src/Core/Checkout/Customer/SalesChannel/ChangePasswordRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangePasswordRoute.php
@@ -73,10 +73,12 @@ class ChangePasswordRoute extends AbstractChangePasswordRoute
     {
         $definition = new DataValidationDefinition('customer.password.update');
 
-        $minPasswordLength = $this->systemConfigService->get('core.loginRegistration.passwordMinLength', $context->getSalesChannelId());
-
+        $minPasswordLength = $this->systemConfigService->getInt('core.loginRegistration.passwordMinLength', $context->getSalesChannelId());
+        if ($minPasswordLength < 0) {
+            $minPasswordLength = null;
+        }
         $definition
-            ->add('newPassword', new NotBlank(), new Length(['min' => $minPasswordLength]), new EqualTo(['propertyPath' => 'newPasswordConfirm']))
+            ->add('newPassword', new NotBlank(), new Length(min: $minPasswordLength), new EqualTo(propertyPath: 'newPasswordConfirm'))
             ->add('password', new CustomerPasswordMatches(['context' => $context]));
 
         $this->dispatchValidationEvent($definition, $data, $context->getContext());

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
@@ -143,7 +143,7 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
     private function getBeforeConfirmValidation(string $emHash): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('registration.opt_in_before');
-        $definition->add('em', new EqualTo(['value' => $emHash]));
+        $definition->add('em', new EqualTo(value: $emHash));
         $definition->add('doubleOptInRegistration', new IsTrue());
 
         return $definition;

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -493,7 +493,7 @@ class RegisterRoute extends AbstractRegisterRoute
         }
 
         $validation->set('zipcode', new CustomerZipCode(['countryId' => $address->get('countryId')]));
-        $validation->add('zipcode', new Length(['max' => 50]));
+        $validation->add('zipcode', new Length(max: 50));
 
         $validationEvent = new BuildValidationEvent($validation, $data, $context->getContext());
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
@@ -515,11 +515,14 @@ class RegisterRoute extends AbstractRegisterRoute
         ]));
 
         if (!$isGuest) {
-            $minLength = $this->systemConfigService->get('core.loginRegistration.passwordMinLength', $context->getSalesChannelId());
+            $minLength = $this->systemConfigService->getInt('core.loginRegistration.passwordMinLength', $context->getSalesChannelId());
+            if ($minLength < 0) {
+                $minLength = 0;
+            }
             $validation->add(
                 'password',
                 new NotBlank(),
-                new Length(['min' => $minLength, 'max' => PasswordHasherInterface::MAX_PASSWORD_LENGTH, 'maxMessage' => 'VIOLATION::PASSWORD_IS_TOO_LONG'])
+                new Length(min: $minLength, max: PasswordHasherInterface::MAX_PASSWORD_LENGTH, maxMessage: 'VIOLATION::PASSWORD_IS_TOO_LONG')
             );
             $options = ['context' => $context->getContext(), 'salesChannelContext' => $context];
             $validation->add('email', new CustomerEmailUnique($options));

--- a/src/Core/Checkout/Customer/SalesChannel/ResetPasswordRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ResetPasswordRoute.php
@@ -107,9 +107,12 @@ class ResetPasswordRoute extends AbstractResetPasswordRoute
     {
         $definition = new DataValidationDefinition('customer.password.update');
 
-        $minPasswordLength = $this->systemConfigService->get('core.loginRegistration.passwordMinLength', $context->getSalesChannelId());
+        $minPasswordLength = $this->systemConfigService->getInt('core.loginRegistration.passwordMinLength', $context->getSalesChannelId());
+        if ($minPasswordLength < 0) {
+            $minPasswordLength = 0;
+        }
 
-        $definition->add('newPassword', new NotBlank(), new Length(['min' => $minPasswordLength]), new EqualTo(['propertyPath' => 'newPasswordConfirm']));
+        $definition->add('newPassword', new NotBlank(), new Length(min: $minPasswordLength), new EqualTo(propertyPath: 'newPasswordConfirm'));
 
         $this->dispatchValidationEvent($definition, $data, $context->getContext());
 

--- a/src/Core/Checkout/Customer/Validation/AddressValidationFactory.php
+++ b/src/Core/Checkout/Customer/Validation/AddressValidationFactory.php
@@ -73,7 +73,7 @@ class AddressValidationFactory implements DataValidationFactoryInterface
         }
 
         if ($this->systemConfigService->get('core.loginRegistration.showPhoneNumberField', $salesChannelId)) {
-            $definition->add('phoneNumber', new Length(['max' => CustomerAddressDefinition::MAX_LENGTH_PHONE_NUMBER], null, null, null, null, null, 'VIOLATION::PHONE_NUMBER_IS_TOO_LONG'));
+            $definition->add('phoneNumber', new Length(max: CustomerAddressDefinition::MAX_LENGTH_PHONE_NUMBER, exactMessage: 'VIOLATION::PHONE_NUMBER_IS_TOO_LONG'));
         }
 
         /**
@@ -81,10 +81,10 @@ class AddressValidationFactory implements DataValidationFactoryInterface
          */
         if (Feature::isActive('ADDRESS_SELECTION_REWORK')) {
             $definition
-                ->add('firstName', new Length(['max' => CustomerAddressDefinition::MAX_LENGTH_FIRST_NAME], null, null, null, null, null, 'VIOLATION::FIRST_NAME_IS_TOO_LONG'))
-                ->add('lastName', new Length(['max' => CustomerAddressDefinition::MAX_LENGTH_LAST_NAME], null, null, null, null, null, 'VIOLATION::LAST_NAME_IS_TOO_LONG'))
-                ->add('title', new Length(['max' => CustomerAddressDefinition::MAX_LENGTH_TITLE], null, null, null, null, null, 'VIOLATION::TITLE_IS_TOO_LONG'))
-                ->add('zipcode', new Length(['max' => CustomerAddressDefinition::MAX_LENGTH_ZIPCODE], null, null, null, null, null, 'VIOLATION::ZIPCODE_IS_TOO_LONG'));
+                ->add('firstName', new Length(max: CustomerAddressDefinition::MAX_LENGTH_FIRST_NAME, exactMessage: 'VIOLATION::FIRST_NAME_IS_TOO_LONG'))
+                ->add('lastName', new Length(max: CustomerAddressDefinition::MAX_LENGTH_LAST_NAME, exactMessage: 'VIOLATION::LAST_NAME_IS_TOO_LONG'))
+                ->add('title', new Length(max: CustomerAddressDefinition::MAX_LENGTH_TITLE, exactMessage: 'VIOLATION::TITLE_IS_TOO_LONG'))
+                ->add('zipcode', new Length(max: CustomerAddressDefinition::MAX_LENGTH_ZIPCODE, exactMessage: 'VIOLATION::ZIPCODE_IS_TOO_LONG'));
         }
 
         return $definition;

--- a/src/Core/Checkout/Customer/Validation/CustomerProfileValidationFactory.php
+++ b/src/Core/Checkout/Customer/Validation/CustomerProfileValidationFactory.php
@@ -53,19 +53,19 @@ class CustomerProfileValidationFactory implements DataValidationFactoryInterface
     {
         $definition
             ->add('salutationId', new EntityExists(['entity' => $this->salutationDefinition->getEntityName(), 'context' => $context->getContext()]))
-            ->add('title', new Length(['max' => CustomerDefinition::MAX_LENGTH_TITLE]))
-            ->add('firstName', new NotBlank(), new Length(['max' => CustomerDefinition::MAX_LENGTH_FIRST_NAME]))
-            ->add('lastName', new NotBlank(), new Length(['max' => CustomerDefinition::MAX_LENGTH_LAST_NAME]))
-            ->add('accountType', new Choice($this->accountTypes));
+            ->add('title', new Length(max: CustomerDefinition::MAX_LENGTH_TITLE))
+            ->add('firstName', new NotBlank(), new Length(max: CustomerDefinition::MAX_LENGTH_FIRST_NAME))
+            ->add('lastName', new NotBlank(), new Length(max: CustomerDefinition::MAX_LENGTH_LAST_NAME))
+            ->add('accountType', new Choice(choices: $this->accountTypes));
 
         $salesChannelId = $context->getSalesChannelId();
 
         if ($this->systemConfigService->get('core.loginRegistration.showBirthdayField', $salesChannelId)
             && $this->systemConfigService->get('core.loginRegistration.birthdayFieldRequired', $salesChannelId)) {
             $definition
-                ->add('birthdayDay', new GreaterThanOrEqual(['value' => 1]), new LessThanOrEqual(['value' => 31]))
-                ->add('birthdayMonth', new GreaterThanOrEqual(['value' => 1]), new LessThanOrEqual(['value' => 12]))
-                ->add('birthdayYear', new GreaterThanOrEqual(['value' => 1900]), new LessThanOrEqual(['value' => date('Y')]));
+                ->add('birthdayDay', new GreaterThanOrEqual(value: 1), new LessThanOrEqual(value: 31))
+                ->add('birthdayMonth', new GreaterThanOrEqual(value: 1), new LessThanOrEqual(value: 12))
+                ->add('birthdayYear', new GreaterThanOrEqual(value: 1900), new LessThanOrEqual(value: date('Y')));
         }
     }
 }

--- a/src/Core/Checkout/Document/DocumentGeneratorController.php
+++ b/src/Core/Checkout/Document/DocumentGeneratorController.php
@@ -49,7 +49,7 @@ class DocumentGeneratorController extends AbstractController
             'documents',
             (new DataValidationDefinition())
                 ->add('orderId', new NotBlank())
-                ->add('fileType', new Choice([PdfRenderer::FILE_EXTENSION]))
+                ->add('fileType', new Choice(choices: [PdfRenderer::FILE_EXTENSION]))
                 ->add('config', new Type('array'))
                 ->add('static', new Type('bool'))
                 ->add('referencedDocumentId', new Uuid())

--- a/src/Core/Content/Cms/DataAbstractionLayer/FieldSerializer/SlotConfigFieldSerializer.php
+++ b/src/Core/Content/Cms/DataAbstractionLayer/FieldSerializer/SlotConfigFieldSerializer.php
@@ -17,26 +17,26 @@ class SlotConfigFieldSerializer extends JsonFieldSerializer
     protected function getConstraints(Field $field): array
     {
         return [
-            new All([
-                'constraints' => new Collection([
-                    'allowExtraFields' => false,
-                    'allowMissingFields' => false,
-                    'fields' => [
+            new All(
+                constraints: new Collection(
+                    fields: [
                         'source' => [
-                            new Choice([
-                                'choices' => [
+                            new Choice(
+                                choices: [
                                     FieldConfig::SOURCE_STATIC,
                                     FieldConfig::SOURCE_MAPPED,
                                     FieldConfig::SOURCE_PRODUCT_STREAM,
                                     FieldConfig::SOURCE_DEFAULT,
-                                ],
-                            ]),
+                                ]
+                            ),
                             new NotBlank(),
                         ],
                         'value' => [],
                     ],
-                ]),
-            ]),
+                    allowExtraFields: false,
+                    allowMissingFields: false
+                ),
+            ),
         ];
     }
 }

--- a/src/Core/Content/ContactForm/Validation/ContactFormValidationFactory.php
+++ b/src/Core/Content/ContactForm/Validation/ContactFormValidationFactory.php
@@ -51,23 +51,17 @@ class ContactFormValidationFactory implements DataValidationFactoryInterface
             ->add('email', new NotBlank(), new Email())
             ->add('subject', new NotBlank())
             ->add('comment', new NotBlank())
-            ->add('firstName', new Regex(['pattern' => self::DOMAIN_NAME_REGEX, 'match' => false]))
-            ->add('lastName', new Regex(['pattern' => self::DOMAIN_NAME_REGEX, 'match' => false]));
+            ->add('firstName', new Regex(pattern: self::DOMAIN_NAME_REGEX, match: false))
+            ->add('lastName', new Regex(pattern: self::DOMAIN_NAME_REGEX, match: false));
 
         $required = $this->systemConfigService->get('core.basicInformation.firstNameFieldRequired', $context->getSalesChannelId());
         if ($required) {
-            $definition->set('firstName', new NotBlank(), new Regex([
-                'pattern' => self::DOMAIN_NAME_REGEX,
-                'match' => false,
-            ]));
+            $definition->set('firstName', new NotBlank(), new Regex(pattern: self::DOMAIN_NAME_REGEX, match: false));
         }
 
         $required = $this->systemConfigService->get('core.basicInformation.lastNameFieldRequired', $context->getSalesChannelId());
         if ($required) {
-            $definition->set('lastName', new NotBlank(), new Regex([
-                'pattern' => self::DOMAIN_NAME_REGEX,
-                'match' => false,
-            ]));
+            $definition->set('lastName', new NotBlank(), new Regex(pattern: self::DOMAIN_NAME_REGEX, match: false));
         }
 
         $required = $this->systemConfigService->get('core.basicInformation.phoneNumberFieldRequired', $context->getSalesChannelId());

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
@@ -87,8 +87,8 @@ class NewsletterConfirmRoute extends AbstractNewsletterConfirmRoute
     {
         $definition = new DataValidationDefinition('newsletter_recipient.opt_in_before');
         $definition->add('id', new NotBlank())
-            ->add('status', new EqualTo(['value' => NewsletterSubscribeRoute::STATUS_NOT_SET]))
-            ->add('em', new EqualTo(['value' => $emHash]));
+            ->add('status', new EqualTo(value: NewsletterSubscribeRoute::STATUS_NOT_SET))
+            ->add('em', new EqualTo(value: $emHash));
 
         return $definition;
     }

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -227,25 +227,19 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
     {
         $definition = new DataValidationDefinition('newsletter_recipient.create');
         $definition->add('email', new NotBlank(), new Email())
-            ->add('option', new NotBlank(), new Choice(array_keys($this->getOptionSelection($context, $dataBag->get('email')))));
+            ->add('option', new NotBlank(), new Choice(choices: array_keys($this->getOptionSelection($context, $dataBag->get('email')))));
 
         if (!empty($dataBag->get('firstName'))) {
-            $definition->add('firstName', new NotBlank(), new Regex([
-                'pattern' => self::DOMAIN_NAME_REGEX,
-                'match' => false,
-            ]));
+            $definition->add('firstName', new NotBlank(), new Regex(pattern: self::DOMAIN_NAME_REGEX, match: false));
         }
 
         if (!empty($dataBag->get('lastName'))) {
-            $definition->add('lastName', new NotBlank(), new Regex([
-                'pattern' => self::DOMAIN_NAME_REGEX,
-                'match' => false,
-            ]));
+            $definition->add('lastName', new NotBlank(), new Regex(pattern: self::DOMAIN_NAME_REGEX, match: false));
         }
 
         if ($validateStorefrontUrl) {
             $definition
-                ->add('storefrontUrl', new NotBlank(), new Choice(array_values($this->getDomainUrls($context))));
+                ->add('storefrontUrl', new NotBlank(), new Choice(choices: array_values($this->getDomainUrls($context))));
         }
 
         $validationEvent = new BuildValidationEvent($definition, $dataBag, $context->getContext());

--- a/src/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRoute.php
@@ -125,8 +125,8 @@ class ProductReviewSaveRoute extends AbstractProductReviewSaveRoute
         $definition = new DataValidationDefinition('product.create_rating');
 
         $definition->add('name', new NotBlank());
-        $definition->add('title', new NotBlank(), new Length(['min' => 5]));
-        $definition->add('content', new NotBlank(), new Length(['min' => 40]));
+        $definition->add('title', new NotBlank(), new Length(min: 5));
+        $definition->add('content', new NotBlank(), new Length(min: 40));
 
         $definition->add('points', new GreaterThanOrEqual(1), new LessThanOrEqual(5));
 

--- a/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
+++ b/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
@@ -426,8 +426,8 @@ class SalesChannelProxyController extends AbstractController
         }
 
         $validation = new DataValidationDefinition('shipping-cost');
-        $validation->add('unitPrice', new NotBlank(), new Type('numeric'), new GreaterThanOrEqual(['value' => 0]));
-        $validation->add('totalPrice', new NotBlank(), new Type('numeric'), new GreaterThanOrEqual(['value' => 0]));
+        $validation->add('unitPrice', new NotBlank(), new Type('numeric'), new GreaterThanOrEqual(value: 0));
+        $validation->add('totalPrice', new NotBlank(), new Type('numeric'), new GreaterThanOrEqual(value: 0));
         $this->validator->validate($request->request->all('shippingCosts'), $validation);
     }
 }

--- a/src/Core/Framework/App/Lifecycle/Persister/RuleConditionPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/RuleConditionPersister.php
@@ -188,13 +188,13 @@ class RuleConditionPersister
             }
 
             if ($field instanceof MultiSelectField) {
-                $constraints[$field->getName()][] = new All([new Choice(array_keys($field->getOptions()))]);
+                $constraints[$field->getName()][] = new All(constraints: new Choice(choices: array_keys($field->getOptions())));
 
                 continue;
             }
 
             if ($field instanceof SingleSelectField) {
-                $constraints[$field->getName()][] = new Choice(array_keys($field->getOptions()));
+                $constraints[$field->getName()][] = new Choice(choices: array_keys($field->getOptions()));
 
                 continue;
             }

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/IntFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/IntFieldSerializer.php
@@ -54,7 +54,7 @@ class IntFieldSerializer extends AbstractFieldSerializer
         ];
 
         if ($field->getMinValue() !== null || $field->getMaxValue() !== null) {
-            $constraints[] = new Range(['min' => $field->getMinValue(), 'max' => $field->getMaxValue()]);
+            $constraints[] = new Range(min: $field->getMinValue(), max: $field->getMaxValue());
         }
 
         return $constraints;

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/PasswordFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/PasswordFieldSerializer.php
@@ -89,11 +89,11 @@ class PasswordFieldSerializer extends AbstractFieldSerializer
 
         $minPasswordLength = $this->configService->getInt($configKey);
 
-        if ($minPasswordLength === 0) {
+        if ($minPasswordLength < 1) {
             return $constraints;
         }
 
-        $constraints[] = new Length(['min' => $minPasswordLength]);
+        $constraints[] = new Length(min: $minPasswordLength);
 
         return $constraints;
     }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
@@ -17,6 +17,9 @@ use Symfony\Component\Validator\Constraints\Type;
 #[Package('framework')]
 class ConstraintBuilder
 {
+    /**
+     * @var Constraint[]
+     */
     private array $constraints = [];
 
     /**
@@ -38,35 +41,39 @@ class ConstraintBuilder
 
     public function isBool(): self
     {
-        $this->addConstraint(new Type('bool'));
+        $this->addConstraint(new Type(type: 'bool'));
 
         return $this;
     }
 
     public function isString(): self
     {
-        $this->addConstraint(new Type('string'));
+        $this->addConstraint(new Type(type: 'string'));
 
         return $this;
     }
 
     public function isNumeric(): self
     {
-        $this->addConstraint(new Type('numeric'));
+        $this->addConstraint(new Type(type: 'numeric'));
 
         return $this;
     }
 
     public function isFloat(): self
     {
-        $this->addConstraint(new Type('numeric'));
+        $this->addConstraint(new Type(type: 'numeric'));
 
         return $this;
     }
 
     public function isLengthLessThanOrEqual(int $maxLength): self
     {
-        $this->addConstraint(new Length(['max' => $maxLength]));
+        if ($maxLength < 1) {
+            $maxLength = null;
+        }
+
+        $this->addConstraint(new Length(max: $maxLength));
 
         return $this;
     }
@@ -104,7 +111,7 @@ class ConstraintBuilder
      */
     public function isEmail(): self
     {
-        $this->addConstraint(new Email(['mode' => 'strict']));
+        $this->addConstraint(new Email(mode: 'strict'));
 
         return $this;
     }
@@ -121,10 +128,12 @@ class ConstraintBuilder
 
     /**
      * Set prop must be in array
+     *
+     * @param array<string> $values
      */
     public function isInArray(array $values): self
     {
-        $this->addConstraint(new Choice($values));
+        $this->addConstraint(new Choice(choices: $values));
 
         return $this;
     }

--- a/src/Core/Framework/Rule/Container/ZipCodeRule.php
+++ b/src/Core/Framework/Rule/Container/ZipCodeRule.php
@@ -29,7 +29,7 @@ abstract class ZipCodeRule extends Rule
         $constraints = [
             'operator' => [
                 new NotBlank(),
-                new Choice([
+                new Choice(choices: [
                     self::OPERATOR_EQ,
                     self::OPERATOR_NEQ,
                     self::OPERATOR_EMPTY,

--- a/src/Core/Framework/Rule/TimeRangeRule.php
+++ b/src/Core/Framework/Rule/TimeRangeRule.php
@@ -40,8 +40,8 @@ class TimeRangeRule extends Rule
     public function getConstraints(): array
     {
         return [
-            'toTime' => [new NotBlank(), new Regex(self::TIME_REGEX)],
-            'fromTime' => [new NotBlank(), new Regex(self::TIME_REGEX)],
+            'toTime' => [new NotBlank(), new Regex(pattern: self::TIME_REGEX)],
+            'fromTime' => [new NotBlank(), new Regex(pattern: self::TIME_REGEX)],
         ];
     }
 

--- a/src/Core/Framework/Rule/WeekdayRule.php
+++ b/src/Core/Framework/Rule/WeekdayRule.php
@@ -35,7 +35,7 @@ class WeekdayRule extends Rule
     {
         return [
             'operator' => RuleConstraints::stringOperators(false),
-            'dayOfWeek' => [new NotBlank(), new Range(['min' => 1, 'max' => 7])],
+            'dayOfWeek' => [new NotBlank(), new Range(min: 1, max: 7)],
         ];
     }
 

--- a/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
+++ b/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
@@ -43,7 +43,6 @@ class SystemConfigValidator
             // If sales channel is defined, nulls are valid values, as they are used to remove custom values in child configuration
             $allowNulls = $saleChannelId !== 'null';
 
-            /** @var string[] $allKeys */
             $allKeys = array_keys($inputValues);
 
             $domains = array_map(fn (string $key) => implode('.', explode('.', $key, -1)), $allKeys);
@@ -78,7 +77,6 @@ class SystemConfigValidator
      */
     private function prepareValidationConstraints(array $formConfig, array $inputConfigKeys, bool $allowNulls): array
     {
-        /** @var array<string, Constraint[]> $constraints */
         $constraints = [];
 
         foreach ($formConfig as $card) {
@@ -101,16 +99,16 @@ class SystemConfigValidator
     /**
      * @param array<string, mixed> $elementConfig
      *
-     * @return array<int, Constraint>
+     * @return list<Constraint>
      */
     private function buildConstraintsWithConfigs(array $elementConfig, bool $allowNulls): array
     {
         /** @var array<string, callable(mixed): Constraint> $constraints */
         $constraints = [
-            'minLength' => fn (mixed $ruleValue) => new Assert\Length(['min' => $ruleValue]),
-            'maxLength' => fn (mixed $ruleValue) => new Assert\Length(['max' => $ruleValue]),
-            'min' => fn (mixed $ruleValue) => new Assert\Range(['min' => $ruleValue]),
-            'max' => fn (mixed $ruleValue) => new Assert\Range(['max' => $ruleValue]),
+            'minLength' => fn (mixed $ruleValue) => new Assert\Length(min: $ruleValue === null ? null : max(0, (int) $ruleValue)),
+            'maxLength' => fn (mixed $ruleValue) => new Assert\Length(max: $ruleValue === null ? null : max(1, (int) $ruleValue)),
+            'min' => fn (mixed $ruleValue) => new Assert\Range(min: $ruleValue),
+            'max' => fn (mixed $ruleValue) => new Assert\Range(max: $ruleValue),
             'dataType' => fn (mixed $ruleValue) => new Assert\Type($ruleValue),
             'required' => fn (mixed $ruleValue) => new Assert\NotBlank(null, null, $allowNulls),
         ];
@@ -137,7 +135,7 @@ class SystemConfigValidator
     {
         try {
             return $this->configurationService->getConfiguration($domain, $context);
-        } catch (BundleConfigNotFoundException $e) {
+        } catch (BundleConfigNotFoundException) {
             return [];
         }
     }

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -218,7 +218,6 @@ class RegisterController extends StorefrontController
         $this->addFlash(self::SUCCESS, $this->trans('account.doubleOptInRegistrationSuccessfully'));
 
         if ($redirectTo = $queryDataBag->get('redirectTo')) {
-            /** @var array<string, mixed> $parameters */
             $parameters = $queryDataBag->all();
             unset($parameters['em'], $parameters['hash'], $parameters['redirectTo']);
 
@@ -259,9 +258,7 @@ class RegisterController extends StorefrontController
         $definition = new DataValidationDefinition('storefront.confirmation');
 
         if ($this->systemConfigService->get('core.loginRegistration.requireEmailConfirmation', $context->getSalesChannelId())) {
-            $definition->add('emailConfirmation', new NotBlank(), new EqualTo([
-                'value' => $data->get('email'),
-            ]));
+            $definition->add('emailConfirmation', new NotBlank(), new EqualTo(value: $data->get('email')));
         }
 
         if ($data->getBoolean('guest')) {
@@ -269,15 +266,13 @@ class RegisterController extends StorefrontController
         }
 
         if ($this->systemConfigService->get('core.loginRegistration.requirePasswordConfirmation', $context->getSalesChannelId())) {
-            $definition->add('passwordConfirmation', new NotBlank(), new EqualTo([
-                'value' => $data->get('password'),
-            ]));
+            $definition->add('passwordConfirmation', new NotBlank(), new EqualTo(value: $data->get('password')));
         }
 
         return $definition;
     }
 
-    private function prepareAffiliateTracking(RequestDataBag $data, SessionInterface $session): DataBag
+    private function prepareAffiliateTracking(RequestDataBag $data, SessionInterface $session): RequestDataBag
     {
         $affiliateCode = $session->get(AffiliateTrackingListener::AFFILIATE_CODE_KEY);
         $campaignCode = $session->get(AffiliateTrackingListener::CAMPAIGN_CODE_KEY);

--- a/tests/unit/Core/Checkout/Cart/Rule/AffiliateCodeOfOrderRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/AffiliateCodeOfOrderRuleTest.php
@@ -33,7 +33,7 @@ class AffiliateCodeOfOrderRuleTest extends TestCase
         static::assertArrayHasKey('affiliateCode', $constraints, 'Constraint affiliateCode not found in Rule');
         static::assertEquals($constraints['affiliateCode'], [
             new NotBlank(),
-            new Type(['type' => 'string']),
+            new Type(type: 'string'),
         ]);
     }
 
@@ -98,7 +98,7 @@ class AffiliateCodeOfOrderRuleTest extends TestCase
 
         $scope = new FlowRuleScope($order, $cart, $salesChannelContext);
         $match = $rule->match($scope);
-        static::assertEquals($match, $isMatching);
+        static::assertSame($match, $isMatching);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Cart/Rule/CampaignCodeOfOrderRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/CampaignCodeOfOrderRuleTest.php
@@ -33,7 +33,7 @@ class CampaignCodeOfOrderRuleTest extends TestCase
         static::assertArrayHasKey('campaignCode', $constraints, 'Constraint campaign not found in Rule');
         static::assertEquals($constraints['campaignCode'], [
             new NotBlank(),
-            new Type(['type' => 'string']),
+            new Type(type: 'string'),
         ]);
     }
 
@@ -94,7 +94,7 @@ class CampaignCodeOfOrderRuleTest extends TestCase
         $order->setCampaignCode($orderCampaignCode);
         $scope = new FlowRuleScope($order, $cart, $salesChannelContext);
         $match = $rule->match($scope);
-        static::assertEquals($match, $isMatching);
+        static::assertSame($match, $isMatching);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Cart/Rule/CartShippingCostRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/CartShippingCostRuleTest.php
@@ -187,7 +187,7 @@ class CartShippingCostRuleTest extends TestCase
         static::assertArrayHasKey('cartShippingCost', $constraints);
         static::assertEquals($constraints['cartShippingCost'], [
             new NotBlank(),
-            new Type(['type' => 'numeric']),
+            new Type(type: 'numeric'),
         ]);
 
         static::assertArrayHasKey('operator', $constraints);

--- a/tests/unit/Core/Checkout/Cart/Rule/CartTotalPurchasePriceRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/CartTotalPurchasePriceRuleTest.php
@@ -30,7 +30,7 @@ class CartTotalPurchasePriceRuleTest extends TestCase
 {
     public function testItReturnsTheCorrectName(): void
     {
-        static::assertEquals('cartTotalPurchasePrice', (new CartTotalPurchasePriceRule())->getName());
+        static::assertSame('cartTotalPurchasePrice', (new CartTotalPurchasePriceRule())->getName());
     }
 
     public function testRulesDoesNotMatchIfScopeNotCartRuleScope(): void
@@ -57,7 +57,7 @@ class CartTotalPurchasePriceRuleTest extends TestCase
             'amount' => $total,
         ]);
 
-        static::assertEquals($matches, $rule->match($ruleScope));
+        static::assertSame($matches, $rule->match($ruleScope));
     }
 
     /**
@@ -95,7 +95,7 @@ class CartTotalPurchasePriceRuleTest extends TestCase
 
         static::assertEquals([
             'operator' => [new NotBlank(),
-                new Choice([
+                new Choice(choices: [
                     Rule::OPERATOR_EQ,
                     Rule::OPERATOR_LTE,
                     Rule::OPERATOR_GTE,
@@ -121,14 +121,14 @@ class CartTotalPurchasePriceRuleTest extends TestCase
         $configData = $config->getData();
 
         static::assertArrayHasKey('operatorSet', $configData);
-        static::assertEquals([
+        static::assertSame([
             'operators' => RuleConfig::OPERATOR_SET_NUMBER,
             'isMatchAny' => false,
         ], $configData['operatorSet']);
 
         static::assertArrayHasKey('fields', $configData);
         static::assertCount(2, $configData['fields']);
-        static::assertEquals([
+        static::assertSame([
             'type' => [
                 'name' => 'type',
                 'type' => 'single-select',

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemCreationDateRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemCreationDateRuleTest.php
@@ -70,10 +70,10 @@ class LineItemCreationDateRuleTest extends TestCase
         $operators = $ruleConstraints['operator'];
 
         static::assertEquals(new NotBlank(), $date[0]);
-        static::assertEquals(new Type(['type' => 'string']), $date[1]);
+        static::assertEquals(new Type(type: 'string'), $date[1]);
 
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
     }
 
     /**
@@ -251,7 +251,7 @@ class LineItemCreationDateRuleTest extends TestCase
         $result = $lineItemCreationDateRule->getConfig()->getData();
 
         static::assertIsArray($result['operatorSet']['operators']);
-        static::assertEquals(RuleConfig::OPERATOR_SET_NUMBER, $result['operatorSet']['operators']);
+        static::assertSame(RuleConfig::OPERATOR_SET_NUMBER, $result['operatorSet']['operators']);
     }
 
     private function createLineItemWithCreatedDate(string $createdAt): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemIsNewRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemIsNewRuleTest.php
@@ -48,7 +48,7 @@ class LineItemIsNewRuleTest extends TestCase
     {
         $ruleConstraints = $this->rule->getConstraints();
 
-        $boolType = new Type(['type' => 'bool']);
+        $boolType = new Type(type: 'bool');
 
         static::assertArrayHasKey('isNew', $ruleConstraints, 'Rule Constraint isNew is not defined');
         static::assertCount(1, $ruleConstraints['isNew']);

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemPromotedRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemPromotedRuleTest.php
@@ -51,7 +51,7 @@ class LineItemPromotedRuleTest extends TestCase
      */
     public function testConstraints(): void
     {
-        $expectedType = new Type(['type' => 'bool']);
+        $expectedType = new Type(type: 'bool');
 
         $ruleConstraints = $this->rule->getConstraints();
 

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemReleaseDateRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemReleaseDateRuleTest.php
@@ -69,10 +69,10 @@ class LineItemReleaseDateRuleTest extends TestCase
         $operators = $ruleConstraints['operator'];
 
         static::assertEquals(new NotBlank(), $date[0]);
-        static::assertEquals(new Type(['type' => 'string']), $date[1]);
+        static::assertEquals(new Type(type: 'string'), $date[1]);
 
         static::assertEquals(new NotBlank(), $operators[0]);
-        static::assertEquals(new Choice($expectedOperators), $operators[1]);
+        static::assertEquals(new Choice(choices: $expectedOperators), $operators[1]);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemStockRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemStockRuleTest.php
@@ -31,7 +31,7 @@ class LineItemStockRuleTest extends TestCase
 {
     public function testItReturnsTheCorrectName(): void
     {
-        static::assertEquals('cartLineItemStock', (new LineItemStockRule())->getName());
+        static::assertSame('cartLineItemStock', (new LineItemStockRule())->getName());
     }
 
     public function testRulesDoesNotMatchIfScopeNoLineItemScopeNorCartRuleScope(): void
@@ -90,7 +90,7 @@ class LineItemStockRuleTest extends TestCase
 
         $rule = new LineItemStockRule($operator, 5);
 
-        static::assertEquals($matches, $rule->match($ruleScope));
+        static::assertSame($matches, $rule->match($ruleScope));
     }
 
     #[DataProvider('provideLineItemTestCases')]
@@ -105,7 +105,7 @@ class LineItemStockRuleTest extends TestCase
 
         $rule = new LineItemStockRule($operator, 5);
 
-        static::assertEquals($matches, $rule->match($ruleScope));
+        static::assertSame($matches, $rule->match($ruleScope));
     }
 
     public function testNoMatchWithEmptyCartRuleScope(): void
@@ -191,7 +191,7 @@ class LineItemStockRuleTest extends TestCase
 
         static::assertEquals([
             'operator' => [new NotBlank(),
-                new Choice([
+                new Choice(choices: [
                     Rule::OPERATOR_EQ,
                     Rule::OPERATOR_LTE,
                     Rule::OPERATOR_GTE,
@@ -213,7 +213,7 @@ class LineItemStockRuleTest extends TestCase
         $configData = $config->getData();
 
         static::assertArrayHasKey('operatorSet', $configData);
-        static::assertEquals([
+        static::assertSame([
             'operators' => RuleConfig::OPERATOR_SET_NUMBER,
             'isMatchAny' => false,
         ], $configData['operatorSet']);
@@ -226,7 +226,7 @@ class LineItemStockRuleTest extends TestCase
 
         static::assertArrayHasKey('fields', $configData);
         static::assertCount(1, $configData['fields']);
-        static::assertEquals([
+        static::assertSame([
             'name' => 'stock',
             'type' => 'int',
             'config' => [],

--- a/tests/unit/Core/Checkout/Customer/Rule/AffiliateCodeRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/AffiliateCodeRuleTest.php
@@ -31,7 +31,7 @@ class AffiliateCodeRuleTest extends TestCase
         static::assertArrayHasKey('affiliateCode', $constraints, 'Constraint affiliateCode not found in Rule');
         static::assertEquals($constraints['affiliateCode'], [
             new NotBlank(),
-            new Type(['type' => 'string']),
+            new Type(type: 'string'),
         ]);
     }
 
@@ -96,7 +96,7 @@ class AffiliateCodeRuleTest extends TestCase
 
         $scope = new CheckoutRuleScope($salesChannelContext);
         $match = $rule->match($scope);
-        static::assertEquals($match, $isMatching);
+        static::assertSame($match, $isMatching);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Customer/Rule/BillingCityRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/BillingCityRuleTest.php
@@ -46,7 +46,7 @@ class BillingCityRuleTest extends TestCase
         static::assertArrayHasKey('cityName', $constraints, 'Constraint cityName not found in Rule');
         static::assertArrayHasKey('operator', $constraints, 'Constraint operator not found in Rule');
 
-        static::assertEquals([new NotBlank(), new Choice([
+        static::assertEquals([new NotBlank(), new Choice(choices: [
             Rule::OPERATOR_EQ,
             Rule::OPERATOR_NEQ,
             Rule::OPERATOR_EMPTY,

--- a/tests/unit/Core/Checkout/Customer/Rule/BillingStateRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/BillingStateRuleTest.php
@@ -46,7 +46,7 @@ class BillingStateRuleTest extends TestCase
         static::assertArrayHasKey('operator', $constraints, 'Constraint operator not found in Rule');
         static::assertArrayHasKey('stateIds', $constraints, 'Constraint stateIds not found in Rule');
 
-        static::assertEquals([new NotBlank(), new Choice([Rule::OPERATOR_EQ, Rule::OPERATOR_NEQ, Rule::OPERATOR_EMPTY])], $constraints['operator']);
+        static::assertEquals([new NotBlank(), new Choice(choices: [Rule::OPERATOR_EQ, Rule::OPERATOR_NEQ, Rule::OPERATOR_EMPTY])], $constraints['operator']);
         static::assertEquals([new NotBlank(), new ArrayOfUuid()], $constraints['stateIds']);
     }
 

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerBirthdayRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerBirthdayRuleTest.php
@@ -58,8 +58,8 @@ class CustomerBirthdayRuleTest extends TestCase
         static::assertArrayHasKey('birthday', $constraints, 'Birthday constraint not found');
         static::assertArrayHasKey('operator', $constraints, 'operator constraints not found');
 
-        static::assertEquals(new Type(['type' => 'string']), $constraints['birthday'][1]);
-        static::assertEquals(new Choice($operators), $constraints['operator'][1]);
+        static::assertEquals(new Type(type: 'string'), $constraints['birthday'][1]);
+        static::assertEquals(new Choice(choices: $operators), $constraints['operator'][1]);
     }
 
     #[DataProvider('getMatchBirthdayValues')]
@@ -145,7 +145,7 @@ class CustomerBirthdayRuleTest extends TestCase
         $operators = RuleConfig::OPERATOR_SET_NUMBER;
         $operators[] = Rule::OPERATOR_EMPTY;
 
-        static::assertEquals([
+        static::assertSame([
             'operators' => $operators,
             'isMatchAny' => false,
         ], $configData['operatorSet']);

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerCreatedByAdminRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerCreatedByAdminRuleTest.php
@@ -31,7 +31,7 @@ class CustomerCreatedByAdminRuleTest extends TestCase
         static::assertArrayHasKey('shouldCustomerBeCreatedByAdmin', $constraints, 'Constraint shouldCustomerBeCreatedByAdmin not found in Rule');
         static::assertEquals($constraints['shouldCustomerBeCreatedByAdmin'], [
             new NotNull(),
-            new Type(['type' => 'bool']),
+            new Type(type: 'bool'),
         ]);
     }
 
@@ -94,7 +94,7 @@ class CustomerCreatedByAdminRuleTest extends TestCase
 
         $scope = new CheckoutRuleScope($salesChannelContext);
         $match = $rule->match($scope);
-        static::assertEquals($match, $isMatching);
+        static::assertSame($match, $isMatching);
     }
 
     public static function getCaseTestMatchValues(): \Generator

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerLoggedInRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerLoggedInRuleTest.php
@@ -30,7 +30,7 @@ class CustomerLoggedInRuleTest extends TestCase
         static::assertArrayHasKey('isLoggedIn', $constraints, 'Constraint isLoggedIn not found in Rule');
         static::assertEquals($constraints['isLoggedIn'], [
             new NotNull(),
-            new Type(['type' => 'bool']),
+            new Type(type: 'bool'),
         ]);
     }
 
@@ -78,7 +78,7 @@ class CustomerLoggedInRuleTest extends TestCase
 
         $scope = new CheckoutRuleScope($salesChannelContext);
         $match = $rule->match($scope);
-        static::assertEquals($match, $isMatching);
+        static::assertSame($match, $isMatching);
     }
 
     public static function getCaseTestMatchValues(): \Generator

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
@@ -224,7 +224,7 @@ class RegisterRouteTest extends TestCase
 
                 $definition->add('company', new NotBlank());
                 $definition->set('zipcode', new CustomerZipCode(['countryId' => null]));
-                $definition->add('zipcode', new Length(['max' => CustomerAddressDefinition::MAX_LENGTH_ZIPCODE]));
+                $definition->add('zipcode', new Length(max: CustomerAddressDefinition::MAX_LENGTH_ZIPCODE));
 
                 static::assertNull($event->getData()->get('shippingAddress'));
                 static::assertSame($event->getData()->get('accountType'), CustomerEntity::ACCOUNT_TYPE_BUSINESS);
@@ -297,7 +297,7 @@ class RegisterRouteTest extends TestCase
 
                 $definition->add('company', new NotBlank());
                 $definition->set('zipcode', new CustomerZipCode(['countryId' => '123']));
-                $definition->add('zipcode', new Length(['max' => CustomerAddressDefinition::MAX_LENGTH_ZIPCODE]));
+                $definition->add('zipcode', new Length(max: CustomerAddressDefinition::MAX_LENGTH_ZIPCODE));
 
                 static::assertNull($event->getData()->get('shippingAddress'));
                 static::assertSame($event->getData()->get('accountType'), CustomerEntity::ACCOUNT_TYPE_BUSINESS);

--- a/tests/unit/Core/Checkout/Customer/Validation/CustomerProfileValidationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Customer/Validation/CustomerProfileValidationFactoryTest.php
@@ -230,21 +230,21 @@ class CustomerProfileValidationFactoryTest extends TestCase
             ->add('salutationId', new EntityExists(['entity' => $this->salutationDefinition->getEntityName(), 'context' => $context->getContext()]))
             ->add('firstName', new NotBlank())
             ->add('lastName', new NotBlank())
-            ->add('accountType', new Choice($this->accountTypes))
-            ->add('title', new Length(['max' => CustomerDefinition::MAX_LENGTH_TITLE]));
+            ->add('accountType', new Choice(choices: $this->accountTypes))
+            ->add('title', new Length(max: CustomerDefinition::MAX_LENGTH_TITLE));
 
         if (Feature::isActive('ADDRESS_SELECTION_REWORK')) {
             $definition
-                ->add('firstName', new Length(['max' => CustomerDefinition::MAX_LENGTH_FIRST_NAME]))
-                ->add('lastName', new Length(['max' => CustomerDefinition::MAX_LENGTH_LAST_NAME]));
+                ->add('firstName', new Length(max: CustomerDefinition::MAX_LENGTH_FIRST_NAME))
+                ->add('lastName', new Length(max: CustomerDefinition::MAX_LENGTH_LAST_NAME));
         }
     }
 
     private function addConstraintsBirthday(DataValidationDefinition $definition): void
     {
         $definition
-            ->add('birthdayDay', new GreaterThanOrEqual(['value' => 1]), new LessThanOrEqual(['value' => 31]))
-            ->add('birthdayMonth', new GreaterThanOrEqual(['value' => 1]), new LessThanOrEqual(['value' => 12]))
-            ->add('birthdayYear', new GreaterThanOrEqual(['value' => 1900]), new LessThanOrEqual(['value' => date('Y')]));
+            ->add('birthdayDay', new GreaterThanOrEqual(value: 1), new LessThanOrEqual(value: 31))
+            ->add('birthdayMonth', new GreaterThanOrEqual(value: 1), new LessThanOrEqual(value: 12))
+            ->add('birthdayYear', new GreaterThanOrEqual(value: 1900), new LessThanOrEqual(value: date('Y')));
     }
 }

--- a/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
@@ -39,7 +39,7 @@ class PromotionLineItemRuleTest extends TestCase
 
         static::assertEquals([
             'identifiers' => [new NotBlank(), new ArrayOfUuid()],
-            'operator' => [new NotBlank(), new Choice([
+            'operator' => [new NotBlank(), new Choice(choices: [
                 Rule::OPERATOR_EQ,
                 Rule::OPERATOR_NEQ,
             ])],
@@ -51,7 +51,7 @@ class PromotionLineItemRuleTest extends TestCase
         $rule = new PromotionLineItemRule(Rule::OPERATOR_EQ, ['foo', 'bar']);
         $config = $rule->getConfig();
 
-        static::assertEquals([
+        static::assertSame([
             'operatorSet' => [
                 'operators' => [
                     Rule::OPERATOR_EQ,

--- a/tests/unit/Core/Checkout/Rule/Rule/Order/AdminSalesChannelSourceRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Order/AdminSalesChannelSourceRuleTest.php
@@ -34,7 +34,7 @@ class AdminSalesChannelSourceRuleTest extends TestCase
 
     public function testGetName(): void
     {
-        static::assertEquals('adminSalesChannelSource', $this->rule->getName());
+        static::assertSame('adminSalesChannelSource', $this->rule->getName());
     }
 
     public function testRuleConfig(): void
@@ -59,7 +59,7 @@ class AdminSalesChannelSourceRuleTest extends TestCase
 
         static::assertArrayHasKey('hasAdminSalesChannelSource', $constraints, 'Constraint hasAdminSalesChannelSource not found in Rule');
         static::assertEquals($constraints['hasAdminSalesChannelSource'], [
-            new Type(['type' => 'bool']),
+            new Type(type: 'bool'),
         ]);
     }
 
@@ -78,7 +78,7 @@ class AdminSalesChannelSourceRuleTest extends TestCase
         $scope = new CheckoutRuleScope($context);
 
         $match = $rule->match($scope);
-        static::assertEquals($match, $isMatching);
+        static::assertSame($match, $isMatching);
     }
 
     public static function getCaseTestMatchValues(): \Generator

--- a/tests/unit/Core/Content/Cms/DataAbstractionLayer/FieldSerializer/SlotConfigFieldSerializerTest.php
+++ b/tests/unit/Core/Content/Cms/DataAbstractionLayer/FieldSerializer/SlotConfigFieldSerializerTest.php
@@ -30,26 +30,26 @@ class SlotConfigFieldSerializerTest extends TestCase
     public function testEncodeUsesSlotConfigFieldSerializerConstraints(): void
     {
         $id = Uuid::randomHex();
-        $expected = new All([
-            'constraints' => new Collection([
-                'allowExtraFields' => false,
-                'allowMissingFields' => false,
-                'fields' => [
+        $expected = new All(
+            constraints: new Collection(
+                fields: [
                     'source' => [
-                        new Choice([
-                            'choices' => [
+                        new Choice(
+                            choices: [
                                 FieldConfig::SOURCE_STATIC,
                                 FieldConfig::SOURCE_MAPPED,
                                 FieldConfig::SOURCE_PRODUCT_STREAM,
                                 FieldConfig::SOURCE_DEFAULT,
                             ],
-                        ]),
+                        ),
                         new NotBlank(),
                     ],
                     'value' => [],
                 ],
-            ]),
-        ]);
+                allowExtraFields: false,
+                allowMissingFields: false,
+            ),
+        );
 
         $serializer = $this->getSerializer($id, $expected);
 

--- a/tests/unit/Core/Content/ContactForm/SalesChannel/ContactFormRouteTest.php
+++ b/tests/unit/Core/Content/ContactForm/SalesChannel/ContactFormRouteTest.php
@@ -71,8 +71,8 @@ class ContactFormRouteTest extends TestCase
         $mock = $this->createMock(DataValidator::class);
         $mock->method('validate')->willReturnCallback(function (array $data, DataValidationDefinition $definition) use ($properties, $constraints): void {
             foreach ($properties as $propertyName => $value) {
-                static::assertEquals($value, $data[$propertyName] ?? null);
-                static::assertEquals($definition->getProperties()[$propertyName] ?? null, $constraints);
+                static::assertSame($value, $data[$propertyName] ?? null);
+                static::assertSame($definition->getProperties()[$propertyName] ?? null, $constraints);
             }
         });
 
@@ -106,10 +106,7 @@ class ContactFormRouteTest extends TestCase
             ['firstName' => 'Y http://localhost', 'lastName' => 'Tran http://localhost'],
             [
                 new NotBlank(),
-                new Regex([
-                    'pattern' => ContactFormValidationFactory::DOMAIN_NAME_REGEX,
-                    'match' => false,
-                ]),
+                new Regex(pattern: ContactFormValidationFactory::DOMAIN_NAME_REGEX, match: false),
             ],
         ];
 
@@ -124,10 +121,7 @@ class ContactFormRouteTest extends TestCase
             ['firstName' => 'Y', 'lastName' => 'Tran'],
             [
                 new NotBlank(),
-                new Regex([
-                    'pattern' => ContactFormValidationFactory::DOMAIN_NAME_REGEX,
-                    'match' => false,
-                ]),
+                new Regex(pattern: ContactFormValidationFactory::DOMAIN_NAME_REGEX, match: false),
             ],
         ];
     }

--- a/tests/unit/Core/Content/ContactForm/Validation/ContactFormValidationFactoryTest.php
+++ b/tests/unit/Core/Content/ContactForm/Validation/ContactFormValidationFactoryTest.php
@@ -56,11 +56,11 @@ class ContactFormValidationFactoryTest extends TestCase
                     'comment' => [new NotBlank()],
                     'firstName' => [
                         new NotBlank(),
-                        new Regex(['pattern' => ContactFormValidationFactory::DOMAIN_NAME_REGEX, 'match' => false]),
+                        new Regex(pattern: ContactFormValidationFactory::DOMAIN_NAME_REGEX, match: false),
                     ],
                     'lastName' => [
                         new NotBlank(),
-                        new Regex(['pattern' => ContactFormValidationFactory::DOMAIN_NAME_REGEX, 'match' => false]),
+                        new Regex(pattern: ContactFormValidationFactory::DOMAIN_NAME_REGEX, match: false),
                     ],
                     'phone' => [new NotBlank()],
                 ]);
@@ -79,10 +79,10 @@ class ContactFormValidationFactoryTest extends TestCase
                     'subject' => [new NotBlank()],
                     'comment' => [new NotBlank()],
                     'firstName' => [
-                        new Regex(['pattern' => ContactFormValidationFactory::DOMAIN_NAME_REGEX, 'match' => false]),
+                        new Regex(pattern: ContactFormValidationFactory::DOMAIN_NAME_REGEX, match: false),
                     ],
                     'lastName' => [
-                        new Regex(['pattern' => ContactFormValidationFactory::DOMAIN_NAME_REGEX, 'match' => false]),
+                        new Regex(pattern: ContactFormValidationFactory::DOMAIN_NAME_REGEX, match: false),
                     ],
                 ]);
             },

--- a/tests/unit/Core/Content/Flow/Rule/OrderCreatedByAdminRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderCreatedByAdminRuleTest.php
@@ -34,7 +34,7 @@ class OrderCreatedByAdminRuleTest extends TestCase
 
     public function testGetName(): void
     {
-        static::assertEquals('orderCreatedByAdmin', $this->rule->getName());
+        static::assertSame('orderCreatedByAdmin', $this->rule->getName());
     }
 
     public function testRuleConfig(): void
@@ -60,7 +60,7 @@ class OrderCreatedByAdminRuleTest extends TestCase
         static::assertArrayHasKey('shouldOrderBeCreatedByAdmin', $constraints, 'Constraint shouldOrderBeCreatedByAdmin not found in Rule');
         static::assertEquals($constraints['shouldOrderBeCreatedByAdmin'], [
             new NotNull(),
-            new Type(['type' => 'bool']),
+            new Type(type: 'bool'),
         ]);
     }
 
@@ -83,7 +83,7 @@ class OrderCreatedByAdminRuleTest extends TestCase
         );
 
         $match = $rule->match($scope);
-        static::assertEquals($match, $isMatching);
+        static::assertSame($match, $isMatching);
     }
 
     public static function getCaseTestMatchValues(): \Generator

--- a/tests/unit/Core/Content/Flow/Rule/OrderTrackingCodeRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderTrackingCodeRuleTest.php
@@ -53,7 +53,6 @@ class OrderTrackingCodeRuleTest extends TestCase
         $order->setDeliveries($orderDeliveryCollection);
 
         $cart = new Cart('token');
-        $context = $this->createMock(SalesChannelContext::class);
 
         $match = $rule->match(new FlowRuleScope(
             $order,
@@ -131,7 +130,7 @@ class OrderTrackingCodeRuleTest extends TestCase
 
         static::assertArrayHasKey('isSet', $constraints);
         static::assertEquals([
-            'isSet' => [new NotNull(), new Type(['type' => 'bool'])],
+            'isSet' => [new NotNull(), new Type(type: 'bool')],
         ], $constraints);
     }
 

--- a/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRouteTest.php
+++ b/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRouteTest.php
@@ -211,10 +211,7 @@ class NewsletterSubscribeRouteTest extends TestCase
             ['firstName' => 'Y http://localhost', 'lastName' => 'Tran http://localhost'],
             [
                 new NotBlank(),
-                new Regex([
-                    'pattern' => NewsletterSubscribeRoute::DOMAIN_NAME_REGEX,
-                    'match' => false,
-                ]),
+                new Regex(pattern: NewsletterSubscribeRoute::DOMAIN_NAME_REGEX, match: false),
             ],
         ];
 
@@ -228,10 +225,7 @@ class NewsletterSubscribeRouteTest extends TestCase
             ['firstName' => 'Y', 'lastName' => 'Tran'],
             [
                 new NotBlank(),
-                new Regex([
-                    'pattern' => NewsletterSubscribeRoute::DOMAIN_NAME_REGEX,
-                    'match' => false,
-                ]),
+                new Regex(pattern: NewsletterSubscribeRoute::DOMAIN_NAME_REGEX, match: false),
             ],
         ];
     }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/PasswordFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/PasswordFieldSerializerTest.php
@@ -106,7 +106,7 @@ class PasswordFieldSerializerTest extends TestCase
             $inputPasswordHashed = !empty(password_get_info($inputPassword)['algo']);
 
             if ($inputPasswordHashed) {
-                static::assertEquals($inputPassword, $result);
+                static::assertSame($inputPassword, $result);
             } else {
                 static::assertTrue(password_verify($inputPassword, $result));
             }
@@ -128,7 +128,7 @@ class PasswordFieldSerializerTest extends TestCase
         $minLengthConstraints = [
             new NotBlank(),
             new Type('string'),
-            new Length(['min' => $minPasswordLength]),
+            new Length(min: $minPasswordLength),
         ];
 
         yield 'with null value without min length required' => [

--- a/tests/unit/Core/Framework/Validation/HappyPathValidatorTest.php
+++ b/tests/unit/Core/Framework/Validation/HappyPathValidatorTest.php
@@ -42,43 +42,43 @@ class HappyPathValidatorTest extends TestCase
     public static function constraintDataProvider(): \Generator
     {
         yield 'min range valid' => [
-            new Range(['min' => 11]),
+            new Range(min: 11),
             11,
             true,
         ];
 
         yield 'min range invalid' => [
-            new Range(['min' => 11]),
+            new Range(min: 11),
             10,
             false,
         ];
 
         yield 'max range valid' => [
-            new Range(['max' => 11]),
+            new Range(max: 11),
             11,
             true,
         ];
 
         yield 'max range invalid' => [
-            new Range(['max' => 11]),
+            new Range(max: 11),
             12,
             false,
         ];
 
         yield 'min max range valid' => [
-            new Range(['min' => 11, 'max' => 20]),
+            new Range(min: 11, max: 20),
             20,
             true,
         ];
 
         yield 'min max range too low' => [
-            new Range(['min' => 11, 'max' => 20]),
+            new Range(min: 11, max: 20),
             10,
             false,
         ];
 
         yield 'min max range too high' => [
-            new Range(['min' => 11, 'max' => 20]),
+            new Range(min: 11, max: 20),
             21,
             false,
         ];

--- a/tests/unit/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
+++ b/tests/unit/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
@@ -115,7 +115,7 @@ class SystemConfigValidatorTest extends TestCase
 
         $result = $refMethod->invoke($systemConfigValidation, 'dummy domain', $contextMock);
 
-        static::assertEquals([], $result);
+        static::assertSame([], $result);
     }
 
     public function testGetSystemConfigByDomainWithException(): void
@@ -134,7 +134,7 @@ class SystemConfigValidatorTest extends TestCase
 
         $result = $refMethod->invoke($systemConfigValidation, 'dummy domain', $contextMock);
 
-        static::assertEquals($result, []);
+        static::assertSame($result, []);
     }
 
     /**
@@ -172,8 +172,8 @@ class SystemConfigValidatorTest extends TestCase
                 'maxLength' => 255,
             ],
             'expected' => [
-                new Assert\Length(['min' => 1]),
-                new Assert\Length(['max' => 255]),
+                new Assert\Length(min: 1),
+                new Assert\Length(max: 255),
                 new Assert\Type('string'),
                 new Assert\NotBlank(),
             ],
@@ -188,8 +188,8 @@ class SystemConfigValidatorTest extends TestCase
                 'max' => 100,
             ],
             'expected' => [
-                new Assert\Range(['min' => 1]),
-                new Assert\Range(['max' => 100]),
+                new Assert\Range(min: 1),
+                new Assert\Range(max: 100),
                 new Assert\Type('int'),
                 new Assert\NotBlank(),
             ],
@@ -204,8 +204,8 @@ class SystemConfigValidatorTest extends TestCase
                 'maxLength' => 255,
             ],
             'expected' => [
-                new Assert\Length(['min' => 1]),
-                new Assert\Length(['max' => 255]),
+                new Assert\Length(min: 1),
+                new Assert\Length(max: 255),
                 new Assert\Type('string'),
                 new Assert\NotBlank(null, null, true),
             ],

--- a/tests/unit/Storefront/Controller/RegisterControllerTest.php
+++ b/tests/unit/Storefront/Controller/RegisterControllerTest.php
@@ -196,8 +196,8 @@ class RegisterControllerTest extends TestCase
         $this->systemConfigService->set('core.loginRegistration.requirePasswordConfirmation', true, $context->getSalesChannelId());
 
         $expectedDefinition = new DataValidationDefinition('storefront.confirmation');
-        $expectedDefinition->add('emailConfirmation', new NotBlank(), new EqualTo(['value' => 'foo@bar.de']));
-        $expectedDefinition->add('passwordConfirmation', new NotBlank(), new EqualTo(['value' => 'password']));
+        $expectedDefinition->add('emailConfirmation', new NotBlank(), new EqualTo(value: 'foo@bar.de'));
+        $expectedDefinition->add('passwordConfirmation', new NotBlank(), new EqualTo(value: 'password'));
         $this->registerRoute
             ->expects($this->once())
             ->method('register')


### PR DESCRIPTION
### 1. Why is this change necessary?
Recently the pipeline was failing and a quick fix was done: https://github.com/shopware/shopware/pull/14402

This is the full missing backport of https://github.com/shopware/shopware/pull/11840

We need this to avoid some random failure when porting back some new tests, as the actual configuration of PHPunit in integration is giving that effect instead of handling properly the deprecation (this is another topic of another PR).

As 6.6.x is following Symfony update anyway, we should have our sources & tests respecting the fixed deprecations too.

### 2. What does this change do, exactly?

Apply recommended changes when invoking Constraints object in tests & src files

- Email
- EqualTo
- LessThanOrEqual
- GreaterThanOrEqual
- All
- Choice
- Range
- Length
- Type
- Regex

Additional files compared to the original PR on trunk were modified, since 6.6.x. is not a 1:1 comparison

Some files are missing compared to the original PR, and after thorough verifications, they were deleted both on trunk & 6.6.x due to various evolution/security patches in between. To make sure we are not missing any file with constraints to fix, a similar manual search per object instantiation was done locally (it's not just simple comparison between trunk & 6.6.x over the files of the original PR)

For unit tests, some assertions (assertSame) were taken too, as a bonus

### 3. Describe each step to reproduce the issue or behaviour.
Run the pipeline

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
