### PR TITLE
fix: TypeError when _httpCache route attribute contains string

### DIFF
--- a/src/Core/Framework/Adapter/Cache/Http/CacheAttribute.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheAttribute.php
@@ -45,24 +45,20 @@ readonly class CacheAttribute
      */
     public static function fromAttributeValue(array|bool|string|int|CacheAttribute|null $attributeValue): ?self
     {
-        if (\is_string($attributeValue)) { // string values can come from XML route definitions
-            $attributeValue = \in_array(strtolower($attributeValue), ['true', '1'], true);
-        } elseif (\is_int($attributeValue)) {
-            $attributeValue = $attributeValue === 1;
-        }
-
-        if ($attributeValue === null || $attributeValue === false) {
-            return null;
-        }
-
-        if ($attributeValue === true) {
-            return new self();
-        }
-
         if ($attributeValue instanceof CacheAttribute) {
             return $attributeValue;
         }
 
-        return self::fromArray($attributeValue);
+        if (\is_array($attributeValue)) {
+            return self::fromArray($attributeValue);
+        }
+
+        // from XML route definitions string values can come
+        $attributeValue = filter_var($attributeValue, \FILTER_VALIDATE_BOOLEAN);
+        if ($attributeValue === true) {
+            return new self();
+        }
+
+        return null;
     }
 }

--- a/src/Core/Framework/Adapter/Cache/Http/CacheAttribute.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheAttribute.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
  * Value object extended for cache attribute in request
  *
  * @phpstan-type CacheAttributeArray array{ clientMaxAge?: int, sharedMaxAge?: int, maxAge?: int, states?: list<string> }
- * @phpstan-type CacheAttributeType CacheAttributeArray|true|CacheAttribute
+ * @phpstan-type CacheAttributeType CacheAttributeArray|bool|string|int|CacheAttribute
  *
  * @internal
  */
@@ -43,8 +43,14 @@ readonly class CacheAttribute
     /**
      * @param CacheAttributeType $attributeValue
      */
-    public static function fromAttributeValue(array|bool|CacheAttribute|null $attributeValue): ?self
+    public static function fromAttributeValue(array|bool|string|int|CacheAttribute|null $attributeValue): ?self
     {
+        if (\is_string($attributeValue)) { // string values can come from XML route definitions
+            $attributeValue = \in_array(strtolower($attributeValue), ['true', '1'], true);
+        } elseif (\is_int($attributeValue)) {
+            $attributeValue = $attributeValue === 1;
+        }
+
         if ($attributeValue === null || $attributeValue === false) {
             return null;
         }

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheAttributeTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheAttributeTest.php
@@ -114,5 +114,40 @@ class CacheAttributeTest extends TestCase
             'input' => ['states' => ['state1', 'state2']],
             'expected' => new CacheAttribute(states: ['state1', 'state2']),
         ];
+
+        yield 'string "true" returns empty CacheAttribute' => [
+            'input' => 'true',
+            'expected' => new CacheAttribute(),
+        ];
+
+        yield 'string "1" returns empty CacheAttribute' => [
+            'input' => '1',
+            'expected' => new CacheAttribute(),
+        ];
+
+        yield 'string "false" returns null' => [
+            'input' => 'false',
+            'expected' => null,
+        ];
+
+        yield 'string "0" returns null' => [
+            'input' => '0',
+            'expected' => null,
+        ];
+
+        yield 'empty string returns null' => [
+            'input' => '',
+            'expected' => null,
+        ];
+
+        yield 'int(0) returns null' => [
+            'input' => 0,
+            'expected' => null,
+        ];
+
+        yield 'int(1) returns empty CacheAttribute' => [
+            'input' => 1,
+            'expected' => new CacheAttribute(),
+        ];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

When route is defined in xml, `_httpCache` attribute may be string.

### 2. What does this change do, exactly?

Adds support for string and int types (for bc reasons).

### 3. Describe each step to reproduce the issue or behaviour.

Create a route definition like below and try to open page with enabled cache:
```xml
<route id="frontend.demo.page"
       path="/demo/{demoId}"
       methods="GET"
       controller="Shopware\Storefront\Controller\DemoController::index">
    <default key="_httpCache">true</default>
    <default key="_routeScope"><list><string>storefront</string></list></default>
    <default key="_controllerName">demo</default>
    <default key="_controllerAction">index</default>
</route>
```

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/14381

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
