### PR TITLE
fix: Freezes when opening tab with card and iframe with meteor plugin

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init/topbar-button.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/topbar-button.init.ts
@@ -12,6 +12,18 @@ export default function initializeTopBarButtons(): void {
     // @ts-expect-error - There are no types for this as it is private API
     Shopware.ExtensionAPI.handle('__upsellingMenuButton', (configuration) => {
         const store = Shopware.Store.get('topBarButton');
+
+        // Check if button already exists to prevent duplicates on HMR
+        // @ts-expect-error - There are no types for this as it is private API
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+        const existingIndex = store.buttons.findIndex((item) => item.label === configuration.label);
+
+        if (existingIndex !== -1) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            store.buttons[existingIndex] = configuration;
+            return;
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
         store.buttons.push(configuration);
     });

--- a/src/Administration/Resources/app/administration/src/app/store/action-buttons.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/action-buttons.store.ts
@@ -25,6 +25,17 @@ const actionButtonsStore = Shopware.Store.register({
          * @param button - The button to add
          */
         add(button: ActionButtonConfig): void {
+            // Check if action button with same name, entity, and view already exists to prevent duplicates on HMR
+            const existingIndex = this.buttons.findIndex(
+                (item) => item.entity === button.entity && item.view === button.view && item.name === button.name,
+            );
+
+            if (existingIndex !== -1) {
+                // Update existing action button
+                this.buttons[existingIndex] = button;
+                return;
+            }
+
             this.buttons.push(button);
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.ts
@@ -34,6 +34,20 @@ const ExtensionComponentSectionsStore = Shopware.Store.register({
                 this.identifier[positionId] = reactive([]);
             }
 
+            // Check if section with same src already exists to prevent duplicates on HMR
+            const existingIndex = this.identifier[positionId].findIndex((item) => item.src === src);
+
+            if (existingIndex !== -1) {
+                // Update existing section
+                this.identifier[positionId][existingIndex] = {
+                    component,
+                    src,
+                    props,
+                    extensionName,
+                };
+                return;
+            }
+
             this.identifier[positionId].push({
                 component,
                 src,

--- a/src/Administration/Resources/app/administration/src/app/store/extension-sdk-module.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extension-sdk-module.store.ts
@@ -71,10 +71,24 @@ const extensionSdkModules = Shopware.Store.register({
         },
 
         addSmartBarButton(button: Omit<smartBarButtonAdd, 'responseType'>) {
+            // Check if smart bar button with same locationId already exists to prevent duplicates on HMR
+            const existingIndex = this.smartBarButtons.findIndex((item) => item.locationId === button.locationId);
+
+            if (existingIndex !== -1) {
+                // Update existing smart bar button
+                this.smartBarButtons[existingIndex] = button;
+                return;
+            }
+
             this.smartBarButtons.push(button);
         },
 
         addHiddenSmartBar(locationId: string) {
+            // Check if locationId already exists to prevent duplicates on HMR
+            if (this.hiddenSmartBars.includes(locationId)) {
+                return;
+            }
+
             this.hiddenSmartBars.push(locationId);
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/store/main-module.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/main-module.store.ts
@@ -22,6 +22,15 @@ const extensionMainModules = Shopware.Store.register({
 
     actions: {
         addMainModule({ extensionName, moduleId }: MainModule) {
+            // Check if main module with same moduleId already exists to prevent duplicates on HMR
+            const existingIndex = this.mainModules.findIndex((item) => item.moduleId === moduleId);
+
+            if (existingIndex !== -1) {
+                // Update existing main module
+                this.mainModules[existingIndex] = { extensionName, moduleId };
+                return;
+            }
+
             this.mainModules.push({
                 extensionName,
                 moduleId,

--- a/src/Administration/Resources/app/administration/src/app/store/menu-item.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/menu-item.store.ts
@@ -18,6 +18,15 @@ const menuItemStore = Shopware.Store.register({
 
     actions: {
         addMenuItem({ label, parent, position, moduleId }: MenuItemEntry) {
+            // Check if menu item with same moduleId already exists to prevent duplicates on HMR
+            const existingIndex = this.menuItems.findIndex((item) => item.moduleId === moduleId);
+
+            if (existingIndex !== -1) {
+                // Update existing menu item
+                this.menuItems[existingIndex] = { label, parent, position, moduleId };
+                return;
+            }
+
             this.menuItems.push({
                 label,
                 parent,

--- a/src/Administration/Resources/app/administration/src/app/store/modals.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/modals.store.ts
@@ -28,6 +28,28 @@ const modalsStore = Shopware.Store.register({
             buttons,
             textContent,
         }: ModalItemEntry) {
+            // Check if modal with same locationId already exists to prevent duplicates on HMR
+            // (only check if locationId is defined, as modals without locationId are stacked)
+            if (locationId) {
+                const existingIndex = this.modals.findIndex((modal) => modal.locationId === locationId);
+
+                if (existingIndex !== -1) {
+                    // Update existing modal
+                    this.modals[existingIndex] = {
+                        title,
+                        closable,
+                        showHeader,
+                        showFooter,
+                        variant,
+                        locationId,
+                        buttons: buttons ?? [],
+                        baseUrl,
+                        textContent,
+                    };
+                    return;
+                }
+            }
+
             this.modals.push({
                 title,
                 closable,

--- a/src/Administration/Resources/app/administration/src/app/store/sidebar.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/sidebar.store.ts
@@ -31,6 +31,23 @@ const sidebarsStore = Shopware.Store.register({
     actions: {
         // Extension API message methods
         addSidebar({ locationId, title, icon, resizable, baseUrl }: SidebarItemEntry) {
+            // Check if sidebar with same locationId already exists to prevent duplicates on HMR
+            const existingIndex = this.sidebars.findIndex((item) => item.locationId === locationId);
+
+            if (existingIndex !== -1) {
+                // Update existing sidebar (preserve active state)
+                const wasActive = this.sidebars[existingIndex].active;
+                this.sidebars[existingIndex] = reactive({
+                    title,
+                    icon,
+                    locationId,
+                    baseUrl,
+                    resizable,
+                    active: wasActive,
+                });
+                return;
+            }
+
             const sidebar = reactive({
                 title,
                 icon,

--- a/src/Administration/Resources/app/administration/src/app/store/tabs.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/tabs.store.ts
@@ -25,6 +25,21 @@ const tabsStore = Shopware.Store.register({
                 this.tabItems[positionId] = [];
             }
 
+            // Check if tab with same componentSectionId already exists to prevent duplicates
+            // This is important for HMR: when extension modules re-execute, they call addTabItem again
+            const existingIndex = this.tabItems[positionId].findIndex(
+                (item) => item.componentSectionId === componentSectionId,
+            );
+
+            if (existingIndex !== -1) {
+                // Update existing tab item (label might have changed)
+                this.tabItems[positionId][existingIndex] = {
+                    label,
+                    componentSectionId,
+                };
+                return;
+            }
+
             this.tabItems[positionId].push({
                 label,
                 componentSectionId,

--- a/src/Administration/Resources/app/administration/src/app/store/teaser-popover.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/teaser-popover.store.ts
@@ -54,6 +54,17 @@ const teaserPopoverStore = Shopware.Store.register({
         },
 
         addSalesChannel(popoverComponent: TeaserSalesChannelConfig): void {
+            // Check if sales channel with same title already exists to prevent duplicates on HMR
+            const existingIndex = this.salesChannels.findIndex(
+                (item) => item.salesChannel.title === popoverComponent.salesChannel.title,
+            );
+
+            if (existingIndex !== -1) {
+                // Update existing sales channel
+                this.salesChannels[existingIndex] = popoverComponent;
+                return;
+            }
+
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             this.salesChannels.push(popoverComponent);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/store/overview-cards.store.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/store/overview-cards.store.ts
@@ -18,6 +18,15 @@ const paymentOverviewCardStore = Shopware.Store.register({
 
     actions: {
         add(paymentOverviewCard: PaymentOverviewCard) {
+            // Check if card with same positionId already exists to prevent duplicates on HMR
+            const existingIndex = this.cards.findIndex((item) => item.positionId === paymentOverviewCard.positionId);
+
+            if (existingIndex !== -1) {
+                // Update existing card
+                this.cards[existingIndex] = paymentOverviewCard;
+                return;
+            }
+
             this.cards.push(paymentOverviewCard);
         },
     },


### PR DESCRIPTION
Closes https://github.com/shopware/shopware/issues/14347.

The issue occurs when Vite reloads the iframe and re-executes the entire plugin, adding items to the frontend again. As this is not problematic enough, it somehow ends in an endless loop of adding items.
In that issue specifically, it added an infinite number of tabs.

**Current state of PR:**
The issue itself is fixed, but there are probably more situations outside of tabs where the same issue could arise.
Band-Aid fixes that deduplicate store mutations.

**Findings:**
All relevant stores provide mutation methods, making deduplication easy, except for the 'topBarButton' store. We should also provide methods here for consistency, which may, unfortunately, lead to breaking changes.

**New approach in development:**
TL;DR: after a reload, remove all items from the extension and add them again.

Example made for the tabs store:
When a tab is added, it is grouped by the extension that added it.
When an iframe is reloaded, the extension initially sends a message that removes all entries from all relevant stores created by this specific extension. Running the extension further adds the tabs back to the stores, at the position where the group was before, resulting in a new state that mirrors the previous one, with the relevant code change incorporated.

Grouping is done because an iframe reload would otherwise change the tab order when multiple extensions add tabs, since they'd be added at the end. Without grouping, it could also cause different orders due to race conditions across multiple extensions.