### PR TITLE
feat: add support for ReverseInherited flag in attributed entities

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Attribute/ReverseInherited.php
+++ b/src/Core/Framework/DataAbstractionLayer/Attribute/ReverseInherited.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Attribute;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class ReverseInherited
+{
+    public function __construct(
+        public string $propertyName
+    ) {
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Attribute\PrimaryKey as Primary
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Protection;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ReferenceVersion;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Required as RequiredAttr;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ReverseInherited as ReverseInheritedAttr;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Serialized;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\State;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Translations;
@@ -45,6 +46,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ReverseInherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SetNullOnDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\WriteProtected;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
@@ -303,6 +305,11 @@ class AttributeEntityCompiler
         if ($inherited = $this->getAttribute($property, InheritedAttr::class)) {
             $instance = $inherited->newInstance();
             $flags[Inherited::class] = ['class' => Inherited::class, 'args' => [$instance->foreignKey]];
+        }
+
+        if ($reverseInherited = $this->getAttribute($property, ReverseInheritedAttr::class)) {
+            $instance = $reverseInherited->newInstance();
+            $flags[ReverseInherited::class] = ['class' => ReverseInherited::class, 'args' => ['propertyName' => $instance->propertyName]];
         }
 
         if ($this->getAttribute($property, AllowEmptyStringAttr::class)) {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ReverseInherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldType\DateInterval;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
@@ -969,6 +970,13 @@ class AttributeEntityIntegrationTest extends TestCase
         $inheritedFlag = $inheritedWithForeignKeyField->getFlag(Inherited::class);
         static::assertInstanceOf(Inherited::class, $inheritedFlag);
         static::assertSame('custom_fk', $inheritedFlag->getForeignKey());
+
+        $productField = $definition->getFields()->get('product');
+        static::assertNotNull($productField, 'product field should exist');
+        static::assertTrue(
+            $productField->is(ReverseInherited::class),
+            'product association field should have ReverseInherited flag'
+        );
     }
 
     /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntityWithInheritance.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntityWithInheritance.php
@@ -2,13 +2,16 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture;
 
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\FieldType;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ForeignKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Inherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ManyToOne;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\OnDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ReverseInherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity as EntityStruct;
 use Shopware\Core\System\Currency\CurrencyEntity;
 
@@ -54,4 +57,11 @@ class AttributeEntityWithInheritance extends EntityStruct
     #[Inherited(foreignKey: 'custom_fk')]
     #[Field(type: FieldType::STRING)]
     public ?string $inheritedWithForeignKey = null;
+
+    /**
+     * Product association - marked as reverse inherited.
+     */
+    #[ManyToOne(entity: 'product', onDelete: OnDelete::RESTRICT)]
+    #[ReverseInherited(propertyName: 'attributed')]
+    public ?ProductEntity $product = null;
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/AttributeEntityCompilerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/AttributeEntityCompilerTest.php
@@ -34,6 +34,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited as Inherit
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ReverseInherited as ReverseInheritedFlag;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SetNullOnDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
@@ -91,11 +92,12 @@ class AttributeEntityCompilerTest extends TestCase
 
         static::assertNotNull($entityDefinition, 'Entity definition not found in compiled result');
 
-        // Find fields with Inherited flag
+        // Find fields with Inherited and ReverseInherited flag
         $inheritedStringField = null;
         $inheritedCurrencyIdField = null;
         $inheritedCurrencyField = null;
         $inheritedWithForeignKeyField = null;
+        $inheritedProductField = null;
 
         foreach ($entityDefinition['fields'] as $field) {
             switch ($field['name'] ?? null) {
@@ -110,6 +112,9 @@ class AttributeEntityCompilerTest extends TestCase
                     break;
                 case 'inheritedWithForeignKey':
                     $inheritedWithForeignKeyField = $field;
+                    break;
+                case 'product':
+                    $inheritedProductField = $field;
                     break;
             }
         }
@@ -139,6 +144,13 @@ class AttributeEntityCompilerTest extends TestCase
         static::assertIsArray($inheritedWithForeignKeyField['flags'][InheritedFlag::class]);
         static::assertSame(InheritedFlag::class, $inheritedWithForeignKeyField['flags'][InheritedFlag::class]['class']);
         static::assertSame(['custom_fk'], $inheritedWithForeignKeyField['flags'][InheritedFlag::class]['args'], 'foreignKey parameter should be passed through');
+
+        // Verify inherited association field has ReverseInherited flag
+        static::assertNotNull($inheritedProductField, 'product field not found');
+        static::assertArrayHasKey(ReverseInheritedFlag::class, $inheritedProductField['flags'], 'product should have ReverseInherited flag');
+        static::assertIsArray($inheritedProductField['flags'][ReverseInheritedFlag::class]);
+        static::assertSame(ReverseInheritedFlag::class, $inheritedProductField['flags'][ReverseInheritedFlag::class]['class']);
+        static::assertSame(['propertyName' => 'attributed'], $inheritedProductField['flags'][ReverseInheritedFlag::class]['args']);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

#14285 fixed the `Inherited` attribute, but we never had a `ReverseInherited` attribute. This change adds it.


### 2. What does this change do, exactly?

Add a `ReverseInherited` attribute that converts into the ` ReverseInherited` flag.

### 3. Describe each step to reproduce the issue or behaviour.

Try to create an attributed entity with a reverse inherited column. You currently can't.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Note: the `Inherited` attribute has no documentation, so I didn't add any for this attribute. Should we (at some point) add docs for both? Also do we need this change in `RELEASE_INFO-6.7.md`? And if so, do we need the change from #14285 there as well?