### PR TITLE
fix: add missing foreign key name

### DIFF
--- a/src/Core/Migration/V6_3/Migration1574082635AddOrderLineItemProductId.php
+++ b/src/Core/Migration/V6_3/Migration1574082635AddOrderLineItemProductId.php
@@ -27,7 +27,7 @@ class Migration1574082635AddOrderLineItemProductId extends MigrationStep
 
         $connection->executeStatement('UPDATE IGNORE order_line_item SET product_id = UNHEX(referenced_id) WHERE type = \'product\'');
 
-        $connection->executeStatement('ALTER TABLE `order_line_item` ADD FOREIGN KEY (`product_id`, `product_version_id`) REFERENCES `product` (`id`, `version_id`) ON DELETE SET NULL ON UPDATE CASCADE');
+        $connection->executeStatement('ALTER TABLE `order_line_item` ADD CONSTRAINT `fk.order_line_item.product` FOREIGN KEY (`product_id`, `product_version_id`) REFERENCES `product` (`id`, `version_id`) ON DELETE SET NULL ON UPDATE CASCADE');
     }
 
     public function updateDestructive(Connection $connection): void

--- a/src/Core/Migration/V6_4/Migration1620215586FixManufacturerForeignKey.php
+++ b/src/Core/Migration/V6_4/Migration1620215586FixManufacturerForeignKey.php
@@ -20,7 +20,7 @@ class Migration1620215586FixManufacturerForeignKey extends MigrationStep
     public function update(Connection $connection): void
     {
         $this->dropForeignKeyIfExists($connection, 'product', 'fk.product.product_manufacturer_id');
-        $connection->executeStatement('ALTER TABLE `product` ADD FOREIGN KEY (`product_manufacturer_id`, `product_manufacturer_version_id`) REFERENCES `product_manufacturer` (`id`, `version_id`) ON DELETE SET NULL ON UPDATE CASCADE;');
+        $connection->executeStatement('ALTER TABLE `product` ADD CONSTRAINT `fk.product.product_manufacturer` FOREIGN KEY (`product_manufacturer_id`, `product_manufacturer_version_id`) REFERENCES `product_manufacturer` (`id`, `version_id`) ON DELETE SET NULL ON UPDATE CASCADE;');
     }
 
     public function updateDestructive(Connection $connection): void


### PR DESCRIPTION
### 1. Why is this change necessary?

MariaDB dump to MySQL 8.4 is not working. As we created foreign key without a name, it got auto increment name `1` unique by table. The foreign key names are unique in MySQL 8.4 by database.

So `product` and `order_line_item` has foreign key `1` and that crashes the import.

I didn't added a new migration as both tables are pretty huge and removing FK and adding FK will take 30s to a hour on larger systems. Don't see the benefit. I am gonna have to patch this anyway in shopware-cli for older versions.


### 2. What does this change do, exactly?

Give the FK a name.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
