### PR TITLE
fix: criteria set includes fields doesnt work when JsonEntityEncoder::encode extensions

### DIFF
--- a/src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
+++ b/src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Struct\Collection;
 use Shopware\Core\Framework\Struct\Struct;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -75,6 +76,7 @@ class JsonEntityEncoder
 
         $includes = $criteria->getIncludes() ?? [];
         $excludes = $criteria->getExcludes() ?? [];
+
         $decoded = $this->filterDecodedFields($includes, $excludes, $decoded, $entity);
 
         if (isset($decoded['customFields']) && $decoded['customFields'] === []) {
@@ -87,6 +89,14 @@ class JsonEntityEncoder
 
         if (isset($decoded['extensions'])) {
             unset($decoded['extensions']['foreignKeys']);
+
+            foreach ($decoded['extensions'] as $extensionName => $extensionData) {
+                if ($extensionData !== [] && $entity->hasExtension($extensionName)) {
+                    $extension = $entity->getExtension($extensionName);
+
+                    $decoded['extensions'][$extensionName] = $this->filterDecodedFields($includes, $excludes, [$extensionName => $extensionData], new ArrayStruct([$extensionName => $extension], $extension->getApiAlias()))[$extensionName];
+                }
+            }
 
             if ($decoded['extensions'] === []) {
                 unset($decoded['extensions']);

--- a/tests/integration/Core/Framework/Api/Serializer/JsonEntityEncoderTest.php
+++ b/tests/integration/Core/Framework/Api/Serializer/JsonEntityEncoderTest.php
@@ -33,6 +33,7 @@ use Shopware\Tests\Integration\Core\Framework\Api\Serializer\fixtures\TestBasicW
 use Shopware\Tests\Integration\Core\Framework\Api\Serializer\fixtures\TestBasicWithToOneRelationship;
 use Shopware\Tests\Integration\Core\Framework\Api\Serializer\fixtures\TestCollectionWithSelfReference;
 use Shopware\Tests\Integration\Core\Framework\Api\Serializer\fixtures\TestCollectionWithToOneRelationship;
+use Shopware\Tests\Integration\Core\Framework\Api\Serializer\fixtures\TestExcludeFieldsWithExtension;
 use Shopware\Tests\Integration\Core\Framework\Api\Serializer\fixtures\TestInternalFieldsAreFiltered;
 use Shopware\Tests\Integration\Core\Framework\Api\Serializer\fixtures\TestMainResourceShouldNotBeInIncluded;
 
@@ -116,6 +117,43 @@ class JsonEntityEncoderTest extends TestCase
         $actual = $encoder->encode(new Criteria(), $extendableDefinition, $fixture->getInput(), SerializationFixture::API_BASE_URL);
 
         unset($actual['apiAlias']);
+        static::assertEquals($fixture->getAdminJsonFixtures(), $actual);
+        $this->assertValues($fixture->getAdminJsonFixtures(), $actual);
+    }
+
+    public function testEncodeStructWithExtensionExcludesFields(): void
+    {
+        $this->registerDefinition(ExtendableDefinition::class, ExtendedDefinition::class);
+        $extendableDefinition = new ExtendableDefinition();
+        $extendableDefinition->addExtension(new AssociationExtension());
+        $extendableDefinition->addExtension(new ScalarRuntimeExtension());
+
+        $extendableDefinition->compile(static::getContainer()->get(DefinitionInstanceRegistry::class));
+        $fixture = new TestExcludeFieldsWithExtension();
+
+        $encoder = static::getContainer()->get(JsonEntityEncoder::class);
+        $criteria = new Criteria();
+
+        $criteria->setIncludes([
+            'array' => [
+                'id',
+                'createdAt',
+                'extensions',
+                'name',
+                'toOne',
+                'toMany',
+            ],
+        ]);
+        $criteria->setExcludes([
+            'array' => [
+                'forbiddenFields',
+            ],
+        ]);
+
+        $actual = $encoder->encode($criteria, $extendableDefinition, $fixture->getInput(), SerializationFixture::API_BASE_URL);
+
+        unset($actual['apiAlias']);
+
         static::assertEquals($fixture->getAdminJsonFixtures(), $actual);
         $this->assertValues($fixture->getAdminJsonFixtures(), $actual);
     }

--- a/tests/integration/Core/Framework/Api/Serializer/fixtures/TestBasicWithToManyExtension.php
+++ b/tests/integration/Core/Framework/Api/Serializer/fixtures/TestBasicWithToManyExtension.php
@@ -138,6 +138,7 @@ class TestBasicWithToManyExtension extends SerializationFixture
                         'extensions' => [],
                         'id' => '548faa1f7846436c85944f4aea792d96',
                         'name' => 'toMany#1',
+                        'apiAlias' => 'array',
                     ],
                 ],
             ],

--- a/tests/integration/Core/Framework/Api/Serializer/fixtures/TestExcludeFieldsWithExtension.php
+++ b/tests/integration/Core/Framework/Api/Serializer/fixtures/TestExcludeFieldsWithExtension.php
@@ -9,45 +9,42 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 /**
  * @internal
  */
-class TestBasicWithExtension extends SerializationFixture
+class TestExcludeFieldsWithExtension extends SerializationFixture
 {
     public function getInput(): EntityCollection|Entity
     {
         $extendable = new ArrayEntity([
             'id' => '1d23c1b015bf43fb97e89008cf42d6fe',
+            'name' => 'main',
             'createdAt' => new \DateTime('2018-01-15T08:01:16.000+00:00'),
         ]);
-
-        $extendable->addExtension('toOne', new ArrayEntity([
-            'id' => '6f51622eb3814c75ae0263cece27ce72',
-            'name' => 'toOne',
-        ]));
-
-        $extendable->addExtension('toOneWithoutApiAware', new ArrayEntity([
-            'id' => '6f51622eb3814c75ae0263cece27ce72',
-            'name' => 'toOneWithoutApiAware',
-        ]));
 
         $collection = new EntityCollection([
             new ArrayEntity([
                 'id' => '548faa1f7846436c85944f4aea792d96',
+                'forbiddenFields' => 'should be excluded',
                 'name' => 'toMany#1',
             ]),
             new ArrayEntity([
-                'id' => '3e352be2d85846dd97529c0f6b544870',
+                'id' => '548faa1f7846436c85944f4aea792d97',
+                'forbiddenFields' => 'should be excluded',
                 'name' => 'toMany#2',
             ]),
         ]);
 
         $extendable->addExtension('toMany', $collection);
-
-        $extendable->addExtension('test', new ArrayEntity([
-            'test' => 'testValue',
+        $extendable->addExtension('toOne', new ArrayEntity([
+            'id' => '548faa1f7846436c85944f4aea792d95',
+            'forbiddenFields' => 'should be excluded',
+            'name' => 'toOne',
         ]));
 
         return $extendable;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getJsonApiFixtures(string $baseUrl): array
     {
         return [
@@ -77,9 +74,9 @@ class TestBasicWithExtension extends SerializationFixture
                     'type' => 'extended',
                     'attributes' => [
                         'name' => 'toMany#1',
-                        'extendableId' => null,
                         'createdAt' => null,
                         'updatedAt' => null,
+                        'extendableId' => null,
                     ],
                     'links' => [
                         'self' => \sprintf('%s/extended/548faa1f7846436c85944f4aea792d96', $baseUrl),
@@ -101,71 +98,9 @@ class TestBasicWithExtension extends SerializationFixture
                     'meta' => [],
                 ],
                 [
-                    'id' => '3e352be2d85846dd97529c0f6b544870',
-                    'type' => 'extended',
-                    'attributes' => [
-                        'name' => 'toMany#2',
-                        'extendableId' => null,
-                        'createdAt' => null,
-                        'updatedAt' => null,
-                    ],
-                    'links' => [
-                        'self' => \sprintf('%s/extended/3e352be2d85846dd97529c0f6b544870', $baseUrl),
-                    ],
-                    'relationships' => [
-                        'toOne' => [
-                            'data' => null,
-                            'links' => [
-                                'related' => \sprintf('%s/extended/3e352be2d85846dd97529c0f6b544870/to-one', $baseUrl),
-                            ],
-                        ],
-                        'toMany' => [
-                            'data' => null,
-                            'links' => [
-                                'related' => \sprintf('%s/extended/3e352be2d85846dd97529c0f6b544870/to-many', $baseUrl),
-                            ],
-                        ],
-                    ],
-                    'meta' => [],
-                ],
-                [
-                    'id' => '6f51622eb3814c75ae0263cece27ce72',
-                    'type' => 'extended',
-                    'attributes' => [
-                        'name' => 'toOne',
-                        'extendableId' => null,
-                        'createdAt' => null,
-                        'updatedAt' => null,
-                    ],
-                    'links' => [
-                        'self' => \sprintf('%s/extended/6f51622eb3814c75ae0263cece27ce72', $baseUrl),
-                    ],
-                    'relationships' => [
-                        'toOne' => [
-                            'data' => null,
-                            'links' => [
-                                'related' => \sprintf('%s/extended/6f51622eb3814c75ae0263cece27ce72/to-one', $baseUrl),
-                            ],
-                        ],
-                        'toMany' => [
-                            'data' => null,
-                            'links' => [
-                                'related' => \sprintf('%s/extended/6f51622eb3814c75ae0263cece27ce72/to-many', $baseUrl),
-                            ],
-                        ],
-                    ],
-                    'meta' => [],
-                ],
-                [
                     'id' => '1d23c1b015bf43fb97e89008cf42d6fe',
                     'type' => 'extension',
-                    'attributes' => [
-                        'test' => [
-                            'extensions' => [],
-                            'translated' => [],
-                            'test' => 'testValue',
-                        ],
-                    ],
+                    'attributes' => [],
                     'links' => [],
                     'relationships' => [
                         'toMany' => [
@@ -174,20 +109,13 @@ class TestBasicWithExtension extends SerializationFixture
                                     'type' => 'extended',
                                     'id' => '548faa1f7846436c85944f4aea792d96',
                                 ],
-                                [
-                                    'type' => 'extended',
-                                    'id' => '3e352be2d85846dd97529c0f6b544870',
-                                ],
                             ],
                             'links' => [
                                 'related' => \sprintf('%s/extendable/1d23c1b015bf43fb97e89008cf42d6fe/extensions/toMany', $baseUrl),
                             ],
                         ],
                         'toOne' => [
-                            'data' => [
-                                'type' => 'extended',
-                                'id' => '6f51622eb3814c75ae0263cece27ce72',
-                            ],
+                            'data' => null,
                             'links' => [
                                 'related' => \sprintf('%s/extendable/1d23c1b015bf43fb97e89008cf42d6fe/extensions/toOne', $baseUrl),
                             ],
@@ -199,43 +127,37 @@ class TestBasicWithExtension extends SerializationFixture
         ];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getJsonFixtures(): array
     {
         return [
-            'id' => '1d23c1b015bf43fb97e89008cf42d6fe',
-            'createdAt' => '2018-01-15T08:01:16.000+00:00',
-            'translated' => [],
             'extensions' => [
-                'toOne' => [
-                    'translated' => [],
-                    'extensions' => [],
-                    'id' => '6f51622eb3814c75ae0263cece27ce72',
-                    'name' => 'toOne',
-                    'apiAlias' => 'array',
-                ],
                 'toMany' => [
                     [
-                        'translated' => [],
                         'extensions' => [],
                         'id' => '548faa1f7846436c85944f4aea792d96',
                         'name' => 'toMany#1',
                         'apiAlias' => 'array',
                     ],
                     [
-                        'translated' => [],
                         'extensions' => [],
-                        'id' => '3e352be2d85846dd97529c0f6b544870',
+                        'id' => '548faa1f7846436c85944f4aea792d97',
                         'name' => 'toMany#2',
                         'apiAlias' => 'array',
                     ],
                 ],
-                'test' => [
-                    'translated' => [],
+                'toOne' => [
                     'extensions' => [],
-                    'test' => 'testValue',
+                    'id' => '548faa1f7846436c85944f4aea792d95',
+                    'name' => 'toOne',
                     'apiAlias' => 'array',
                 ],
             ],
+            'id' => '1d23c1b015bf43fb97e89008cf42d6fe',
+            'name' => 'main',
+            'createdAt' => '2018-01-15T08:01:16.000+00:00',
         ];
     }
 }


### PR DESCRIPTION
When requesting API with header `application/json` and provide criteria.includes or criteria.excludes in the request payload, it should includes/excludes given fields in the response. It works fine for normal entities, but for Extensions (for e.g, add association via EntityExtension and load them over admin api), the includes/excludes doesn't work for the extensions entities.