### PR TITLE
fix: shop logo size when using smaller viewports in checkout

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_header-minimal.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_header-minimal.scss
@@ -39,6 +39,10 @@ Contains custom styles for the minimal header which is used on checkout pages.
     display: flex;
     align-items: center;
     margin-bottom: $spacer-xs;
+
+    .header-logo-picture {
+        min-width: unset;
+    }
 }
 
 .header-minimal-home {

--- a/src/Storefront/Resources/views/storefront/layout/header/header-minimal.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/header-minimal.html.twig
@@ -19,7 +19,7 @@
                         {% endblock %}
 
                         {% block layout_header_minimal_button %}
-                            <div class="col-md-4 header-minimal-back-to-shop">
+                            <div class="col-6 col-md-4 header-minimal-back-to-shop">
                                 <a href="{{ path('frontend.home.page') }}"
                                    class="btn btn-outline-primary header-minimal-back-to-shop-button"
                                    title="{{ 'checkout.finishButtonBackToShop'|trans|striptags }}">

--- a/src/Storefront/Resources/views/storefront/page/account/order/header.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order/header.html.twig
@@ -1,7 +1,7 @@
 {% sw_extends '@Storefront/storefront/layout/header/header-minimal.html.twig' %}
 
 {% block layout_header_minimal_button %}
-    <div class="col-md-4 header-minimal-back-to-shop">
+    <div class="col-6 col-md-4 header-minimal-back-to-shop">
         {% if context.customer and context.customer.guest %}
             <a href="{{ path('frontend.account.order.single.page', {deepLinkCode: page.order.deepLinkCode}) }}"
             class="btn btn-outline-primary header-minimal-back-to-shop-button"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfill our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

This change is necessary so that on smaller screens the "Back to Shop" button stays next to the logo.

### 2. What does this change do, exactly?

* Unsetting the minimal width of the logo in the minimal header via css
* Adding `col-6` to the `header-minimal-back-to-shop` column

### 3. Describe each step to reproduce the issue or behaviour.

Navigate to `/checkout/register` and scale the viewport to something smaller than 390 px. The "Back to Shop" button and the shop logo get in the way of each other.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes https://github.com/shopware/shopware/issues/8459

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
