### PR TITLE
Fix: proxy sales channel supported language

### DIFF
--- a/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
+++ b/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
@@ -491,7 +491,7 @@ class SalesChannelProxyController extends AbstractController
 
     private function validLanguageId(SalesChannelEntity $salesChannel, ?string $languageId): bool
     {
-        if ($salesChannel->getLanguageId() === $languageId) {
+        if ($languageId === null || $salesChannel->getLanguageId() === $languageId) {
             return true;
         }
 

--- a/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
+++ b/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
@@ -292,6 +292,10 @@ class SalesChannelProxyController extends AbstractController
         $subrequest->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $contextToken);
         $subrequest->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_CLIENT_ID, $salesChannel->getAccessKey());
 
+        if (!$this->validLanguageId($salesChannel, $request->headers->get(PlatformRequest::HEADER_LANGUAGE_ID))) {
+            $subrequest->headers->set(PlatformRequest::HEADER_LANGUAGE_ID, $salesChannel->getLanguageId());
+        }
+
         $salesChannelContext = $this->fetchSalesChannelContext($salesChannelId, $subrequest, $context);
 
         if ($path === self::SEARCH_ROUTE) {
@@ -483,5 +487,18 @@ class SalesChannelProxyController extends AbstractController
         $validation->add('unitPrice', new NotBlank(), new Type('numeric'), new GreaterThanOrEqual(value: 0));
         $validation->add('totalPrice', new NotBlank(), new Type('numeric'), new GreaterThanOrEqual(value: 0));
         $this->validator->validate($request->request->all('shippingCosts'), $validation);
+    }
+
+    private function validLanguageId(SalesChannelEntity $salesChannel, ?string $languageId): bool
+    {
+        if ($salesChannel->getLanguageId() === $languageId) {
+            return true;
+        }
+
+        $criteria = (new Criteria([$salesChannel->getId()]))
+            ->setLimit(1)
+            ->addFilter(new EqualsFilter('languages.id', $languageId));
+
+        return (bool) $this->salesChannelRepository->searchIds($criteria, Context::createDefaultContext())->getTotal();
     }
 }

--- a/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
@@ -190,6 +190,51 @@ class SalesChannelProxyControllerTest extends TestCase
         );
     }
 
+    public function testNonValidLanguages(): void
+    {
+        $salesChannelLanguageId = Uuid::randomHex();
+        $salesChannel = $this->createSalesChannel();
+        $this->createLanguage($salesChannelLanguageId, $salesChannel['id']);
+
+        $salesChannelData = ['languageId' => $salesChannelLanguageId];
+        $this->getBrowser()->jsonRequest('PATCH', '/api/sales-channel/' . $salesChannel['id'], $salesChannelData);
+
+        // create a new language not connected to the sales channel
+        $langId = Uuid::randomHex();
+        $localeId = Uuid::randomHex();
+        $languageData = [
+            'id' => $langId,
+            'name' => 'random language ' . $langId,
+            'locale' => [
+                'id' => $localeId,
+                'code' => 'x-tst_' . $localeId,
+                'name' => 'Random locale ' . $localeId,
+                'territory' => 'Random territory ' . $localeId,
+            ],
+            'translationCodeId' => $localeId,
+            'active' => true,
+        ];
+
+        $this->getBrowser()->jsonRequest('POST', '/api/language', $languageData);
+        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
+
+        $this->getBrowser()->request('GET', '/api/language/' . $langId);
+
+
+        $this->assertTranslation(
+            ['name' => 'third translation', 'translated' => ['name' => 'third translation']],
+            [
+                'translations' => [
+                    Defaults::LANGUAGE_SYSTEM => ['name' => 'not translated'],
+                    $langId => ['name' => 'second translated'],
+                    $salesChannelLanguageId => ['name' => 'third translation'],
+                ],
+            ],
+            $salesChannel['id'],
+            $langId
+        );
+    }
+
     public function testUpdatingPromotionAfterUpdateProductLineItem(): void
     {
         $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);


### PR DESCRIPTION
### 1. Why is this change necessary?
While creating an order via admin, a not supported language could be used in the request.

### 2. What does this change do, exactly?
Checks, if a language is supported by the sales channel. Otherwise, the default language of the sales channel will be used

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a Sales Channel and select only German as Language.
2. Use English (Default) for administration
3. Add new order → Select customer → select Sales Channel above

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/11389

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
