### PR TITLE
fix: transitive dependency for phpseclib/phpseclib

### DIFF
--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -90,6 +90,7 @@
         "psr/http-factory": "^1.0.1",
         "psr/http-message": "^1.1 || ^2.0",
         "psr/log": "^3.0.0",
+        "phpseclib/phpseclib": "^3.0",
         "ramsey/uuid": "^4.7",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",


### PR DESCRIPTION
### 1. Why is this change necessary?

IAP works by luck that we have phpseclib as transitive dependency: https://github.com/search?q=repo%3Ashopware%2Fshopware+phpseclib+path%3A%2F%5Esrc%5C%2FCore%2F&type=code

it's not required right now by shopware/core


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
