### PR TITLE
fix: optimize default product seo category selection

### DIFF
--- a/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
+++ b/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
@@ -94,6 +95,7 @@ class CategoryBreadcrumbBuilder
         $criteria->setTitle('breadcrumb-builder');
         $criteria->setLimit(1);
         $criteria->addFilter(new EqualsFilter('active', true));
+        $criteria->addFilter(new EqualsFilter('visible', true));
 
         if (!empty($categoryIds)) {
             $criteria->setIds($categoryIds);
@@ -103,6 +105,7 @@ class CategoryBreadcrumbBuilder
         }
 
         $criteria->addFilter($this->getSalesChannelFilter($context->getSalesChannel()));
+        $criteria->addSorting(new FieldSorting('level', FieldSorting::DESCENDING));
 
         return $this->categoryRepository->search($criteria, $context->getContext())->first();
     }

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -19,6 +19,9 @@ use Shopware\Core\Content\Seo\MainCategory\MainCategoryCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -134,6 +137,67 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
 
         static::assertNotNull($categoryEntity);
+    }
+
+    public function testGetProductSeoCategoryShouldReturnDeepestVisibleActiveCategory(): void
+    {
+        $categoryIds = [Uuid::randomHex()];
+
+        $categoryEntity = new CategoryEntity();
+        $categoryEntity->setId($categoryIds[0]);
+        $categoryEntity->setName('category-name-1');
+
+        $categoryRepositoryMock = $this->getCategoryRepositoryMock([], [$categoryEntity]);
+        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
+            $categoryRepositoryMock,
+            $this->getProductRepositoryMock([], []),
+            $this->getConnectionMock()
+        );
+        $product = $this->getProductEntity([], $categoryIds);
+
+        $searchCalls = 0;
+
+        $categoryRepositoryMock->expects($this->exactly(2))
+            ->method('search')
+            ->willReturnCallback(function (Criteria $criteria) use (&$searchCalls): void {
+                ++$searchCalls;
+
+                if ($searchCalls !== 2) {
+                    return;
+                }
+
+                $levelSorting = array_values(array_filter(
+                    $criteria->getSorting(),
+                    static fn (FieldSorting $sorting) => $sorting->getField() === 'level'
+                ))[0] ?? null;
+
+                static::assertNotNull($levelSorting);
+                static::assertSame(FieldSorting::DESCENDING, $levelSorting->getDirection());
+
+                static::assertTrue($criteria->hasEqualsFilter('visible'));
+
+                /** @var EqualsFilter|null $visibleFilter */
+                $visibleFilter = array_values(array_filter(
+                    $criteria->getFilters(),
+                    static fn (Filter $filter) => $filter instanceof EqualsFilter && $filter->getField() === 'visible'
+                ))[0] ?? null;
+
+                static::assertNotNull($visibleFilter);
+                static::assertTrue($visibleFilter->getValue());
+
+                static::assertTrue($criteria->hasEqualsFilter('active'));
+
+                /** @var EqualsFilter|null $activeFilter */
+                $activeFilter = array_values(array_filter(
+                    $criteria->getFilters(),
+                    static fn (Filter $filter) => $filter instanceof EqualsFilter && $filter->getField() === 'active'
+                ))[0] ?? null;
+
+                static::assertNotNull($activeFilter);
+                static::assertTrue($activeFilter->getValue());
+            });
+
+        $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
     }
 
     public function testConvertCategoriesToBreadcrumbUrlsWithSeoUrls(): void

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -176,24 +176,22 @@ class CategoryBreadcrumbBuilderTest extends TestCase
 
                 static::assertTrue($criteria->hasEqualsFilter('visible'));
 
-                /** @var EqualsFilter|null $visibleFilter */
                 $visibleFilter = array_values(array_filter(
                     $criteria->getFilters(),
                     static fn (Filter $filter) => $filter instanceof EqualsFilter && $filter->getField() === 'visible'
                 ))[0] ?? null;
 
-                static::assertNotNull($visibleFilter);
+                static::assertInstanceOf(EqualsFilter::class, $visibleFilter);
                 static::assertTrue($visibleFilter->getValue());
 
                 static::assertTrue($criteria->hasEqualsFilter('active'));
 
-                /** @var EqualsFilter|null $activeFilter */
                 $activeFilter = array_values(array_filter(
                     $criteria->getFilters(),
                     static fn (Filter $filter) => $filter instanceof EqualsFilter && $filter->getField() === 'active'
                 ))[0] ?? null;
 
-                static::assertNotNull($activeFilter);
+                static::assertInstanceOf(EqualsFilter::class, $activeFilter);
                 static::assertTrue($activeFilter->getValue());
             });
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
1. I do not expect hidden categories in breadcrumbs.
2. Deepest category should be selected as default breadcrumb to get the most informative one if there are multiple associated categories on a product.

### 2. What does this change do, exactly?
Adjust the criteria by adding `visible` filter and `level` sorting.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
