### PR TITLE
feat: add optional prompt param to sso redirect

### DIFF
--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -1197,6 +1197,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('jwks_path')->isRequired()->end()
                 ->scalarNode('scope')->isRequired()->end()
                 ->scalarNode('register_url')->isRequired()->end()
+                ->scalarNode('prompt')->defaultNull()->end()
             ->end();
 
         return $rootNode;

--- a/src/Core/Framework/Sso/Config/LoginConfig.php
+++ b/src/Core/Framework/Sso/Config/LoginConfig.php
@@ -20,6 +20,7 @@ final readonly class LoginConfig
      * @param non-empty-string $jwksPath
      * @param non-empty-string $scope
      * @param non-empty-string $registerUrl
+     * @param non-empty-string|null $prompt
      */
     public function __construct(
         public bool $useDefault,
@@ -32,6 +33,7 @@ final readonly class LoginConfig
         public string $jwksPath,
         public string $scope,
         public string $registerUrl,
+        public ?string $prompt,
     ) {
     }
 }

--- a/src/Core/Framework/Sso/Config/LoginConfigService.php
+++ b/src/Core/Framework/Sso/Config/LoginConfigService.php
@@ -9,6 +9,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\Url;
@@ -31,7 +32,8 @@ final readonly class LoginConfigService
      *     token_path: non-empty-string,
      *     jwks_path: non-empty-string,
      *     scope: non-empty-string,
-     *     register_url: non-empty-string
+     *     register_url: non-empty-string,
+     *     prompt?: non-empty-string
      * } $rawConfig
      */
     public function __construct(
@@ -59,6 +61,7 @@ final readonly class LoginConfigService
             $this->rawConfig['jwks_path'],
             $this->rawConfig['scope'],
             $this->rawConfig['register_url'],
+            $this->rawConfig['prompt'] ?? null,
         );
     }
 
@@ -81,20 +84,34 @@ final readonly class LoginConfigService
 
         $state = $this->router->generate('api.oauth.sso.code', ['rdm' => $random], UrlGeneratorInterface::ABSOLUTE_URL);
 
+        $params = [
+            'client_id' => $loginConfig->clientId,
+            'redirect_uri' => $loginConfig->redirectUri,
+            'response_type' => 'code',
+            'scope' => $loginConfig->scope,
+            'state' => $state,
+        ];
+
+        if ($loginConfig->prompt !== null) {
+            $params['prompt'] = $loginConfig->prompt;
+        }
+
         return \sprintf(
-            '%s%s?client_id=%s&redirect_uri=%s&response_type=code&scope=%s&state=%s',
+            '%s%s?%s',
             $loginConfig->baseUrl,
             $loginConfig->authorizePath,
-            $loginConfig->clientId,
-            \urlencode($loginConfig->redirectUri ?? ''),
-            \urlencode($loginConfig->scope),
-            \urlencode($state)
+            \http_build_query($params, '', '&', \PHP_QUERY_RFC3986)
         );
     }
 
     private function validate(): void
     {
-        $violations = Validation::createValidator()->validate($this->rawConfig, $this->createConstraint());
+        $rawConfig = $this->rawConfig;
+        if (($rawConfig['prompt'] ?? null) === null) {
+            unset($rawConfig['prompt']);
+        }
+
+        $violations = Validation::createValidator()->validate($rawConfig, $this->createConstraint());
         if ($violations->count() === 0) {
             return;
         }
@@ -173,6 +190,10 @@ final readonly class LoginConfigService
                     new Type('string', $invalidStringMessage),
                     new Url(message: $invalidUrlMessage, requireTld: true),
                 ],
+                'prompt' => new Optional([
+                    new NotBlank(null, $notBlankMessage),
+                    new Type('string', $invalidStringMessage),
+                ]),
             ],
             allowExtraFields: true,
             allowMissingFields: false,

--- a/tests/integration/Core/Framework/Sso/Helper/ValidUserServiceCreator.php
+++ b/tests/integration/Core/Framework/Sso/Helper/ValidUserServiceCreator.php
@@ -86,6 +86,7 @@ class ValidUserServiceCreator extends TestCase
             'jwks_path' => '/jwks.json',
             'scope' => 'scope',
             'register_url' => 'https://register.url',
+            'prompt' => 'login',
         ];
 
         return new LoginConfigService($rawConfig, $this->createMock(RouterInterface::class));

--- a/tests/integration/Core/Framework/Sso/ShopwareGrantTypeTest.php
+++ b/tests/integration/Core/Framework/Sso/ShopwareGrantTypeTest.php
@@ -137,6 +137,7 @@ class ShopwareGrantTypeTest extends TestCase
                 'jwks_path' => '/jwks.json',
                 'scope' => 'scope',
                 'register_url' => 'https://register.url',
+                'prompt' => 'login',
             ],
             $this->createMock(RouterInterface::class)
         );

--- a/tests/integration/Core/Framework/Sso/UserService/ShopwareRefreshTokenGrantTypeTest.php
+++ b/tests/integration/Core/Framework/Sso/UserService/ShopwareRefreshTokenGrantTypeTest.php
@@ -306,6 +306,7 @@ class ShopwareRefreshTokenGrantTypeTest extends TestCase
                 'jwks_path' => '/jwks.json',
                 'scope' => 'scope',
                 'register_url' => 'https://register.url',
+                'prompt' => 'login',
             ],
             $this->createMock(RouterInterface::class)
         );

--- a/tests/unit/Core/Framework/Api/OAuth/UserRepositoryTest.php
+++ b/tests/unit/Core/Framework/Api/OAuth/UserRepositoryTest.php
@@ -136,6 +136,7 @@ class UserRepositoryTest extends TestCase
                 'jwks_path' => '/jwks.json',
                 'scope' => 'scope',
                 'register_url' => 'https://register.url',
+                'prompt' => 'login',
             ],
             $this->createMock(RouterInterface::class)
         );

--- a/tests/unit/Core/Framework/Sso/Config/LoginConfigServiceTest.php
+++ b/tests/unit/Core/Framework/Sso/Config/LoginConfigServiceTest.php
@@ -40,6 +40,7 @@ class LoginConfigServiceTest extends TestCase
             'jwks_path' => '/jwks.json',
             'scope' => 'scope',
             'register_url' => 'http://register.url',
+            'prompt' => 'login',
         ];
 
         $configService = $this->createLoginConfigService($rawConfig);
@@ -54,10 +55,11 @@ class LoginConfigServiceTest extends TestCase
         static::assertSame($rawConfig['base_url'], $config->baseUrl);
         static::assertSame($rawConfig['authorize_path'], $config->authorizePath);
         static::assertSame($rawConfig['token_path'], $config->tokenPath);
+        static::assertSame($rawConfig['prompt'], $config->prompt);
     }
 
     /**
-     * @param array{use_default: bool, client_id: non-empty-string, client_secret: non-empty-string, redirect_uri: non-empty-string, base_url: non-empty-string, authorize_path: non-empty-string, token_path: non-empty-string, jwks_path: non-empty-string, scope: non-empty-string, register_url: non-empty-string} $rawConfig
+     * @param array{use_default: bool, client_id: non-empty-string, client_secret: non-empty-string, redirect_uri: non-empty-string, base_url: non-empty-string, authorize_path: non-empty-string, token_path: non-empty-string, jwks_path: non-empty-string, scope: non-empty-string, register_url: non-empty-string, prompt?: non-empty-string} $rawConfig
      */
     #[DataProvider('getConfigErrorsTestDataProvider')]
     public function testGetConfigErrors(array $rawConfig, string $exceptionMessage): void
@@ -274,6 +276,14 @@ class LoginConfigServiceTest extends TestCase
                 'rawConfig' => self::createConfig(['register_url' => 'registerUrl']),
                 'exceptionMessage' => 'Login config is incomplete or misconfigured. Field errors: [register_url] is invalid URL',
             ],
+            'prompt is blank' => [
+                'rawConfig' => self::createConfig(['prompt' => '']),
+                'exceptionMessage' => 'Login config is incomplete or misconfigured. Field errors: [prompt] is blank',
+            ],
+            'prompt is not a string' => [
+                'rawConfig' => self::createConfig(['prompt' => 12]),
+                'exceptionMessage' => 'Login config is incomplete or misconfigured. Field errors: [prompt] is invalid string',
+            ],
         ];
     }
 
@@ -300,6 +310,7 @@ class LoginConfigServiceTest extends TestCase
             'jwks_path' => '/jwks.json',
             'scope' => 'scope',
             'register_url' => 'http://register.url',
+            'prompt' => 'login',
         ];
 
         $configService = $this->createLoginConfigService($rawConfig);
@@ -308,6 +319,20 @@ class LoginConfigServiceTest extends TestCase
 
         static::assertFalse($result->useDefault);
         static::assertSame('oauth.sso.auth?rdm=randomString', $result->url);
+    }
+
+    public function testCreateRedirectUrlOmitsNullPrompt(): void
+    {
+        $rawConfig = self::createConfig(['prompt' => null]);
+        $configService = $this->createLoginConfigService($rawConfig);
+
+        $loginConfig = $configService->getConfig();
+        static::assertInstanceOf(LoginConfig::class, $loginConfig);
+        static::assertNull($loginConfig->prompt);
+
+        $result = $configService->createRedirectUrl('random');
+        $query = $this->getQueryParamsAsArray($result);
+        static::assertArrayNotHasKey('prompt', $query);
     }
 
     /**
@@ -327,6 +352,11 @@ class LoginConfigServiceTest extends TestCase
         $query = $this->getQueryParamsAsArray($result);
         static::assertSame($loginConfig->clientId, $query['client_id']);
         static::assertSame($loginConfig->redirectUri, $query['redirect_uri']);
+        if ($loginConfig->prompt !== null) {
+            static::assertSame($loginConfig->prompt, $query['prompt']);
+        } else {
+            static::assertArrayNotHasKey('prompt', $query);
+        }
 
         static::assertIsString($query['state']);
 
@@ -361,8 +391,9 @@ class LoginConfigServiceTest extends TestCase
                     'jwks_path' => '/jwks.json',
                     'scope' => 'scope',
                     'register_url' => 'http://register.url',
+                    'prompt' => 'login',
                 ],
-                'expectedUrl' => 'http://justABaseUrl.net/authorize?client_id=justAClientID&redirect_uri=http%3A%2F%2FjustARedirectUri.org&response_type=code&scope=scope&state=api.oauth.sso.code%3Frdm%3DjustARandomString',
+                'expectedUrl' => 'http://justABaseUrl.net/authorize?client_id=justAClientID&redirect_uri=http%3A%2F%2FjustARedirectUri.org&response_type=code&scope=scope&state=api.oauth.sso.code%3Frdm%3DjustARandomString&prompt=login',
             ],
 
             'Test case two' => [
@@ -378,8 +409,25 @@ class LoginConfigServiceTest extends TestCase
                     'jwks_path' => '/jwks.json',
                     'scope' => 'scope',
                     'register_url' => 'http://register.url',
+                    'prompt' => 'login',
                 ],
-                'expectedUrl' => 'http://another-base-url.net/authorize?client_id=anotherClientID&redirect_uri=http%3A%2F%2Fanother-redirect-url.org&response_type=code&scope=scope&state=api.oauth.sso.code%3Frdm%3DjustARandomString',
+                'expectedUrl' => 'http://another-base-url.net/authorize?client_id=anotherClientID&redirect_uri=http%3A%2F%2Fanother-redirect-url.org&response_type=code&scope=scope&state=api.oauth.sso.code%3Frdm%3DjustARandomString&prompt=login',
+            ],
+            'Test case without prompt' => [
+                'random' => 'justARandomString',
+                'rawConfig' => [
+                    'use_default' => true,
+                    'client_id' => 'clientIDNoPrompt',
+                    'client_secret' => 'clientSecretNoPrompt',
+                    'redirect_uri' => 'http://redirect-no-prompt.org',
+                    'base_url' => 'http://base-no-prompt.net',
+                    'authorize_path' => '/authorize',
+                    'token_path' => '/token',
+                    'jwks_path' => '/jwks.json',
+                    'scope' => 'scope',
+                    'register_url' => 'http://register.url',
+                ],
+                'expectedUrl' => 'http://base-no-prompt.net/authorize?client_id=clientIDNoPrompt&redirect_uri=http%3A%2F%2Fredirect-no-prompt.org&response_type=code&scope=scope&state=api.oauth.sso.code%3Frdm%3DjustARandomString',
             ],
         ];
     }
@@ -417,6 +465,7 @@ class LoginConfigServiceTest extends TestCase
             'jwks_path' => '/jwks.json',
             'scope' => 'scope',
             'register_url' => 'http://register.url',
+            'prompt' => 'login',
         ];
 
         foreach ($unset as $key) {

--- a/tests/unit/Core/Framework/Sso/TokenService/ExternalTokenServiceTest.php
+++ b/tests/unit/Core/Framework/Sso/TokenService/ExternalTokenServiceTest.php
@@ -89,6 +89,7 @@ class ExternalTokenServiceTest extends TestCase
             'jwks_path' => '/json.json',
             'scope' => 'scope',
             'register_url' => 'https://register.url',
+            'prompt' => 'login',
         ];
 
         if ($withEmptyConfig) {

--- a/tests/unit/Core/Framework/Sso/TokenService/IdTokenParserTest.php
+++ b/tests/unit/Core/Framework/Sso/TokenService/IdTokenParserTest.php
@@ -112,6 +112,7 @@ class IdTokenParserTest extends TestCase
                 'jwks_path' => '/json.json',
                 'scope' => 'scope',
                 'register_url' => 'https://register.url',
+                'prompt' => 'login',
             ],
             $this->createMock(RouterInterface::class)
         );

--- a/tests/unit/Core/Framework/Sso/TokenService/PublicKeyLoaderTest.php
+++ b/tests/unit/Core/Framework/Sso/TokenService/PublicKeyLoaderTest.php
@@ -136,6 +136,7 @@ class PublicKeyLoaderTest extends TestCase
             'jwks_path' => '/jwks.json',
             'scope' => 'scope',
             'register_url' => 'https://register.url',
+            'prompt' => 'login',
         ];
 
         return new LoginConfigService($rawConfig, $this->createMock(RouterInterface::class));

--- a/tests/unit/Core/Saas/SsoServiceTest.php
+++ b/tests/unit/Core/Saas/SsoServiceTest.php
@@ -30,6 +30,7 @@ class SsoServiceTest extends TestCase
                 'jwks_path' => '/jwks.json',
                 'scope' => 'scope',
                 'register_url' => 'https://register.url',
+                'prompt' => 'login',
             ],
             $this->createMock(RouterInterface::class)
         );


### PR DESCRIPTION
### 1. Why is this change necessary?

Auth.shopware.com will support passwordless sessions, but SaaS logins should always force reauthentication. We need a configurable prompt parameter so SaaS can enforce
prompt=login while self‑hosted installations can omit it.

### 2. What does this change do, exactly?

Adds an optional prompt field to the SSO login configuration and appends it to the authorization redirect only when configured. This keeps the default behavior unchanged
unless SaaS sets admin_login.prompt=login.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure SSO without admin_login.prompt: the redirect URL does not include prompt.
2. Configure admin_login.prompt=login: the redirect URL includes prompt=login.

### 4. Please link to the relevant issues (if any).

closes #14183

  ### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is relevant for external developers:
    - Add a short entry to RELEASE_INFO-6.<major>.md under “Upcoming” for informational changes, including the consequences of the change and how it affects external
      developers.
    - Add an UPGRADE section in UPGRADE-6.<next-major>.md for breaking changes (what/why/impact/how to adapt).
    - See the Documenting a Release Process (https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them