### PR TITLE
fix: DateRangeRule empty timezone

### DIFF
--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -39,7 +39,10 @@ class DateRangeRule extends Rule
         if (\is_string($this->toDate)) {
             $this->toDate = new \DateTime($this->toDate);
         }
-        if (\is_string($this->timezone)) {
+
+        if (!isset($this->timezone)) {
+            $this->timezone = null;
+        } elseif (\is_string($this->timezone)) {
             $this->timezone = new \DateTimeZone($this->timezone);
         }
     }

--- a/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
@@ -312,7 +312,7 @@ class DateRangeRuleTest extends TestCase
 
     public function testWakeupSetsTimezoneToNullWhenMissingInLegacySerializedData(): void
     {
-        $legacySerialized = "O:42:\"Shopware\\Core\\Framework\\Rule\\DateRangeRule\":5:{"
+        $legacySerialized = 'O:42:"Shopware\\Core\\Framework\\Rule\\DateRangeRule":5:{'
             . "s:13:\"\0*\0extensions\";a:0:{}"
             . "s:8:\"\0*\0_name\";s:9:\"dateRange\";"
             . "s:11:\"\0*\0fromDate\";O:8:\"DateTime\":3:{s:4:\"date\";s:26:\"2026-01-01 00:00:00.000000\";s:13:\"timezone_type\";i:3;s:8:\"timezone\";s:3:\"UTC\";}"

--- a/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
@@ -310,6 +310,26 @@ class DateRangeRuleTest extends TestCase
         static::assertTrue($result);
     }
 
+    public function testWakeupSetsTimezoneToNullWhenMissingInLegacySerializedData(): void
+    {
+        $legacySerialized = "O:42:\"Shopware\\Core\\Framework\\Rule\\DateRangeRule\":5:{"
+            . "s:13:\"\0*\0extensions\";a:0:{}"
+            . "s:8:\"\0*\0_name\";s:9:\"dateRange\";"
+            . "s:11:\"\0*\0fromDate\";O:8:\"DateTime\":3:{s:4:\"date\";s:26:\"2026-01-01 00:00:00.000000\";s:13:\"timezone_type\";i:3;s:8:\"timezone\";s:3:\"UTC\";}"
+            . "s:9:\"\0*\0toDate\";O:8:\"DateTime\":3:{s:4:\"date\";s:26:\"2026-01-16 23:59:59.000000\";s:13:\"timezone_type\";i:3;s:8:\"timezone\";s:3:\"UTC\";}"
+            . "s:10:\"\0*\0useTime\";b:0;";
+
+        $unserializedRule = unserialize($legacySerialized . '}');
+        static::assertInstanceOf(DateRangeRule::class, $unserializedRule);
+
+        $timezone = (new \ReflectionProperty(DateRangeRule::class, 'timezone'))->getValue($unserializedRule);
+        static::assertNull($timezone);
+
+        $scopeMock = $this->createMock(RuleScope::class);
+        $scopeMock->method('getCurrentTime')->willReturn(new \DateTimeImmutable('2026-01-10 12:00:00'));
+        static::assertTrue($unserializedRule->match($scopeMock));
+    }
+
     /**
      * @param array<string, string|bool|\DateTime> $options
      */


### PR DESCRIPTION
### 1. Why is this change necessary?
I noted when performing an update of Shopware to 6.7 and having an old rule serialized (before this change: https://github.com/shopware/shopware/commit/42daca735e78bef1be84a0dd2bc971ca3ea28b33) in the `rule.payload` the rule fails after the update, as the serialized rule is missing the `timezone` property. The added test replicates this:
```
1) Shopware\Tests\Unit\Core\Framework\Rule\DateRangeRuleTest::testWakeupSetsTimezoneToNullWhenMissingInLegacySerializedData
Error: Typed property Shopware\Core\Framework\Rule\DateRangeRule::$timezone must not be accessed before initialization
```

### 2. What does this change do, exactly?
Check if the timezone is there, when unserializing it, and if not initialize it with `null`.

### 3. Describe each step to reproduce the issue or behaviour.
Update from an old Shopware version, and have a `dateRange` rule stored in a serialized way.

### 4. Please link to the relevant issues (if any).
\- 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
