### PR TITLE
fix: add product version check in variant listing query

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
@@ -95,7 +95,7 @@ class VariantListingUpdater
 
                 $query->innerJoin('root', 'product_option', $mappingAlias, $mappingAlias . '.product_id IS NOT NULL');
                 $query->innerJoin($mappingAlias, 'property_group_option', $optionAlias, $optionAlias . '.id = ' . $mappingAlias . '.property_group_option_id AND ' . $optionAlias . '.property_group_id = :' . $optionAlias);
-                $query->andWhere($mappingAlias . '.product_id = product.id');
+                $query->andWhere($mappingAlias . '.product_id = product.id AND ' . $mappingAlias . '.product_version_id = :versionId');
 
                 $fields[] = 'LOWER(HEX(' . $optionAlias . '.id))';
 

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/VariantListingUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/VariantListingUpdaterTest.php
@@ -137,6 +137,54 @@ class VariantListingUpdaterTest extends TestCase
         static::assertSame($expectedRed, $displayByNumber['vl-updater-a']);
         static::assertSame($expectedGreen, $displayByNumber['vl-updater-b']);
 
+        $draftVersionId = Uuid::randomHex();
+        $draftVersionBytes = Uuid::fromHexToBytes($draftVersionId);
+
+        $this->connection->executeStatement(
+            'INSERT INTO product (id, version_id, parent_id, parent_version_id, product_number, stock, variant_listing_config, display_group)
+                SELECT id, :draftVersion, parent_id, IF(parent_id IS NULL, NULL, :draftVersion), product_number, stock, variant_listing_config, display_group
+                FROM product
+                WHERE id = :parentId AND version_id = :liveVersion',
+            [
+                'parentId' => $parentId,
+                'draftVersion' => $draftVersionBytes,
+                'liveVersion' => $liveVersion,
+            ]
+        );
+        $this->connection->executeStatement(
+            'INSERT INTO product (id, version_id, parent_id, parent_version_id, product_number, stock, variant_listing_config, display_group)
+                SELECT id, :draftVersion, parent_id, :draftVersion, product_number, stock, variant_listing_config, display_group
+                FROM product
+                WHERE id IN (:ids) AND version_id = :liveVersion',
+            [
+                'ids' => [$variantAId, $variantBId],
+                'draftVersion' => $draftVersionBytes,
+                'liveVersion' => $liveVersion,
+            ],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+        $this->connection->insert('product_option', [
+            'product_id' => $variantAId,
+            'product_version_id' => $draftVersionBytes,
+            'property_group_option_id' => $optionGreenBytes,
+        ]);
+        $this->connection->insert('product_option', [
+            'product_id' => $variantBId,
+            'product_version_id' => $draftVersionBytes,
+            'property_group_option_id' => $optionRedBytes,
+        ]);
+
+        $this->updater->update([$parentHex], Context::createDefaultContext()->createWithVersionId($draftVersionId));
+
+        $draftDisplayByNumber = $this->connection->fetchAllKeyValue(
+            'SELECT product_number, display_group FROM product WHERE id IN (:ids) AND version_id = :version ORDER BY product_number ASC',
+            ['ids' => [$variantAId, $variantBId], 'version' => $draftVersionBytes],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+
+        static::assertSame($expectedGreen, $draftDisplayByNumber['vl-updater-a']);
+        static::assertSame($expectedRed, $draftDisplayByNumber['vl-updater-b']);
+
         $this->cleanupVariantListingFixture(
             [$variantAId, $variantBId, $parentId],
             [$optionRedBytes, $optionGreenBytes],


### PR DESCRIPTION
The indexing should be consistent within a version. Otherwise this can cause "Subquery returns more than 1 row"

### 1. Why is this change necessary?

We have a couple of versions of a product in the database and the indexing is broken.

### 2. What does this change do, exactly?

It ensures consistency within the version during the indexing process.

### 3. Describe each step to reproduce the issue or behaviour.

You need to have several versions of the product and product_options.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
