### PR TITLE
test: deprecation fix for integration tests around CustomerVatIdentification

### DIFF
--- a/tests/integration/Core/Checkout/Customer/Validation/Constraint/CustomerVatIdentificationValidatorTest.php
+++ b/tests/integration/Core/Checkout/Customer/Validation/Constraint/CustomerVatIdentificationValidatorTest.php
@@ -67,11 +67,11 @@ class CustomerVatIdentificationValidatorTest extends TestCase
     #[DataProvider('dataProviderValidatesVatIdsCorrectly')]
     public function testValidatesVatIdsCorrectly(string $iso, array $vatIds): void
     {
-        $constraint = new CustomerVatIdentification([
-            'message' => 'Invalid VAT ID',
-            'countryId' => $this->countries[$iso],
-            'shouldCheck' => true,
-        ]);
+        $constraint = new CustomerVatIdentification(
+            countryId: $this->countries[$iso],
+            shouldCheck: true,
+            message: 'Invalid VAT ID'
+        );
 
         $this->validator->validate($vatIds, $constraint);
 
@@ -84,11 +84,11 @@ class CustomerVatIdentificationValidatorTest extends TestCase
     #[DataProvider('dataProviderValidatesVatIdsInCorrectly')]
     public function testValidateVatIdsInCorrectly(string $iso, int $count, array $vatIds): void
     {
-        $constraint = new CustomerVatIdentification([
-            'message' => 'Invalid VAT ID',
-            'countryId' => $this->countries[$iso],
-            'shouldCheck' => true,
-        ]);
+        $constraint = new CustomerVatIdentification(
+            countryId: $this->countries[$iso],
+            shouldCheck: true,
+            message: 'Invalid VAT ID'
+        );
 
         $this->validator->validate($vatIds, $constraint);
 
@@ -107,11 +107,11 @@ class CustomerVatIdentificationValidatorTest extends TestCase
 
     public function testDoesNotValidateWhenVatIdsIsNull(): void
     {
-        $constraint = new CustomerVatIdentification([
-            'message' => 'Invalid VAT ID',
-            'countryId' => $this->countries['DE'],
-            'shouldCheck' => true,
-        ]);
+        $constraint = new CustomerVatIdentification(
+            countryId: $this->countries['DE'],
+            shouldCheck: true,
+            message: 'Invalid VAT ID',
+        );
 
         $this->validator->validate(null, $constraint);
 
@@ -120,11 +120,11 @@ class CustomerVatIdentificationValidatorTest extends TestCase
 
     public function testDoesNotValidateWhenShouldCheckIsFalse(): void
     {
-        $constraint = new CustomerVatIdentification([
-            'message' => 'Invalid VAT ID',
-            'countryId' => $this->countries['DE'],
-            'shouldCheck' => false,
-        ]);
+        $constraint = new CustomerVatIdentification(
+            countryId: $this->countries['DE'],
+            shouldCheck: false,
+            message: 'Invalid VAT ID',
+        );
 
         $this->validator->validate(['DE123456789'], $constraint);
 

--- a/tests/integration/Core/Checkout/Validation/CustomerVatIdentificationValidatorTest.php
+++ b/tests/integration/Core/Checkout/Validation/CustomerVatIdentificationValidatorTest.php
@@ -46,9 +46,7 @@ class CustomerVatIdentificationValidatorTest extends TestCase
     {
         $this->expectExceptionObject(new ConstraintViolationException(ConstraintViolationList::createFromMessage('This value should be of type array.'), []));
 
-        $constraint = new CustomerVatIdentification([
-            'countryId' => $this->getValidCountryId(),
-        ]);
+        $constraint = new CustomerVatIdentification(countryId: $this->getValidCountryId());
 
         $validation = new DataValidationDefinition('customer.create');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
To get a clear output of the different test suite in unit/integration, deprecation should be fixed (see issue for example of output).
The main object in use was fixed in https://github.com/shopware/shopware/pull/12125 but some tests were forgotten.

### 2. What does this change do, exactly?
Use the proper initialisation with named argument rather than an array for CustomerVatIdentification in tests.

### 3. Describe each step to reproduce the issue or behaviour.
`php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --filter CustomerVatIdentificationValidatorTest`

Or check the pipeline job for these tests (nightly or Checkout integration tests)
Before these changes, a lot of deprecation are displayed like described in the attached issue

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/14500


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
