### PR TITLE
feat: allow apps to extend OpenAPI schema

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -31,10 +31,31 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767281941,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -66,32 +87,14 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769069492,
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     }
   },

--- a/devenv.lock
+++ b/devenv.lock
@@ -31,31 +31,10 @@
         "type": "github"
       }
     },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1767281941,
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "git-hooks",
+          "pre-commit-hooks",
           "nixpkgs"
         ]
       },
@@ -87,14 +66,32 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     }
   },

--- a/src/Core/Framework/Api/ApiDefinition/Generator/BundleSchemaPathCollection.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/BundleSchemaPathCollection.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Api\ApiDefinition\Generator;
 
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -17,8 +18,11 @@ class BundleSchemaPathCollection
     /**
      * @param iterable<Bundle> $bundles
      */
-    public function __construct(private readonly iterable $bundles)
-    {
+    public function __construct(
+        private readonly iterable $bundles,
+        private readonly ActiveAppsLoader $activeAppsLoader,
+        private readonly string $projectDir,
+    ) {
     }
 
     /**
@@ -30,6 +34,7 @@ class BundleSchemaPathCollection
     {
         $apiFolder = $api === DefinitionService::API ? 'AdminApi' : 'StoreApi';
         $openApiDirs = [];
+
         foreach ($this->bundles as $bundle) {
             $path = $bundle->getPath() . '/Resources/Schema/' . $apiFolder;
             if (!is_dir($path)) {
@@ -39,6 +44,15 @@ class BundleSchemaPathCollection
             if ($bundle->getName() === $bundleName) {
                 return [$path];
             }
+        }
+
+        foreach ($this->activeAppsLoader->getActiveApps() as $app) {
+            $appPath = str_starts_with($app['path'], '/') ? $app['path'] : $this->projectDir . '/' . $app['path'];
+            $path = $appPath . '/Resources/Schema/' . $apiFolder;
+            if (!is_dir($path)) {
+                continue;
+            }
+            $openApiDirs[] = $path;
         }
 
         return $openApiDirs;

--- a/src/Core/Framework/DependencyInjection/api.xml
+++ b/src/Core/Framework/DependencyInjection/api.xml
@@ -136,6 +136,8 @@
 
         <service id="Shopware\Core\Framework\Api\ApiDefinition\Generator\BundleSchemaPathCollection">
             <argument type="service" id="kernel.bundles"/>
+            <argument type="service" id="Shopware\Core\Framework\App\ActiveAppsLoader"/>
+            <argument>%kernel.project_dir%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi3Generator">

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/BundleSchemaPathCollectionTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/BundleSchemaPathCollectionTest.php
@@ -3,9 +3,11 @@
 namespace Shopware\Tests\Unit\Core\Framework\Api\ApiDefinition\Generator;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\BundleSchemaPathCollection;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Tests\Unit\Core\Framework\Api\ApiDefinition\Generator\_fixtures\CustomBundleWithApiSchema\ShopwareBundleWithName;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -15,11 +17,13 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 #[CoversClass(BundleSchemaPathCollection::class)]
 class BundleSchemaPathCollectionTest extends TestCase
 {
-    private Bundle $bundleWithSchemas;
+    private Bundle&MockObject $bundleWithSchemas;
 
-    private Bundle $bundleWithoutSchemas;
+    private Bundle&MockObject $bundleWithoutSchemas;
 
-    private Bundle $customBundleSchemas;
+    private ShopwareBundleWithName $customBundleSchemas;
+
+    private ActiveAppsLoader $activeAppsLoader;
 
     protected function setUp(): void
     {
@@ -28,11 +32,13 @@ class BundleSchemaPathCollectionTest extends TestCase
         $this->bundleWithoutSchemas = $this->createMock(Bundle::class);
         $this->bundleWithoutSchemas->method('getPath')->willReturn(__DIR__ . '/_fixtures/BundleWithoutApiSchema');
         $this->customBundleSchemas = new ShopwareBundleWithName();
+        $this->activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $this->activeAppsLoader->method('getActiveApps')->willReturn([]);
     }
 
     public function testGetPathsForStoreApi(): void
     {
-        $factory = new BundleSchemaPathCollection([$this->bundleWithSchemas, $this->bundleWithoutSchemas]);
+        $factory = new BundleSchemaPathCollection([$this->bundleWithSchemas, $this->bundleWithoutSchemas], $this->activeAppsLoader, __DIR__);
 
         $paths = $factory->getSchemaPaths(DefinitionService::STORE_API, null);
         static::assertContains(__DIR__ . '/_fixtures/BundleWithApiSchema/Resources/Schema/StoreApi', $paths);
@@ -41,7 +47,7 @@ class BundleSchemaPathCollectionTest extends TestCase
 
     public function testGetPathsForAdminApi(): void
     {
-        $factory = new BundleSchemaPathCollection([$this->bundleWithSchemas, $this->bundleWithoutSchemas]);
+        $factory = new BundleSchemaPathCollection([$this->bundleWithSchemas, $this->bundleWithoutSchemas], $this->activeAppsLoader, __DIR__);
 
         $paths = $factory->getSchemaPaths(DefinitionService::API, null);
         static::assertContains(__DIR__ . '/_fixtures/BundleWithApiSchema/Resources/Schema/AdminApi', $paths);
@@ -50,7 +56,7 @@ class BundleSchemaPathCollectionTest extends TestCase
 
     public function testGetPathsForSingleBundleAdminApi(): void
     {
-        $factory = new BundleSchemaPathCollection([$this->bundleWithSchemas, $this->bundleWithoutSchemas, $this->customBundleSchemas]);
+        $factory = new BundleSchemaPathCollection([$this->bundleWithSchemas, $this->bundleWithoutSchemas, $this->customBundleSchemas], $this->activeAppsLoader, __DIR__);
 
         $paths = $factory->getSchemaPaths(DefinitionService::API, $this->customBundleSchemas->getName());
         static::assertContains(__DIR__ . '/_fixtures/CustomBundleWithApiSchema/Resources/Schema/AdminApi', $paths);
@@ -60,7 +66,7 @@ class BundleSchemaPathCollectionTest extends TestCase
 
     public function testGetPathsForSingleBundleStoreApi(): void
     {
-        $factory = new BundleSchemaPathCollection([$this->bundleWithSchemas, $this->bundleWithoutSchemas, $this->customBundleSchemas]);
+        $factory = new BundleSchemaPathCollection([$this->bundleWithSchemas, $this->bundleWithoutSchemas, $this->customBundleSchemas], $this->activeAppsLoader, __DIR__);
 
         $paths = $factory->getSchemaPaths(DefinitionService::STORE_API, $this->customBundleSchemas->getName());
         static::assertContains(__DIR__ . '/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi', $paths);

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApi3GeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApi3GeneratorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiDefinitio
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiPathBuilder;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiSchemaBuilder;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi3Generator;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Tests\Unit\Core\Framework\Api\ApiDefinition\Generator\_fixtures\CustomBundleWithApiSchema\ShopwareBundleWithName;
@@ -32,6 +33,9 @@ class OpenApi3GeneratorTest extends TestCase
 
     protected function setUp(): void
     {
+        $activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $activeAppsLoader->method('getActiveApps')->willReturn([]);
+
         $this->generator = new OpenApi3Generator(
             new OpenApiSchemaBuilder('0.1.0'),
             new OpenApiPathBuilder(),
@@ -39,11 +43,11 @@ class OpenApi3GeneratorTest extends TestCase
             [
                 'Framework' => ['path' => __DIR__ . '/_fixtures'],
             ],
-            new BundleSchemaPathCollection([])
+            new BundleSchemaPathCollection([], $activeAppsLoader, __DIR__)
         );
 
         $this->customBundleSchemas = new ShopwareBundleWithName();
-        $customBundlePathCollection = new BundleSchemaPathCollection([$this->customBundleSchemas]);
+        $customBundlePathCollection = new BundleSchemaPathCollection([$this->customBundleSchemas], $activeAppsLoader, __DIR__);
 
         $this->customApiGenerator = new OpenApi3Generator(
             new OpenApiSchemaBuilder('0.1.0'),

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiDefinitio
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiSchemaBuilder;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\StoreApiGenerator;
 use Shopware\Core\Framework\Api\ApiException;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Tests\Unit\Core\Framework\Api\ApiDefinition\Generator\_fixtures\CustomBundleWithApiSchema\ShopwareBundleWithName;
@@ -35,17 +36,20 @@ class StoreApiGeneratorTest extends TestCase
 
     protected function setUp(): void
     {
+        $activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $activeAppsLoader->method('getActiveApps')->willReturn([]);
+
         $this->generator = new StoreApiGenerator(
             new OpenApiSchemaBuilder('0.1.0'),
             new OpenApiDefinitionSchemaBuilder(),
             [
                 'Framework' => ['path' => __DIR__ . '/_fixtures'],
             ],
-            new BundleSchemaPathCollection([]),
+            new BundleSchemaPathCollection([], $activeAppsLoader, __DIR__),
         );
 
         $this->customBundleSchemas = new ShopwareBundleWithName();
-        $customBundlePathCollection = new BundleSchemaPathCollection([$this->customBundleSchemas]);
+        $customBundlePathCollection = new BundleSchemaPathCollection([$this->customBundleSchemas], $activeAppsLoader, __DIR__);
 
         $this->customApiGenerator = new StoreApiGenerator(
             new OpenApiSchemaBuilder('0.1.0'),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently, only plugins (Symfony bundles) can extend the OpenAPI schema by placing JSON files in Resources/Schema/StoreApi/ or Resources/Schema/AdminApi/. Apps cannot do this because BundleSchemaPathCollection only iterates over registered bundles, not apps.

This limitation prevents apps from documenting additional request parameters they add to existing endpoints. For example, a payment app that extends /handle-payment with custom parameters (like braintreeNonce) cannot have these parameters appear in the generated OpenAPI specification.

### 2. What does this change do, exactly?

This change extends BundleSchemaPathCollection to also discover OpenAPI schema files from active apps.

- Injects ActiveAppsLoader to retrieve the list of active apps
- Injects projectDir to resolve relative app paths to absolute paths
- Iterates over active apps and includes their Resources/Schema/{StoreApi,AdminApi}/ directories in the schema path collection

### 3. Describe each step to reproduce the issue or behaviour.

Before this change:

- Create an app with Resources/Schema/StoreApi/my-extension.json
- Install and activate the app
- Access /store-api/_info/openapi3.json
- The app's schema definitions are not included


After this change:

- Create an app with Resources/Schema/StoreApi/my-extension.json
- Install and activate the app
- Access /store-api/_info/openapi3.json
- The app's schema definitions are merged into the OpenAPI spec

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

relates https://github.com/shopware/frontends/pull/2246 https://github.com/shopware/braintree-app/pull/308

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
