### PR TITLE
chore: add current user id to QuerySigner

### DIFF
--- a/src/Core/Framework/App/Hmac/QuerySigner.php
+++ b/src/Core/Framework/App/Hmac/QuerySigner.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\App\Hmac;
 
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
@@ -44,6 +45,7 @@ class QuerySigner
             'in-app-purchases' => \urlencode($this->inAppPurchase->getJWTByExtension($app->getName()) ?? ''),
             AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE => $context->getLanguageId(),
             AuthMiddleware::SHOPWARE_USER_LANGUAGE => $this->localeProvider->getLocaleFromContext($context),
+            'user-id' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getUserId() : null,
         ]);
 
         return Uri::withQueryValue(

--- a/src/Core/Framework/App/Hmac/QuerySigner.php
+++ b/src/Core/Framework/App/Hmac/QuerySigner.php
@@ -45,7 +45,7 @@ class QuerySigner
             'in-app-purchases' => \urlencode($this->inAppPurchase->getJWTByExtension($app->getName()) ?? ''),
             AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE => $context->getLanguageId(),
             AuthMiddleware::SHOPWARE_USER_LANGUAGE => $this->localeProvider->getLocaleFromContext($context),
-            'user-id' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getUserId() : '',
+            'sw-user-id' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getUserId() : '',
         ]);
 
         return Uri::withQueryValue(

--- a/src/Core/Framework/App/Hmac/QuerySigner.php
+++ b/src/Core/Framework/App/Hmac/QuerySigner.php
@@ -45,7 +45,7 @@ class QuerySigner
             'in-app-purchases' => \urlencode($this->inAppPurchase->getJWTByExtension($app->getName()) ?? ''),
             AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE => $context->getLanguageId(),
             AuthMiddleware::SHOPWARE_USER_LANGUAGE => $this->localeProvider->getLocaleFromContext($context),
-            'user-id' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getUserId() : null,
+            'user-id' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getUserId() : '',
         ]);
 
         return Uri::withQueryValue(

--- a/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -2,9 +2,11 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\App\Hmac;
 
+use Doctrine\DBAL\Connection;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Hmac\QuerySigner;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
@@ -13,6 +15,7 @@ use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
@@ -44,7 +47,15 @@ class QuerySignerTest extends TestCase
 
     public function testSignUri(): void
     {
-        $signedUri = $this->querySigner->signUri('http://app.url/?foo=bar', $this->app, Context::createDefaultContext());
+        $connection = static::getContainer()->get(Connection::class);
+
+        $userId = Uuid::fromBytesToHex(
+            (string) $connection->fetchOne('SELECT id FROM `user` WHERE username = "admin"')
+        );
+
+        $context = new Context(new AdminApiSource($userId));
+
+        $signedUri = $this->querySigner->signUri('http://app.url/?foo=bar', $this->app, $context);
         parse_str($signedUri->getQuery(), $signedQuery);
 
         $shopIdConfig = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
@@ -64,13 +75,16 @@ class QuerySignerTest extends TestCase
         static::assertSame(static::getContainer()->getParameter('kernel.shopware_version'), $signedQuery['sw-version']);
 
         static::assertArrayHasKey('sw-context-language', $signedQuery);
-        static::assertSame(Context::createDefaultContext()->getLanguageId(), $signedQuery['sw-context-language']);
+        static::assertSame($context->getLanguageId(), $signedQuery['sw-context-language']);
 
         static::assertArrayHasKey('sw-user-language', $signedQuery);
         static::assertSame('en-GB', $signedQuery['sw-user-language']);
 
         static::assertArrayHasKey('app-version', $signedQuery);
         static::assertSame('1.0.0', $signedQuery['app-version']);
+
+        static::assertArrayHasKey('user-id', $signedQuery);
+        static::assertSame($userId, $signedQuery['user-id']);
 
         static::assertNotNull($this->app->getAppSecret());
 

--- a/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -83,8 +83,8 @@ class QuerySignerTest extends TestCase
         static::assertArrayHasKey('app-version', $signedQuery);
         static::assertSame('1.0.0', $signedQuery['app-version']);
 
-        static::assertArrayHasKey('user-id', $signedQuery);
-        static::assertSame($userId, $signedQuery['user-id']);
+        static::assertArrayHasKey('sw-user-id', $signedQuery);
+        static::assertSame($userId, $signedQuery['sw-user-id']);
 
         static::assertNotNull($this->app->getAppSecret());
 

--- a/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -77,6 +77,49 @@ class QuerySignerTest extends TestCase
         static::assertSame($userId, $url['user-id']);
     }
 
+    public function testUserIdIsEmptyStringWhenSourceIsNotAdminApiSource(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $localeProvider = $this->createMock(LocaleProvider::class);
+        $localeProvider
+            ->expects($this->once())
+            ->method('getLocaleFromContext')
+            ->with($context)
+            ->willReturn('en-GB');
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider
+            ->expects($this->once())
+            ->method('getShopId')
+            ->willReturn('shopId');
+
+        $app = new AppEntity();
+        $app->setName('extension-1');
+        $app->setAppSecret('devSecret');
+        $app->setId(Uuid::randomHex());
+        $app->setVersion('1.0.0');
+
+        $querySigner = new QuerySigner(
+            'http://shop.url',
+            '1.0.0',
+            $localeProvider,
+            $shopIdProvider,
+            StaticInAppPurchaseFactory::createWithFeatures(),
+        );
+
+        $signedQuery = $querySigner->signUri(
+            'http://app.url/?foo=bar',
+            $app,
+            $context
+        );
+
+        \parse_str($signedQuery->getQuery(), $url);
+
+        static::assertArrayHasKey('user-id', $url);
+        static::assertSame('', $url['user-id']);
+    }
+
     public function testThrowsWithoutAppSecret(): void
     {
         $app = new AppEntity();

--- a/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -27,7 +27,9 @@ class QuerySignerTest extends TestCase
     {
         $inAppPurchase = StaticInAppPurchaseFactory::createWithFeatures(['extension-1' => ['purchase-1', 'purchase-2'], 'extension-2' => ['purchase-3']]);
 
-        $context = new Context(new AdminApiSource(null));
+        $userId = Uuid::randomHex();
+
+        $context = new Context(new AdminApiSource($userId));
 
         $localeProvider = $this->createMock(LocaleProvider::class);
         $localeProvider
@@ -62,6 +64,7 @@ class QuerySignerTest extends TestCase
         static::assertArrayHasKey('sw-user-language', $url);
         static::assertArrayHasKey('shopware-shop-signature', $url);
         static::assertArrayHasKey('app-version', $url);
+        static::assertArrayHasKey('user-id', $url);
 
         static::assertSame('shopId', $url['shop-id']);
         static::assertSame('http://shop.url', $url['shop-url']);
@@ -71,6 +74,7 @@ class QuerySignerTest extends TestCase
         static::assertSame(Defaults::LANGUAGE_SYSTEM, $url['sw-context-language']);
         static::assertSame('en-GB', $url['sw-user-language']);
         static::assertSame('1.0.0', $url['app-version']);
+        static::assertSame($userId, $url['user-id']);
     }
 
     public function testThrowsWithoutAppSecret(): void

--- a/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -64,7 +64,7 @@ class QuerySignerTest extends TestCase
         static::assertArrayHasKey('sw-user-language', $url);
         static::assertArrayHasKey('shopware-shop-signature', $url);
         static::assertArrayHasKey('app-version', $url);
-        static::assertArrayHasKey('user-id', $url);
+        static::assertArrayHasKey('sw-user-id', $url);
 
         static::assertSame('shopId', $url['shop-id']);
         static::assertSame('http://shop.url', $url['shop-url']);
@@ -74,7 +74,7 @@ class QuerySignerTest extends TestCase
         static::assertSame(Defaults::LANGUAGE_SYSTEM, $url['sw-context-language']);
         static::assertSame('en-GB', $url['sw-user-language']);
         static::assertSame('1.0.0', $url['app-version']);
-        static::assertSame($userId, $url['user-id']);
+        static::assertSame($userId, $url['sw-user-id']);
     }
 
     public function testUserIdIsEmptyStringWhenSourceIsNotAdminApiSource(): void
@@ -116,8 +116,8 @@ class QuerySignerTest extends TestCase
 
         \parse_str($signedQuery->getQuery(), $url);
 
-        static::assertArrayHasKey('user-id', $url);
-        static::assertSame('', $url['user-id']);
+        static::assertArrayHasKey('sw-user-id', $url);
+        static::assertSame('', $url['sw-user-id']);
     }
 
     public function testThrowsWithoutAppSecret(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In context of the Services we need to know the current logged in user id.


### 2. What does this change do, exactly?
This change adds the current logged in user id in the signed querystring.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes #14399 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
