### PR TITLE
fix: caches invalidation performance issues on property changes

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -151,6 +151,12 @@ This behaviour differs from the existing ìsCacheable` property, which will also
 
 Added logging for invalidated cache tags at the info level, with the ability to enable or disable the logging via configuration for debugging and transparency.
 
+### Removed `CacheInvalidationSubscriber::getChangedPropertyFilterTags` due to performance issues
+
+The `getChangedPropertyFilterTags` method has been removed from `CacheInvalidationSubscriber` due to performance issues where it could cause invalidation storms by selecting all product IDs for popular property options.
+
+Changing a property group or option will no longer automatically invalidate product and product list caches. It's recommended to rely on TTLs for bigger shops. If you experience issues after changing a property group, a manual cache clear may be required.
+
 ## Administration
 
 ### Deprecations in mail template components

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
@@ -27,10 +27,6 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
 use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
-use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionDefinition;
-use Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\PropertyGroupOptionTranslationDefinition;
-use Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation\PropertyGroupTranslationDefinition;
-use Shopware\Core\Content\Property\PropertyGroupDefinition;
 use Shopware\Core\Content\Sitemap\Event\SitemapGeneratedEvent;
 use Shopware\Core\Content\Sitemap\SalesChannel\SitemapRoute;
 use Shopware\Core\Defaults;
@@ -390,7 +386,7 @@ class CacheInvalidationSubscriber
 
     public function invalidatePropertyFilters(EntityWrittenContainerEvent $event): void
     {
-        $this->cacheInvalidator->invalidate([...$this->getChangedPropertyFilterTags($event), ...$this->getDeletedPropertyFilterTags($event)]);
+        $this->cacheInvalidator->invalidate($this->getDeletedPropertyFilterTags($event));
     }
 
     public function invalidateStreamsBeforeIndexing(EntityWrittenContainerEvent $event): void
@@ -435,72 +431,6 @@ class CacheInvalidationSubscriber
             array_map(ProductDetailRoute::buildName(...), array_unique($productIds)),
             array_map(ProductListingRoute::buildName(...), $this->getProductCategoryIds($productIds))
         );
-    }
-
-    /**
-     * @return string[]
-     */
-    private function getChangedPropertyFilterTags(EntityWrittenContainerEvent $event): array
-    {
-        // invalidates the product listing route and detail rule, each time a property group changed
-        $propertyGroupIds = array_unique(array_merge(
-            $event->getPrimaryKeysWithPayloadIgnoringFields(PropertyGroupDefinition::ENTITY_NAME, ['id', 'updatedAt']),
-            array_column($event->getPrimaryKeysWithPayloadIgnoringFields(PropertyGroupTranslationDefinition::ENTITY_NAME, ['propertyGroupId', 'languageId', 'updatedAt']), 'propertyGroupId')
-        ));
-
-        // invalidates the product listing route and detail rule, each time a property option changed
-        $propertyOptionIds = array_unique(array_merge(
-            $event->getPrimaryKeysWithPayloadIgnoringFields(PropertyGroupOptionDefinition::ENTITY_NAME, ['id', 'updatedAt']),
-            array_column($event->getPrimaryKeysWithPayloadIgnoringFields(PropertyGroupOptionTranslationDefinition::ENTITY_NAME, ['propertyGroupOptionId', 'languageId', 'updatedAt']), 'propertyGroupOptionId')
-        ));
-
-        if (empty($propertyGroupIds) && empty($propertyOptionIds)) {
-            return [];
-        }
-
-        $productIds = $this->connection->fetchFirstColumn(
-            'SELECT product_property.product_id
-             FROM product_property
-                LEFT JOIN property_group_option productProperties ON productProperties.id = product_property.property_group_option_id
-             WHERE productProperties.property_group_id IN (:ids) OR productProperties.id IN (:optionIds)
-             AND product_property.product_version_id = :version',
-            ['ids' => Uuid::fromHexToBytesList($propertyGroupIds), 'optionIds' => Uuid::fromHexToBytesList($propertyOptionIds), 'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)],
-            ['ids' => ArrayParameterType::BINARY, 'optionIds' => ArrayParameterType::BINARY]
-        );
-        $productIds = array_unique([...$productIds, ...$this->connection->fetchFirstColumn(
-            'SELECT product_option.product_id
-                 FROM product_option
-                    LEFT JOIN property_group_option productOptions ON productOptions.id = product_option.property_group_option_id
-                 WHERE productOptions.property_group_id IN (:ids) OR productOptions.id IN (:optionIds)
-                 AND product_option.product_version_id = :version',
-            ['ids' => Uuid::fromHexToBytesList($propertyGroupIds), 'optionIds' => Uuid::fromHexToBytesList($propertyOptionIds), 'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)],
-            ['ids' => ArrayParameterType::BINARY, 'optionIds' => ArrayParameterType::BINARY]
-        )]);
-
-        if (empty($productIds)) {
-            return [];
-        }
-
-        $parentIds = $this->connection->fetchFirstColumn(
-            'SELECT DISTINCT LOWER(HEX(COALESCE(parent_id, id)))
-            FROM product
-            WHERE id in (:productIds) AND version_id = :version',
-            ['productIds' => $productIds, 'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)],
-            ['productIds' => ArrayParameterType::BINARY]
-        );
-
-        $categoryIds = $this->connection->fetchFirstColumn(
-            'SELECT DISTINCT LOWER(HEX(category_id))
-            FROM product_category_tree
-            WHERE product_id in (:productIds) AND product_version_id = :version',
-            ['productIds' => $productIds, 'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)],
-            ['productIds' => ArrayParameterType::BINARY]
-        );
-
-        return [
-            ...array_map(ProductDetailRoute::buildName(...), array_filter($parentIds)),
-            ...array_map(ProductListingRoute::buildName(...), array_filter($categoryIds)),
-        ];
     }
 
     /**

--- a/tests/integration/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
@@ -66,7 +66,47 @@ class CacheInvalidationSubscriberTest extends TestCase
         );
     }
 
-    public function testItInvalidatesCacheIfPropertyGroupIsChanged(): void
+    public function testItInvalidatesCacheIfPropertyIsDeleted(): void
+    {
+        $this->insertDefaultPropertyGroup();
+
+        $productPropertyRepository = static::getContainer()->get('product_property.repository');
+        $event = $productPropertyRepository->delete([
+            [
+                'productId' => $this->ids->get('product1'),
+                'optionId' => $this->ids->get('property-assigned'),
+            ],
+        ], Context::createDefaultContext());
+
+        $this->backtraceCollector->expects($this->once())->method('collectDebugBacktrace')->willReturn([
+            [
+                'class' => CacheInvalidationSubscriber::class,
+                'function' => 'invalidatePropertyFilters',
+            ],
+        ]);
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with(
+                'Purged tags (1).',
+                static::callback(function (array $context): bool {
+                    static::assertCount(1, $context['tags']);
+                    static::assertSame(
+                        (new Frame(
+                            'Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber',
+                            'invalidatePropertyFilters'
+                        ))->toArray(),
+                        $context['caller']
+                    );
+
+                    return true;
+                })
+            );
+
+        $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);
+    }
+
+    public function testItDoesNotInvalidateCacheIfNoPropertyIsDeleted(): void
     {
         $this->insertDefaultPropertyGroup();
 
@@ -77,235 +117,6 @@ class CacheInvalidationSubscriberTest extends TestCase
                 'sortingType' => PropertyGroupDefinition::SORTING_TYPE_POSITION,
             ],
         ], Context::createDefaultContext());
-
-        $this->backtraceCollector->expects($this->once())->method('collectDebugBacktrace')->willReturn([
-            [
-                'function' => 'invalidate', // must be skipped
-            ],
-            [
-                'class' => CacheInvalidator::class, // must be skipped
-            ],
-            [
-                'class' => null,
-                'function' => 'invalidate',  // must be skipped
-            ],
-            [
-                'class' => CacheInvalidator::class,
-                'function' => null,  // must be skipped
-            ],
-            [
-                'class' => CacheInvalidator::class, // must be skipped
-                'function' => 'invalidate',
-            ],
-            [
-                'class' => CacheInvalidationSubscriber::class,
-                'function' => 'invalidatePropertyFilters',
-            ],
-        ]);
-
-        $this->logger->expects($this->once())
-            ->method('info')
-            ->with(
-                'Purged tags (1).',
-                static::callback(function (array $context): bool {
-                    static::assertCount(1, $context['tags']);
-                    static::assertSame(
-                        (new Frame(
-                            'Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber',
-                            'invalidatePropertyFilters'
-                        ))->toArray(),
-                        $context['caller']
-                    );
-
-                    return true;
-                })
-            );
-
-        $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);
-    }
-
-    public function testItInvalidatesCacheIfPropertyGroupTranslationIsChanged(): void
-    {
-        $this->insertDefaultPropertyGroup();
-
-        $groupRepository = static::getContainer()->get('property_group.repository');
-        $event = $groupRepository->update([
-            [
-                'id' => $this->ids->get('group1'),
-                'name' => 'new name',
-            ],
-        ], Context::createDefaultContext());
-
-        $this->backtraceCollector->expects($this->once())->method('collectDebugBacktrace')->willReturn([
-            [
-                'class' => CacheInvalidationSubscriber::class,
-                'function' => 'invalidateSnippets',
-            ],
-        ]);
-
-        $this->logger->expects($this->once())
-            ->method('info')
-            ->with(
-                'Purged tags (1).',
-                static::callback(function (array $context): bool {
-                    static::assertCount(1, $context['tags']);
-                    static::assertSame(
-                        (new Frame(
-                            'Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber',
-                            'invalidateSnippets'
-                        ))->toArray(),
-                        $context['caller']
-                    );
-
-                    return true;
-                })
-            );
-
-        $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);
-    }
-
-    public function testItDoesNotInvalidateCacheIfPropertyOptionIsAddedToGroup(): void
-    {
-        $this->insertDefaultPropertyGroup();
-
-        $groupRepository = static::getContainer()->get('property_group.repository');
-        $event = $groupRepository->update([
-            [
-                'id' => $this->ids->get('group1'),
-                'options' => [
-                    [
-                        'id' => $this->ids->get('new-property'),
-                        'name' => 'new-property',
-                    ],
-                ],
-            ],
-        ], Context::createDefaultContext());
-
-        $this->logger->expects($this->never())->method('log');
-        $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);
-    }
-
-    public function testItInvalidatesCacheIfPropertyOptionIsChanged(): void
-    {
-        $this->insertDefaultPropertyGroup();
-
-        $optionRepository = static::getContainer()->get('property_group_option.repository');
-        $event = $optionRepository->update([
-            [
-                'id' => $this->ids->get('property-assigned'),
-                'colorHexCode' => '#000000',
-            ],
-        ], Context::createDefaultContext());
-
-        $this->backtraceCollector->expects($this->once())->method('collectDebugBacktrace')->willReturn([
-            [
-                'class' => CacheInvalidationSubscriber::class,
-                'function' => 'invalidatePropertyFilters',
-            ],
-        ]);
-
-        $this->logger->expects($this->once())
-            ->method('info')
-            ->with(
-                'Purged tags (1).',
-                static::callback(function (array $context): bool {
-                    static::assertCount(1, $context['tags']);
-                    static::assertSame(
-                        (new Frame(
-                            'Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber',
-                            'invalidatePropertyFilters'
-                        ))->toArray(),
-                        $context['caller']
-                    );
-
-                    return true;
-                })
-            );
-
-        $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);
-    }
-
-    public function testItDoesNotInvalidateCacheIfUnassignedPropertyOptionIsChanged(): void
-    {
-        $this->insertDefaultPropertyGroup();
-
-        $optionRepository = static::getContainer()->get('property_group_option.repository');
-        $event = $optionRepository->update([
-            [
-                'id' => $this->ids->get('property-unassigned'),
-                'colorHexCode' => '#000000',
-            ],
-        ], Context::createDefaultContext());
-
-        $this->logger->expects($this->never())->method('log');
-        $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);
-    }
-
-    public function testItInvalidatesCacheIfPropertyOptionTranslationIsChanged(): void
-    {
-        $this->insertDefaultPropertyGroup();
-
-        $optionRepository = static::getContainer()->get('property_group_option.repository');
-        $event = $optionRepository->update([
-            [
-                'id' => $this->ids->get('property-assigned'),
-                'name' => 'updated',
-            ],
-        ], Context::createDefaultContext());
-
-        $this->backtraceCollector->expects($this->once())->method('collectDebugBacktrace')->willReturn([
-            [
-                'class' => CacheInvalidationSubscriber::class,
-                'function' => 'invalidatePropertyFilters',
-            ],
-        ]);
-
-        $this->logger->expects($this->once())
-            ->method('info')
-            ->with(
-                'Purged tags (1).',
-                static::callback(function (array $context): bool {
-                    static::assertCount(1, $context['tags']);
-                    static::assertSame(
-                        (new Frame(
-                            'Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber',
-                            'invalidatePropertyFilters'
-                        ))->toArray(),
-                        $context['caller']
-                    );
-
-                    return true;
-                })
-            );
-
-        $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);
-    }
-
-    public function testItDoesNotInvalidateCacheIfUnassignedPropertyOptionTranslationIsChanged(): void
-    {
-        $this->insertDefaultPropertyGroup();
-
-        $optionRepository = static::getContainer()->get('property_group_option.repository');
-        $event = $optionRepository->update([
-            [
-                'id' => $this->ids->get('property-unassigned'),
-                'name' => 'updated',
-            ],
-        ], Context::createDefaultContext());
-
-        $this->logger->expects($this->never())->method('log');
-        $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);
-    }
-
-    public function testItDoesNotInvalidateCacheIfProductIsCreatedWithExistingOption(): void
-    {
-        $this->insertDefaultPropertyGroup();
-
-        $builder = new ProductBuilder($this->ids, 'product2');
-        $builder->price(10)
-            ->property('property-assigned', '');
-
-        $event = static::getContainer()->get('product.repository')->create([$builder->build()], Context::createDefaultContext());
 
         $this->logger->expects($this->never())->method('log');
         $this->cacheInvalidationSubscriber->invalidatePropertyFilters($event);


### PR DESCRIPTION
### 1. Why is this change necessary?

The `getChangedPropertyFilterTags` method causes performance issues on large installations. When a popular property option (e.g., size_m) is updated, the method queries all products using that option. For options used by a lot of products, this:

- generates huge invalidation lists (tens of thousands of product IDs)
- triggers slow database queries
- causes high memory consumption when processing these lists
- leads to invalidation storms that slow down the system during property group/option updates

This becomes a problem on shops with large catalogs and popular options.

### 2. What does this change do, exactly?

This change removes the automatic cache invalidation for property group and option changes. Instead of invalidating all related product caches when a property group or option is modified, the system now only invalidates caches when properties are deleted from products (via getDeletedPropertyFilterTags).

#### Why not using batching?

Batching would only speed up invalidation processing; it does not solve the underlying issue. The problem is the volume of invalidations generated, not how they are processed. Batching still requires:
- querying all affected products
- building large invalidation lists
- potential system slowdown during processing

Property groups and options are edited not so often. Large installations can rely on TTL-based cache expiration, while smaller ones can still manually trigger a cache clear when needed.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/8518

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
