### PR TITLE
fix: SQL MD5 function usage (replace with SHA2 - 256)

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
@@ -41,7 +41,7 @@ class VariantListingUpdater
 
         $displayParent = new RetryableQuery(
             $this->connection,
-            $this->connection->prepare('UPDATE product SET display_group = MD5(HEX(product.id)) WHERE product.id = :id AND product.version_id = :versionId')
+            $this->connection->prepare('UPDATE product SET display_group = SHA2(HEX(product.id), 256) WHERE product.id = :id AND product.version_id = :versionId')
         );
 
         $hideParent = new RetryableQuery(
@@ -51,7 +51,7 @@ class VariantListingUpdater
 
         $singleVariant = new RetryableQuery(
             $this->connection,
-            $this->connection->prepare('UPDATE product SET display_group = MD5(HEX(product.parent_id)) WHERE product.parent_id = :id AND product.version_id = :versionId')
+            $this->connection->prepare('UPDATE product SET display_group = SHA2(HEX(product.parent_id), 256) WHERE product.parent_id = :id AND product.version_id = :versionId')
         );
 
         foreach ($listingConfiguration as $parentId => $config) {
@@ -99,12 +99,12 @@ class VariantListingUpdater
             $query->addSelect('CONCAT(' . implode(',', $fields) . ')');
 
             $sql = '
-            UPDATE product SET display_group = MD5(
+            UPDATE product SET display_group = SHA2(
                 CONCAT(
                     LOWER(HEX(product.parent_id)),
                     (' . $query->getSQL() . ')
                 )
-            ) WHERE parent_id = :parentId AND version_id = :versionId';
+            , 256) WHERE parent_id = :parentId AND version_id = :versionId';
 
             RetryableQuery::retryable($this->connection, function () use ($sql, $params): void {
                 $this->connection->executeStatement($sql, $params);

--- a/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
+++ b/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
@@ -41,10 +41,14 @@ class Migration1726049442UpdateVariantListingConfigInProductTable extends Migrat
             ['ids' => ArrayParameterType::STRING]
         );
 
-        $connection->executeStatement(
-            'UPDATE `product` SET `display_group` = MD5(HEX(`parent_id`)) WHERE `parent_id` IN (:ids)',
-            ['ids' => $productIds],
-            ['ids' => ArrayParameterType::STRING]
-        );
+        try {
+            $connection->executeStatement(
+                'UPDATE `product` SET `display_group` = MD5(HEX(`parent_id`)) WHERE `parent_id` IN (:ids)',
+                ['ids' => $productIds],
+                ['ids' => ArrayParameterType::STRING]
+            );
+        } catch (\Throwable) {
+           // On MySQL 9.6+ there is no longer support for MD5, so we silently ignore the missing function error here.
+        }
     }
 }

--- a/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
+++ b/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
@@ -47,8 +47,12 @@ class Migration1726049442UpdateVariantListingConfigInProductTable extends Migrat
                 ['ids' => $productIds],
                 ['ids' => ArrayParameterType::STRING]
             );
-        } catch (\Throwable) {
+        } catch (\Throwable $e) {
             // On MySQL 9.6+ there is no longer support for MD5, so we silently ignore the missing function error here.
+            if (str_contains($e->getMessage(), 'MD5')) {
+                return;
+            }
+            throw $e;
         }
     }
 }

--- a/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
+++ b/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
@@ -48,7 +48,7 @@ class Migration1726049442UpdateVariantListingConfigInProductTable extends Migrat
                 ['ids' => ArrayParameterType::STRING]
             );
         } catch (\Throwable) {
-           // On MySQL 9.6+ there is no longer support for MD5, so we silently ignore the missing function error here.
+            // On MySQL 9.6+ there is no longer support for MD5, so we silently ignore the missing function error here.
         }
     }
 }

--- a/src/Core/Migration/V6_7/Migration1769175229ModifyDisplayGroupLength.php
+++ b/src/Core/Migration/V6_7/Migration1769175229ModifyDisplayGroupLength.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1769175229ModifyDisplayGroupLength extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1769175229;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('ALTER TABLE `product` MODIFY COLUMN `display_group` VARCHAR(64) NULL;');
+
+        $this->registerIndexer($connection, 'product.indexer');
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1769175229ModifyDisplayGroupLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1769175229ModifyDisplayGroupLengthTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1769175229ModifyDisplayGroupLength;
 
 /**
@@ -37,11 +38,8 @@ class Migration1769175229ModifyDisplayGroupLengthTest extends TestCase
         $migration->update($this->connection);
         $migration->update($this->connection);
 
-        $columns = $this->connection->createSchemaManager()->listTableColumns('product');
-        static::assertArrayHasKey('display_group', $columns);
-
-        $column = $columns['display_group'];
-        static::assertSame(64, $column->getLength());
+        $column = TableHelper::getColumnOfTable($this->connection, 'product', 'display_group');
+        static::assertSame(64, $column->length);
     }
 
     private function rollback(): void

--- a/tests/migration/Core/V6_7/Migration1769175229ModifyDisplayGroupLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1769175229ModifyDisplayGroupLengthTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1769175229ModifyDisplayGroupLength;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1769175229ModifyDisplayGroupLength::class)]
+class Migration1769175229ModifyDisplayGroupLengthTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        $migration = new Migration1769175229ModifyDisplayGroupLength();
+        static::assertSame(1769175229, $migration->getCreationTimestamp());
+    }
+
+    public function testMigration(): void
+    {
+        $this->rollback();
+
+        $migration = new Migration1769175229ModifyDisplayGroupLength();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $columns = $this->connection->createSchemaManager()->listTableColumns('product');
+        static::assertArrayHasKey('display_group', $columns);
+
+        $column = $columns['display_group'];
+        static::assertSame(64, $column->getLength());
+    }
+
+    private function rollback(): void
+    {
+        $this->connection->executeStatement('ALTER TABLE `product` MODIFY COLUMN `display_group` VARCHAR(50) NULL;');
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
- With MySQL 9.6 the MD5 function was removed, which is still used in the VariantListingUpdater for the display_group field
- Using a MySQL 9.6 database will prevent all product updates / indexer tasks for products

### 2. What does this change do, exactly?
- Changed the sql usage of the `MD5()` function to `SHA2(, 256)`
- Changed the `display_group` to varchar(64) to correctly match the hash size

### 3. Describe each step to reproduce the issue or behaviour.
- Use a MySQL 9.6 database
- Update a product

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
