### PR TITLE
chore: mention php-redis upgrade in release info

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,7 +6,7 @@
 
 All symfony packages have been updated to version 7.4. 
 Take a look at the [Symfony 7.4 release post](https://symfony.com/blog/symfony-7-4-0-released) for more information.
-Especially note that Symfony now requires php-redis extension v6.2 or higher: https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md#cache.
+Especially note that Symfony now requires php-redis extension v6.1 or higher: https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md#cache.
 If you note compatibility issues with the Redis extension please check the installed version php-redis.
 
 ### Changed maintenance mode redirect

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,6 +6,8 @@
 
 All symfony packages have been updated to version 7.4. 
 Take a look at the [Symfony 7.4 release post](https://symfony.com/blog/symfony-7-4-0-released) for more information.
+Especially note that Symfony now requires php-redis extension v6.2 or higher: https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md#cache.
+If you note compatibility issues with the Redis extension please check the installed version php-redis.
 
 ### Changed maintenance mode redirect
 After maintenance ends, users are now redirected back to the page they were on before maintenance.


### PR DESCRIPTION


### 1. Why is this change necessary?
Symfony requires a newer phpredis version since 7.4:
https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md#cache
https://github.com/symfony/symfony/pull/61072

### 2. What does this change do, exactly?

Mention the new requirement
