### PR TITLE
chore: add changelog for symfony upgrade

### DIFF
--- a/changelog/_unreleased/2026-01-23-symfony-7-4.md
+++ b/changelog/_unreleased/2026-01-23-symfony-7-4.md
@@ -11,5 +11,5 @@ ___
 
 All symfony packages have been updated to version 7.4.
 Take a look at the [Symfony 7.4 release post](https://symfony.com/blog/symfony-7-4-0-released) for more information.
-Especially note that Symfony now requires php-redis extension v6.2 or higher: https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md#cache.
+Especially note that Symfony now requires php-redis extension v6.1 or higher: https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md#cache.
 If you note compatibility issues with the Redis extension please check the installed version php-redis.

--- a/changelog/_unreleased/2026-01-23-symfony-7-4.md
+++ b/changelog/_unreleased/2026-01-23-symfony-7-4.md
@@ -1,0 +1,15 @@
+---
+title: Symfony 7.4 Update
+issue: 13968
+---
+# Core
+* Changed version of symfony packages to 7.4.
+___
+# Upgrade Information
+
+## Symfony 7.4 Update
+
+All symfony packages have been updated to version 7.4.
+Take a look at the [Symfony 7.4 release post](https://symfony.com/blog/symfony-7-4-0-released) for more information.
+Especially note that Symfony now requires php-redis extension v6.2 or higher: https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md#cache.
+If you note compatibility issues with the Redis extension please check the installed version php-redis.

--- a/changelog/_unreleased/2026-01-23-symfony-7-4.md
+++ b/changelog/_unreleased/2026-01-23-symfony-7-4.md
@@ -3,13 +3,13 @@ title: Symfony 7.4 Update
 issue: 13968
 ---
 # Core
-* Changed version of symfony packages to 7.4.
+* Changed version of Symfony packages to 7.4.
 ___
 # Upgrade Information
 
 ## Symfony 7.4 Update
 
-All symfony packages have been updated to version 7.4.
+All Symfony packages have been updated to version 7.4.
 Take a look at the [Symfony 7.4 release post](https://symfony.com/blog/symfony-7-4-0-released) for more information.
 Especially note that Symfony now requires php-redis extension v6.1 or higher: https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md#cache.
 If you note compatibility issues with the Redis extension please check the installed version php-redis.


### PR DESCRIPTION

### 1. Why is this change necessary?

changelog was missing for symfony update

