### PR TITLE
fix: display selling and packaging information in pdp with product has advanced pricing

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -177,7 +177,8 @@ The following deprecations apply to `sw-mail-template-index`:
 
 ### Selling and packaging information in the product detail page
 
-Deprecated block `buy_widget_price_unit` in `Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig`, will be moved into `Resources/views/storefront/component/buy-widget/buy-widget.html.twig`.
+* Display the selling and packaging information with the product that has advanced pricing.
+* Deprecated block `buy_widget_price_unit` in `Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig`, will be moved into `Resources/views/storefront/component/buy-widget/buy-widget.html.twig`.
 
 ### Cookie consent now language-aware
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -169,6 +169,10 @@ The following deprecations apply to `sw-mail-template-index`:
 
 ## Storefront
 
+### Selling and packaging information in the product detail page
+
+Deprecated block `buy_widget_price_unit` in `Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig`, will be moved into `Resources/views/storefront/component/buy-widget/buy-widget.html.twig`.
+
 ### Cookie consent now language-aware
 
 The cookie consent banner now tracks cookie configuration per language. Previously, switching languages would cause the cookie banner to reappear because the configuration hash changed due to translated cookie descriptions. Now, switching back to a previously accepted language will not show the banner again.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -178,7 +178,7 @@ The following deprecations apply to `sw-mail-template-index`:
 ### Selling and packaging information in the product detail page
 
 * Display the selling and packaging information with the product that has advanced pricing.
-* Deprecated block `buy_widget_price_unit` in `Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig`, will be moved into `Resources/views/storefront/component/buy-widget/buy-widget.html.twig`.
+* Deprecated block `buy_widget_price_unit` and it childrens in `Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig`, will be moved into `Resources/views/storefront/component/buy-widget/buy-widget.html.twig`.
 
 ### Cookie consent now language-aware
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -875,6 +875,11 @@ The error handling for the route `/account/order/document/{documentId}/{deepLink
 - `406` (Not Acceptable) for invalid/unsupported `fileType` values
 - `404` (Not Found) when no generated document exists for the requested `fileType`.
 
+## Removed block `buy_widget_price_unit` from `@Storefront/storefront/component/buy-widget/buy-widget-price.html.twig`
+
+The block `buy_widget_price_unit` and its childrens has been moved into `@Storefront/storefront/component/buy-widget/buy-widget.html.twig`.
+Instead of overwriting any of those blocks inside `@Storefront/storefront/component/buy-widget/buy-widget-price.html.twig`, extend the new `@Storefront/storefront/component/buy-widget/buy-widget.html.twig` file using the same blocks.
+
 
 </details>
 

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
@@ -600,7 +600,7 @@ a.line-item-label {
 }
 
 .line-item-total-price-value {
-    text-align: right;
+    text-align: left;
 }
 
 .line-item-tax-price-label {

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -125,6 +125,17 @@
 
         <!-- @deprecated tag:v6.8.0 - block will be moved into buy-widget.html.twig -->
         {% block buy_widget_price_unit %}
+            <!-- @deprecated tag:v6.8.0 - block will be moved into buy-widget.html.twig -->
+            {% block buy_widget_price_unit_label %}
+            {% endblock %}
+
+            <!-- @deprecated tag:v6.8.0 - block will be moved into buy-widget.html.twig -->
+            {% block buy_widget_price_unit_content %}
+            {% endblock %}
+
+            <!-- @deprecated tag:v6.8.0 - block will be moved into buy-widget.html.twig -->
+            {% block buy_widget_price_unit_reference_content %}
+            {% endblock %}
         {% endblock %}
     {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -123,30 +123,8 @@
             {% endif %}
         {% endblock %}
 
-        {% if product.purchaseUnit %}
-            {% block buy_widget_price_unit %}
-                <div class="product-detail-price-unit">
-                    {% block buy_widget_price_unit_label %}
-                        <span class="price-unit-label">
-                            {{ 'detail.priceUnitName'|trans|sw_sanitize }}
-                        </span>
-                    {% endblock %}
-
-                    {% block buy_widget_price_unit_content %}
-                        <span class="price-unit-content">
-                            {{ product.purchaseUnit }} {{ product.unit.translated.name }}
-                        </span>
-                    {% endblock %}
-
-                    {% if price.referencePrice is not null %}
-                        {% block buy_widget_price_unit_reference_content %}
-                            <span class="price-unit-reference-content">
-                                ({{ price.referencePrice.price|currency }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
-                            </span>
-                        {% endblock %}
-                    {% endif %}
-                </div>
-            {% endblock %}
-        {% endif %}
+        <!-- @deprecated tag:v6.8.0 - block will be moved into buy-widget.html.twig -->
+        {% block buy_widget_price_unit %}
+        {% endblock %}
     {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -131,6 +131,32 @@
                         </div>
                     {% endblock %}
 
+                    {% if product.purchaseUnit %}
+                        {% block buy_widget_price_unit %}
+                            <div class="product-detail-price-unit">
+                                {% block buy_widget_price_unit_label %}
+                                    <span class="price-unit-label">
+                                        {{ 'detail.priceUnitName'|trans|sw_sanitize }}
+                                    </span>
+                                {% endblock %}
+
+                                {% block buy_widget_price_unit_content %}
+                                    <span class="price-unit-content">
+                                        {{ product.purchaseUnit }} {{ product.unit.translated.name }}
+                                    </span>
+                                {% endblock %}
+
+                                {% if price.referencePrice is not null %}
+                                    {% block buy_widget_price_unit_reference_content %}
+                                        <span class="price-unit-reference-content">
+                                            ({{ price.referencePrice.price|currency }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
+                                        </span>
+                                    {% endblock %}
+                                {% endif %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
+
                     {% block buy_widget_tax %}
                         <div class="product-detail-tax-container">
                             {% if context.taxState == 'gross' %}

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -146,12 +146,16 @@
                                     </span>
                                 {% endblock %}
 
-                                {% if price.referencePrice is not null %}
-                                    {% block buy_widget_price_unit_reference_content %}
-                                        <span class="price-unit-reference-content">
-                                            ({{ price.referencePrice.price|currency }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
-                                        </span>
-                                    {% endblock %}
+                                {% if product.calculatedPrices|length == 0 %}
+                                    {% set price = product.calculatedPrice %}
+
+                                    {% if price.referencePrice is not null %}
+                                        {% block buy_widget_price_unit_reference_content %}
+                                            <span class="price-unit-reference-content">
+                                                ({{ price.referencePrice.price|currency }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
+                                            </span>
+                                        {% endblock %}
+                                    {% endif %}
                                 {% endif %}
                             </div>
                         {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This pull request improves how selling and packaging information is displayed on the product detail page, especially for products with advanced pricing.

### 2. What does this change do, exactly?
 The main change is moving the display logic for price per unit from `buy-widget-price.html.twig` to `buy-widget.html.twig`, and marking the old block as deprecated.
<img width="1375" height="581" alt="Screenshot 2026-01-26 at 11 17 22" src="https://github.com/user-attachments/assets/53485509-721e-4276-a8a5-35001ff04455" />

**Storefront template changes:**

* Moved the `buy_widget_price_unit` block (showing price per unit and reference price) from `buy-widget-price.html.twig` to `buy-widget.html.twig`, and marked the old block as deprecated. [[1]](diffhunk://#diff-75af62e77de0ee42efc4d84dcd9ecb810f45badf3521fa42cc56ad29a91b692bL126-L151) [[2]](diffhunk://#diff-50b0e0bb0ac9975cd0f391dd36f0d506def2ffcd2c97158213b6c3138b1e4b8eR134-R163)
* Updated the release notes to document the new display of selling and packaging information and the deprecation/move of the `buy_widget_price_unit` block.

### 3. Describe each step to reproduce the issue or behaviour.
Follow [this issue](https://github.com/shopware/shopware/issues/14023)

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/14023

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
