### PR TITLE
fix: Release date input is vertically misaligned on Admin product detail page

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.scss
@@ -1,9 +1,5 @@
 .sw-product-settings-form {
     .sw-product-settings-form__release-date {
-        .sw-inherit-wrapper__toggle-wrapper {
-            margin-bottom: var(--scale-size-0);
-        }
-
         .mt-datepicker__hint {
             margin-top: var(--scale-size-12);
         }


### PR DESCRIPTION
### Solution 
<img width="1091" height="323" alt="image" src="https://github.com/user-attachments/assets/c827149b-a0a3-495d-8aa3-b30c8ee3ddfd" />
