### PR TITLE
fix: Partial entity loading with nested association

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -115,6 +115,8 @@ class EntityReader implements EntityReaderInterface
             return $collection;
         }
 
+        // Do not re-use `$isPartialLoading` here, as this method could be called for associations
+        // and only the initial call is relevant for marking the whole read as partial
         if ($fieldsForPartialLoading !== []) {
             $fields = $definition->getFields()->filter(function (Field $field) use (&$fieldsForPartialLoading) {
                 if ($field->getFlag(PrimaryKey::class)) {
@@ -685,6 +687,8 @@ class EntityReader implements EntityReaderInterface
 
         $ids = array_values($collection->getIds());
 
+        // Do not re-use `$isPartialLoading` here, as this method could be called for associations
+        // and only the initial call is relevant for marking the whole read as partial
         if ($fieldsForPartialLoading !== []) {
             // Make sure our collection index will be loaded
             $fieldsForPartialLoading[$association->getPropertyName()] = [];
@@ -1391,6 +1395,8 @@ class EntityReader implements EntityReaderInterface
                 continue;
             }
 
+            // Do not re-use `$isPartialLoading` here, as this method could be called for associations
+            // and only the initial call is relevant for marking the whole read as partial
             if ($fieldsForPartialLoading !== [] && !\array_key_exists($association->getPropertyName(), $fieldsForPartialLoading)) {
                 continue;
             }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -143,7 +143,7 @@ class EntityReader implements EntityReaderInterface
             $rows,
             $definition->getEntityName(),
             $context,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
         );
 
         $collection = $this->fetchAssociations(
@@ -174,7 +174,7 @@ class EntityReader implements EntityReaderInterface
         QueryBuilder $query,
         FieldCollection $fields,
         ?Criteria $criteria = null,
-        array $fieldsForPartialLoading = []
+        array $fieldsForPartialLoading = [],
     ): void {
         $isPartial = $fieldsForPartialLoading !== [];
         $filtered = $fields->filter(static function (Field $field) use ($isPartial, $fieldsForPartialLoading) {
@@ -252,7 +252,7 @@ class EntityReader implements EntityReaderInterface
                     $query,
                     $basics,
                     $joinCriteria,
-                    $fieldsForPartialLoading[$field->getPropertyName()] ?? []
+                    $fieldsForPartialLoading[$field->getPropertyName()] ?? [],
                 );
 
                 continue;
@@ -330,7 +330,7 @@ class EntityReader implements EntityReaderInterface
                 $definition,
                 $query,
                 $context,
-                $fieldsForPartialLoading
+                $fieldsForPartialLoading,
             );
         }
     }
@@ -345,7 +345,7 @@ class EntityReader implements EntityReaderInterface
         EntityDefinition $definition,
         Context $context,
         FieldCollection $fields,
-        array $fieldsForPartialLoading = []
+        array $fieldsForPartialLoading = [],
     ): array {
         $table = $definition->getEntityName();
 
@@ -363,7 +363,7 @@ class EntityReader implements EntityReaderInterface
             $query,
             $fields,
             $criteria,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
         );
 
         if (!empty($criteria->getIds())) {

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -41,6 +41,8 @@ use function Symfony\Component\String\u;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore - Covered by integration test {@see \Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Reader\EntityReaderTest}
  */
 #[Package('framework')]
 class EntityReader implements EntityReaderInterface
@@ -80,7 +82,8 @@ class EntityReader implements EntityReaderInterface
             new $collectionClass(),
             $definition->getFields()->getBasicFields(),
             true,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
+            $fieldsForPartialLoading !== [],
         );
     }
 
@@ -102,7 +105,8 @@ class EntityReader implements EntityReaderInterface
         EntityCollection $collection,
         FieldCollection $fields,
         bool $performEmptySearch,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): EntityCollection {
         $hasFilters = !empty($criteria->getFilters()) || !empty($criteria->getPostFilters());
         $hasIds = !empty($criteria->getIds());
@@ -148,7 +152,8 @@ class EntityReader implements EntityReaderInterface
             $context,
             $collection,
             $fields,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
+            $isPartialLoading,
         );
 
         $hasIds = !empty($criteria->getIds());
@@ -384,7 +389,8 @@ class EntityReader implements EntityReaderInterface
         ManyToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): void {
         $associationCriteria = $criteria->getAssociation($association->getPropertyName());
 
@@ -403,7 +409,8 @@ class EntityReader implements EntityReaderInterface
                 $association,
                 $context,
                 $collection,
-                $fieldsForPartialLoading
+                $fieldsForPartialLoading,
+                $isPartialLoading,
             );
 
             return;
@@ -416,7 +423,8 @@ class EntityReader implements EntityReaderInterface
             $association,
             $context,
             $collection,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
+            $isPartialLoading,
         );
     }
 
@@ -495,7 +503,8 @@ class EntityReader implements EntityReaderInterface
         OneToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): void {
         $fieldCriteria = new Criteria();
         if ($criteria->hasAssociation($association->getPropertyName())) {
@@ -516,7 +525,8 @@ class EntityReader implements EntityReaderInterface
                 $context,
                 $collection,
                 $fieldCriteria,
-                $fieldsForPartialLoading
+                $fieldsForPartialLoading,
+                $isPartialLoading,
             );
 
             return;
@@ -529,7 +539,8 @@ class EntityReader implements EntityReaderInterface
             $context,
             $collection,
             $fieldCriteria,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
+            $isPartialLoading,
         );
     }
 
@@ -543,7 +554,8 @@ class EntityReader implements EntityReaderInterface
         Context $context,
         EntityCollection $collection,
         Criteria $fieldCriteria,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): void {
         $ref = $association->getReferenceDefinition()->getFields()->getByStorageName(
             $association->getReferenceField()
@@ -580,7 +592,7 @@ class EntityReader implements EntityReaderInterface
         /** @var EntityCollection<Entity> $collectionClass */
         $collectionClass = $referenceClass->getCollectionClass();
 
-        if ($fieldsForPartialLoading !== []) {
+        if ($isPartialLoading) {
             // Make sure our collection index will be loaded
             $fieldsForPartialLoading[$propertyName] = [];
             $collectionClass = EntityCollection::class;
@@ -593,7 +605,8 @@ class EntityReader implements EntityReaderInterface
             new $collectionClass(),
             $referenceClass->getFields()->getBasicFields(),
             false,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
+            $isPartialLoading,
         );
 
         $grouped = [];
@@ -656,7 +669,8 @@ class EntityReader implements EntityReaderInterface
         Context $context,
         EntityCollection $collection,
         Criteria $fieldCriteria,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): void {
         $propertyAccessor = $this->buildOneToManyPropertyAccessor($definition, $association);
 
@@ -714,7 +728,8 @@ class EntityReader implements EntityReaderInterface
             new $collectionClass(),
             $referenceClass->getFields()->getBasicFields(),
             false,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
+            $isPartialLoading,
         );
 
         // assign loaded reference collections to root entities
@@ -772,7 +787,8 @@ class EntityReader implements EntityReaderInterface
         ManyToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): void {
         // collect all ids of many-to-many association which already stored inside the struct instances
         $ids = $this->collectManyToManyIds($collection, $association);
@@ -792,7 +808,8 @@ class EntityReader implements EntityReaderInterface
             new $collectionClass(),
             $referenceClass->getFields()->getBasicFields(),
             false,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
+            $isPartialLoading,
         );
 
         foreach ($collection as $struct) {
@@ -829,7 +846,8 @@ class EntityReader implements EntityReaderInterface
         ManyToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): void {
         $fields = $association->getToManyReferenceDefinition()->getFields();
         $reference = null;
@@ -989,7 +1007,8 @@ class EntityReader implements EntityReaderInterface
                 new $collectionClass(),
                 $referenceClass->getFields()->getBasicFields(),
                 false,
-                $fieldsForPartialLoading
+                $fieldsForPartialLoading,
+                $isPartialLoading,
             );
         } else {
             $data = new $collectionClass();
@@ -1264,7 +1283,8 @@ class EntityReader implements EntityReaderInterface
         Context $context,
         EntityCollection $collection,
         Criteria $criteria,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): void {
         if (!$association instanceof OneToOneAssociationField && !$association instanceof ManyToOneAssociationField) {
             return;
@@ -1296,7 +1316,7 @@ class EntityReader implements EntityReaderInterface
         $referenceDefinition = $association->getReferenceDefinition();
         $collectionClass = $referenceDefinition->getCollectionClass();
 
-        if ($fieldsForPartialLoading !== []) {
+        if ($isPartialLoading) {
             $collectionClass = EntityCollection::class;
         }
 
@@ -1317,7 +1337,8 @@ class EntityReader implements EntityReaderInterface
             $context,
             $relatedCollection,
             $fields,
-            $fieldsForPartialLoading
+            $fieldsForPartialLoading,
+            $isPartialLoading,
         );
 
         foreach ($collection as $entity) {
@@ -1358,7 +1379,8 @@ class EntityReader implements EntityReaderInterface
         Context $context,
         EntityCollection $collection,
         FieldCollection $fields,
-        array $fieldsForPartialLoading
+        array $fieldsForPartialLoading,
+        bool $isPartialLoading,
     ): EntityCollection {
         if ($collection->count() <= 0) {
             return $collection;
@@ -1379,7 +1401,8 @@ class EntityReader implements EntityReaderInterface
                     $context,
                     $collection,
                     $criteria,
-                    $fieldsForPartialLoading[$association->getPropertyName()] ?? []
+                    $fieldsForPartialLoading[$association->getPropertyName()] ?? [],
+                    $isPartialLoading,
                 );
 
                 continue;
@@ -1392,7 +1415,8 @@ class EntityReader implements EntityReaderInterface
                     $association,
                     $context,
                     $collection,
-                    $fieldsForPartialLoading[$association->getPropertyName()] ?? []
+                    $fieldsForPartialLoading[$association->getPropertyName()] ?? [],
+                    $isPartialLoading,
                 );
 
                 continue;
@@ -1405,7 +1429,8 @@ class EntityReader implements EntityReaderInterface
                     $association,
                     $context,
                     $collection,
-                    $fieldsForPartialLoading[$association->getPropertyName()] ?? []
+                    $fieldsForPartialLoading[$association->getPropertyName()] ?? [],
+                    $isPartialLoading,
                 );
             }
         }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -71,7 +71,7 @@ class EntityReader implements EntityReaderInterface
         /** @var EntityCollection<Entity> $collectionClass */
         $collectionClass = $definition->getCollectionClass();
 
-        $fields = $this->criteriaFieldsResolver->resolve($criteria, $definition);
+        $fieldsForPartialLoading = $this->criteriaFieldsResolver->resolve($criteria, $definition);
 
         return $this->_read(
             $criteria,
@@ -80,7 +80,7 @@ class EntityReader implements EntityReaderInterface
             new $collectionClass(),
             $definition->getFields()->getBasicFields(),
             true,
-            $fields
+            $fieldsForPartialLoading
         );
     }
 
@@ -91,7 +91,7 @@ class EntityReader implements EntityReaderInterface
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      *
      * @return EntityCollection<Entity>
      */
@@ -101,8 +101,8 @@ class EntityReader implements EntityReaderInterface
         Context $context,
         EntityCollection $collection,
         FieldCollection $fields,
-        bool $performEmptySearch = false,
-        array $partial = []
+        bool $performEmptySearch,
+        array $fieldsForPartialLoading
     ): EntityCollection {
         $hasFilters = !empty($criteria->getFilters()) || !empty($criteria->getPostFilters());
         $hasIds = !empty($criteria->getIds());
@@ -111,15 +111,15 @@ class EntityReader implements EntityReaderInterface
             return $collection;
         }
 
-        if ($partial !== []) {
-            $fields = $definition->getFields()->filter(function (Field $field) use (&$partial) {
+        if ($fieldsForPartialLoading !== []) {
+            $fields = $definition->getFields()->filter(function (Field $field) use (&$fieldsForPartialLoading) {
                 if ($field->getFlag(PrimaryKey::class)) {
-                    $partial[$field->getPropertyName()] = [];
+                    $fieldsForPartialLoading[$field->getPropertyName()] = [];
 
                     return true;
                 }
 
-                return isset($partial[$field->getPropertyName()]);
+                return isset($fieldsForPartialLoading[$field->getPropertyName()]);
             });
         }
 
@@ -130,11 +130,26 @@ class EntityReader implements EntityReaderInterface
             throw DataAbstractionLayerException::parentAssociationCannotBeFetched();
         }
 
-        $rows = $this->fetch($criteria, $definition, $context, $fields, $partial);
+        $rows = $this->fetch($criteria, $definition, $context, $fields, $fieldsForPartialLoading);
 
-        $collection = $this->hydrator->hydrate($collection, $definition->getEntityClass(), $definition, $rows, $definition->getEntityName(), $context, $partial);
+        $collection = $this->hydrator->hydrate(
+            $collection,
+            $definition->getEntityClass(),
+            $definition,
+            $rows,
+            $definition->getEntityName(),
+            $context,
+            $fieldsForPartialLoading
+        );
 
-        $collection = $this->fetchAssociations($criteria, $definition, $context, $collection, $fields, $partial);
+        $collection = $this->fetchAssociations(
+            $criteria,
+            $definition,
+            $context,
+            $collection,
+            $fields,
+            $fieldsForPartialLoading
+        );
 
         $hasIds = !empty($criteria->getIds());
         if ($hasIds && empty($criteria->getSorting())) {
@@ -145,7 +160,7 @@ class EntityReader implements EntityReaderInterface
     }
 
     /**
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      */
     private function joinBasic(
         EntityDefinition $definition,
@@ -154,10 +169,10 @@ class EntityReader implements EntityReaderInterface
         QueryBuilder $query,
         FieldCollection $fields,
         ?Criteria $criteria = null,
-        array $partial = []
+        array $fieldsForPartialLoading = []
     ): void {
-        $isPartial = $partial !== [];
-        $filtered = $fields->filter(static function (Field $field) use ($isPartial, $partial) {
+        $isPartial = $fieldsForPartialLoading !== [];
+        $filtered = $fields->filter(static function (Field $field) use ($isPartial, $fieldsForPartialLoading) {
             if ($field->is(Runtime::class)) {
                 return false;
             }
@@ -166,7 +181,7 @@ class EntityReader implements EntityReaderInterface
                 return true;
             }
 
-            return isset($partial[$field->getPropertyName()]);
+            return isset($fieldsForPartialLoading[$field->getPropertyName()]);
         });
 
         $parentAssociation = null;
@@ -192,7 +207,11 @@ class EntityReader implements EntityReaderInterface
             }
 
             // self references can not be resolved if set to autoload, otherwise we get an endless loop
-            if (!$field instanceof ParentAssociationField && $field instanceof AssociationField && $field->getAutoload() && $field->getReferenceDefinition() === $definition) {
+            if (!$field instanceof ParentAssociationField
+                && $field instanceof AssociationField
+                && $field->getAutoload()
+                && $field->getReferenceDefinition() === $definition
+            ) {
                 continue;
             }
 
@@ -214,12 +233,22 @@ class EntityReader implements EntityReaderInterface
                 }
 
                 $referenceField = $reference->getFields()->getByStorageName($field->getReferenceField());
-                if ($isPartial && $referenceField && !isset($partial[$fieldPropertyName][$referenceField->getPropertyName()])) {
-                    $partial[$fieldPropertyName] ??= [];
-                    $partial[$fieldPropertyName][$referenceField->getPropertyName()] = [];
+                if ($isPartial && $referenceField
+                    && !isset($fieldsForPartialLoading[$fieldPropertyName][$referenceField->getPropertyName()])
+                ) {
+                    $fieldsForPartialLoading[$fieldPropertyName] ??= [];
+                    $fieldsForPartialLoading[$fieldPropertyName][$referenceField->getPropertyName()] = [];
                 }
 
-                $this->joinBasic($reference, $context, $alias, $query, $basics, $joinCriteria, $partial[$field->getPropertyName()] ?? []);
+                $this->joinBasic(
+                    $reference,
+                    $context,
+                    $alias,
+                    $query,
+                    $basics,
+                    $joinCriteria,
+                    $fieldsForPartialLoading[$field->getPropertyName()] ?? []
+                );
 
                 continue;
             }
@@ -291,17 +320,28 @@ class EntityReader implements EntityReaderInterface
         }
 
         if ($addTranslation) {
-            $this->queryHelper->addTranslationSelect($root, $definition, $query, $context, $partial);
+            $this->queryHelper->addTranslationSelect(
+                $root,
+                $definition,
+                $query,
+                $context,
+                $fieldsForPartialLoading
+            );
         }
     }
 
     /**
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      *
      * @return list<array<string, mixed>>
      */
-    private function fetch(Criteria $criteria, EntityDefinition $definition, Context $context, FieldCollection $fields, array $partial = []): array
-    {
+    private function fetch(
+        Criteria $criteria,
+        EntityDefinition $definition,
+        Context $context,
+        FieldCollection $fields,
+        array $fieldsForPartialLoading = []
+    ): array {
         $table = $definition->getEntityName();
 
         $query = $this->criteriaQueryBuilder->build(
@@ -311,7 +351,15 @@ class EntityReader implements EntityReaderInterface
             $context
         );
 
-        $this->joinBasic($definition, $context, $table, $query, $fields, $criteria, $partial);
+        $this->joinBasic(
+            $definition,
+            $context,
+            $table,
+            $query,
+            $fields,
+            $criteria,
+            $fieldsForPartialLoading
+        );
 
         if (!empty($criteria->getIds())) {
             $this->queryHelper->addIdCondition($criteria, $definition, $query);
@@ -328,7 +376,7 @@ class EntityReader implements EntityReaderInterface
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      */
     private function loadManyToMany(
         Criteria $criteria,
@@ -336,7 +384,7 @@ class EntityReader implements EntityReaderInterface
         ManyToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
-        array $partial
+        array $fieldsForPartialLoading
     ): void {
         $associationCriteria = $criteria->getAssociation($association->getPropertyName());
 
@@ -349,14 +397,27 @@ class EntityReader implements EntityReaderInterface
         // check if the requested criteria is restricted (limit, offset, sorting, filtering)
         if ($this->isAssociationRestricted($criteria, $association->getPropertyName())) {
             // if restricted load paginated list of many to many
-            $this->loadManyToManyWithCriteria($definition, $associationCriteria, $association, $context, $collection, $partial);
+            $this->loadManyToManyWithCriteria(
+                $definition,
+                $associationCriteria,
+                $association,
+                $context,
+                $collection,
+                $fieldsForPartialLoading
+            );
 
             return;
         }
 
         // otherwise the association is loaded in the root query of the entity as sub select which contains all ids
         // the ids are extracted in the entity hydrator (see: \Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator::extractManyToManyIds)
-        $this->loadManyToManyOverExtension($associationCriteria, $association, $context, $collection, $partial);
+        $this->loadManyToManyOverExtension(
+            $associationCriteria,
+            $association,
+            $context,
+            $collection,
+            $fieldsForPartialLoading
+        );
     }
 
     private function addManyToManySelect(
@@ -426,7 +487,7 @@ class EntityReader implements EntityReaderInterface
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      */
     private function loadOneToMany(
         Criteria $criteria,
@@ -434,7 +495,7 @@ class EntityReader implements EntityReaderInterface
         OneToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
-        array $partial
+        array $fieldsForPartialLoading
     ): void {
         $fieldCriteria = new Criteria();
         if ($criteria->hasAssociation($association->getPropertyName())) {
@@ -449,18 +510,32 @@ class EntityReader implements EntityReaderInterface
 
         // association should not be paginated > load data over foreign key condition
         if ($fieldCriteria->getLimit() === null) {
-            $this->loadOneToManyWithoutPagination($definition, $association, $context, $collection, $fieldCriteria, $partial);
+            $this->loadOneToManyWithoutPagination(
+                $definition,
+                $association,
+                $context,
+                $collection,
+                $fieldCriteria,
+                $fieldsForPartialLoading
+            );
 
             return;
         }
 
         // load association paginated > use internal counter loops
-        $this->loadOneToManyWithPagination($definition, $association, $context, $collection, $fieldCriteria, $partial);
+        $this->loadOneToManyWithPagination(
+            $definition,
+            $association,
+            $context,
+            $collection,
+            $fieldCriteria,
+            $fieldsForPartialLoading
+        );
     }
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      */
     private function loadOneToManyWithoutPagination(
         EntityDefinition $definition,
@@ -468,7 +543,7 @@ class EntityReader implements EntityReaderInterface
         Context $context,
         EntityCollection $collection,
         Criteria $fieldCriteria,
-        array $partial
+        array $fieldsForPartialLoading
     ): void {
         $ref = $association->getReferenceDefinition()->getFields()->getByStorageName(
             $association->getReferenceField()
@@ -505,9 +580,9 @@ class EntityReader implements EntityReaderInterface
         /** @var EntityCollection<Entity> $collectionClass */
         $collectionClass = $referenceClass->getCollectionClass();
 
-        if ($partial !== []) {
+        if ($fieldsForPartialLoading !== []) {
             // Make sure our collection index will be loaded
-            $partial[$propertyName] = [];
+            $fieldsForPartialLoading[$propertyName] = [];
             $collectionClass = EntityCollection::class;
         }
 
@@ -518,7 +593,7 @@ class EntityReader implements EntityReaderInterface
             new $collectionClass(),
             $referenceClass->getFields()->getBasicFields(),
             false,
-            $partial
+            $fieldsForPartialLoading
         );
 
         $grouped = [];
@@ -573,7 +648,7 @@ class EntityReader implements EntityReaderInterface
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      */
     private function loadOneToManyWithPagination(
         EntityDefinition $definition,
@@ -581,10 +656,8 @@ class EntityReader implements EntityReaderInterface
         Context $context,
         EntityCollection $collection,
         Criteria $fieldCriteria,
-        array $partial
+        array $fieldsForPartialLoading
     ): void {
-        $isPartial = $partial !== [];
-
         $propertyAccessor = $this->buildOneToManyPropertyAccessor($definition, $association);
 
         // inject sorting for foreign key, otherwise the internal counter wouldn't work `order by customer_address.customer_id, other_sortings`
@@ -598,9 +671,9 @@ class EntityReader implements EntityReaderInterface
 
         $ids = array_values($collection->getIds());
 
-        if ($isPartial) {
+        if ($fieldsForPartialLoading !== []) {
             // Make sure our collection index will be loaded
-            $partial[$association->getPropertyName()] = [];
+            $fieldsForPartialLoading[$association->getPropertyName()] = [];
         }
 
         $isInheritanceAware = $definition->isInheritanceAware() && $context->considerInheritance();
@@ -641,7 +714,7 @@ class EntityReader implements EntityReaderInterface
             new $collectionClass(),
             $referenceClass->getFields()->getBasicFields(),
             false,
-            $partial
+            $fieldsForPartialLoading
         );
 
         // assign loaded reference collections to root entities
@@ -692,14 +765,14 @@ class EntityReader implements EntityReaderInterface
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      */
     private function loadManyToManyOverExtension(
         Criteria $criteria,
         ManyToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
-        array $partial
+        array $fieldsForPartialLoading
     ): void {
         // collect all ids of many-to-many association which already stored inside the struct instances
         $ids = $this->collectManyToManyIds($collection, $association);
@@ -719,7 +792,7 @@ class EntityReader implements EntityReaderInterface
             new $collectionClass(),
             $referenceClass->getFields()->getBasicFields(),
             false,
-            $partial
+            $fieldsForPartialLoading
         );
 
         foreach ($collection as $struct) {
@@ -748,7 +821,7 @@ class EntityReader implements EntityReaderInterface
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      */
     private function loadManyToManyWithCriteria(
         EntityDefinition $definition,
@@ -756,7 +829,7 @@ class EntityReader implements EntityReaderInterface
         ManyToManyAssociationField $association,
         Context $context,
         EntityCollection $collection,
-        array $partial
+        array $fieldsForPartialLoading
     ): void {
         $fields = $association->getToManyReferenceDefinition()->getFields();
         $reference = null;
@@ -797,7 +870,8 @@ class EntityReader implements EntityReaderInterface
         $localColumn = EntityDefinitionQueryHelper::escape($association->getMappingLocalColumn());
         $referenceColumn = EntityDefinitionQueryHelper::escape($association->getMappingReferenceColumn());
 
-        $condition = $root . '.' . $referenceColumn . ' = ' . EntityDefinitionQueryHelper::escape($association->getToManyReferenceDefinition()->getEntityName()) . '.id';
+        $condition = $root . '.' . $referenceColumn . ' = '
+            . EntityDefinitionQueryHelper::escape($association->getToManyReferenceDefinition()->getEntityName()) . '.id';
 
         if (str_ends_with($association->getMappingReferenceColumn(), '_id')) {
             $referenceVersionColumn = u($association->getMappingReferenceColumn())->trimSuffix('_id')->append('_version_id')->toString();
@@ -805,8 +879,11 @@ class EntityReader implements EntityReaderInterface
             $referenceVersionColumn = $association->getMappingReferenceColumn() . '_version_id';
         }
 
-        if ($association->getToManyReferenceDefinition()->isVersionAware() && $association->getMappingDefinition()->getField($referenceVersionColumn)) {
-            $condition .= ' AND ' . $root . '.version_id = ' . EntityDefinitionQueryHelper::escape($referenceVersionColumn) . '.version_id';
+        if ($association->getToManyReferenceDefinition()->isVersionAware()
+            && $association->getMappingDefinition()->getField($referenceVersionColumn)
+        ) {
+            $condition .= ' AND ' . $root . '.version_id = '
+                . EntityDefinitionQueryHelper::escape($referenceVersionColumn) . '.version_id';
         }
 
         $query
@@ -823,10 +900,14 @@ class EntityReader implements EntityReaderInterface
         } else {
             // When the association is inherited, we need to join the base entity to the local table
             // the "join column" (column name = property name) contains the id of the parent entity if the association is inherited
-            $joinCondition = $root . '.' . $localColumn . ' = ' . EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.' . EntityDefinitionQueryHelper::escape($association->getPropertyName());
+            $joinCondition = $root . '.' . $localColumn . ' = '
+                . EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.'
+                . EntityDefinitionQueryHelper::escape($association->getPropertyName());
 
             if ($definition->isVersionAware()) {
-                $joinCondition .= ' AND ' . $root . '.' . EntityDefinitionQueryHelper::escape($definition->getEntityName() . '_version_id') . ' = ' . EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.version_id';
+                $joinCondition .= ' AND ' . $root . '.'
+                    . EntityDefinitionQueryHelper::escape($definition->getEntityName() . '_version_id') . ' = '
+                    . EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.version_id';
             }
             $query->innerJoin(
                 $root,
@@ -908,7 +989,7 @@ class EntityReader implements EntityReaderInterface
                 new $collectionClass(),
                 $referenceClass->getFields()->getBasicFields(),
                 false,
-                $partial
+                $fieldsForPartialLoading
             );
         } else {
             $data = new $collectionClass();
@@ -1176,14 +1257,14 @@ class EntityReader implements EntityReaderInterface
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      */
     private function loadToOne(
         AssociationField $association,
         Context $context,
         EntityCollection $collection,
         Criteria $criteria,
-        array $partial
+        array $fieldsForPartialLoading
     ): void {
         if (!$association instanceof OneToOneAssociationField && !$association instanceof ManyToOneAssociationField) {
             return;
@@ -1215,7 +1296,7 @@ class EntityReader implements EntityReaderInterface
         $referenceDefinition = $association->getReferenceDefinition();
         $collectionClass = $referenceDefinition->getCollectionClass();
 
-        if ($partial !== []) {
+        if ($fieldsForPartialLoading !== []) {
             $collectionClass = EntityCollection::class;
         }
 
@@ -1230,7 +1311,14 @@ class EntityReader implements EntityReaderInterface
 
         $relatedCollection->fill($related);
 
-        $this->fetchAssociations($associationCriteria, $referenceDefinition, $context, $relatedCollection, $fields, $partial);
+        $this->fetchAssociations(
+            $associationCriteria,
+            $referenceDefinition,
+            $context,
+            $relatedCollection,
+            $fields,
+            $fieldsForPartialLoading
+        );
 
         foreach ($collection as $entity) {
             if ($association->is(Extension::class)) {
@@ -1260,7 +1348,7 @@ class EntityReader implements EntityReaderInterface
 
     /**
      * @param EntityCollection<Entity> $collection
-     * @param array<string, mixed> $partial
+     * @param array<string, mixed> $fieldsForPartialLoading
      *
      * @return EntityCollection<Entity>
      */
@@ -1270,7 +1358,7 @@ class EntityReader implements EntityReaderInterface
         Context $context,
         EntityCollection $collection,
         FieldCollection $fields,
-        array $partial
+        array $fieldsForPartialLoading
     ): EntityCollection {
         if ($collection->count() <= 0) {
             return $collection;
@@ -1281,24 +1369,44 @@ class EntityReader implements EntityReaderInterface
                 continue;
             }
 
-            if ($partial !== [] && !\array_key_exists($association->getPropertyName(), $partial)) {
+            if ($fieldsForPartialLoading !== [] && !\array_key_exists($association->getPropertyName(), $fieldsForPartialLoading)) {
                 continue;
             }
 
             if ($association instanceof OneToOneAssociationField || $association instanceof ManyToOneAssociationField) {
-                $this->loadToOne($association, $context, $collection, $criteria, $partial[$association->getPropertyName()] ?? []);
+                $this->loadToOne(
+                    $association,
+                    $context,
+                    $collection,
+                    $criteria,
+                    $fieldsForPartialLoading[$association->getPropertyName()] ?? []
+                );
 
                 continue;
             }
 
             if ($association instanceof OneToManyAssociationField) {
-                $this->loadOneToMany($criteria, $definition, $association, $context, $collection, $partial[$association->getPropertyName()] ?? []);
+                $this->loadOneToMany(
+                    $criteria,
+                    $definition,
+                    $association,
+                    $context,
+                    $collection,
+                    $fieldsForPartialLoading[$association->getPropertyName()] ?? []
+                );
 
                 continue;
             }
 
             if ($association instanceof ManyToManyAssociationField) {
-                $this->loadManyToMany($criteria, $definition, $association, $context, $collection, $partial[$association->getPropertyName()] ?? []);
+                $this->loadManyToMany(
+                    $criteria,
+                    $definition,
+                    $association,
+                    $context,
+                    $collection,
+                    $fieldsForPartialLoading[$association->getPropertyName()] ?? []
+                );
             }
         }
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -255,8 +255,7 @@ class EntityReaderTest extends TestCase
         $criteria->addAssociation('seoUrls');
         $criteria->addFields(['name', 'seoUrls.routeName']);
 
-        $values = static::getContainer()
-            ->get('category.repository')
+        $values = $this->categoryRepository
             ->search($criteria, Context::createDefaultContext());
 
         $entity = $values->first();
@@ -273,8 +272,7 @@ class EntityReaderTest extends TestCase
 
         $criteria->setLimit(50);
         $criteria->getAssociation('seoUrls')->setLimit(50);
-        $values = static::getContainer()
-            ->get('category.repository')
+        $values = $this->categoryRepository
             ->search($criteria, Context::createDefaultContext());
 
         $entity = $values->first();
@@ -301,7 +299,7 @@ class EntityReaderTest extends TestCase
             ->build(),
         ];
 
-        static::getContainer()->get('product.repository')
+        $this->productRepository
             ->create($products, Context::createDefaultContext());
 
         $criteria = new Criteria([$ids->get('p1')]);
@@ -310,8 +308,7 @@ class EntityReaderTest extends TestCase
         $criteria->getAssociation('categories')->addSorting(new FieldSorting('name', FieldSorting::ASCENDING));
         $criteria->addFields(['name', 'categories.name', 'manufacturer.name']);
 
-        $values = static::getContainer()
-            ->get('product.repository')
+        $values = $this->productRepository
             ->search($criteria, Context::createDefaultContext());
 
         $entity = $values->first();
@@ -330,8 +327,7 @@ class EntityReaderTest extends TestCase
         $criteria->getAssociation('categories')->setLimit(50);
         $criteria->getAssociation('manufacturer')->setLimit(50);
 
-        $values = static::getContainer()
-            ->get('product.repository')
+        $values = $this->productRepository
             ->search($criteria, Context::createDefaultContext());
 
         $entity = $values->first();
@@ -344,6 +340,36 @@ class EntityReaderTest extends TestCase
         static::assertSame('c1', $entity->get('categories')->first()->get('name'));
         static::assertInstanceOf(PartialEntity::class, $entity->get('manufacturer'));
         static::assertSame('m1', $entity->get('manufacturer')->get('name'));
+    }
+
+    public function testPartialLoadingWithLongAssociationChain(): void
+    {
+        $ids = new IdsCollection();
+
+        $productNumber = 'p1';
+        $products = [
+            (new ProductBuilder($ids, $productNumber))
+                ->price(100)
+                ->categories(['c1', 'c2'])
+                ->visibility()
+                ->manufacturer('m1')
+                ->cover('cover1')
+                ->build(),
+        ];
+        $context = Context::createDefaultContext();
+        $this->productRepository->create($products, $context);
+
+        $criteria = new Criteria();
+        $criteria->addFields(['cover.media']);
+        $criteria->addFilter(new EqualsFilter('productNumber', $productNumber));
+        $criteria->addAssociation('cover.media.thumbnails');
+
+        $product = $this->productRepository->search($criteria, $context)->first();
+        static::assertInstanceOf(PartialEntity::class, $product);
+        $cover = $product->get('cover');
+        static::assertInstanceOf(PartialEntity::class, $cover);
+        $media = $cover->get('media');
+        static::assertInstanceOf(PartialEntity::class, $media);
     }
 
     public function testTranslated(): void
@@ -2226,13 +2252,13 @@ class EntityReaderTest extends TestCase
             'tax' => ['name' => 'test', 'taxRate' => 15],
         ];
 
-        static::getContainer()->get('product.repository')
+        $this->productRepository
             ->create([$data], Context::createDefaultContext());
 
         $exception = null;
 
         try {
-            static::getContainer()->get('product.repository')
+            $this->productRepository
                 ->search($criteria, Context::createDefaultContext());
         } catch (ParentAssociationCanNotBeFetched $e) {
             $exception = $e;
@@ -2600,7 +2626,7 @@ class EntityReaderTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $productRepository = static::getContainer()->get('product.repository');
+        $productRepository = $this->productRepository;
         $productRepository->create([
             $product->build(),
         ], $context);
@@ -2656,7 +2682,7 @@ class EntityReaderTest extends TestCase
             ->active(false)
             ->price(50, 50);
 
-        $productRepository = static::getContainer()->get('product.repository');
+        $productRepository = $this->productRepository;
         $productRepository->create([
             $product->build(),
             $product2->build(),
@@ -2683,7 +2709,7 @@ class EntityReaderTest extends TestCase
 
         $criteria->getAssociation('consistsOf')->addFilter(new EqualsFilter('active', true));
 
-        $result = static::getContainer()->get('product.repository')
+        $result = $this->productRepository
             ->search($criteria, Context::createDefaultContext());
 
         static::assertCount(1, $result->getEntities());

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -170,8 +170,8 @@ class EntityReaderTest extends TestCase
         static::assertSame('p1', $entity->get('name'));
         static::assertNull($entity->get('active'));
 
-        /** @var EntityCollection<PartialEntity> $collection */
         $collection = $entity->get('categories');
+        static::assertInstanceOf(EntityCollection::class, $collection);
 
         static::assertInstanceOf(PartialEntity::class, $collection->first());
         $collection->sortByIdArray([$ids->get('c1'), $ids->get('c2')]);
@@ -1636,8 +1636,8 @@ class EntityReaderTest extends TestCase
             ->setIds([$productId])
             ->addAssociation('categories');
 
-        /** @var ProductManufacturerEntity $manufacturer */
         $manufacturer = $manufacturerRepo->search($manufacturerCriteria, $context)->get($manufacturerId);
+        static::assertInstanceOf(ProductManufacturerEntity::class, $manufacturer);
         $products = $manufacturer->getProducts();
         static::assertNotNull($products);
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTransla
 use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationEntity;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceCollection;
@@ -370,6 +371,9 @@ class EntityReaderTest extends TestCase
         static::assertInstanceOf(PartialEntity::class, $cover);
         $media = $cover->get('media');
         static::assertInstanceOf(PartialEntity::class, $media);
+        $thumbnails = $media->get('thumbnails');
+        static::assertInstanceOf(EntityCollection::class, $thumbnails);
+        static::assertNotInstanceOf(MediaThumbnailCollection::class, $thumbnails);
     }
 
     public function testTranslated(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Loading partial entities with nested associations fails. See linked issue

### 2. What does this change do, exactly?

Change the detection of partial entity loading in the `EntityReader`, so it is determined at the beginning of the read and is passed down.
Inspired by a PR of @OliverSkroblin https://github.com/shopware/shopware/pull/5169

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/5114

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
