### PR TITLE
test: Covered sw-theme-manager and sw-sales-channel with jest tests

### DIFF
--- a/src/Administration/Resources/app/administration/jest.config.js
+++ b/src/Administration/Resources/app/administration/jest.config.js
@@ -32,6 +32,10 @@ if (isCi) {
 }
 
 module.exports = {
+    roots: [
+        '<rootDir>',
+        '<rootDir>/../../../../Storefront/Resources/app/administration',
+    ],
     cacheDirectory: process.env.JEST_CACHE_DIR,
     preset: '@shopware-ag/jest-preset-sw6-admin',
     globals: {
@@ -54,6 +58,9 @@ module.exports = {
         'src/**/*.ts',
         '!src/**/*.spec.js',
         '!**/*.d.ts',
+        '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.js',
+        '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.ts',
+        '!<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec.js',
 
         // Exception in the build dir for vite plugins
         'build/vite-plugins/**/*.ts',
@@ -88,6 +95,7 @@ module.exports = {
         '^\@shopware-ag\/meteor-admin-sdk\/es\/(.*)': '<rootDir>/node_modules/@shopware-ag/meteor-admin-sdk/umd/$1',
         '^@shopware-ag/meteor-component-library$': '<rootDir>/node_modules/@shopware-ag/meteor-component-library/dist/common/index.js',
         '^@shopware-ag/meteor-component-library/dist/esm/(.*)$': '<rootDir>/node_modules/@shopware-ag/meteor-component-library/dist/common/$1',
+        '^@vue/test-utils$': '<rootDir>/node_modules/@vue/test-utils',
         '^lodash-es$': 'lodash',
         '^lodash-es/(.*)$': 'lodash/$1',
         vue$: 'vue/dist/vue.cjs.js',
@@ -115,6 +123,7 @@ module.exports = {
     testMatch: [
         '<rootDir>/src/**/*.spec.js',
         '<rootDir>/src/**/*.spec.ts',
+        '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec.js',
         '<rootDir>/eslint-rules/**/*.spec.js',
         '<rootDir>/build/vite-plugins/**/*.spec.ts',
         '<rootDir>/build/vite-plugins/**/*.spec.js',

--- a/src/Storefront/Resources/app/administration/src/core/service/api/theme.api.service.spec.js
+++ b/src/Storefront/Resources/app/administration/src/core/service/api/theme.api.service.spec.js
@@ -1,0 +1,130 @@
+/**
+ * @sw-package discovery
+ */
+import ThemeApiService from './theme.api.service';
+import createLoginService from 'src/core/service/login.service';
+import createHTTPClient from 'src/core/factory/http.factory';
+
+function createService(client = null, loginService = null) {
+    if (!client) {
+        client = createHTTPClient();
+    }
+
+    if (!loginService) {
+        loginService = createLoginService(client, Shopware.Context.api);
+    }
+
+    return new ThemeApiService(client, loginService);
+}
+
+describe('ThemeApiService', () => {
+    beforeEach(() => {
+        Shopware.Store.get('session').languageId = 'en-GB';
+    });
+
+    it('assigns theme to a sales channel', async () => {
+        const service = createService();
+        const postSpy = jest.spyOn(service.httpClient, 'post').mockResolvedValue({ data: { foo: 'bar' } });
+
+        const result = await service.assignTheme('theme-id', 'sales-channel-id', { foo: 'bar' }, { baz: 'qux' });
+
+        expect(postSpy).toHaveBeenCalledWith(
+            '/_action/theme/theme-id/assign/sales-channel-id',
+            {},
+            expect.objectContaining({
+                params: { foo: 'bar' },
+                headers: expect.objectContaining({ Authorization: expect.any(String) }),
+            }),
+        );
+        expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('updates theme config via PATCH', async () => {
+        const service = createService();
+        const patchSpy = jest.spyOn(service.httpClient, 'patch').mockResolvedValue({ data: { success: true } });
+
+        const result = await service.updateTheme('theme-id', { config: { foo: 'bar' } }, { reset: true });
+
+        expect(patchSpy).toHaveBeenCalledWith(
+            '/_action/theme/theme-id',
+            { config: { foo: 'bar' } },
+            expect.objectContaining({
+                params: { reset: true },
+                headers: expect.objectContaining({ Authorization: expect.any(String) }),
+            }),
+        );
+        expect(result).toEqual({ success: true });
+    });
+
+    it('resets theme via PATCH', async () => {
+        const service = createService();
+        const patchSpy = jest.spyOn(service.httpClient, 'patch').mockResolvedValue({ data: { reset: true } });
+
+        const result = await service.resetTheme('theme-id');
+
+        expect(patchSpy).toHaveBeenCalledWith(
+            '/_action/theme/theme-id/reset',
+            {},
+            expect.objectContaining({
+                params: {},
+                headers: expect.objectContaining({ Authorization: expect.any(String) }),
+            }),
+        );
+        expect(result).toEqual({ reset: true });
+    });
+
+    it('loads configuration with language header', async () => {
+        const service = createService();
+        const getSpy = jest.spyOn(service.httpClient, 'get').mockResolvedValue({ data: { fields: {} } });
+
+        const result = await service.getConfiguration('theme-id');
+
+        expect(getSpy).toHaveBeenCalledWith(
+            '/_action/theme/theme-id/configuration',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Authorization: expect.any(String),
+                    'sw-language-id': 'en-GB',
+                }),
+            }),
+        );
+        expect(result).toEqual({ fields: {} });
+    });
+
+    it('loads structured fields with language header', async () => {
+        const service = createService();
+        const getSpy = jest.spyOn(service.httpClient, 'get').mockResolvedValue({ data: { tabs: {} } });
+
+        const result = await service.getStructuredFields('theme-id');
+
+        expect(getSpy).toHaveBeenCalledWith(
+            '/_action/theme/theme-id/structured-fields',
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Authorization: expect.any(String),
+                    'sw-language-id': 'en-GB',
+                }),
+            }),
+        );
+        expect(result).toEqual({ tabs: {} });
+    });
+
+    it('validates fields with language header', async () => {
+        const service = createService();
+        const postSpy = jest.spyOn(service.httpClient, 'post').mockResolvedValue({ data: { valid: true } });
+
+        const result = await service.validateFields({ foo: 'bar' });
+
+        expect(postSpy).toHaveBeenCalledWith(
+            '/_action/theme/validate-fields',
+            { fields: { foo: 'bar' } },
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Authorization: expect.any(String),
+                    'sw-language-id': 'en-GB',
+                }),
+            }),
+        );
+        expect(result).toEqual({ valid: true });
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/page/sw-sales-channel-detail/index.spec.js
+++ b/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/page/sw-sales-channel-detail/index.spec.js
@@ -1,0 +1,99 @@
+/**
+ * @sw-package discovery
+ */
+describe('sw-sales-channel-detail extension', () => {
+    function getOverrideConfig() {
+        const overrideSpy = jest.spyOn(Shopware.Component, 'override');
+
+        jest.isolateModules(() => {
+            require('./index');
+        });
+
+        return overrideSpy.mock.calls[0][1];
+    }
+
+    it('extends load criteria with themes association', () => {
+        const overrideConfig = getOverrideConfig();
+        const criteria = { addAssociation: jest.fn() };
+        const vm = {
+            $super: jest.fn(() => criteria),
+        };
+
+        const result = overrideConfig.methods.getLoadSalesChannelCriteria.call(vm);
+
+        expect(result).toBe(criteria);
+        expect(criteria.addAssociation).toHaveBeenCalledWith('themes');
+    });
+
+    it('assigns theme when sales channel theme changes', async () => {
+        const overrideConfig = getOverrideConfig();
+        const themeService = { assignTheme: jest.fn(() => Promise.resolve()) };
+        const vm = {
+            themeService,
+            salesChannel: {
+                id: 'sales-channel-id',
+                getOrigin: () => ({ extensions: { themes: [{ id: 'old-theme-id' }] } }),
+                extensions: { themes: [{ id: 'new-theme-id' }] },
+            },
+            createNotificationError: jest.fn(),
+        };
+
+        await overrideConfig.methods.assignSalesChannelTheme.call(vm);
+
+        expect(themeService.assignTheme).toHaveBeenCalledWith('new-theme-id', 'sales-channel-id');
+    });
+
+    it('does not assign theme when nothing changed', async () => {
+        const overrideConfig = getOverrideConfig();
+        const themeService = { assignTheme: jest.fn(() => Promise.resolve()) };
+        const vm = {
+            themeService,
+            salesChannel: {
+                id: 'sales-channel-id',
+                getOrigin: () => ({ extensions: { themes: [{ id: 'theme-id' }] } }),
+                extensions: { themes: [{ id: 'theme-id' }] },
+            },
+            createNotificationError: jest.fn(),
+        };
+
+        await overrideConfig.methods.assignSalesChannelTheme.call(vm);
+
+        expect(themeService.assignTheme).not.toHaveBeenCalled();
+    });
+
+    it('notifies when theme assignment fails', async () => {
+        const overrideConfig = getOverrideConfig();
+        const themeService = { assignTheme: jest.fn(() => Promise.reject(new Error('fail'))) };
+        const vm = {
+            themeService,
+            salesChannel: {
+                id: 'sales-channel-id',
+                getOrigin: () => ({ extensions: { themes: [{ id: 'old-theme-id' }] } }),
+                extensions: { themes: [{ id: 'new-theme-id' }] },
+            },
+            createNotificationError: jest.fn(),
+            $tc: (key) => key,
+        };
+
+        await overrideConfig.methods.assignSalesChannelTheme.call(vm);
+
+        expect(vm.createNotificationError).toHaveBeenCalledWith({
+            message: 'sw-theme-manager.general.messageSaveError',
+        });
+    });
+
+    it('onSave calls assignment and super handler', async () => {
+        const overrideConfig = getOverrideConfig();
+        const vm = {
+            isLoading: false,
+            assignSalesChannelTheme: jest.fn(() => Promise.resolve()),
+            $super: jest.fn(() => Promise.resolve()),
+        };
+
+        await overrideConfig.methods.onSave.call(vm);
+
+        expect(vm.isLoading).toBe(true);
+        expect(vm.assignSalesChannelTheme).toHaveBeenCalled();
+        expect(vm.$super).toHaveBeenCalledWith('onSave');
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/view/sw-sales-channel-detail-theme/index.spec.js
+++ b/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/view/sw-sales-channel-detail-theme/index.spec.js
@@ -1,0 +1,123 @@
+/**
+ * @sw-package discovery
+ */
+import { shallowMount } from '@vue/test-utils';
+import './index';
+
+describe('sw-sales-channel-detail-theme', () => {
+    async function createWrapper({ aclCan = true, salesChannel = null, themeRepositoryGet = null } = {}) {
+        const component = await Shopware.Component.build('sw-sales-channel-detail-theme');
+
+        const themeRepository = {
+            get: themeRepositoryGet || jest.fn(() => Promise.resolve({ id: 'theme-id' })),
+        };
+
+        return shallowMount(component, {
+            props: {
+                salesChannel: salesChannel || {
+                    id: 'sales-channel-id',
+                    extensions: { themes: [{ id: 'theme-id' }] },
+                },
+            },
+            global: {
+                stubs: {
+                    'sw-card': true,
+                    'sw-theme-list-item': true,
+                    'sw-theme-modal': true,
+                    'sw-button': true,
+                },
+                provide: {
+                    repositoryFactory: {
+                        create: () => themeRepository,
+                    },
+                    themeService: {},
+                    acl: {
+                        can: jest.fn(() => aclCan),
+                    },
+                },
+                mocks: {
+                    $router: { push: jest.fn() },
+                },
+            },
+        });
+    }
+
+    it('loads theme from sales channel on creation', async () => {
+        const theme = { id: 'theme-id', name: 'Theme' };
+        const wrapper = await createWrapper({
+            themeRepositoryGet: jest.fn(() => Promise.resolve(theme)),
+        });
+
+        await flushPromises();
+
+        expect(wrapper.vm.theme).toEqual(theme);
+    });
+
+    it('skips theme load when id is null', async () => {
+        const themeRepositoryGet = jest.fn(() => Promise.resolve({ id: 'theme-id' }));
+        const wrapper = await createWrapper({
+            themeRepositoryGet,
+            salesChannel: {
+                id: 'sales-channel-id',
+                extensions: { themes: [] },
+            },
+        });
+        themeRepositoryGet.mockClear();
+
+        await wrapper.vm.getTheme(null);
+
+        expect(themeRepositoryGet).not.toHaveBeenCalled();
+    });
+
+    it('opens theme selection modal when ACL allows', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.openThemeModal();
+
+        expect(wrapper.vm.showThemeSelectionModal).toBe(true);
+    });
+
+    it('does not open theme selection modal when ACL blocks', async () => {
+        const wrapper = await createWrapper({ aclCan: false });
+
+        wrapper.vm.openThemeModal();
+
+        expect(wrapper.vm.showThemeSelectionModal).toBe(false);
+    });
+
+    it('navigates to theme manager detail when theme exists', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.theme = { id: 'theme-id' };
+
+        wrapper.vm.openInThemeManager();
+
+        expect(wrapper.vm.$router.push).toHaveBeenCalledWith({
+            name: 'sw.theme.manager.detail',
+            params: { id: 'theme-id' },
+        });
+    });
+
+    it('navigates to theme manager list when theme is missing', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.theme = null;
+
+        wrapper.vm.openInThemeManager();
+
+        expect(wrapper.vm.$router.push).toHaveBeenCalledWith({
+            name: 'sw.theme.manager.index',
+        });
+    });
+
+    it('changes theme and updates sales channel extension', async () => {
+        const theme = { id: 'theme-id', name: 'Theme' };
+        const wrapper = await createWrapper({
+            themeRepositoryGet: jest.fn(() => Promise.resolve(theme)),
+        });
+
+        await wrapper.vm.onChangeTheme('theme-id');
+        await flushPromises();
+
+        expect(wrapper.vm.showThemeSelectionModal).toBe(false);
+        expect(wrapper.vm.salesChannel.extensions.themes[0]).toEqual(theme);
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/init/api-service.init.spec.js
+++ b/src/Storefront/Resources/app/administration/src/init/api-service.init.spec.js
@@ -1,0 +1,34 @@
+/**
+ * @sw-package discovery
+ */
+
+describe('src/init/api-service.init.js', () => {
+    it('registers themeService with init container http client', () => {
+        const registerSpy = jest.spyOn(Shopware.Application, 'addServiceProvider');
+        const getContainerSpy = jest.spyOn(Shopware.Application, 'getContainer');
+
+        const initContainer = {
+            httpClient: {
+                get: jest.fn(),
+                post: jest.fn(),
+                patch: jest.fn(),
+            },
+        };
+        getContainerSpy.mockReturnValue(initContainer);
+
+        jest.resetModules();
+
+        const ThemeService = require('../core/service/api/theme.api.service').default;
+        require('./api-service.init');
+
+        const serviceRegistration = registerSpy.mock.calls.find(([serviceName]) => serviceName === 'themeService');
+
+        expect(serviceRegistration).toBeDefined();
+
+        const factory = serviceRegistration[1];
+        const service = factory({ loginService: {} });
+
+        expect(service).toBeInstanceOf(ThemeService);
+        expect(service.httpClient).toBe(initContainer.httpClient);
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/component/sw-settings-storefront-configuration/sw-settings-storefront-configuration.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/component/sw-settings-storefront-configuration/sw-settings-storefront-configuration.spec.js
@@ -1,0 +1,31 @@
+/**
+ * @sw-package framework
+ */
+import { shallowMount } from '@vue/test-utils';
+import './index';
+
+describe('sw-settings-storefront-configuration', () => {
+    it('renders with required storefront settings', async () => {
+        const component = await Shopware.Component.build('sw-settings-storefront-configuration');
+
+        const wrapper = shallowMount(component, {
+            props: {
+                storefrontSettings: {
+                    'core.storefrontSettings.iconCache': true,
+                },
+            },
+            global: {
+                stubs: {
+                    'sw-switch-field': true,
+                },
+                provide: {
+                    feature: {},
+                },
+            },
+        });
+
+        expect(wrapper.props('storefrontSettings')).toEqual({
+            'core.storefrontSettings.iconCache': true,
+        });
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/index.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/index.spec.js
@@ -1,0 +1,26 @@
+/**
+ * @sw-package framework
+ */
+describe('sw-settings-storefront module', () => {
+    it('registers storefront settings module', () => {
+        const registerSpy = jest.spyOn(Shopware.Module, 'register');
+
+        jest.isolateModules(() => {
+            require('./index');
+        });
+
+        expect(registerSpy).toHaveBeenCalledWith('sw-settings-storefront', expect.objectContaining({
+            routes: expect.objectContaining({
+                index: expect.objectContaining({
+                    components: expect.objectContaining({ default: 'sw-settings-storefront-index' }),
+                }),
+            }),
+            settingsItem: expect.arrayContaining([
+                expect.objectContaining({
+                    to: 'sw.settings.storefront.index',
+                    privilege: 'system.system_config',
+                }),
+            ]),
+        }));
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/page/sw-settings-storefront-index/sw-settings-storefront-index.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/page/sw-settings-storefront-index/sw-settings-storefront-index.spec.js
@@ -1,0 +1,94 @@
+/**
+ * @sw-package framework
+ */
+import { shallowMount } from '@vue/test-utils';
+import './index';
+
+describe('sw-settings-storefront-index', () => {
+    async function createWrapper({ getValues = null, saveValues = null } = {}) {
+        const component = await Shopware.Component.build('sw-settings-storefront-index');
+        component.methods.createdComponent = jest.fn();
+
+        return shallowMount(component, {
+            global: {
+                stubs: {
+                    'sw-page': true,
+                    'sw-button-process': true,
+                    'sw-card-view': true,
+                    'sw-skeleton': true,
+                    'sw-card': true,
+                    'sw-settings-storefront-configuration': true,
+                    'mt-icon': true,
+                },
+                provide: {
+                    systemConfigApiService: {
+                        getValues: getValues || jest.fn(() => Promise.resolve({})),
+                        saveValues: saveValues || jest.fn(() => Promise.resolve()),
+                    },
+                },
+                mocks: {
+                    $createTitle: jest.fn(() => 'title'),
+                },
+            },
+        });
+    }
+
+    it('loads default settings when config is empty', async () => {
+        const wrapper = await createWrapper({
+            getValues: jest.fn(() => Promise.resolve({})),
+        });
+
+        await wrapper.vm.loadstorefrontSettings();
+
+        expect(wrapper.vm.storefrontSettings).toEqual({
+            'core.storefrontSettings.iconCache': true,
+            'core.storefrontSettings.asyncThemeCompilation': false,
+            'core.storefrontSettings.speculationRules': false,
+        });
+        expect(wrapper.vm.isLoading).toBe(false);
+    });
+
+    it('keeps stored settings when config is not empty', async () => {
+        const stored = {
+            'core.storefrontSettings.iconCache': false,
+        };
+        const wrapper = await createWrapper({
+            getValues: jest.fn(() => Promise.resolve(stored)),
+        });
+
+        await wrapper.vm.loadstorefrontSettings();
+
+        expect(wrapper.vm.storefrontSettings).toEqual(stored);
+        expect(wrapper.vm.isLoading).toBe(false);
+    });
+
+    it('normalizes empty values before saving', async () => {
+        const saveValues = jest.fn(() => Promise.resolve());
+        const wrapper = await createWrapper({ saveValues });
+
+        wrapper.vm.storefrontSettings = {
+            'core.storefrontSettings.iconCache': '',
+            'core.storefrontSettings.asyncThemeCompilation': '',
+            'core.storefrontSettings.speculationRules': '',
+        };
+
+        await wrapper.vm.savestorefrontSettings();
+
+        expect(wrapper.vm.storefrontSettings).toEqual({
+            'core.storefrontSettings.iconCache': true,
+            'core.storefrontSettings.asyncThemeCompilation': false,
+            'core.storefrontSettings.speculationRules': false,
+        });
+        expect(saveValues).toHaveBeenCalledWith(wrapper.vm.storefrontSettings);
+        expect(wrapper.vm.isLoading).toBe(false);
+    });
+
+    it('reloads content after save finish', async () => {
+        const wrapper = await createWrapper();
+        const loadSpy = jest.spyOn(wrapper.vm, 'loadPageContent').mockImplementation(() => {});
+
+        await wrapper.vm.onSaveFinish();
+
+        expect(loadSpy).toHaveBeenCalled();
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/acl/index.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/acl/index.spec.js
@@ -1,0 +1,64 @@
+/**
+ * @sw-package discovery
+ */
+import PrivilegesService from 'src/app/service/privileges.service';
+
+Shopware.Application.addServiceProvider('privileges', () => {
+    return new PrivilegesService();
+});
+
+describe('sw-theme-manager acl', () => {
+    it('registers theme privilege mapping', () => {
+        const privilegeService = Shopware.Service('privileges');
+        const addSpy = jest.spyOn(privilegeService, 'addPrivilegeMappingEntry');
+        const getPrivilegesSpy = jest.spyOn(privilegeService, 'getPrivileges')
+            .mockImplementation((key) => {
+                if (key === 'media.viewer') {
+                    return () => ['media.viewer'];
+                }
+
+                if (key === 'media.creator') {
+                    return () => ['media.creator'];
+                }
+
+                return () => [key];
+            });
+
+        jest.isolateModules(() => {
+            require('./index');
+        });
+
+        expect(getPrivilegesSpy).toHaveBeenCalledWith('media.viewer');
+        expect(getPrivilegesSpy).toHaveBeenCalledWith('media.creator');
+
+        expect(addSpy).toHaveBeenCalledWith(expect.objectContaining({
+            key: 'theme',
+            roles: expect.objectContaining({
+                viewer: expect.objectContaining({
+                    privileges: expect.arrayContaining([
+                        'theme:read',
+                        'sales_channel:read',
+                        expect.any(Function),
+                    ]),
+                }),
+                editor: expect.objectContaining({
+                    privileges: expect.arrayContaining([
+                        'theme:update',
+                        expect.any(Function),
+                    ]),
+                    dependencies: ['theme.viewer'],
+                }),
+                creator: expect.objectContaining({
+                    privileges: expect.arrayContaining(['theme:create']),
+                    dependencies: ['theme.viewer', 'theme.editor'],
+                }),
+                deleter: expect.objectContaining({
+                    privileges: expect.arrayContaining(['theme:delete']),
+                    dependencies: ['theme.viewer'],
+                }),
+            }),
+        }));
+
+        getPrivilegesSpy.mockRestore();
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-list-item/sw-theme-list-item.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-list-item/sw-theme-list-item.spec.js
@@ -1,0 +1,162 @@
+/**
+ * @sw-package discovery
+ */
+import { shallowMount } from '@vue/test-utils';
+import './index';
+
+describe('sw-theme-list-item', () => {
+    async function createWrapper(props = {}) {
+        const component = await Shopware.Component.build('sw-theme-list-item');
+
+        return shallowMount(component, {
+            props: {
+                theme: {
+                    id: 'theme-id',
+                    previewMedia: null,
+                    salesChannels: [],
+                    save: jest.fn(),
+                    ...props.theme,
+                },
+                ...props,
+            },
+            global: {
+                stubs: {
+                    'sw-icon': true,
+                },
+                mocks: {
+                    $t: (key) => key,
+                },
+            },
+        });
+    }
+
+    it('returns preview media style when preview media exists', async () => {
+        const wrapper = await createWrapper({
+            theme: {
+                previewMedia: { id: 'media-id', url: 'https://example.com/image.png' },
+            },
+        });
+
+        expect(wrapper.vm.previewMedia).toEqual({
+            'background-image': "url('https://example.com/image.png')",
+            'background-size': 'cover',
+        });
+    });
+
+    it('falls back to default theme asset when preview media is missing', async () => {
+        const assetSpy = jest.spyOn(Shopware.Filter, 'getByName').mockReturnValue(() => 'preview.jpg');
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.previewMedia).toEqual({
+            'background-image': 'url(preview.jpg)',
+        });
+
+        assetSpy.mockRestore();
+    });
+
+    it('detects active state from sales channels or active prop', async () => {
+        const wrapperWithChannel = await createWrapper({
+            theme: { salesChannels: [{ id: 'sales-channel-id' }] },
+        });
+        const wrapperActiveProp = await createWrapper({ active: true });
+
+        expect(wrapperWithChannel.vm.isActive()).toBe(true);
+        expect(wrapperActiveProp.vm.isActive()).toBe(true);
+    });
+
+    it('builds component classes based on active and disabled', async () => {
+        const wrapper = await createWrapper({
+            active: true,
+            disabled: true,
+        });
+
+        expect(wrapper.vm.componentClasses).toEqual({
+            'is--active': true,
+            'is--disabled': true,
+        });
+    });
+
+    it('emits preview-image-change when enabled', async () => {
+        const wrapper = await createWrapper();
+        const theme = { id: 'theme-id' };
+
+        wrapper.vm.onChangePreviewImage(theme);
+
+        expect(wrapper.emitted('preview-image-change')[0]).toEqual([theme]);
+    });
+
+    it('does not emit preview-image-change when disabled', async () => {
+        const wrapper = await createWrapper({ disabled: true });
+
+        wrapper.vm.onChangePreviewImage({ id: 'theme-id' });
+
+        expect(wrapper.emitted('preview-image-change')).toBeUndefined();
+    });
+
+    it('emits item-click when enabled', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.onThemeClick();
+
+        expect(wrapper.emitted('item-click')[0]).toEqual([wrapper.props('theme')]);
+    });
+
+    it('does not emit item-click when disabled', async () => {
+        const wrapper = await createWrapper({ disabled: true });
+
+        wrapper.vm.onThemeClick();
+
+        expect(wrapper.emitted('item-click')).toBeUndefined();
+    });
+
+    it('removes preview image and saves theme', async () => {
+        const wrapper = await createWrapper({
+            theme: {
+                previewMediaId: 'media-id',
+                previewMedia: { id: 'media-id' },
+                save: jest.fn(),
+            },
+        });
+        const theme = wrapper.props('theme');
+
+        wrapper.vm.onRemovePreviewImage(theme);
+
+        expect(theme.previewMediaId).toBeNull();
+        expect(theme.previewMedia).toBeNull();
+        expect(theme.save).toHaveBeenCalled();
+    });
+
+    it('emits theme-delete when enabled', async () => {
+        const wrapper = await createWrapper();
+        const theme = { id: 'theme-id' };
+
+        wrapper.vm.onDelete(theme);
+
+        expect(wrapper.emitted('theme-delete')[0]).toEqual([theme]);
+    });
+
+    it('does not emit theme-delete when disabled', async () => {
+        const wrapper = await createWrapper({ disabled: true });
+
+        wrapper.vm.onDelete({ id: 'theme-id' });
+
+        expect(wrapper.emitted('theme-delete')).toBeUndefined();
+    });
+
+    it('emits item-click from emitItemClick when enabled', async () => {
+        const wrapper = await createWrapper();
+        const item = { id: 'item-id' };
+
+        wrapper.vm.emitItemClick(item);
+
+        expect(wrapper.emitted('item-click')[0]).toEqual([item]);
+    });
+
+    it('does not emit item-click from emitItemClick when disabled', async () => {
+        const wrapper = await createWrapper({ disabled: true });
+
+        wrapper.vm.emitItemClick({ id: 'item-id' });
+
+        expect(wrapper.emitted('item-click')).toBeUndefined();
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/sw-theme-modal.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/sw-theme-modal.spec.js
@@ -1,0 +1,107 @@
+/**
+ * @sw-package discovery
+ */
+import { shallowMount } from '@vue/test-utils';
+import './index';
+
+describe('sw-theme-modal', () => {
+    async function createWrapper({ repositorySearch = null, selectedThemeId = null } = {}) {
+        const component = await Shopware.Component.build('sw-theme-modal');
+        const themeRepository = {
+            search: repositorySearch || jest.fn(() => Promise.resolve({ total: 0, length: 0 })),
+        };
+
+        return shallowMount(component, {
+            props: {
+                selectedThemeId,
+            },
+            global: {
+                stubs: {
+                    'sw-modal': true,
+                    'sw-card-section': true,
+                    'sw-container': true,
+                    'sw-simple-search-field': true,
+                    'sw-loader': true,
+                    'sw-theme-list-item': true,
+                    'sw-button': true,
+                    'mt-checkbox': true,
+                },
+                provide: {
+                    repositoryFactory: {
+                        create: () => themeRepository,
+                    },
+                    feature: {},
+                    searchRankingService: {
+                        getSearchFieldsByEntity: () => ({}),
+                    },
+                },
+                mocks: {
+                    $t: (key) => key,
+                    $route: { name: 'sw.theme.manager.index', query: {} },
+                },
+            },
+        });
+    }
+
+    it('sets selected theme on created', async () => {
+        const wrapper = await createWrapper({ selectedThemeId: 'theme-id' });
+
+        expect(wrapper.vm.selected).toBe('theme-id');
+    });
+
+    it('loads theme list and updates state', async () => {
+        const searchSpy = jest.fn(() => Promise.resolve({ total: 2, length: 2 }));
+        const wrapper = await createWrapper({ repositorySearch: searchSpy });
+
+        const result = await wrapper.vm.getList();
+
+        expect(searchSpy).toHaveBeenCalledWith(expect.any(Object), Shopware.Context.api);
+        expect(result).toEqual({ total: 2, length: 2 });
+        expect(wrapper.vm.total).toBe(2);
+        expect(wrapper.vm.themes).toEqual({ total: 2, length: 2 });
+        expect(wrapper.vm.isLoading).toBe(false);
+    });
+
+    it('clears loading state when list fetch fails', async () => {
+        const wrapper = await createWrapper({
+            repositorySearch: jest.fn(() => Promise.reject(new Error('fail'))),
+        });
+
+        await wrapper.vm.getList();
+        await flushPromises();
+
+        expect(wrapper.vm.isLoading).toBe(false);
+    });
+
+    it('selects and emits modal theme selection', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.selected = 'theme-id';
+        wrapper.vm.selectLayout();
+
+        expect(wrapper.emitted('modal-theme-select')[0]).toEqual(['theme-id']);
+        expect(wrapper.emitted('modal-close')).toBeDefined();
+        expect(wrapper.vm.selected).toBeNull();
+        expect(wrapper.vm.term).toBeNull();
+    });
+
+    it('updates selected item', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.selectItem('theme-id');
+
+        expect(wrapper.vm.selected).toBe('theme-id');
+    });
+
+    it('search resets page and triggers list loading', async () => {
+        const wrapper = await createWrapper();
+        const getListSpy = jest.spyOn(wrapper.vm, 'getList').mockImplementation(() => {});
+
+        wrapper.vm.page = 3;
+        wrapper.vm.onSearch('Foo');
+
+        expect(wrapper.vm.term).toBe('Foo');
+        expect(wrapper.vm.page).toBe(1);
+        expect(getListSpy).toHaveBeenCalled();
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/index.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/index.spec.js
@@ -1,0 +1,61 @@
+/**
+ * @sw-package discovery
+ */
+import PrivilegesService from 'src/app/service/privileges.service';
+
+describe('sw-theme-manager module', () => {
+    beforeAll(() => {
+        Shopware.Application.addServiceProvider('privileges', () => new PrivilegesService());
+
+        jest.isolateModules(() => {
+            require('./index');
+        });
+    });
+
+    it('registers module with routes and navigation', () => {
+        const module = Shopware.Module.getModuleRegistry().get('sw-theme-manager');
+
+        expect(module).toBeDefined();
+        expect(module.manifest.navigation).toEqual(expect.arrayContaining([
+            expect.objectContaining({ id: 'sw-theme-manager', path: 'sw.theme.manager.index' }),
+        ]));
+
+        const routes = module.routes;
+        expect(routes.get('sw.theme.manager.index').components.default).toBe('sw-theme-manager-list');
+        expect(routes.get('sw.theme.manager.detail').components.default).toBe('sw-theme-manager-detail');
+    });
+
+    it('adds sales channel detail theme route when missing', () => {
+        const module = Shopware.Module.getModuleRegistry().get('sw-theme-manager');
+        const routeMiddleware = module.manifest.routeMiddleware;
+        const next = jest.fn();
+        const currentRoute = {
+            name: 'sw.sales.channel.detail',
+            children: [],
+        };
+
+        routeMiddleware(next, currentRoute);
+
+        expect(currentRoute.children).toHaveLength(1);
+        expect(currentRoute.children[0]).toEqual(expect.objectContaining({
+            name: 'sw.sales.channel.detail.theme',
+            component: 'sw-sales-channel-detail-theme',
+        }));
+        expect(next).toHaveBeenCalledWith(currentRoute);
+    });
+
+    it('does not duplicate sales channel detail theme route', () => {
+        const module = Shopware.Module.getModuleRegistry().get('sw-theme-manager');
+        const routeMiddleware = module.manifest.routeMiddleware;
+        const currentRoute = {
+            name: 'sw.sales.channel.detail',
+            children: [
+                { name: 'sw.sales.channel.detail.theme' },
+            ],
+        };
+
+        routeMiddleware(jest.fn(), currentRoute);
+
+        expect(currentRoute.children).toHaveLength(1);
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/mixin/sw-theme.mixin.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/mixin/sw-theme.mixin.spec.js
@@ -1,0 +1,275 @@
+/**
+ * @sw-package discovery
+ */
+import { mount } from '@vue/test-utils';
+import './sw-theme.mixin';
+
+async function createWrapper({
+    aclCan = true,
+    getList = null,
+    repositoryOverrides = {},
+} = {}) {
+    const themeRepository = {
+        delete: jest.fn(() => Promise.resolve()),
+        create: jest.fn(() => ({ id: 'new-theme-id' })),
+        save: jest.fn(() => Promise.resolve()),
+        ...repositoryOverrides,
+    };
+
+    return mount({
+        template: '<div></div>',
+        mixins: [Shopware.Mixin.getByName('theme')],
+        data() {
+            return {
+                isLoading: false,
+                getList,
+            };
+        },
+    }, {
+        global: {
+            provide: {
+                repositoryFactory: {
+                    create: () => themeRepository,
+                },
+                themeService: {},
+                acl: {
+                    can: jest.fn(() => aclCan),
+                },
+            },
+            mocks: {
+                $t: (key) => key,
+                $router: {
+                    push: jest.fn(),
+                },
+            },
+        },
+    });
+}
+
+describe('sw-theme.mixin', () => {
+    it('does not open delete modal when ACL blocks', async () => {
+        const wrapper = await createWrapper({ aclCan: false });
+
+        wrapper.vm.onDeleteTheme({ id: 'theme-id' });
+
+        expect(wrapper.vm.showDeleteModal).toBe(false);
+        expect(wrapper.vm.modalTheme).toBeNull();
+    });
+
+    it('opens delete modal when ACL allows', async () => {
+        const wrapper = await createWrapper();
+        const theme = { id: 'theme-id' };
+
+        wrapper.vm.onDeleteTheme(theme);
+
+        expect(wrapper.vm.showDeleteModal).toBe(true);
+        expect(wrapper.vm.modalTheme).toEqual(theme);
+    });
+
+    it('closes delete modal and clears theme', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.showDeleteModal = true;
+        wrapper.vm.modalTheme = { id: 'theme-id' };
+
+        wrapper.vm.onCloseDeleteModal();
+
+        expect(wrapper.vm.showDeleteModal).toBe(false);
+        expect(wrapper.vm.modalTheme).toBeNull();
+    });
+
+    it('confirms delete and resets modal state', async () => {
+        const wrapper = await createWrapper();
+        const deleteSpy = jest.spyOn(wrapper.vm, 'deleteTheme').mockImplementation(() => {});
+
+        wrapper.vm.modalTheme = { id: 'theme-id' };
+        wrapper.vm.showDeleteModal = true;
+
+        wrapper.vm.onConfirmThemeDelete();
+
+        expect(deleteSpy).toHaveBeenCalledWith({ id: 'theme-id' });
+        expect(wrapper.vm.showDeleteModal).toBe(false);
+        expect(wrapper.vm.modalTheme).toBeNull();
+    });
+
+    it('deletes theme and refreshes list when getList exists', async () => {
+        const getList = jest.fn();
+        const wrapper = await createWrapper({ getList });
+
+        await wrapper.vm.deleteTheme({ id: 'theme-id' });
+        await flushPromises();
+
+        expect(getList).toHaveBeenCalled();
+        expect(wrapper.vm.$router.push).not.toHaveBeenCalled();
+    });
+
+    it('deletes theme and redirects when getList is missing', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.vm.deleteTheme({ id: 'theme-id' });
+        await flushPromises();
+
+        expect(wrapper.vm.$router.push).toHaveBeenCalledWith({ name: 'sw.theme.manager.index' });
+    });
+
+    it('shows error notification when delete fails', async () => {
+        const wrapper = await createWrapper({
+            repositoryOverrides: {
+                delete: jest.fn(() => Promise.reject(new Error('fail'))),
+            },
+        });
+        wrapper.vm.createNotificationError = jest.fn();
+
+        await wrapper.vm.deleteTheme({ id: 'theme-id' });
+        await flushPromises();
+
+        expect(wrapper.vm.createNotificationError).toHaveBeenCalledWith({
+            title: 'sw-theme-manager.components.themeListItem.notificationDeleteErrorTitle',
+            message: 'sw-theme-manager.components.themeListItem.notificationDeleteErrorMessage',
+        });
+    });
+
+    it('opens duplicate modal when ACL allows', async () => {
+        const wrapper = await createWrapper();
+        const theme = { id: 'theme-id' };
+
+        wrapper.vm.onDuplicateTheme(theme);
+
+        expect(wrapper.vm.showDuplicateModal).toBe(true);
+        expect(wrapper.vm.modalTheme).toEqual(theme);
+    });
+
+    it('does not open duplicate modal when ACL blocks', async () => {
+        const wrapper = await createWrapper({ aclCan: false });
+
+        wrapper.vm.onDuplicateTheme({ id: 'theme-id' });
+
+        expect(wrapper.vm.showDuplicateModal).toBe(false);
+    });
+
+    it('closes duplicate modal and resets state', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.showDuplicateModal = true;
+        wrapper.vm.modalTheme = { id: 'theme-id' };
+        wrapper.vm.newThemeName = 'New name';
+
+        wrapper.vm.onCloseDuplicateModal();
+
+        expect(wrapper.vm.showDuplicateModal).toBe(false);
+        expect(wrapper.vm.modalTheme).toBeNull();
+        expect(wrapper.vm.newThemeName).toBe('');
+    });
+
+    it('confirms duplicate and resets modal state', async () => {
+        const wrapper = await createWrapper();
+        const duplicateSpy = jest.spyOn(wrapper.vm, 'duplicateTheme').mockImplementation(() => {});
+
+        wrapper.vm.modalTheme = { id: 'theme-id' };
+        wrapper.vm.newThemeName = 'New name';
+
+        wrapper.vm.onConfirmThemeDuplicate();
+
+        expect(duplicateSpy).toHaveBeenCalledWith({ id: 'theme-id' }, 'New name');
+        expect(wrapper.vm.showDuplicateModal).toBe(false);
+        expect(wrapper.vm.modalTheme).toBeNull();
+        expect(wrapper.vm.newThemeName).toBe('');
+    });
+
+    it('duplicates theme and redirects to detail', async () => {
+        const wrapper = await createWrapper();
+        const parentTheme = {
+            id: 'parent-id',
+            author: 'author',
+            description: 'description',
+            labels: { foo: 'bar' },
+            helpTexts: { baz: 'qux' },
+            customFields: { custom: true },
+            previewMediaId: 'media-id',
+        };
+
+        await wrapper.vm.duplicateTheme(parentTheme, 'New theme');
+        await flushPromises();
+
+        expect(wrapper.vm.themeRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+            name: 'New theme',
+            parentThemeId: 'parent-id',
+            author: 'author',
+            description: 'description',
+            previewMediaId: 'media-id',
+            active: true,
+        }), Shopware.Context.api);
+        expect(wrapper.vm.$router.push).toHaveBeenCalledWith({
+            name: 'sw.theme.manager.detail',
+            params: { id: 'new-theme-id' },
+        });
+    });
+
+    it('opens rename modal with current theme name', async () => {
+        const wrapper = await createWrapper();
+        const theme = { id: 'theme-id', name: 'Old name' };
+
+        wrapper.vm.onRenameTheme(theme);
+
+        expect(wrapper.vm.showRenameModal).toBe(true);
+        expect(wrapper.vm.modalTheme).toEqual(theme);
+        expect(wrapper.vm.newThemeName).toBe('Old name');
+    });
+
+    it('does not open rename modal when ACL blocks', async () => {
+        const wrapper = await createWrapper({ aclCan: false });
+
+        wrapper.vm.onRenameTheme({ id: 'theme-id' });
+
+        expect(wrapper.vm.showRenameModal).toBe(false);
+    });
+
+    it('closes rename modal and resets state', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.showRenameModal = true;
+        wrapper.vm.modalTheme = { id: 'theme-id' };
+        wrapper.vm.newThemeName = 'New name';
+
+        wrapper.vm.onCloseRenameModal();
+
+        expect(wrapper.vm.showRenameModal).toBe(false);
+        expect(wrapper.vm.modalTheme).toBeNull();
+        expect(wrapper.vm.newThemeName).toBe('');
+    });
+
+    it('confirms rename and resets modal state', async () => {
+        const wrapper = await createWrapper();
+        const renameSpy = jest.spyOn(wrapper.vm, 'RenameTheme').mockImplementation(() => {});
+
+        wrapper.vm.modalTheme = { id: 'theme-id' };
+        wrapper.vm.newThemeName = 'New name';
+
+        wrapper.vm.onConfirmThemeRename();
+
+        expect(renameSpy).toHaveBeenCalledWith({ id: 'theme-id' }, 'New name');
+        expect(wrapper.vm.showRenameModal).toBe(false);
+        expect(wrapper.vm.modalTheme).toBeNull();
+        expect(wrapper.vm.newThemeName).toBe('');
+    });
+
+    it('renames theme and saves', async () => {
+        const wrapper = await createWrapper();
+        const theme = { id: 'theme-id', name: 'Old name' };
+
+        wrapper.vm.RenameTheme(theme, 'New name');
+
+        expect(theme.name).toBe('New name');
+        expect(wrapper.vm.themeRepository.save).toHaveBeenCalledWith(theme, Shopware.Context.api);
+    });
+
+    it('saves theme even if name is empty', async () => {
+        const wrapper = await createWrapper();
+        const theme = { id: 'theme-id', name: 'Old name' };
+
+        wrapper.vm.RenameTheme(theme, '');
+
+        expect(theme.name).toBe('Old name');
+        expect(wrapper.vm.themeRepository.save).toHaveBeenCalledWith(theme, Shopware.Context.api);
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.spec.js
@@ -1,0 +1,417 @@
+/**
+ * @sw-package discovery
+ */
+import { shallowMount } from '@vue/test-utils';
+
+describe('sw-theme-manager-detail', () => {
+    function ensureThemeMixinRegistered() {
+        try {
+            Shopware.Mixin.getByName('theme');
+        } catch {
+            require('../../mixin/sw-theme.mixin');
+        }
+    }
+
+    beforeAll(() => {
+        ensureThemeMixinRegistered();
+
+        jest.isolateModules(() => {
+            require('./index');
+        });
+    });
+
+    async function createWrapper({ aclCan = true, themeServiceOverrides = {}, themeOverrides = {} } = {}) {
+        const component = await Shopware.Component.build('sw-theme-manager-detail');
+        component.methods.createdComponent = jest.fn();
+
+        const themeRepository = {
+            schema: { entity: 'theme' },
+            get: jest.fn(() => Promise.resolve(null)),
+            search: jest.fn(() => Promise.resolve({ first: () => null })),
+            save: jest.fn(() => Promise.resolve()),
+            getSyncChangeset: jest.fn(() => ({ changeset: [], deletions: [] })),
+        };
+
+        const defaultFolderRepository = {
+            search: jest.fn(() => Promise.resolve({
+                first: () => ({ folder: { id: 'default-folder-id' } }),
+            })),
+        };
+
+        const salesChannelRepository = {
+            search: jest.fn(() => Promise.resolve({
+                getIds: () => ['sc-1'],
+            })),
+        };
+
+        const themeService = {
+            validateFields: jest.fn(() => Promise.resolve()),
+            updateTheme: jest.fn(() => Promise.resolve()),
+            assignTheme: jest.fn(() => Promise.resolve()),
+            resetTheme: jest.fn(() => Promise.resolve()),
+            getStructuredFields: jest.fn(() => Promise.resolve({ tabs: {}, configInheritance: [] })),
+            getConfiguration: jest.fn(() => Promise.resolve({
+                currentFields: {},
+                fields: {},
+                baseThemeFields: {},
+            })),
+            ...themeServiceOverrides,
+        };
+
+        return shallowMount(component, {
+            data() {
+                return {
+                    theme: {
+                        id: 'theme-id',
+                        technicalName: 'MyTheme',
+                        salesChannels: [],
+                        configValues: {},
+                        getOrigin: () => ({ salesChannels: new Map() }),
+                        ...themeOverrides,
+                    },
+                };
+            },
+            global: {
+                stubs: {
+                    'sw-alert': true,
+                    'sw-button-group': true,
+                    'sw-button-process': true,
+                    'sw-card': true,
+                    'sw-card-section': true,
+                    'sw-colorpicker': true,
+                    'sw-container': true,
+                    'sw-context-button': true,
+                    'sw-context-menu-item': true,
+                    'sw-entity-multi-select': true,
+                    'sw-form-field-renderer': true,
+                    'sw-icon': true,
+                    'sw-inherit-wrapper': true,
+                    'sw-media-modal-v2': true,
+                    'sw-media-upload-v2': true,
+                    'sw-modal': true,
+                    'sw-page': true,
+                    'sw-search-bar': true,
+                    'sw-select-field': true,
+                    'sw-sidebar': true,
+                    'sw-sidebar-media-item': true,
+                    'sw-skeleton': true,
+                    'sw-tabs': true,
+                    'sw-tabs-item': true,
+                    'sw-text-field': true,
+                    'sw-upload-listener': true,
+                    'sw-url-field': true,
+                    'mt-button': true,
+                    'mt-icon': true,
+                    'mt-text-field': true,
+                },
+                provide: {
+                    repositoryFactory: {
+                        create: (entity) => {
+                            if (entity === 'theme') {
+                                return themeRepository;
+                            }
+                            if (entity === 'media_default_folder') {
+                                return defaultFolderRepository;
+                            }
+                            if (entity === 'sales_channel') {
+                                return salesChannelRepository;
+                            }
+                            return { get: jest.fn() };
+                        },
+                    },
+                    themeService,
+                    acl: {
+                        can: jest.fn(() => aclCan),
+                    },
+                    feature: {},
+                },
+                mocks: {
+                    $t: (key) => key,
+                    $tc: (key) => key,
+                    $route: { params: { id: 'theme-id' } },
+                    $router: { push: jest.fn() },
+                    $createTitle: jest.fn(() => 'title'),
+                },
+            },
+        });
+    }
+
+    beforeEach(() => {
+        Shopware.Store.get('session').currentLocale = 'en-GB';
+    });
+
+    it('determines derived state based on theme inheritance', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.theme = null;
+        expect(wrapper.vm.isDerived).toBe(false);
+
+        wrapper.vm.theme = { technicalName: 'Storefront' };
+        expect(wrapper.vm.isDerived).toBe(false);
+
+        wrapper.vm.theme = { technicalName: 'Custom', baseConfig: { configInheritance: ['@Storefront'] } };
+        wrapper.vm.parentTheme = null;
+        expect(wrapper.vm.isDerived).toBe(true);
+
+        wrapper.vm.theme = { technicalName: 'Custom', baseConfig: { configInheritance: ['@Other'] } };
+        expect(wrapper.vm.isDerived).toBe(false);
+
+        wrapper.vm.parentTheme = { id: 'parent' };
+        expect(wrapper.vm.isDerived).toBe(true);
+    });
+
+    it('sanitizes CSS values', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.cssValue(null)).toBe('');
+        expect(wrapper.vm.cssValue('`foo´bar`')).toBe('foobar');
+    });
+
+    it('builds clean changeset without invalid config entries', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.theme.configValues = { existing: 'value' };
+        wrapper.vm.currentThemeConfigInitial = {
+            foo: { value: 'a' },
+            bar: { value: 'b' },
+        };
+        wrapper.vm.currentThemeConfig = {
+            foo: { value: 'changed' },
+            bar: { value: 'b' },
+        };
+        wrapper.vm.themeConfig = {
+            foo: { type: 'text' },
+            bar: { type: null },
+        };
+
+        const changeset = wrapper.vm.getCurrentChangeset(true);
+
+        expect(changeset).toEqual({
+            foo: { value: 'changed' },
+        });
+    });
+
+    it('removes inherited values from changeset', async () => {
+        const wrapper = await createWrapper();
+
+        const { removeInheritedFromChangeset } = wrapper.vm.$options.methods;
+        const context = {
+            wrapperIsVisible: (key) => key === 'foo',
+            $refs: {
+                'wrapper-foo': [{ isInherited: true }],
+            },
+            inheritanceChanged: {
+                'wrapper-bar': true,
+            },
+        };
+
+        const changes = { foo: 'value', bar: 'value', baz: 'value' };
+        removeInheritedFromChangeset.call(context, changes);
+
+        expect(changes).toEqual({ baz: 'value' });
+    });
+
+    it('builds field bindings with component-specific config', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.getSnippet = jest.fn(() => 'Translated');
+
+        const bind = wrapper.vm.getBind({
+            type: 'text',
+            label: 'Label',
+            custom: { componentName: 'sw-text-field' },
+        });
+
+        expect(bind).toEqual({
+            type: 'text',
+            config: expect.objectContaining({
+                componentName: 'sw-text-field',
+            }),
+        });
+
+        const selectBind = wrapper.vm.getBind({
+            type: 'select',
+            label: 'Label',
+            custom: {
+                componentName: 'sw-single-select',
+                options: [{ labelSnippetKey: 'label.key', label: 'Fallback' }],
+            },
+        });
+
+        expect(selectBind.config.options[0].label).toBe('Translated');
+        expect(selectBind.config.custom).toBeUndefined();
+        expect(selectBind.config.componentName).toBe('sw-single-select');
+    });
+
+    it('gets snippets with prefix fallback and warns when missing', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const wrapper = await createWrapper();
+        wrapper.vm.inheritedSnippetPrefixes = ['MyTheme'];
+
+        wrapper.vm.$t = (key) => {
+            if (key === 'sw-theme.MyTheme.label.key') {
+                return 'Translated';
+            }
+            return key;
+        };
+
+        expect(wrapper.vm.getSnippet('label.key', 'Fallback')).toBe('Translated');
+
+        wrapper.vm.$t = (key) => key;
+        expect(wrapper.vm.getSnippet('missing.key', 'Fallback')).toBe('Fallback');
+        expect(warnSpy).toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+    });
+
+    it('returns field labels with fallback to field name', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.getSnippet = jest.fn(() => 'Name');
+
+        expect(wrapper.vm.getFieldLabel({ labelSnippetKey: 'foo', label: 'Label' }, 'field')).toBe('Name');
+
+        wrapper.vm.getSnippet = jest.fn(() => '');
+        expect(wrapper.vm.getFieldLabel({ labelSnippetKey: 'foo', label: '' }, 'field')).toBe('field');
+    });
+
+    it('returns help text from snippets or locale map', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.getSnippet = jest.fn(() => 'Help text');
+
+        expect(wrapper.vm.getHelpText({ helpTextSnippetKey: 'foo', helpText: '' })).toBe('Help text');
+
+        wrapper.vm.getSnippet = jest.fn(() => ({ 'en-GB': 'Locale help' }));
+        expect(wrapper.vm.getHelpText({ helpTextSnippetKey: 'foo', helpText: {} })).toBe('Locale help');
+    });
+
+    it('returns default tab label when snippet is empty', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.getSnippet = jest.fn(() => '');
+        wrapper.vm.$t = jest.fn(() => 'Default');
+
+        expect(wrapper.vm.getTabLabel('tab.key', '')).toBe('Default');
+    });
+
+    it('disables selection when default theme and sales channel already assigned', async () => {
+        const wrapper = await createWrapper({
+            themeOverrides: {
+                getOrigin: () => ({
+                    salesChannels: new Map([['sc-1', {}]]),
+                }),
+            },
+        });
+        wrapper.vm.defaultTheme = { id: 'theme-id' };
+        wrapper.vm.theme = { id: 'theme-id', getOrigin: wrapper.vm.theme.getOrigin };
+
+        expect(wrapper.vm.selectionDisablingMethod({ id: 'sc-1' })).toBe(true);
+
+        wrapper.vm.defaultTheme = { id: 'other' };
+        expect(wrapper.vm.selectionDisablingMethod({ id: 'sc-1' })).toBe(false);
+    });
+
+    it('validates theme fields and handles invalid scss errors', async () => {
+        const error = {
+            response: {
+                data: {
+                    errors: [{
+                        code: 'THEME__INVALID_SCSS_VAR',
+                        detail: 'Bad var',
+                    }],
+                },
+            },
+        };
+        const themeService = {
+            validateFields: jest.fn(() => Promise.reject(error)),
+        };
+        const wrapper = await createWrapper({ themeServiceOverrides: themeService });
+        wrapper.vm.createNotificationError = jest.fn();
+        wrapper.vm.getCurrentChangeset = jest.fn(() => ({ foo: 'bar' }));
+        wrapper.vm.removeInheritedFromChangeset = jest.fn();
+
+        await wrapper.vm.onValidate();
+        await flushPromises();
+
+        expect(wrapper.vm.createNotificationError).toHaveBeenCalledWith(expect.objectContaining({
+            title: 'sw-theme-manager.detail.validate.failed',
+            autoClose: false,
+        }));
+    });
+
+    it('saves theme config via API with reset and validation', async () => {
+        const themeService = {
+            updateTheme: jest.fn(() => Promise.resolve()),
+        };
+        const wrapper = await createWrapper({ themeServiceOverrides: themeService });
+        wrapper.vm.getCurrentChangeset = jest.fn(() => ({ foo: 'bar' }));
+        wrapper.vm.removeInheritedFromChangeset = jest.fn();
+
+        await wrapper.vm.saveThemeConfig();
+
+        expect(themeService.updateTheme).toHaveBeenCalledWith('theme-id', { config: { foo: 'bar' } }, { reset: true, validate: true });
+    });
+
+    it('handles compiling error on save', async () => {
+        const error = {
+            response: {
+                data: {
+                    errors: [{
+                        code: 'THEME__COMPILING_ERROR',
+                        detail: 'Compile error',
+                    }],
+                },
+            },
+        };
+        const wrapper = await createWrapper();
+        wrapper.vm.createNotificationError = jest.fn();
+        wrapper.vm.saveSalesChannels = jest.fn(() => Promise.resolve());
+        wrapper.vm.saveThemeConfig = jest.fn(() => Promise.reject(error));
+
+        await wrapper.vm.onSaveTheme();
+        await flushPromises();
+
+        expect(wrapper.vm.createNotificationError).toHaveBeenCalledWith(expect.objectContaining({
+            title: 'sw-theme-manager.detail.error.themeCompile.title',
+            autoClose: false,
+        }));
+    });
+
+    it('handles invalid configuration errors on save', async () => {
+        const error = {
+            response: {
+                data: {
+                    errors: [{
+                        code: 'THEME__INVALID_SCSS_VAR',
+                        detail: 'Invalid var',
+                        meta: { parameters: { name: 'config-field' } },
+                    }],
+                },
+            },
+        };
+        const wrapper = await createWrapper();
+        wrapper.vm.createNotificationError = jest.fn();
+        wrapper.vm.saveSalesChannels = jest.fn(() => Promise.resolve());
+        wrapper.vm.saveThemeConfig = jest.fn(() => Promise.reject(error));
+
+        await wrapper.vm.onSaveTheme();
+        await flushPromises();
+
+        expect(wrapper.vm.createNotificationError).toHaveBeenCalledWith(expect.objectContaining({
+            title: 'sw-theme-manager.detail.error.invalidConfiguration.title',
+            autoClose: true,
+        }));
+        expect(wrapper.vm.themeConfigErrors['config-field']).toBeDefined();
+    });
+
+    it('uses first media item when changing media selection', async () => {
+        const wrapper = await createWrapper();
+        const addSpy = jest.spyOn(wrapper.vm, 'onAddMediaToTheme').mockImplementation(() => {});
+
+        wrapper.vm.activeMediaField = 'field';
+        wrapper.vm.currentThemeConfig = {
+            field: { value: null },
+        };
+
+        wrapper.vm.onMediaChange([{ id: 'media-id' }]);
+
+        expect(addSpy).toHaveBeenCalledWith({ id: 'media-id' }, wrapper.vm.currentThemeConfig.field);
+    });
+});

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.spec.js
@@ -1,0 +1,204 @@
+/**
+ * @sw-package discovery
+ */
+import { shallowMount } from '@vue/test-utils';
+
+describe('sw-theme-manager-list', () => {
+    function ensureThemeMixinRegistered() {
+        try {
+            Shopware.Mixin.getByName('theme');
+        } catch {
+            require('../../mixin/sw-theme.mixin');
+        }
+    }
+
+    beforeAll(() => {
+        ensureThemeMixinRegistered();
+
+        jest.isolateModules(() => {
+            require('./index');
+        });
+    });
+
+    async function createWrapper({ aclCan = true, searchResult = null } = {}) {
+        const component = await Shopware.Component.build('sw-theme-manager-list');
+        const themes = searchResult || (() => {
+            const result = [{ id: 'theme-id', salesChannels: [] }];
+            result.total = 1;
+            return result;
+        })();
+
+        const themeRepository = {
+            search: jest.fn(() => Promise.resolve(themes)),
+            save: jest.fn(() => Promise.resolve()),
+        };
+
+        return shallowMount(component, {
+            global: {
+                stubs: {
+                    'sw-card': true,
+                    'sw-card-view': true,
+                    'sw-context-button': true,
+                    'sw-context-menu-item': true,
+                    'sw-data-grid': true,
+                    'sw-icon': true,
+                    'sw-media-modal-v2': true,
+                    'sw-modal': true,
+                    'sw-page': true,
+                    'sw-pagination': true,
+                    'sw-search-bar': true,
+                    'sw-skeleton': true,
+                    'sw-sorting-select': true,
+                    'sw-text-field': true,
+                    'sw-theme-list-item': true,
+                    'mt-button': true,
+                    'mt-icon': true,
+                    'router-link': true,
+                },
+                provide: {
+                    repositoryFactory: {
+                        create: () => themeRepository,
+                    },
+                    acl: {
+                        can: jest.fn(() => aclCan),
+                    },
+                    themeService: {},
+                    feature: {},
+                    searchRankingService: {
+                        isValidTerm: () => true,
+                        getSearchFieldsByEntity: () => ({}),
+                    },
+                },
+                mocks: {
+                    $t: (key) => key,
+                    $route: { params: { id: 'sales-channel-id' } },
+                    $router: { push: jest.fn() },
+                    $createTitle: jest.fn(() => 'title'),
+                },
+            },
+        });
+    }
+
+    it('loads theme list and updates state', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.vm.getList();
+
+        expect(wrapper.vm.total).toBe(1);
+        expect(wrapper.vm.themes).toHaveLength(1);
+        expect(wrapper.vm.isLoading).toBe(false);
+    });
+
+    it('clears loading state when list fetch fails', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.themeRepository.search.mockRejectedValueOnce(new Error('fail'));
+
+        await wrapper.vm.getList();
+        await flushPromises();
+
+        expect(wrapper.vm.isLoading).toBe(false);
+    });
+
+    it('search resets list and normalizes empty term', async () => {
+        const wrapper = await createWrapper();
+        const resetSpy = jest.spyOn(wrapper.vm, 'resetList').mockImplementation(() => {});
+
+        wrapper.vm.onSearch('');
+
+        expect(wrapper.vm.term).toBeNull();
+        expect(resetSpy).toHaveBeenCalled();
+    });
+
+    it('changes sorting and resets list', async () => {
+        const wrapper = await createWrapper();
+        const resetSpy = jest.spyOn(wrapper.vm, 'resetList').mockImplementation(() => {});
+
+        wrapper.vm.onSortingChanged('updatedAt:ASC');
+
+        expect(wrapper.vm.sortBy).toBe('updatedAt');
+        expect(wrapper.vm.sortDirection).toBe('ASC');
+        expect(resetSpy).toHaveBeenCalled();
+    });
+
+    it('toggles list mode and updates limit', async () => {
+        const wrapper = await createWrapper();
+        const resetSpy = jest.spyOn(wrapper.vm, 'resetList').mockImplementation(() => {});
+
+        wrapper.vm.listMode = 'grid';
+        wrapper.vm.onListModeChange();
+
+        expect(wrapper.vm.listMode).toBe('list');
+        expect(wrapper.vm.limit).toBe(10);
+        expect(resetSpy).toHaveBeenCalled();
+    });
+
+    it('opens media modal when ACL allows', async () => {
+        const wrapper = await createWrapper();
+        const theme = { id: 'theme-id' };
+
+        wrapper.vm.onPreviewChange(theme);
+
+        expect(wrapper.vm.showMediaModal).toBe(true);
+        expect(wrapper.vm.currentTheme).toBe(theme);
+    });
+
+    it('does not open media modal when ACL blocks', async () => {
+        const wrapper = await createWrapper({ aclCan: false });
+
+        wrapper.vm.onPreviewChange({ id: 'theme-id' });
+
+        expect(wrapper.vm.showMediaModal).toBe(false);
+        expect(wrapper.vm.currentTheme).toBeUndefined();
+    });
+
+    it('removes preview image when ACL allows', async () => {
+        const wrapper = await createWrapper();
+        const saveSpy = jest.spyOn(wrapper.vm, 'saveTheme').mockImplementation(() => {});
+        const theme = { previewMediaId: 'media-id', previewMedia: { id: 'media-id' } };
+
+        wrapper.vm.onPreviewImageRemove(theme);
+
+        expect(theme.previewMediaId).toBeNull();
+        expect(theme.previewMedia).toBeNull();
+        expect(saveSpy).toHaveBeenCalledWith(theme);
+    });
+
+    it('skips preview image removal when ACL blocks', async () => {
+        const wrapper = await createWrapper({ aclCan: false });
+        const theme = { previewMediaId: 'media-id', previewMedia: { id: 'media-id' } };
+
+        wrapper.vm.onPreviewImageRemove(theme);
+
+        expect(theme.previewMediaId).toBe('media-id');
+    });
+
+    it('updates current theme preview image', async () => {
+        const wrapper = await createWrapper();
+        const saveSpy = jest.spyOn(wrapper.vm, 'saveTheme').mockImplementation(() => {});
+        const image = { id: 'media-id' };
+
+        wrapper.vm.currentTheme = { previewMediaId: null, previewMedia: null };
+        wrapper.vm.onPreviewImageChange([image]);
+
+        expect(wrapper.vm.currentTheme.previewMediaId).toBe('media-id');
+        expect(wrapper.vm.currentTheme.previewMedia).toBe(image);
+        expect(saveSpy).toHaveBeenCalledWith(wrapper.vm.currentTheme);
+    });
+
+    it('saves theme and clears loading state on error', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.themeRepository.save.mockRejectedValueOnce(new Error('fail'));
+
+        await wrapper.vm.saveTheme({ id: 'theme-id' });
+        await flushPromises();
+
+        expect(wrapper.vm.isLoading).toBe(false);
+    });
+
+    it('returns delete tooltip disabled when theme has no sales channels', async () => {
+        const wrapper = await createWrapper();
+        const tooltip = wrapper.vm.deleteDisabledToolTip({ salesChannels: [] });
+
+        expect(tooltip.disabled).toBe(true);
+    });
+});


### PR DESCRIPTION
fixes [#14324](https://github.com/shopware/shopware/issues/14324)

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The storefront administration unit tests for theme management and storefront settings were missing and the coverage wasn’t reliable. We need them covering our prod code, green and aligned with Shopware 6 test conventions.

### 2. What does this change do, exactly?
It adds/aligns Jest unit tests covering the storefront administration domains (theme manager module/ACL/mixin/modal/list/detail, storefront settings module/index/configuration, sales-channel theme detail, and API service init). It also updates Jest resolution for @vue/test-utils, stubs required components/services, and adjusts expectations to match runtime behavior.

### 3. Describe each step to reproduce the issue or behaviour.
Run the admin unit testsuite -> tests should be included and green.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
