### PR TITLE
fix(storefront-js): JS errors in CmsGdprVideoElement

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -99,11 +99,11 @@ PluginManager.register('DatePicker', () => import('src/plugin/date-picker/date-p
 PluginManager.register('FormCmsHandler', () => import('src/plugin/forms/form-cms-handler.plugin'), '.cms-element-form form');
 PluginManager.register('CountryStateSelect', () => import('src/plugin/forms/form-country-state-select.plugin'), '[data-country-state-select]');
 PluginManager.register('ClearInput', () => import('src/plugin/clear-input-button/clear-input.plugin'), '[data-clear-input]'); // Not used in core, but implemented for plugins
-PluginManager.register('CmsGdprVideoElement', () => import('src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin'), '[data-cms-gdpr-video-element]');
 PluginManager.register('BuyBox', () => import('src/plugin/buy-box/buy-box.plugin'), '[data-buy-box]');
 PluginManager.register('BasicCaptcha', () => import('src/plugin/captcha/basic-captcha.plugin'), '[data-basic-captcha]');
 PluginManager.register('QuantitySelector', () => import('src/plugin/quantity-selector/quantity-selector.plugin'), '[data-quantity-selector]');
 PluginManager.register('AjaxModal', () => import('src/plugin/ajax-modal/ajax-modal.plugin'), '[data-ajax-modal][data-url]');
+PluginManager.register('CmsGdprVideoElement', () => import('src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin'), '[data-cms-gdpr-video-element]');
 
 /**
  * @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES

--- a/src/Storefront/Resources/app/storefront/src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.js
@@ -22,7 +22,7 @@ export default class CmsGdprVideoElement extends Plugin {
         overlayText: null,
         backdropClasses: ['element-loader-backdrop', 'element-loader-backdrop-open'],
         confirmButtonText: null,
-        modalTriggerSelector: '[data-bs-toggle="modal"][data-url]',
+        modalTriggerSelector: '[data-ajax-modal][data-url]',
         urlAttribute: 'data-url',
     };
 
@@ -32,7 +32,7 @@ export default class CmsGdprVideoElement extends Plugin {
      * @returns {void|boolean}
      */
     init() {
-        document.$emitter.subscribe(COOKIE_CONFIGURATION_CLOSE_OFF_CANVAS, this.checkConsentAndReplaceVideo.bind(this));
+        // document.$emitter.subscribe(COOKIE_CONFIGURATION_CLOSE_OFF_CANVAS, this.checkConsentAndReplaceVideo.bind(this));
         document.$emitter.subscribe(COOKIE_CONFIGURATION_UPDATE, this.checkConsentAndReplaceVideo.bind(this));
         document.$emitter.subscribe(CMS_GDPR_VIDEO_ELEMENT_REPLACE_ELEMENT_WITH_VIDEO, this._replaceElementWithVideo.bind(this));
 
@@ -42,6 +42,7 @@ export default class CmsGdprVideoElement extends Plugin {
         this._client = new HttpClient();
         this.backdropElement = this.createElementBackdrop();
         this.el.appendChild(this.backdropElement);
+        window.PluginManager.initializePlugin('AjaxModal', this.options.modalTriggerSelector);
     }
 
     /**
@@ -52,10 +53,7 @@ export default class CmsGdprVideoElement extends Plugin {
     createElementBackdrop() {
         const backdropElement = document.createElement('div');
 
-        // Iterating over the classes for IE11 compatibility, see {@link https://caniuse.com/#feat=classlist}
-        this.options.backdropClasses.forEach((cls) => {
-            backdropElement.classList.add(cls);
-        });
+        backdropElement.classList.add(...this.options.backdropClasses);
 
         const childWrapper = document.createElement('div');
         childWrapper.appendChild(this.createTextOverlay());
@@ -87,11 +85,9 @@ export default class CmsGdprVideoElement extends Plugin {
         const buttonElement = document.createElement('button');
         buttonElement.innerHTML = this.options.confirmButtonText;
 
-        this.options.btnClasses.forEach((cls) => {
-            buttonElement.classList.add(cls);
-        });
+        buttonElement.classList.add(...this.options.btnClasses);
 
-        buttonElement.addEventListener('click', this.onReplaceElementWithVideo.bind(this), false, {
+        buttonElement.addEventListener('click', this.onReplaceElementWithVideo.bind(this), {
             once: true,
         });
 
@@ -132,9 +128,7 @@ export default class CmsGdprVideoElement extends Plugin {
         videoElement.setAttribute('title', this.options.iframeTitle);
         videoElement.setAttribute('allowfullscreen', 'allowfullscreen');
 
-        this.options.iframeClasses.forEach((cls) => {
-            videoElement.classList.add(cls);
-        });
+        videoElement.classList.add(...this.options.iframeClasses);
 
         const parentNode = this.el.parentNode;
         parentNode.appendChild(videoElement);

--- a/src/Storefront/Resources/app/storefront/src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.js
@@ -1,5 +1,5 @@
 import CookieStorageHelper from 'src/helper/storage/cookie-storage.helper';
-import { COOKIE_CONFIGURATION_CLOSE_OFF_CANVAS, COOKIE_CONFIGURATION_UPDATE } from 'src/plugin/cookie/cookie-configuration.plugin';
+import { COOKIE_CONFIGURATION_UPDATE } from 'src/plugin/cookie/cookie-configuration.plugin';
 import Plugin from 'src/plugin-system/plugin.class';
 /** @deprecated tag:v6.8.0 - HttpClient is deprecated. Use native fetch API instead. */
 import HttpClient from 'src/service/http-client.service';
@@ -32,7 +32,6 @@ export default class CmsGdprVideoElement extends Plugin {
      * @returns {void|boolean}
      */
     init() {
-        // document.$emitter.subscribe(COOKIE_CONFIGURATION_CLOSE_OFF_CANVAS, this.checkConsentAndReplaceVideo.bind(this));
         document.$emitter.subscribe(COOKIE_CONFIGURATION_UPDATE, this.checkConsentAndReplaceVideo.bind(this));
         document.$emitter.subscribe(CMS_GDPR_VIDEO_ELEMENT_REPLACE_ELEMENT_WITH_VIDEO, this._replaceElementWithVideo.bind(this));
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.js
@@ -33,8 +33,14 @@ export default class CmsGdprVideoElement extends Plugin {
      */
     init() {
         document.$emitter.subscribe(COOKIE_CONFIGURATION_UPDATE, this.checkConsentAndReplaceVideo.bind(this));
+        document.$emitter.subscribe(CMS_GDPR_VIDEO_ELEMENT_REPLACE_ELEMENT_WITH_VIDEO, this._replaceElementWithVideo.bind(this));
 
         this.checkConsentAndReplaceVideo();
+
+        // When cookie is already set, do not add the backdrop overlay.
+        if (CookieStorageHelper.getItem(this.options.cookieName)) {
+            return;
+        }
 
         /** @deprecated tag:v6.8.0 - HttpClient is deprecated. Use native fetch API instead. */
         this._client = new HttpClient();
@@ -104,7 +110,6 @@ export default class CmsGdprVideoElement extends Plugin {
 
         CookieStorageHelper.setItem(this.options.cookieName, '1', '30');
 
-        this._replaceElementWithVideo();
         document.$emitter.publish(CMS_GDPR_VIDEO_ELEMENT_REPLACE_ELEMENT_WITH_VIDEO);
 
         return true;
@@ -119,6 +124,11 @@ export default class CmsGdprVideoElement extends Plugin {
     _replaceElementWithVideo() {
         // Check if the cookie for this specific video type is set
         if (!CookieStorageHelper.getItem(this.options.cookieName)) {
+            return false;
+        }
+
+        // When video was already replaced, do not create the iframe.
+        if (this.el.parentNode === null) {
             return false;
         }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.js
@@ -33,7 +33,6 @@ export default class CmsGdprVideoElement extends Plugin {
      */
     init() {
         document.$emitter.subscribe(COOKIE_CONFIGURATION_UPDATE, this.checkConsentAndReplaceVideo.bind(this));
-        document.$emitter.subscribe(CMS_GDPR_VIDEO_ELEMENT_REPLACE_ELEMENT_WITH_VIDEO, this._replaceElementWithVideo.bind(this));
 
         this.checkConsentAndReplaceVideo();
 
@@ -105,6 +104,7 @@ export default class CmsGdprVideoElement extends Plugin {
 
         CookieStorageHelper.setItem(this.options.cookieName, '1', '30');
 
+        this._replaceElementWithVideo();
         document.$emitter.publish(CMS_GDPR_VIDEO_ELEMENT_REPLACE_ELEMENT_WITH_VIDEO);
 
         return true;

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
@@ -95,7 +95,7 @@ General styling for cms elements
         text-align: center;
 
         > div {
-            background: rgba(255, 255, 255, 0.5);
+            background: rgba(255, 255, 255, 0.9);
             padding: $spacer;
         }
     }
@@ -142,7 +142,7 @@ General styling for cms elements
         text-align: center;
 
         > div {
-            background: rgba(255, 255, 255, 0.5);
+            background: rgba(255, 255, 255, 0.9);
             padding: $spacer;
         }
     }

--- a/src/Storefront/Resources/app/storefront/test/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.test.js
@@ -22,6 +22,8 @@ describe('src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin', () =
         document.body.innerHTML = template;
         document.$emitter.subscribe = jest.fn();
 
+        window.PluginManager.initializePlugin = jest.fn();
+
         cmsGdprVideoElement = initPlugin();
     });
 
@@ -43,7 +45,7 @@ describe('src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin', () =
 
         cmsGdprVideoElement.init();
 
-        expect(document.$emitter.subscribe).toHaveBeenCalledWith(COOKIE_CONFIGURATION_CLOSE_OFF_CANVAS, expect.any(Function));
+        // expect(document.$emitter.subscribe).toHaveBeenCalledWith(COOKIE_CONFIGURATION_CLOSE_OFF_CANVAS, expect.any(Function));
         expect(document.$emitter.subscribe).toHaveBeenCalledWith(COOKIE_CONFIGURATION_UPDATE, expect.any(Function));
         expect(CookieStorageHelper.getItem(cmsGdprVideoElement.options.cookieName)).toBe('1');
         expect(_replaceElementWithVideo).toHaveBeenCalled();

--- a/src/Storefront/Resources/app/storefront/test/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.test.js
@@ -45,7 +45,6 @@ describe('src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin', () =
 
         cmsGdprVideoElement.init();
 
-        // expect(document.$emitter.subscribe).toHaveBeenCalledWith(COOKIE_CONFIGURATION_CLOSE_OFF_CANVAS, expect.any(Function));
         expect(document.$emitter.subscribe).toHaveBeenCalledWith(COOKIE_CONFIGURATION_UPDATE, expect.any(Function));
         expect(CookieStorageHelper.getItem(cmsGdprVideoElement.options.cookieName)).toBe('1');
         expect(_replaceElementWithVideo).toHaveBeenCalled();

--- a/src/Storefront/Resources/app/storefront/test/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin.test.js
@@ -1,6 +1,6 @@
 import CookieStorageHelper from 'src/helper/storage/cookie-storage.helper';
 import CmsGdprVideoElement, { CMS_GDPR_VIDEO_ELEMENT_REPLACE_ELEMENT_WITH_VIDEO } from 'src/plugin/cms-gdpr-video-element/cms-gdpr-video-element.plugin';
-import { COOKIE_CONFIGURATION_CLOSE_OFF_CANVAS, COOKIE_CONFIGURATION_UPDATE } from 'src/plugin/cookie/cookie-configuration.plugin';
+import { COOKIE_CONFIGURATION_UPDATE } from 'src/plugin/cookie/cookie-configuration.plugin';
 
 /**
  * @sw-package discovery


### PR DESCRIPTION
fixes: https://github.com/shopware/shopware/issues/3510

- Fix the JS event syntax issue mentioned in the original issue.
- Fix JS error on page load (when a CMS video element is present)
- Fix broken "Privacy" modal
- Fix JS error when accepting YouTube/Vimeo via Cookie OffCanvas (duplicate events)
- Fix JS error when accepting multiple videos (Vimeo and YouTube) on the same page (global document event subscriber effecting also other videos)
- Fix transparency of the GDPR overlay because it is very hard to read depending on the bg image.
